### PR TITLE
feat(turn-flow): block accidental idle turns with required choices

### DIFF
--- a/docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md
+++ b/docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md
@@ -128,7 +128,19 @@ MR review theme:
 
 - “Can the player still move smoothly, but no longer waste turns by accident?”
 
-### Slice 5: Local Balance Audit And Debug View
+### Slice 5: Required-Choice Flow Review Fixes
+
+Player value:
+
+- the forced-choice flow stays active until all required production and research picks are resolved
+- quick-pick actions no longer drop the player back onto stale city or tech panels
+- idle city recommendations actually prefer the fastest momentum-preserving options
+
+MR review theme:
+
+- “Does the required-choice flow stay truthful, uninterrupted, and genuinely helpful?”
+
+### Slice 6: Local Balance Audit And Debug View
 
 Player value:
 
@@ -1108,7 +1120,278 @@ git commit -m "feat(turn-flow): block accidental idle turns with required choice
 
 ---
 
-## Task 5: Local Balance Audit And Debug View
+## Task 5: Required-Choice Flow Review Fixes
+
+**Goal:** Fix the Task 4 chooser so it stays active until all blockers are resolved, cannot reveal stale underlying planning panels, and recommends truly fast next-step city picks.
+
+**Why this task delivers value:** The blocker becomes smoother and more trustworthy, and its quick recommendations actually reinforce the faster-opening pacing instead of fighting it.
+
+**Files:**
+- Modify: `src/main.ts`
+- Modify: `src/systems/planning-system.ts`
+- Test: `tests/integration/end-turn-gating.test.ts`
+- Test: `tests/systems/planning-system.test.ts`
+- Test: `tests/ui/required-choice-panel.test.ts`
+
+**Player Truth Table**
+
+- Before: the player has idle research and/or one or more idle cities, and may already have the tech or city panel open
+- Click: `End Turn`
+- Must visibly change immediately: stale planning panels are removed, the required-choice overlay appears, and normal map interaction is blocked
+- Click: a quick research or production choice
+- Must visibly change immediately: the overlay refreshes to show only the remaining blockers
+- Final state: the overlay disappears only after no valid idle production or research choices remain
+
+**Misleading UI Risks**
+
+- The chooser text promises a `quick next step`, so recommendations cannot be based on registry insertion order
+- The chooser is a forced flow, so dismissing it while blockers remain would make the UI misleading even if the raw game state is correct
+- If stale tech or city panels survive underneath the overlay, the player can see outdated queue or research state immediately after acting
+
+**Interaction Replay Checklist**
+
+- End turn with missing research only
+- End turn with one idle city only
+- End turn with missing research plus multiple idle cities
+- Pick one quick action and verify the chooser stays open for remaining blockers
+- Open the city panel, then end turn, then verify no stale city panel remains under the chooser
+- Open the tech panel, then end turn, then verify no stale tech panel remains under the chooser
+- Verify the quick city recommendation in a fresh Era 1 city prefers a truly fast item instead of the first registered building
+
+- [ ] **Step 1: Write the failing regression tests**
+
+Extend `tests/integration/end-turn-gating.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { getIdleCityIds, getRecommendedIdleCityChoice, needsResearchChoice } from '@/systems/planning-system';
+import { foundCity } from '@/systems/city-system';
+
+describe('end-turn gating', () => {
+  it('detects when the player has no active research but valid options exist', () => {
+    const state = createNewGame(undefined, 'end-turn-gating-seed', 'small');
+    expect(needsResearchChoice(state, state.currentPlayer)).toBe(true);
+  });
+
+  it('still reports blockers after only one of multiple idle choices is resolved', () => {
+    const state = createNewGame(undefined, 'end-turn-multi-blocker-seed', 'small');
+    const player = state.currentPlayer;
+    const settlerId = state.civilizations[player].units.find(unitId => state.units[unitId]?.type === 'settler')!;
+    const basePos = state.units[settlerId].position;
+
+    const firstCity = foundCity(player, basePos, state.map);
+    const secondCity = foundCity(player, { q: basePos.q + 2, r: basePos.r }, state.map);
+    state.cities[firstCity.id] = firstCity;
+    state.cities[secondCity.id] = secondCity;
+    state.civilizations[player].cities.push(firstCity.id, secondCity.id);
+
+    expect(getIdleCityIds(state, player)).toHaveLength(2);
+    expect(needsResearchChoice(state, player)).toBe(true);
+
+    state.civilizations[player].techState.currentResearch = 'fire';
+
+    expect(getIdleCityIds(state, player)).toHaveLength(2);
+    expect(needsResearchChoice(state, player)).toBe(false);
+  });
+});
+```
+
+Extend `tests/systems/planning-system.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { getRecommendedIdleCityChoice } from '@/systems/planning-system';
+import { foundCity } from '@/systems/city-system';
+
+describe('planning-system idle recommendations', () => {
+  it('recommends a truly fast opening option instead of the first registered building', () => {
+    const state = createNewGame(undefined, 'idle-choice-seed', 'small');
+    const player = state.currentPlayer;
+    const settlerId = state.civilizations[player].units.find(unitId => state.units[unitId]?.type === 'settler')!;
+    const city = foundCity(player, state.units[settlerId].position, state.map);
+    state.cities[city.id] = city;
+    state.civilizations[player].cities.push(city.id);
+
+    const choice = getRecommendedIdleCityChoice(state, player, city.id);
+
+    expect(choice).not.toBeNull();
+    expect(choice?.itemId).not.toBe('herbalist');
+  });
+});
+```
+
+Extend `tests/ui/required-choice-panel.test.ts`:
+
+```typescript
+it('can be recreated cleanly for the next required choice after one action resolves', () => {
+  const first = createRequiredChoicePanel(document.body, {
+    researchChoices: [{ techId: 'fire', label: 'Fire', turns: 4 }],
+    cityChoices: [{ cityId: 'city-1', cityName: 'Roma', itemId: 'warrior', label: 'Warrior', turns: 3 }],
+    onChooseResearch: vi.fn(),
+    onChooseCityBuild: vi.fn(),
+    onOpenTech: vi.fn(),
+    onOpenCity: vi.fn(),
+  });
+
+  expect(first.textContent).toContain('Fire');
+
+  const second = createRequiredChoicePanel(document.body, {
+    researchChoices: [],
+    cityChoices: [{ cityId: 'city-2', cityName: 'Neapolis', itemId: 'shrine', label: 'Shrine', turns: 2 }],
+    onChooseResearch: vi.fn(),
+    onChooseCityBuild: vi.fn(),
+    onOpenTech: vi.fn(),
+    onOpenCity: vi.fn(),
+  });
+
+  expect(document.querySelectorAll('#required-choice-panel')).toHaveLength(1);
+  expect(second.textContent).toContain('Neapolis');
+  expect(second.textContent).not.toContain('Fire');
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/integration/end-turn-gating.test.ts tests/systems/planning-system.test.ts tests/ui/required-choice-panel.test.ts
+```
+
+Expected: FAIL because the chooser still dismisses after one quick action, recommendation logic is registry-ordered, and there is no shared recommendation helper yet.
+
+- [ ] **Step 3: Add a shared idle-city recommendation helper**
+
+Extend `src/systems/planning-system.ts`:
+
+```typescript
+import { calculateCityYields } from '@/systems/resource-system';
+
+export function getRecommendedIdleCityChoice(
+  state: GameState,
+  civId: string,
+  cityId: string,
+): { itemId: string; label: string; cost: number; turns: number } | null {
+  const civ = state.civilizations[civId];
+  const city = state.cities[cityId];
+  if (!civ || !city) {
+    return null;
+  }
+
+  const productionPerTurn = Math.max(1, calculateCityYields(city, state.map).production);
+  const completedTechs = civ.techState.completed ?? [];
+  const buildingCandidates = getAvailableBuildings(city, completedTechs).map(building => ({
+    itemId: building.id,
+    label: building.name,
+    cost: building.productionCost,
+    turns: Math.ceil(building.productionCost / productionPerTurn),
+    priority: building.pacing?.band === 'starter' ? 0 : 1,
+  }));
+  const unitCandidates = TRAINABLE_UNITS
+    .filter(unit => !unit.techRequired || completedTechs.includes(unit.techRequired))
+    .map(unit => ({
+      itemId: unit.type,
+      label: unit.name,
+      cost: unit.cost,
+      turns: Math.ceil(unit.cost / productionPerTurn),
+      priority: unit.pacing?.band === 'starter' ? 0 : 1,
+    }));
+
+  const best = [...buildingCandidates, ...unitCandidates]
+    .sort((left, right) => left.turns - right.turns || left.cost - right.cost || left.priority - right.priority)[0];
+
+  return best ?? null;
+}
+```
+
+- [ ] **Step 4: Keep the chooser active until all blockers are cleared**
+
+In `src/main.ts`, add helpers:
+
+```typescript
+function closePlanningPanels(): void {
+  document.getElementById('tech-panel')?.remove();
+  document.getElementById('city-panel')?.remove();
+}
+
+function refreshRequiredChoicesAfterAction(): void {
+  document.getElementById('required-choice-panel')?.remove();
+  closePlanningPanels();
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  const stillBlocked = showRequiredChoicesIfNeeded();
+  if (!stillBlocked) {
+    uiInteractions.setBlockingOverlay(null);
+  }
+}
+```
+
+Then update `showRequiredChoicesIfNeeded()` to:
+
+```typescript
+closePlanningPanels();
+
+const cityChoices = idleCityIds
+  .map(cityId => {
+    const city = gameState.cities[cityId];
+    const choice = getRecommendedIdleCityChoice(gameState, civId, cityId);
+    if (!city || !choice) {
+      return null;
+    }
+    return {
+      cityId,
+      cityName: city.name,
+      itemId: choice.itemId,
+      label: choice.label,
+      turns: choice.turns,
+    };
+  })
+  .filter((choice): choice is NonNullable<typeof choice> => choice !== null);
+```
+
+Update the quick-pick callbacks:
+
+```typescript
+onChooseResearch: (techId) => {
+  currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
+  showNotification(`Researching ${techId}...`, 'info');
+  refreshRequiredChoicesAfterAction();
+},
+onChooseCityBuild: (cityId, itemId) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  gameState.cities[cityId] = enqueueCityProduction(city, itemId);
+  showNotification(`${city.name}: queued ${itemId}`, 'info');
+  refreshRequiredChoicesAfterAction();
+},
+```
+
+This keeps the forced-choice flow active until every valid idle research/production blocker is resolved and guarantees stale planning panels are gone before the chooser reappears.
+
+- [ ] **Step 5: Run targeted tests, rule checks, and build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/integration/end-turn-gating.test.ts tests/systems/planning-system.test.ts tests/ui/required-choice-panel.test.ts
+scripts/check-src-rule-violations.sh src/systems/planning-system.ts src/main.ts
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/planning-system.ts src/main.ts tests/integration/end-turn-gating.test.ts tests/systems/planning-system.test.ts tests/ui/required-choice-panel.test.ts docs/superpowers/plans/2026-04-16-game-pacing-overhaul.md
+git commit -m "fix(turn-flow): tighten required-choice guidance"
+```
+
+---
+
+## Task 6: Local Balance Audit And Debug View
 
 **Goal:** Add deterministic, local-only pacing audit/debug tools and use them to validate the current retuned catalog.
 
@@ -1328,7 +1611,8 @@ For every task above, complete all of the following before moving on:
 - Research 3-item queue with reorder/remove: Task 3
 - Issue `#56` tech tree redesign: Task 3
 - Forced player choice for idle production/research: Task 4
-- Browser-only local audit/debug tooling: Task 5
+- Forced-choice flow review fixes for idle planning: Task 5
+- Browser-only local audit/debug tooling: Task 6
 
 ### User-Value Check
 
@@ -1338,7 +1622,8 @@ Every task now ends in something the player will notice:
 - Task 2: city queues and smoother city momentum
 - Task 3: research queues and a better tech tree
 - Task 4: no more accidental idle turns
-- Task 5: visible local pacing/debug inspection and safer broader tuning
+- Task 5: smoother and more trustworthy forced-choice guidance
+- Task 6: visible local pacing/debug inspection and safer broader tuning
 
 ### Reviewability Check
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { getMovementRange, moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits } from '@/systems/unit-system';
-import { foundCity } from '@/systems/city-system';
-import { enqueueCityProduction, enqueueResearch, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+import { foundCity, getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
+import { enqueueCityProduction, enqueueResearch, getIdleCityIds, moveQueuedId, needsResearchChoice, removeQueuedId } from '@/systems/planning-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
@@ -31,13 +31,16 @@ import { createGameShell } from '@/ui/game-shell';
 import { createContextMenu } from '@/ui/context-menu';
 import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
+import { createRequiredChoicePanel } from '@/ui/required-choice-panel';
 import { showCampaignSetup } from '@/ui/campaign-setup';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyDiplomaticAction, declareWar, makePeace, modifyRelationship } from '@/systems/diplomacy-system';
 import { calculateCityYields } from '@/systems/resource-system';
+import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import { visitVillage } from '@/systems/village-system';
 import { processWonderDiscovery } from '@/systems/wonder-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { getAvailableTechs } from '@/systems/tech-system';
 import { getNextPlayer, getAIPlayers, isRoundComplete } from '@/core/turn-cycling';
 import { showTurnHandoff } from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
@@ -462,6 +465,97 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       if (nextCity) openCityPanelForCity(nextCity);
     },
   });
+}
+
+function closeRequiredChoicePanel(): void {
+  document.getElementById('required-choice-panel')?.remove();
+  uiInteractions.setBlockingOverlay(null);
+}
+
+function showRequiredChoicesIfNeeded(): boolean {
+  const civId = gameState.currentPlayer;
+  const idleCityIds = getIdleCityIds(gameState, civId);
+  const missingResearch = needsResearchChoice(gameState, civId);
+  const existing = document.getElementById('required-choice-panel');
+
+  if (!idleCityIds.length && !missingResearch) {
+    closeRequiredChoicePanel();
+    return false;
+  }
+
+  if (existing) {
+    return true;
+  }
+
+  const civ = currentCiv();
+  const sciencePerTurn = Math.max(
+    1,
+    civ.cities
+      .map(cityId => gameState.cities[cityId])
+      .filter((city): city is NonNullable<typeof gameState.cities[string]> => city !== undefined)
+      .reduce((total, city) => total + calculateCityYields(city, gameState.map).science, 0),
+  );
+  const researchChoices = missingResearch
+    ? getAvailableTechs(civ.techState).slice(0, 3).map(tech => ({
+      techId: tech.id,
+      label: tech.name,
+      turns: estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: sciencePerTurn }),
+    }))
+    : [];
+
+  const cityChoices = idleCityIds.map(cityId => {
+    const city = gameState.cities[cityId];
+    const completedTechs = civ.techState.completed;
+    const buildingChoice = getAvailableBuildings(city, completedTechs)[0];
+    const unitChoice = TRAINABLE_UNITS.find(unit => !unit.techRequired || completedTechs.includes(unit.techRequired));
+    const chosen = buildingChoice
+      ? { itemId: buildingChoice.id, label: buildingChoice.name, cost: buildingChoice.productionCost }
+      : unitChoice
+        ? { itemId: unitChoice.type, label: unitChoice.name, cost: unitChoice.cost }
+        : { itemId: 'warrior', label: 'Warrior', cost: 8 };
+    const productionPerTurn = Math.max(1, calculateCityYields(city, gameState.map).production);
+    return {
+      cityId,
+      cityName: city.name,
+      itemId: chosen.itemId,
+      label: chosen.label,
+      turns: estimateTurnsToComplete({ cost: chosen.cost, outputPerTurn: productionPerTurn }),
+    };
+  });
+
+  uiInteractions.setBlockingOverlay('required-choice');
+  createRequiredChoicePanel(uiLayer, {
+    researchChoices,
+    cityChoices,
+    onChooseResearch: (techId) => {
+      currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
+      closeRequiredChoicePanel();
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      showNotification(`Researching ${techId}...`, 'info');
+    },
+    onChooseCityBuild: (cityId, itemId) => {
+      const city = gameState.cities[cityId];
+      if (!city) return;
+      gameState.cities[cityId] = enqueueCityProduction(city, itemId);
+      closeRequiredChoicePanel();
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      showNotification(`${city.name}: queued ${itemId}`, 'info');
+    },
+    onOpenTech: () => {
+      closeRequiredChoicePanel();
+      togglePanel('tech');
+    },
+    onOpenCity: (cityId) => {
+      const city = gameState.cities[cityId];
+      if (!city) return;
+      closeRequiredChoicePanel();
+      openCityPanelForCity(city);
+    },
+  });
+
+  return true;
 }
 
 function togglePanel(panel: string): void {
@@ -1249,6 +1343,11 @@ function handleHexLongPress(rawCoord: HexCoord): void {
 
 async function endTurn(): Promise<void> {
   try {
+    if (showRequiredChoicesIfNeeded()) {
+      showNotification('Choose production and research before ending the turn.', 'info');
+      return;
+    }
+
     SFX.endTurn();
     deselectUnit();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,8 +8,8 @@ import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { getMovementRange, moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits } from '@/systems/unit-system';
-import { foundCity, getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
-import { enqueueCityProduction, enqueueResearch, getIdleCityIds, moveQueuedId, needsResearchChoice, removeQueuedId } from '@/systems/planning-system';
+import { foundCity } from '@/systems/city-system';
+import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId } from '@/systems/planning-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
@@ -31,7 +31,7 @@ import { createGameShell } from '@/ui/game-shell';
 import { createContextMenu } from '@/ui/context-menu';
 import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
-import { createRequiredChoicePanel } from '@/ui/required-choice-panel';
+import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
 import { showCampaignSetup } from '@/ui/campaign-setup';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyDiplomaticAction, declareWar, makePeace, modifyRelationship } from '@/systems/diplomacy-system';
@@ -472,6 +472,14 @@ function closeRequiredChoicePanel(): void {
   uiInteractions.setBlockingOverlay(null);
 }
 
+function refreshRequiredChoicesAfterAction(): void {
+  document.getElementById('required-choice-panel')?.remove();
+  closePlanningPanels(document);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  showRequiredChoicesIfNeeded();
+}
+
 function showRequiredChoicesIfNeeded(): boolean {
   const civId = gameState.currentPlayer;
   const idleCityIds = getIdleCityIds(gameState, civId);
@@ -486,6 +494,8 @@ function showRequiredChoicesIfNeeded(): boolean {
   if (existing) {
     return true;
   }
+
+  closePlanningPanels(document);
 
   const civ = currentCiv();
   const sciencePerTurn = Math.max(
@@ -503,25 +513,22 @@ function showRequiredChoicesIfNeeded(): boolean {
     }))
     : [];
 
-  const cityChoices = idleCityIds.map(cityId => {
-    const city = gameState.cities[cityId];
-    const completedTechs = civ.techState.completed;
-    const buildingChoice = getAvailableBuildings(city, completedTechs)[0];
-    const unitChoice = TRAINABLE_UNITS.find(unit => !unit.techRequired || completedTechs.includes(unit.techRequired));
-    const chosen = buildingChoice
-      ? { itemId: buildingChoice.id, label: buildingChoice.name, cost: buildingChoice.productionCost }
-      : unitChoice
-        ? { itemId: unitChoice.type, label: unitChoice.name, cost: unitChoice.cost }
-        : { itemId: 'warrior', label: 'Warrior', cost: 8 };
-    const productionPerTurn = Math.max(1, calculateCityYields(city, gameState.map).production);
-    return {
-      cityId,
-      cityName: city.name,
-      itemId: chosen.itemId,
-      label: chosen.label,
-      turns: estimateTurnsToComplete({ cost: chosen.cost, outputPerTurn: productionPerTurn }),
-    };
-  });
+  const cityChoices = idleCityIds
+    .map(cityId => {
+      const city = gameState.cities[cityId];
+      const choice = getRecommendedIdleCityChoice(gameState, civId, cityId);
+      if (!city || !choice) {
+        return null;
+      }
+      return {
+        cityId,
+        cityName: city.name,
+        itemId: choice.itemId,
+        label: choice.label,
+        turns: choice.turns,
+      };
+    })
+    .filter((choice): choice is NonNullable<typeof choice> => choice !== null);
 
   uiInteractions.setBlockingOverlay('required-choice');
   createRequiredChoicePanel(uiLayer, {
@@ -529,19 +536,15 @@ function showRequiredChoicesIfNeeded(): boolean {
     cityChoices,
     onChooseResearch: (techId) => {
       currentCiv().techState = enqueueResearch(currentCiv().techState, techId);
-      closeRequiredChoicePanel();
-      renderLoop.setGameState(gameState);
-      updateHUD();
       showNotification(`Researching ${techId}...`, 'info');
+      refreshRequiredChoicesAfterAction();
     },
     onChooseCityBuild: (cityId, itemId) => {
       const city = gameState.cities[cityId];
       if (!city) return;
       gameState.cities[cityId] = enqueueCityProduction(city, itemId);
-      closeRequiredChoicePanel();
-      renderLoop.setGameState(gameState);
-      updateHUD();
       showNotification(`${city.name}: queued ${itemId}`, 'info');
+      refreshRequiredChoicesAfterAction();
     },
     onOpenTech: () => {
       closeRequiredChoicePanel();

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -1,5 +1,6 @@
 import type { City, GameState, TechState } from '@/core/types';
 import { getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
+import { calculateCityYields } from '@/systems/resource-system';
 import { getAvailableTechs } from '@/systems/tech-system';
 
 const MAX_QUEUE_ITEMS = 3;
@@ -93,4 +94,51 @@ export function needsResearchChoice(state: GameState, civId: string): boolean {
     return false;
   }
   return getAvailableTechs(civ.techState).length > 0;
+}
+
+export function getRecommendedIdleCityChoice(
+  state: GameState,
+  civId: string,
+  cityId: string,
+): { itemId: string; label: string; cost: number; turns: number } | null {
+  const civ = state.civilizations[civId];
+  const city = state.cities[cityId];
+  if (!civ || !city) {
+    return null;
+  }
+
+  const completedTechs = civ.techState.completed ?? [];
+  const productionPerTurn = Math.max(1, calculateCityYields(city, state.map).production);
+  const candidates = [
+    ...getAvailableBuildings(city, completedTechs).map(building => ({
+      itemId: building.id,
+      label: building.name,
+      cost: building.productionCost,
+      turns: Math.ceil(building.productionCost / productionPerTurn),
+      priority: building.pacing?.band === 'starter' ? 0 : 1,
+    })),
+    ...TRAINABLE_UNITS
+      .filter(unit => !unit.techRequired || completedTechs.includes(unit.techRequired))
+      .map(unit => ({
+        itemId: unit.type,
+        label: unit.name,
+        cost: unit.cost,
+        turns: Math.ceil(unit.cost / productionPerTurn),
+        priority: unit.pacing?.band === 'starter' ? 0 : 1,
+      })),
+  ];
+
+  const best = candidates
+    .sort((left, right) => left.turns - right.turns || left.cost - right.cost || left.priority - right.priority)[0];
+
+  if (!best) {
+    return null;
+  }
+
+  return {
+    itemId: best.itemId,
+    label: best.label,
+    cost: best.cost,
+    turns: best.turns,
+  };
 }

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -1,4 +1,6 @@
-import type { City, TechState } from '@/core/types';
+import type { City, GameState, TechState } from '@/core/types';
+import { getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
+import { getAvailableTechs } from '@/systems/tech-system';
 
 const MAX_QUEUE_ITEMS = 3;
 
@@ -62,4 +64,33 @@ export function enqueueResearch(state: TechState, techId: string): TechState {
     ...state,
     researchQueue: [...state.researchQueue, techId],
   };
+}
+
+export function getIdleCityIds(state: GameState, civId: string): string[] {
+  const civ = state.civilizations[civId];
+  if (!civ) {
+    return [];
+  }
+
+  const completedTechs = civ.techState.completed ?? [];
+  return Object.values(state.cities)
+    .filter(city => city.owner === civId)
+    .filter(city => city.productionQueue.length === 0)
+    .filter(city => {
+      const buildableBuildings = getAvailableBuildings(city, completedTechs).length > 0;
+      const buildableUnits = TRAINABLE_UNITS.some(unit => !unit.techRequired || completedTechs.includes(unit.techRequired));
+      return buildableBuildings || buildableUnits;
+    })
+    .map(city => city.id);
+}
+
+export function needsResearchChoice(state: GameState, civId: string): boolean {
+  const civ = state.civilizations[civId];
+  if (!civ) {
+    return false;
+  }
+  if (civ.techState.currentResearch) {
+    return false;
+  }
+  return getAvailableTechs(civ.techState).length > 0;
 }

--- a/src/ui/advisor-system.ts
+++ b/src/ui/advisor-system.ts
@@ -3,6 +3,7 @@ import { EventBus } from '@/core/event-bus';
 import { isAtWar, getRelationship } from '@/systems/diplomacy-system';
 import { hasDiscoveredMinorCiv } from '@/systems/discovery-system';
 import { getNextCouncilCallback, markCouncilCallbackDelivered } from '@/systems/council-memory';
+import { getIdleCityIds, needsResearchChoice } from '@/systems/planning-system';
 
 interface AdvisorMessage {
   id: string;
@@ -45,10 +46,7 @@ const ADVISOR_MESSAGES: AdvisorMessage[] = [
     advisor: 'builder',
     icon: '🏗️',
     message: 'Your city can train units. Open the city panel and queue up a Warrior to defend your borders.',
-    trigger: (state) => {
-      const cities = Object.values(state.cities).filter(c => c.owner === state.currentPlayer);
-      return cities.length > 0 && cities[0].productionQueue.length === 0;
-    },
+    trigger: (state) => getIdleCityIds(state, state.currentPlayer).length > 0,
     tutorialStep: 'build_unit',
   },
 
@@ -66,10 +64,7 @@ const ADVISOR_MESSAGES: AdvisorMessage[] = [
     advisor: 'scholar',
     icon: '📚',
     message: 'Knowledge is power! Open the Tech panel and choose something to research. Each discovery unlocks new possibilities.',
-    trigger: (state) => {
-      const civ = state.civilizations[state.currentPlayer];
-      return civ?.techState.currentResearch === null && state.turn >= 2;
-    },
+    trigger: (state) => needsResearchChoice(state, state.currentPlayer) && state.turn >= 2,
     tutorialStep: 'research_tech',
   },
   {
@@ -310,7 +305,7 @@ const ADVISOR_MESSAGES: AdvisorMessage[] = [
       const civ = state.civilizations[state.currentPlayer];
       if (!civ) return false;
       if (civ.techState.completed.length === 0) return false;
-      return civ.techState.currentResearch === null && state.turn >= 2;
+      return needsResearchChoice(state, state.currentPlayer) && state.turn >= 2;
     },
   },
   {

--- a/src/ui/required-choice-panel.ts
+++ b/src/ui/required-choice-panel.ts
@@ -1,0 +1,98 @@
+export interface RequiredChoiceConfig {
+  researchChoices: Array<{ techId: string; label: string; turns: number }>;
+  cityChoices: Array<{ cityId: string; cityName: string; itemId: string; label: string; turns: number }>;
+  onChooseResearch: (techId: string) => void;
+  onChooseCityBuild: (cityId: string, itemId: string) => void;
+  onOpenTech: () => void;
+  onOpenCity: (cityId: string) => void;
+}
+
+function buildSectionTitle(text: string): HTMLHeadingElement {
+  const heading = document.createElement('h3');
+  heading.textContent = text;
+  heading.style.cssText = 'font-size:16px;color:#e8c170;margin:0 0 8px;';
+  return heading;
+}
+
+export function createRequiredChoicePanel(
+  container: HTMLElement,
+  config: RequiredChoiceConfig,
+): HTMLElement {
+  container.querySelector('#required-choice-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'required-choice-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:40;padding:16px;overflow:auto;';
+
+  const title = document.createElement('h2');
+  title.textContent = 'Choose Your Next Step';
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0 0 8px;';
+  panel.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Your empire has useful work available. Pick a quick next step to keep momentum going.';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  panel.appendChild(intro);
+
+  const researchSection = document.createElement('section');
+  researchSection.style.cssText = 'margin-bottom:16px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+  researchSection.appendChild(buildSectionTitle('Choose Research'));
+
+  if (config.researchChoices.length === 0) {
+    const empty = document.createElement('div');
+    empty.textContent = 'No research choice is required right now.';
+    empty.style.cssText = 'font-size:12px;opacity:0.7;';
+    researchSection.appendChild(empty);
+  } else {
+    config.researchChoices.forEach(choice => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = `${choice.label} · ${choice.turns} turns`;
+      button.style.cssText = 'display:block;width:100%;text-align:left;margin-bottom:8px;padding:10px;border-radius:8px;border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);color:inherit;';
+      button.addEventListener('click', () => config.onChooseResearch(choice.techId));
+      researchSection.appendChild(button);
+    });
+  }
+
+  const openTechButton = document.createElement('button');
+  openTechButton.type = 'button';
+  openTechButton.textContent = 'Open Tech Panel';
+  openTechButton.addEventListener('click', () => config.onOpenTech());
+  researchSection.appendChild(openTechButton);
+  panel.appendChild(researchSection);
+
+  const citySection = document.createElement('section');
+  citySection.style.cssText = 'background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+  citySection.appendChild(buildSectionTitle('Choose Production'));
+
+  if (config.cityChoices.length === 0) {
+    const empty = document.createElement('div');
+    empty.textContent = 'No city production choice is required right now.';
+    empty.style.cssText = 'font-size:12px;opacity:0.7;';
+    citySection.appendChild(empty);
+  } else {
+    config.cityChoices.forEach(choice => {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;gap:8px;align-items:center;margin-bottom:8px;';
+
+      const buildButton = document.createElement('button');
+      buildButton.type = 'button';
+      buildButton.textContent = `${choice.cityName}: ${choice.label} · ${choice.turns} turns`;
+      buildButton.style.cssText = 'flex:1;text-align:left;padding:10px;border-radius:8px;border:1px solid rgba(255,255,255,0.18);background:rgba(255,255,255,0.08);color:inherit;';
+      buildButton.addEventListener('click', () => config.onChooseCityBuild(choice.cityId, choice.itemId));
+      row.appendChild(buildButton);
+
+      const openCityButton = document.createElement('button');
+      openCityButton.type = 'button';
+      openCityButton.textContent = 'Open City';
+      openCityButton.addEventListener('click', () => config.onOpenCity(choice.cityId));
+      row.appendChild(openCityButton);
+
+      citySection.appendChild(row);
+    });
+  }
+
+  panel.appendChild(citySection);
+  container.appendChild(panel);
+  return panel;
+}

--- a/src/ui/required-choice-panel.ts
+++ b/src/ui/required-choice-panel.ts
@@ -14,6 +14,11 @@ function buildSectionTitle(text: string): HTMLHeadingElement {
   return heading;
 }
 
+export function closePlanningPanels(container: ParentNode = document): void {
+  container.querySelector('#tech-panel')?.remove();
+  container.querySelector('#city-panel')?.remove();
+}
+
 export function createRequiredChoicePanel(
   container: HTMLElement,
   config: RequiredChoiceConfig,

--- a/src/ui/tutorial.ts
+++ b/src/ui/tutorial.ts
@@ -1,5 +1,6 @@
 import type { GameState, TutorialStep } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
+import { getIdleCityIds, needsResearchChoice } from '@/systems/planning-system';
 
 interface TutorialMessage {
   step: TutorialStep;
@@ -37,16 +38,13 @@ const TUTORIAL_MESSAGES: TutorialMessage[] = [
     step: 'research_tech',
     advisor: 'explorer',
     message: 'Knowledge is power! Open the Tech panel and choose something to research. Each discovery unlocks new possibilities.',
-    trigger: (state) => state.civilizations[state.currentPlayer]?.techState.currentResearch === null && state.turn >= 2,
+    trigger: (state) => needsResearchChoice(state, state.currentPlayer) && state.turn >= 2,
   },
   {
     step: 'build_unit',
     advisor: 'builder',
     message: 'Your city can train units. Open the city panel and queue up a Warrior to defend your borders.',
-    trigger: (state) => {
-      const cities = Object.values(state.cities).filter(c => c.owner === state.currentPlayer);
-      return cities.length > 0 && cities[0].productionQueue.length === 0;
-    },
+    trigger: (state) => getIdleCityIds(state, state.currentPlayer).length > 0,
   },
   {
     step: 'combat',

--- a/tests/integration/end-turn-gating.test.ts
+++ b/tests/integration/end-turn-gating.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { needsResearchChoice } from '@/systems/planning-system';
+import { foundCity } from '@/systems/city-system';
+import { getIdleCityIds, needsResearchChoice } from '@/systems/planning-system';
 
 describe('end-turn gating', () => {
   it('detects when the player has no active research but valid options exist', () => {
     const state = createNewGame(undefined, 'end-turn-gating-seed', 'small');
     expect(needsResearchChoice(state, state.currentPlayer)).toBe(true);
+  });
+
+  it('still reports blockers after only one of multiple idle choices is resolved', () => {
+    const state = createNewGame(undefined, 'end-turn-multi-blocker-seed', 'small');
+    const playerId = state.currentPlayer;
+    const settlerId = state.civilizations[playerId].units.find(unitId => state.units[unitId]?.type === 'settler');
+    expect(settlerId).toBeDefined();
+    const basePosition = state.units[settlerId!].position;
+
+    const firstCity = foundCity(playerId, basePosition, state.map);
+    const secondCity = foundCity(playerId, { q: basePosition.q + 2, r: basePosition.r }, state.map);
+    state.cities[firstCity.id] = firstCity;
+    state.cities[secondCity.id] = secondCity;
+    state.civilizations[playerId].cities.push(firstCity.id, secondCity.id);
+
+    expect(getIdleCityIds(state, playerId)).toHaveLength(2);
+    expect(needsResearchChoice(state, playerId)).toBe(true);
+
+    state.civilizations[playerId].techState.currentResearch = 'fire';
+
+    expect(getIdleCityIds(state, playerId)).toHaveLength(2);
+    expect(needsResearchChoice(state, playerId)).toBe(false);
   });
 });

--- a/tests/integration/end-turn-gating.test.ts
+++ b/tests/integration/end-turn-gating.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { needsResearchChoice } from '@/systems/planning-system';
+
+describe('end-turn gating', () => {
+  it('detects when the player has no active research but valid options exist', () => {
+    const state = createNewGame(undefined, 'end-turn-gating-seed', 'small');
+    expect(needsResearchChoice(state, state.currentPlayer)).toBe(true);
+  });
+});

--- a/tests/systems/planning-system.test.ts
+++ b/tests/systems/planning-system.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { foundCity } from '@/systems/city-system';
 import { createTechState } from '@/systems/tech-system';
-import { enqueueCityProduction, enqueueResearch, moveQueuedId, removeQueuedId } from '@/systems/planning-system';
+import {
+  enqueueCityProduction,
+  enqueueResearch,
+  getRecommendedIdleCityChoice,
+  moveQueuedId,
+  removeQueuedId,
+} from '@/systems/planning-system';
 
 describe('planning-system city queues', () => {
   it('appends new city builds up to a limit of three', () => {
@@ -25,5 +33,21 @@ describe('planning-system city queues', () => {
 
     expect(started.currentResearch).toBe('fire');
     expect(queued.researchQueue).toEqual(['writing']);
+  });
+
+  it('recommends a truly fast opening option instead of the first registered building', () => {
+    const state = createNewGame(undefined, 'idle-choice-seed', 'small');
+    const playerId = state.currentPlayer;
+    const settlerId = state.civilizations[playerId].units.find(unitId => state.units[unitId]?.type === 'settler');
+    expect(settlerId).toBeDefined();
+
+    const city = foundCity(playerId, state.units[settlerId!].position, state.map);
+    state.cities[city.id] = city;
+    state.civilizations[playerId].cities.push(city.id);
+
+    const choice = getRecommendedIdleCityChoice(state, playerId, city.id);
+
+    expect(choice).not.toBeNull();
+    expect(choice?.itemId).not.toBe('herbalist');
   });
 });

--- a/tests/ui/advisor-system.test.ts
+++ b/tests/ui/advisor-system.test.ts
@@ -242,6 +242,30 @@ describe('AdvisorSystem', () => {
     expect(messages[0].message).toContain('fortune');
   });
 
+  it('shows build-unit guidance when a later city is idle', () => {
+    const bus = new EventBus();
+    const advisor = new AdvisorSystem(bus);
+    const state = stateWithCity();
+    state.settings.advisorsEnabled = { builder: true, explorer: false, chancellor: false, warchief: false, treasurer: false, scholar: false, spymaster: false, artisan: false };
+    state.tutorial.active = true;
+    state.tutorial.completedSteps = ['welcome', 'found_city', 'explore', 'build_improvement', 'research_tech'];
+
+    const secondCity = foundCity('player', { q: 3, r: 0 }, state.map);
+    secondCity.productionQueue = [];
+    state.cities[secondCity.id] = secondCity;
+    state.civilizations.player.cities.push(secondCity.id);
+
+    const firstCityId = state.civilizations.player.cities[0];
+    state.cities[firstCityId].productionQueue = ['warrior'];
+
+    const messages: any[] = [];
+    bus.on('advisor:message', (msg) => messages.push(msg));
+
+    advisor.check(state);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('queue up a Warrior');
+  });
+
   it('getAdvisorMessageIds includes new advisor IDs', () => {
     const ids = getAdvisorMessageIds();
     expect(ids).toContain('welcome');

--- a/tests/ui/required-choice-panel.test.ts
+++ b/tests/ui/required-choice-panel.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it, vi } from 'vitest';
-import { createRequiredChoicePanel } from '@/ui/required-choice-panel';
+import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
 
 describe('required-choice-panel', () => {
   it('renders both research and production prompts with actionable buttons', () => {
@@ -17,5 +17,45 @@ describe('required-choice-panel', () => {
     expect(panel.textContent).toContain('Choose Research');
     expect(panel.textContent).toContain('Choose Production');
     expect(panel.querySelectorAll('button').length).toBeGreaterThan(1);
+  });
+
+  it('can be recreated cleanly for the next required choice after one action resolves', () => {
+    const first = createRequiredChoicePanel(document.body, {
+      researchChoices: [{ techId: 'fire', label: 'Fire', turns: 4 }],
+      cityChoices: [{ cityId: 'city-1', cityName: 'Roma', itemId: 'warrior', label: 'Warrior', turns: 3 }],
+      onChooseResearch: vi.fn(),
+      onChooseCityBuild: vi.fn(),
+      onOpenTech: vi.fn(),
+      onOpenCity: vi.fn(),
+    });
+
+    expect(first.textContent).toContain('Fire');
+
+    const second = createRequiredChoicePanel(document.body, {
+      researchChoices: [],
+      cityChoices: [{ cityId: 'city-2', cityName: 'Neapolis', itemId: 'shrine', label: 'Shrine', turns: 2 }],
+      onChooseResearch: vi.fn(),
+      onChooseCityBuild: vi.fn(),
+      onOpenTech: vi.fn(),
+      onOpenCity: vi.fn(),
+    });
+
+    expect(document.querySelectorAll('#required-choice-panel')).toHaveLength(1);
+    expect(second.textContent).toContain('Neapolis');
+    expect(second.textContent).not.toContain('Fire');
+  });
+
+  it('removes stale city and tech panels before the chooser is shown', () => {
+    const techPanel = document.createElement('div');
+    techPanel.id = 'tech-panel';
+    const cityPanel = document.createElement('div');
+    cityPanel.id = 'city-panel';
+    document.body.appendChild(techPanel);
+    document.body.appendChild(cityPanel);
+
+    closePlanningPanels(document);
+
+    expect(document.getElementById('tech-panel')).toBeNull();
+    expect(document.getElementById('city-panel')).toBeNull();
   });
 });

--- a/tests/ui/required-choice-panel.test.ts
+++ b/tests/ui/required-choice-panel.test.ts
@@ -1,0 +1,21 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { createRequiredChoicePanel } from '@/ui/required-choice-panel';
+
+describe('required-choice-panel', () => {
+  it('renders both research and production prompts with actionable buttons', () => {
+    const panel = createRequiredChoicePanel(document.body, {
+      researchChoices: [{ techId: 'fire', label: 'Fire', turns: 4 }],
+      cityChoices: [{ cityId: 'city-1', cityName: 'Roma', itemId: 'warrior', label: 'Warrior', turns: 3 }],
+      onChooseResearch: vi.fn(),
+      onChooseCityBuild: vi.fn(),
+      onOpenTech: vi.fn(),
+      onOpenCity: vi.fn(),
+    });
+
+    expect(panel.textContent).toContain('Choose Research');
+    expect(panel.textContent).toContain('Choose Production');
+    expect(panel.querySelectorAll('button').length).toBeGreaterThan(1);
+  });
+});

--- a/tests/ui/tutorial.test.ts
+++ b/tests/ui/tutorial.test.ts
@@ -61,4 +61,32 @@ describe('tutorial hot-seat support', () => {
     // Should not trigger found_city because the city belongs to player-1, not currentPlayer (player-2)
     expect(emitted).toBe(false);
   });
+
+  it('build_unit tutorial triggers when any current-player city is idle, not just the first one', () => {
+    const bus = new EventBus();
+    const tutorial = new TutorialSystem(bus);
+    const emittedSteps: string[] = [];
+    bus.on('tutorial:step', ({ step }) => emittedSteps.push(step));
+
+    const state = makeTutorialState({
+      tutorial: {
+        active: true,
+        currentStep: 'research_tech',
+        completedSteps: ['welcome', 'found_city', 'explore', 'build_improvement', 'research_tech'],
+      } as any,
+      cities: {
+        'city-1': { id: 'city-1', owner: 'player-2', name: 'Busy', position: { q: 0, r: 0 }, population: 1, buildings: [], productionQueue: ['warrior'], productionProgress: 0, grid: [], gridSize: 3, food: 0, housing: 5 } as any,
+        'city-2': { id: 'city-2', owner: 'player-2', name: 'Idle', position: { q: 1, r: 0 }, population: 1, buildings: [], productionQueue: [], productionProgress: 0, grid: [], gridSize: 3, food: 0, housing: 5 } as any,
+      },
+      civilizations: {
+        'player-2': {
+          ...makeTutorialState().civilizations['player-2'],
+          cities: ['city-1', 'city-2'],
+        },
+      } as any,
+    });
+
+    tutorial.check(state);
+    expect(emittedSteps).toContain('build_unit');
+  });
 });


### PR DESCRIPTION
## Summary
- block end turn when the player has idle city production or research and valid choices exist
- show a required-choice overlay with quick actions into research and city production
- align tutorial and advisor prompts with shared idle-choice helpers and add regression coverage

## Testing
- ./scripts/run-with-mise.sh yarn test --run tests/ui/required-choice-panel.test.ts tests/ui/tutorial.test.ts tests/ui/advisor-system.test.ts tests/integration/end-turn-gating.test.ts
- scripts/check-src-rule-violations.sh src/systems/planning-system.ts src/ui/required-choice-panel.ts src/ui/tutorial.ts src/ui/advisor-system.ts src/main.ts
- ./scripts/run-with-mise.sh yarn build