### PR TITLE
fix(ui): clarify hot seat civ picker actions

### DIFF
--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -119,6 +119,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
         },
       }, {
         civDefinitions,
+        primaryActionText: 'Confirm Civilization',
       });
     });
   };

--- a/src/ui/civ-select.ts
+++ b/src/ui/civ-select.ts
@@ -11,6 +11,7 @@ export interface CivSelectOptions {
   disabledCivs?: string[];
   headerText?: string;
   civDefinitions?: CivDefinition[];
+  primaryActionText?: string;
 }
 
 function createButton(label: string): HTMLButtonElement {
@@ -35,6 +36,7 @@ export function createCivSelectPanel(
   const disabledCivs = options?.disabledCivs ?? [];
   const headerText = options?.headerText ?? 'Choose Your Civilization';
   const civDefinitions = options?.civDefinitions ?? CIV_DEFINITIONS;
+  const primaryActionText = options?.primaryActionText ?? 'Start Game';
   const panel = document.createElement('div');
   panel.id = 'civ-select';
   panel.style.position = 'absolute';
@@ -170,7 +172,7 @@ export function createCivSelectPanel(
     actionBar.appendChild(createCustomButton);
   }
 
-  const startButton = createButton('Start Game');
+  const startButton = createButton(primaryActionText);
   startButton.id = 'civ-start';
   startButton.style.background = 'rgba(232,193,112,0.3)';
   startButton.style.border = '2px solid #e8c170';

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -253,6 +253,7 @@ export function showHotSeatSetup(
         disabledCivs: chosenCivs,
         headerText: `${players[playerIdx].name}, choose your civilization`,
         civDefinitions,
+        primaryActionText: playerIdx + 1 < players.length ? 'Next Player' : 'Start Game',
       });
     });
   }

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -61,7 +61,17 @@ const baseCustomCiv: CustomCivDefinition = {
   temperamentTraits: ['diplomatic', 'trader'],
 };
 
+function click(root: ParentNode, selector: string): void {
+  const element = root.querySelector(selector) as HTMLElement | null;
+  if (!element) throw new Error(`Missing element: ${selector}`);
+  element.click();
+}
+
 describe('campaign-setup', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('requires map size, civ selection, opponent count, and campaign title before starting a solo game', () => {
     const container = document.createElement('div');
     const onStart = vi.fn();
@@ -359,5 +369,14 @@ describe('campaign-setup', () => {
 
     clickButtonWithText('Choose civilization');
     expect(document.body.textContent).toContain('Sunfolk');
+  });
+
+  it('shows a confirmation CTA when choosing a civilization inside solo setup', () => {
+    const container = document.createElement('div');
+
+    showCampaignSetup(container, { onStartSolo: () => {}, onCancel: () => {} });
+    click(container, '[data-action="choose-civ"]');
+
+    expect((container.querySelector('#civ-start') as HTMLButtonElement | null)?.textContent).toBe('Confirm Civilization');
   });
 });

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment jsdom */
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
 import type { CustomCivDefinition } from '@/core/types';
@@ -21,6 +22,30 @@ async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function click(selector: string): void {
+  const element = document.querySelector(selector) as HTMLElement | null;
+  if (!element) throw new Error(`Missing element: ${selector}`);
+  element.click();
+}
+
+function setInputValue(selector: string, value: string): void {
+  const input = document.querySelector(selector) as HTMLInputElement | null;
+  if (!input) throw new Error(`Missing input: ${selector}`);
+  input.value = value;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function chooseCiv(civId: string): void {
+  click(`.civ-card[data-civ-id="${civId}"]`);
+  click('#civ-start');
+}
+
+function primaryCivActionLabel(): string {
+  const button = document.querySelector('#civ-start') as HTMLButtonElement | null;
+  if (!button) throw new Error('Missing #civ-start button');
+  return button.textContent ?? '';
 }
 
 function fillAndSaveCustomCiv(name: string): void {
@@ -67,9 +92,9 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
 
     expect(document.body.textContent).toContain('Sunfolk');
   });
@@ -87,22 +112,22 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
 
     const civCard = Array.from(document.querySelectorAll('.civ-card'))
       .find(node => node.textContent?.includes('Sunfolk'));
     expect(civCard).toBeTruthy();
     civCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    (document.querySelector('#civ-start') as HTMLButtonElement)?.click();
-    (document.querySelector('#hs-civ-ready') as HTMLButtonElement).click();
+    click('#civ-start');
+    click('#hs-civ-ready');
 
     const secondPlayerCiv = Array.from(document.querySelectorAll('.civ-card'))
       .find(node => !node.textContent?.includes('Sunfolk'));
     expect(secondPlayerCiv).toBeTruthy();
     secondPlayerCiv?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+    click('#civ-start');
 
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
@@ -131,22 +156,22 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
 
     const firstPlayerCiv = Array.from(document.querySelectorAll('.civ-card'))
       .find(node => node.textContent?.includes('Sunfolk'));
     expect(firstPlayerCiv).toBeTruthy();
     firstPlayerCiv?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+    click('#civ-start');
 
-    (document.querySelector('#hs-civ-ready') as HTMLButtonElement).click();
+    click('#hs-civ-ready');
     const secondPlayerCiv = Array.from(document.querySelectorAll('.civ-card'))
       .find(node => !node.textContent?.includes('Sunfolk'));
     expect(secondPlayerCiv).toBeTruthy();
     secondPlayerCiv?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+    click('#civ-start');
 
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
@@ -168,24 +193,24 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
-    (document.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    click('[data-action="create-custom-civ"]');
     fillAndSaveCustomCiv('Sunfolk');
     await flushAsyncWork();
 
     expect(document.querySelectorAll('#civ-select')).toHaveLength(1);
-    (document.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-action="create-custom-civ"]');
     expect(document.querySelectorAll('#custom-civ-panel')).toHaveLength(1);
-    (document.querySelector('[data-action="cancel-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-action="cancel-custom-civ"]');
     expect(document.querySelectorAll('#custom-civ-panel')).toHaveLength(0);
 
     const civCard = Array.from(document.querySelectorAll('.civ-card'))
       .find(node => node.textContent?.includes('Sunfolk'));
     expect(civCard).toBeTruthy();
     civCard?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+    click('#civ-start');
 
     expect(document.querySelector('#hs-civ-ready')).toBeTruthy();
     expect(onComplete).not.toHaveBeenCalled();
@@ -208,10 +233,10 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
-    (document.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    click('[data-action="create-custom-civ"]');
     fillAndSaveCustomCiv('Sunfolk');
     await flushAsyncWork();
 
@@ -258,10 +283,10 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
-    (document.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    click('[data-action="create-custom-civ"]');
     fillAndSaveCustomCiv('Sunfolk');
     await flushAsyncWork();
 
@@ -307,10 +332,10 @@ describe('hotseat-setup', () => {
       },
     );
 
-    (document.querySelector('[data-size="small"]') as HTMLElement).click();
-    (document.querySelector('[data-count="2"]') as HTMLElement).click();
-    (document.querySelector('#hs-names-next') as HTMLButtonElement).click();
-    (document.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
+    click('[data-size="small"]');
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    click('[data-action="create-custom-civ"]');
     fillAndSaveCustomCiv('Moonfolk');
     await flushAsyncWork();
 
@@ -325,5 +350,92 @@ describe('hotseat-setup', () => {
         name: 'Moonfolk',
       }),
     ]));
+  });
+
+  it('does not finish after the first human chooses a civilization', () => {
+    const onComplete = vi.fn();
+
+    showHotSeatSetup(document.body, {
+      onComplete,
+      onCancel: () => {},
+    });
+
+    click('.map-size-card[data-size="small"]');
+    click('.count-card[data-count="2"]');
+    setInputValue('.player-name-input[data-idx="0"]', 'Alice');
+    setInputValue('.player-name-input[data-idx="1"]', 'Bob');
+    click('#hs-names-next');
+
+    chooseCiv('egypt');
+
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain('Pass the device to');
+    expect(document.body.textContent).toContain('Bob');
+  });
+
+  it('lets the second human choose a different civilization and completes with both picks', () => {
+    const onComplete = vi.fn();
+
+    showHotSeatSetup(document.body, {
+      onComplete,
+      onCancel: () => {},
+    });
+
+    click('.map-size-card[data-size="small"]');
+    click('.count-card[data-count="2"]');
+    setInputValue('.player-name-input[data-idx="0"]', 'Alice');
+    setInputValue('.player-name-input[data-idx="1"]', 'Bob');
+    click('#hs-names-next');
+
+    chooseCiv('egypt');
+    click('#hs-civ-ready');
+
+    expect(document.body.textContent).toContain('Bob, choose your civilization');
+    expect((document.querySelector('.civ-card[data-civ-id="egypt"]') as HTMLElement).style.cssText).toContain('pointer-events: none;');
+
+    chooseCiv('rome');
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    const config = onComplete.mock.calls[0][0];
+    const humanPlayers = config.players.filter((player: { isHuman: boolean }) => player.isHuman);
+    expect(humanPlayers).toEqual([
+      expect.objectContaining({ name: 'Alice', slotId: 'player-1', civType: 'egypt', isHuman: true }),
+      expect.objectContaining({ name: 'Bob', slotId: 'player-2', civType: 'rome', isHuman: true }),
+    ]);
+  });
+
+  it('shows Next Player as the civ-pick CTA for non-final human players', () => {
+    showHotSeatSetup(document.body, {
+      onComplete: () => {},
+      onCancel: () => {},
+    });
+
+    click('.map-size-card[data-size="small"]');
+    click('.count-card[data-count="2"]');
+    setInputValue('.player-name-input[data-idx="0"]', 'Alice');
+    setInputValue('.player-name-input[data-idx="1"]', 'Bob');
+    click('#hs-names-next');
+
+    expect(document.body.textContent).toContain('Alice, choose your civilization');
+    expect(primaryCivActionLabel()).toBe('Next Player');
+  });
+
+  it('shows Start Game as the civ-pick CTA for the final human player', () => {
+    showHotSeatSetup(document.body, {
+      onComplete: () => {},
+      onCancel: () => {},
+    });
+
+    click('.map-size-card[data-size="small"]');
+    click('.count-card[data-count="2"]');
+    setInputValue('.player-name-input[data-idx="0"]', 'Alice');
+    setInputValue('.player-name-input[data-idx="1"]', 'Bob');
+    click('#hs-names-next');
+
+    chooseCiv('egypt');
+    click('#hs-civ-ready');
+
+    expect(document.body.textContent).toContain('Bob, choose your civilization');
+    expect(primaryCivActionLabel()).toBe('Start Game');
   });
 });


### PR DESCRIPTION
## Summary
- make the shared civ picker CTA text configurable instead of always saying Start Game
- show Next Player for non-final hot-seat picks, keep Start Game for the final human, and use Confirm Civilization in solo setup
- add UI regressions covering hot-seat CTA labels, disabled civ behavior, and solo civ confirmation text

## Test Plan
- [x] ./scripts/run-with-mise.sh yarn test --run tests/ui/hotseat-setup.test.ts tests/ui/campaign-setup.test.ts
- [x] ./scripts/run-with-mise.sh yarn test --run tests/ui/hotseat-setup.test.ts tests/ui/campaign-setup.test.ts tests/core/game-state.test.ts
- [x] git diff --check