### PR TITLE
fix(tech): align tech.unlocks copy with real gating (#78)

### DIFF
--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -34,7 +34,7 @@ export const BUILDINGS: Record<string, Building> = {
   harbor: { id: 'harbor', name: 'Harbor', category: 'economy', yields: { food: 1, production: 0, gold: 3, science: 0 }, productionCost: 80, description: 'Enables sea trade', techRequired: 'harbor-tech', adjacencyBonuses: [] },
 
   // Military
-  barracks: { id: 'barracks', name: 'Barracks', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 40, description: 'Trains soldiers', techRequired: null, adjacencyBonuses: [] },
+  barracks: { id: 'barracks', name: 'Barracks', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 40, description: 'A training ground. Required by future military doctrines.', techRequired: null, adjacencyBonuses: [] },
   walls: { id: 'walls', name: 'Walls', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 60, description: 'Defends the city', techRequired: 'fortification', adjacencyBonuses: [] },
   stable: { id: 'stable', name: 'Stable', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 55, description: 'Trains mounted units', techRequired: 'horseback-riding', adjacencyBonuses: [] },
 

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -4,16 +4,16 @@ export const TECH_TREE: Tech[] = [
   // === MILITARY TRACK (8 techs, existing) ===
   { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 20, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1 },
   { id: 'archery', name: 'Archery', track: 'military', cost: 35, prerequisites: ['stone-weapons'], unlocks: ['Unlock Archer unit'], era: 1 },
-  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 50, prerequisites: ['stone-weapons'], unlocks: ['Unlock Barracks building', 'swordsman'], era: 2 },
+  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 50, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit'], era: 2 },
   { id: 'horseback-riding', name: 'Horseback Riding', track: 'military', cost: 55, prerequisites: ['animal-husbandry'], unlocks: ['Unlock Stable, mounted units'], era: 2 },
   { id: 'fortification', name: 'Fortification', track: 'military', cost: 60, prerequisites: ['bronze-working'], unlocks: ['Unlock Walls building', 'pikeman'], era: 3 },
   { id: 'iron-forging', name: 'Iron Forging', track: 'military', cost: 80, prerequisites: ['bronze-working', 'mining-tech'], unlocks: ['Stronger melee units'], era: 3 },
-  { id: 'siege-warfare', name: 'Siege Warfare', track: 'military', cost: 90, prerequisites: ['iron-forging', 'engineering'], unlocks: ['Unlock Catapult unit'], era: 4 },
+  { id: 'siege-warfare', name: 'Siege Warfare', track: 'military', cost: 90, prerequisites: ['iron-forging', 'engineering'], unlocks: ['Siege weapon doctrine'], era: 4 },
   { id: 'tactics', name: 'Tactics', track: 'military', cost: 100, prerequisites: ['iron-forging'], unlocks: ['Units get +10% combat bonus', 'musketeer'], era: 4 },
 
   // === ECONOMY TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 15, prerequisites: [], unlocks: ['Unlock Granary building'], era: 1 },
-  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 25, prerequisites: ['gathering'], unlocks: ['Unlock Herbalist building'], era: 1 },
+  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 15, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1 },
+  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 25, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge'], era: 1 },
   { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 35, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
   { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 45, prerequisites: ['pottery'], unlocks: ['Farms yield +1 food'], era: 2 },
   { id: 'currency', name: 'Currency', track: 'economy', cost: 60, prerequisites: ['pottery'], unlocks: ['Unlock Marketplace building'], era: 3 },
@@ -25,7 +25,7 @@ export const TECH_TREE: Tech[] = [
   // === SCIENCE TRACK (9 techs, with Slice 3 late-era scaffolding) ===
   { id: 'fire', name: 'Fire', track: 'science', cost: 15, prerequisites: [], unlocks: ['Unlock basic research'], era: 1 },
   { id: 'writing', name: 'Writing', track: 'science', cost: 30, prerequisites: ['fire'], unlocks: ['Unlock Library building'], era: 1 },
-  { id: 'wheel', name: 'The Wheel', track: 'science', cost: 40, prerequisites: ['fire'], unlocks: ['Unlock Workshop building'], era: 2 },
+  { id: 'wheel', name: 'The Wheel', track: 'science', cost: 40, prerequisites: ['fire'], unlocks: ['Foundational mechanics knowledge'], era: 2 },
   { id: 'mathematics', name: 'Mathematics', track: 'science', cost: 60, prerequisites: ['writing'], unlocks: ['Unlock Archive building'], era: 2 },
   { id: 'engineering', name: 'Engineering', track: 'science', cost: 80, prerequisites: ['mathematics', 'wheel'], unlocks: ['Unlock Aqueduct, Forge'], era: 3 },
   { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: ['Unlock Temple building'], era: 3 },

--- a/tests/systems/tech-unlocks-consistency.test.ts
+++ b/tests/systems/tech-unlocks-consistency.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+
+describe('tech.unlocks copy matches gameplay gating', () => {
+  it('every "Unlock <Name> building" claim corresponds to a building gated by that tech', () => {
+    const failures: string[] = [];
+    for (const tech of TECH_TREE) {
+      for (const u of tech.unlocks) {
+        const m = u.match(/^Unlock (.+?) building$/);
+        if (!m) continue;
+        const name = m[1];
+        const building = Object.values(BUILDINGS).find(b => b.name === name);
+        if (!building) {
+          failures.push(`${tech.id}: claims "${u}" but no building named "${name}" exists`);
+          continue;
+        }
+        if (building.techRequired !== tech.id) {
+          failures.push(`${tech.id}: claims "${u}" but ${building.id}.techRequired is ${building.techRequired}`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+
+  it('every "Unlock <Name> unit" claim corresponds to a trainable unit gated by that tech', () => {
+    const failures: string[] = [];
+    for (const tech of TECH_TREE) {
+      for (const u of tech.unlocks) {
+        const m = u.match(/^Unlock (.+?) unit$/);
+        if (!m) continue;
+        const name = m[1];
+        const unit = TRAINABLE_UNITS.find(t => t.name === name);
+        if (!unit) {
+          failures.push(`${tech.id}: claims "${u}" but no trainable unit named "${name}" exists`);
+          continue;
+        }
+        if (unit.techRequired !== tech.id) {
+          failures.push(`${tech.id}: claims "${u}" but ${unit.type}.techRequired is ${unit.techRequired}`);
+        }
+      }
+    }
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Drops the false `Bronze Working → Unlock Barracks building` claim (Barracks has `techRequired: null`).
- Adds `tests/systems/tech-unlocks-consistency.test.ts` — a regression that walks every `tech.unlocks` string matching `Unlock <Name> building` or `Unlock <Name> unit` and asserts the named entity exists and is gated by that tech.
- The regression caught **four additional drift bugs** across the tree, all fixed in this PR:
  - `gathering` claimed to unlock Granary (actually gated by `granary-design`)
  - `pottery` claimed to unlock Herbalist (un-gated)
  - `wheel` claimed to unlock Workshop (un-gated)
  - `siege-warfare` claimed to unlock Catapult (no Catapult unit exists)
- Rewrites the vague Barracks description to match its currently-no-op role.

Closes #78.

## Test plan
- [x] `yarn test` → 994 tests pass (was 992; +2 new regressions)
- [x] `yarn build` → clean
- [ ] Visit the Tech panel in `yarn dev`, verify each affected tech displays its new unlock copy and nothing crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)