### PR TITLE
docs(codex): align AGENTS guidance with Claude rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,14 @@
 # Repository Guidelines
 
+## Purpose
+`AGENTS.md` is the official repo instruction file for Codex.
+
+Canonical project policy lives in:
+- `CLAUDE.md`
+- `.claude/rules/*.md`
+
+Claude-specific hook scripts in `.claude/hooks/` are enforcement helpers, not the policy source. When Codex is working in this repo, follow the policy files above and run the repo checks listed below.
+
 ## Project Structure & Module Organization
 Core game code lives in `src/`. Use the existing domain split: `src/core/` for shared state and turn flow, `src/systems/` for gameplay rules, `src/renderer/` for Canvas rendering, `src/ui/` for DOM panels, `src/input/` for controls, `src/ai/` for opponents, `src/audio/` for sound, and `src/storage/` for saves. Static assets and PWA files live in `public/`. Tests live in `tests/` and generally mirror `src/` paths, for example `src/systems/map-generator.ts` pairs with `tests/systems/map-generator.test.ts`.
 
@@ -20,8 +29,44 @@ For legendary wonder, quest-race, or wonder-panel changes, run:
 
 - `./scripts/run-wonder-regressions.sh`
 
+## Architecture Notes
+Respect the event-driven design: systems communicate through the event bus, while state mutations still happen directly in state-updating code. Shared gameplay consequences must live in canonical system helpers, not only in `main.ts` UI handlers. If the player, AI, and turn loop can all trigger the same outcome, the mutation path should be shared and the UI layer should only add viewer-specific notifications.
+
+Keep gameplay state serializable plain objects, not class instances. Use axial hex coordinates `(q, r)` throughout gameplay code and convert to pixels only inside renderer code. Canvas 2D renders the hex map; DOM/CSS handles UI panels. Mobile-first and offline-first assumptions still apply.
+
+## Rule Files
+If you touch files in these areas, read the matching rule file before editing:
+
+- `src/systems/**`, `src/core/**`, `src/ai/**` -> `.claude/rules/game-systems.md`
+- `src/ui/**`, `src/renderer/**`, `src/main.ts` -> `.claude/rules/ui-panels.md`
+- `src/systems/**`, `src/core/**` for mechanic-completeness, wonder-race, and storage rules -> `.claude/rules/strategy-game-mechanics.md`
+- `src/**` -> `.claude/rules/end-to-end-wiring.md`
+- `docs/superpowers/specs/**`, `docs/superpowers/plans/**`, or any spec-driven implementation -> `.claude/rules/spec-fidelity.md`
+
+Use `CLAUDE.md` for repo-wide architecture, command, and gameplay conventions.
+
+## Required Verification
+After editing files under `src/`, run:
+
+- `scripts/check-src-rule-violations.sh path/to/changed-src-file.ts [more changed src files...]`
+- `./scripts/run-with-mise.sh yarn test --run tests/path/to/mirrored-file.test.ts [more mirrored tests...]`
+
+Test-selection rule:
+
+- For each changed `src/foo/bar.ts`, first look for the mirrored test file `tests/foo/bar.test.ts`.
+- If one or more mirrored test files exist, run all of them in the same `yarn test --run ...` command.
+- If no mirrored test file exists for the changed area, run the smallest existing relevant test file in the same domain directory.
+- If no targeted test can be identified confidently, run `./scripts/run-with-mise.sh yarn test`.
+
+Before `git push`, PR creation, or merge when `HEAD` is ahead of `origin/main`, review both:
+
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+
+If either diff includes source changes, inspect the full diff before concluding review is complete.
+
 ## Coding Style & Naming Conventions
-Follow `.editorconfig`: UTF-8, LF endings, 2-space indentation, final newline. Write TypeScript modules with one clear responsibility per file. Prefer kebab-case filenames such as `city-system.ts` and `fog-of-war.ts`; keep tests named `*.test.ts`. Keep gameplay state serializable plain objects, not class instances. Use axial hex coordinates `(q, r)` throughout gameplay code and convert to pixels only inside renderer code. For DOM updates, use `textContent` or `createTextNode()` instead of `innerHTML`.
+Follow `.editorconfig`: UTF-8, LF endings, 2-space indentation, final newline. Write TypeScript modules with one clear responsibility per file. Prefer kebab-case filenames such as `city-system.ts` and `fog-of-war.ts`; keep tests named `*.test.ts`. For DOM updates, use `textContent` or `createTextNode()` instead of `innerHTML`.
 
 ## Testing Guidelines
 Vitest is the test runner. Add tests beside the relevant domain under `tests/`, and mirror the source directory structure. Cover deterministic gameplay behavior, especially systems that affect turn order, diplomacy, combat, map generation, or save persistence. Do not use `Math.random()` in game logic; seeded randomness is required so tests stay reproducible.
@@ -53,11 +98,6 @@ When adding or changing legendary wonder rules:
 
 ## Commit & Pull Request Guidelines
 Recent history uses concise Conventional Commit style, often with scopes, for example `fix(m5): wire marketplace supply/demand from game state` or `docs: triage open issues`. Keep commit subjects imperative and specific. PRs should explain gameplay impact, list tests run, link the relevant issue or milestone, and include screenshots when UI or rendering changes are visible.
-
-## Architecture Notes
-Respect the event-driven design: systems communicate through the event bus, while state mutations still happen directly in state-updating code. Hot-seat features must use `state.currentPlayer` rather than hardcoded player IDs, and bilateral diplomacy changes must update both sides.
-
-Shared gameplay consequences must live in canonical system helpers, not only in `main.ts` UI handlers. If the player, AI, and turn loop can all trigger the same outcome, the mutation path should be shared and the UI layer should only add viewer-specific notifications.
 
 ## Spec Fidelity
 When working from `docs/superpowers/specs/` or `docs/superpowers/plans/`, preserve the exact gameplay contract unless the user explicitly changes it. Do not broaden gated mission effects, relax resolution conditions, or leave bonus-effect fields partially wired. Review branch work against both `origin/main...HEAD` and the local uncommitted delta, not just untracked files, before claiming review coverage.

--- a/docs/superpowers/plans/2026-04-12-agents-md-codex-alignment.md
+++ b/docs/superpowers/plans/2026-04-12-agents-md-codex-alignment.md
@@ -1,0 +1,255 @@
+# AGENTS.md Codex Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `AGENTS.md` accurate, lower-drift, and Codex-native by replacing prose-only enforcement with concrete runnable checks and by clearly separating canonical policy from enforcement helpers.
+
+**Architecture:** Keep `CLAUDE.md` and `.claude/rules/*.md` as the canonical policy layer, and add one repo-level validation script that Codex can run directly after `src/` edits. Then slim `AGENTS.md` down so it points to the canonical rule files, names the exact verification commands to run, and avoids duplicating large policy summaries that will drift.
+
+**Tech Stack:** Markdown, POSIX shell, `rg`, git, existing repo wrapper scripts
+
+---
+
+### Task 1: Add a Codex-runnable source-rule verification script
+
+**Files:**
+- Create: `scripts/check-src-rule-violations.sh`
+- Verify against: `.claude/hooks/check-src-edit.sh`
+
+**Parity requirements:**
+- The new script is a direct-file Codex wrapper around the same heuristics already enforced by `.claude/hooks/check-src-edit.sh`; do not intentionally broaden or narrow the checks.
+- Keep the same allowed path exceptions as the Claude hook: `src/ai/**` and `src/systems/faction-system.ts` are exempt from the `.cities[0]` check.
+- Keep the same `Math.random()` behavior as the Claude hook by ignoring matches on lines filtered out by `grep -v '//'`.
+- Keep the same target scope as the Claude hook: only existing `.ts` files under `src/` should be scanned, and non-`src` files passed on the command line should be skipped without error.
+- Exit `0` when no violations are found, `1` for usage errors such as no arguments, and `2` when one or more violations are found.
+- Output should stay human-readable and multiline, matching the spirit of the hook output rather than printing literal `\n` sequences.
+
+- [ ] **Step 1: Write the script skeleton with direct file arguments**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <file> [file...]" >&2
+  exit 1
+fi
+
+status=0
+
+append_violation() {
+  local file="$1"
+  local message="$2"
+  printf 'check-src-rule-violations: %s\n%s\n' "$file" "$message" >&2
+  status=2
+}
+
+append_match_block() {
+  local label="$1"
+  local lines="$2"
+  printf -v violations '%s- %s:\n%s\n' "$violations" "$label" "$lines"
+}
+```
+
+- [ ] **Step 2: Mirror the existing Claude hook heuristics in a direct file scan**
+
+```bash
+for file_path in "$@"; do
+  case "$file_path" in
+    src/*.ts|src/**/*.ts) ;;
+    *) continue ;;
+  esac
+
+  [ -f "$file_path" ] || continue
+  violations=""
+
+  case "$file_path" in
+    src/ai/*|src/systems/faction-system.ts) ;;
+    *)
+      if rg -n '\.cities\[0\]' "$file_path" >/dev/null; then
+        lines="$(rg -n '\.cities\[0\]' "$file_path" | head -5)"
+        append_match_block "cities[0] used outside approved capital heuristics" "$lines"
+      fi
+      ;;
+  esac
+
+  if rg -n 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" >/dev/null; then
+    lines="$(rg -n 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" | head -5)"
+    append_match_block "Direct state mutation in turn-processing path" "$lines"
+  fi
+
+  if grep -nE 'Math\.random\(' "$file_path" | grep -v '//' >/dev/null; then
+    lines="$(grep -nE 'Math\.random\(' "$file_path" | grep -v '//' | head -5)"
+    append_match_block "Math.random() is banned in src/" "$lines"
+  fi
+
+  if rg -n "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" >/dev/null; then
+    lines="$(rg -n "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" | head -5)"
+    append_match_block "Hardcoded player ownership check" "$lines"
+  fi
+
+  if rg -n 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" >/dev/null; then
+    lines="$(rg -n 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" | head -5)"
+    append_match_block "innerHTML with interpolated game data" "$lines"
+  fi
+
+  if rg -n ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" >/dev/null; then
+    lines="$(rg -n ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" | head -5)"
+    append_match_block "Placeholder return field left for later calculation" "$lines"
+  fi
+
+  if [ -n "$violations" ]; then
+    append_violation "$file_path" "$violations"
+  fi
+done
+
+exit "$status"
+```
+
+- [ ] **Step 3: Make the script executable**
+
+Run: `chmod +x scripts/check-src-rule-violations.sh`
+Expected: command exits successfully with no output
+
+- [ ] **Step 4: Smoke-test the script against the current source tree subset**
+
+Run: `scripts/check-src-rule-violations.sh src/main.ts src/ui/advisor-system.ts`
+Expected: exits `0` if the files are clean, or exits `2` with specific violations if not
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-src-rule-violations.sh
+git commit -m "chore(codex): add src rule verification script"
+```
+
+### Task 2: Rewrite AGENTS.md around canonical sources and exact commands
+
+**Files:**
+- Modify: `AGENTS.md`
+- Reference: `CLAUDE.md`
+- Reference: `.claude/rules/game-systems.md`
+- Reference: `.claude/rules/ui-panels.md`
+- Reference: `.claude/rules/strategy-game-mechanics.md`
+- Reference: `.claude/rules/end-to-end-wiring.md`
+- Reference: `.claude/rules/spec-fidelity.md`
+- Reference: `scripts/check-src-rule-violations.sh`
+
+- [ ] **Step 1: Replace the purpose section so policy and enforcement are clearly separated**
+
+```md
+## Purpose
+`AGENTS.md` is the official repo instruction file for Codex.
+
+Canonical project policy lives in:
+- `CLAUDE.md`
+- `.claude/rules/*.md`
+
+Claude-specific hook scripts in `.claude/hooks/` are enforcement helpers, not the policy source. When Codex is working in this repo, follow the policy files above and run the repo checks listed below.
+```
+
+- [ ] **Step 2: Replace the rule-summary block with a short routing section**
+
+```md
+## Rule Files
+If you touch files in these areas, read the matching rule file before editing:
+
+- `src/systems/**`, `src/core/**`, `src/ai/**` → `.claude/rules/game-systems.md`
+- `src/ui/**`, `src/renderer/**`, `src/main.ts` → `.claude/rules/ui-panels.md`
+- `src/**` → `.claude/rules/end-to-end-wiring.md`
+- `docs/superpowers/specs/**`, `docs/superpowers/plans/**` or any spec-driven implementation → `.claude/rules/spec-fidelity.md`
+
+Use `CLAUDE.md` for repo-wide architecture, command, and gameplay conventions.
+```
+
+- [ ] **Step 3: Replace the manual parity section with exact commands Codex must run**
+
+```md
+## Required Verification
+After editing files under `src/`, run:
+
+- `scripts/check-src-rule-violations.sh path/to/changed-src-file.ts [more changed src files...]`
+- `./scripts/run-with-mise.sh yarn test --run tests/path/to/mirrored-file.test.ts [more mirrored tests...]`
+
+Test-selection rule:
+
+- For each changed `src/foo/bar.ts`, first look for the mirrored test file `tests/foo/bar.test.ts`.
+- If one or more mirrored test files exist, run all of them in the same `yarn test --run ...` command.
+- If no mirrored test file exists for the changed area, run the smallest existing relevant test file in the same domain directory.
+- If no targeted test can be identified confidently, run `./scripts/run-with-mise.sh yarn test`.
+
+Before `git push`, PR creation, or merge when `HEAD` is ahead of `origin/main`, review both:
+
+- `git diff --stat origin/main...HEAD`
+- `git diff --stat`
+
+If either diff includes source changes, inspect the full diff before concluding review is complete.
+```
+
+- [ ] **Step 4: Remove duplicated policy bullets that already exist in canonical rule files**
+
+Delete the long duplicated summaries under:
+
+```md
+## Rules Index
+## Codex Enforcement Parity
+## Gameplay And UI Rules
+```
+
+Keep only short high-signal repo guidance that is not already maintained elsewhere.
+
+- [ ] **Step 5: Verify the rewritten file still keeps the repo-specific commands and architecture notes**
+
+Run: `sed -n '1,220p' AGENTS.md`
+Expected: file still includes project layout, preferred commands, architecture notes, testing guidance, and commit/PR guidance, but no longer duplicates large rule summaries
+
+- [ ] **Step 5a: Verify the `Required Verification` section contains no placeholders**
+
+Run: `sed -n '/## Required Verification/,/## /p' AGENTS.md`
+Expected: the section contains concrete command forms plus the explicit mirrored-test fallback rule, not angle-bracket placeholders
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "docs(codex): tighten AGENTS.md guidance"
+```
+
+### Task 3: Verify Codex guidance matches the updated AGENTS contract
+
+**Files:**
+- Modify: `AGENTS.md` if needed after verification
+- Reference: `docs/superpowers/plans/2026-04-12-agents-md-codex-alignment.md`
+
+- [ ] **Step 1: Check the source-edit flow end to end**
+
+Run: `git diff -- AGENTS.md scripts/check-src-rule-violations.sh`
+Expected: diff shows `AGENTS.md` routing Codex to canonical policy files and naming runnable verification commands instead of prose-only reminders
+
+- [ ] **Step 2: Confirm the required commands are repo-real**
+
+Run: `test -x scripts/check-src-rule-violations.sh && test -x ./scripts/run-with-mise.sh`
+Expected: command exits `0`
+
+- [ ] **Step 3: Do a final drift check against the Claude policy files**
+
+Run: `rg -n "canonical|Rule Files|Required Verification|Gameplay And UI Rules|Rules Index" AGENTS.md CLAUDE.md .claude/rules`
+Expected: `AGENTS.md` points to the canonical rule files and no longer presents a second full copy of the same policy surface
+
+- [ ] **Step 4: Make any final wording adjustments if the drift check reveals duplicated policy**
+
+```md
+If AGENTS still contains long gameplay-policy lists copied from `.claude/rules/*.md`, replace them with one-line pointers to the matching canonical rule file.
+```
+
+- [ ] **Step 5: Run final doc verification**
+
+Run: `git diff --check`
+Expected: no whitespace or formatting errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AGENTS.md scripts/check-src-rule-violations.sh
+git commit -m "docs(codex): align AGENTS.md with Codex best practices"
+```

--- a/scripts/check-src-rule-violations.sh
+++ b/scripts/check-src-rule-violations.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <file> [file...]" >&2
+  exit 1
+fi
+
+status=0
+
+append_violation() {
+  local file="$1"
+  local message="$2"
+  printf 'check-src-rule-violations: %s\n%s\n' "$file" "$message" >&2
+  status=2
+}
+
+append_match_block() {
+  local label="$1"
+  local lines="$2"
+  printf -v violations '%s- %s:\n%s\n' "$violations" "$label" "$lines"
+}
+
+for file_path in "$@"; do
+  case "$file_path" in
+    src/*.ts|src/**/*.ts) ;;
+    *) continue ;;
+  esac
+
+  [ -f "$file_path" ] || continue
+  violations=""
+
+  case "$file_path" in
+    src/ai/*|src/systems/faction-system.ts)
+      : # allowed: capital heuristics
+      ;;
+    *)
+      if grep -nE '\.cities\[0\]' "$file_path" >/dev/null; then
+        lines="$(grep -nE '\.cities\[0\]' "$file_path" | head -5)"
+        append_match_block "cities[0] used in a UI/recommendation path — cycle all cities (see .claude/rules/ui-panels.md)" "$lines"
+      fi
+      ;;
+  esac
+
+  if grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" >/dev/null; then
+    lines="$(grep -nE 'state\.(cities|units|civilizations)\[[^]]+\]\s*=' "$file_path" | head -5)"
+    append_match_block "Direct state mutation detected. Turn-processing systems must return a new GameState (see .claude/rules/game-systems.md#immutable-turn-processing)" "$lines"
+  fi
+
+  if grep -nE 'Math\.random\(' "$file_path" | grep -v '//' >/dev/null; then
+    lines="$(grep -nE 'Math\.random\(' "$file_path" | grep -v '//' | head -5)"
+    append_match_block "Math.random() is banned in src/ — use seeded RNG (see .claude/rules/game-systems.md#deterministic-rng)" "$lines"
+  fi
+
+  if grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" >/dev/null; then
+    lines="$(grep -nE "=== ['\"]player['\"]|owner === ['\"]player['\"]" "$file_path" | head -5)"
+    append_match_block "Hardcoded 'player' ownership check — use state.currentPlayer (see .claude/rules/ui-panels.md#hot-seat-multiplayer)" "$lines"
+  fi
+
+  if grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" >/dev/null; then
+    lines="$(grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" | head -5)"
+    append_match_block "innerHTML with interpolated game data — use textContent or data-text placeholders (see .claude/rules/ui-panels.md#unit-info-panels)" "$lines"
+  fi
+
+  if grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" >/dev/null; then
+    lines="$(grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" | head -5)"
+    append_match_block "Placeholder return field with 'calculated elsewhere' comment — populate it or remove the field (see .claude/rules/game-systems.md#no-dead-return-fields)" "$lines"
+  fi
+
+  if [ -n "$violations" ]; then
+    append_violation "$file_path" "$violations"
+  fi
+done
+
+exit "$status"

--- a/tests/scripts/check-src-rule-violations.test.ts
+++ b/tests/scripts/check-src-rule-violations.test.ts
@@ -1,0 +1,82 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const SCRIPT_PATH = resolve(process.cwd(), 'scripts/check-src-rule-violations.sh');
+
+const tempDirs: string[] = [];
+
+function makeWorkspace(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'check-src-rule-violations-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writeWorkspaceFile(workspace: string, relativePath: string, content: string): void {
+  const fullPath = join(workspace, relativePath);
+  mkdirSync(dirname(fullPath), { recursive: true });
+  writeFileSync(fullPath, content);
+}
+
+function runScript(workspace: string, ...args: string[]) {
+  return spawnSync(SCRIPT_PATH, args, {
+    cwd: workspace,
+    encoding: 'utf8',
+  });
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe('check-src-rule-violations.sh', () => {
+  it('returns a usage error when no file paths are provided', () => {
+    const workspace = makeWorkspace();
+
+    const result = runScript(workspace);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Usage:');
+  });
+
+  it('reports src rule violations with multiline diagnostics', () => {
+    const workspace = makeWorkspace();
+    writeWorkspaceFile(
+      workspace,
+      'src/ui/problem-panel.ts',
+      [
+        "const owner = unit.owner === 'player';",
+        'const roll = Math.random();',
+      ].join('\n'),
+    );
+
+    const result = runScript(workspace, 'src/ui/problem-panel.ts');
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('check-src-rule-violations: src/ui/problem-panel.ts');
+    expect(result.stderr).toContain("Hardcoded 'player' ownership check");
+    expect(result.stderr).toContain('Math.random() is banned in src/');
+    expect(result.stderr).toContain('\n2:const roll = Math.random();\n');
+  });
+
+  it('matches Claude hook exceptions for comments and allowed cities[0] files', () => {
+    const workspace = makeWorkspace();
+    writeWorkspaceFile(
+      workspace,
+      'src/ai/capital-heuristic.ts',
+      [
+        'const firstCity = civ.cities[0];',
+        '// const roll = Math.random();',
+      ].join('\n'),
+    );
+
+    const result = runScript(workspace, 'src/ai/capital-heuristic.ts');
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- align AGENTS.md with Codex best practices by pointing to canonical Claude policy files and exact verification commands
- add a runnable src rule checker that mirrors the existing Claude hook heuristics for Codex workflows
- add a focused Vitest regression test for the new checker and keep the implementation plan in docs/superpowers/plans

## Test Plan
- [x] ./scripts/run-with-mise.sh yarn test --run tests/scripts/check-src-rule-violations.test.ts
- [x] scripts/check-src-rule-violations.sh src/main.ts src/ui/advisor-system.ts
- [x] ./scripts/run-with-mise.sh yarn test
- [x] git diff --check