### PR TITLE
Code review April 12 — Bundle 0: prevention guardrails

### DIFF
--- a/.claude/hooks/check-src-edit.sh
+++ b/.claude/hooks/check-src-edit.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook — inspects the most recent Write/Edit target
+# and returns exit 2 with stderr feedback if it contains known bug patterns.
+#
+# This script is fired by settings.json after every Write/Edit under src/.
+# Exit 2 means "non-blocking error"; the tool already ran, stderr goes back
+# to Claude as feedback for its next turn.
+
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty')"
+
+# Only police TypeScript source under src/
+case "$file_path" in
+  */src/*.ts|*/src/**/*.ts) : ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$file_path" ] || exit 0
+
+violations=""
+
+append() {
+  violations+="- $1
+"
+}
+
+# --- cities[0] outside known-OK files ---
+case "$file_path" in
+  */src/ai/*|*/src/systems/faction-system.ts)
+    : # allowed: capital heuristics
+    ;;
+  *)
+    if grep -nE '\.cities\[0\]' "$file_path" >/dev/null; then
+      lines="$(grep -nE '\.cities\[0\]' "$file_path" | head -5)"
+      append "cities[0] used in a UI/recommendation path — cycle all cities (see .claude/rules/ui-panels.md):
+$lines"
+    fi
+    ;;
+esac
+
+# --- direct state mutation in turn processing ---
+if grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" >/dev/null; then
+  lines="$(grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" | head -5)"
+  append "Direct state mutation detected. Turn-processing systems must return a new GameState (see .claude/rules/game-systems.md#immutable-turn-processing):
+$lines"
+fi
+
+# --- Math.random in src ---
+if grep -nE 'Math\.random\(' "$file_path" | grep -v '//' >/dev/null; then
+  lines="$(grep -nE 'Math\.random\(' "$file_path" | grep -v '//' | head -5)"
+  append "Math.random() is banned in src/ — use seeded RNG (see .claude/rules/game-systems.md#deterministic-rng):
+$lines"
+fi
+
+# --- hardcoded 'player' ownership check ---
+if grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" >/dev/null; then
+  lines="$(grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" | head -5)"
+  append "Hardcoded 'player' ownership check — use state.currentPlayer (see .claude/rules/ui-panels.md#hot-seat-multiplayer):
+$lines"
+fi
+
+# --- innerHTML with template-literal game text ---
+if grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" >/dev/null; then
+  lines="$(grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" | head -5)"
+  append "innerHTML with interpolated game data — use textContent or data-text placeholders (see .claude/rules/ui-panels.md#unit-info-panels):
+$lines"
+fi
+
+# --- dead return field (heuristic: literal 0/null followed by 'computed' comment) ---
+if grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" >/dev/null; then
+  lines="$(grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" | head -5)"
+  append "Placeholder return field with 'calculated elsewhere' comment — populate it or remove the field (see .claude/rules/game-systems.md#no-dead-return-fields):
+$lines"
+fi
+
+if [ -n "$violations" ]; then
+  printf 'check-src-edit: possible rule violations in %s\n%s\n' "$file_path" "$violations" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/pre-push-review-reminder.sh
+++ b/.claude/hooks/pre-push-review-reminder.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook for Bash — reminds Claude to run the
+# code-review skill before pushing or merging if the current branch
+# has commits ahead of origin/main.
+
+set -u
+payload="$(cat)"
+cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')"
+
+case "$cmd" in
+  *"git push"*|*"gh pr merge"*|*"gh pr create"*) : ;;
+  *) exit 0 ;;
+esac
+
+# How many commits ahead of origin/main?
+ahead=0
+if git rev-parse --verify origin/main >/dev/null 2>&1; then
+  ahead="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+fi
+
+if [ "${ahead:-0}" -ge 1 ]; then
+  reason="This branch has $ahead commit(s) ahead of origin/main. Run the 'code-review:code-review' skill before pushing/merging. If you've already reviewed this branch in this session, proceed."
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+fi
+
+exit 0

--- a/.claude/rules/game-systems.md
+++ b/.claude/rules/game-systems.md
@@ -31,3 +31,20 @@ paths:
 ## Production Bonuses
 - `applyProductionBonus()` must be called when processing city production
 - Civ-specific bonuses come from `getCivDefinition(civ.civType).bonusEffect`
+
+## Immutable Turn Processing
+- Systems that process a turn (faction, minor-civ, diplomacy, wonder tick, etc.) MUST return a new `GameState`; never mutate `state.cities[id] = ...`, `state.units[id] = ...`, `state.civilizations[id] = ...`, or nested fields on those objects.
+- Use spread-copy: `{ ...state, cities: { ...state.cities, [id]: { ...city, field: newValue } } }`.
+- If you need to chain updates, thread a `let nextState = state;` through the loop and reassign; do not reach into the input state.
+- Helpers that spawn entities (rebels, free units, barbarians) must return the new `units` map; never write through `state.units[...] = ...`.
+
+## Diplomacy Lifecycle
+- When a new civ is introduced mid-game (breakaway, rebellion statehood), every existing civ's `diplomacy.relationships` must get an entry for the new civ id, and the new civ's `relationships` must get an entry for every existing civ id.
+- When a civ is removed (reabsorbed, eliminated), every other civ's `diplomacy.relationships` AND `diplomacy.atWarWith` AND active treaties involving that id must be scrubbed in the same operation. Dangling ids cause silent lookup failures downstream.
+
+## No Dead Return Fields
+- If a function's return type declares a field, populate it with real data.
+- Do not return a placeholder (`0`, `null`, `''`) with a `// computed elsewhere` comment. Either compute it, or remove the field from the return type.
+
+## Spawn Occupancy
+- Any code that adds a unit to the map (rebel spawns, free unit rewards, barbarian raids, scenario seeding) MUST check `state.map.tiles[key]` exists AND no existing unit occupies that tile. If no free adjacent tile is found, skip the spawn — never stack.

--- a/.claude/rules/ui-panels.md
+++ b/.claude/rules/ui-panels.md
@@ -50,3 +50,23 @@ paths:
 - Prefer one shared system helper for “reachable opportunities” instead of duplicating eligibility filters in each panel
 - Recommendation sections may be selective. Browse/action sections may not become inaccessible because of recommendation ranking.
 - Persistent intel UI must render from viewer-safe snapshots, not from the richer source object if the player did not earn that detail.
+
+## Cities[0] Is Never The Answer (Extended)
+The "cycle through all cities" rule applies to EVERY surface that gives city-scoped advice, not just the main city panel. This includes:
+- Advisor triggers (`src/ui/advisor-system.ts`)
+- Council agenda cards (`src/systems/council-system.ts`)
+- Tutorial hints (`src/ui/tutorial.ts`)
+- Turn summaries and HUD chips
+
+Use `Object.values(state.cities).filter(c => c.owner === civId)` and then pick the relevant city (hungriest, most under-garrisoned, etc.) — never `civ.cities[0]`.
+
+Exceptions: AI internal decisions that legitimately mean "capital" (e.g., `src/ai/basic-ai.ts` capital-distance heuristics, `src/systems/faction-system.ts` unrest-from-distance). Those may use `cities[0]` with a `// capital = cities[0] by convention` comment, so the hook script can tell intent from accident.
+
+## Privacy And Discovery
+- `getMinorCivPresentationForPlayer`, `getQuest*ForPlayer`, `getLegendaryWonderIntel*`, and any other `*ForPlayer` helper must mask EVERY player-visible field — name, color, icon, flavor text — behind the `known` / `discovered` check. Returning the real color while masking the name is a leak.
+- UI code must prefer `*ForPlayer` helpers; never read `state.minorCivs[id].color` etc. directly from a viewer-side render path.
+
+## No Silent Destructive UI
+- Never silently replace a player-visible list (production queue, research queue, unit stack, trade route roster) when the player takes an action.
+- If starting a new activity would discard scheduled work, preserve it (prepend/append the new item, keep the tail) or prompt for explicit confirmation.
+- Regression tests must assert that pre-existing queue entries survive the operation.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-src-edit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-review-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,19 @@ Civilization-building strategy game. TypeScript + Canvas 2D + Vite.
 - `yarn test` — Run tests with vitest
 - `yarn test:watch` — Run tests in watch mode
 
+## Rules Index
+
+Detailed rules live in `.claude/rules/` and auto-apply based on the files you edit:
+- `.claude/rules/game-systems.md` — RNG, events-vs-state, diplomacy, unit types, **immutable turn processing**, **diplomacy lifecycle**, **no dead return fields**, **spawn occupancy**
+- `.claude/rules/ui-panels.md` — hot-seat `currentPlayer`, **cities[0] is never the answer**, **privacy and discovery**, **no silent destructive UI**, XSS-safe rendering
+- `.claude/rules/strategy-game-mechanics.md` — combat, tech gating, victory
+- `.claude/rules/end-to-end-wiring.md` — computed-data-must-render
+- `.claude/rules/spec-fidelity.md` — spec conjunctions and gating preservation
+
+A PostToolUse hook (`.claude/hooks/check-src-edit.sh`) greps every Write/Edit under `src/` for known rule violations and returns feedback in the same turn.
+
+Before pushing or merging, run the `code-review:code-review` skill. A PreToolUse hook will remind you if the branch is ahead of `origin/main`.
+
 ## Architecture
 - Event-driven: systems communicate via EventBus, not direct imports
 - All game state is a single serializable plain object (no class instances)

--- a/docs/superpowers/plans/2026-04-12-code-review-milestone.md
+++ b/docs/superpowers/plans/2026-04-12-code-review-milestone.md
@@ -1,0 +1,31 @@
+# Code Review April 12 Milestone
+
+**Context:** Retrospective code review of commits `caa30cc..9eae2dc` (April 5 – April 12, 128 commits, ~37k LOC). Review found 7 real issues across correctness, rule compliance, and UX categories.
+
+**Goal:** Close every issue surfaced by the April 12 review with tests-first fixes, landed in three small bundles so each ships independently.
+
+**Milestone split:**
+
+0. **Bundle 0 — Prevention (Claude config)** — `2026-04-12-cr-bundle0-prevention.md`
+   - New `.claude/rules/*.md` sections: immutable turn processing, diplomacy lifecycle, no dead return fields, spawn occupancy, cities[0] extended, privacy/discovery masking, no silent destructive UI
+   - PostToolUse hook: `.claude/hooks/check-src-edit.sh`
+   - PreToolUse hook: `.claude/hooks/pre-push-review-reminder.sh`
+   - Committed `.claude/settings.json`
+   - Back-test against the April 12 bugs
+
+1. **Bundle 1 — Correctness** — `2026-04-12-cr-bundle1-correctness.md`
+   - Issue 2: Direct state mutation in faction/minor-civ/save-manager
+   - Issue 3: Breakaway diplomacy wiring + reabsorb dangling refs
+   - Issue 5: `turn-summary.sciencePerTurn` always 0
+
+2. **Bundle 2 — Rule compliance & UX** — `2026-04-12-cr-bundle2-rule-compliance.md`
+   - Issue 1: `cities[0]` patterns in advisor and council
+   - Issue 4: `startLegendaryWonderBuild` silently wipes production queue
+
+3. **Bundle 3 — Hardening** — `2026-04-12-cr-bundle3-hardening.md`
+   - Issue 6: Rebel spawn occupancy check
+   - Issue 7: Minor-civ presentation color leak
+
+**Execution order:** Bundle 0 first (guardrails in place before any src changes). Bundle 1 second (data-integrity wins). Bundle 2 third (user-visible). Bundle 3 last (latent-trap hardening).
+
+**Out of scope:** Anything not on the review list — no drive-by cleanup, no new features. If a fix uncovers adjacent rot, file a follow-up rather than expanding scope.

--- a/docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md
+++ b/docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md
@@ -1,0 +1,45 @@
+# Bundle 0 Back-Test — April 12 Bugs vs New Enforcement Hook
+
+Verifies that `.claude/hooks/check-src-edit.sh` would have caught the three regex-detectable bugs surfaced in the April 12 code review, had it been in place earlier.
+
+**Baseline SHA checked:** `9eae2dc` (state at review time).
+
+## Results
+
+| Issue | File | Pattern matched | Hook exit | Caught? |
+|-------|-----------------------------------|-----------------------|-----------|---------|
+| 2     | `src/systems/faction-system.ts`   | Direct state mutation | 2         | Yes |
+| 1     | `src/systems/council-system.ts`   | `cities[0]` in UI/rec | 2         | Yes |
+| 5     | `src/core/hotseat-events.ts`      | Dead-field heuristic  | 2         | Yes |
+
+## Reproduce
+
+```bash
+BACKTEST=/tmp/cr-backtest
+rm -rf "$BACKTEST"; mkdir -p "$BACKTEST/src/systems" "$BACKTEST/src/core"
+
+git show 9eae2dc:src/systems/faction-system.ts > "$BACKTEST/src/systems/faction-system.ts"
+git show 9eae2dc:src/systems/council-system.ts > "$BACKTEST/src/systems/council-system.ts"
+git show 9eae2dc:src/core/hotseat-events.ts > "$BACKTEST/src/core/hotseat-events.ts"
+
+for f in \
+  "$BACKTEST/src/systems/faction-system.ts" \
+  "$BACKTEST/src/systems/council-system.ts" \
+  "$BACKTEST/src/core/hotseat-events.ts" ; do
+  echo "=== $f ==="
+  echo "{\"tool_input\":{\"file_path\":\"$f\"}}" | .claude/hooks/check-src-edit.sh
+  echo "exit=$?"
+done
+```
+
+## Captured hits
+
+**faction-system.ts** — 5 mutation sites flagged including `state.units[rebel.id] = rebel` (line 104) and `state.cities[cityId] = updated` (lines 127, 134, 140).
+
+**council-system.ts** — `state.civilizations[civId]?.cities[0]` (line 12) flagged; file not on allowlist (allowlist is `src/ai/**` and `src/systems/faction-system.ts` only).
+
+**hotseat-events.ts** — `sciencePerTurn: 0, // calculated at render time from city yields` (line 72) flagged by the placeholder-with-`// calculated`-comment heuristic.
+
+## Not regex-detectable (would still need review)
+
+Issues 3 (breakaway diplomacy wiring), 4 (queue truncation), 6 (rebel spawn occupancy), 7 (minor-civ color leak) are too semantic for a grep rule. They are addressed by documented rule sections in `.claude/rules/*.md` and remain reliant on the `code-review:code-review` skill before merge, which the pre-push hook now reminds about.

--- a/docs/superpowers/plans/2026-04-12-cr-bundle0-prevention.md
+++ b/docs/superpowers/plans/2026-04-12-cr-bundle0-prevention.md
@@ -1,0 +1,487 @@
+# Code Review Bundle 0 — Prevention (Claude Config Changes) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the April 12 bug classes from recurring by extending `.claude/rules/*.md` and adding PostToolUse / PreToolUse hooks that catch the same mistakes while Claude is writing the code, not three weeks later in review.
+
+**Why Bundle 0:** Every bug in Bundles 1-3 was either a violation of an existing written rule (`cities[0]`, hotseat `'player'`) or a violation of an *unwritten* rule the codebase clearly follows elsewhere (immutable turn processing, full-civ diplomacy wiring, no silent destructive UI). The fix is two-pronged: write the missing rules down, and enforce every rule with a hook script that fires on Write/Edit.
+
+**Architecture:** Three layers.
+
+1. **Rules** — extend `.claude/rules/*.md` with the missing guidance. Rules files are auto-loaded based on path frontmatter.
+2. **Enforcement hooks** — a single `.claude/hooks/check-src-edit.sh` script invoked via `PostToolUse` on `Write|Edit`. It greps the edited file for forbidden patterns and returns exit 2 with a stderr reminder, which the Claude Code harness feeds back as non-blocking feedback (tool already ran — Claude sees the violation and fixes it in the next turn).
+3. **Pre-push reminder** — a `PreToolUse` hook on `Bash` matching git push / gh pr merge commands that reminds to run the `code-review:code-review` skill before shipping.
+
+**Tech Stack:** Bash, `jq`, grep, `.claude/settings.json` (checked in), existing `.claude/rules/*.md` layout.
+
+**Reference:** April 12 code review. Claude Code hooks documentation: https://code.claude.com/docs/en/hooks. Baseline SHA: `9eae2dc`.
+
+**Scope boundary:** This bundle changes ONLY `.claude/**`, `docs/**`, and adds shell scripts under `.claude/hooks/**`. It does not touch `src/**` or `tests/**`. Ship before Bundles 1-3 so those bundles get the benefit of the new guardrails as they land.
+
+---
+
+## Task 1: Document the "immutable turn processing" rule
+
+**Files:**
+- Modify: `.claude/rules/game-systems.md`
+
+- [ ] **Step 1: Append the new section**
+
+Add at the bottom of `.claude/rules/game-systems.md`:
+
+```markdown
+## Immutable Turn Processing
+- Systems that process a turn (faction, minor-civ, diplomacy, wonder tick, etc.) MUST return a new `GameState`; never mutate `state.cities[id] = ...`, `state.units[id] = ...`, `state.civilizations[id] = ...`, or nested fields on those objects.
+- Use spread-copy: `{ ...state, cities: { ...state.cities, [id]: { ...city, field: newValue } } }`.
+- If you need to chain updates, thread a `let nextState = state;` through the loop and reassign; do not reach into the input state.
+- Helpers that spawn entities (rebels, free units, barbarians) must return the new `units` map; never write through `state.units[...] = ...`.
+
+## Diplomacy Lifecycle
+- When a new civ is introduced mid-game (breakaway, rebellion statehood), every existing civ's `diplomacy.relationships` must get an entry for the new civ id, and the new civ's `relationships` must get an entry for every existing civ id.
+- When a civ is removed (reabsorbed, eliminated), every other civ's `diplomacy.relationships` AND `diplomacy.atWarWith` AND active treaties involving that id must be scrubbed in the same operation. Dangling ids cause silent lookup failures downstream.
+
+## No Dead Return Fields
+- If a function's return type declares a field, populate it with real data.
+- Do not return a placeholder (`0`, `null`, `''`) with a `// computed elsewhere` comment. Either compute it, or remove the field from the return type.
+
+## Spawn Occupancy
+- Any code that adds a unit to the map (rebel spawns, free unit rewards, barbarian raids, scenario seeding) MUST check `state.map.tiles[key]` exists AND no existing unit occupies that tile. If no free adjacent tile is found, skip the spawn — never stack.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/game-systems.md
+git commit -m "docs(claude): document immutable turn processing and diplomacy lifecycle rules"
+```
+
+---
+
+## Task 2: Strengthen the UI rules for recommendation surfaces and destructive mutations
+
+**Files:**
+- Modify: `.claude/rules/ui-panels.md`
+
+- [ ] **Step 1: Append new sections**
+
+Add at the bottom of `.claude/rules/ui-panels.md`:
+
+```markdown
+## Cities[0] Is Never The Answer (Extended)
+The "cycle through all cities" rule applies to EVERY surface that gives city-scoped advice, not just the main city panel. This includes:
+- Advisor triggers (`src/ui/advisor-system.ts`)
+- Council agenda cards (`src/systems/council-system.ts`)
+- Tutorial hints (`src/ui/tutorial.ts`)
+- Turn summaries and HUD chips
+
+Use `Object.values(state.cities).filter(c => c.owner === civId)` and then pick the relevant city (hungriest, most under-garrisoned, etc.) — never `civ.cities[0]`.
+
+Exceptions: AI internal decisions that legitimately mean "capital" (e.g., `src/ai/basic-ai.ts` capital-distance heuristics, `src/systems/faction-system.ts` unrest-from-distance). Those may use `cities[0]` with a `// capital = cities[0] by convention` comment, so the hook script can tell intent from accident.
+
+## Privacy And Discovery
+- `getMinorCivPresentationForPlayer`, `getQuest*ForPlayer`, `getLegendaryWonderIntel*`, and any other `*ForPlayer` helper must mask EVERY player-visible field — name, color, icon, flavor text — behind the `known` / `discovered` check. Returning the real color while masking the name is a leak.
+- UI code must prefer `*ForPlayer` helpers; never read `state.minorCivs[id].color` etc. directly from a viewer-side render path.
+
+## No Silent Destructive UI
+- Never silently replace a player-visible list (production queue, research queue, unit stack, trade route roster) when the player takes an action.
+- If starting a new activity would discard scheduled work, preserve it (prepend/append the new item, keep the tail) or prompt for explicit confirmation.
+- Regression tests must assert that pre-existing queue entries survive the operation.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/ui-panels.md
+git commit -m "docs(claude): extend UI rules for cities[0], privacy masking, and destructive UI"
+```
+
+---
+
+## Task 3: Create the PostToolUse enforcement script
+
+**Files:**
+- Create: `.claude/hooks/check-src-edit.sh`
+
+- [ ] **Step 1: Create the hook script**
+
+Write `.claude/hooks/check-src-edit.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Claude Code PostToolUse hook — inspects the most recent Write/Edit target
+# and returns exit 2 with stderr feedback if it contains known bug patterns.
+#
+# This script is fired by settings.json after every Write/Edit under src/.
+# Exit 2 means "non-blocking error"; the tool already ran, stderr goes back
+# to Claude as feedback for its next turn.
+
+set -u
+
+payload="$(cat)"
+file_path="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty')"
+
+# Only police TypeScript source under src/
+case "$file_path" in
+  */src/*.ts|*/src/**/*.ts) : ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$file_path" ] || exit 0
+
+violations=""
+
+append() {
+  violations+="- $1
+"
+}
+
+# --- cities[0] outside known-OK files ---
+case "$file_path" in
+  */src/ai/*|*/src/systems/faction-system.ts)
+    : # allowed: capital heuristics
+    ;;
+  *)
+    if grep -nE '\.cities\[0\]' "$file_path" >/dev/null; then
+      lines="$(grep -nE '\.cities\[0\]' "$file_path" | head -5)"
+      append "cities[0] used in a UI/recommendation path — cycle all cities (see .claude/rules/ui-panels.md):
+$lines"
+    fi
+    ;;
+esac
+
+# --- direct state mutation in turn processing ---
+if grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" >/dev/null; then
+  lines="$(grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" | head -5)"
+  append "Direct state mutation detected. Turn-processing systems must return a new GameState (see .claude/rules/game-systems.md#immutable-turn-processing):
+$lines"
+fi
+
+# --- Math.random in src ---
+if grep -nE 'Math\.random\(' "$file_path" | grep -v '//' >/dev/null; then
+  lines="$(grep -nE 'Math\.random\(' "$file_path" | grep -v '//' | head -5)"
+  append "Math.random() is banned in src/ — use seeded RNG (see .claude/rules/game-systems.md#deterministic-rng):
+$lines"
+fi
+
+# --- hardcoded 'player' ownership check ---
+if grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" >/dev/null; then
+  lines="$(grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" | head -5)"
+  append "Hardcoded 'player' ownership check — use state.currentPlayer (see .claude/rules/ui-panels.md#hot-seat-multiplayer):
+$lines"
+fi
+
+# --- innerHTML with template-literal game text ---
+if grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" >/dev/null; then
+  lines="$(grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" | head -5)"
+  append "innerHTML with interpolated game data — use textContent or data-text placeholders (see .claude/rules/ui-panels.md#unit-info-panels):
+$lines"
+fi
+
+# --- dead return field (heuristic: literal 0/null followed by 'computed' comment) ---
+if grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" >/dev/null; then
+  lines="$(grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" | head -5)"
+  append "Placeholder return field with 'calculated elsewhere' comment — populate it or remove the field (see .claude/rules/game-systems.md#no-dead-return-fields):
+$lines"
+fi
+
+if [ -n "$violations" ]; then
+  printf 'check-src-edit: possible rule violations in %s\n%s\n' "$file_path" "$violations" >&2
+  exit 2
+fi
+
+exit 0
+```
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x .claude/hooks/check-src-edit.sh`
+
+- [ ] **Step 3: Smoke-test the script manually**
+
+Run:
+
+```bash
+echo '{"tool_input":{"file_path":"'"$PWD"'/src/ai/ai-personality.ts"}}' | .claude/hooks/check-src-edit.sh
+echo "exit=$?"
+```
+
+Expected: `exit=0` (clean file).
+
+Now test the detection path on a deliberately bad temp file:
+
+```bash
+mkdir -p /tmp/fakesrc/src
+cat > /tmp/fakesrc/src/bad.ts <<'EOF'
+const x = Math.random();
+state.cities['c1'] = { id: 'c1' };
+EOF
+echo '{"tool_input":{"file_path":"/tmp/fakesrc/src/bad.ts"}}' | .claude/hooks/check-src-edit.sh
+echo "exit=$?"
+rm -rf /tmp/fakesrc
+```
+
+Expected: `exit=2`, stderr contains `Math.random()` and `Direct state mutation` violations.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/hooks/check-src-edit.sh
+git commit -m "feat(claude): add PostToolUse src edit enforcement hook"
+```
+
+---
+
+## Task 4: Create the pre-push code-review reminder hook
+
+**Files:**
+- Create: `.claude/hooks/pre-push-review-reminder.sh`
+
+- [ ] **Step 1: Create the script**
+
+Write `.claude/hooks/pre-push-review-reminder.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Claude Code PreToolUse hook for Bash — reminds Claude to run the
+# code-review skill before pushing or merging if the current branch
+# has commits ahead of origin/main.
+
+set -u
+payload="$(cat)"
+cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')"
+
+case "$cmd" in
+  *"git push"*|*"gh pr merge"*|*"gh pr create"*) : ;;
+  *) exit 0 ;;
+esac
+
+# How many commits ahead of origin/main?
+ahead=0
+if git rev-parse --verify origin/main >/dev/null 2>&1; then
+  ahead="$(git rev-list --count origin/main..HEAD 2>/dev/null || echo 0)"
+fi
+
+if [ "${ahead:-0}" -ge 1 ]; then
+  reason="This branch has $ahead commit(s) ahead of origin/main. Run the 'code-review:code-review' skill before pushing/merging. If you've already reviewed this branch in this session, proceed."
+  jq -n --arg r "$reason" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "ask",
+      permissionDecisionReason: $r
+    }
+  }'
+  exit 0
+fi
+
+exit 0
+```
+
+- [ ] **Step 2: Make executable**
+
+Run: `chmod +x .claude/hooks/pre-push-review-reminder.sh`
+
+- [ ] **Step 3: Smoke test**
+
+Run:
+
+```bash
+echo '{"tool_input":{"command":"git push origin feature/x"}}' | .claude/hooks/pre-push-review-reminder.sh
+```
+
+Expected: if ahead of origin/main, emits JSON with `permissionDecision: "ask"`; otherwise exit 0 with no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/hooks/pre-push-review-reminder.sh
+git commit -m "feat(claude): add pre-push code-review reminder hook"
+```
+
+---
+
+## Task 5: Wire both hooks into committed `.claude/settings.json`
+
+**Files:**
+- Create: `.claude/settings.json` (note: `settings.local.json` exists but is gitignored; we want these hooks shared across the team)
+
+- [ ] **Step 1: Create the settings file**
+
+Write `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/check-src-edit.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-push-review-reminder.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- [ ] **Step 2: Verify the harness picks it up**
+
+Run: `/hooks` in Claude Code (interactive — tell the user to run it).
+
+Expected: both hooks show up under their event names, source file `.claude/settings.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/settings.json
+git commit -m "feat(claude): enable src edit + pre-push hooks in shared settings"
+```
+
+---
+
+## Task 6: Add rule reference to CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Read the current CLAUDE.md**
+
+Run: `cat CLAUDE.md` and note the existing structure. The rule content should stay in `.claude/rules/*.md`; `CLAUDE.md` should just point there with a short reminder.
+
+- [ ] **Step 2: Add a short "Rules Index" section near the top**
+
+Insert after the intro block:
+
+```markdown
+## Rules Index
+
+Detailed rules live in `.claude/rules/` and auto-apply based on the files you edit:
+- `.claude/rules/game-systems.md` — RNG, events-vs-state, diplomacy, unit types, **immutable turn processing**, **diplomacy lifecycle**, **no dead return fields**, **spawn occupancy**
+- `.claude/rules/ui-panels.md` — hot-seat `currentPlayer`, **cities[0] is never the answer**, **privacy and discovery**, **no silent destructive UI**, XSS-safe rendering
+- `.claude/rules/strategy-game-mechanics.md` — combat, tech gating, victory
+- `.claude/rules/end-to-end-wiring.md` — computed-data-must-render
+- `.claude/rules/spec-fidelity.md` — spec conjunctions and gating preservation
+
+A PostToolUse hook (`.claude/hooks/check-src-edit.sh`) greps every Write/Edit under `src/` for known rule violations and returns feedback in the same turn.
+
+Before pushing or merging, run the `code-review:code-review` skill. A PreToolUse hook will remind you if the branch is ahead of `origin/main`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): add rules index and hook summary to CLAUDE.md"
+```
+
+---
+
+## Task 7: Back-test hooks against the April 12 bugs
+
+This step proves the new guardrails would have caught the bugs that landed. No code changes — just a reproducible record that the hooks work on real historical violations.
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md`
+
+- [ ] **Step 1: Check out each buggy file at the offending SHA and run the hook**
+
+Run each of the following from the repo root. Record outputs into the backtest doc as they run.
+
+```bash
+BACKTEST=/tmp/cr-backtest
+rm -rf "$BACKTEST"; mkdir -p "$BACKTEST"
+
+# Issue 2 — faction-system.ts direct mutation
+git show 9eae2dc:src/systems/faction-system.ts > "$BACKTEST/faction-system.ts"
+echo '{"tool_input":{"file_path":"'"$BACKTEST"'/faction-system.ts"}}' | \
+  .claude/hooks/check-src-edit.sh; echo "exit=$?"
+
+# Issue 1 — council-system.ts cities[0]
+git show 9eae2dc:src/systems/council-system.ts > "$BACKTEST/council-system.ts"
+echo '{"tool_input":{"file_path":"'"$BACKTEST"'/council-system.ts"}}' | \
+  .claude/hooks/check-src-edit.sh; echo "exit=$?"
+
+# Issue 5 — hotseat-events.ts dead sciencePerTurn field
+git show 9eae2dc:src/core/hotseat-events.ts > "$BACKTEST/hotseat-events.ts"
+echo '{"tool_input":{"file_path":"'"$BACKTEST"'/hotseat-events.ts"}}' | \
+  .claude/hooks/check-src-edit.sh; echo "exit=$?"
+```
+
+Expected:
+- faction-system: exit 2, flags direct mutation.
+- council-system: exit 2, flags `cities[0]` (the file path is not `src/ai/*` or `src/systems/faction-system.ts`, so it is NOT on the allowlist — good, it should warn).
+- hotseat-events: exit 2, flags the dead-field heuristic.
+
+If any of the three fail to flag, refine `check-src-edit.sh` until they do, then re-run.
+
+- [ ] **Step 2: Write the backtest record**
+
+Create `docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md` with the three commands, their outputs, and a one-line "caught / missed" verdict per issue. Keep it under 50 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md .claude/hooks/check-src-edit.sh
+git commit -m "test(claude): back-test enforcement hook against april 12 bugs"
+```
+
+---
+
+## Task 8: Bundle verification
+
+- [ ] **Step 1: Confirm hooks do not false-positive on a clean, already-good file**
+
+Run:
+
+```bash
+echo '{"tool_input":{"file_path":"'"$PWD"'/src/systems/diplomacy-system.ts"}}' | .claude/hooks/check-src-edit.sh
+echo "exit=$?"
+```
+
+Expected: `exit=0` (this file is known clean — it dedupes `atWarWith` correctly).
+
+If it flags, tighten the regex.
+
+- [ ] **Step 2: Confirm the AI allowlist works**
+
+Run:
+
+```bash
+echo '{"tool_input":{"file_path":"'"$PWD"'/src/ai/basic-ai.ts"}}' | .claude/hooks/check-src-edit.sh
+echo "exit=$?"
+```
+
+Expected: `exit=0`, because `cities[0]` in AI capital heuristics is allowlisted.
+
+- [ ] **Step 3: Final commit of any regex tweaks**
+
+```bash
+git add -p
+git commit -m "fix(claude): tune hook regexes after verification"
+```
+
+---
+
+**Done when:**
+- `.claude/rules/game-systems.md` and `ui-panels.md` carry the new rules.
+- `.claude/hooks/check-src-edit.sh` and `pre-push-review-reminder.sh` exist, are executable, and catch all three back-test scenarios.
+- `.claude/settings.json` is committed and wires both hooks.
+- `CLAUDE.md` points at the rules index.
+- Backtest doc shows 3/3 caught.
+
+**Ship order:** Bundle 0 first, then Bundles 1-3 benefit from the new guardrails while being implemented.

--- a/docs/superpowers/plans/2026-04-12-cr-bundle1-correctness.md
+++ b/docs/superpowers/plans/2026-04-12-cr-bundle1-correctness.md
@@ -1,0 +1,681 @@
+# Code Review Bundle 1 — Correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate direct state mutation in turn-processing paths, fully wire breakaway diplomacy in both directions, and stop reporting `sciencePerTurn: 0` in hot-seat summaries.
+
+**Architecture:** All three fixes follow the codebase's established pattern — return a new `GameState` object (spread/replace), never mutate. Diplomacy fixes propagate new civ IDs through every other civ's `relationships` map and scrub deleted civ IDs from every civ's `atWarWith` list. The summary fix computes per-turn science from city yields and civ-wide modifiers, reusing existing `resource-system` helpers.
+
+**Tech Stack:** TypeScript, Vitest, single-object `GameState`, EventBus for event emission.
+
+**Reference:** April 12 code review, issues 2, 3, 5. Baseline SHA: `9eae2dc`.
+
+---
+
+## Task 1: Negative test — faction turn must not mutate caller's state
+
+**Files:**
+- Test: `tests/systems/faction-system.test.ts`
+
+- [ ] **Step 1: Add failing test at the end of the existing `describe('processFactionTurn', ...)` block (or at the bottom of the file if no such block)**
+
+```typescript
+it('does not mutate the caller state when unrest escalates', () => {
+  const state = makeState({
+    unrestLevel: 1,
+    unrestTurns: 4, // one tick from revolt
+    cityCount: 6,   // drives enough pressure
+    conquestTurn: 0,
+  });
+  const snapshotUnrestLevel = state.cities['city-1'].unrestLevel;
+  const snapshotUnrestTurns = state.cities['city-1'].unrestTurns;
+  const unitCountBefore = Object.keys(state.units).length;
+
+  processFactionTurn(state, new EventBus());
+
+  expect(state.cities['city-1'].unrestLevel).toBe(snapshotUnrestLevel);
+  expect(state.cities['city-1'].unrestTurns).toBe(snapshotUnrestTurns);
+  expect(Object.keys(state.units).length).toBe(unitCountBefore);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `yarn test tests/systems/faction-system.test.ts -t "does not mutate the caller state"`
+Expected: FAIL — the test should observe mutated `unrestLevel`/`unrestTurns` or new units added on the input `state`.
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add tests/systems/faction-system.test.ts
+git commit -m "test(m4-review): pin faction turn immutability expectation"
+```
+
+---
+
+## Task 2: Make `processFactionTurn` return a new state
+
+**Files:**
+- Modify: `src/systems/faction-system.ts:110-167`
+
+- [ ] **Step 1: Rewrite `processFactionTurn` to build a new state**
+
+Replace the function body (lines 110-167) with:
+
+```typescript
+export function processFactionTurn(state: GameState, bus: EventBus): GameState {
+  let cities = { ...state.cities };
+  let units = { ...state.units };
+  let civilizations = state.civilizations;
+  let map = state.map;
+  let turnState: GameState = { ...state, cities, units };
+
+  for (const cityId of Object.keys(state.cities)) {
+    const baseline = cities[cityId];
+    if (!baseline) continue;
+
+    let city = baseline;
+
+    if (city.conquestTurn !== undefined &&
+        (state.turn - city.conquestTurn) >= CONQUEST_UNREST_DURATION) {
+      city = { ...city, conquestTurn: undefined };
+    }
+
+    const pressure = computeUnrestPressure(cityId, { ...turnState, cities });
+
+    if (city.unrestLevel === 0) {
+      if (pressure > UNREST_TRIGGER_PRESSURE) {
+        city = { ...city, unrestLevel: 1, unrestTurns: 0 };
+        bus.emit('faction:unrest-started', { cityId, owner: city.owner });
+      }
+    } else if (city.unrestLevel === 1) {
+      const garrisoned = canGarrisonCity(cityId, { ...turnState, cities });
+      if (pressure <= UNREST_TRIGGER_PRESSURE || garrisoned) {
+        city = { ...city, unrestLevel: 0, unrestTurns: 0 };
+        bus.emit('faction:unrest-resolved', { cityId, owner: city.owner });
+      } else {
+        const nextTurns = city.unrestTurns + 1;
+        if (nextTurns >= REVOLT_UNREST_TURNS) {
+          city = { ...city, unrestLevel: 2, unrestTurns: 0 };
+          const spawned = spawnRebelUnitsImmutable(city, units, map, `revolt-${cityId}-${state.turn}`);
+          units = spawned;
+          bus.emit('faction:revolt-started', { cityId, owner: city.owner });
+        } else {
+          city = { ...city, unrestTurns: nextTurns };
+        }
+      }
+    } else if (city.unrestLevel === 2) {
+      const nearbyRebels = Object.values(units).filter(
+        u => u.owner === 'rebels' && hexDistance(u.position, city.position) <= 3,
+      );
+      if (nearbyRebels.length === 0 && pressure <= UNREST_TRIGGER_PRESSURE) {
+        city = { ...city, unrestLevel: 0, unrestTurns: 0 };
+        bus.emit('faction:unrest-resolved', { cityId, owner: city.owner });
+      } else {
+        const nextTurns = city.unrestTurns + 1;
+        city = { ...city, unrestTurns: nextTurns };
+        cities = { ...cities, [cityId]: city };
+        turnState = { ...turnState, cities, units };
+        if (nextTurns >= 10) {
+          turnState = createBreakawayFromCity(turnState, cityId, bus);
+          cities = turnState.cities;
+          units = turnState.units;
+          civilizations = turnState.civilizations;
+          map = turnState.map;
+          continue;
+        }
+      }
+    }
+
+    cities = { ...cities, [cityId]: city };
+    turnState = { ...turnState, cities, units };
+  }
+
+  return { ...turnState, cities, units, civilizations, map };
+}
+```
+
+- [ ] **Step 2: Replace `spawnRebelUnits` with an immutable variant**
+
+Replace the `spawnRebelUnits` function (lines 89-106) with:
+
+```typescript
+function spawnRebelUnitsImmutable(
+  city: City,
+  units: GameState['units'],
+  map: GameState['map'],
+  seed: string,
+): GameState['units'] {
+  const rng = createRng(seed);
+  const offsets: HexCoord[] = [
+    { q: 1, r: 0 }, { q: -1, r: 0 }, { q: 0, r: 1 },
+    { q: 0, r: -1 }, { q: 1, r: -1 }, { q: -1, r: 1 },
+  ];
+  const unitType: UnitType = city.population >= 4 ? 'swordsman' : 'warrior';
+  const spawnCount = 1 + Math.floor(rng() * 2);
+  let nextUnits = units;
+
+  for (let i = 0; i < spawnCount; i++) {
+    const offset = offsets[Math.floor(rng() * offsets.length)];
+    const pos: HexCoord = { q: city.position.q + offset.q, r: city.position.r + offset.r };
+    const key = `${pos.q},${pos.r}`;
+    if (!map.tiles[key]) continue;
+    const rebel = createUnit(unitType, 'rebels', pos);
+    nextUnits = { ...nextUnits, [rebel.id]: rebel };
+  }
+
+  return nextUnits;
+}
+```
+
+- [ ] **Step 3: Run the test from Task 1**
+
+Run: `yarn test tests/systems/faction-system.test.ts`
+Expected: All tests pass — including the new immutability test and all prior faction tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/systems/faction-system.ts
+git commit -m "fix(m4-review): return new state from processFactionTurn"
+```
+
+---
+
+## Task 3: Immutable minor-civ ally bonus ticks
+
+**Files:**
+- Test: `tests/systems/minor-civ-system.test.ts`
+- Modify: `src/systems/minor-civ-system.ts:217-234`
+
+- [ ] **Step 1: Add failing test for immutability of production ally bonus**
+
+Add to the end of `tests/systems/minor-civ-system.test.ts`:
+
+```typescript
+it('production_per_turn ally bonus does not mutate caller city objects', () => {
+  const { state, allyCivId, cityId } = buildAllyProductionFixture(); // see Step 2
+  const originalProgress = state.cities[cityId].productionProgress;
+  const cityRef = state.cities[cityId];
+
+  processMinorCivAllyBonuses(state, allyCivId); // or whichever exported entry calls this switch case
+
+  expect(cityRef.productionProgress).toBe(originalProgress);
+});
+```
+
+- [ ] **Step 2: Add `buildAllyProductionFixture` helper at the top of the test file, wiring a minor civ whose `allyBonus.type === 'production_per_turn'` and a player civ with one city that has a queued build. Use existing `MINOR_CIV_DEFINITIONS` — pick one with the right bonus type, or craft the civ/minor-civ objects directly if none exists.**
+
+- [ ] **Step 3: Run and verify it fails**
+
+Run: `yarn test tests/systems/minor-civ-system.test.ts -t "production_per_turn"`
+Expected: FAIL — the cityRef was mutated.
+
+- [ ] **Step 4: Replace the mutating branch (lines 217-223) with an immutable update**
+
+Old:
+```typescript
+case 'production_per_turn': {
+  const firstCityId = civ.cities[0];
+  const firstCity = firstCityId ? state.cities[firstCityId] : null;
+  if (firstCity && firstCity.productionQueue.length > 0) {
+    firstCity.productionProgress += def.allyBonus.amount;
+  }
+  break;
+}
+```
+
+New:
+```typescript
+case 'production_per_turn': {
+  const firstCityId = civ.cities[0];
+  const firstCity = firstCityId ? state.cities[firstCityId] : null;
+  if (firstCity && firstCity.productionQueue.length > 0) {
+    state.cities = {
+      ...state.cities,
+      [firstCityId]: {
+        ...firstCity,
+        productionProgress: firstCity.productionProgress + def.allyBonus.amount,
+      },
+    };
+  }
+  break;
+}
+```
+
+Note: if the enclosing function receives `state` and mutates it wholesale, also audit the `free_unit` branch (lines 225-234) — replace with:
+
+```typescript
+case 'free_unit': {
+  if (state.turn % def.allyBonus.everyNTurns === 0) {
+    const firstCityId = civ.cities[0];
+    const city = firstCityId ? state.cities[firstCityId] : null;
+    if (city) {
+      const freeUnit = createUnit(def.allyBonus.unitType, civId, city.position);
+      state.units = { ...state.units, [freeUnit.id]: freeUnit };
+      state.civilizations = {
+        ...state.civilizations,
+        [civId]: { ...civ, units: [...civ.units, freeUnit.id] },
+      };
+    }
+  }
+  break;
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `yarn test tests/systems/minor-civ-system.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/systems/minor-civ-system.test.ts src/systems/minor-civ-system.ts
+git commit -m "fix(m4-review): immutable minor-civ ally bonus tick"
+```
+
+---
+
+## Task 4: `ensureGameIdentity` must not mutate the caller
+
+**Files:**
+- Test: `tests/ui/save-panel.test.ts` (or create `tests/storage/save-manager.test.ts` if it doesn't exist)
+- Modify: `src/storage/save-manager.ts:11-20` and every caller inside the same file.
+
+- [ ] **Step 1: Check whether `tests/storage/save-manager.test.ts` exists**
+
+Run: `ls tests/storage/ 2>/dev/null`
+
+If it does not exist, create the directory; add the test to a new file.
+
+- [ ] **Step 2: Write failing test**
+
+Add to `tests/storage/save-manager.test.ts` (create if needed):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '@/core/types';
+import { saveGame } from '@/storage/save-manager';
+
+function makeBareState(): GameState {
+  return {
+    turn: 3,
+    era: 1,
+    currentPlayer: 'player',
+    civilizations: { player: { id: 'player', civType: 'generic' } as unknown as GameState['civilizations'][string] },
+    cities: {},
+    units: {},
+    map: { tiles: {}, width: 10, height: 10, wrapsHorizontally: false } as GameState['map'],
+  } as unknown as GameState;
+}
+
+describe('saveGame', () => {
+  it('does not mutate gameId or gameTitle on the caller state', async () => {
+    const state = makeBareState();
+    expect(state.gameId).toBeUndefined();
+    expect(state.gameTitle).toBeUndefined();
+
+    await saveGame('slot-x', 'Slot X', state);
+
+    expect(state.gameId).toBeUndefined();
+    expect(state.gameTitle).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 3: Run and verify it fails**
+
+Run: `yarn test tests/storage/save-manager.test.ts`
+Expected: FAIL — `state.gameId` is populated by `ensureGameIdentity`.
+
+- [ ] **Step 4: Refactor `ensureGameIdentity` to be pure**
+
+Replace lines 11-20 in `src/storage/save-manager.ts` with:
+
+```typescript
+function ensureGameIdentity(state: GameState): GameState {
+  if (state.gameId && state.gameTitle) {
+    return state;
+  }
+  const gameId = state.gameId ?? `game-${Date.now()}`;
+  const civType = state.hotSeat ? 'Hot Seat' : (state.civilizations[state.currentPlayer]?.civType ?? 'Unknown');
+  const gameTitle = state.gameTitle ?? `Recovered ${civType} Campaign`;
+  return { ...state, gameId, gameTitle };
+}
+```
+
+Then audit every caller in `save-manager.ts`. In `buildSaveMeta` (line 22) the returned value is already read via `resolved.*`, so it still works — good. If any caller of `ensureGameIdentity` expects the mutation to persist on the caller's state (e.g. `saveGame` assigning identity back to the *live* state so subsequent autosaves reuse the same id), find that call site and have the caller explicitly assign the returned object back into its own state variable. Grep for `ensureGameIdentity(` to find all call sites.
+
+Run: `grep -n "ensureGameIdentity" src/storage/save-manager.ts`
+
+For each caller, update the pattern to `const withId = ensureGameIdentity(state); /* use withId */` and, only where the *live* game state is owned by the caller (e.g. inside `main.ts` save flow), surface the new state back up. Do NOT reintroduce mutation.
+
+- [ ] **Step 5: Run tests**
+
+Run: `yarn test tests/storage/save-manager.test.ts tests/ui/save-panel.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/storage/save-manager.ts tests/storage/save-manager.test.ts
+git commit -m "fix(m4-review): make ensureGameIdentity pure"
+```
+
+---
+
+## Task 5: Breakaway wires relationship into every civ
+
+**Files:**
+- Test: `tests/systems/breakaway-system.test.ts`
+- Modify: `src/systems/breakaway-system.ts:72-108`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/systems/breakaway-system.test.ts`:
+
+```typescript
+it('propagates the breakaway civ into every existing civ relationship map', () => {
+  const baseState = makeStateWithCivs(['player', 'ai-1', 'ai-2']); // existing helper — re-use whatever is already in this file
+  const cityId = baseState.civilizations['player'].cities[0];
+  const bus = new EventBus();
+
+  const nextState = createBreakawayFromCity(baseState, cityId, bus);
+  const breakawayId = `breakaway-${cityId}`;
+
+  for (const civId of ['ai-1', 'ai-2']) {
+    expect(nextState.civilizations[civId].diplomacy.relationships).toHaveProperty(breakawayId);
+  }
+  // And the breakaway knows about every pre-existing civ
+  for (const civId of ['player', 'ai-1', 'ai-2']) {
+    expect(nextState.civilizations[breakawayId].diplomacy.relationships).toHaveProperty(civId);
+  }
+});
+```
+
+If `makeStateWithCivs` does not exist in the test file, write the minimal fixture inline — only three civs, one city owned by `player`, empty map tiles for the city's `ownedTiles` is fine. Reuse the existing fixture style in the file.
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/systems/breakaway-system.test.ts -t "propagates the breakaway civ"`
+Expected: FAIL — `ai-1`/`ai-2` have no entry for the breakaway.
+
+- [ ] **Step 3: Propagate relationship into every other civ**
+
+In `src/systems/breakaway-system.ts`, after line 108 (inside `createBreakawayFromCity`, right before `updatedCivilizations[breakawayId] = breakawayCiv;` on line 109), insert:
+
+```typescript
+for (const [otherId, otherCiv] of Object.entries(updatedCivilizations)) {
+  if (otherId === previousOwner.id || otherId === breakawayId) continue;
+  updatedCivilizations[otherId] = {
+    ...otherCiv,
+    diplomacy: {
+      ...otherCiv.diplomacy,
+      relationships: {
+        ...otherCiv.diplomacy.relationships,
+        [breakawayId]: 0,
+      },
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/systems/breakaway-system.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/systems/breakaway-system.test.ts src/systems/breakaway-system.ts
+git commit -m "fix(m4-review): wire breakaway relationship into every civ"
+```
+
+---
+
+## Task 6: Reabsorb scrubs breakaway ID from every civ's `atWarWith`
+
+**Files:**
+- Test: `tests/systems/breakaway-system.test.ts`
+- Modify: `src/systems/breakaway-system.ts:198-226`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `tests/systems/breakaway-system.test.ts`:
+
+```typescript
+it('reabsorb removes the breakaway id from every civ atWarWith list', () => {
+  const baseState = makeStateWithCivs(['player', 'ai-1', 'ai-2']);
+  const cityId = baseState.civilizations['player'].cities[0];
+  const bus = new EventBus();
+
+  let state = createBreakawayFromCity(baseState, cityId, bus);
+  const breakawayId = `breakaway-${cityId}`;
+
+  // Put ai-1 at war with the breakaway
+  state = {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      'ai-1': {
+        ...state.civilizations['ai-1'],
+        diplomacy: {
+          ...state.civilizations['ai-1'].diplomacy,
+          atWarWith: [...state.civilizations['ai-1'].diplomacy.atWarWith, breakawayId],
+        },
+      },
+    },
+  };
+
+  // Meet reabsorb preconditions
+  state.civilizations['player'].gold = 1000;
+  state.civilizations['player'].diplomacy.relationships[breakawayId] = 80;
+
+  const after = tryReabsorbBreakaway(state, 'player', breakawayId);
+
+  expect(after.civilizations[breakawayId]).toBeUndefined();
+  expect(after.civilizations['ai-1'].diplomacy.atWarWith).not.toContain(breakawayId);
+});
+```
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/systems/breakaway-system.test.ts -t "reabsorb removes"`
+Expected: FAIL — `atWarWith` still contains the deleted id.
+
+- [ ] **Step 3: Scrub `atWarWith` in `tryReabsorbBreakaway`**
+
+In `src/systems/breakaway-system.ts`, inside the `for (const civ of Object.values(updatedCivilizations))` loop starting at line 215, replace the body with:
+
+```typescript
+for (const civ of Object.values(updatedCivilizations)) {
+  if (civ.id === ownerId) continue;
+  const hasRelEntry = civ.diplomacy.relationships[breakawayId] !== undefined;
+  const hasWarEntry = civ.diplomacy.atWarWith.includes(breakawayId);
+  if (!hasRelEntry && !hasWarEntry) continue;
+
+  const nextRelationships = { ...civ.diplomacy.relationships };
+  delete nextRelationships[breakawayId];
+
+  civ.diplomacy = {
+    ...civ.diplomacy,
+    relationships: nextRelationships,
+    atWarWith: civ.diplomacy.atWarWith.filter(id => id !== breakawayId),
+  };
+}
+```
+
+Also apply the same scrub in `reconquerBreakawayCity` if it ever fully destroys the breakaway civ — audit that function: it does NOT currently delete the civ, so no change needed unless a later cleanup step in the same flow removes it. Leave as-is.
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/systems/breakaway-system.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/systems/breakaway-system.test.ts src/systems/breakaway-system.ts
+git commit -m "fix(m4-review): scrub reabsorbed breakaway id from atWarWith"
+```
+
+---
+
+## Task 7: `turn-summary.sciencePerTurn` is computed, not hardcoded
+
+**Files:**
+- Test: `tests/core/hotseat-events.test.ts` (create if absent)
+- Modify: `src/core/hotseat-events.ts:53-77`
+
+- [ ] **Step 1: Locate or create test file**
+
+Run: `ls tests/core/hotseat-events.test.ts 2>/dev/null`
+
+If absent, create it.
+
+- [ ] **Step 2: Write failing test**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '@/core/types';
+import { generateSummary } from '@/core/hotseat-events';
+
+describe('generateSummary.sciencePerTurn', () => {
+  it('reports the civ-wide science yield for the turn', () => {
+    const state: GameState = {
+      turn: 5,
+      era: 1,
+      currentPlayer: 'player',
+      civilizations: {
+        player: {
+          id: 'player',
+          cities: ['c1'],
+          units: [],
+          gold: 0,
+          civType: 'generic',
+          techState: { completed: [], currentResearch: null, researchProgress: 0, trackPriorities: {} },
+          diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
+          visibility: { tiles: {} },
+          score: 0,
+        } as unknown as GameState['civilizations'][string],
+      },
+      cities: {
+        c1: {
+          id: 'c1', name: 'c1', owner: 'player',
+          position: { q: 0, r: 0 },
+          population: 3, food: 0, foodNeeded: 20,
+          buildings: ['library'], productionQueue: [], productionProgress: 0,
+          ownedTiles: [{ q: 0, r: 0 }],
+          grid: [[null]], gridSize: 3,
+          unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+        } as unknown as GameState['cities'][string],
+      },
+      units: {},
+      map: {
+        tiles: { '0,0': { q: 0, r: 0, terrain: 'plains', owner: 'player' } },
+        width: 10, height: 10, wrapsHorizontally: false,
+      } as unknown as GameState['map'],
+    } as unknown as GameState;
+
+    const summary = generateSummary(state, 'player');
+    expect(summary.sciencePerTurn).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 3: Run and verify fail**
+
+Run: `yarn test tests/core/hotseat-events.test.ts`
+Expected: FAIL — `sciencePerTurn` is 0.
+
+- [ ] **Step 4: Compute science in `generateSummary`**
+
+In `src/core/hotseat-events.ts`, replace the function with:
+
+```typescript
+import type { CouncilInterrupt, GameState, GameEvent } from './types';
+import { calculateCityYields } from '@/systems/resource-system';
+import { getCivDefinition } from '@/systems/civ-definitions';
+
+// ... existing code above unchanged ...
+
+export function generateSummary(
+  state: GameState,
+  civId: string,
+): TurnSummary {
+  const civ = state.civilizations[civId];
+  const pending = state.pendingEvents ?? {};
+
+  const allies = civ?.diplomacy?.treaties
+    .filter(t => t.type === 'alliance')
+    .map(t => t.civA === civId ? t.civB : t.civA) ?? [];
+
+  let sciencePerTurn = 0;
+  if (civ) {
+    const bonus = getCivDefinition(civ.civType ?? '')?.bonusEffect;
+    for (const cityId of civ.cities) {
+      const city = state.cities[cityId];
+      if (!city) continue;
+      const yields = calculateCityYields(city, state.map, bonus);
+      sciencePerTurn += yields.science ?? 0;
+    }
+  }
+
+  return {
+    turn: state.turn,
+    era: state.era,
+    gold: civ?.gold ?? 0,
+    cities: civ?.cities.length ?? 0,
+    units: civ?.units.length ?? 0,
+    currentResearch: civ?.techState.currentResearch ?? null,
+    researchProgress: civ?.techState.researchProgress ?? 0,
+    sciencePerTurn,
+    atWarWith: civ?.diplomacy?.atWarWith ?? [],
+    allies,
+    events: pending[civId] ?? [],
+  };
+}
+```
+
+If `calculateCityYields` does not return a `.science` field in this codebase, inspect `src/systems/resource-system.ts` and use whichever field represents per-turn science; update the test expectation accordingly.
+
+- [ ] **Step 5: Run the test**
+
+Run: `yarn test tests/core/hotseat-events.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/hotseat-events.ts tests/core/hotseat-events.test.ts
+git commit -m "fix(m4-review): compute sciencePerTurn in hot-seat summary"
+```
+
+---
+
+## Task 8: Bundle verification
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `yarn test`
+Expected: All suites pass, no new skips.
+
+- [ ] **Step 2: Typecheck / build smoke**
+
+Run: `yarn build`
+Expected: Success.
+
+- [ ] **Step 3: Final commit if verification turned up touch-ups**
+
+If any adjustments were needed above (e.g. a missing field on `calculateCityYields`), commit them as a single follow-up:
+
+```bash
+git add -p
+git commit -m "fix(m4-review): bundle 1 verification follow-ups"
+```
+
+---
+
+**Done when:** all eight tasks green, `yarn test` passes, commits follow the `fix(m4-review): …` convention.

--- a/docs/superpowers/plans/2026-04-12-cr-bundle2-rule-compliance.md
+++ b/docs/superpowers/plans/2026-04-12-cr-bundle2-rule-compliance.md
@@ -1,0 +1,291 @@
+# Code Review Bundle 2 — Rule Compliance & UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Honour the CLAUDE.md rule that city-scoped UI must cycle through every city rather than `cities[0]`, and stop silently discarding city production queues when a legendary wonder build starts.
+
+**Architecture:** Replace `cities[0]` shortcuts in advisor/council with full-iteration helpers that pick the *worst-off* or *most-relevant* city. For the wonder build, preserve any existing non-wonder queue entries by prepending the legendary marker and carrying progress, keeping queued items behind it.
+
+**Tech Stack:** TypeScript, Vitest.
+
+**Reference:** April 12 code review, issues 1 and 4. Baseline SHA: `9eae2dc` (or after Bundle 1 lands).
+
+---
+
+## Task 1: Advisor "empty production queue" check covers every city
+
+**Files:**
+- Test: `tests/ui/advisor-system.test.ts`
+- Modify: `src/ui/advisor-system.ts:49-50`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/ui/advisor-system.test.ts`:
+
+```typescript
+it('flags empty-production-queue when any player city has an empty queue', () => {
+  const state = makeAdvisorState({
+    cities: [
+      { id: 'c1', owner: 'player', productionQueue: ['warrior'] },
+      { id: 'c2', owner: 'player', productionQueue: [] },
+    ],
+  });
+
+  const triggered = ADVISOR_TRIGGERS.find(t => t.id === 'empty-production-queue');
+  expect(triggered?.trigger(state)).toBe(true);
+});
+```
+
+Use the existing `makeAdvisorState` / `ADVISOR_TRIGGERS` export patterns already in the file. If `makeAdvisorState` does not exist, inline a minimal state fixture.
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/ui/advisor-system.test.ts -t "empty-production-queue"`
+Expected: FAIL — current check only inspects `cities[0]`.
+
+- [ ] **Step 3: Update the trigger**
+
+In `src/ui/advisor-system.ts`, change lines 47-51 (the trigger whose body is `return cities.length > 0 && cities[0].productionQueue.length === 0;`) to:
+
+```typescript
+trigger: (state) => {
+  const cities = Object.values(state.cities).filter(c => c.owner === state.currentPlayer);
+  return cities.some(c => c.productionQueue.length === 0);
+},
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/ui/advisor-system.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/ui/advisor-system.test.ts src/ui/advisor-system.ts
+git commit -m "fix(m4-review): advisor empty-queue trigger scans all cities"
+```
+
+---
+
+## Task 2: Council food card picks the hungriest city, not `cities[0]`
+
+**Files:**
+- Test: `tests/ui/council-panel.test.ts` (or `tests/systems/council-system.test.ts`)
+- Modify: `src/systems/council-system.ts:11-14, :114-139`
+
+- [ ] **Step 1: Locate the right test file**
+
+Run: `grep -l "buildCouncilAgenda" tests/` to find where council-system tests live.
+
+- [ ] **Step 2: Write failing test**
+
+Append to that file (adapt imports/fixtures to match the file's style):
+
+```typescript
+it('food-warning card surfaces the hungriest player city, not just cities[0]', () => {
+  const state = makeCouncilState({
+    civId: 'player',
+    cities: [
+      { id: 'c1', population: 3, yields: { food: 3 } },  // breaking even
+      { id: 'c2', population: 6, yields: { food: 1 } },  // starving
+    ],
+  });
+
+  const agenda = buildCouncilAgenda(state, 'player');
+  const foodCard = agenda.doNow.find(c => c.id === 'food-warning');
+
+  expect(foodCard).toBeDefined();
+  expect(foodCard?.title).toContain('c2');
+});
+```
+
+If no `makeCouncilState` exists, construct the state object directly; the key is that two cities exist, one starving and one breaking even, and the starving one is NOT `cities[0]`.
+
+- [ ] **Step 3: Run and verify fail**
+
+Run: `yarn test -t "hungriest player city"`
+Expected: FAIL — card references `c1` or is missing.
+
+- [ ] **Step 4: Replace `getPrimaryCity` usage with hungriest-city logic**
+
+In `src/systems/council-system.ts`, replace `getPrimaryCity` (lines 11-14) and the "food warning" block inside `buildCouncilAgenda` (lines 114-139) with:
+
+```typescript
+function findHungriestCity(
+  state: GameState,
+  civId: string,
+  civBonus: ReturnType<typeof getCivDefinition>['bonusEffect'] | undefined,
+): { city: GameState['cities'][string]; surplus: number } | undefined {
+  const cityIds = state.civilizations[civId]?.cities ?? [];
+  let worst: { city: GameState['cities'][string]; surplus: number } | undefined;
+  for (const cityId of cityIds) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+    const yields = calculateCityYields(city, state.map, civBonus);
+    const surplus = yields.food - city.population;
+    if (!worst || surplus < worst.surplus) {
+      worst = { city, surplus };
+    }
+  }
+  return worst;
+}
+```
+
+Then in `buildCouncilAgenda`, replace:
+
+```typescript
+const primaryCity = getPrimaryCity(state, civId);
+const civBonus = getCivDefinition(state.civilizations[civId]?.civType ?? '')?.bonusEffect;
+// ...
+if (primaryCity) {
+  const yields = calculateCityYields(primaryCity, state.map, civBonus);
+  const foodSurplus = yields.food - primaryCity.population;
+  // ... existing food-warning branches ...
+}
+```
+
+with:
+
+```typescript
+const civBonus = getCivDefinition(state.civilizations[civId]?.civType ?? '')?.bonusEffect;
+const hungriest = findHungriestCity(state, civId, civBonus);
+if (hungriest) {
+  const { city: targetCity, surplus: foodSurplus } = hungriest;
+  const yieldsSummary = calculateCityYields(targetCity, state.map, civBonus);
+  if (foodSurplus < 0) {
+    doNow.unshift({
+      id: 'food-warning',
+      advisor: 'treasurer',
+      bucket: 'do-now' as const,
+      title: `Feed ${targetCity.name}`,
+      summary: `${targetCity.name} is only making ${yieldsSummary.food} food for ${targetCity.population} citizens. ${getFoodRecommendation(targetCity)}`,
+      why: 'Food keeps growth alive. If the pantry is flat, every future plan slows down.',
+      priority: 95,
+      actionLabel: 'Fix food',
+    });
+  } else if (foodSurplus === 0) {
+    doNow.push({
+      id: 'food-warning',
+      advisor: 'treasurer',
+      bucket: 'do-now' as const,
+      title: `Keep ${targetCity.name} growing`,
+      summary: `${targetCity.name} is breaking even on food. ${getFoodRecommendation(targetCity)}`,
+      why: 'A city that only treads water stops feeling lively fast.',
+      priority: 20,
+      actionLabel: 'Add food',
+    });
+  }
+}
+```
+
+Delete the now-unused `getPrimaryCity` helper.
+
+- [ ] **Step 5: Run the test**
+
+Run: `yarn test -t "hungriest player city"`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full council test file to catch regressions**
+
+Run: `yarn test tests/ui/council-panel.test.ts tests/systems/council-system.test.ts` (whichever exist)
+Expected: All pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/council-system.ts tests/ui/council-panel.test.ts tests/systems/council-system.test.ts
+git commit -m "fix(m4-review): council food card picks the hungriest city"
+```
+
+---
+
+## Task 3: `startLegendaryWonderBuild` preserves existing production queue
+
+**Files:**
+- Test: `tests/systems/legendary-wonder-system.test.ts`
+- Modify: `src/systems/legendary-wonder-system.ts:653-675`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/systems/legendary-wonder-system.test.ts`:
+
+```typescript
+it('startLegendaryWonderBuild preserves queued items after the wonder marker', () => {
+  const state = makeWonderReadyState({
+    civId: 'player',
+    cityId: 'c1',
+    wonderId: 'TEST_WONDER',               // pick a real wonder id available in fixtures
+    existingQueue: ['warrior', 'granary'],
+  });
+
+  const next = startLegendaryWonderBuild(state, 'player', 'c1', 'TEST_WONDER');
+
+  const queue = next.cities['c1'].productionQueue;
+  expect(queue[0]).toBe('legendary:TEST_WONDER');
+  expect(queue).toContain('warrior');
+  expect(queue).toContain('granary');
+});
+```
+
+Replace `TEST_WONDER` with any real id from `getLegendaryWonderDefinitions()`. Adapt `makeWonderReadyState` to whatever helper the file already provides for seeded `ready_to_build` fixtures.
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/systems/legendary-wonder-system.test.ts -t "preserves queued items"`
+Expected: FAIL — queue is just `['legendary:TEST_WONDER']`.
+
+- [ ] **Step 3: Preserve the existing queue**
+
+In `src/systems/legendary-wonder-system.ts`, inside `startLegendaryWonderBuild`, replace the `cities:` field in the returned state (around lines 657-664) with:
+
+```typescript
+cities: city ? {
+  ...seededState.cities,
+  [cityId]: {
+    ...city,
+    productionQueue: [
+      `legendary:${wonderId}`,
+      ...city.productionQueue.filter(entry => entry !== `legendary:${wonderId}`),
+    ],
+    productionProgress: carriedProduction,
+  },
+} : state.cities,
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/systems/legendary-wonder-system.test.ts`
+Expected: PASS, and no existing tests broken (any test that explicitly asserted a single-element queue needs updating to allow the preserved tail — adjust those tests to assert only on index 0 being the legendary marker).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/legendary-wonder-system.ts tests/systems/legendary-wonder-system.test.ts
+git commit -m "fix(m4-review): preserve production queue when starting legendary wonder"
+```
+
+---
+
+## Task 4: Bundle verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `yarn test`
+Expected: All green.
+
+- [ ] **Step 2: Build smoke**
+
+Run: `yarn build`
+Expected: Success.
+
+- [ ] **Step 3: Commit any verification follow-ups**
+
+```bash
+git add -p
+git commit -m "fix(m4-review): bundle 2 verification follow-ups"
+```
+
+---
+
+**Done when:** all tasks green, food card targets the hungriest city, wonder build preserves queued items.

--- a/docs/superpowers/plans/2026-04-12-cr-bundle3-hardening.md
+++ b/docs/superpowers/plans/2026-04-12-cr-bundle3-hardening.md
@@ -1,0 +1,199 @@
+# Code Review Bundle 3 — Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close two latent-trap issues: rebel spawns must respect tile occupancy, and `getMinorCivPresentationForPlayer` must not leak a minor civ's color before discovery.
+
+**Architecture:** Both fixes are small, well-contained, and test-first. Rebel spawning iterates the offset list until it finds an unoccupied tile (or gives up). Minor-civ presentation returns a neutral color when `known` is false.
+
+**Tech Stack:** TypeScript, Vitest.
+
+**Reference:** April 12 code review, issues 6 and 7. Baseline SHA: `9eae2dc` (or after Bundles 1 and 2 land).
+
+---
+
+## Task 1: Rebel spawn respects tile occupancy
+
+**Files:**
+- Test: `tests/systems/faction-system.test.ts`
+- Modify: `src/systems/faction-system.ts` (the `spawnRebelUnitsImmutable` function if Bundle 1 landed, otherwise the `spawnRebelUnits` function at lines 89-106)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/systems/faction-system.test.ts`:
+
+```typescript
+it('revolt does not spawn rebels on top of existing units', () => {
+  // Pre-populate all six neighbour tiles with friendly units
+  const cityPos = { q: 0, r: 0 };
+  const neighbours = [
+    { q: 1, r: 0 }, { q: -1, r: 0 }, { q: 0, r: 1 },
+    { q: 0, r: -1 }, { q: 1, r: -1 }, { q: -1, r: 1 },
+  ];
+
+  const state = makeState({
+    cityPosition: cityPos,
+    unrestLevel: 1,
+    unrestTurns: REVOLT_UNREST_TURNS - 1,
+    cityCount: 6,
+    conquestTurn: 0,
+    unitPositions: neighbours,
+  });
+
+  const before = { ...state.units };
+  const next = processFactionTurn(state, new EventBus());
+
+  for (const unitId of Object.keys(next.units)) {
+    if (before[unitId]) continue; // pre-existing unit, ignore
+    const newUnit = next.units[unitId];
+    // Any newly-spawned rebel must NOT share a tile with an existing occupant
+    const key = `${newUnit.position.q},${newUnit.position.r}`;
+    const occupants = Object.values(before).filter(u =>
+      `${u.position.q},${u.position.r}` === key,
+    );
+    expect(occupants.length).toBe(0);
+  }
+});
+```
+
+If `REVOLT_UNREST_TURNS` is not exported, import it from `@/systems/faction-system` or inline the literal `5`.
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/systems/faction-system.test.ts -t "does not spawn rebels on top"`
+Expected: FAIL — rebels spawn on tiles that are already occupied.
+
+- [ ] **Step 3: Skip occupied tiles when spawning**
+
+In `src/systems/faction-system.ts`, update the spawn helper. If Bundle 1 landed, edit `spawnRebelUnitsImmutable`; otherwise edit `spawnRebelUnits`.
+
+Replace the inner spawn loop body with (immutable variant shown — adjust for mutating variant analogously):
+
+```typescript
+const occupied = new Set<string>();
+for (const unit of Object.values(nextUnits)) {
+  occupied.add(`${unit.position.q},${unit.position.r}`);
+}
+
+for (let i = 0; i < spawnCount; i++) {
+  // Try up to the full offset list to find a free tile
+  let placed = false;
+  const startIdx = Math.floor(rng() * offsets.length);
+  for (let step = 0; step < offsets.length && !placed; step++) {
+    const offset = offsets[(startIdx + step) % offsets.length];
+    const pos: HexCoord = { q: city.position.q + offset.q, r: city.position.r + offset.r };
+    const key = `${pos.q},${pos.r}`;
+    if (!map.tiles[key]) continue;
+    if (occupied.has(key)) continue;
+    const rebel = createUnit(unitType, 'rebels', pos);
+    nextUnits = { ...nextUnits, [rebel.id]: rebel };
+    occupied.add(key);
+    placed = true;
+  }
+  // If no free tile found, silently skip this rebel — better than stacking.
+}
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/systems/faction-system.test.ts`
+Expected: PASS, and all prior faction tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/systems/faction-system.test.ts src/systems/faction-system.ts
+git commit -m "fix(m4-review): rebel spawn respects tile occupancy"
+```
+
+---
+
+## Task 2: Minor-civ presentation masks color when undiscovered
+
+**Files:**
+- Test: `tests/systems/minor-civ-presentation.test.ts`
+- Modify: `src/systems/minor-civ-presentation.ts:20-26`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/systems/minor-civ-presentation.test.ts`:
+
+```typescript
+it('returns a neutral color when the minor civ is not yet discovered', () => {
+  const { state, viewerCivId, undiscoveredMcId } = buildUndiscoveredMcFixture();
+
+  const presentation = getMinorCivPresentationForPlayer(state, viewerCivId, undiscoveredMcId);
+
+  expect(presentation.known).toBe(false);
+  expect(presentation.color).toBe('#888');
+});
+```
+
+Add a helper `buildUndiscoveredMcFixture` at the top of the file (or inline) that builds a minimal state with one minor civ that the viewer has NOT discovered. If the existing fixtures already have a "known: false" case, read them and just assert the color.
+
+- [ ] **Step 2: Run and verify fail**
+
+Run: `yarn test tests/systems/minor-civ-presentation.test.ts -t "neutral color"`
+Expected: FAIL — returns the real `def.color`.
+
+- [ ] **Step 3: Mask color behind `known`**
+
+In `src/systems/minor-civ-presentation.ts`, replace the `return` block (lines 21-25) with:
+
+```typescript
+return {
+  known,
+  name: known ? (def?.name ?? unknownName) : unknownName,
+  color: known ? (def?.color ?? '#888') : '#888',
+};
+```
+
+- [ ] **Step 4: Run the test**
+
+Run: `yarn test tests/systems/minor-civ-presentation.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Audit existing consumers**
+
+Run: `grep -rn "getMinorCivPresentationForPlayer" src/ | grep -v "\.test\."`
+
+For each hit, confirm that using `'#888'` for undiscovered city-states is visually correct (diplomacy panel, notifications, quest presentation). Current call sites render only known city-states in the diplomacy panel list and use color in notification chips — masked color for undiscovered is the desired behaviour.
+
+If any consumer depends on the real color for *internal* logic (not display), switch that call to a new helper `getMinorCivTrueColor(state, mcId)` that returns the raw color regardless of discovery. If no such consumer exists, skip this step.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/systems/minor-civ-presentation.test.ts src/systems/minor-civ-presentation.ts
+git commit -m "fix(m4-review): mask minor-civ color until discovered"
+```
+
+---
+
+## Task 3: Bundle verification
+
+- [ ] **Step 1: Full suite**
+
+Run: `yarn test`
+Expected: All green.
+
+- [ ] **Step 2: Build smoke**
+
+Run: `yarn build`
+Expected: Success.
+
+- [ ] **Step 3: Manual sanity check (UI)**
+
+Run: `yarn dev`
+Open the game. Start a new game where one or more city-states are off-screen. Open the diplomacy panel. Confirm undiscovered city-states (if any are listed) show neutral grey chips rather than their real color. Stop the dev server.
+
+- [ ] **Step 4: Commit any follow-ups**
+
+```bash
+git add -p
+git commit -m "fix(m4-review): bundle 3 verification follow-ups"
+```
+
+---
+
+**Done when:** all tasks green, rebels never stack, undiscovered city-states present as grey.


### PR DESCRIPTION
## Summary

Bundle 0 of the April 12 code-review milestone — installs enforcement guardrails so the bug classes surfaced by the review are caught while Claude is writing the code, not weeks later in review.

- Extends `.claude/rules/game-systems.md` and `ui-panels.md` with rules that were implicit but unwritten: immutable turn processing, diplomacy lifecycle, no dead return fields, spawn occupancy, cities[0] scope extension, privacy/discovery masking, no silent destructive UI.
- Adds `.claude/hooks/check-src-edit.sh` — PostToolUse grep that flags rule violations in edited `src/**/*.ts` files. Back-tested against three April 12 bugs (faction-system mutation, council cities[0], hotseat dead field) — all 3 caught.
- Adds `.claude/hooks/pre-push-review-reminder.sh` — PreToolUse that asks to run the `code-review:code-review` skill when pushing/merging a branch ahead of origin/main.
- Commits `.claude/settings.json` so both hooks are shared across the team (previously only `settings.local.json` existed).
- Adds a Rules Index + hook summary to `CLAUDE.md`.
- Includes the full milestone plan set for Bundles 0-3.

No `src/` or `tests/` changes. Safe to merge independently of Bundles 1-3.

## Test Plan

- [x] `yarn test` — 935/935 pass (no src changes, sanity check only)
- [x] Back-test: 3/3 April 12 bugs caught by `check-src-edit.sh` (see `docs/superpowers/plans/2026-04-12-cr-bundle0-backtest.md`)
- [x] False-positive check: clean file (`diplomacy-system.ts`) and allowlisted file (`basic-ai.ts`) both exit 0
- [ ] Run `/hooks` in Claude Code and confirm both hooks show up under `.claude/settings.json`
- [ ] On next `git push` attempt, confirm the pre-push hook prompts with the review reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)