### PR TITLE
fix(renderer): hide foreign territorial intel outside visibility

### DIFF
--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -1,7 +1,8 @@
-import type { GameMap, HexCoord, HexTile, TerrainType } from '@/core/types';
+import type { GameMap, HexCoord, HexTile, TerrainType, VisibilityMap } from '@/core/types';
 import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY } from '@/systems/hex-utils';
 import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { shouldRenderOwnedTileBorder } from './render-visibility';
 
 // --- Terrain labels ---
 
@@ -54,9 +55,10 @@ function drawTileAtScreen(
   tile: HexTile,
   isVillage: boolean,
   currentPlayer: string | undefined,
+  viewerVisibility: VisibilityMap | undefined,
   zoom: number,
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility);
   if (shouldShowTerrainLabel(zoom)) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -73,6 +75,7 @@ export function drawHexMap(
   camera: Camera,
   villagePositions?: Set<string>,
   currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
 ): void {
   const size = camera.hexSize;
 
@@ -88,7 +91,7 @@ export function drawHexMap(
       const pixel = hexToPixel(renderCoord, size);
       const screen = camera.worldToScreen(pixel.x, pixel.y);
       const scaledSize = size * camera.zoom;
-      drawTileAtScreen(ctx, screen, scaledSize, tile, isVillage, currentPlayer, camera.zoom);
+      drawTileAtScreen(ctx, screen, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, camera.zoom);
     }
   }
 }
@@ -179,6 +182,7 @@ function drawHex(
   tile: HexTile,
   isVillage: boolean = false,
   currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -243,7 +247,7 @@ function drawHex(
   }
 
   // Draw ownership indicator
-  if (tile.owner && currentPlayer) {
+  if (tile.owner && currentPlayer && shouldRenderOwnedTileBorder(viewerVisibility, currentPlayer, tile.owner, tile.coord)) {
     ctx.strokeStyle = tile.owner === currentPlayer ? 'rgba(74,144,217,0.5)' : 'rgba(217,74,74,0.5)';
     ctx.lineWidth = 2;
     ctx.stroke();
@@ -277,9 +281,20 @@ export function drawMinorCivTerritory(
   camera: Camera,
   mapWidth?: number,
   wrapsHorizontally = false,
+  viewerVisibility?: VisibilityMap,
+  viewerCivId?: string,
+  territoryOwnerId?: string,
 ): void {
   const hexes = hexesInRange(center, 2);
   for (const hex of hexes) {
+    if (
+      territoryOwnerId
+      && viewerCivId
+      && !shouldRenderOwnedTileBorder(viewerVisibility, viewerCivId, territoryOwnerId, hex)
+    ) {
+      continue;
+    }
+
     const renderCoords = wrapsHorizontally && mapWidth
       ? getHorizontalWrapRenderCoords(hex, mapWidth, camera)
       : [hex];

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -77,6 +77,8 @@ export class RenderLoop {
 
   private render(): void {
     if (!this.state) return;
+    const viewerId = this.state.currentPlayer;
+    const viewerVisibility = this.state.civilizations[viewerId]?.visibility;
 
     const { width, height } = this.canvas.getBoundingClientRect();
     this.ctx.clearRect(0, 0, width, height);
@@ -89,7 +91,7 @@ export class RenderLoop {
     const villagePositions = new Set(
       Object.values(this.state.tribalVillages ?? {}).map(v => `${v.position.q},${v.position.r}`),
     );
-    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, this.state.currentPlayer);
+    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility);
 
     // Draw rivers
     drawRivers(this.ctx, this.state.map, this.camera);
@@ -109,6 +111,9 @@ export class RenderLoop {
           this.camera,
           this.state.map.width,
           this.state.map.wrapsHorizontally,
+          viewerVisibility,
+          viewerId,
+          mc.id,
         );
       }
     }
@@ -130,12 +135,10 @@ export class RenderLoop {
     }
 
     // Draw cities
-    drawCities(this.ctx, this.state, this.camera, this.state.currentPlayer);
+    drawCities(this.ctx, this.state, this.camera, viewerId);
 
     // Draw units
-    const currentCiv = this.state.civilizations[this.state.currentPlayer];
-    const playerVis = currentCiv?.visibility;
-    if (playerVis) {
+    if (viewerVisibility) {
       const colorLookup: Record<string, string> = { barbarian: '#8b4513' };
       for (const [id, civ] of Object.entries(this.state.civilizations)) {
         colorLookup[id] = civ.color;
@@ -145,14 +148,14 @@ export class RenderLoop {
         const def = MINOR_CIV_DEFINITIONS.find(d => d.id === mc.definitionId);
         if (def) colorLookup[mc.id] = def.color;
       }
-      drawUnits(this.ctx, this.state.units, this.camera, playerVis, this.state, this.state.currentPlayer, colorLookup);
+      drawUnits(this.ctx, this.state.units, this.camera, viewerVisibility, this.state, viewerId, colorLookup);
     }
 
     // Draw fog of war
-    if (playerVis) {
+    if (viewerVisibility) {
       drawFogOfWar(
         this.ctx,
-        playerVis,
+        viewerVisibility,
         this.state.map.width,
         this.state.map.height,
         this.camera,

--- a/src/renderer/render-visibility.ts
+++ b/src/renderer/render-visibility.ts
@@ -1,0 +1,26 @@
+import type { HexCoord, VisibilityMap } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+
+export function shouldRenderOwnedTileBorder(
+  visibility: VisibilityMap | undefined,
+  viewerCivId: string | undefined,
+  ownerId: string | undefined,
+  coord: HexCoord,
+): boolean {
+  if (!visibility || !viewerCivId || !ownerId) return false;
+
+  const visibilityState = getVisibility(visibility, coord);
+  if (ownerId === viewerCivId) {
+    return visibilityState === 'visible' || visibilityState === 'fog';
+  }
+
+  return visibilityState === 'visible';
+}
+
+export function shouldRenderForeignPresenceHex(
+  visibility: VisibilityMap | undefined,
+  coord: HexCoord,
+): boolean {
+  if (!visibility) return false;
+  return getVisibility(visibility, coord) === 'visible';
+}

--- a/src/renderer/render-visibility.ts
+++ b/src/renderer/render-visibility.ts
@@ -16,11 +16,3 @@ export function shouldRenderOwnedTileBorder(
 
   return visibilityState === 'visible';
 }
-
-export function shouldRenderForeignPresenceHex(
-  visibility: VisibilityMap | undefined,
-  coord: HexCoord,
-): boolean {
-  if (!visibility) return false;
-  return getVisibility(visibility, coord) === 'visible';
-}

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { Camera } from '@/renderer/camera';
+import { drawHexMap, drawMinorCivTerritory } from '@/renderer/hex-renderer';
+import type { GameMap, VisibilityMap } from '@/core/types';
+
+class MockCanvasContext {
+  strokeCalls: string[] = [];
+  fillStyle = '';
+  strokeStyle = '';
+  lineWidth = 0;
+  font = '';
+  textAlign: CanvasTextAlign = 'start';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+  globalAlpha = 1;
+  shadowColor = '';
+  shadowBlur = 0;
+
+  beginPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  closePath(): void {}
+  fill(): void {}
+  fillText(): void {}
+  stroke(): void {
+    this.strokeCalls.push(this.strokeStyle);
+  }
+}
+
+function makeMap(): GameMap {
+  return {
+    width: 2,
+    height: 1,
+    wrapsHorizontally: false,
+    rivers: [],
+    tiles: {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'grassland',
+        elevation: 'flat',
+        movementCost: 1,
+        owner: 'player',
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+      },
+      '1,0': {
+        coord: { q: 1, r: 0 },
+        terrain: 'grassland',
+        elevation: 'flat',
+        movementCost: 1,
+        owner: 'ai-1',
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+      },
+    },
+  } as unknown as GameMap;
+}
+
+function makeCamera(): Camera {
+  return {
+    hexSize: 48,
+    zoom: 1,
+    isHexVisible: () => true,
+    worldToScreen: (x: number, y: number) => ({ x, y }),
+  } as unknown as Camera;
+}
+
+describe('hex renderer privacy', () => {
+  it('does not draw foreign ownership borders on fogged tiles', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible', '1,0': 'fog' } };
+
+    drawHexMap(ctx, makeMap(), makeCamera(), undefined, 'player', visibility);
+
+    expect((ctx as unknown as MockCanvasContext).strokeCalls).not.toContain('rgba(217,74,74,0.5)');
+  });
+
+  it('keeps player ownership borders on fogged tiles', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'fog', '1,0': 'unexplored' } };
+
+    drawHexMap(ctx, makeMap(), makeCamera(), undefined, 'player', visibility);
+
+    expect((ctx as unknown as MockCanvasContext).strokeCalls).toContain('rgba(74,144,217,0.5)');
+  });
+
+  it('draws only visible minor-civ territory hexes', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = {
+      tiles: {
+        '0,0': 'visible',
+        '1,0': 'visible',
+        '-1,0': 'fog',
+        '0,1': 'fog',
+        '0,-1': 'unexplored',
+      },
+    };
+
+    drawMinorCivTerritory(
+      ctx,
+      { q: 0, r: 0 },
+      '#ccaa44',
+      makeCamera(),
+      10,
+      false,
+      visibility,
+      'player',
+      'mc-sparta',
+    );
+
+    expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
+    expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeLessThan(19);
+  });
+});

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -65,6 +65,15 @@ function makeCamera(): Camera {
 }
 
 describe('hex renderer privacy', () => {
+  it('draws foreign ownership borders on visible tiles', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible', '1,0': 'visible' } };
+
+    drawHexMap(ctx, makeMap(), makeCamera(), undefined, 'player', visibility);
+
+    expect((ctx as unknown as MockCanvasContext).strokeCalls).toContain('rgba(217,74,74,0.5)');
+  });
+
   it('does not draw foreign ownership borders on fogged tiles', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     const visibility: VisibilityMap = { tiles: { '0,0': 'visible', '1,0': 'fog' } };

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -117,6 +117,9 @@ describe('render-loop wrap parity', () => {
       expect.anything(),
       5,
       true,
+      state.civilizations.player.visibility,
+      'player',
+      'mc-sparta',
     );
   });
 });


### PR DESCRIPTION
## Summary
- fix issue #60 by stopping foreign territorial signals from leaking through fogged or unexplored tiles
- gate foreign ownership borders and minor-civ territory rings on current viewer visibility instead of relying on fog opacity
- preserve player-owned fog memory and wrapped rendering behavior while adding focused renderer regressions

## Why
Issue #60 reports that city-states and rival civ presence can flash or reveal themselves between turns. The root cause was that some renderer layers painted foreign-presence overlays first and depended on the fog layer to hide them later. That was safe for visuals, but not for privacy.

## Testing
- ./scripts/run-with-mise.sh yarn test --run tests/renderer/hex-renderer.test.ts tests/renderer/render-loop-wrap.test.ts tests/renderer/city-renderer.test.ts tests/renderer/unit-renderer.test.ts tests/renderer/fog-renderer.test.ts
- scripts/check-src-rule-violations.sh src/renderer/render-visibility.ts src/renderer/hex-renderer.ts src/renderer/render-loop.ts
- ./scripts/run-with-mise.sh yarn build
