### PR TITLE
feat(pacing): speed up the opening and add ETA feedback

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -eu
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+./scripts/pre-commit-checks.sh

--- a/docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md
+++ b/docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md
@@ -1,0 +1,1357 @@
+# Game Pacing Overhaul Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Conquestoria noticeably more active and less boring from the first turns by shipping reviewable vertical slices that each deliver player-visible pacing improvements, safer production/research flow, and clearer UI feedback.
+
+**Architecture:** Implement the overhaul as small, mergeable vertical slices that share a thin pacing/planning foundation. Each slice must be understandable to a Sonnet 4.5-level implementation agent, must preserve existing behavior outside its scope, and must finish in a player-visible improvement that can be demonstrated immediately in the browser.
+
+**Tech Stack:** TypeScript, DOM/CSS UI panels, Vitest, `./scripts/run-with-mise.sh`, IndexedDB/local storage persistence
+
+---
+
+## Delivery Rules
+
+These rules are part of the plan, not optional guidance.
+
+### 1. Model Target
+
+This plan is intentionally sized so `Sonnet 4.5` can execute each task with high confidence:
+
+- each task changes a limited set of files
+- each task has one primary player-facing outcome
+- each task includes targeted tests and explicit verification
+- each task avoids mixing unrelated refactors with feature work
+
+### 2. User-Value Rule
+
+Every task must deliver something the player will notice immediately. Internal scaffolding is allowed only when it is tightly bundled with a visible improvement in the same task.
+
+### 3. MR Quality Rule
+
+Every task should produce an MR that is:
+
+- easy to review
+- easy to demo
+- properly tested
+- matched to the approved spec
+- regression-conscious
+- correct before merge
+
+### 4. Slice Rule
+
+Do not land a “foundation-only” MR that has no player-visible impact. If a helper or metadata layer is needed, pair it with the smallest visible feature that uses it.
+
+### 5. Verification Rule
+
+Before any task is called done:
+
+- run the targeted tests for the changed behavior
+- run `scripts/check-src-rule-violations.sh` on changed `src/` files
+- run any additional relevant integration/build verification
+- inspect the changed UI/flow mentally or interactively and confirm the feature is actually surfaced to the player
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `src/core/types.ts` | Queue-aware `TechState` and pacing metadata types |
+| `src/core/game-state.ts` | Seed new planning fields in fresh games |
+| `src/storage/save-manager.ts` | Migrate older saves to queue-aware fields |
+| `src/systems/pacing-model.ts` | Band tables, ETA helpers, recommended-cost helpers |
+| `src/systems/pacing-audit.ts` | Local audit rows for techs/buildings/units |
+| `src/systems/planning-system.ts` | Shared enqueue/reorder/remove helpers and idle-choice detection |
+| `src/systems/tech-definitions.ts` | Tech pacing metadata and retuned costs |
+| `src/systems/city-system.ts` | Building/unit pacing metadata and queue-safe production behavior |
+| `src/systems/tech-system.ts` | Research queue helpers and queue progression |
+| `src/systems/legendary-wonder-system.ts` | Preserve queue tails when wonder builds start/resolve |
+| `src/core/turn-manager.ts` | Queue progression regressions and shared turn behavior |
+| `src/ui/tech-panel.ts` | Layered dependency view, ETA text, research queue controls |
+| `src/ui/city-panel.ts` | ETA-first production list and production queue controls |
+| `src/ui/required-choice-panel.ts` | Blocking chooser for idle production/research |
+| `src/ui/pacing-debug-panel.ts` | Optional local-only pacing/debug surface |
+| `src/ui/tutorial.ts` | Shared idle-choice logic for tutorial prompts |
+| `src/ui/advisor-system.ts` | Shared idle-choice logic for advisor prompts |
+| `src/main.ts` | Queue-aware UI callbacks, end-turn gating, debug wiring |
+
+---
+
+## Slice Overview
+
+The implementation is split into five vertical slices. Each slice is independently reviewable and delivers immediate player value.
+
+### Slice 1: Faster Opening And Visible ETAs
+
+Player value:
+
+- early units/buildings/techs finish noticeably faster
+- city and tech panels start showing meaningful ETA language
+
+MR review theme:
+
+- “Does the opening feel faster and do the panels explain that speed?”
+
+### Slice 2: City Planning Momentum
+
+Player value:
+
+- cities can queue up to 3 builds
+- players can reorder/remove queued builds
+- city panel feels less stop-start
+
+MR review theme:
+
+- “Can players keep cities moving without losing control or scheduled work?”
+
+### Slice 3: Research Momentum And Better Tech Tree
+
+Player value:
+
+- research can queue up to 3 techs
+- tech tree shows current/available/next-layer focus
+- issue `#56` is directly improved
+
+MR review theme:
+
+- “Does the tech UI feel less overwhelming and more alive?”
+
+### Slice 4: No More Accidental Idle Turns
+
+Player value:
+
+- the game no longer lets players ignore idle research or idle cities when valid options exist
+- prompts are helpful and actionable, not punitive
+
+MR review theme:
+
+- “Can the player still move smoothly, but no longer waste turns by accident?”
+
+### Slice 5: Local Balance Audit And Debug View
+
+Player value:
+
+- visible developer/debug support for pacing inspection
+- better tuned broader roster with confidence against regressions
+
+MR review theme:
+
+- “Is the pacing model inspectable, deterministic, and actually reflected in the current costs?”
+
+---
+
+## Task 1: Faster Opening And Visible ETAs
+
+**Goal:** Make Era 1 feel faster right away and expose that improvement through ETA text in the existing city and tech panels.
+
+**Why this task delivers value:** Players will notice faster opening completions immediately, and the UI will finally tell them how soon things happen.
+
+**Files:**
+- Create: `src/systems/pacing-model.ts`
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/tech-definitions.ts`
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/ui/tech-panel.ts`
+- Test: `tests/systems/pacing-model.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/ui/tech-panel.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/systems/pacing-model.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { estimateTurnsToComplete, getTargetTurnWindow } from '@/systems/pacing-model';
+
+describe('pacing-model', () => {
+  it('gives Era 1 starter items a 2-4 turn target window', () => {
+    expect(getTargetTurnWindow({ era: 1, band: 'starter', contentType: 'building' })).toEqual({ min: 2, max: 4 });
+  });
+
+  it('rounds ETA values up by turn', () => {
+    expect(estimateTurnsToComplete({ cost: 12, outputPerTurn: 4 })).toBe(3);
+    expect(estimateTurnsToComplete({ cost: 13, outputPerTurn: 4 })).toBe(4);
+  });
+});
+```
+
+Extend `tests/ui/city-panel.test.ts`:
+
+```typescript
+it('shows ETA text for buildable units and buildings', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  const panel = createCityPanel(container, city, state, {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.textContent).toContain('turns');
+});
+```
+
+Extend `tests/ui/tech-panel.test.ts`:
+
+```typescript
+it('shows ETA language for the active research summary', () => {
+  const state = createNewGame(undefined, 'tech-eta-test');
+  state.civilizations.player.techState.currentResearch = 'fire';
+
+  const panel = createTechPanel(document.body, state, {
+    onStartResearch: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.textContent).toContain('Turns remaining');
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts
+```
+
+Expected: FAIL because pacing helpers and the ETA language are not implemented yet.
+
+- [ ] **Step 3: Add pacing types and helpers**
+
+In `src/core/types.ts`, add:
+
+```typescript
+export type PacingBand =
+  | 'starter'
+  | 'core'
+  | 'specialist'
+  | 'infrastructure'
+  | 'power-spike'
+  | 'marquee';
+
+export type PacingContentType = 'building' | 'unit' | 'tech' | 'wonder';
+
+export interface PacingMetadata {
+  band: PacingBand;
+  role: string;
+  impact: number;
+  scope: 'city' | 'military' | 'empire';
+  snowball: number;
+  urgency: number;
+  situationality: number;
+  unlockBreadth: number;
+}
+```
+
+Create `src/systems/pacing-model.ts`:
+
+```typescript
+import type { PacingBand, PacingContentType } from '@/core/types';
+
+const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number, number] }> = {
+  starter: { early: [2, 4], late: [2, 5] },
+  core: { early: [3, 5], late: [4, 7] },
+  specialist: { early: [4, 6], late: [5, 8] },
+  infrastructure: { early: [5, 8], late: [6, 10] },
+  'power-spike': { early: [6, 9], late: [7, 11] },
+  marquee: { early: [10, 12], late: [10, 16] },
+};
+
+export function getTargetTurnWindow(input: { era: number; band: PacingBand; contentType: PacingContentType }): { min: number; max: number } {
+  const [min, max] = input.era <= 1 ? BAND_WINDOWS[input.band].early : BAND_WINDOWS[input.band].late;
+  return { min, max };
+}
+
+export function estimateTurnsToComplete(input: { cost: number; outputPerTurn: number }): number {
+  if (input.outputPerTurn <= 0) return Number.POSITIVE_INFINITY;
+  return Math.ceil(input.cost / input.outputPerTurn);
+}
+```
+
+- [ ] **Step 4: Retune the opening catalog and annotate starter items**
+
+In `src/systems/city-system.ts`, retune visible opening items and add pacing metadata:
+
+```typescript
+shrine: {
+  id: 'shrine',
+  name: 'Shrine',
+  category: 'culture',
+  yields: { food: 0, production: 0, gold: 0, science: 1 },
+  productionCost: 15,
+  description: 'Place of worship',
+  techRequired: null,
+  adjacencyBonuses: [],
+  pacing: {
+    band: 'starter',
+    role: 'early-science',
+    impact: 1,
+    scope: 'city',
+    snowball: 1.1,
+    urgency: 1.1,
+    situationality: 1,
+    unlockBreadth: 1,
+  },
+},
+barracks: {
+  id: 'barracks',
+  name: 'Barracks',
+  category: 'military',
+  yields: { food: 0, production: 0, gold: 0, science: 0 },
+  productionCost: 18,
+  description: 'A training ground. Required by future military doctrines.',
+  techRequired: null,
+  adjacencyBonuses: [],
+  pacing: {
+    band: 'starter',
+    role: 'military-enabler',
+    impact: 1,
+    scope: 'city',
+    snowball: 1,
+    urgency: 1.15,
+    situationality: 1,
+    unlockBreadth: 1.05,
+  },
+},
+```
+
+And:
+
+```typescript
+export const TRAINABLE_UNITS = [
+  { type: 'warrior', name: 'Warrior', cost: 15 },
+  { type: 'scout', name: 'Scout', cost: 12 },
+  { type: 'worker', name: 'Worker', cost: 20 },
+  // ...
+];
+```
+
+In `src/systems/tech-definitions.ts`, retune visible opening techs:
+
+```typescript
+{ id: 'fire', name: 'Fire', track: 'science', cost: 12, prerequisites: [], unlocks: ['Unlock basic research'], era: 1, pacing: { band: 'starter', role: 'foundational-science', impact: 1, scope: 'empire', snowball: 1.15, urgency: 1.1, situationality: 1, unlockBreadth: 1.1 } },
+{ id: 'gathering', name: 'Gathering', track: 'economy', cost: 12, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
+{ id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 12, prerequisites: [], unlocks: ['Basic governance'], era: 1, pacing: { band: 'starter', role: 'foundational-civics', impact: 1, scope: 'empire', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1.05 } },
+{ id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 12, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1, pacing: { band: 'starter', role: 'foundational-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
+{ id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 15, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
+```
+
+- [ ] **Step 5: Show ETAs in city and tech panels**
+
+In `src/ui/city-panel.ts`, keep the current turn display but make the active section explicit:
+
+```typescript
+<div style="font-size:12px;opacity:0.7;"><span data-text="prod-turns"></span> turns remaining</div>
+```
+
+And ensure build cards continue to show:
+
+```typescript
+<div style="font-size:11px;opacity:0.7;">${yieldStr}${turns} turns</div>
+```
+
+In `src/ui/tech-panel.ts`, update the summary block:
+
+```typescript
+function buildCurrentResearchSummary(currentTech: Tech | undefined, progress: number, turnsRemaining: number | null): HTMLDivElement | null {
+  if (!currentTech) {
+    return null;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.style.cssText = 'background:rgba(255,255,255,0.1);border-radius:10px;padding:12px;margin-bottom:16px;';
+
+  const heading = document.createElement('div');
+  heading.textContent = `Researching: ${currentTech.name}`;
+  heading.style.cssText = 'font-weight:bold;color:#e8c170;';
+  wrapper.appendChild(heading);
+
+  const summary = document.createElement('div');
+  summary.textContent = turnsRemaining === null
+    ? `${titleCase(currentTech.track)}`
+    : `${titleCase(currentTech.track)} · Turns remaining: ${turnsRemaining}`;
+  summary.style.cssText = 'font-size:12px;opacity:0.7;';
+  wrapper.appendChild(summary);
+
+  return wrapper;
+}
+```
+
+Then compute:
+
+```typescript
+const estimatedSciencePerTurn = 3;
+const turnsRemaining = currentTech
+  ? estimateTurnsToComplete({
+      cost: Math.max(0, currentTech.cost - civ.techState.researchProgress),
+      outputPerTurn: estimatedSciencePerTurn,
+    })
+  : null;
+```
+
+- [ ] **Step 6: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/pacing-model.ts src/systems/tech-definitions.ts src/systems/city-system.ts src/ui/city-panel.ts src/ui/tech-panel.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/types.ts src/systems/pacing-model.ts src/systems/tech-definitions.ts src/systems/city-system.ts src/ui/city-panel.ts src/ui/tech-panel.ts tests/systems/pacing-model.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts
+git commit -m "feat(pacing): speed up the opening and add eta feedback"
+```
+
+---
+
+## Task 2: City Planning Momentum
+
+**Goal:** Add a 3-item city production queue with reorder/remove controls and preserve scheduled work across city actions.
+
+**Why this task delivers value:** Players can keep cities progressing without revisiting the panel every completion, and the city panel will feel much more alive.
+
+**Files:**
+- Create: `src/systems/planning-system.ts`
+- Modify: `src/core/types.ts`
+- Modify: `src/core/game-state.ts`
+- Modify: `src/storage/save-manager.ts`
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/systems/legendary-wonder-system.ts`
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/planning-system.test.ts`
+- Test: `tests/systems/city-system.test.ts`
+- Test: `tests/systems/legendary-wonder-system.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/storage/save-persistence.test.ts`
+
+- [ ] **Step 1: Write the failing queue tests**
+
+Create `tests/systems/planning-system.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { enqueueCityProduction, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+
+describe('planning-system city queues', () => {
+  it('appends new city builds up to a limit of three', () => {
+    const city = { productionQueue: ['warrior'] } as any;
+    const queued = enqueueCityProduction(city, 'shrine');
+    expect(queued.productionQueue).toEqual(['warrior', 'shrine']);
+  });
+
+  it('reorders queue items without dropping them', () => {
+    expect(moveQueuedId(['warrior', 'shrine', 'worker'], 2, 0)).toEqual(['worker', 'warrior', 'shrine']);
+  });
+
+  it('removes queue items cleanly', () => {
+    expect(removeQueuedId(['warrior', 'shrine', 'worker'], 1)).toEqual(['warrior', 'worker']);
+  });
+});
+```
+
+Extend `tests/ui/city-panel.test.ts`:
+
+```typescript
+it('renders production queue rows with move and remove controls', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  city.productionQueue = ['warrior', 'shrine', 'worker'];
+
+  const panel = createCityPanel(container, city, state, {
+    onBuild: () => {},
+    onMoveQueueItem: () => {},
+    onRemoveQueueItem: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  } as any);
+
+  expect(panel.textContent).toContain('Queue');
+  expect(panel.querySelector('[data-queue-action="remove"]')).toBeTruthy();
+});
+```
+
+Extend `tests/systems/legendary-wonder-system.test.ts`:
+
+```typescript
+it('preserves existing queue entries when a legendary wonder starts', () => {
+  const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
+  state.cities['city-river'].productionQueue = ['library', 'warrior'];
+
+  const result = startLegendaryWonderBuild(state, 'player', 'city-river', 'oracle-of-delphi', new EventBus());
+
+  expect(result.cities['city-river'].productionQueue).toEqual(['legendary:oracle-of-delphi', 'library', 'warrior']);
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/planning-system.test.ts tests/ui/city-panel.test.ts tests/systems/legendary-wonder-system.test.ts tests/storage/save-persistence.test.ts
+```
+
+Expected: FAIL because the queue helpers and controls do not exist yet.
+
+- [ ] **Step 3: Add queue helpers and save-safe city state**
+
+In `src/systems/planning-system.ts`, add:
+
+```typescript
+import type { City } from '@/core/types';
+
+const MAX_QUEUE_ITEMS = 3;
+
+export function enqueueCityProduction(city: City, itemId: string): City {
+  if (city.productionQueue.includes(itemId)) return city;
+  if (city.productionQueue.length >= MAX_QUEUE_ITEMS) {
+    throw new Error('Queue limit reached');
+  }
+  return {
+    ...city,
+    productionQueue: [...city.productionQueue, itemId],
+  };
+}
+
+export function moveQueuedId<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+export function removeQueuedId<T>(items: T[], index: number): T[] {
+  return items.filter((_, currentIndex) => currentIndex !== index);
+}
+```
+
+In `src/storage/save-manager.ts`, keep old saves safe:
+
+```typescript
+function migrateLegacyPlanningState(state: GameState): GameState {
+  for (const city of Object.values(state.cities ?? {})) {
+    city.productionQueue ??= [];
+    if (city.productionQueue.length > 3) {
+      city.productionQueue = city.productionQueue.slice(0, 3);
+    }
+  }
+  return state;
+}
+```
+
+Thread that migration through the existing load paths.
+
+- [ ] **Step 4: Make city build actions append instead of replace**
+
+In `src/main.ts`, replace:
+
+```typescript
+targetCity.productionQueue = [itemId];
+targetCity.productionProgress = 0;
+```
+
+with:
+
+```typescript
+gameState.cities[cityId] = enqueueCityProduction(targetCity, itemId);
+renderLoop.setGameState(gameState);
+showNotification(`${targetCity.name}: queued ${itemId}`, 'info');
+```
+
+This preserves scheduled work and satisfies the `No Silent Destructive UI` rule.
+
+- [ ] **Step 5: Add queue controls to `createCityPanel`**
+
+Extend `CityPanelCallbacks`:
+
+```typescript
+export interface CityPanelCallbacks {
+  onBuild: (cityId: string, itemId: string) => void;
+  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => void;
+  onRemoveQueueItem?: (cityId: string, index: number) => void;
+  onOpenWonderPanel: (cityId: string) => void;
+  onClose: () => void;
+  onPrevCity?: () => void;
+  onNextCity?: () => void;
+}
+```
+
+Render a queue section:
+
+```typescript
+const queueRows = city.productionQueue.map((itemId, index) => `
+  <div data-queue-index="${index}" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+    <div>
+      <div style="font-weight:bold;">${itemId}</div>
+      <div style="font-size:11px;opacity:0.7;">Queue slot ${index + 1}</div>
+    </div>
+    <div style="display:flex;gap:6px;">
+      <button type="button" data-queue-action="up" data-queue-index="${index}">↑</button>
+      <button type="button" data-queue-action="down" data-queue-index="${index}">↓</button>
+      <button type="button" data-queue-action="remove" data-queue-index="${index}">✕</button>
+    </div>
+  </div>
+`).join('');
+```
+
+Wire the event listeners to `callbacks.onMoveQueueItem` and `callbacks.onRemoveQueueItem`.
+
+- [ ] **Step 6: Preserve queue tails for legendary wonders**
+
+In `src/systems/legendary-wonder-system.ts`, prepend the wonder instead of wiping the queue:
+
+```typescript
+const preservedTail = city.productionQueue.filter(item => item !== `legendary:${wonderId}`);
+
+productionQueue: [`legendary:${wonderId}`, ...preservedTail].slice(0, 3),
+```
+
+- [ ] **Step 7: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/planning-system.test.ts tests/ui/city-panel.test.ts tests/systems/city-system.test.ts tests/systems/legendary-wonder-system.test.ts tests/storage/save-persistence.test.ts
+scripts/check-src-rule-violations.sh src/core/types.ts src/core/game-state.ts src/storage/save-manager.ts src/systems/planning-system.ts src/systems/city-system.ts src/systems/legendary-wonder-system.ts src/ui/city-panel.ts src/main.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/types.ts src/core/game-state.ts src/storage/save-manager.ts src/systems/planning-system.ts src/systems/city-system.ts src/systems/legendary-wonder-system.ts src/ui/city-panel.ts src/main.ts tests/systems/planning-system.test.ts tests/systems/city-system.test.ts tests/systems/legendary-wonder-system.test.ts tests/ui/city-panel.test.ts tests/storage/save-persistence.test.ts
+git commit -m "feat(city-ui): add build queues and preserve scheduled work"
+```
+
+---
+
+## Task 3: Research Momentum And Better Tech Tree
+
+**Goal:** Add a 3-item research queue and redesign the tech panel so it emphasizes current research, available choices, and the next unlock layer instead of a giant wall of disabled items.
+
+**Why this task delivers value:** Players will feel less overwhelmed, see that progress is real, and avoid repeated “pick one tech, wait, reopen” friction.
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/storage/save-manager.ts`
+- Modify: `src/systems/planning-system.ts`
+- Modify: `src/systems/tech-system.ts`
+- Modify: `src/ui/tech-panel.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/planning-system.test.ts`
+- Test: `tests/systems/tech-system.test.ts`
+- Test: `tests/ui/tech-panel.test.ts`
+- Test: `tests/storage/save-persistence.test.ts`
+
+- [ ] **Step 1: Write the failing research-queue and layered-UI tests**
+
+Extend `tests/systems/planning-system.test.ts`:
+
+```typescript
+import { enqueueResearch } from '@/systems/planning-system';
+
+it('starts research immediately and queues follow-up techs after that', () => {
+  const techState = {
+    completed: [],
+    currentResearch: null,
+    researchQueue: [],
+    researchProgress: 0,
+    trackPriorities: {} as any,
+  };
+
+  const started = enqueueResearch(techState, 'fire');
+  const queued = enqueueResearch(started, 'writing');
+
+  expect(started.currentResearch).toBe('fire');
+  expect(queued.researchQueue).toEqual(['writing']);
+});
+```
+
+Extend `tests/ui/tech-panel.test.ts`:
+
+```typescript
+it('keeps deep locked items out of the default view while keeping a show-all affordance', () => {
+  const state = createNewGame(undefined, 'tech-layer-test');
+  const panel = createTechPanel(document.body, state, {
+    onQueueResearch: () => {},
+    onMoveQueuedResearch: () => {},
+    onRemoveQueuedResearch: () => {},
+    onClose: () => {},
+  } as any);
+
+  expect(panel.querySelector('[data-action="show-all-techs"]')).toBeTruthy();
+});
+
+it('renders research queue controls', () => {
+  const state = createNewGame(undefined, 'tech-queue-test');
+  state.civilizations.player.techState.currentResearch = 'fire';
+  state.civilizations.player.techState.researchQueue = ['writing', 'wheel'];
+
+  const panel = createTechPanel(document.body, state, {
+    onQueueResearch: () => {},
+    onMoveQueuedResearch: () => {},
+    onRemoveQueuedResearch: () => {},
+    onClose: () => {},
+  } as any);
+
+  expect(panel.textContent).toContain('Research Queue');
+  expect(panel.querySelector('[data-queue-action="remove"]')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/planning-system.test.ts tests/systems/tech-system.test.ts tests/ui/tech-panel.test.ts tests/storage/save-persistence.test.ts
+```
+
+Expected: FAIL because `researchQueue` and the new panel behavior do not exist.
+
+- [ ] **Step 3: Add `researchQueue` to `TechState` and migrate old saves**
+
+In `src/core/types.ts`:
+
+```typescript
+export interface TechState {
+  completed: string[];
+  currentResearch: string | null;
+  researchQueue: string[];
+  researchProgress: number;
+  trackPriorities: Record<TechTrack, 'high' | 'medium' | 'low' | 'ignore'>;
+}
+```
+
+In `src/systems/tech-system.ts`, update `createTechState()`:
+
+```typescript
+return {
+  completed: [],
+  currentResearch: null,
+  researchQueue: [],
+  researchProgress: 0,
+  trackPriorities: { /* existing defaults */ },
+};
+```
+
+In `src/storage/save-manager.ts`:
+
+```typescript
+for (const civ of Object.values(state.civilizations ?? {})) {
+  civ.techState.researchQueue ??= [];
+}
+```
+
+- [ ] **Step 4: Add shared research queue helpers and progression**
+
+In `src/systems/planning-system.ts`:
+
+```typescript
+import type { TechState } from '@/core/types';
+
+export function enqueueResearch(state: TechState, techId: string): TechState {
+  if (state.completed.includes(techId) || state.currentResearch === techId || state.researchQueue.includes(techId)) {
+    return state;
+  }
+
+  if (!state.currentResearch) {
+    return { ...state, currentResearch: techId, researchProgress: 0 };
+  }
+
+  if (1 + state.researchQueue.length >= 3) {
+    throw new Error('Queue limit reached');
+  }
+
+  return { ...state, researchQueue: [...state.researchQueue, techId] };
+}
+```
+
+In `src/systems/tech-system.ts`, auto-advance on completion:
+
+```typescript
+if (newProgress >= tech.cost) {
+  const [nextQueuedResearch, ...remainingQueue] = state.researchQueue;
+  return {
+    state: {
+      ...state,
+      completed: [...state.completed, tech.id],
+      currentResearch: nextQueuedResearch ?? null,
+      researchQueue: remainingQueue,
+      researchProgress: 0,
+    },
+    completedTech: tech.id,
+  };
+}
+```
+
+- [ ] **Step 5: Rebuild the tech panel around visible layers and queue controls**
+
+Update the callbacks:
+
+```typescript
+export interface TechPanelCallbacks {
+  onQueueResearch: (techId: string) => void;
+  onMoveQueuedResearch: (fromIndex: number, toIndex: number) => void;
+  onRemoveQueuedResearch: (index: number) => void;
+  onClose: () => void;
+}
+```
+
+Add a helper to compute next-layer tech ids:
+
+```typescript
+function getNextLayerTechIds(civ: GameState['civilizations'][string]): Set<string> {
+  const availableIds = new Set(getAvailableTechs(civ.techState).map(tech => tech.id));
+  const completedIds = new Set(civ.techState.completed);
+  return new Set(
+    TECH_TREE
+      .filter(tech => !availableIds.has(tech.id) && !completedIds.has(tech.id))
+      .filter(tech => tech.prerequisites.some(prereq => availableIds.has(prereq) || civ.techState.currentResearch === prereq))
+      .map(tech => tech.id),
+  );
+}
+```
+
+Default rendering rules:
+
+- show current research
+- show available-now techs
+- show next-layer techs
+- do not show deep locked items by default
+- show a `Show all techs` button to expose the full catalog
+
+Render a `Research Queue` section mirroring the city queue pattern.
+
+- [ ] **Step 6: Wire `main.ts` to enqueue, reorder, and remove research**
+
+In `src/main.ts`:
+
+```typescript
+createTechPanel(uiLayer, gameState, {
+  onQueueResearch: (techId) => {
+    currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
+    renderLoop.setGameState(gameState);
+    updateHUD();
+  },
+  onMoveQueuedResearch: (fromIndex, toIndex) => {
+    currentCiv().techState = {
+      ...currentCiv().techState,
+      researchQueue: moveQueuedId(currentCiv().techState.researchQueue, fromIndex, toIndex),
+    };
+    renderLoop.setGameState(gameState);
+    updateHUD();
+  },
+  onRemoveQueuedResearch: (index) => {
+    currentCiv().techState = {
+      ...currentCiv().techState,
+      researchQueue: removeQueuedId(currentCiv().techState.researchQueue, index),
+    };
+    renderLoop.setGameState(gameState);
+    updateHUD();
+  },
+  onClose: () => {},
+});
+```
+
+- [ ] **Step 7: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/planning-system.test.ts tests/systems/tech-system.test.ts tests/ui/tech-panel.test.ts tests/storage/save-persistence.test.ts
+scripts/check-src-rule-violations.sh src/core/types.ts src/storage/save-manager.ts src/systems/planning-system.ts src/systems/tech-system.ts src/ui/tech-panel.ts src/main.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/core/types.ts src/storage/save-manager.ts src/systems/planning-system.ts src/systems/tech-system.ts src/ui/tech-panel.ts src/main.ts tests/systems/planning-system.test.ts tests/systems/tech-system.test.ts tests/ui/tech-panel.test.ts tests/storage/save-persistence.test.ts
+git commit -m "feat(tech-ui): add research queues and layered tree focus"
+```
+
+---
+
+## Task 4: No More Accidental Idle Turns
+
+**Goal:** Block end turn when the player has idle production or idle research with valid options, and present a helpful chooser instead of letting the player waste turns.
+
+**Why this task delivers value:** Players stop losing momentum to accidental empty queues and immediately feel the game is guiding them toward meaningful play.
+
+**Files:**
+- Create: `src/ui/required-choice-panel.ts`
+- Modify: `src/systems/planning-system.ts`
+- Modify: `src/ui/tutorial.ts`
+- Modify: `src/ui/advisor-system.ts`
+- Modify: `src/main.ts`
+- Test: `tests/ui/required-choice-panel.test.ts`
+- Test: `tests/ui/tutorial.test.ts`
+- Test: `tests/ui/advisor-system.test.ts`
+- Test: `tests/integration/end-turn-gating.test.ts`
+
+- [ ] **Step 1: Write the failing required-choice tests**
+
+Create `tests/ui/required-choice-panel.test.ts`:
+
+```typescript
+import { describe, expect, it, vi } from 'vitest';
+import { createRequiredChoicePanel } from '@/ui/required-choice-panel';
+
+describe('required-choice-panel', () => {
+  it('renders both research and production prompts with actionable buttons', () => {
+    const panel = createRequiredChoicePanel(document.body, {
+      researchChoices: [{ techId: 'fire', label: 'Fire', turns: 4 }],
+      cityChoices: [{ cityId: 'city-1', cityName: 'Roma', itemId: 'warrior', label: 'Warrior', turns: 3 }],
+      onChooseResearch: vi.fn(),
+      onChooseCityBuild: vi.fn(),
+      onOpenTech: vi.fn(),
+      onOpenCity: vi.fn(),
+    });
+
+    expect(panel.textContent).toContain('Choose Research');
+    expect(panel.textContent).toContain('Choose Production');
+  });
+});
+```
+
+Create `tests/integration/end-turn-gating.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { needsResearchChoice } from '@/systems/planning-system';
+
+describe('end-turn gating', () => {
+  it('detects when the player has no active research but valid options exist', () => {
+    const state = createNewGame(undefined, 'end-turn-gating-seed', 'small');
+    expect(needsResearchChoice(state, state.currentPlayer)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/required-choice-panel.test.ts tests/ui/tutorial.test.ts tests/ui/advisor-system.test.ts tests/integration/end-turn-gating.test.ts
+```
+
+Expected: FAIL because the shared idle-choice helpers and required-choice panel do not exist.
+
+- [ ] **Step 3: Add shared idle-choice helpers**
+
+Extend `src/systems/planning-system.ts`:
+
+```typescript
+import type { GameState } from '@/core/types';
+import { getAvailableTechs } from '@/systems/tech-system';
+import { getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
+
+export function getIdleCityIds(state: GameState, civId: string): string[] {
+  const completedTechs = state.civilizations[civId]?.techState.completed ?? [];
+  return Object.values(state.cities)
+    .filter(city => city.owner === civId)
+    .filter(city => city.productionQueue.length === 0)
+    .filter(city => {
+      const buildableBuildings = getAvailableBuildings(city, completedTechs).length > 0;
+      const buildableUnits = TRAINABLE_UNITS.some(unit => !unit.techRequired || completedTechs.includes(unit.techRequired));
+      return buildableBuildings || buildableUnits;
+    })
+    .map(city => city.id);
+}
+
+export function needsResearchChoice(state: GameState, civId: string): boolean {
+  const civ = state.civilizations[civId];
+  if (!civ) return false;
+  if (civ.techState.currentResearch) return false;
+  return getAvailableTechs(civ.techState).length > 0;
+}
+```
+
+- [ ] **Step 4: Add the required-choice panel**
+
+Create `src/ui/required-choice-panel.ts`:
+
+```typescript
+export function createRequiredChoicePanel(
+  container: HTMLElement,
+  config: {
+    researchChoices: Array<{ techId: string; label: string; turns: number }>;
+    cityChoices: Array<{ cityId: string; cityName: string; itemId: string; label: string; turns: number }>;
+    onChooseResearch: (techId: string) => void;
+    onChooseCityBuild: (cityId: string, itemId: string) => void;
+    onOpenTech: () => void;
+    onOpenCity: (cityId: string) => void;
+  },
+): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'required-choice-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:40;padding:16px;overflow:auto;';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Choose Your Next Step';
+  panel.appendChild(title);
+
+  const researchHeading = document.createElement('h3');
+  researchHeading.textContent = 'Choose Research';
+  panel.appendChild(researchHeading);
+
+  const cityHeading = document.createElement('h3');
+  cityHeading.textContent = 'Choose Production';
+  panel.appendChild(cityHeading);
+
+  container.appendChild(panel);
+  return panel;
+}
+```
+
+Use `textContent` / `createElement()` throughout.
+
+- [ ] **Step 5: Gate `endTurn()` and align tutorial/advisor prompts**
+
+In `src/main.ts`, add:
+
+```typescript
+function showRequiredChoicesIfNeeded(): boolean {
+  const civId = gameState.currentPlayer;
+  const idleCityIds = getIdleCityIds(gameState, civId);
+  const missingResearch = needsResearchChoice(gameState, civId);
+
+  if (!idleCityIds.length && !missingResearch) {
+    return false;
+  }
+
+  uiInteractions.setBlockingOverlay('required-choice');
+  createRequiredChoicePanel(uiLayer, {
+    researchChoices: [],
+    cityChoices: idleCityIds.map(cityId => ({ cityId, cityName: gameState.cities[cityId].name, itemId: 'warrior', label: 'Warrior', turns: 3 })),
+    onChooseResearch: (techId) => {
+      currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
+      document.getElementById('required-choice-panel')?.remove();
+      uiInteractions.setBlockingOverlay(null);
+      renderLoop.setGameState(gameState);
+      updateHUD();
+    },
+    onChooseCityBuild: (cityId, itemId) => {
+      const city = gameState.cities[cityId];
+      if (!city) return;
+      gameState.cities[cityId] = enqueueCityProduction(city, itemId);
+      document.getElementById('required-choice-panel')?.remove();
+      uiInteractions.setBlockingOverlay(null);
+      renderLoop.setGameState(gameState);
+      updateHUD();
+    },
+    onOpenTech: () => togglePanel('tech'),
+    onOpenCity: (cityId) => openCityPanelForCity(gameState.cities[cityId]),
+  });
+
+  return true;
+}
+```
+
+At the top of `endTurn()`:
+
+```typescript
+if (showRequiredChoicesIfNeeded()) {
+  showNotification('Choose production and research before ending the turn.', 'info');
+  return;
+}
+```
+
+In `src/ui/tutorial.ts`, replace the current checks:
+
+```typescript
+trigger: (state) => needsResearchChoice(state, state.currentPlayer) && state.turn >= 2,
+```
+
+and:
+
+```typescript
+trigger: (state) => getIdleCityIds(state, state.currentPlayer).length > 0,
+```
+
+In `src/ui/advisor-system.ts`, replace the existing `cities[0]` / `currentResearch === null` idle logic with the same shared helpers.
+
+- [ ] **Step 6: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/required-choice-panel.test.ts tests/ui/tutorial.test.ts tests/ui/advisor-system.test.ts tests/integration/end-turn-gating.test.ts
+scripts/check-src-rule-violations.sh src/systems/planning-system.ts src/ui/required-choice-panel.ts src/ui/tutorial.ts src/ui/advisor-system.ts src/main.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/planning-system.ts src/ui/required-choice-panel.ts src/ui/tutorial.ts src/ui/advisor-system.ts src/main.ts tests/ui/required-choice-panel.test.ts tests/ui/tutorial.test.ts tests/ui/advisor-system.test.ts tests/integration/end-turn-gating.test.ts
+git commit -m "feat(turn-flow): block accidental idle turns with required choices"
+```
+
+---
+
+## Task 5: Local Balance Audit And Debug View
+
+**Goal:** Add deterministic, local-only pacing audit/debug tools and use them to validate the current retuned catalog.
+
+**Why this task delivers value:** Developers and playtesters can inspect pacing locally, and the retune becomes easier to trust and maintain without a server.
+
+**Files:**
+- Create: `src/systems/pacing-audit.ts`
+- Create: `src/ui/pacing-debug-panel.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/pacing-audit.test.ts`
+- Test: `tests/integration/pacing-simulation.test.ts`
+
+- [ ] **Step 1: Write the failing audit and simulation tests**
+
+Create `tests/systems/pacing-audit.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { buildPacingAudit } from '@/systems/pacing-audit';
+
+describe('pacing-audit', () => {
+  it('returns audit rows for current techs, units, and buildings', () => {
+    const rows = buildPacingAudit();
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.some(row => row.id === 'warrior')).toBe(true);
+    expect(rows.some(row => row.id === 'fire')).toBe(true);
+  });
+});
+```
+
+Create `tests/integration/pacing-simulation.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
+import { foundCity } from '@/systems/city-system';
+
+describe('pacing simulation', () => {
+  it('produces an early completion within a few turns on a deterministic seed', () => {
+    const state = createNewGame(undefined, 'pacing-sim-seed', 'small');
+    const bus = new EventBus();
+    const city = foundCity('player', state.units[state.civilizations.player.units[0]].position, state.map);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.cities[city.id].productionQueue = ['warrior'];
+    state.civilizations.player.techState.currentResearch = 'fire';
+
+    let next = state;
+    let warriorDone = false;
+    let fireDone = false;
+
+    for (let i = 0; i < 6; i++) {
+      next = processTurn(next, bus);
+      warriorDone = warriorDone || Object.values(next.units).some(unit => unit.owner === 'player' && unit.type === 'warrior' && unit.id !== state.civilizations.player.units[1]);
+      fireDone = fireDone || next.civilizations.player.techState.completed.includes('fire');
+    }
+
+    expect(warriorDone || fireDone).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-audit.test.ts tests/integration/pacing-simulation.test.ts
+```
+
+Expected: FAIL because the audit module and debug surface do not exist yet.
+
+- [ ] **Step 3: Add a local audit builder**
+
+Create `src/systems/pacing-audit.ts`:
+
+```typescript
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { estimateTurnsToComplete, getTargetTurnWindow } from '@/systems/pacing-model';
+
+export interface PacingAuditRow {
+  id: string;
+  label: string;
+  contentType: 'building' | 'unit' | 'tech';
+  era: number;
+  band: string;
+  currentCost: number;
+  estimatedTurns: number;
+  target: { min: number; max: number };
+}
+
+export function buildPacingAudit(): PacingAuditRow[] {
+  return [
+    ...Object.values(BUILDINGS).map(building => ({
+      id: building.id,
+      label: building.name,
+      contentType: 'building' as const,
+      era: building.techRequired ? 2 : 1,
+      band: building.pacing?.band ?? 'core',
+      currentCost: building.productionCost,
+      estimatedTurns: estimateTurnsToComplete({ cost: building.productionCost, outputPerTurn: 4 }),
+      target: getTargetTurnWindow({ era: building.techRequired ? 2 : 1, band: building.pacing?.band ?? 'core', contentType: 'building' }),
+    })),
+    ...TRAINABLE_UNITS.map(unit => ({
+      id: unit.type,
+      label: unit.name,
+      contentType: 'unit' as const,
+      era: unit.techRequired ? 2 : 1,
+      band: unit.type === 'warrior' || unit.type === 'scout' ? 'starter' : 'core',
+      currentCost: unit.cost,
+      estimatedTurns: estimateTurnsToComplete({ cost: unit.cost, outputPerTurn: 4 }),
+      target: getTargetTurnWindow({ era: unit.techRequired ? 2 : 1, band: unit.type === 'warrior' || unit.type === 'scout' ? 'starter' : 'core', contentType: 'unit' }),
+    })),
+    ...TECH_TREE.map(tech => ({
+      id: tech.id,
+      label: tech.name,
+      contentType: 'tech' as const,
+      era: tech.era,
+      band: tech.pacing?.band ?? 'core',
+      currentCost: tech.cost,
+      estimatedTurns: estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: tech.era === 1 ? 3 : 8 }),
+      target: getTargetTurnWindow({ era: tech.era, band: tech.pacing?.band ?? 'core', contentType: 'tech' }),
+    })),
+  ];
+}
+```
+
+- [ ] **Step 4: Add a local-only pacing debug panel**
+
+Create `src/ui/pacing-debug-panel.ts`:
+
+```typescript
+import type { GameState } from '@/core/types';
+import { buildPacingAudit } from '@/systems/pacing-audit';
+
+export function createPacingDebugPanel(container: HTMLElement, _state: GameState): HTMLElement {
+  const panel = document.createElement('div');
+  panel.id = 'pacing-debug-panel';
+  panel.style.cssText = 'position:absolute;top:12px;right:12px;z-index:45;background:rgba(0,0,0,0.88);color:white;padding:12px;border-radius:10px;width:320px;max-height:70vh;overflow:auto;';
+
+  const title = document.createElement('h3');
+  title.textContent = 'Pacing Debug';
+  panel.appendChild(title);
+
+  buildPacingAudit().slice(0, 12).forEach(row => {
+    const entry = document.createElement('div');
+    entry.textContent = `${row.label}: ${row.estimatedTurns} turns (target ${row.target.min}-${row.target.max})`;
+    entry.style.cssText = 'font-size:12px;margin-bottom:6px;';
+    panel.appendChild(entry);
+  });
+
+  container.appendChild(panel);
+  return panel;
+}
+```
+
+Wire it in `src/main.ts` behind a developer-only toggle, for example:
+
+```typescript
+let pacingDebugOpen = false;
+window.addEventListener('keydown', event => {
+  if (event.key === '`') {
+    pacingDebugOpen = !pacingDebugOpen;
+    document.getElementById('pacing-debug-panel')?.remove();
+    if (pacingDebugOpen) {
+      createPacingDebugPanel(uiLayer, gameState);
+    }
+  }
+});
+```
+
+- [ ] **Step 5: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-audit.test.ts tests/integration/pacing-simulation.test.ts
+scripts/check-src-rule-violations.sh src/systems/pacing-audit.ts src/ui/pacing-debug-panel.ts src/main.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/pacing-audit.ts src/ui/pacing-debug-panel.ts src/main.ts tests/systems/pacing-audit.test.ts tests/integration/pacing-simulation.test.ts
+git commit -m "feat(balance): add local pacing audit and debug tools"
+```
+
+---
+
+## Verification Checklist Per Task
+
+For every task above, complete all of the following before moving on:
+
+- [ ] Feature behavior is visible in the browser or clearly demonstrable from tests
+- [ ] Targeted tests pass
+- [ ] `scripts/check-src-rule-violations.sh` passes for changed `src/` files
+- [ ] Relevant UI/reachability regressions are covered
+- [ ] No pre-existing queue content is silently discarded
+- [ ] Save/load behavior is still correct when queue state changes
+- [ ] The task’s MR diff is small enough to review comfortably
+
+---
+
+## Self-Review
+
+### Spec Coverage
+
+- Faster early pacing: Task 1
+- ETA visibility in city and tech UI: Task 1
+- City 3-item queue with reorder/remove: Task 2
+- Research 3-item queue with reorder/remove: Task 3
+- Issue `#56` tech tree redesign: Task 3
+- Forced player choice for idle production/research: Task 4
+- Browser-only local audit/debug tooling: Task 5
+
+### User-Value Check
+
+Every task now ends in something the player will notice:
+
+- Task 1: faster opening plus ETA feedback
+- Task 2: city queues and smoother city momentum
+- Task 3: research queues and a better tech tree
+- Task 4: no more accidental idle turns
+- Task 5: visible local pacing/debug inspection and safer broader tuning
+
+### Reviewability Check
+
+Every task is a single MR theme with bounded file touch points and targeted verification.
+
+## Execution Handoff
+
+Plan updated and saved to `docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md`.
+
+Recommended execution approach:
+
+**1. Subagent-Driven** - one fresh implementation agent per task, with review between tasks. Best fit for the “each MR should be easy to review and deliver user value” requirement.
+
+**2. Inline Execution** - do the tasks in this session with checkpoints after each slice.
+
+If you want, I can start with **Task 1** and keep each slice MR-shaped from the beginning.

--- a/docs/superpowers/specs/2026-04-16-game-pacing-overhaul-design.md
+++ b/docs/superpowers/specs/2026-04-16-game-pacing-overhaul-design.md
@@ -1,0 +1,643 @@
+# Game Pacing Overhaul Design Specification
+
+**Date:** 2026-04-16
+**Status:** Proposed
+**Depends on:** Current `main` as of 2026-04-16
+**Goal:** Make Conquestoria feel active, rewarding, and strategically rich from the first turns onward by overhauling pacing, build/research flow, and the surfaces that communicate progress.
+
+---
+
+## 1. Intent
+
+The current early game is too slow in the wrong ways. The problem is not only that numbers are high. The problem is that the player spends too many turns with little visible payoff, too many disabled choices, and too many opportunities to accidentally do nothing productive.
+
+This design keeps the game's breadth of choices. It does **not** solve pacing by shrinking the tech tree, deleting buildings, or flattening the roster. Instead, it changes how quickly different kinds of content should arrive, how that timing is calculated, and how the UI keeps momentum visible.
+
+The desired experience is:
+
+- the early game feels alive within the first few turns
+- foundational units, buildings, and techs arrive fast enough to create momentum
+- later eras contain both quick wins and longer projects
+- the player can always see what is progressing, what comes next, and how long it will take
+- the game does not allow avoidable idle states when valid choices exist
+
+This is a design for a **medium-length campaign with a snappy opening**.
+
+---
+
+## 2. Product Goals
+
+### 2.1 Primary Goals
+
+- Reduce boring early turns and dead air in Era 1
+- Preserve the full breadth of tech, unit, and building choices
+- Establish a repeatable cost formula for future content additions
+- Make pacing legible in the UI through clear turn estimates and clearer progression presentation
+- Prevent "I ended turn but nothing meaningful was queued" states for human players
+- Add light forward planning tools so turns continue to feel active after completions
+
+### 2.2 Secondary Goals
+
+- Make later eras reachable in normal playtests without making the entire campaign feel trivial
+- Improve the feel of the tech tree by addressing issue `#56`
+- Ensure browser-only, offline-friendly balance analysis and pacing validation
+- Keep all new systems compatible with save/load, local storage, and the existing event-driven architecture
+
+### 2.3 Non-Goals
+
+This design does not:
+
+- require a server, analytics backend, or remote telemetry
+- reduce the number of tech tracks or the overall content breadth
+- automate the player's empire so heavily that choices stop mattering
+- promise final numeric costs in the spec itself
+- redesign victory conditions
+
+---
+
+## 3. Current Diagnosis
+
+The current "nothing is happening" feel comes from several compounding issues:
+
+1. **Basic early costs are too slow for the available output**
+   Era 1 cities begin with modest production and science, but many foundational units, buildings, and techs still take too many turns relative to how early they matter.
+
+2. **The tech tree presents too much disabled content at once**
+   The current panel shows an overwhelming wall of options, including many items the player cannot act on yet. This makes progression feel blocked rather than branching.
+
+3. **Progress is not communicated strongly enough**
+   The player can see costs, but not always the right "how soon will this change my game?" framing. The missing or insufficient ETA emphasis contributes to the sense of stall.
+
+4. **The game allows unproductive idle states**
+   Human players can have cities building nothing or research set to nothing even when valid options exist. This creates avoidable dead turns and makes the game feel less responsive than it is.
+
+5. **Completions do not chain into momentum**
+   Even after something finishes, the player may need to manually revisit each surface before progress resumes. This makes advancement feel stop-start instead of continuous.
+
+The pacing overhaul must address all five, not only raw cost tables.
+
+---
+
+## 4. Pacing Philosophy
+
+Conquestoria should feel active from the opening turns without losing strategic breadth.
+
+The balancing philosophy is:
+
+- foundational choices should arrive quickly enough to teach the game and create momentum
+- not all discoveries should take the same amount of time
+- not all builds should take the same amount of time
+- some things should feel like quick breakthroughs
+- some things should feel like long, deliberate investments
+- long waits are acceptable only when the payoff feels transformative
+
+The game's pacing should be inspired by the real world's uneven tempo of discovery and construction, but fun takes precedence over simulation. Historical intuition can inform whether a thing feels like a fast follow-up, a deliberate infrastructure project, or a marquee breakthrough. Historical realism must not justify boring waits for basic game actions.
+
+The central question is not "How many turns long is the campaign?" The central question is "How often does the player get meaningful progress, new capability, or a satisfying next step?"
+
+---
+
+## 5. Campaign Target
+
+The target is a **medium campaign** with a **snappy opening**.
+
+Interpretation:
+
+- the game should commonly reach later eras in normal play
+- the campaign should still have weight and escalation
+- the opening should not feel like a long prelude before the game begins
+
+Era 1 targets:
+
+- foundational units and buildings should often complete in roughly `3-4` turns in a new capital
+- foundational techs should complete quickly enough that early research feels like momentum, not homework
+- there should be visible movement in the player's empire almost every few turns
+
+Later-era target:
+
+- later eras should contain a mixture of quick, medium, and long projects
+- later projects may take longer, but there should still be shorter follow-up options available
+- the game should avoid eras where every meaningful choice becomes uniformly slow
+
+---
+
+## 6. Pacing Bands
+
+Every costed item should belong to a pacing band. The band determines the intended time-to-payoff profile before item-specific modifiers are applied.
+
+### 6.1 Bands
+
+| Band | Purpose | Era 1 target | Later-era target |
+|---|---|---:|---:|
+| `starter` | Immediate momentum and onboarding payoff | `2-4` turns | `2-5` turns |
+| `core` | Bread-and-butter progression | `3-5` turns | `4-7` turns |
+| `specialist` | Niche or synergy-driven options | `4-6` turns | `5-8` turns |
+| `infrastructure` | Long-term empire investments | `5-8` turns | `6-10` turns |
+| `power-spike` | Strong capability jumps or broad accelerants | `6-9` turns | `7-11` turns |
+| `marquee` | Transformative capstones and wonders | `10+` turns | `10-16+` turns |
+
+### 6.2 Example Intent
+
+- `starter`: warrior, scout, shrine, first-step research that unlocks immediate new play
+- `core`: library, workshop, archer, everyday research that develops an empire normally
+- `specialist`: mounted, naval, espionage, diplomacy, or counter-focused branches
+- `infrastructure`: aqueduct-like, trade-network-like, growth-network-like content
+- `power-spike`: strong empire-wide boosters, strong military breakpoints, broad unlock hubs
+- `marquee`: legendary wonders and major capstone-like investments
+
+### 6.3 Band Rules
+
+- A band describes intended pacing, not thematic importance
+- Two items in the same era may intentionally land in very different turn windows
+- Early foundational military, economy, and science options should rarely be above `core`
+- A long wait is allowed only if the item changes the game meaningfully enough to earn that wait
+
+---
+
+## 7. Cost Formula Framework
+
+The game should move from hand-authored ad hoc costs toward a metadata-driven formula.
+
+### 7.1 Core Formula
+
+For any costed item:
+
+`recommended_cost = expected_output_profile * target_turn_window * item_modifiers`
+
+Where:
+
+- `expected_output_profile` is the expected production or science available for the relevant stage of the game
+- `target_turn_window` comes from `band x era x content type`
+- `item_modifiers` adjust for scope, unlock power, urgency, and specialization
+
+### 7.2 Content Types
+
+The formula should operate separately for at least:
+
+- `building`
+- `unit`
+- `tech`
+- `wonder`
+
+Different content types use different expected-output profiles:
+
+- city production for buildings and units
+- empire science for techs
+- city or empire production assumptions for wonders depending on final implementation
+
+### 7.3 Required Metadata
+
+Each costed item should eventually declare:
+
+- `era`
+- `contentType`
+- `pacingBand`
+- `role`
+- `impact`
+- `scope`
+- `snowballRisk`
+- `urgency`
+- `situationality`
+- `unlockBreadth`
+
+Suggested interpretation:
+
+- `impact`: how strong the direct payoff is
+- `scope`: local city, local military role, or empire-wide
+- `snowballRisk`: how strongly the item accelerates future output
+- `urgency`: whether the player needs access quickly to avoid frustration or helplessness
+- `situationality`: how niche the item is
+- `unlockBreadth`: how much downstream content this item opens
+
+### 7.4 Modifier Principles
+
+- Empire-wide accelerants should cost more than local equivalents
+- High-snowball items should cost more than low-snowball items in the same band
+- Niche or situational items may be cheaper than universally useful items
+- Defensive or foundational basics should not be overpriced
+- Unlock hubs that gate many follow-up choices should be priced carefully so the player does not feel bottlenecked out of whole categories
+
+### 7.5 Human-Friendly Numbers
+
+Recommended costs should be rounded to human-friendly values so the final roster still feels authored rather than machine-generated.
+
+---
+
+## 8. Era Output Profiles
+
+The formula depends on expected output assumptions. These assumptions must be explicit and local to the repository.
+
+### 8.1 Purpose
+
+Era output profiles provide the baseline production and science that the formula expects an average player empire to have when evaluating item timing.
+
+### 8.2 Profile Types
+
+At minimum, define local profiles for:
+
+- `new capital`
+- `developed single city`
+- `small empire`
+- `midgame empire`
+- `lategame empire`
+
+The exact implementation can evolve, but the important point is that costs are compared against a declared expectation instead of vibes.
+
+### 8.3 Design Constraint
+
+Profiles are not telemetry. They are authored local balance assumptions, calibrated through local simulations and playtests.
+
+---
+
+## 9. Browser-Only Balance And Validation Tooling
+
+This project is a browser game with local storage and no server. All balance analysis must be local, deterministic, and repo-native.
+
+### 9.1 Offline Balance Audit
+
+Create a developer-facing local audit tool that:
+
+- reads tech, building, unit, and wonder definitions from local files
+- applies the cost formula
+- reports current cost vs recommended cost
+- shows estimated completion turns under the configured output profiles
+- flags outliers and suspicious bottlenecks
+
+The output can be CLI text, JSON, Markdown, or all three. It does not depend on a backend.
+
+### 9.2 Deterministic Local Simulation
+
+Create a local simulation or scripted playtest harness that can run from fixed seeds and output comparable summaries such as:
+
+- turn of first completed unit/building/tech
+- turn of first era advance
+- number of dead turns
+- average completion times by category
+- pacing variance across seeds
+
+This should be deterministic so that changes in pacing are attributable to code and data changes rather than noise.
+
+### 9.3 In-Browser Debug Telemetry
+
+Add an optional local-only debug view or export path that can surface pacing-relevant information during playtests:
+
+- production per turn
+- science per turn
+- current item ETA
+- queued next items
+- recent completion timeline
+- current idle warnings
+- dead-turn streak counter
+
+If needed, the data can be manually copied or downloaded. No remote collection is required.
+
+### 9.4 Success Standard
+
+The game should be balanceable and reviewable by developers and playtesters using only local tools, saved games, seeded runs, and optional exported local reports.
+
+---
+
+## 10. Tech Tree UX Overhaul
+
+This design explicitly absorbs issue `#56`.
+
+### 10.1 Problem
+
+The current tech panel is too long, too scroll-heavy, and shows too many disabled options at once. This contributes directly to the "nothing is happening" feel because the player's eye is drawn to unavailable content instead of reachable momentum.
+
+### 10.2 Required Direction
+
+The tech tree should present research as a dependency-driven progression surface, not a giant list of tracks with large blocks of unavailable entries.
+
+Required behavior:
+
+- display research as a dependency tree or dependency-aware progression surface
+- default emphasis should be on:
+  - current research
+  - available now
+  - next unlock layer
+- de-emphasize deeper locked items instead of presenting a full overwhelming wall of disabled entries
+
+### 10.3 ETA Requirements
+
+The tech UI must show:
+
+- turns remaining for the active research
+- estimated turns for each currently available tech
+- clear visual distinction between quick picks and long investments
+
+### 10.4 Pacing-Friendly UX Goals
+
+The player should be able to answer all of these quickly:
+
+- What am I researching right now?
+- How long until it finishes?
+- Which techs can I pick immediately after this?
+- Which options are quick momentum plays?
+- Which options are bigger investments?
+
+### 10.5 Locked Content Treatment
+
+Deeply locked items should not dominate the screen.
+
+Acceptable patterns:
+
+- collapsed future layers
+- faint dependency previews
+- optional expand-to-see-full-tree behavior
+
+Unacceptable pattern:
+
+- default view as an oversized scroll of mostly disabled cards
+
+---
+
+## 11. City Production UX Overhaul
+
+The city panel must communicate pacing as clearly as the tech panel.
+
+### 11.1 ETA Requirements
+
+For buildable buildings and units, the city panel should show:
+
+- estimated turns to complete
+- current queue ordering
+- what is active now
+- what is next
+
+### 11.2 Pacing-Friendly Presentation
+
+The city panel should make quick-payoff items easy to spot without hiding broader options.
+
+The player should be able to quickly distinguish:
+
+- fast foundational picks
+- medium investments
+- long projects
+
+This can be visual, textual, or both, but the result must reduce decision fatigue and reinforce momentum.
+
+### 11.3 Queue Visibility
+
+The panel must make it clear when a city is already planned for the next few completions so the player feels progress is lined up, not constantly resetting to zero.
+
+---
+
+## 12. Queues And Forward Planning
+
+To keep the feel that something is always happening, both city production and research gain short queues.
+
+### 12.1 Queue Limits
+
+- each city may queue up to `3` items
+- research may queue up to `3` techs
+
+### 12.2 Supported Actions
+
+Players must be able to:
+
+- add an item to the queue
+- reorder the queue
+- remove an item from the queue
+
+### 12.3 Shared UX Rules
+
+Production and research queues should behave consistently enough that learning one teaches the other.
+
+Common behavior:
+
+- show active item first
+- show the next two planned items
+- recalculate ETA presentation when order changes
+- make removal explicit and easy
+- make reorder interaction straightforward on both desktop and mobile
+
+### 12.4 Why Queueing Matters
+
+Short queueing reduces dead turns without removing player agency.
+
+It helps because:
+
+- completions can chain into more progress automatically
+- the player can plan a short sequence without setting the empire on autopilot
+- the game feels active between panel visits
+
+### 12.5 Constraints
+
+- queue depth is intentionally short at `3`
+- queueing should support momentum, not replace meaningful choices
+- the game should still bring the player back to decision points often
+
+### 12.6 Invalid Queue States
+
+If a queued item becomes invalid by the time it would start, the UI must clearly surface that and require the player to resolve it. The game must not silently waste turns on a broken queue entry.
+
+---
+
+## 13. No-Avoidable-Idle Rule
+
+Human players should not be allowed to accidentally leave valid work undone when meaningful options exist.
+
+### 13.1 Research Rule
+
+If the human player has:
+
+- no current research selected
+- fewer than `3` techs in the research queue
+- at least one valid research option
+
+then the game should prompt the player to choose research before allowing the turn flow to continue past the relevant decision boundary.
+
+### 13.2 City Rule
+
+If the human player has at least one city with:
+
+- no active production item
+- fewer than `3` items in that city's production queue
+- at least one valid build option
+
+then the game should prompt the player to choose production before allowing the turn flow to continue past the relevant decision boundary.
+
+### 13.3 UX Framing
+
+This should feel like helpful guidance, not punishment.
+
+The chooser should:
+
+- explain why a choice is needed
+- show the best short options clearly
+- show ETAs
+- make it easy to commit a sensible choice quickly
+
+### 13.4 Recommendation Behavior
+
+The game may recommend sensible picks, but it must not silently auto-pick for the player when valid choices exist, unless a separate future feature explicitly introduces optional automation.
+
+### 13.5 Edge Cases
+
+The forced-choice rule should only trigger when valid options exist. It must not trap the player in cases where:
+
+- no research is available
+- no buildable item is available
+- a city is blocked by a special rule and has no valid production target
+
+---
+
+## 14. Fun Guardrails
+
+The pacing overhaul must be judged by feel as much as by formulas.
+
+### 14.1 Required Feel
+
+- early turns should produce regular payoffs
+- there should usually be at least one short-payoff option visible
+- the player should feel their empire waking up quickly
+- long waits should be reserved for things that feel important
+
+### 14.2 Anti-Patterns To Avoid
+
+- every visible option in an era taking a long time
+- the only interesting techs being hidden several layers deep
+- core military or science basics priced like capstones
+- the player finishing something and immediately falling back into a blank state
+- menus that make progression feel more stalled than it actually is
+
+### 14.3 Strategic Breadth Preservation
+
+Depth and breadth are preserved by:
+
+- keeping many available branches
+- differentiating them by pacing bands
+- using queueing to preserve momentum
+- using UI emphasis to show near-term action without deleting long-term ambition
+
+---
+
+## 15. Content Classification Pass
+
+Before final numeric rebalance, the current roster should be classified.
+
+### 15.1 Required Scope
+
+Classify all current:
+
+- units
+- buildings
+- techs
+- legendary wonder production projects
+
+If some content is not yet wired into the same systems, it should still be classified so future convergence is straightforward.
+
+### 15.2 Classification Output
+
+The classification should record, at minimum:
+
+- current cost
+- target era
+- pacing band
+- role
+- notable modifiers
+- recommended target range
+
+This classification pass is the bridge between current ad hoc values and the future balancing formula.
+
+---
+
+## 16. Validation Criteria
+
+The pacing overhaul is successful only if both systemic and experiential criteria improve.
+
+### 16.1 System Criteria
+
+- the balance audit runs locally
+- the formula can generate recommendations for all classified content
+- queueing is save/load safe
+- forced-choice behavior respects valid-option checks
+- UI ETA values match actual completion logic
+
+### 16.2 Experience Criteria
+
+- Era 1 foundational units and buildings commonly finish within the intended opening band
+- foundational techs complete often enough that research feels active early
+- later eras still contain both short and long options
+- the tech tree feels less overwhelming and less stalled
+- the player cannot casually waste turns by forgetting to pick production or research when valid options exist
+
+### 16.3 Review Criteria
+
+Before implementation is considered complete, reviewers should be able to inspect:
+
+- the cost-model assumptions
+- local audit output
+- deterministic simulation summaries
+- UI behavior for queueing, ETA display, and forced-choice prompts
+
+---
+
+## 17. Risks And Mitigations
+
+### 17.1 Risk: Early game becomes too cheap and loses weight
+
+Mitigation:
+
+- use banding instead of across-the-board reductions
+- preserve longer timings for infrastructure, power-spike, and marquee content
+
+### 17.2 Risk: Queueing becomes accidental automation
+
+Mitigation:
+
+- keep queues short at `3`
+- keep active progress and near-future choices highly visible
+
+### 17.3 Risk: Formula creates bland, overly normalized costs
+
+Mitigation:
+
+- treat the formula as a recommendation engine, then round and review
+- preserve authored exceptions when justified by playtest evidence
+
+### 17.4 Risk: Forced-choice flow becomes annoying
+
+Mitigation:
+
+- trigger only when valid options exist
+- design the chooser for speed and clarity
+- use recommendations and ETA-rich presentation
+
+### 17.5 Risk: UI redesign becomes disconnected from pacing work
+
+Mitigation:
+
+- explicitly treat issue `#56`, ETA display, queue visibility, and idle-state prevention as part of the pacing overhaul scope
+
+---
+
+## 18. Implementation Scope Boundaries
+
+This design intentionally combines systems work and UX work because the current problem is cross-cutting. A successful implementation must include:
+
+- balance metadata and recommendation logic
+- cost retuning for current content
+- local-only audit and validation tooling
+- tech tree redesign and ETA display
+- city panel ETA and queue visibility improvements
+- queueing for production and research
+- no-avoidable-idle enforcement
+
+Treating any one of these as optional polish would leave the root pacing problem unresolved.
+
+---
+
+## 19. Acceptance Summary
+
+This design is approved when Conquestoria can truthfully claim all of the following:
+
+- the opening game is materially faster and less boring
+- the game keeps its breadth of choices
+- some content is quick, some is slow, and the differences feel intentional
+- the player can see how many turns remain for current and available research/build choices
+- the tech tree no longer defaults to an exhausting wall of disabled content
+- the player can queue, reorder, and remove up to `3` research and production items
+- the game does not let human players accidentally idle production or research when valid options exist
+- all pacing analysis remains fully local and compatible with an offline browser game

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "setup:hooks": "git config core.hooksPath .githooks",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/pre-commit-checks.sh
+++ b/scripts/pre-commit-checks.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+echo "Running pre-commit checks: tests"
+./scripts/run-with-mise.sh yarn test
+
+echo "Running pre-commit checks: build"
+./scripts/run-with-mise.sh yarn build

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -242,6 +242,7 @@ export interface Building {
   description: string;
   techRequired?: string | null;
   adjacencyBonuses?: AdjacencyBonus[];
+  pacing?: PacingMetadata;
 }
 
 export interface City {
@@ -274,6 +275,27 @@ export type TechTrack =
 
 export type TechStatus = 'locked' | 'available' | 'researching' | 'completed';
 
+export type PacingBand =
+  | 'starter'
+  | 'core'
+  | 'specialist'
+  | 'infrastructure'
+  | 'power-spike'
+  | 'marquee';
+
+export type PacingContentType = 'building' | 'unit' | 'tech' | 'wonder';
+
+export interface PacingMetadata {
+  band: PacingBand;
+  role: string;
+  impact: number;
+  scope: 'city' | 'military' | 'empire';
+  snowball: number;
+  urgency: number;
+  situationality: number;
+  unlockBreadth: number;
+}
+
 export interface Tech {
   id: string;
   name: string;
@@ -283,6 +305,7 @@ export interface Tech {
   unlocks: string[];         // what this tech enables (descriptions)
   era: number;               // 1-3 for milestone 1
   countsForEraAdvancement?: boolean;
+  pacing?: PacingMetadata;
 }
 
 export interface TechState {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -19,13 +19,13 @@ export const BUILDINGS: Record<string, Building> = {
   aqueduct: { id: 'aqueduct', name: 'Aqueduct', category: 'food', yields: { food: 2, production: 0, gold: 0, science: 0 }, productionCost: 80, description: 'Brings fresh water for growth', techRequired: 'engineering', adjacencyBonuses: [] },
 
   // Production
-  workshop: { id: 'workshop', name: 'Workshop', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 50, description: 'Tools boost production', techRequired: null, adjacencyBonuses: [] },
+  workshop: { id: 'workshop', name: 'Workshop', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 12, description: 'Tools boost production', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'early-production', impact: 1, scope: 'city', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1 } },
   forge: { id: 'forge', name: 'Forge', category: 'production', yields: { food: 0, production: 3, gold: 0, science: 0 }, productionCost: 70, description: 'Metalworking facility', techRequired: 'engineering', adjacencyBonuses: [] },
   lumbermill: { id: 'lumbermill', name: 'Lumbermill', category: 'production', yields: { food: 0, production: 2, gold: 1, science: 0 }, productionCost: 50, description: 'Processes timber efficiently', techRequired: 'state-workforce', adjacencyBonuses: [] },
   'quarry-building': { id: 'quarry-building', name: 'Quarry', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 55, description: 'Cuts stone for construction', techRequired: 'state-workforce', adjacencyBonuses: [] },
 
   // Science
-  library: { id: 'library', name: 'Library', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 60, description: 'Knowledge repository', techRequired: 'writing', adjacencyBonuses: [] },
+  library: { id: 'library', name: 'Library', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 16, description: 'Knowledge repository', techRequired: 'writing', adjacencyBonuses: [] },
   archive: { id: 'archive', name: 'Archive', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 75, description: 'Preserves ancient knowledge', techRequired: 'mathematics', adjacencyBonuses: [] },
   observatory: { id: 'observatory', name: 'Observatory', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 3 }, productionCost: 100, description: 'Studies the stars', techRequired: 'astronomy', adjacencyBonuses: [] },
 
@@ -34,7 +34,7 @@ export const BUILDINGS: Record<string, Building> = {
   harbor: { id: 'harbor', name: 'Harbor', category: 'economy', yields: { food: 1, production: 0, gold: 3, science: 0 }, productionCost: 80, description: 'Enables sea trade', techRequired: 'harbor-tech', adjacencyBonuses: [] },
 
   // Military
-  barracks: { id: 'barracks', name: 'Barracks', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 40, description: 'A training ground. Required by future military doctrines.', techRequired: null, adjacencyBonuses: [] },
+  barracks: { id: 'barracks', name: 'Barracks', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 10, description: 'A training ground. Required by future military doctrines.', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'military-enabler', impact: 1, scope: 'city', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1.05 } },
   walls: { id: 'walls', name: 'Walls', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 60, description: 'Defends the city', techRequired: 'fortification', adjacencyBonuses: [] },
   stable: { id: 'stable', name: 'Stable', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 55, description: 'Trains mounted units', techRequired: 'horseback-riding', adjacencyBonuses: [] },
 
@@ -42,15 +42,15 @@ export const BUILDINGS: Record<string, Building> = {
   temple: { id: 'temple', name: 'Temple', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 45, description: 'Spiritual center', techRequired: 'philosophy', adjacencyBonuses: [] },
   monument: { id: 'monument', name: 'Monument', category: 'culture', yields: { food: 0, production: 0, gold: 1, science: 0 }, productionCost: 30, description: 'Commemorates your civilization', techRequired: 'code-of-laws', adjacencyBonuses: [] },
   amphitheater: { id: 'amphitheater', name: 'Amphitheater', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 1 }, productionCost: 85, description: 'Entertainment and culture', techRequired: 'drama-poetry', adjacencyBonuses: [] },
-  shrine: { id: 'shrine', name: 'Shrine', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 25, description: 'Place of worship', techRequired: null, adjacencyBonuses: [] },
+  shrine: { id: 'shrine', name: 'Shrine', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 8, description: 'Place of worship', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'early-science', impact: 1, scope: 'city', snowball: 1.1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   forum: { id: 'forum', name: 'Forum', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 0 }, productionCost: 70, description: 'Public gathering place', techRequired: 'civil-service', adjacencyBonuses: [] },
 };
 
-export const TRAINABLE_UNITS: Array<{ type: UnitType; name: string; cost: number; techRequired?: string }> = [
-  { type: 'warrior', name: 'Warrior', cost: 25 },
+export const TRAINABLE_UNITS: Array<{ type: UnitType; name: string; cost: number; techRequired?: string; pacing?: Building['pacing'] }> = [
+  { type: 'warrior', name: 'Warrior', cost: 8, pacing: { band: 'starter', role: 'early-military', impact: 1, scope: 'military', snowball: 1, urgency: 1.2, situationality: 1, unlockBreadth: 1 } },
   { type: 'archer', name: 'Archer', cost: 35, techRequired: 'archery' },
-  { type: 'scout', name: 'Scout', cost: 20 },
-  { type: 'worker', name: 'Worker', cost: 30 },
+  { type: 'scout', name: 'Scout', cost: 6, pacing: { band: 'starter', role: 'early-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
+  { type: 'worker', name: 'Worker', cost: 12 },
   { type: 'settler', name: 'Settler', cost: 50 },
   { type: 'swordsman', name: 'Swordsman', cost: 50, techRequired: 'bronze-working' },
   { type: 'pikeman', name: 'Pikeman', cost: 70, techRequired: 'fortification' },

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -1,0 +1,23 @@
+import type { PacingBand, PacingContentType } from '@/core/types';
+
+const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number, number] }> = {
+  starter: { early: [2, 4], late: [2, 5] },
+  core: { early: [3, 5], late: [4, 7] },
+  specialist: { early: [4, 6], late: [5, 8] },
+  infrastructure: { early: [5, 8], late: [6, 10] },
+  'power-spike': { early: [6, 9], late: [7, 11] },
+  marquee: { early: [10, 12], late: [10, 16] },
+};
+
+export function getTargetTurnWindow(input: { era: number; band: PacingBand; contentType: PacingContentType }): { min: number; max: number } {
+  const [min, max] = input.era <= 1 ? BAND_WINDOWS[input.band].early : BAND_WINDOWS[input.band].late;
+  return { min, max };
+}
+
+export function estimateTurnsToComplete(input: { cost: number; outputPerTurn: number }): number {
+  if (input.outputPerTurn <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return Math.ceil(input.cost / input.outputPerTurn);
+}

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -2,7 +2,7 @@ import type { Tech } from '@/core/types';
 
 export const TECH_TREE: Tech[] = [
   // === MILITARY TRACK (8 techs, existing) ===
-  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 20, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1 },
+  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 10, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
   { id: 'archery', name: 'Archery', track: 'military', cost: 35, prerequisites: ['stone-weapons'], unlocks: ['Unlock Archer unit'], era: 1 },
   { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 50, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit'], era: 2 },
   { id: 'horseback-riding', name: 'Horseback Riding', track: 'military', cost: 55, prerequisites: ['animal-husbandry'], unlocks: ['Unlock Stable, mounted units'], era: 2 },
@@ -12,7 +12,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'tactics', name: 'Tactics', track: 'military', cost: 100, prerequisites: ['iron-forging'], unlocks: ['Units get +10% combat bonus', 'musketeer'], era: 4 },
 
   // === ECONOMY TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 15, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1 },
+  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 8, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
   { id: 'pottery', name: 'Pottery', track: 'economy', cost: 25, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge'], era: 1 },
   { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 35, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
   { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 45, prerequisites: ['pottery'], unlocks: ['Farms yield +1 food'], era: 2 },
@@ -23,7 +23,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'global-logistics', name: 'Global Logistics', track: 'economy', cost: 155, prerequisites: ['trade-routes', 'banking'], unlocks: ['Late-era supply chains and wonder distribution requirements'], era: 5, countsForEraAdvancement: false },
 
   // === SCIENCE TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'fire', name: 'Fire', track: 'science', cost: 15, prerequisites: [], unlocks: ['Unlock basic research'], era: 1 },
+  { id: 'fire', name: 'Fire', track: 'science', cost: 8, prerequisites: [], unlocks: ['Unlock basic research'], era: 1, pacing: { band: 'starter', role: 'foundational-science', impact: 1, scope: 'empire', snowball: 1.15, urgency: 1.1, situationality: 1, unlockBreadth: 1.1 } },
   { id: 'writing', name: 'Writing', track: 'science', cost: 30, prerequisites: ['fire'], unlocks: ['Unlock Library building'], era: 1 },
   { id: 'wheel', name: 'The Wheel', track: 'science', cost: 40, prerequisites: ['fire'], unlocks: ['Foundational mechanics knowledge'], era: 2 },
   { id: 'mathematics', name: 'Mathematics', track: 'science', cost: 60, prerequisites: ['writing'], unlocks: ['Unlock Archive building'], era: 2 },
@@ -34,7 +34,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'nuclear-theory', name: 'Nuclear Theory', track: 'science', cost: 165, prerequisites: ['astronomy', 'medicine'], unlocks: ['Late-era atomic research and wonder prerequisites'], era: 5, countsForEraAdvancement: false },
 
   // === CIVICS TRACK (8 techs, existing) ===
-  { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 15, prerequisites: [], unlocks: ['Basic governance'], era: 1 },
+  { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 8, prerequisites: [], unlocks: ['Basic governance'], era: 1, pacing: { band: 'starter', role: 'foundational-civics', impact: 1, scope: 'empire', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1.05 } },
   { id: 'code-of-laws', name: 'Code of Laws', track: 'civics', cost: 30, prerequisites: ['tribal-council'], unlocks: ['Unlock Monument building'], era: 1 },
   { id: 'early-empire', name: 'Early Empire', track: 'civics', cost: 45, prerequisites: ['code-of-laws'], unlocks: ['Cities claim +1 tile radius'], era: 2 },
   { id: 'state-workforce', name: 'State Workforce', track: 'civics', cost: 55, prerequisites: ['early-empire'], unlocks: ['Unlock Lumbermill, Quarry'], era: 2 },
@@ -44,7 +44,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'political-philosophy', name: 'Political Philosophy', track: 'civics', cost: 100, prerequisites: ['civil-service', 'philosophy'], unlocks: ['Unlock alliances'], era: 4 },
 
   // === EXPLORATION TRACK (8 techs, existing) ===
-  { id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 15, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1 },
+  { id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 8, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1, pacing: { band: 'starter', role: 'foundational-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   { id: 'cartography', name: 'Cartography', track: 'exploration', cost: 30, prerequisites: ['pathfinding'], unlocks: ['Reveal map edges'], era: 1 },
   { id: 'sailing', name: 'Sailing', track: 'exploration', cost: 45, prerequisites: ['pathfinding'], unlocks: ['Units can embark on coast'], era: 2 },
   { id: 'celestial-navigation', name: 'Celestial Navigation', track: 'exploration', cost: 55, prerequisites: ['sailing', 'fire'], unlocks: ['Units can cross ocean'], era: 2 },

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -1,5 +1,7 @@
 import type { GameState, Tech, TechTrack } from '@/core/types';
 import { getAvailableTechs, TECH_TREE } from '@/systems/tech-system';
+import { calculateCityYields } from '@/systems/resource-system';
+import { estimateTurnsToComplete } from '@/systems/pacing-model';
 
 export interface TechPanelCallbacks {
   onStartResearch: (techId: string) => void;
@@ -38,7 +40,7 @@ function getEraLabel(era: number): string {
   return era === 5 ? 'Late Era Foundations' : `Era ${era}`;
 }
 
-function buildCurrentResearchSummary(currentTech: Tech | undefined, progress: number): HTMLDivElement | null {
+function buildCurrentResearchSummary(currentTech: Tech | undefined, progress: number, turnsRemaining: number | null): HTMLDivElement | null {
   if (!currentTech) {
     return null;
   }
@@ -52,7 +54,9 @@ function buildCurrentResearchSummary(currentTech: Tech | undefined, progress: nu
   wrapper.appendChild(heading);
 
   const summary = document.createElement('div');
-  summary.textContent = `${titleCase(currentTech.track)} · ${currentTech.unlocks[0] ?? 'New options for your empire'}`;
+  summary.textContent = turnsRemaining === null
+    ? `${titleCase(currentTech.track)} · ${currentTech.unlocks[0] ?? 'New options for your empire'}`
+    : `${titleCase(currentTech.track)} · Turns remaining: ${turnsRemaining}`;
   summary.style.cssText = 'font-size:12px;opacity:0.7;';
   wrapper.appendChild(summary);
 
@@ -77,6 +81,7 @@ function createTechItem(
     isCompleted: boolean;
     isCurrent: boolean;
     isAvailable: boolean;
+    turnsToResearch: number | null;
     onStartResearch: (techId: string) => void;
     onClosePanel: () => void;
   },
@@ -115,7 +120,8 @@ function createTechItem(
 
   const detail = document.createElement('div');
   detail.style.cssText = 'font-size:11px;opacity:0.7;';
-  detail.textContent = `${tech.unlocks[0] ?? 'New options'} · Cost: ${tech.cost}`;
+  const etaText = opts.turnsToResearch === null ? 'ETA unknown' : `${opts.turnsToResearch} turns`;
+  detail.textContent = `${tech.unlocks[0] ?? 'New options'} · ${etaText} · Cost: ${tech.cost}`;
   item.appendChild(detail);
 
   if (opts.isAvailable) {
@@ -135,6 +141,7 @@ function buildEraSection(
   available: Tech[],
   callbacks: TechPanelCallbacks,
   panel: HTMLElement,
+  outputPerTurn: number,
 ): HTMLElement {
   const section = document.createElement('div');
   section.dataset.era = String(era);
@@ -152,6 +159,9 @@ function buildEraSection(
       isCompleted: civ.techState.completed.includes(tech.id),
       isCurrent: civ.techState.currentResearch === tech.id,
       isAvailable: available.some(candidate => candidate.id === tech.id),
+      turnsToResearch: available.some(candidate => candidate.id === tech.id)
+        ? estimateTurnsToComplete({ cost: tech.cost, outputPerTurn })
+        : null,
       onStartResearch: callbacks.onStartResearch,
       onClosePanel: () => panel.remove(),
     }));
@@ -174,6 +184,13 @@ export function createTechPanel(
 
   const civ = state.civilizations[state.currentPlayer];
   const available = getAvailableTechs(civ.techState);
+  const sciencePerTurn = Math.max(
+    1,
+    civ.cities
+      .map(cityId => state.cities[cityId])
+      .filter((city): city is NonNullable<typeof state.cities[string]> => city !== undefined)
+      .reduce((total, city) => total + calculateCityYields(city, state.map).science, 0),
+  );
 
   const header = document.createElement('div');
   header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;';
@@ -202,7 +219,13 @@ export function createTechPanel(
   const currentProgress = currentTech
     ? Math.round((civ.techState.researchProgress / currentTech.cost) * 100)
     : 0;
-  const summary = buildCurrentResearchSummary(currentTech, currentProgress);
+  const turnsRemaining = currentTech
+    ? estimateTurnsToComplete({
+      cost: Math.max(0, currentTech.cost - civ.techState.researchProgress),
+      outputPerTurn: sciencePerTurn,
+    })
+    : null;
+  const summary = buildCurrentResearchSummary(currentTech, currentProgress, turnsRemaining);
   if (summary) {
     panel.appendChild(summary);
   }
@@ -225,7 +248,7 @@ export function createTechPanel(
     const eras = [...new Set(techs.map(tech => tech.era))].sort((a, b) => a - b);
     for (const era of eras) {
       const eraTechs = techs.filter(tech => tech.era === era);
-      trackBlock.appendChild(buildEraSection(era, eraTechs, civ, available, callbacks, panel));
+      trackBlock.appendChild(buildEraSection(era, eraTechs, civ, available, callbacks, panel, sciencePerTurn));
     }
 
     grid.appendChild(trackBlock);

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -236,26 +236,26 @@ describe('processTurn', () => {
     const startPos = state.units[playerCiv.units[0]].position;
     const city = foundCity('player', startPos, state.map);
     city.buildings = ['workshop'];
-    city.productionQueue = ['warrior'];
-    city.productionProgress = 20;
+    city.productionQueue = ['worker'];
+    city.productionProgress = 4;
     state.cities[city.id] = city;
     playerCiv.cities.push(city.id);
     state.cities[city.id].productionDisabledTurns = 3;
 
     const turn1 = processTurn(state, bus);
-    expect(turn1.cities[city.id].productionProgress).toBe(20);
+    expect(turn1.cities[city.id].productionProgress).toBe(4);
     expect(turn1.cities[city.id].productionDisabledTurns).toBe(2);
 
     const turn2 = processTurn(turn1, bus);
-    expect(turn2.cities[city.id].productionProgress).toBe(20);
+    expect(turn2.cities[city.id].productionProgress).toBe(4);
     expect(turn2.cities[city.id].productionDisabledTurns).toBe(1);
 
     const turn3 = processTurn(turn2, bus);
     expect(turn3.cities[city.id].productionDisabledTurns).toBe(0);
-    expect(turn3.cities[city.id].productionProgress).toBe(20);
+    expect(turn3.cities[city.id].productionProgress).toBe(4);
 
     const turn4 = processTurn(turn3, bus);
-    expect(turn4.cities[city.id].productionProgress).toBeGreaterThan(20);
+    expect(turn4.cities[city.id].productionProgress).toBeGreaterThan(4);
   });
 
   it('applies misinformation research penalties for exactly 10 turns', () => {

--- a/tests/systems/pacing-model.test.ts
+++ b/tests/systems/pacing-model.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { estimateTurnsToComplete, getTargetTurnWindow } from '@/systems/pacing-model';
+
+describe('pacing-model', () => {
+  it('gives Era 1 starter items a 2-4 turn target window', () => {
+    expect(getTargetTurnWindow({ era: 1, band: 'starter', contentType: 'building' })).toEqual({ min: 2, max: 4 });
+  });
+
+  it('rounds ETA values up by turn', () => {
+    expect(estimateTurnsToComplete({ cost: 12, outputPerTurn: 4 })).toBe(3);
+    expect(estimateTurnsToComplete({ cost: 13, outputPerTurn: 4 })).toBe(4);
+  });
+});

--- a/tests/systems/tech-system.test.ts
+++ b/tests/systems/tech-system.test.ts
@@ -130,8 +130,8 @@ describe('processResearch', () => {
     const state = createTechState();
     const available = getAvailableTechs(state);
     const updated = startResearch({ ...state }, available[0].id);
-    const result = processResearch(updated, 10);
-    expect(result.state.researchProgress).toBe(10);
+    const result = processResearch(updated, 1);
+    expect(result.state.researchProgress).toBe(1);
     expect(result.completedTech).toBeNull();
   });
 

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -87,4 +87,16 @@ describe('city-panel navigation', () => {
     nextBtn?.click?.();
     expect(onNext).toHaveBeenCalledOnce();
   });
+
+  it('shows ETA text for buildable units and buildings', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
+    expect(rendered).toContain('turns');
+  });
 });

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -37,4 +37,13 @@ describe('tech-panel', () => {
     expect(panel.querySelector('[data-era="5"]')).toBeTruthy();
     expect(panel.textContent).toContain('Late Era Foundations');
   });
+
+  it('shows ETA language for the active research summary', () => {
+    const state = createNewGame(undefined, 'tech-eta-test');
+    state.civilizations.player.techState.currentResearch = 'fire';
+
+    const panel = createTechPanel(document.body, state, { onStartResearch: () => {}, onClose: () => {} });
+
+    expect(panel.textContent).toContain('Turns remaining');
+  });
 });


### PR DESCRIPTION
## Summary
- speed up the Era 1 opening by lowering the first visible unit, building, and foundational tech costs
- add a small pacing helper plus ETA coverage tests for this slice
- update the tech panel to show turns remaining for current research and ETA text for available techs
- include the approved pacing implementation plan in this branch so Task 1 has the requested backup

## Player Value
- the opening should feel noticeably faster
- players can see when current research will finish and how long visible research options will take

## Verification
- ./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/systems/city-system.test.ts tests/systems/tech-definitions.test.ts tests/ui/city-panel.test.ts tests/ui/tech-panel.test.ts
- scripts/check-src-rule-violations.sh src/core/types.ts src/systems/pacing-model.ts src/systems/tech-definitions.ts src/systems/city-system.ts src/ui/tech-panel.ts
- ./scripts/run-with-mise.sh yarn build