### PR TITLE
feat(ui): finish solo setup flow polish

### DIFF
--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -53,6 +53,13 @@ function createChoiceButton(label: string): HTMLButtonElement {
   return button;
 }
 
+function syncChoiceButtonState(button: HTMLButtonElement, selected: boolean): void {
+  button.dataset.selected = selected ? 'true' : 'false';
+  button.style.borderColor = selected ? '#e8c170' : 'rgba(255,255,255,0.18)';
+  button.style.background = selected ? 'rgba(232,193,112,0.16)' : 'rgba(255,255,255,0.08)';
+  button.style.color = selected ? '#f7f1d7' : '#f4f1e8';
+}
+
 export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSetupCallbacks, options?: CampaignSetupOptions): HTMLElement {
   container.querySelector('#campaign-setup')?.remove();
 
@@ -142,11 +149,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   const mapSizeCards = new Map<'small' | 'medium' | 'large', HTMLButtonElement>();
   const syncMapSizeCards = (): void => {
     for (const [size, button] of mapSizeCards.entries()) {
-      const selected = mapSizeField.select.value === size;
-      button.dataset.selected = selected ? 'true' : 'false';
-      button.style.borderColor = selected ? '#e8c170' : 'rgba(255,255,255,0.18)';
-      button.style.background = selected ? 'rgba(232,193,112,0.16)' : 'rgba(255,255,255,0.08)';
-      button.style.color = selected ? '#f7f1d7' : '#f4f1e8';
+      syncChoiceButtonState(button, mapSizeField.select.value === size);
     }
   };
   for (const size of ['small', 'medium', 'large'] as const) {
@@ -167,8 +170,26 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
   hero.appendChild(opponentSection.section);
 
+  const opponentCardRow = document.createElement('div');
+  Object.assign(opponentCardRow.style, {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+    gap: '10px',
+  });
+  opponentSection.content.appendChild(opponentCardRow);
+
   const opponentsField = createLabeledSelect('Opponents', 'campaign-opponents');
+  opponentsField.wrapper.hidden = true;
   opponentSection.content.appendChild(opponentsField.wrapper);
+
+  const syncOpponentCards = (): void => {
+    for (const button of opponentCardRow.querySelectorAll('[data-opponent-count]')) {
+      syncChoiceButtonState(
+        button as HTMLButtonElement,
+        (button as HTMLButtonElement).dataset.opponentCount === opponentsField.select.value,
+      );
+    }
+  };
 
   const refreshOpponentOptions = (): void => {
     const mapSize = mapSizeField.select.value as 'small' | 'medium' | 'large';
@@ -181,12 +202,31 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       option.textContent = String(count);
       opponentsField.select.appendChild(option);
     }
-    opponentsField.select.value = currentValue && Number(currentValue) <= maxOpponents ? currentValue : '1';
+
+    const normalizedValue = !currentValue
+      ? 1
+      : Math.max(1, Math.min(Number(currentValue), maxOpponents));
+    opponentsField.select.value = String(normalizedValue);
+
+    opponentCardRow.textContent = '';
+    for (let count = 1; count <= maxOpponents; count++) {
+      const button = createChoiceButton(String(count));
+      button.dataset.opponentCount = String(count);
+      button.addEventListener('click', () => {
+        opponentsField.select.value = String(count);
+        syncOpponentCards();
+      });
+      opponentCardRow.appendChild(button);
+    }
+    syncOpponentCards();
   };
 
   refreshOpponentOptions();
   syncMapSizeCards();
-  mapSizeField.select.addEventListener('change', refreshOpponentOptions);
+  mapSizeField.select.addEventListener('change', () => {
+    refreshOpponentOptions();
+    syncMapSizeCards();
+  });
 
   let selectedCivId: string | null = null;
   let customCivilizations: CustomCivDefinition[] = [...(options?.initialCustomCivilizations ?? [])];

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -34,6 +34,25 @@ function createLabeledSelect(labelText: string, id: string): { wrapper: HTMLDivE
   return { wrapper, select };
 }
 
+function createChoiceButton(label: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  Object.assign(button.style, {
+    minHeight: '44px',
+    minWidth: '44px',
+    padding: '12px 16px',
+    borderRadius: '12px',
+    border: '1px solid rgba(255,255,255,0.18)',
+    background: 'rgba(255,255,255,0.08)',
+    color: '#f4f1e8',
+    cursor: 'pointer',
+    fontSize: '14px',
+    textTransform: 'capitalize',
+  });
+  button.textContent = label;
+  return button;
+}
+
 export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSetupCallbacks, options?: CampaignSetupOptions): HTMLElement {
   container.querySelector('#campaign-setup')?.remove();
 
@@ -102,7 +121,16 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
   hero.appendChild(mapSection.section);
 
+  const mapSizeCardRow = document.createElement('div');
+  Object.assign(mapSizeCardRow.style, {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
+    gap: '10px',
+  });
+  mapSection.content.appendChild(mapSizeCardRow);
+
   const mapSizeField = createLabeledSelect('Map size', 'campaign-map-size');
+  mapSizeField.wrapper.hidden = true;
   for (const size of ['small', 'medium', 'large'] as const) {
     const option = document.createElement('option');
     option.value = size;
@@ -110,6 +138,28 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     mapSizeField.select.appendChild(option);
   }
   mapSection.content.appendChild(mapSizeField.wrapper);
+
+  const mapSizeCards = new Map<'small' | 'medium' | 'large', HTMLButtonElement>();
+  const syncMapSizeCards = (): void => {
+    for (const [size, button] of mapSizeCards.entries()) {
+      const selected = mapSizeField.select.value === size;
+      button.dataset.selected = selected ? 'true' : 'false';
+      button.style.borderColor = selected ? '#e8c170' : 'rgba(255,255,255,0.18)';
+      button.style.background = selected ? 'rgba(232,193,112,0.16)' : 'rgba(255,255,255,0.08)';
+      button.style.color = selected ? '#f7f1d7' : '#f4f1e8';
+    }
+  };
+  for (const size of ['small', 'medium', 'large'] as const) {
+    const button = createChoiceButton(size);
+    button.dataset.size = size;
+    button.addEventListener('click', () => {
+      mapSizeField.select.value = size;
+      refreshOpponentOptions();
+      syncMapSizeCards();
+    });
+    mapSizeCards.set(size, button);
+    mapSizeCardRow.appendChild(button);
+  }
 
   const opponentSection = createSetupSection({
     title: 'Opponents',
@@ -135,6 +185,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   };
 
   refreshOpponentOptions();
+  syncMapSizeCards();
   mapSizeField.select.addEventListener('change', refreshOpponentOptions);
 
   let selectedCivId: string | null = null;
@@ -148,6 +199,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       ? `Leading civilization: ${selectedDefinition.name}`
       : 'No civilization selected yet';
     startButton.disabled = !selectedCivId || !gameTitle;
+    startButton.dataset.ready = startButton.disabled ? 'false' : 'true';
   };
 
   const replaceSetupOverlay = (render: () => void): void => {

--- a/src/ui/civ-select.ts
+++ b/src/ui/civ-select.ts
@@ -154,7 +154,7 @@ export function createCivSelectPanel(
     actionBar.appendChild(cancelButton);
   }
 
-  const randomButton = createButton('Random');
+  const randomButton = createButton('Surprise Me');
   randomButton.id = 'civ-random';
   randomButton.style.background = 'rgba(255,255,255,0.1)';
   randomButton.style.color = 'white';

--- a/src/ui/custom-civ-panel.ts
+++ b/src/ui/custom-civ-panel.ts
@@ -111,6 +111,7 @@ export function createCustomCivPanel(
   panel.appendChild(traitBudget);
 
   const validationMessage = document.createElement('p');
+  validationMessage.dataset.role = 'custom-civ-validation';
   validationMessage.style.margin = '0';
   validationMessage.style.fontSize = '0.85em';
   validationMessage.style.color = '#f2c572';
@@ -291,9 +292,11 @@ export function createCustomCivPanel(
       const definition = buildDefinition();
       validateCustomCivDefinition(definition);
       saveButton.disabled = false;
+      saveButton.dataset.ready = 'true';
       validationMessage.textContent = 'Ready to save.';
     } catch (error) {
       saveButton.disabled = true;
+      saveButton.dataset.ready = 'false';
       validationMessage.textContent = error instanceof Error ? error.message : 'Complete the form to save.';
     }
   }

--- a/src/ui/custom-civ-panel.ts
+++ b/src/ui/custom-civ-panel.ts
@@ -293,10 +293,22 @@ export function createCustomCivPanel(
       validateCustomCivDefinition(definition);
       saveButton.disabled = false;
       saveButton.dataset.ready = 'true';
+      saveButton.style.opacity = '1';
+      saveButton.style.cursor = 'pointer';
+      saveButton.style.background = '#d9a441';
+      saveButton.style.color = '#1f1400';
+      saveButton.style.boxShadow = '0 10px 24px rgba(217,164,65,0.28)';
+      validationMessage.style.color = '#9fe0a8';
       validationMessage.textContent = 'Ready to save.';
     } catch (error) {
       saveButton.disabled = true;
       saveButton.dataset.ready = 'false';
+      saveButton.style.opacity = '0.45';
+      saveButton.style.cursor = 'not-allowed';
+      saveButton.style.background = 'rgba(255,255,255,0.12)';
+      saveButton.style.color = 'rgba(244,241,232,0.68)';
+      saveButton.style.boxShadow = 'none';
+      validationMessage.style.color = '#f2c572';
       validationMessage.textContent = error instanceof Error ? error.message : 'Complete the form to save.';
     }
   }

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -98,20 +98,40 @@ describe('campaign-setup', () => {
     expect(startButton.dataset.ready).toBe('true');
   });
 
-  it('renders map-size cards and keeps the selected size visibly in sync', () => {
+  it('updates the visible map-size and opponent cards together, preserving valid counts and snapping invalid ones', () => {
     showCampaignSetup(document.body, {
       onStartSolo: () => {},
       onCancel: () => {},
     });
 
     const sizeCards = Array.from(document.querySelectorAll('[data-size]')) as HTMLButtonElement[];
+    const opponentsSelect = document.querySelector('#campaign-opponents') as HTMLSelectElement;
     expect(sizeCards.map(card => card.dataset.size)).toEqual(['small', 'medium', 'large']);
     expect(document.querySelector('[data-size="small"]')?.getAttribute('data-selected')).toBe('true');
+    expect(Array.from(document.querySelectorAll('[data-opponent-count]')).map(card => card.getAttribute('data-opponent-count'))).toEqual(['1', '2']);
+    expect(opponentsSelect.value).toBe('1');
 
     click(document, '[data-size="large"]');
 
     expect(document.querySelector('[data-size="small"]')?.getAttribute('data-selected')).toBe('false');
     expect(document.querySelector('[data-size="large"]')?.getAttribute('data-selected')).toBe('true');
+    expect(Array.from(document.querySelectorAll('[data-opponent-count]')).map(card => card.getAttribute('data-opponent-count'))).toEqual([
+      '1', '2', '3', '4', '5', '6', '7',
+    ]);
+
+    click(document, '[data-opponent-count="2"]');
+    expect(opponentsSelect.value).toBe('2');
+
+    click(document, '[data-size="medium"]');
+    expect(opponentsSelect.value).toBe('2');
+    expect(document.querySelector('[data-opponent-count="2"]')?.getAttribute('data-selected')).toBe('true');
+
+    click(document, '[data-opponent-count="4"]');
+    expect(opponentsSelect.value).toBe('4');
+
+    click(document, '[data-size="small"]');
+    expect(opponentsSelect.value).toBe('2');
+    expect(document.querySelector('[data-opponent-count="2"]')?.getAttribute('data-selected')).toBe('true');
   });
 
   it('keeps campaign setup visible when the civ picker is dismissed through the back action', () => {

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -95,6 +95,36 @@ describe('campaign-setup', () => {
 
     expect(document.querySelector('[data-role="selected-civ-summary"]')?.textContent).not.toContain('No civilization selected');
     expect(startButton.disabled).toBe(false);
+    expect(startButton.dataset.ready).toBe('true');
+  });
+
+  it('renders map-size cards and keeps the selected size visibly in sync', () => {
+    showCampaignSetup(document.body, {
+      onStartSolo: () => {},
+      onCancel: () => {},
+    });
+
+    const sizeCards = Array.from(document.querySelectorAll('[data-size]')) as HTMLButtonElement[];
+    expect(sizeCards.map(card => card.dataset.size)).toEqual(['small', 'medium', 'large']);
+    expect(document.querySelector('[data-size="small"]')?.getAttribute('data-selected')).toBe('true');
+
+    click(document, '[data-size="large"]');
+
+    expect(document.querySelector('[data-size="small"]')?.getAttribute('data-selected')).toBe('false');
+    expect(document.querySelector('[data-size="large"]')?.getAttribute('data-selected')).toBe('true');
+  });
+
+  it('keeps campaign setup visible when the civ picker is dismissed through the back action', () => {
+    showCampaignSetup(document.body, {
+      onStartSolo: () => {},
+      onCancel: () => {},
+    });
+
+    clickButtonWithText('Choose civilization');
+    click(document, '[data-action="cancel-civ-select"]');
+
+    expect(document.querySelector('#campaign-setup')).toBeTruthy();
+    expect(document.querySelector('#civ-select')).toBeNull();
   });
 
   it('requires map size, civ selection, opponent count, and campaign title before starting a solo game', () => {

--- a/tests/ui/civ-select.test.ts
+++ b/tests/ui/civ-select.test.ts
@@ -79,4 +79,21 @@ describe('civ-select', () => {
     (panel.querySelector('[data-action="create-custom-civ"]') as HTMLButtonElement).click();
     expect(onCreateCustomCiv).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps the full civ catalog reachable and presents the refreshed action labels', () => {
+    const civDefinitions = getPlayableCivDefinitions({ customCivilizations: [customCiv] });
+    const panel = createCivSelectPanel(document.body, {
+      onSelect: () => {},
+      onCreateCustomCiv: () => {},
+      onCancel: () => {},
+    }, {
+      civDefinitions,
+      primaryActionText: 'Confirm Civilization',
+    });
+
+    expect(panel.querySelectorAll('.civ-card').length).toBe(civDefinitions.length);
+    expect(panel.textContent).toContain('Surprise Me');
+    expect(panel.textContent).toContain('Create Custom Civilization');
+    expect(panel.textContent).toContain('Confirm Civilization');
+  });
 });

--- a/tests/ui/custom-civ-panel.test.ts
+++ b/tests/ui/custom-civ-panel.test.ts
@@ -31,6 +31,8 @@ describe('custom-civ-panel', () => {
     expect(save.disabled).toBe(true);
     expect(save.dataset.ready).toBe('false');
     expect(validation.textContent).toBeTruthy();
+    expect(save.style.opacity).toBe('0.45');
+    expect(save.style.cursor).toBe('not-allowed');
   });
 
   it('enables save after all required fields are filled', () => {
@@ -44,6 +46,8 @@ describe('custom-civ-panel', () => {
     expect(save.disabled).toBe(false);
     expect(save.dataset.ready).toBe('true');
     expect(validation.textContent).toContain('Ready to save');
+    expect(save.style.opacity).toBe('1');
+    expect(save.style.cursor).toBe('pointer');
   });
 
   it('calls onSave with a valid CustomCivDefinition when save is clicked', () => {

--- a/tests/ui/custom-civ-panel.test.ts
+++ b/tests/ui/custom-civ-panel.test.ts
@@ -27,7 +27,10 @@ describe('custom-civ-panel', () => {
     const panel = createCustomCivPanel(document.body, { onSave, onCancel: () => {} });
 
     const save = panel.querySelector('[data-action="save-custom-civ"]') as HTMLButtonElement;
+    const validation = panel.querySelector('[data-role="custom-civ-validation"]') as HTMLElement;
     expect(save.disabled).toBe(true);
+    expect(save.dataset.ready).toBe('false');
+    expect(validation.textContent).toBeTruthy();
   });
 
   it('enables save after all required fields are filled', () => {
@@ -37,7 +40,10 @@ describe('custom-civ-panel', () => {
     fillRequiredFields(panel);
 
     const save = panel.querySelector('[data-action="save-custom-civ"]') as HTMLButtonElement;
+    const validation = panel.querySelector('[data-role="custom-civ-validation"]') as HTMLElement;
     expect(save.disabled).toBe(false);
+    expect(save.dataset.ready).toBe('true');
+    expect(validation.textContent).toContain('Ready to save');
   });
 
   it('calls onSave with a valid CustomCivDefinition when save is clicked', () => {


### PR DESCRIPTION
## Summary
- add campaign setup map-size cards and visible CTA readiness state
- keep the full civ catalog reachable while polishing the solo civ picker action row
- expose custom civilization validation and readiness hooks for the refreshed editor

## Testing
- ./scripts/run-with-mise.sh yarn test --run tests/ui/game-mode-select.test.ts tests/ui/campaign-setup.test.ts tests/ui/civ-select.test.ts tests/ui/custom-civ-panel.test.ts
- scripts/check-src-rule-violations.sh src/ui/campaign-setup.ts src/ui/civ-select.ts src/ui/custom-civ-panel.ts