### PR TITLE
feat(m4e): add slice 3 late era foundations

### DIFF
--- a/src/systems/legendary-wonder-definitions.ts
+++ b/src/systems/legendary-wonder-definitions.ts
@@ -1,5 +1,10 @@
 import type { LegendaryWonderDefinition } from '@/core/types';
 
+export interface LateEraWonderTechRequirement {
+  wonderId: string;
+  requiredTechs: string[];
+}
+
 export const LEGENDARY_WONDER_DEFINITIONS: LegendaryWonderDefinition[] = [
   {
     id: 'oracle-of-delphi',
@@ -74,4 +79,22 @@ export const LEGENDARY_WONDER_DEFINITIONS: LegendaryWonderDefinition[] = [
 
 export function getLegendaryWonderDefinition(wonderId: string): LegendaryWonderDefinition | undefined {
   return LEGENDARY_WONDER_DEFINITIONS.find(wonder => wonder.id === wonderId);
+}
+
+const LATE_ERA_WONDER_TECH_REQUIREMENTS: LateEraWonderTechRequirement[] = [
+  {
+    wonderId: 'manhattan-project',
+    requiredTechs: ['nuclear-theory'],
+  },
+  {
+    wonderId: 'internet',
+    requiredTechs: ['mass-media', 'global-logistics'],
+  },
+];
+
+export function getLateEraWonderTechRequirements(): LateEraWonderTechRequirement[] {
+  return LATE_ERA_WONDER_TECH_REQUIREMENTS.map(requirement => ({
+    wonderId: requirement.wonderId,
+    requiredTechs: [...requirement.requiredTechs],
+  }));
 }

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -11,7 +11,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'siege-warfare', name: 'Siege Warfare', track: 'military', cost: 90, prerequisites: ['iron-forging', 'engineering'], unlocks: ['Unlock Catapult unit'], era: 4 },
   { id: 'tactics', name: 'Tactics', track: 'military', cost: 100, prerequisites: ['iron-forging'], unlocks: ['Units get +10% combat bonus', 'musketeer'], era: 4 },
 
-  // === ECONOMY TRACK (8 techs, existing — redistributed to 2 per era) ===
+  // === ECONOMY TRACK (9 techs, with Slice 3 late-era scaffolding) ===
   { id: 'gathering', name: 'Gathering', track: 'economy', cost: 15, prerequisites: [], unlocks: ['Unlock Granary building'], era: 1 },
   { id: 'pottery', name: 'Pottery', track: 'economy', cost: 25, prerequisites: ['gathering'], unlocks: ['Unlock Herbalist building'], era: 1 },
   { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 35, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
@@ -20,8 +20,9 @@ export const TECH_TREE: Tech[] = [
   { id: 'mining-tech', name: 'Advanced Mining', track: 'economy', cost: 65, prerequisites: ['animal-husbandry'], unlocks: ['Mines yield +1 production'], era: 3 },
   { id: 'trade-routes', name: 'Trade Routes', track: 'economy', cost: 85, prerequisites: ['currency'], unlocks: ['Enable trade routes between cities'], era: 4 },
   { id: 'banking', name: 'Banking', track: 'economy', cost: 95, prerequisites: ['trade-routes', 'mathematics'], unlocks: ['+20% gold in all cities'], era: 4 },
+  { id: 'global-logistics', name: 'Global Logistics', track: 'economy', cost: 155, prerequisites: ['trade-routes', 'banking'], unlocks: ['Late-era supply chains and wonder distribution requirements'], era: 5 },
 
-  // === SCIENCE TRACK (8 techs, existing) ===
+  // === SCIENCE TRACK (9 techs, with Slice 3 late-era scaffolding) ===
   { id: 'fire', name: 'Fire', track: 'science', cost: 15, prerequisites: [], unlocks: ['Unlock basic research'], era: 1 },
   { id: 'writing', name: 'Writing', track: 'science', cost: 30, prerequisites: ['fire'], unlocks: ['Unlock Library building'], era: 1 },
   { id: 'wheel', name: 'The Wheel', track: 'science', cost: 40, prerequisites: ['fire'], unlocks: ['Unlock Workshop building'], era: 2 },
@@ -30,6 +31,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: ['Unlock Temple building'], era: 3 },
   { id: 'astronomy', name: 'Astronomy', track: 'science', cost: 90, prerequisites: ['mathematics'], unlocks: ['Unlock Observatory building'], era: 4 },
   { id: 'medicine', name: 'Medicine', track: 'science', cost: 85, prerequisites: ['philosophy', 'pottery'], unlocks: ['City population grows faster'], era: 4 },
+  { id: 'nuclear-theory', name: 'Nuclear Theory', track: 'science', cost: 165, prerequisites: ['astronomy', 'medicine'], unlocks: ['Late-era atomic research and wonder prerequisites'], era: 5 },
 
   // === CIVICS TRACK (8 techs, existing) ===
   { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 15, prerequisites: [], unlocks: ['Basic governance'], era: 1 },
@@ -121,7 +123,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'fortresses', name: 'Fortresses', track: 'construction', cost: 125, prerequisites: ['arches'], unlocks: ['Fortress'], era: 4 },
   { id: 'city-planning', name: 'City Planning', track: 'construction', cost: 130, prerequisites: ['aqueducts', 'arches'], unlocks: ['Planned city'], era: 4 },
 
-  // === COMMUNICATION TRACK (8 techs, new) ===
+  // === COMMUNICATION TRACK (9 techs, with Slice 3 late-era scaffolding) ===
   { id: 'drums', name: 'Drums', track: 'communication', cost: 20, prerequisites: [], unlocks: ['Signal drums'], era: 1 },
   { id: 'smoke-signals', name: 'Smoke Signals', track: 'communication', cost: 25, prerequisites: ['drums'], unlocks: ['Watchtower'], era: 1 },
   { id: 'pictographs', name: 'Pictographs', track: 'communication', cost: 45, prerequisites: ['smoke-signals', 'writing'], unlocks: ['Record keeping'], era: 2 },
@@ -130,6 +132,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'ciphers', name: 'Ciphers', track: 'communication', cost: 85, prerequisites: ['pictographs'], unlocks: ['Encoded messages'], era: 3 },
   { id: 'printing', name: 'Printing', track: 'communication', cost: 120, prerequisites: ['courier-networks'], unlocks: ['Newspaper'], era: 4 },
   { id: 'diplomats', name: 'Diplomats', track: 'communication', cost: 130, prerequisites: ['courier-networks', 'ciphers'], unlocks: ['Embassy'], era: 4 },
+  { id: 'mass-media', name: 'Mass Media', track: 'communication', cost: 150, prerequisites: ['printing', 'diplomats'], unlocks: ['Global broadcasts and late-era cultural coordination'], era: 5 },
 
   // === ESPIONAGE TRACK (8 techs — M4a stages 1-2, expanded in later milestones) ===
   { id: 'espionage-scouting', name: 'Scouting Networks', track: 'espionage', cost: 40, prerequisites: [], unlocks: ['Recruit spies', 'Passive city surveillance', 'Scout Area mission', 'Monitor Troops mission'], era: 1 },

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -34,6 +34,10 @@ function titleCase(track: string): string {
   return track.charAt(0).toUpperCase() + track.slice(1);
 }
 
+function getEraLabel(era: number): string {
+  return era === 5 ? 'Late Era Foundations' : `Era ${era}`;
+}
+
 function buildCurrentResearchSummary(currentTech: Tech | undefined, progress: number): HTMLDivElement | null {
   if (!currentTech) {
     return null;
@@ -124,6 +128,38 @@ function createTechItem(
   return item;
 }
 
+function buildEraSection(
+  era: number,
+  techs: Tech[],
+  civ: GameState['civilizations'][string],
+  available: Tech[],
+  callbacks: TechPanelCallbacks,
+  panel: HTMLElement,
+): HTMLElement {
+  const section = document.createElement('div');
+  section.dataset.era = String(era);
+  section.style.cssText = 'margin-bottom:10px;';
+
+  const heading = document.createElement('div');
+  heading.textContent = getEraLabel(era);
+  heading.style.cssText = era === 5
+    ? 'font-size:11px;font-weight:bold;letter-spacing:0.06em;text-transform:uppercase;color:#e8c170;margin:0 0 6px;'
+    : 'font-size:11px;font-weight:bold;letter-spacing:0.04em;text-transform:uppercase;opacity:0.65;margin:0 0 6px;';
+  section.appendChild(heading);
+
+  for (const tech of techs) {
+    section.appendChild(createTechItem(tech, {
+      isCompleted: civ.techState.completed.includes(tech.id),
+      isCurrent: civ.techState.currentResearch === tech.id,
+      isAvailable: available.some(candidate => candidate.id === tech.id),
+      onStartResearch: callbacks.onStartResearch,
+      onClosePanel: () => panel.remove(),
+    }));
+  }
+
+  return section;
+}
+
 export function createTechPanel(
   container: HTMLElement,
   state: GameState,
@@ -186,14 +222,10 @@ export function createTechPanel(
     trackBlock.appendChild(heading);
 
     const techs = TECH_TREE.filter(tech => tech.track === track);
-    for (const tech of techs) {
-      trackBlock.appendChild(createTechItem(tech, {
-        isCompleted: civ.techState.completed.includes(tech.id),
-        isCurrent: civ.techState.currentResearch === tech.id,
-        isAvailable: available.some(candidate => candidate.id === tech.id),
-        onStartResearch: callbacks.onStartResearch,
-        onClosePanel: () => panel.remove(),
-      }));
+    const eras = [...new Set(techs.map(tech => tech.era))].sort((a, b) => a - b);
+    for (const era of eras) {
+      const eraTechs = techs.filter(tech => tech.era === era);
+      trackBlock.appendChild(buildEraSection(era, eraTechs, civ, available, callbacks, panel));
     }
 
     grid.appendChild(trackBlock);

--- a/tests/systems/legendary-wonder-definitions.test.ts
+++ b/tests/systems/legendary-wonder-definitions.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getLateEraWonderTechRequirements } from '@/systems/legendary-wonder-definitions';
+
+describe('legendary-wonder-definitions', () => {
+  it('maps the remaining late-era wonder scaffolding to real Slice 3 techs', () => {
+    const requirements = getLateEraWonderTechRequirements();
+
+    expect(requirements.find(entry => entry.wonderId === 'manhattan-project')).toEqual({
+      wonderId: 'manhattan-project',
+      requiredTechs: ['nuclear-theory'],
+    });
+    expect(requirements.find(entry => entry.wonderId === 'internet')).toEqual({
+      wonderId: 'internet',
+      requiredTechs: ['mass-media', 'global-logistics'],
+    });
+  });
+});

--- a/tests/systems/tech-definitions.test.ts
+++ b/tests/systems/tech-definitions.test.ts
@@ -2,23 +2,27 @@ import { describe, it, expect } from 'vitest';
 import { TECH_TREE } from '@/systems/tech-definitions';
 
 describe('tech definitions', () => {
-  it('has exactly 122 techs after the Stage 5 espionage expansion', () => {
-    expect(TECH_TREE.length).toBe(122);
+  it('has exactly 125 techs after adding late-era Slice 3 scaffolding', () => {
+    expect(TECH_TREE.length).toBe(125);
   });
 
-  it('keeps 15 tracks while expanding espionage to 10 techs', () => {
+  it('keeps 15 tracks while expanding economy, science, and communication into era 5', () => {
     const tracks = new Map<string, number>();
     for (const tech of TECH_TREE) {
       tracks.set(tech.track, (tracks.get(tech.track) ?? 0) + 1);
     }
     expect(tracks.size).toBe(15);
     for (const [track, count] of tracks) {
-      const expected = track === 'espionage' ? 10 : 8;
+      const expected = track === 'espionage'
+        ? 10
+        : ['economy', 'science', 'communication'].includes(track)
+          ? 9
+          : 8;
       expect(count, `track ${track} should have ${expected} techs`).toBe(expected);
     }
   });
 
-  it('keeps 2 techs per era, with espionage extending into era 5', () => {
+  it('keeps the original 2-tech era rhythm through era 4 and adds only the planned era 5 scaffolding', () => {
     const trackEra = new Map<string, number>();
     for (const tech of TECH_TREE) {
       const key = `${tech.track}-${tech.era}`;
@@ -32,6 +36,9 @@ describe('tech definitions', () => {
       }
     }
     expect(trackEra.get('espionage-5'), 'espionage-5 should have 2 techs').toBe(2);
+    expect(trackEra.get('economy-5'), 'economy-5 should have 1 tech').toBe(1);
+    expect(trackEra.get('science-5'), 'science-5 should have 1 tech').toBe(1);
+    expect(trackEra.get('communication-5'), 'communication-5 should have 1 tech').toBe(1);
   });
 
   it('all prerequisites reference existing tech IDs', () => {
@@ -94,5 +101,16 @@ describe('tech definitions', () => {
     const ids = TECH_TREE.filter(t => t.track === 'espionage').map(t => t.id);
     expect(ids).toContain('digital-surveillance');
     expect(ids).toContain('cyber-warfare');
+  });
+
+  it('contains the late-era tech prerequisites for the remaining M4 wonder scaffolding', () => {
+    expect(TECH_TREE.find(t => t.id === 'mass-media')).toBeDefined();
+    expect(TECH_TREE.find(t => t.id === 'global-logistics')).toBeDefined();
+    expect(TECH_TREE.find(t => t.id === 'nuclear-theory')).toBeDefined();
+  });
+
+  it('has no orphan late-era nodes', () => {
+    const lateEra = TECH_TREE.filter(t => t.era >= 5);
+    expect(lateEra.every(t => t.prerequisites.length > 0)).toBe(true);
   });
 });

--- a/tests/systems/tech-system.test.ts
+++ b/tests/systems/tech-system.test.ts
@@ -20,19 +20,23 @@ describe('TECH_TREE', () => {
     }
   });
 
-  it('keeps the legacy 8-tech structure for most tracks and extends espionage to 10 techs', () => {
+  it('keeps the legacy shape while adding the planned era-5 foundation nodes', () => {
     const allTracks = [...new Set(TECH_TREE.map(t => t.track))];
     for (const track of allTracks) {
       const techs = TECH_TREE.filter(t => t.track === track);
-      const expectedCount = track === 'espionage' ? 10 : 8;
+      const expectedCount = track === 'espionage'
+        ? 10
+        : ['economy', 'science', 'communication'].includes(track)
+          ? 9
+          : 8;
       expect(techs.length, `track ${track} should have ${expectedCount} techs`).toBe(expectedCount);
     }
   });
 });
 
 describe('expanded tech tree', () => {
-  it('has 122 techs total after adding Stage 5 espionage', () => {
-    expect(TECH_TREE.length).toBe(122);
+  it('has 125 techs total after adding Slice 3 late-era foundations', () => {
+    expect(TECH_TREE.length).toBe(125);
   });
 
   it('supports cross-track prerequisites', () => {
@@ -58,6 +62,17 @@ describe('expanded tech tree', () => {
     expect(eras).toContain(3);
     expect(eras).toContain(4);
     expect(eras).toContain(5);
+  });
+
+  it('unlocks the new late-era nodes only after their era-4 prerequisites are complete', () => {
+    const state = createTechState();
+
+    expect(getAvailableTechs(state).find(t => t.id === 'mass-media')).toBeUndefined();
+
+    state.completed.push('printing', 'diplomats');
+    const available = getAvailableTechs(state);
+
+    expect(available.find(t => t.id === 'mass-media')).toBeDefined();
   });
 });
 

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -27,4 +27,14 @@ describe('tech-panel', () => {
 
     expect(panel.querySelector('[data-layout="tech-tree-grid"]')).toBeTruthy();
   });
+
+  it('groups late-era nodes into readable sections instead of appending a confusing tail', () => {
+    const state = createNewGame(undefined, 'tech-panel-late-era');
+    state.civilizations.player.techState.completed.push('printing', 'diplomats', 'trade-routes', 'banking', 'astronomy', 'medicine');
+
+    const panel = createTechPanel(document.body, state, { onStartResearch: () => {}, onClose: () => {} });
+
+    expect(panel.querySelector('[data-era="5"]')).toBeTruthy();
+    expect(panel.textContent).toContain('Late Era Foundations');
+  });
 });


### PR DESCRIPTION
## Summary
- add Slice 3 late-era tech foundations for economy, science, and communication
- reorganize the tech panel into readable era-grouped sections, including Late Era Foundations
- add stable tech requirement scaffolding for the remaining late-era legendary wonders

## Tests
- ./scripts/run-with-mise.sh yarn test --run tests/systems/tech-definitions.test.ts tests/systems/tech-system.test.ts tests/ui/tech-panel.test.ts tests/systems/legendary-wonder-definitions.test.ts
- ./scripts/run-with-mise.sh yarn test --run
- ./scripts/run-with-mise.sh yarn build