### PR TITLE
feat(city-ui): add build queues and preserve scheduled work

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { getMovementRange, moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits } from '@/systems/unit-system';
 import { foundCity } from '@/systems/city-system';
+import { enqueueCityProduction, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { startResearch } from '@/systems/tech-system';
 import { createTechPanel } from '@/ui/tech-panel';
@@ -401,11 +402,34 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
     onBuild: (cityId, itemId) => {
       const targetCity = gameState.cities[cityId];
       if (targetCity) {
-        targetCity.productionQueue = [itemId];
-        targetCity.productionProgress = 0;
-        renderLoop.setGameState(gameState);
-        showNotification(`${targetCity.name}: building ${itemId}`, 'info');
+        try {
+          gameState.cities[cityId] = enqueueCityProduction(targetCity, itemId);
+          renderLoop.setGameState(gameState);
+          showNotification(`${targetCity.name}: queued ${itemId}`, 'info');
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'Queue limit reached';
+          showNotification(`${targetCity.name}: ${message}`, 'warning');
+        }
       }
+    },
+    onMoveQueueItem: (cityId, fromIndex, toIndex) => {
+      const targetCity = gameState.cities[cityId];
+      if (!targetCity) return;
+      gameState.cities[cityId] = {
+        ...targetCity,
+        productionQueue: moveQueuedId(targetCity.productionQueue, fromIndex, toIndex),
+      };
+      renderLoop.setGameState(gameState);
+    },
+    onRemoveQueueItem: (cityId, index) => {
+      const targetCity = gameState.cities[cityId];
+      if (!targetCity) return;
+      gameState.cities[cityId] = {
+        ...targetCity,
+        productionQueue: removeQueuedId(targetCity.productionQueue, index),
+        productionProgress: index === 0 ? 0 : targetCity.productionProgress,
+      };
+      renderLoop.setGameState(gameState);
     },
     onOpenWonderPanel: (selectedCityId) => {
       gameState = initializeLegendaryWonderProjectsForCity(gameState, gameState.currentPlayer, selectedCityId);

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -22,6 +22,20 @@ function ensureGameIdentity(state: GameState): GameState {
   return state;
 }
 
+function migrateLegacyPlanningState(state: GameState): GameState {
+  for (const city of Object.values(state.cities ?? {})) {
+    city.productionQueue ??= [];
+    if (city.productionQueue.length > 3) {
+      city.productionQueue = city.productionQueue.slice(0, 3);
+    }
+  }
+  return state;
+}
+
+function normalizeLoadedState(state: GameState): GameState {
+  return migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)));
+}
+
 function getCityNamingInfo(state: GameState, ownerId: string): { civType: string; civName: string; namingPool?: string[] } {
   const majorCiv = state.civilizations[ownerId];
   if (majorCiv) {
@@ -150,13 +164,13 @@ async function listPersistedMetas(): Promise<SaveSlotMeta[]> {
 async function loadLegacyAutoSave(): Promise<GameState | undefined> {
   const idbSave = await dbGet<GameState>(LEGACY_AUTO_SAVE_KEY);
   if (idbSave) {
-    return migrateLegacyNamingState(ensureGameIdentity(idbSave));
+    return normalizeLoadedState(idbSave);
   }
 
   try {
     const raw = localStorage.getItem(LOCALSTORAGE_AUTOSAVE_KEY);
     if (raw) {
-      return migrateLegacyNamingState(ensureGameIdentity(JSON.parse(raw) as GameState));
+      return normalizeLoadedState(JSON.parse(raw) as GameState);
     }
   } catch {
     console.warn('[save] localStorage fallback parse failed');
@@ -218,7 +232,7 @@ async function loadMostRecentPersistedAutosave(): Promise<GameState | undefined>
   }
 
   const state = await dbGet<GameState>(getSaveStorageKey(newestMeta.id, 'autosave'));
-  return state ? migrateLegacyNamingState(ensureGameIdentity(state)) : undefined;
+  return state ? normalizeLoadedState(state) : undefined;
 }
 
 async function retireLegacyAutosaveIfRealAutosavesExist(): Promise<boolean> {
@@ -291,7 +305,7 @@ export async function loadSettings(): Promise<GameState['settings'] | undefined>
 // --- Multi-slot saves ---
 
 export async function saveGame(slotId: string, name: string, state: GameState): Promise<void> {
-  const resolved = ensureGameIdentity(state);
+  const resolved = normalizeLoadedState(state);
   const meta = buildSaveMeta(slotId, name, resolved, 'manual');
   await dbPut(getSaveStorageKey(slotId, 'manual'), resolved);
   await dbPut(getMetaStorageKey(slotId), meta);
@@ -303,11 +317,11 @@ export async function loadGame(slotId: string): Promise<GameState | undefined> {
       return loadLegacyAutoSave();
     }
     const save = await dbGet<GameState>(getSaveStorageKey(slotId, 'autosave'));
-    return save ? migrateLegacyNamingState(ensureGameIdentity(save)) : undefined;
+    return save ? normalizeLoadedState(save) : undefined;
   }
 
   const save = await dbGet<GameState>(getSaveStorageKey(slotId, 'manual'));
-  return save ? migrateLegacyNamingState(ensureGameIdentity(save)) : undefined;
+  return save ? normalizeLoadedState(save) : undefined;
 }
 
 export async function deleteSaveEntry(entryId: string, kind: 'manual' | 'autosave'): Promise<void> {

--- a/src/systems/legendary-wonder-system.ts
+++ b/src/systems/legendary-wonder-system.ts
@@ -658,7 +658,7 @@ export function startLegendaryWonderBuild(
       ...seededState.cities,
       [cityId]: {
         ...city,
-        productionQueue: [`legendary:${wonderId}`],
+        productionQueue: [`legendary:${wonderId}`, ...city.productionQueue.filter(item => item !== `legendary:${wonderId}`)].slice(0, 3),
         productionProgress: carriedProduction,
       },
     } : state.cities,

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -1,0 +1,42 @@
+import type { City } from '@/core/types';
+
+const MAX_QUEUE_ITEMS = 3;
+
+export function enqueueCityProduction(city: City, itemId: string): City {
+  if (city.productionQueue.includes(itemId)) {
+    return city;
+  }
+
+  if (city.productionQueue.length >= MAX_QUEUE_ITEMS) {
+    throw new Error('Queue limit reached');
+  }
+
+  return {
+    ...city,
+    productionQueue: [...city.productionQueue, itemId],
+  };
+}
+
+export function moveQueuedId<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  if (
+    fromIndex < 0
+    || toIndex < 0
+    || fromIndex >= items.length
+    || toIndex >= items.length
+    || fromIndex === toIndex
+  ) {
+    return [...items];
+  }
+
+  const next = [...items];
+  const [moved] = next.splice(fromIndex, 1);
+  if (moved === undefined) {
+    return [...items];
+  }
+  next.splice(toIndex, 0, moved);
+  return next;
+}
+
+export function removeQueuedId<T>(items: T[], index: number): T[] {
+  return items.filter((_, currentIndex) => currentIndex !== index);
+}

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -5,6 +5,8 @@ import { createCityGrid } from './city-grid';
 
 export interface CityPanelCallbacks {
   onBuild: (cityId: string, itemId: string) => void;
+  onMoveQueueItem?: (cityId: string, fromIndex: number, toIndex: number) => void;
+  onRemoveQueueItem?: (cityId: string, index: number) => void;
   onOpenWonderPanel: (cityId: string) => void;
   onClose: () => void;
   onPrevCity?: () => void;
@@ -87,6 +89,23 @@ export function createCityPanel(
     `;
   }
 
+  let queueRowsHtml = '';
+  for (let idx = 0; idx < city.productionQueue.length; idx++) {
+    queueRowsHtml += `
+      <div data-queue-index="${idx}" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;">
+        <div>
+          <div style="font-weight:bold;" data-text="queue-name-${idx}"></div>
+          <div style="font-size:11px;opacity:0.7;">Queue slot ${idx + 1}</div>
+        </div>
+        <div style="display:flex;gap:6px;">
+          <button type="button" data-queue-action="up" data-queue-index="${idx}">↑</button>
+          <button type="button" data-queue-action="down" data-queue-index="${idx}">↓</button>
+          <button type="button" data-queue-action="remove" data-queue-index="${idx}">✕</button>
+        </div>
+      </div>
+    `;
+  }
+
   const navHtml = (callbacks.onPrevCity || callbacks.onNextCity)
     ? `<div style="display:flex;align-items:center;gap:8px;">
         <span id="city-prev" style="cursor:pointer;font-size:20px;opacity:0.7;padding:4px 8px;background:rgba(255,255,255,0.1);border-radius:6px;">&#8249;</span>
@@ -120,6 +139,7 @@ export function createCityPanel(
     </div>
     <div id="city-list-view">
       ${currentProductionHtml}
+      ${city.productionQueue.length > 0 ? `<div style="margin-bottom:16px;"><h3 style="font-size:14px;margin:0 0 8px;">Queue</h3>${queueRowsHtml}</div>` : ''}
       ${cityWonderProject ? `<div style="margin-bottom:12px;font-size:12px;opacity:0.75;">Wonder carryover: ${cityWonderProject.transferableProduction}</div>` : ''}
       ${city.buildings.length > 0 ? `<div style="margin-bottom:16px;"><h3 style="font-size:14px;margin:0 0 8px;">Buildings</h3>${buildingPlaceholders}</div>` : ''}
       <div><h3 style="font-size:14px;margin:0 0 8px;">Build</h3>
@@ -175,7 +195,23 @@ export function createCityPanel(
     setText(`unit-name-${i}`, u.name);
   });
 
+  city.productionQueue.forEach((itemId, index) => {
+    setText(`queue-name-${index}`, BUILDINGS[itemId]?.name ?? TRAINABLE_UNITS.find(unit => unit.type === itemId)?.name ?? itemId);
+  });
+
   container.appendChild(panel);
+
+  const reopenPanel = () => {
+    const refreshedCity = state.cities[city.id];
+    if (!refreshedCity) {
+      panel.remove();
+      callbacks.onClose();
+      return;
+    }
+
+    panel.remove();
+    createCityPanel(container, refreshedCity, state, callbacks);
+  };
 
   panel.querySelector('#city-close')?.addEventListener('click', () => {
     panel.remove();
@@ -199,7 +235,36 @@ export function createCityPanel(
     el.addEventListener('click', () => {
       const itemId = (el as HTMLElement).dataset.itemId!;
       callbacks.onBuild(city.id, itemId);
-      panel.remove();
+      reopenPanel();
+    });
+  });
+
+  panel.querySelectorAll('[data-queue-action]').forEach(el => {
+    el.addEventListener('click', event => {
+      event.stopPropagation();
+      const action = (el as HTMLElement).dataset.queueAction;
+      const index = Number((el as HTMLElement).dataset.queueIndex);
+
+      if (!Number.isInteger(index)) {
+        return;
+      }
+
+      if (action === 'remove') {
+        callbacks.onRemoveQueueItem?.(city.id, index);
+        reopenPanel();
+        return;
+      }
+
+      if (action === 'up' && index > 0) {
+        callbacks.onMoveQueueItem?.(city.id, index, index - 1);
+        reopenPanel();
+        return;
+      }
+
+      if (action === 'down' && index < city.productionQueue.length - 1) {
+        callbacks.onMoveQueueItem?.(city.id, index, index + 1);
+        reopenPanel();
+      }
     });
   });
 

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -308,6 +308,34 @@ describe('save persistence (#38)', () => {
     expect(resolved?.bonusEffect).toEqual({ type: 'extra_tech_speed', speedMultiplier: 1.15 });
   });
 
+  it('trims legacy production queues to three items on load', async () => {
+    const state = createNewGame('rome', 'legacy-queue-seed');
+    state.cities['city-1'] = {
+      id: 'city-1',
+      name: 'Rome',
+      owner: 'player',
+      position: { q: 2, r: 2 },
+      population: 2,
+      food: 0,
+      foodNeeded: 15,
+      buildings: [],
+      productionQueue: ['warrior', 'shrine', 'worker', 'library'],
+      productionProgress: 0,
+      ownedTiles: [{ q: 2, r: 2 }],
+      grid: [[null]],
+      gridSize: 3,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    };
+    state.civilizations.player.cities = ['city-1'];
+
+    await saveGame('slot-legacy-queue', 'Legacy Queue Save', state);
+    const loaded = await loadGame('slot-legacy-queue');
+
+    expect(loaded?.cities['city-1'].productionQueue).toEqual(['warrior', 'shrine', 'worker']);
+  });
+
   it('normalizes legacy duplicate or off-pool city names on load', () => {
     const state = createNewGame('rome', 'legacy-naming-seed');
     state.cities['city-1'] = {

--- a/tests/systems/legendary-wonder-system.test.ts
+++ b/tests/systems/legendary-wonder-system.test.ts
@@ -512,7 +512,7 @@ describe('legendary-wonder-system', () => {
   it('preserves existing city production when starting a wonder build', () => {
     const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
-    state.cities['city-river'].productionQueue = ['library'];
+    state.cities['city-river'].productionQueue = ['library', 'warrior'];
     state.cities['city-river'].productionProgress = 35;
 
     const result = startLegendaryWonderBuild(state, 'player', 'city-river', 'oracle-of-delphi');
@@ -520,6 +520,7 @@ describe('legendary-wonder-system', () => {
     expect(result.legendaryWonderProjects!['oracle-of-delphi'].phase).toBe('building');
     expect(result.legendaryWonderProjects!['oracle-of-delphi'].investedProduction).toBe(35);
     expect(result.legendaryWonderProjects!['oracle-of-delphi'].transferableProduction).toBe(0);
+    expect(result.cities['city-river'].productionQueue).toEqual(['legendary:oracle-of-delphi', 'library', 'warrior']);
   });
 
   it('exposes passive city and civ bonuses from completed legendary wonders', () => {

--- a/tests/systems/planning-system.test.ts
+++ b/tests/systems/planning-system.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { enqueueCityProduction, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+
+describe('planning-system city queues', () => {
+  it('appends new city builds up to a limit of three', () => {
+    const city = { productionQueue: ['warrior'] } as any;
+    const queued = enqueueCityProduction(city, 'shrine');
+    expect(queued.productionQueue).toEqual(['warrior', 'shrine']);
+  });
+
+  it('reorders queue items without dropping them', () => {
+    expect(moveQueuedId(['warrior', 'shrine', 'worker'], 2, 0)).toEqual(['worker', 'warrior', 'shrine']);
+  });
+
+  it('removes queue items cleanly', () => {
+    expect(removeQueuedId(['warrior', 'shrine', 'worker'], 1)).toEqual(['warrior', 'worker']);
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -99,4 +99,21 @@ describe('city-panel navigation', () => {
     const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
     expect(rendered).toContain('turns');
   });
+
+  it('renders production queue rows with move and remove controls', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.productionQueue = ['warrior', 'shrine', 'worker'];
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onMoveQueueItem: () => {},
+      onRemoveQueueItem: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    } as any);
+
+    const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
+    expect(rendered).toContain('Queue');
+    expect(rendered).toContain('data-queue-action="remove"');
+  });
 });


### PR DESCRIPTION
## Summary
- add a shared city production queue helper with append, move, and remove behavior
- update the city panel and main game flow so players can plan, reorder, and trim up to three builds without silently replacing scheduled work
- preserve queued follow-up items when legendary wonder construction starts and trim oversized legacy queues on load

## Player Value
- cities can now queue up to three items instead of stopping after each completion
- the city panel shows the current queue and lets players reorder or remove items directly
- starting a wonder no longer wipes out the rest of a city plan

## Verification
- ./scripts/run-with-mise.sh yarn test --run tests/systems/planning-system.test.ts tests/ui/city-panel.test.ts tests/systems/city-system.test.ts tests/systems/legendary-wonder-system.test.ts tests/storage/save-persistence.test.ts
- scripts/check-src-rule-violations.sh src/storage/save-manager.ts src/systems/planning-system.ts src/systems/legendary-wonder-system.ts src/ui/city-panel.ts src/main.ts
- ./scripts/run-with-mise.sh yarn build
- git commit exercised the pre-commit hook, which reran the full test suite and build successfully