### PR TITLE
feat(espionage): MR3 — spy disguise system

### DIFF
--- a/.claude/hooks/require-green-before-push.sh
+++ b/.claude/hooks/require-green-before-push.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# PreToolUse hook — blocks `git push`, `gh pr create`, `gh pr merge` unless
+# `yarn build` and `yarn test` both pass on the current tree.
+#
+# Hook contract (see .claude/rules/hooks-and-tooling.md):
+# - Tool input arrives as JSON on stdin
+# - Exit 0 allows the tool call
+# - Exit 2 blocks; stderr is returned to Claude as the reason
+# - Any other exit code is a non-blocking error
+
+set -u
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Only inspect push/PR-create/PR-merge commands
+if [ -z "$COMMAND" ]; then
+  exit 0
+fi
+if ! echo "$COMMAND" | grep -qE '(^|[[:space:]&;|])(git[[:space:]]+push|gh[[:space:]]+pr[[:space:]]+(create|merge))([[:space:]]|$)'; then
+  exit 0
+fi
+
+# Test-only short-circuit so the smoke test can exercise the gate logic
+# without running the real build/test pipeline.
+case "${REQUIRE_GREEN_TEST_MODE:-}" in
+  pass) exit 0 ;;
+  fail)
+    echo "ERROR: [test-mode] build/test failed" >&2
+    exit 2
+    ;;
+esac
+
+# mise is how this repo installs node/yarn; activate silently if available
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate bash)" >/dev/null 2>&1 || true
+fi
+
+if ! command -v yarn >/dev/null 2>&1; then
+  echo "ERROR: yarn not found on PATH — run \`eval \"\$(mise activate bash)\"\` and retry." >&2
+  exit 2
+fi
+
+BUILD_LOG=$(mktemp)
+TEST_LOG=$(mktemp)
+trap 'rm -f "$BUILD_LOG" "$TEST_LOG"' EXIT
+
+if ! yarn -s build >"$BUILD_LOG" 2>&1; then
+  {
+    echo "ERROR: \`yarn build\` failed — fix type/build errors before pushing."
+    echo "--- last 30 lines of build output ---"
+    tail -n 30 "$BUILD_LOG"
+  } >&2
+  exit 2
+fi
+
+if ! yarn -s test >"$TEST_LOG" 2>&1; then
+  {
+    echo "ERROR: \`yarn test\` failed — fix failing tests before pushing."
+    echo "--- last 30 lines of test output ---"
+    tail -n 30 "$TEST_LOG"
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,11 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-commit-on-main.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-green-before-push.sh",
+            "timeout": 180
           }
         ]
       },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Civilization-building strategy game. TypeScript + Canvas 2D + Vite.
 - `eval "$(mise activate bash)"` — Activate mise for node/yarn (run first in any new shell)
 - `yarn dev` — Start dev server
 - `yarn build` — Production build
-- `yarn test` — Run tests with vitest
+- `yarn test` — Run vitest + hook smoke tests. DOES NOT type-check — `yarn build` is the only path that runs `tsc`. Before any `git push`, `gh pr create`, or `gh pr merge`, run `yarn build` and `yarn test` and confirm both exit 0. The `require-green-before-push` hook enforces this, but catching it locally is faster.
 - `yarn test:watch` — Run tests in watch mode
 
 ## Rules Index

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,6 +72,7 @@ import {
   getAvailableMissions,
   missionRequiresPlacedSpy,
   recallSpy,
+  setDisguise,
   startMission,
   verifyAgent,
 } from '@/systems/espionage-system';
@@ -867,6 +868,23 @@ function selectUnit(unitId: string): void {
       onBuildMine: () => buildImprovementAction('mine'),
       onRest: () => restAction(),
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
+      onSetDisguise: (uid, disguise) => {
+        const unit = gameState.units[uid];
+        if (!unit || unit.hasActed) return;
+        if (unit.owner !== gameState.currentPlayer) return;
+        const civEsp = gameState.espionage?.[gameState.currentPlayer];
+        if (!civEsp) return;
+        const spy = civEsp.spies[uid];
+        if (!spy || spy.status !== 'idle') return;
+        gameState.espionage![gameState.currentPlayer] = setDisguise(civEsp, uid, disguise);
+        if (disguise !== null) {
+          gameState.units[uid] = { ...unit, hasActed: true, movementPointsLeft: 0 };
+        }
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        selectUnit(uid);
+        showNotification(disguise ? `Spy disguised as ${disguise}.` : 'Disguise removed.', 'info');
+      },
     });
   }
 

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -8,6 +8,7 @@ import { drawCities } from './city-renderer';
 import { AnimationSystem } from './animation-system';
 import { hexToPixel } from '@/systems/hex-utils';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
 
 export interface HexHighlight {
   coord: HexCoord;
@@ -148,7 +149,8 @@ export class RenderLoop {
         const def = MINOR_CIV_DEFINITIONS.find(d => d.id === mc.definitionId);
         if (def) colorLookup[mc.id] = def.color;
       }
-      drawUnits(this.ctx, this.state.units, this.camera, viewerVisibility, this.state, viewerId, colorLookup);
+      const visibleUnits = getVisibleUnitsForPlayer(this.state.units, this.state, viewerId);
+      drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup);
     }
 
     // Draw fog of war

--- a/src/systems/espionage-stealth.ts
+++ b/src/systems/espionage-stealth.ts
@@ -1,0 +1,59 @@
+// src/systems/espionage-stealth.ts
+import type { Unit, GameState, UnitType } from '@/core/types';
+import { UNIT_DEFINITIONS } from './unit-system';
+import { isSpyUnitType } from './espionage-system';
+import { hexDistance } from './hex-utils';
+
+function hasNearbyDetector(units: Record<string, Unit>, viewerCivId: string, spyPosition: { q: number; r: number }): boolean {
+  for (const u of Object.values(units)) {
+    if (u.owner !== viewerCivId) continue;
+    const def = UNIT_DEFINITIONS[u.type];
+    const isDetector = !!def?.spyDetectionChance || isSpyUnitType(u.type);
+    if (!isDetector) continue;
+    if (hexDistance(u.position, spyPosition) <= (def?.visionRange ?? 2)) return true;
+  }
+  return false;
+}
+
+const DISGUISE_TYPE_MAP: Record<string, UnitType> = {
+  barbarian: 'warrior',
+  warrior: 'warrior',
+  scout: 'scout',
+  archer: 'archer',
+  worker: 'worker',
+};
+
+export function getVisibleUnitsForPlayer(
+  units: Record<string, Unit>,
+  state: GameState,
+  viewerCivId: string,
+): Record<string, Unit> {
+  const result: Record<string, Unit> = {};
+
+  for (const [id, unit] of Object.entries(units)) {
+    if (unit.owner === viewerCivId) {
+      result[id] = unit;
+      continue;
+    }
+
+    const spyRecord = state.espionage?.[unit.owner]?.spies[id];
+    const disguise = spyRecord?.disguiseAs;
+
+    if (!disguise || !spyRecord || spyRecord.status !== 'idle') {
+      result[id] = unit;
+      continue;
+    }
+
+    // Own spy units and scout_hound units see through all disguises
+    if (hasNearbyDetector(units, viewerCivId, unit.position)) {
+      result[id] = unit;
+      continue;
+    }
+
+    const fakeType = DISGUISE_TYPE_MAP[disguise] ?? 'warrior';
+    const fakeOwner = disguise === 'barbarian' ? 'barbarian' : unit.owner;
+    result[id] = { ...unit, type: fakeType as UnitType, owner: fakeOwner };
+  }
+
+  return result;
+}

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -3,7 +3,7 @@ import type {
   Spy, SpyMission, SpyMissionType, SpyStatus, SpyPromotion,
   EspionageCivState, EspionageState, HexCoord, GameState,
   DiplomacyState, Treaty, UnitType, AdvisorType,
-  CivBonusEffect, DetectedSpyThreat,
+  CivBonusEffect, DetectedSpyThreat, DisguiseType,
 } from '../core/types';
 import type { EventBus } from '../core/event-bus';
 import { createRng } from './map-generator'; // Reuse existing seeded RNG
@@ -146,6 +146,20 @@ export function createSpyFromUnit(
   return {
     state: { ...state, spies: { ...state.spies, [unitId]: spy } },
     spy,
+  };
+}
+
+export function setDisguise(
+  state: EspionageCivState,
+  spyId: string,
+  disguiseAs: DisguiseType | null,
+): EspionageCivState {
+  const spy = state.spies[spyId];
+  if (!spy) throw new Error(`Spy ${spyId} not found`);
+  if (spy.status !== 'idle') throw new Error('Disguise can only be set while spy is on the map (idle)');
+  return {
+    ...state,
+    spies: { ...state.spies, [spyId]: { ...spy, disguiseAs } },
   };
 }
 

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -1,5 +1,6 @@
-import type { GameState } from '@/core/types';
+import type { GameState, DisguiseType } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
+import { isSpyUnitType } from '@/systems/espionage-system';
 import { canBuildImprovement } from '@/systems/improvement-system';
 import { hexKey } from '@/systems/hex-utils';
 
@@ -10,6 +11,7 @@ export interface SelectedUnitInfoCallbacks {
   onBuildMine?: () => void;
   onRest?: () => void;
   onCancelAutoExplore?: () => void;
+  onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
 }
 
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
@@ -101,6 +103,39 @@ export function renderSelectedUnitInfo(
 
   if (canHeal(unit) && !unit.hasActed && callbacks.onRest) {
     actionsDiv.appendChild(makeButton('Rest (+15 HP)', '#4a90d9', callbacks.onRest));
+  }
+
+  if (isSpyUnitType(unit.type) && !unit.hasActed && callbacks.onSetDisguise) {
+    const spy = state.espionage?.[unit.owner]?.spies[unitId];
+    if (spy?.status === 'idle') {
+    const ownerTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+    type DisguiseOption = { label: string; value: DisguiseType | null; tech?: string };
+    const allDisguises: DisguiseOption[] = [
+      { label: 'No Disguise', value: null },
+      { label: 'As Barbarian', value: 'barbarian', tech: 'espionage-informants' },
+      { label: 'As Warrior',   value: 'warrior',   tech: 'espionage-informants' },
+      { label: 'As Scout',     value: 'scout',     tech: 'spy-networks' },
+      { label: 'As Archer',    value: 'archer',    tech: 'spy-networks' },
+      { label: 'As Worker',    value: 'worker',    tech: 'cryptography' },
+    ];
+    const disguiseOptions = allDisguises.filter(opt => !opt.tech || ownerTechs.includes(opt.tech));
+
+    if (disguiseOptions.length > 1) {
+      const disguiseSection = document.createElement('div');
+      disguiseSection.style.cssText = 'margin-top:8px;display:flex;flex-wrap:wrap;gap:6px;';
+      const sectionLabel = document.createElement('div');
+      sectionLabel.textContent = "Set disguise (costs this turn's move):";
+      sectionLabel.style.cssText = 'font-size:10px;opacity:0.6;width:100%;';
+      disguiseSection.appendChild(sectionLabel);
+      for (const opt of disguiseOptions) {
+        const active = (spy?.disguiseAs ?? null) === opt.value;
+        const btn = makeButton(active ? `✓ ${opt.label}` : opt.label, active ? '#7c3aed' : '#374151',
+          () => callbacks.onSetDisguise!(unitId, opt.value));
+        disguiseSection.appendChild(btn);
+      }
+      actionsDiv.appendChild(disguiseSection);
+    }
+    } // end spy?.status === 'idle'
   }
 
   if (actionsDiv.childElementCount > 0) {

--- a/tests/hooks/require-green-before-push.test.sh
+++ b/tests/hooks/require-green-before-push.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Smoke test: require-green-before-push.sh
+# - Non-matching commands: exit 0
+# - Matching command + REQUIRE_GREEN_TEST_MODE=fail: exit 2
+# - Matching command + REQUIRE_GREEN_TEST_MODE=pass: exit 0
+set -u
+HOOK="$(cd "$(dirname "$0")/../.." && pwd)/.claude/hooks/require-green-before-push.sh"
+fail=0
+
+run() {
+  local payload="$1" mode="${2:-}"
+  REQUIRE_GREEN_TEST_MODE="$mode" bash "$HOOK" <<<"$payload" >/dev/null 2>&1
+  echo "rc=$?"
+}
+
+# Non-matching commands pass without running build
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}')"             = "rc=0" ] || { echo "expected allow on ls"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"git status"}}')"         = "rc=0" ] || { echo "expected allow on git status"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"git commit -m foo"}}')"  = "rc=0" ] || { echo "expected allow on git commit"; fail=1; }
+
+# Matching commands run the gate
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"git push"}}'            fail)" = "rc=2" ] || { echo "expected block on git push (fail mode)"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"git push origin HEAD"}}' fail)" = "rc=2" ] || { echo "expected block on git push origin (fail mode)"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"gh pr create --fill"}}' fail)" = "rc=2" ] || { echo "expected block on gh pr create (fail mode)"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"gh pr merge 124"}}'     fail)" = "rc=2" ] || { echo "expected block on gh pr merge (fail mode)"; fail=1; }
+
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"git push"}}'            pass)" = "rc=0" ] || { echo "expected allow on git push (pass mode)"; fail=1; }
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"gh pr create"}}'        pass)" = "rc=0" ] || { echo "expected allow on gh pr create (pass mode)"; fail=1; }
+
+# Word-boundary: "pushing" as substring must not match
+[ "$(run '{"tool_name":"Bash","tool_input":{"command":"echo pushing"}}'        fail)" = "rc=0" ] || { echo "expected allow on non-git push substring"; fail=1; }
+
+exit "$fail"

--- a/tests/systems/espionage-stealth.test.ts
+++ b/tests/systems/espionage-stealth.test.ts
@@ -1,0 +1,134 @@
+// tests/systems/espionage-stealth.test.ts
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '@/core/types';
+import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
+import { createEspionageCivState, createSpyFromUnit, setDisguise } from '@/systems/espionage-system';
+
+function makeStealthState(disguise?: string): GameState {
+  let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+  const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'stealth-seed');
+  civEsp = disguise
+    ? setDisguise(esp, 'unit-1', disguise as any)
+    : esp;
+  return {
+    espionage: { player: civEsp, 'ai-egypt': createEspionageCivState() },
+    units: {
+      'unit-1': {
+        id: 'unit-1', type: 'spy_scout', owner: 'player',
+        position: { q: 5, r: 3 },
+        health: 100, maxHealth: 100,
+        movementPointsLeft: 2, movement: 2,
+        hasActed: false,
+        status: 'idle',
+      } as any,
+    },
+    civilizations: {
+      player: { techState: { completed: ['espionage-scouting', 'disguise'] } },
+      'ai-egypt': { techState: { completed: [] } },
+    },
+  } as unknown as GameState;
+}
+
+describe('getVisibleUnitsForPlayer', () => {
+  it('spy without disguise is visible to enemy as spy unit', () => {
+    const state = makeStealthState();
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1']).toBeDefined();
+    expect(visible['unit-1'].type).toBe('spy_scout');
+    expect(visible['unit-1'].owner).toBe('player');
+  });
+
+  it('spy disguised as barbarian appears as barbarian warrior to enemy', () => {
+    const state = makeStealthState('barbarian');
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1'].type).toBe('warrior');
+    expect(visible['unit-1'].owner).toBe('barbarian');
+  });
+
+  it('spy disguised as barbarian appears as true self to owner', () => {
+    const state = makeStealthState('barbarian');
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'player');
+    expect(visible['unit-1'].type).toBe('spy_scout');
+    expect(visible['unit-1'].owner).toBe('player');
+  });
+
+  it('enemy scout_hound unit sees through barbarian disguise', () => {
+    const state = makeStealthState('barbarian');
+    (state.units as any)['hound-1'] = {
+      id: 'hound-1', type: 'scout_hound', owner: 'ai-egypt',
+      position: { q: 5, r: 3 },
+      health: 100, maxHealth: 100,
+      movementPointsLeft: 3, movement: 3,
+      hasActed: false, status: 'idle',
+    };
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1'].type).toBe('spy_scout');
+    expect(visible['unit-1'].owner).toBe('player');
+  });
+
+  it('spy disguised as archer appears as archer', () => {
+    const state = makeStealthState('archer');
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1'].type).toBe('archer');
+    expect(visible['unit-1'].owner).toBe('player');
+  });
+
+  it('stationed spy is not affected by disguise filter (not idle)', () => {
+    const state = makeStealthState('barbarian');
+    state.espionage!['player'].spies['unit-1'].status = 'stationed';
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    // stationed spy has no physical unit on map but if it were, it would show as-is
+    expect(visible['unit-1'].type).toBe('spy_scout');
+  });
+
+  it('on_mission spy is not filtered — disguise only applies when idle', () => {
+    const state = makeStealthState('barbarian');
+    state.espionage!['player'].spies['unit-1'].status = 'on_mission' as any;
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1'].type).toBe('spy_scout');
+  });
+
+  it('friendly detector owned by owner does not help a third-party viewer see through disguise', () => {
+    const state = makeStealthState('barbarian');
+    (state.units as any)['hound-owner'] = {
+      id: 'hound-owner', type: 'scout_hound', owner: 'player',
+      position: { q: 5, r: 3 },
+      health: 100, maxHealth: 100,
+      movementPointsLeft: 3, movement: 3,
+      hasActed: false, status: 'idle',
+    };
+    // ai-egypt is the viewer — the player-owned hound is irrelevant to their detection
+    const visible = getVisibleUnitsForPlayer(state.units, state, 'ai-egypt');
+    expect(visible['unit-1'].type).toBe('warrior');
+    expect(visible['unit-1'].owner).toBe('barbarian');
+  });
+});
+
+describe('setDisguise', () => {
+  it('sets disguiseAs on the spy record', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    const { state: esp } = createSpyFromUnit(civEsp, 'spy-x', 'player', 'spy_scout', 'seed-x');
+    civEsp = setDisguise(esp, 'spy-x', 'warrior');
+    expect(civEsp.spies['spy-x'].disguiseAs).toBe('warrior');
+  });
+
+  it('clears disguise when passed null', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    const { state: esp } = createSpyFromUnit(civEsp, 'spy-x', 'player', 'spy_scout', 'seed-x');
+    civEsp = setDisguise(esp, 'spy-x', 'warrior');
+    civEsp = setDisguise(civEsp, 'spy-x', null);
+    expect(civEsp.spies['spy-x'].disguiseAs).toBeNull();
+  });
+
+  it('throws if spy not found', () => {
+    const civEsp = createEspionageCivState();
+    expect(() => setDisguise(civEsp, 'nonexistent', 'warrior')).toThrow();
+  });
+
+  it('throws if spy is not idle', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    const { state: esp } = createSpyFromUnit(civEsp, 'spy-x', 'player', 'spy_scout', 'seed-x');
+    civEsp = { ...esp, spies: { ...esp.spies, 'spy-x': { ...esp.spies['spy-x'], status: 'stationed' as any } } };
+    expect(() => setDisguise(civEsp, 'spy-x', 'warrior')).toThrow();
+  });
+});

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
+import { createEspionageCivState, createSpyFromUnit, setDisguise } from '@/systems/espionage-system';
+import type { GameState } from '@/core/types';
+
+class MockElement {
+  tagName: string;
+  children: MockElement[] = [];
+  style = { cssText: '', display: '' };
+  textContent = '';
+  type = '';
+  listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  get childElementCount(): number {
+    return this.children.length;
+  }
+
+  constructor(tagName: string) {
+    this.tagName = tagName.toUpperCase();
+  }
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.listeners[event] ??= [];
+    this.listeners[event].push(listener);
+  }
+
+  replaceChildren(...newChildren: MockElement[]): void {
+    this.children = newChildren;
+  }
+
+  createTextNode(text: string): MockElement {
+    const node = new MockElement('#text');
+    node.textContent = text;
+    return node;
+  }
+
+  click(): void {
+    for (const fn of this.listeners.click ?? []) fn();
+  }
+}
+
+class MockDocument {
+  createElement(tag: string): MockElement {
+    return new MockElement(tag);
+  }
+  createTextNode(text: string): MockElement {
+    const node = new MockElement('#text');
+    node.textContent = text;
+    return node;
+  }
+}
+
+function installMockDocument(): void {
+  (globalThis as any).document = new MockDocument();
+}
+
+function restoreMockDocument(): void {
+  (globalThis as any).document = undefined;
+}
+
+function collectAllText(node: unknown): string[] {
+  const el = node as { textContent?: string; children?: unknown[] };
+  const texts: string[] = [];
+  if (el.textContent) texts.push(el.textContent);
+  for (const child of el.children ?? []) texts.push(...collectAllText(child));
+  return texts;
+}
+
+function findButtons(node: unknown): MockElement[] {
+  const el = node as { tagName?: string; children?: unknown[] };
+  const result: MockElement[] = [];
+  if (el.tagName === 'BUTTON') result.push(el as MockElement);
+  for (const child of el.children ?? []) result.push(...findButtons(child));
+  return result;
+}
+
+function makeSpyState(techs: string[], spyStatus: string = 'idle'): GameState {
+  let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+  const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed');
+  civEsp = { ...esp, spies: { ...esp.spies, 'unit-1': { ...esp.spies['unit-1'], status: spyStatus as any } } };
+  return {
+    turn: 1, era: 1, currentPlayer: 'player', gameOver: false, winner: null,
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {
+      'unit-1': {
+        id: 'unit-1', type: 'spy_scout', owner: 'player',
+        position: { q: 0, r: 0 }, health: 100, maxHealth: 100,
+        movementPointsLeft: 2, movement: 2, hasActed: false, status: 'idle',
+      } as any,
+    },
+    cities: {},
+    civilizations: {
+      player: { color: '#fff', techState: { completed: techs } },
+    },
+    espionage: { player: civEsp },
+  } as unknown as GameState;
+}
+
+describe('renderSelectedUnitInfo — spy disguise buttons', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('does not render "As Scout" button without spy-networks tech', () => {
+    const state = makeSpyState(['espionage-informants']); // spy-networks NOT researched
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onSetDisguise: () => {},
+    });
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns.some(t => t.includes('As Scout'))).toBe(false);
+    expect(btns.some(t => t.includes('As Archer'))).toBe(false);
+  });
+
+  it('renders "As Scout" and "As Archer" buttons when spy-networks is researched', () => {
+    const state = makeSpyState(['espionage-informants', 'spy-networks']);
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onSetDisguise: () => {},
+    });
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns.some(t => t.includes('As Scout'))).toBe(true);
+    expect(btns.some(t => t.includes('As Archer'))).toBe(true);
+  });
+
+  it('does not render disguise section when spy is not idle', () => {
+    const state = makeSpyState(['espionage-informants', 'spy-networks'], 'on_mission');
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onSetDisguise: () => {},
+    });
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns.some(t => t.includes('As Barbarian'))).toBe(false);
+  });
+
+  it('marks the active disguise with a checkmark', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed');
+    civEsp = setDisguise(esp, 'unit-1', 'barbarian');
+    const gameState = makeSpyState(['espionage-informants']);
+    (gameState.espionage as any).player = civEsp;
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, gameState, 'unit-1', {
+      onSetDisguise: () => {},
+    });
+    const buttons = findButtons(container);
+    const barbarianBtn = buttons.find(b => b.textContent?.includes('Barbarian'));
+    expect(barbarianBtn?.textContent).toMatch(/✓/);
+  });
+
+  it('fires onSetDisguise with the correct value when a button is clicked', () => {
+    const state = makeSpyState(['espionage-informants', 'spy-networks']);
+    const container = new MockElement('div');
+    let called: [string, unknown] | null = null;
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onSetDisguise: (uid, disguise) => { called = [uid, disguise]; },
+    });
+    const buttons = findButtons(container);
+    const archerBtn = buttons.find(b => b.textContent?.includes('Archer'));
+    archerBtn?.click();
+    expect(called).toEqual(['unit-1', 'archer']);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `setDisguise(civState, spyId, disguiseAs)` to `espionage-system.ts` — immutable update on idle spies; throws for unknown id or non-idle status
- Adds `espionage-stealth.ts` with `getVisibleUnitsForPlayer`: owner always sees truth; scout_hound / spy-unit detectors within visionRange pierce disguise; others see fake type/owner per `DISGUISE_TYPE_MAP`
- Wires stealth filter into `render-loop.ts` so `drawUnits` receives the masked unit map (end-to-end visual effect)
- Renders tech-gated disguise button group in `selected-unit-info.ts` for idle spies (barbarian+warrior: espionage-informants; scout+archer: spy-networks; worker: cryptography); active disguise marked with ✓; idle guard prevents display when spy is not on the map
- `main.ts` `onSetDisguise` callback: ownership guard for hot-seat safety, marks `hasActed + movementPointsLeft=0`, calls `selectUnit` to repaint the info panel, calls `updateHUD`
- Adds `require-green-before-push` PreToolUse hook that gates `git push` / `gh pr create` / `gh pr merge` on `yarn build && yarn test` — catches TS type errors before they reach CI
- Updates `CLAUDE.md` to document that `yarn test` does not type-check (`yarn build` is the only `tsc` path)

## Test Plan

- [x] `tests/systems/espionage-stealth.test.ts` — 9 tests: undisguised visible, barbarian→warrior/barbarian to enemy, owner sees truth, enemy scout_hound pierces, archer disguise, stationed spy unaffected, on_mission spy unaffected, friendly hound irrelevant to third-party viewer
- [x] `tests/ui/selected-unit-info.test.ts` — 5 tests: no Scout button without spy-networks, Scout+Archer appear with spy-networks, no disguise section when not idle, active disguise checkmark, button click fires callback
- [x] `tests/hooks/require-green-before-push.test.sh` — pass/fail/non-matching path coverage
- [x] `yarn build` exits 0 (tsc clean)
- [x] `yarn test` 1137 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)