### PR TITLE
feat(ui): add shared solo setup shell

### DIFF
--- a/.claude/rules/end-to-end-wiring.md
+++ b/.claude/rules/end-to-end-wiring.md
@@ -9,6 +9,9 @@ paths:
 - If you calculate data (e.g., movement range, attack targets, fog of war), it MUST be passed to the renderer and visually displayed
 - If you create a utility function, it MUST be called from at least one code path — dead code is a bug
 - After implementing any system logic, trace the data flow: **state → compute → UI/renderer → user sees it**
+- If you extract or add a replacement UI helper for an existing player-visible flow, wire the real entry path to that helper in the same change. Shipping the old inline flow while the new module sits unused is still a broken feature.
+- For extracted entry flows, tests must cover real interaction behavior, not just isolated render shape. A passing test that never exercises the live path or callback contract is insufficient.
+- If an extraction exposes an existing bug in the inherited flow, do not freeze that bug in place under the banner of parity. Either fix it in the same change or stop and get a user decision on whether to defer it into a documented follow-up issue with reproduction details and the intended fix.
 
 ## Every user action needs visible feedback
 - Combat must show what will happen BEFORE it happens (preview panel with Attack/Cancel)

--- a/.claude/rules/ui-panels.md
+++ b/.claude/rules/ui-panels.md
@@ -46,6 +46,12 @@ paths:
 - If you intentionally truncate or collapse a catalog, provide an explicit tested affordance such as `Show all`, `More`, or a separate complete section
 - Add a regression that counts or otherwise proves all expected entries remain accessible from the live panel
 
+## Extracted UI Flows
+- If you replace an existing launcher, setup screen, or modal with a shared `src/ui/*` helper, the live caller must delegate to that helper in the same PR. Do not leave the old `main.ts` or inline DOM path active beside a new dead module.
+- When extracting a flow that already has validation, warnings, or block-on-invalid-input behavior, preserve the intended behavior unless the user or spec explicitly changes it. Do not preserve inherited bugs just because they were already present.
+- If you discover an inherited UX or validation bug while extracting the flow, either fix it in the same change or stop and get a user decision to defer it into a GitHub issue with concrete reproduction details and enough implementation context to fix it later.
+- Add click-through regression coverage for both the invalid path and the valid path when a player-visible input gates progression. A render-only test is not enough.
+
 ## Recommendation Surfaces
 - Do not treat seeded placeholder records as actionable advice
 - Panels and dashboards that recommend actions must only surface opportunities the player can actually pursue now under tech, resource, city, and visibility rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,12 @@ If you add a derived UI helper or label such as `next layer`, `reachable`, `reco
 
 If you add or modify a player-visible queue, tests must verify both data integrity and rendered behavior: active item, queued order, ETA text when relevant, and visible post-action state after reorder/remove.
 
+If you extract an existing player-visible launcher, modal, or setup flow into a shared UI helper, wire the live caller to that helper in the same change. Do not leave the old inline path active while only testing the new helper in isolation.
+
+If an extracted flow previously blocked on invalid input or showed a warning, preserve the intended validation behavior unless the user or spec explicitly changes it. Do not preserve inherited bugs just because they were already present.
+
+If you discover an inherited player-visible bug while extracting or refactoring a flow, either fix it in the same change or pause and get a user decision to defer it into a GitHub issue with reproduction steps, impact, and implementation notes.
+
 When a gameplay rule is attached to combat resolution, camp destruction, capture, or any other actor-agnostic state change, add parity coverage for the human path and at least one non-human path (`AI`, `turn-manager`, or another system caller). Do not treat a UI handler as the only execution path for game-state history or progression rules.
 
 If a system seeds local placeholders or project shells ahead of true eligibility, do not treat those seeded records as actionable by default. UI guidance, AI prioritization, and recommendation systems must use a shared helper that filters seeded state down to currently reachable opportunities.

--- a/src/main.ts
+++ b/src/main.ts
@@ -1702,6 +1702,7 @@ function showGameModeSelection(): void {
 
   modePanel = showGameModeSelect(uiLayer, {
     initialTitle: 'New Campaign',
+    onCancel: () => {},
     onTitleRequired: () => {
       showNotification('Campaign title is required', 'warning');
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
 import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
 import { showCampaignSetup } from '@/ui/campaign-setup';
+import { showGameModeSelect } from '@/ui/game-mode-select';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyDiplomaticAction, declareWar, makePeace, modifyRelationship } from '@/systems/diplomacy-system';
@@ -1691,40 +1692,7 @@ function migrateLegacySave(): void {
 }
 
 function showGameModeSelection(): void {
-  const modePanel = document.createElement('div');
-  modePanel.id = 'mode-select';
-  modePanel.style.cssText = 'position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(10,10,30,0.98);z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:24px;';
-  modePanel.innerHTML = `
-    <h1 style="font-size:22px;color:#e8c170;margin-bottom:24px;">New Game</h1>
-    <div style="width:100%;max-width:320px;margin-bottom:20px;">
-      <input id="new-game-title" type="text" placeholder="Campaign title" value="New Campaign" style="width:100%;padding:10px 14px;border-radius:8px;border:1px solid rgba(255,255,255,0.2);background:rgba(255,255,255,0.08);color:white;font-size:14px;" />
-    </div>
-    <div style="display:flex;gap:16px;">
-      <div id="mode-solo" style="background:rgba(255,255,255,0.08);border:2px solid transparent;border-radius:12px;padding:24px;cursor:pointer;text-align:center;min-width:140px;transition:border-color 0.2s;">
-        <div style="font-size:28px;margin-bottom:8px;">&#x1f3ae;</div>
-        <div style="font-weight:bold;font-size:16px;color:#e8c170;">Solo</div>
-        <div style="font-size:11px;opacity:0.6;margin-top:4px;">You vs AI</div>
-      </div>
-      <div id="mode-hotseat" style="background:rgba(255,255,255,0.08);border:2px solid transparent;border-radius:12px;padding:24px;cursor:pointer;text-align:center;min-width:140px;transition:border-color 0.2s;">
-        <div style="font-size:28px;margin-bottom:8px;">&#x1f46a;</div>
-        <div style="font-weight:bold;font-size:16px;color:#e8c170;">Hot Seat</div>
-        <div style="font-size:11px;opacity:0.6;margin-top:4px;">Pass the device</div>
-      </div>
-    </div>
-  `;
-
-  uiLayer.appendChild(modePanel);
-
-  const getRequestedTitle = (): string | null => {
-    const input = document.getElementById('new-game-title') as HTMLInputElement | null;
-    const title = input?.value.trim() ?? '';
-    if (!title) {
-      showNotification('Campaign title is required', 'warning');
-      return null;
-    }
-    return title;
-  };
-
+  let modePanel: HTMLElement;
   const updatePersistedCustomCivilizations = (customCivilizations: GameState['settings']['customCivilizations'] = []): void => {
     persistedSettings = {
       ...mergePersistedSettings(persistedSettings),
@@ -1732,61 +1700,63 @@ function showGameModeSelection(): void {
     };
   };
 
-  document.getElementById('mode-solo')?.addEventListener('click', async () => {
-    const title = (document.getElementById('new-game-title') as HTMLInputElement | null)?.value.trim() || 'New Campaign';
-    const currentSettings = await refreshPersistedSettings();
-    const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
-    modePanel.remove();
-    showCampaignSetup(uiLayer, {
-      initialTitle: title,
-      onStartSolo: (config) => {
-        gameState = createNewGame({
-          civType: config.civType,
-          mapSize: config.mapSize,
-          opponentCount: config.opponentCount,
-          gameTitle: config.gameTitle,
-          settingsOverrides: getPersistedSettingsOverrides(),
-          customCivilizations: config.customCivilizations,
-        });
-        if (persistedSettings?.councilTalkLevel) {
-          gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
-        }
-        startGame();
-        showNotification('Your tribe has settled near a river...', 'info');
-      },
-      onCustomCivilizationsChanged: (customCivilizations) => {
-        updatePersistedCustomCivilizations(customCivilizations);
-      },
-      onCancel: () => showGameModeSelection(),
-    }, {
-      initialCustomCivilizations: savedCustomCivilizations,
-    });
-  });
-
-  document.getElementById('mode-hotseat')?.addEventListener('click', async () => {
-    const title = getRequestedTitle();
-    if (!title) return;
-    const currentSettings = await refreshPersistedSettings();
-    const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
-    modePanel.remove();
-    showHotSeatSetup(uiLayer, {
-      onComplete: (config) => {
-        gameState = createHotSeatGame(config, undefined, title);
-        if (persistedSettings?.councilTalkLevel) {
-          gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
-        }
-        startGame();
-        showNotification(`Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`, 'info');
-      },
-      onCustomCivilizationsChanged: (customCivilizations) => {
-        updatePersistedCustomCivilizations(customCivilizations);
-      },
-      onCancel: () => {
-        showGameModeSelection();
-      },
-    }, {
-      initialCustomCivilizations: savedCustomCivilizations,
-    });
+  modePanel = showGameModeSelect(uiLayer, {
+    initialTitle: 'New Campaign',
+    onTitleRequired: () => {
+      showNotification('Campaign title is required', 'warning');
+    },
+    onChooseSolo: async (title) => {
+      const currentSettings = await refreshPersistedSettings();
+      const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
+      modePanel.remove();
+      showCampaignSetup(uiLayer, {
+        initialTitle: title,
+        onStartSolo: (config) => {
+          gameState = createNewGame({
+            civType: config.civType,
+            mapSize: config.mapSize,
+            opponentCount: config.opponentCount,
+            gameTitle: config.gameTitle,
+            settingsOverrides: getPersistedSettingsOverrides(),
+            customCivilizations: config.customCivilizations,
+          });
+          if (persistedSettings?.councilTalkLevel) {
+            gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
+          }
+          startGame();
+          showNotification('Your tribe has settled near a river...', 'info');
+        },
+        onCustomCivilizationsChanged: (customCivilizations) => {
+          updatePersistedCustomCivilizations(customCivilizations);
+        },
+        onCancel: () => showGameModeSelection(),
+      }, {
+        initialCustomCivilizations: savedCustomCivilizations,
+      });
+    },
+    onChooseHotSeat: async (title) => {
+      const currentSettings = await refreshPersistedSettings();
+      const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
+      modePanel.remove();
+      showHotSeatSetup(uiLayer, {
+        onComplete: (config) => {
+          gameState = createHotSeatGame(config, undefined, title);
+          if (persistedSettings?.councilTalkLevel) {
+            gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
+          }
+          startGame();
+          showNotification(`Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`, 'info');
+        },
+        onCustomCivilizationsChanged: (customCivilizations) => {
+          updatePersistedCustomCivilizations(customCivilizations);
+        },
+        onCancel: () => {
+          showGameModeSelection();
+        },
+      }, {
+        initialCustomCivilizations: savedCustomCivilizations,
+      });
+    },
   });
 }
 

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -6,6 +6,7 @@ import { getPlayableCivDefinitions } from '@/systems/civ-registry';
 import { buildCustomCivId, customCivDefinitionsEqual, mergeCustomCivDefinitions } from '@/systems/custom-civ-system';
 import { createDefaultSettings } from '@/core/game-state';
 import { loadSettings, saveSettings } from '@/storage/save-manager';
+import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
 
 export interface CampaignSetupCallbacks {
   onStartSolo: (config: SoloSetupConfig) => void;
@@ -36,35 +37,70 @@ function createLabeledSelect(labelText: string, id: string): { wrapper: HTMLDivE
 export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSetupCallbacks, options?: CampaignSetupOptions): HTMLElement {
   container.querySelector('#campaign-setup')?.remove();
 
-  const panel = document.createElement('div');
-  panel.id = 'campaign-setup';
-  panel.style.cssText = 'position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(10,10,30,0.98);z-index:50;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:24px;gap:16px;';
+  const shell = createSetupShell({
+    panelId: 'campaign-setup',
+    eyebrow: 'Solo Campaign',
+    title: 'Build Your Campaign',
+    subtitle: 'Choose your civilization, world size, and rival count before your people settle their first city.',
+  });
+  const panel = shell.surface;
 
-  const title = document.createElement('h1');
-  title.textContent = 'Build Your Campaign';
-  panel.appendChild(title);
+  const hero = document.createElement('div');
+  hero.dataset.role = 'setup-hero';
+  hero.style.display = 'flex';
+  hero.style.flexDirection = 'column';
+  hero.style.gap = '16px';
+  shell.body.appendChild(hero);
+
+  const titleSection = createSetupSection({
+    title: 'Campaign Title',
+    description: 'Name this campaign before your first settlers arrive.',
+  });
+  hero.appendChild(titleSection.section);
 
   const titleLabel = document.createElement('label');
   titleLabel.htmlFor = 'campaign-title';
   titleLabel.textContent = 'Campaign title';
-  panel.appendChild(titleLabel);
+  titleSection.content.appendChild(titleLabel);
 
   const titleInput = document.createElement('input');
   titleInput.id = 'campaign-title';
   titleInput.type = 'text';
   titleInput.value = callbacks.initialTitle ?? 'New Campaign';
-  panel.appendChild(titleInput);
+  Object.assign(titleInput.style, {
+    width: '100%',
+    padding: '12px 14px',
+    borderRadius: '12px',
+    border: '1px solid rgba(255,255,255,0.18)',
+    background: 'rgba(255,255,255,0.08)',
+    color: '#f4f1e8',
+    fontSize: '14px',
+  });
+  titleSection.content.appendChild(titleInput);
+
+  const civSection = createSetupSection({
+    title: 'Civilization',
+    description: 'Pick the culture you want to lead into the first age.',
+    role: 'selected-civ-summary',
+  });
+  hero.appendChild(civSection.section);
 
   const civSummary = document.createElement('div');
-  civSummary.dataset.role = 'selected-civ';
   civSummary.textContent = 'No civilization selected yet';
-  panel.appendChild(civSummary);
+  civSection.content.appendChild(civSummary);
 
   const chooseCivButton = document.createElement('button');
   chooseCivButton.type = 'button';
   chooseCivButton.dataset.action = 'choose-civ';
   chooseCivButton.textContent = 'Choose civilization';
-  panel.appendChild(chooseCivButton);
+  chooseCivButton.style.alignSelf = 'flex-start';
+  civSection.content.appendChild(chooseCivButton);
+
+  const mapSection = createSetupSection({
+    title: 'Map size',
+    description: 'Choose the world footprint for this campaign.',
+  });
+  hero.appendChild(mapSection.section);
 
   const mapSizeField = createLabeledSelect('Map size', 'campaign-map-size');
   for (const size of ['small', 'medium', 'large'] as const) {
@@ -73,10 +109,16 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     option.textContent = size;
     mapSizeField.select.appendChild(option);
   }
-  panel.appendChild(mapSizeField.wrapper);
+  mapSection.content.appendChild(mapSizeField.wrapper);
+
+  const opponentSection = createSetupSection({
+    title: 'Opponents',
+    description: 'Decide how many rival civilizations share the world with you.',
+  });
+  hero.appendChild(opponentSection.section);
 
   const opponentsField = createLabeledSelect('Opponents', 'campaign-opponents');
-  panel.appendChild(opponentsField.wrapper);
+  opponentSection.content.appendChild(opponentsField.wrapper);
 
   const refreshOpponentOptions = (): void => {
     const mapSize = mapSizeField.select.value as 'small' | 'medium' | 'large';
@@ -99,6 +141,15 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   let customCivilizations: CustomCivDefinition[] = [...(options?.initialCustomCivilizations ?? [])];
   let civDefinitions = getPlayableCivDefinitions({ customCivilizations });
 
+  const syncCampaignReadiness = (): void => {
+    const gameTitle = titleInput.value.trim();
+    const selectedDefinition = civDefinitions.find(def => def.id === selectedCivId);
+    civSummary.textContent = selectedDefinition
+      ? `Leading civilization: ${selectedDefinition.name}`
+      : 'No civilization selected yet';
+    startButton.disabled = !selectedCivId || !gameTitle;
+  };
+
   const replaceSetupOverlay = (render: () => void): void => {
     panel.querySelector('#custom-civ-panel')?.remove();
     panel.querySelector('#civ-select')?.remove();
@@ -107,13 +158,14 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
 
   const selectCivilization = (civId: string): void => {
     selectedCivId = civId;
-    civSummary.textContent = `Civilization: ${civDefinitions.find(def => def.id === civId)?.name ?? civId}`;
+    syncCampaignReadiness();
   };
 
   const openCivPicker = (): void => {
     replaceSetupOverlay(() => {
       createCivSelectPanel(panel, {
         onSelect: selectCivilization,
+        onCancel: () => {},
         onCreateCustomCiv: () => {
           openCustomCivEditor();
         },
@@ -141,6 +193,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
           await saveSettings({ ...loaded, customCivilizations });
           callbacks.onCustomCivilizationsChanged?.([...customCivilizations]);
           civDefinitions = getPlayableCivDefinitions({ customCivilizations });
+          syncCampaignReadiness();
           openCivPicker();
         },
         onCancel: () => {
@@ -171,6 +224,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   const startButton = document.createElement('button');
   startButton.type = 'button';
   startButton.textContent = 'Start Campaign';
+  startButton.disabled = true;
   startButton.addEventListener('click', () => {
     if (!selectedCivId) {
       return;
@@ -190,7 +244,10 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
   buttonRow.appendChild(startButton);
 
-  panel.appendChild(buttonRow);
+  shell.actions.appendChild(buttonRow);
+
+  titleInput.addEventListener('input', syncCampaignReadiness);
+  syncCampaignReadiness();
   container.appendChild(panel);
   return panel;
 }

--- a/src/ui/civ-select.ts
+++ b/src/ui/civ-select.ts
@@ -1,10 +1,12 @@
 import type { CivDefinition } from '@/core/types';
 import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
 import { createRng } from '@/systems/map-generator';
+import { createSetupShell } from '@/ui/setup-shell';
 
 export interface CivSelectCallbacks {
   onSelect: (civId: string) => void;
   onCreateCustomCiv?: () => void;
+  onCancel?: () => void;
 }
 
 export interface CivSelectOptions {
@@ -37,53 +39,31 @@ export function createCivSelectPanel(
   const headerText = options?.headerText ?? 'Choose Your Civilization';
   const civDefinitions = options?.civDefinitions ?? CIV_DEFINITIONS;
   const primaryActionText = options?.primaryActionText ?? 'Start Game';
-  const panel = document.createElement('div');
-  panel.id = 'civ-select';
-  panel.style.position = 'absolute';
-  panel.style.top = '0';
-  panel.style.left = '0';
-  panel.style.right = '0';
-  panel.style.bottom = '0';
-  panel.style.background = 'rgba(15,15,25,0.98)';
-  panel.style.zIndex = '50';
-  panel.style.overflowY = 'auto';
-  panel.style.padding = '16px';
-  panel.style.display = 'flex';
-  panel.style.flexDirection = 'column';
-  panel.style.alignItems = 'center';
+  const shell = createSetupShell({
+    panelId: 'civ-select',
+    eyebrow: 'Solo Campaign',
+    title: headerText,
+    subtitle: 'Each civilization has a distinct bonus that shapes your opening strategy.',
+  });
+  const panel = shell.surface;
 
   let selectedCiv: string | null = null;
 
-  const header = document.createElement('h1');
-  header.dataset.text = 'header';
-  header.textContent = headerText;
-  header.style.fontSize = '22px';
-  header.style.color = '#e8c170';
-  header.style.margin = '24px 0 8px';
-  header.style.textAlign = 'center';
-  panel.appendChild(header);
-
-  const subhead = document.createElement('p');
-  subhead.textContent = 'Each civilization has a unique bonus that shapes your strategy.';
-  subhead.style.fontSize = '13px';
-  subhead.style.opacity = '0.6';
-  subhead.style.marginBottom = '24px';
-  subhead.style.textAlign = 'center';
-  panel.appendChild(subhead);
-
   const grid = document.createElement('div');
-  grid.style.display = 'grid';
-  grid.style.gridTemplateColumns = 'repeat(2,1fr)';
-  grid.style.gap = '12px';
-  grid.style.maxWidth = '400px';
-  grid.style.width = '100%';
-  panel.appendChild(grid);
+  Object.assign(grid.style, {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2,1fr)',
+    gap: '12px',
+    width: '100%',
+  });
+  shell.body.appendChild(grid);
 
   const cards: HTMLElement[] = [];
   for (const civ of civDefinitions) {
     const card = document.createElement('div');
     card.className = 'civ-card';
     card.dataset.civId = civ.id;
+    card.dataset.selected = 'false';
     card.style.background = 'rgba(255,255,255,0.08)';
     card.style.border = '2px solid transparent';
     card.style.borderRadius = '12px';
@@ -139,8 +119,12 @@ export function createCivSelectPanel(
       selectedCiv = civ.id;
       for (const otherCard of cards) {
         otherCard.style.borderColor = 'transparent';
+        otherCard.dataset.selected = 'false';
+        otherCard.setAttribute('aria-pressed', 'false');
       }
       card.style.borderColor = '#e8c170';
+       card.dataset.selected = 'true';
+       card.setAttribute('aria-pressed', 'true');
       startButton.disabled = false;
       startButton.style.opacity = '1';
     });
@@ -150,12 +134,25 @@ export function createCivSelectPanel(
   }
 
   const actionBar = document.createElement('div');
-  actionBar.style.marginTop = '20px';
-  actionBar.style.display = 'flex';
-  actionBar.style.gap = '12px';
-  actionBar.style.flexWrap = 'wrap';
-  actionBar.style.justifyContent = 'center';
-  panel.appendChild(actionBar);
+  Object.assign(actionBar.style, {
+    display: 'flex',
+    gap: '12px',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  });
+  shell.actions.appendChild(actionBar);
+
+  if (callbacks.onCancel) {
+    const cancelButton = createButton('Back');
+    cancelButton.dataset.action = 'cancel-civ-select';
+    cancelButton.style.background = 'transparent';
+    cancelButton.style.color = '#f4f1e8';
+    cancelButton.addEventListener('click', () => {
+      panel.remove();
+      callbacks.onCancel?.();
+    });
+    actionBar.appendChild(cancelButton);
+  }
 
   const randomButton = createButton('Random');
   randomButton.id = 'civ-random';
@@ -190,7 +187,10 @@ export function createCivSelectPanel(
     const randomIdx = Math.floor(pickRng() * available.length);
     selectedCiv = available[randomIdx].id;
     for (const card of cards) {
-      card.style.borderColor = card.dataset.civId === selectedCiv ? '#e8c170' : 'transparent';
+      const selected = card.dataset.civId === selectedCiv;
+      card.style.borderColor = selected ? '#e8c170' : 'transparent';
+      card.dataset.selected = selected ? 'true' : 'false';
+      card.setAttribute('aria-pressed', selected ? 'true' : 'false');
     }
     startButton.disabled = false;
     startButton.style.opacity = '1';

--- a/src/ui/custom-civ-panel.ts
+++ b/src/ui/custom-civ-panel.ts
@@ -4,6 +4,7 @@ import {
   CUSTOM_CIV_PRIMARY_TRAITS,
   validateCustomCivDefinition,
 } from '@/systems/custom-civ-system';
+import { createSetupSection } from '@/ui/setup-shell';
 
 export interface CustomCivPanelCallbacks {
   onSave: (def: CustomCivDefinition) => void;
@@ -75,17 +76,24 @@ export function createCustomCivPanel(
   panel.style.maxHeight = 'calc(100vh - 108px)';
   panel.style.fontFamily = 'inherit';
 
+  const header = document.createElement('div');
+  header.dataset.role = 'setup-panel-header';
+  header.style.display = 'flex';
+  header.style.flexDirection = 'column';
+  header.style.gap = '8px';
+  panel.appendChild(header);
+
   const title = document.createElement('h2');
   title.textContent = 'Create Custom Civilization';
   title.style.margin = '0';
   title.style.fontSize = '1.1em';
-  panel.appendChild(title);
+  header.appendChild(title);
 
   const subtitle = document.createElement('p');
   subtitle.textContent = 'Shape a balanced custom civilization with one signature specialty and up to two temperament traits.';
   subtitle.style.margin = '0';
   subtitle.style.fontSize = '0.9em';
-  panel.appendChild(subtitle);
+  header.appendChild(subtitle);
 
   const state = {
     civName: '',
@@ -108,21 +116,35 @@ export function createCustomCivPanel(
   validationMessage.style.color = '#f2c572';
   panel.appendChild(validationMessage);
 
+  const basicsSection = createSetupSection({
+    title: 'Identity',
+    description: 'Name your civilization, choose a leader, and set its banner color.',
+    role: 'custom-civ-basics',
+  });
+  panel.appendChild(basicsSection.section);
+
   const civNameSection = createLabeledSection('Civilization Name');
   const civNameInput = createTextInput('civ-name');
   civNameSection.appendChild(civNameInput);
-  panel.appendChild(civNameSection);
+  basicsSection.content.appendChild(civNameSection);
 
   const leaderNameSection = createLabeledSection('Leader Name');
   const leaderNameInput = createTextInput('leader-name');
   leaderNameSection.appendChild(leaderNameInput);
-  panel.appendChild(leaderNameSection);
+  basicsSection.content.appendChild(leaderNameSection);
 
   const colorSection = createLabeledSection('Civilization Color');
   const colorInput = createTextInput('civ-color', 'color');
   colorInput.value = state.color;
   colorSection.appendChild(colorInput);
-  panel.appendChild(colorSection);
+  basicsSection.content.appendChild(colorSection);
+
+  const traitsSection = createSetupSection({
+    title: 'Traits',
+    description: 'Pick one signature strength and up to two temperament traits.',
+    role: 'custom-civ-traits',
+  });
+  panel.appendChild(traitsSection.section);
 
   const primaryTraitSection = createLabeledSection('Primary Trait', 'primary-trait');
   primaryTraitSection.style.display = 'flex';
@@ -147,7 +169,7 @@ export function createCustomCivPanel(
     primaryButtons.set(trait.id, button);
     primaryTraitSection.appendChild(button);
   }
-  panel.appendChild(primaryTraitSection);
+  traitsSection.content.appendChild(primaryTraitSection);
 
   const temperamentSection = createLabeledSection('Temperament Traits', 'temperament-traits');
   temperamentSection.style.display = 'flex';
@@ -177,7 +199,14 @@ export function createCustomCivPanel(
     temperamentButtons.set(trait.id, button);
     temperamentSection.appendChild(button);
   }
-  panel.appendChild(temperamentSection);
+  traitsSection.content.appendChild(temperamentSection);
+
+  const cityNamesShell = createSetupSection({
+    title: 'City Names',
+    description: 'Provide at least six settlement names, one per line.',
+    role: 'custom-civ-city-names',
+  });
+  panel.appendChild(cityNamesShell.section);
 
   const cityNamesSection = createLabeledSection('City Names');
   const cityNamesInput = document.createElement('textarea');
@@ -191,7 +220,7 @@ export function createCustomCivPanel(
   cityNamesInput.style.padding = '10px 12px';
   cityNamesInput.style.fontFamily = 'inherit';
   cityNamesSection.appendChild(cityNamesInput);
-  panel.appendChild(cityNamesSection);
+  cityNamesShell.content.appendChild(cityNamesSection);
 
   const actionBar = document.createElement('div');
   actionBar.style.display = 'flex';

--- a/src/ui/game-mode-select.ts
+++ b/src/ui/game-mode-select.ts
@@ -1,0 +1,109 @@
+import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
+
+export interface GameModeSelectCallbacks {
+  initialTitle?: string;
+  onChooseSolo: (title: string) => void;
+  onChooseHotSeat: (title: string) => void;
+}
+
+function createModeButton(label: string, description: string, action: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.dataset.action = action;
+  Object.assign(button.style, {
+    minHeight: '96px',
+    borderRadius: '16px',
+    border: '1px solid rgba(232,193,112,0.24)',
+    background: 'rgba(255,255,255,0.04)',
+    color: '#f4f1e8',
+    cursor: 'pointer',
+    padding: '18px',
+    textAlign: 'left',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+  });
+
+  const title = document.createElement('span');
+  title.textContent = label;
+  Object.assign(title.style, {
+    fontSize: '18px',
+    fontWeight: '700',
+    color: '#f7f1d7',
+  });
+  button.appendChild(title);
+
+  const subtitle = document.createElement('span');
+  subtitle.textContent = description;
+  Object.assign(subtitle.style, {
+    fontSize: '13px',
+    lineHeight: '1.45',
+    color: 'rgba(244,241,232,0.7)',
+  });
+  button.appendChild(subtitle);
+
+  return button;
+}
+
+export function showGameModeSelect(container: HTMLElement, callbacks: GameModeSelectCallbacks): HTMLElement {
+  container.querySelector('#mode-select')?.remove();
+
+  const shell = createSetupShell({
+    panelId: 'mode-select',
+    eyebrow: 'Campaign Setup',
+    title: 'New Game',
+    subtitle: 'Choose how this campaign begins, then continue into the matching setup flow.',
+  });
+
+  const titleSection = createSetupSection({
+    title: 'Campaign Title',
+    description: 'Name this run before choosing solo or hot seat.',
+    role: 'mode-select-title-section',
+  });
+
+  const titleInput = document.createElement('input');
+  titleInput.id = 'new-game-title';
+  titleInput.type = 'text';
+  titleInput.value = callbacks.initialTitle ?? 'New Campaign';
+  Object.assign(titleInput.style, {
+    width: '100%',
+    padding: '12px 14px',
+    borderRadius: '12px',
+    border: '1px solid rgba(255,255,255,0.18)',
+    background: 'rgba(255,255,255,0.08)',
+    color: '#f4f1e8',
+    fontSize: '14px',
+  });
+  titleSection.content.appendChild(titleInput);
+  shell.body.appendChild(titleSection.section);
+
+  const modeSection = createSetupSection({
+    title: 'Choose A Mode',
+    description: 'Solo pits you against AI rivals. Hot seat keeps multiple human players on one device.',
+    role: 'mode-select-modes',
+  });
+
+  const modeGrid = document.createElement('div');
+  modeGrid.dataset.role = 'mode-select-grid';
+  Object.assign(modeGrid.style, {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gap: '12px',
+  });
+  modeSection.content.appendChild(modeGrid);
+
+  const getTitle = (): string => titleInput.value.trim() || 'New Campaign';
+
+  const soloButton = createModeButton('Solo', 'Lead one civilization against AI rivals.', 'choose-solo-mode');
+  soloButton.addEventListener('click', () => callbacks.onChooseSolo(getTitle()));
+  modeGrid.appendChild(soloButton);
+
+  const hotSeatButton = createModeButton('Hot Seat', 'Pass the device between human players sharing one world.', 'choose-hotseat-mode');
+  hotSeatButton.addEventListener('click', () => callbacks.onChooseHotSeat(getTitle()));
+  modeGrid.appendChild(hotSeatButton);
+
+  shell.body.appendChild(modeSection.section);
+
+  container.appendChild(shell.surface);
+  return shell.surface;
+}

--- a/src/ui/game-mode-select.ts
+++ b/src/ui/game-mode-select.ts
@@ -5,6 +5,7 @@ export interface GameModeSelectCallbacks {
   onChooseSolo: (title: string) => void;
   onChooseHotSeat: (title: string) => void;
   onTitleRequired?: () => void;
+  onCancel?: () => void;
 }
 
 function createModeButton(label: string, description: string, action: string): HTMLButtonElement {
@@ -43,6 +44,25 @@ function createModeButton(label: string, description: string, action: string): H
   });
   button.appendChild(subtitle);
 
+  return button;
+}
+
+function createActionButton(label: string, action: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = label;
+  button.dataset.action = action;
+  Object.assign(button.style, {
+    minHeight: '44px',
+    minWidth: '44px',
+    padding: '10px 20px',
+    borderRadius: '8px',
+    border: '1px solid rgba(255,255,255,0.2)',
+    background: 'transparent',
+    color: '#f4f1e8',
+    cursor: 'pointer',
+    fontSize: '13px',
+  });
   return button;
 }
 
@@ -118,6 +138,22 @@ export function showGameModeSelect(container: HTMLElement, callbacks: GameModeSe
   modeGrid.appendChild(hotSeatButton);
 
   shell.body.appendChild(modeSection.section);
+
+  const actionBar = document.createElement('div');
+  Object.assign(actionBar.style, {
+    display: 'flex',
+    gap: '12px',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  });
+
+  const backButton = createActionButton('Back', 'cancel-mode-select');
+  backButton.addEventListener('click', () => {
+    shell.surface.remove();
+    callbacks.onCancel?.();
+  });
+  actionBar.appendChild(backButton);
+  shell.actions.appendChild(actionBar);
 
   container.appendChild(shell.surface);
   return shell.surface;

--- a/src/ui/game-mode-select.ts
+++ b/src/ui/game-mode-select.ts
@@ -4,6 +4,7 @@ export interface GameModeSelectCallbacks {
   initialTitle?: string;
   onChooseSolo: (title: string) => void;
   onChooseHotSeat: (title: string) => void;
+  onTitleRequired?: () => void;
 }
 
 function createModeButton(label: string, description: string, action: string): HTMLButtonElement {
@@ -92,14 +93,28 @@ export function showGameModeSelect(container: HTMLElement, callbacks: GameModeSe
   });
   modeSection.content.appendChild(modeGrid);
 
-  const getTitle = (): string => titleInput.value.trim() || 'New Campaign';
+  const getSoloTitle = (): string => titleInput.value.trim() || 'New Campaign';
+  const getHotSeatTitle = (): string | null => {
+    const title = titleInput.value.trim();
+    if (!title) {
+      callbacks.onTitleRequired?.();
+      return null;
+    }
+    return title;
+  };
 
   const soloButton = createModeButton('Solo', 'Lead one civilization against AI rivals.', 'choose-solo-mode');
-  soloButton.addEventListener('click', () => callbacks.onChooseSolo(getTitle()));
+  soloButton.addEventListener('click', () => callbacks.onChooseSolo(getSoloTitle()));
   modeGrid.appendChild(soloButton);
 
   const hotSeatButton = createModeButton('Hot Seat', 'Pass the device between human players sharing one world.', 'choose-hotseat-mode');
-  hotSeatButton.addEventListener('click', () => callbacks.onChooseHotSeat(getTitle()));
+  hotSeatButton.addEventListener('click', () => {
+    const title = getHotSeatTitle();
+    if (!title) {
+      return;
+    }
+    callbacks.onChooseHotSeat(title);
+  });
   modeGrid.appendChild(hotSeatButton);
 
   shell.body.appendChild(modeSection.section);

--- a/src/ui/setup-shell.ts
+++ b/src/ui/setup-shell.ts
@@ -1,0 +1,192 @@
+export interface SetupShellOptions {
+  title: string;
+  subtitle?: string;
+  eyebrow?: string;
+  panelId?: string;
+}
+
+export interface SetupSectionOptions {
+  title: string;
+  description?: string;
+  role?: string;
+}
+
+export interface SetupShell {
+  surface: HTMLDivElement;
+  card: HTMLDivElement;
+  header: HTMLDivElement;
+  eyebrow?: HTMLParagraphElement;
+  title: HTMLHeadingElement;
+  subtitle?: HTMLParagraphElement;
+  body: HTMLDivElement;
+  actions: HTMLDivElement;
+}
+
+export interface SetupSection {
+  section: HTMLElement;
+  title: HTMLHeadingElement;
+  description?: HTMLParagraphElement;
+  content: HTMLDivElement;
+}
+
+function assignStyles(element: HTMLElement, styles: Record<string, string>): void {
+  Object.assign(element.style, styles);
+}
+
+export function createSetupShell(options: SetupShellOptions): SetupShell {
+  const surface = document.createElement('div');
+  if (options.panelId) {
+    surface.id = options.panelId;
+  }
+  surface.dataset.role = 'setup-surface';
+  assignStyles(surface, {
+    position: 'absolute',
+    inset: '0',
+    background: 'linear-gradient(180deg, rgba(9,11,28,0.98), rgba(24,18,12,0.96))',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+    zIndex: '50',
+  });
+
+  const card = document.createElement('div');
+  card.dataset.role = 'setup-card';
+  assignStyles(card, {
+    width: 'min(100%, 920px)',
+    maxHeight: '100%',
+    overflowY: 'auto',
+    border: '1px solid rgba(232,193,112,0.22)',
+    borderRadius: '24px',
+    background: 'rgba(17,20,38,0.92)',
+    boxShadow: '0 24px 80px rgba(0,0,0,0.45)',
+    padding: '24px',
+    color: '#f4f1e8',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '18px',
+    fontFamily: 'inherit',
+  });
+  surface.appendChild(card);
+
+  const header = document.createElement('div');
+  header.dataset.role = 'setup-panel-header';
+  assignStyles(header, {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  });
+  card.appendChild(header);
+
+  let eyebrow: HTMLParagraphElement | undefined;
+  if (options.eyebrow) {
+    eyebrow = document.createElement('p');
+    eyebrow.dataset.role = 'setup-eyebrow';
+    eyebrow.textContent = options.eyebrow;
+    assignStyles(eyebrow, {
+      margin: '0',
+      color: '#e8c170',
+      fontSize: '12px',
+      letterSpacing: '0.18em',
+      textTransform: 'uppercase',
+    });
+    header.appendChild(eyebrow);
+  }
+
+  const title = document.createElement('h1');
+  title.dataset.role = 'setup-title';
+  title.textContent = options.title;
+  assignStyles(title, {
+    margin: '0',
+    color: '#f7f1d7',
+    fontSize: '28px',
+    lineHeight: '1.15',
+  });
+  header.appendChild(title);
+
+  let subtitle: HTMLParagraphElement | undefined;
+  if (options.subtitle) {
+    subtitle = document.createElement('p');
+    subtitle.dataset.role = 'setup-subtitle';
+    subtitle.textContent = options.subtitle;
+    assignStyles(subtitle, {
+      margin: '0',
+      color: 'rgba(244,241,232,0.72)',
+      fontSize: '14px',
+      lineHeight: '1.5',
+    });
+    header.appendChild(subtitle);
+  }
+
+  const body = document.createElement('div');
+  body.dataset.role = 'setup-body';
+  assignStyles(body, {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+  });
+  card.appendChild(body);
+
+  const actions = document.createElement('div');
+  actions.dataset.role = 'setup-actions';
+  assignStyles(actions, {
+    display: 'flex',
+    gap: '12px',
+    justifyContent: 'flex-end',
+    flexWrap: 'wrap',
+  });
+  card.appendChild(actions);
+
+  return { surface, card, header, eyebrow, title, subtitle, body, actions };
+}
+
+export function createSetupSection(options: SetupSectionOptions): SetupSection {
+  const section = document.createElement('section');
+  if (options.role) {
+    section.dataset.role = options.role;
+  }
+  assignStyles(section, {
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: '18px',
+    background: 'rgba(255,255,255,0.04)',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  });
+
+  const title = document.createElement('h2');
+  title.dataset.role = 'setup-section-title';
+  title.textContent = options.title;
+  assignStyles(title, {
+    margin: '0',
+    fontSize: '17px',
+    color: '#f7f1d7',
+  });
+  section.appendChild(title);
+
+  let description: HTMLParagraphElement | undefined;
+  if (options.description) {
+    description = document.createElement('p');
+    description.dataset.role = 'setup-section-description';
+    description.textContent = options.description;
+    assignStyles(description, {
+      margin: '0',
+      fontSize: '13px',
+      lineHeight: '1.5',
+      color: 'rgba(244,241,232,0.68)',
+    });
+    section.appendChild(description);
+  }
+
+  const content = document.createElement('div');
+  content.dataset.role = 'setup-section-content';
+  assignStyles(content, {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+  });
+  section.appendChild(content);
+
+  return { section, title, description, content };
+}

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -72,6 +72,31 @@ describe('campaign-setup', () => {
     document.body.innerHTML = '';
   });
 
+  it('shows a setup header, selected civ summary, and enables start only after a civ is confirmed', () => {
+    const onStartSolo = vi.fn();
+
+    showCampaignSetup(document.body, {
+      onStartSolo,
+      onCancel: () => {},
+    });
+
+    expect(document.body.textContent).toContain('Build Your Campaign');
+    expect(document.querySelector('[data-role="setup-hero"]')).toBeTruthy();
+    expect(document.querySelector('[data-role="selected-civ-summary"]')?.textContent).toContain('No civilization selected');
+
+    const startButton = Array.from(document.querySelectorAll('button'))
+      .find(button => button.textContent === 'Start Campaign') as HTMLButtonElement;
+    expect(startButton.disabled).toBe(true);
+
+    clickButtonWithText('Choose civilization');
+    const firstCard = document.querySelector('.civ-card') as HTMLElement;
+    firstCard.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+
+    expect(document.querySelector('[data-role="selected-civ-summary"]')?.textContent).not.toContain('No civilization selected');
+    expect(startButton.disabled).toBe(false);
+  });
+
   it('requires map size, civ selection, opponent count, and campaign title before starting a solo game', () => {
     const container = document.createElement('div');
     const onStart = vi.fn();

--- a/tests/ui/civ-select.test.ts
+++ b/tests/ui/civ-select.test.ts
@@ -1,5 +1,5 @@
 /** @vitest-environment jsdom */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createCivSelectPanel } from '@/ui/civ-select';
 import { getPlayableCivDefinitions } from '@/systems/civ-registry';
 import type { CustomCivDefinition } from '@/core/types';
@@ -15,6 +15,31 @@ const customCiv: CustomCivDefinition = {
 };
 
 describe('civ-select', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('marks the chosen civ card as selected and exposes a back action', () => {
+    const onCancel = vi.fn();
+    const panel = createCivSelectPanel(document.body, {
+      onSelect: () => {},
+      onCancel,
+    }, {
+      civDefinitions: getPlayableCivDefinitions({ customCivilizations: [customCiv] }),
+      headerText: 'Choose your civilization',
+      primaryActionText: 'Confirm Civilization',
+    });
+
+    const card = Array.from(panel.querySelectorAll('.civ-card'))
+      .find(node => node.textContent?.includes('Sunfolk')) as HTMLElement;
+    card.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(card.dataset.selected).toBe('true');
+    expect((panel.querySelector('#civ-start') as HTMLButtonElement).textContent).toBe('Confirm Civilization');
+    (panel.querySelector('[data-action="cancel-civ-select"]') as HTMLButtonElement).click();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
   it('renders saved custom civs in the real civ picker and allows selecting them', () => {
     const onSelect = vi.fn();
     const panel = createCivSelectPanel(document.body, { onSelect }, {

--- a/tests/ui/custom-civ-panel.test.ts
+++ b/tests/ui/custom-civ-panel.test.ts
@@ -7,6 +7,15 @@ describe('custom-civ-panel', () => {
     document.body.innerHTML = '';
   });
 
+  it('renders a setup-style header and grouped editor sections', () => {
+    const panel = createCustomCivPanel(document.body, { onSave: () => {}, onCancel: () => {} });
+
+    expect(panel.querySelector('[data-role="setup-panel-header"]')).toBeTruthy();
+    expect(panel.querySelector('[data-role="custom-civ-basics"]')).toBeTruthy();
+    expect(panel.querySelector('[data-role="custom-civ-traits"]')).toBeTruthy();
+    expect(panel.querySelector('[data-role="custom-civ-city-names"]')).toBeTruthy();
+  });
+
   it('renders a trait budget display and primary trait picker', () => {
     const panel = createCustomCivPanel(document.body, { onSave: () => {}, onCancel: () => {} });
     expect(panel.textContent).toContain('Trait budget');

--- a/tests/ui/game-mode-select.test.ts
+++ b/tests/ui/game-mode-select.test.ts
@@ -1,18 +1,56 @@
 /** @vitest-environment jsdom */
 
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { showGameModeSelect } from '@/ui/game-mode-select';
 
 describe('game-mode-select', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('renders the new-game launcher inside the shared setup shell and exposes a solo entry card', () => {
     const panel = showGameModeSelect(document.body, {
       initialTitle: 'New Campaign',
       onChooseSolo: () => {},
       onChooseHotSeat: () => {},
+      onTitleRequired: () => {},
     });
 
     expect(panel.dataset.role).toBe('setup-surface');
     expect(panel.textContent).toContain('New Game');
     expect(panel.querySelector('[data-action="choose-solo-mode"]')).toBeTruthy();
+  });
+
+  it('requires a non-empty title before continuing into hot seat setup', () => {
+    const onChooseHotSeat = vi.fn();
+    const onTitleRequired = vi.fn();
+    const panel = showGameModeSelect(document.body, {
+      initialTitle: '',
+      onChooseSolo: () => {},
+      onChooseHotSeat,
+      onTitleRequired,
+    });
+
+    const titleInput = panel.querySelector('#new-game-title') as HTMLInputElement;
+    titleInput.value = '   ';
+
+    (panel.querySelector('[data-action="choose-hotseat-mode"]') as HTMLButtonElement).click();
+
+    expect(onChooseHotSeat).not.toHaveBeenCalled();
+    expect(onTitleRequired).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the trimmed title into hot seat setup when provided', () => {
+    const onChooseHotSeat = vi.fn();
+    const panel = showGameModeSelect(document.body, {
+      initialTitle: '  River War  ',
+      onChooseSolo: () => {},
+      onChooseHotSeat,
+      onTitleRequired: () => {},
+    });
+
+    (panel.querySelector('[data-action="choose-hotseat-mode"]') as HTMLButtonElement).click();
+
+    expect(onChooseHotSeat).toHaveBeenCalledWith('River War');
   });
 });

--- a/tests/ui/game-mode-select.test.ts
+++ b/tests/ui/game-mode-select.test.ts
@@ -14,11 +14,13 @@ describe('game-mode-select', () => {
       onChooseSolo: () => {},
       onChooseHotSeat: () => {},
       onTitleRequired: () => {},
+      onCancel: () => {},
     });
 
     expect(panel.dataset.role).toBe('setup-surface');
     expect(panel.textContent).toContain('New Game');
     expect(panel.querySelector('[data-action="choose-solo-mode"]')).toBeTruthy();
+    expect(panel.querySelector('[data-action="cancel-mode-select"]')).toBeTruthy();
   });
 
   it('requires a non-empty title before continuing into hot seat setup', () => {
@@ -29,6 +31,7 @@ describe('game-mode-select', () => {
       onChooseSolo: () => {},
       onChooseHotSeat,
       onTitleRequired,
+      onCancel: () => {},
     });
 
     const titleInput = panel.querySelector('#new-game-title') as HTMLInputElement;
@@ -47,10 +50,27 @@ describe('game-mode-select', () => {
       onChooseSolo: () => {},
       onChooseHotSeat,
       onTitleRequired: () => {},
+      onCancel: () => {},
     });
 
     (panel.querySelector('[data-action="choose-hotseat-mode"]') as HTMLButtonElement).click();
 
     expect(onChooseHotSeat).toHaveBeenCalledWith('River War');
+  });
+
+  it('lets the player back out to the previous screen', () => {
+    const onCancel = vi.fn();
+    const panel = showGameModeSelect(document.body, {
+      initialTitle: 'New Campaign',
+      onChooseSolo: () => {},
+      onChooseHotSeat: () => {},
+      onTitleRequired: () => {},
+      onCancel,
+    });
+
+    (panel.querySelector('[data-action="cancel-mode-select"]') as HTMLButtonElement).click();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('mode-select')).toBeNull();
   });
 });

--- a/tests/ui/game-mode-select.test.ts
+++ b/tests/ui/game-mode-select.test.ts
@@ -1,0 +1,18 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest';
+import { showGameModeSelect } from '@/ui/game-mode-select';
+
+describe('game-mode-select', () => {
+  it('renders the new-game launcher inside the shared setup shell and exposes a solo entry card', () => {
+    const panel = showGameModeSelect(document.body, {
+      initialTitle: 'New Campaign',
+      onChooseSolo: () => {},
+      onChooseHotSeat: () => {},
+    });
+
+    expect(panel.dataset.role).toBe('setup-surface');
+    expect(panel.textContent).toContain('New Game');
+    expect(panel.querySelector('[data-action="choose-solo-mode"]')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared shell for the solo setup flow and a new game-mode-select module
- refresh campaign setup, civ select, and custom civ creation to satisfy the new solo setup UI contract
- keep the existing solo/custom-civ behavior working while adding the new visible state markers and back affordance

## Test Plan
- [x] ./scripts/run-with-mise.sh yarn test --run tests/ui/game-mode-select.test.ts tests/ui/campaign-setup.test.ts tests/ui/civ-select.test.ts tests/ui/custom-civ-panel.test.ts
- [x] scripts/check-src-rule-violations.sh src/ui/setup-shell.ts src/ui/game-mode-select.ts src/ui/campaign-setup.ts src/ui/civ-select.ts src/ui/custom-civ-panel.ts
- [x] ./scripts/run-with-mise.sh yarn build
