### PR TITLE
fix(combat): resolve exposed city assaults

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -21,6 +21,7 @@ import {
   joinEmbargo,
   inviteToLeague,
 } from '@/systems/diplomacy-system';
+import { resolveMajorCityCapture } from '@/systems/city-capture-system';
 import {
   getAvailableMissions,
   assignSpyDefensive,
@@ -264,7 +265,7 @@ function scoreLegendaryWonderOpportunity(state: GameState, civId: string, cityId
 
 export function processAITurn(state: GameState, civId: string, bus: EventBus): GameState {
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
-  const civ = newState.civilizations[civId];
+  let civ = newState.civilizations[civId];
   if (!civ) return newState;
 
   const personality = getPersonality(newState, civ.civType ?? 'generic');
@@ -293,6 +294,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
 
   const abandonment = abandonLostLegendaryWonderRace(newState, civId);
   newState = abandonment.state;
+  civ = newState.civilizations[civId];
   for (const event of abandonment.lostEvents) {
     bus.emit('wonder:legendary-lost', event);
   }
@@ -397,6 +399,34 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     }
 
     if (attacked) continue;
+
+    const exposedEnemyCity = Object.values(newState.cities).find(city =>
+      city.owner !== civId
+      && !city.owner.startsWith('mc-')
+      && (civ.diplomacy?.atWarWith.includes(city.owner) ?? false)
+      && hexDistance(unit.position, city.position) === 1,
+    );
+
+    if (exposedEnemyCity) {
+      const movedAttacker = moveUnit(unit, exposedEnemyCity.position, 1);
+      newState.units[unit.id] = {
+        ...movedAttacker,
+        movementPointsLeft: 0,
+        hasMoved: true,
+      };
+      delete unitPositions[hexKey(unit.position)];
+      unitPositions[hexKey(exposedEnemyCity.position)] = unit.id;
+      const captureResult = resolveMajorCityCapture(
+        newState,
+        exposedEnemyCity.id,
+        civId,
+        'occupy',
+        newState.turn,
+      );
+      newState = captureResult.state;
+      civ = newState.civilizations[civId];
+      continue;
+    }
 
     // Explore: move toward unexplored territory
     const range = getMovementRange(unit, newState.map, unitPositions);

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -38,6 +38,7 @@ import { applyProductionBonus } from '@/systems/city-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
+import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
 import {
   getLegendaryWonderCityYieldBonus,
@@ -54,6 +55,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   // Resolve unrest and revolts before city yields so instability impacts the current turn.
   newState = processFactionTurn(newState, bus);
   newState = processBreakawayTurn(newState, bus);
+  newState = tickOccupiedCities(newState);
 
   // --- Process each civilization ---
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
@@ -69,7 +71,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
 
       const baseYields = calculateCityYields(city, newState.map, civDef?.bonusEffect);
       const wonderCityBonuses = getLegendaryWonderCityYieldBonus(newState, civId, cityId);
-      const unrestMultiplier = getUnrestYieldMultiplier(city);
+      const unrestMultiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city));
       const yields = {
         food: Math.floor((baseYields.food + (wonderCityBonuses.food ?? 0)) * unrestMultiplier),
         production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0)) * unrestMultiplier),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -250,6 +250,11 @@ export interface Building {
   pacing?: PacingMetadata;
 }
 
+export interface OccupiedCityState {
+  originalOwnerId: string;
+  turnsRemaining: number;
+}
+
 export interface City {
   id: string;
   name: string;
@@ -267,6 +272,7 @@ export interface City {
   unrestLevel: 0 | 1 | 2;     // 0=stable, 1=unrest, 2=revolt
   unrestTurns: number;         // turns spent at current unrest level (>= 1 when unrestLevel > 0)
   conquestTurn?: number;       // turn this city was captured; cleared after 15 turns
+  occupation?: OccupiedCityState;
   spyUnrestBonus: number;      // bonus pressure injected by enemy espionage; decays 5/turn
   productionDisabledTurns?: number; // late-game sabotage/cyber effect timer
 }

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -1,4 +1,4 @@
-import type { City, GameState } from '@/core/types';
+import type { City, GameState, LegendaryWonderProject } from '@/core/types';
 import { reconquerBreakawayCity } from '@/systems/breakaway-system';
 import { BUILDINGS } from '@/systems/city-system';
 import { modifyRelationship } from '@/systems/diplomacy-system';
@@ -12,6 +12,44 @@ export function computeRazeGold(city: City): number {
     return sum + Math.floor((building?.productionCost ?? 0) / 2);
   }, 0);
   return 10 + salvage;
+}
+
+function buildLegendaryWonderProjectKey(project: LegendaryWonderProject): string {
+  return `${project.wonderId}:${project.ownerId}:${project.cityId}`;
+}
+
+function transferLegendaryWonderProjectsForCity(
+  projects: GameState['legendaryWonderProjects'],
+  cityId: string,
+  newOwnerId: string,
+): GameState['legendaryWonderProjects'] {
+  const entries = Object.entries(projects ?? {});
+  if (entries.length === 0) {
+    return projects;
+  }
+
+  const updated = Object.fromEntries(entries.map(([projectId, project]) => {
+    if (project.cityId !== cityId) {
+      return [projectId, project];
+    }
+
+    const movedProject = { ...project, ownerId: newOwnerId };
+    return [buildLegendaryWonderProjectKey(movedProject), movedProject];
+  }));
+
+  return updated;
+}
+
+function removeLegendaryWonderProjectsForCity(
+  projects: GameState['legendaryWonderProjects'],
+  cityId: string,
+): GameState['legendaryWonderProjects'] {
+  const entries = Object.entries(projects ?? {});
+  if (entries.length === 0) {
+    return projects;
+  }
+
+  return Object.fromEntries(entries.filter(([, project]) => project.cityId !== cityId));
 }
 
 export function resolveMajorCityCapture(
@@ -38,6 +76,22 @@ export function resolveMajorCityCapture(
   }
 
   const forcedDisposition: MajorCityCaptureDisposition = city.population <= 1 ? 'raze' : disposition;
+
+  if (forcedDisposition === 'occupy' && previousOwner?.breakaway?.originOwnerId === newOwnerId) {
+    const reconquered = reconquerBreakawayCity(state, newOwnerId, previousOwnerId, cityId);
+    return {
+      state: {
+        ...reconquered,
+        legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
+          reconquered.legendaryWonderProjects,
+          cityId,
+          newOwnerId,
+        ),
+      },
+      outcome: 'occupied',
+      goldAwarded: 0,
+    };
+  }
 
   if (forcedDisposition === 'occupy') {
     const occupiedCity: City = {
@@ -86,6 +140,11 @@ export function resolveMajorCityCapture(
             cities: capturingCiv.cities.includes(cityId) ? capturingCiv.cities : [...capturingCiv.cities, cityId],
           },
         },
+        legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
+          state.legendaryWonderProjects,
+          cityId,
+          newOwnerId,
+        ),
       },
       outcome: 'occupied',
       goldAwarded: 0,
@@ -128,6 +187,7 @@ export function resolveMajorCityCapture(
       },
       cities: nextCities,
       civilizations: nextCivilizations,
+      legendaryWonderProjects: removeLegendaryWonderProjectsForCity(state.legendaryWonderProjects, cityId),
     },
     outcome: 'razed',
     goldAwarded,

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -1,5 +1,138 @@
-import type { GameState } from '@/core/types';
+import type { City, GameState } from '@/core/types';
 import { reconquerBreakawayCity } from '@/systems/breakaway-system';
+import { BUILDINGS } from '@/systems/city-system';
+import { modifyRelationship } from '@/systems/diplomacy-system';
+import { hexKey } from '@/systems/hex-utils';
+
+export type MajorCityCaptureDisposition = 'occupy' | 'raze';
+
+export function computeRazeGold(city: City): number {
+  const salvage = city.buildings.reduce((sum, buildingId) => {
+    const building = BUILDINGS[buildingId];
+    return sum + Math.floor((building?.productionCost ?? 0) / 2);
+  }, 0);
+  return 10 + salvage;
+}
+
+export function resolveMajorCityCapture(
+  state: GameState,
+  cityId: string,
+  newOwnerId: string,
+  disposition: MajorCityCaptureDisposition,
+  turn: number,
+): {
+  state: GameState;
+  outcome: 'occupied' | 'razed';
+  goldAwarded: number;
+} {
+  const city = state.cities[cityId];
+  if (!city) {
+    return { state, outcome: 'razed', goldAwarded: 0 };
+  }
+
+  const previousOwnerId = city.owner;
+  const previousOwner = state.civilizations[previousOwnerId];
+  const capturingCiv = state.civilizations[newOwnerId];
+  if (!capturingCiv || previousOwnerId === newOwnerId) {
+    return { state, outcome: 'razed', goldAwarded: 0 };
+  }
+
+  const forcedDisposition: MajorCityCaptureDisposition = city.population <= 1 ? 'raze' : disposition;
+
+  if (forcedDisposition === 'occupy') {
+    const occupiedCity: City = {
+      ...city,
+      owner: newOwnerId,
+      population: Math.max(1, Math.floor(city.population / 2)),
+      conquestTurn: turn,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+      occupation: {
+        originalOwnerId: previousOwnerId,
+        turnsRemaining: 10,
+      },
+    };
+
+    const nextTiles = { ...state.map.tiles };
+    for (const coord of occupiedCity.ownedTiles) {
+      const key = hexKey(coord);
+      if (nextTiles[key]) {
+        nextTiles[key] = { ...nextTiles[key], owner: newOwnerId };
+      }
+    }
+
+    return {
+      state: {
+        ...state,
+        map: {
+          ...state.map,
+          tiles: nextTiles,
+        },
+        cities: {
+          ...state.cities,
+          [cityId]: occupiedCity,
+        },
+        civilizations: {
+          ...state.civilizations,
+          ...(previousOwner ? {
+            [previousOwnerId]: {
+              ...previousOwner,
+              cities: previousOwner.cities.filter(id => id !== cityId),
+            },
+          } : {}),
+          [newOwnerId]: {
+            ...capturingCiv,
+            cities: capturingCiv.cities.includes(cityId) ? capturingCiv.cities : [...capturingCiv.cities, cityId],
+          },
+        },
+      },
+      outcome: 'occupied',
+      goldAwarded: 0,
+    };
+  }
+
+  const goldAwarded = computeRazeGold(city);
+  const nextTiles = { ...state.map.tiles };
+  for (const coord of city.ownedTiles) {
+    const key = hexKey(coord);
+    if (nextTiles[key]) {
+      nextTiles[key] = { ...nextTiles[key], owner: null };
+    }
+  }
+
+  const nextCivilizations = {
+    ...state.civilizations,
+    ...(previousOwner ? {
+      [previousOwnerId]: {
+        ...previousOwner,
+        cities: previousOwner.cities.filter(id => id !== cityId),
+        diplomacy: modifyRelationship(previousOwner.diplomacy, newOwnerId, -40),
+      },
+    } : {}),
+    [newOwnerId]: {
+      ...capturingCiv,
+      gold: capturingCiv.gold + goldAwarded,
+    },
+  };
+
+  const nextCities = { ...state.cities };
+  delete nextCities[cityId];
+
+  return {
+    state: {
+      ...state,
+      map: {
+        ...state.map,
+        tiles: nextTiles,
+      },
+      cities: nextCities,
+      civilizations: nextCivilizations,
+    },
+    outcome: 'razed',
+    goldAwarded,
+  };
+}
 
 export function transferCapturedCityOwnership(
   state: GameState,

--- a/src/systems/city-occupation-system.ts
+++ b/src/systems/city-occupation-system.ts
@@ -1,0 +1,39 @@
+import type { City, GameState } from '@/core/types';
+
+export function getOccupiedCityYieldMultiplier(city: City): 0.5 | 0.75 | 1 {
+  const turnsRemaining = city.occupation?.turnsRemaining ?? 0;
+  if (turnsRemaining >= 6) {
+    return 0.5;
+  }
+  if (turnsRemaining >= 1) {
+    return 0.75;
+  }
+  return 1;
+}
+
+export function tickOccupiedCities(state: GameState): GameState {
+  let changed = false;
+  const cities = Object.fromEntries(
+    Object.entries(state.cities).map(([cityId, city]) => {
+      if (!city.occupation) {
+        return [cityId, city];
+      }
+
+      changed = true;
+      const turnsRemaining = city.occupation.turnsRemaining - 1;
+      if (turnsRemaining <= 0) {
+        return [cityId, { ...city, occupation: undefined }];
+      }
+
+      return [cityId, {
+        ...city,
+        occupation: {
+          ...city.occupation,
+          turnsRemaining,
+        },
+      }];
+    }),
+  );
+
+  return changed ? { ...state, cities } : state;
+}

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -2,7 +2,9 @@ import { processAITurn } from '@/ai/basic-ai';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import type { GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
+import { hexKey } from '@/systems/hex-utils';
 import { tickLegendaryWonderProjects } from '@/systems/legendary-wonder-system';
 
 function makeAiRebelState(): GameState {
@@ -408,6 +410,44 @@ function makeAiBreakawayState(): GameState {
     embargoes: [],
     defensiveLeagues: [],
   } as GameState;
+}
+
+function makeAdjacentExposedCityState({ population }: { population: number }): GameState {
+  const state = createNewGame(undefined, 'ai-city-capture', 'small');
+  state.currentPlayer = 'ai-1';
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations.player.diplomacy.relationships['ai-1'] = -60;
+  state.civilizations['ai-1'].diplomacy.relationships.player = -60;
+
+  const template = Object.values(state.units).find(unit => unit.owner === 'ai-1' && unit.type === 'warrior');
+  if (!template) {
+    throw new Error('missing ai warrior fixture');
+  }
+
+  state.units['ai-attacker'] = {
+    ...template,
+    id: 'ai-attacker',
+    owner: 'ai-1',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    hasMoved: false,
+  };
+  state.civilizations['ai-1'].units = ['ai-attacker'];
+
+  state.cities['city-player'] = {
+    ...foundCity('player', { q: 1, r: 0 }, state.map),
+    id: 'city-player',
+    name: 'Memphis',
+    owner: 'player',
+    position: { q: 1, r: 0 },
+    population,
+    ownedTiles: [{ q: 1, r: 0 }],
+  };
+  state.civilizations.player.cities = ['city-player'];
+  state.map.tiles[hexKey({ q: 1, r: 0 })].owner = 'player';
+
+  return state;
 }
 
 function makeLegendaryWonderAiFixture(options: { duplicateLostRace?: boolean } = {}): GameState {
@@ -971,6 +1011,17 @@ function makeAiBarbarianCampAttackState(): GameState {
 }
 
 describe('processAITurn', () => {
+  it('assaults and occupies an exposed enemy city', () => {
+    const state = makeAdjacentExposedCityState({ population: 5 });
+    const bus = new EventBus();
+
+    const result = processAITurn(state, 'ai-1', bus);
+
+    expect(result.cities['city-player'].owner).toBe('ai-1');
+    expect(result.cities['city-player'].population).toBe(2);
+    expect(result.cities['city-player'].occupation?.turnsRemaining).toBe(10);
+  });
+
   it('does not throw on a fresh game', () => {
     const state = createNewGame(undefined, 'ai-test');
     const bus = new EventBus();

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -7,6 +7,7 @@ import { foundCity } from '@/systems/city-system';
 import { getAvailableTechs } from '@/systems/tech-system';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { resolveCivDefinition } from '@/systems/civ-registry';
+import { calculateCityYields } from '@/systems/resource-system';
 import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
@@ -68,6 +69,26 @@ describe('processTurn', () => {
 
     const newState = processTurn(state, bus);
     expect(newState).toBeDefined();
+  });
+
+  it('applies occupied-city penalties and decrements the occupation timer during turn processing', () => {
+    const state = createNewGame(undefined, 'occupied-turn', 'small');
+    const bus = new EventBus();
+    const city = foundCity('player', { q: 1, r: 0 }, state.map);
+    city.id = 'athens';
+    city.population = 4;
+    city.buildings = ['granary'];
+    city.productionQueue = ['library'];
+    city.productionProgress = 0;
+    city.occupation = { originalOwnerId: 'ai-1', turnsRemaining: 8 };
+    state.cities[city.id] = city;
+    state.civilizations.player.cities = [city.id];
+
+    const baseProduction = calculateCityYields(city, state.map).production;
+    const result = processTurn(state, bus);
+
+    expect(result.cities.athens.occupation?.turnsRemaining).toBe(7);
+    expect(result.cities.athens.productionProgress).toBe(Math.floor(baseProduction * 0.5));
   });
 
   it('processes minor civ turn phase', () => {

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -37,6 +37,21 @@ describe('city-capture-system', () => {
     return state;
   }
 
+  function addLegendaryProject(state: GameState, ownerId: string, cityId: string, wonderId = 'oracle-of-delphi'): void {
+    state.legendaryWonderProjects = {
+      ...(state.legendaryWonderProjects ?? {}),
+      [`${wonderId}:${ownerId}:${cityId}`]: {
+        wonderId,
+        ownerId,
+        cityId,
+        phase: 'questing',
+        investedProduction: 12,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+  }
+
   it('keeps instability pressure when the former owner reconquers its own breakaway city', () => {
     const { state, cityId } = makeBreakawayFixture({ breakawayStartedTurn: 12 });
 
@@ -45,6 +60,18 @@ describe('city-capture-system', () => {
     expect(result.cities[cityId].owner).toBe('player');
     expect(result.cities[cityId].unrestLevel).toBe(1);
     expect(result.cities[cityId].conquestTurn).toBeUndefined();
+  });
+
+  it('preserves breakaway reconquest behavior in the shared occupy resolver', () => {
+    const { state, cityId } = makeBreakawayFixture({ breakawayStartedTurn: 12 });
+
+    const result = resolveMajorCityCapture(state, cityId, 'player', 'occupy', state.turn);
+
+    expect(result.outcome).toBe('occupied');
+    expect(result.state.cities[cityId].owner).toBe('player');
+    expect(result.state.cities[cityId].unrestLevel).toBe(1);
+    expect(result.state.cities[cityId].conquestTurn).toBeUndefined();
+    expect(result.state.cities[cityId].occupation).toBeUndefined();
   });
 
   it('occupies a captured city by halving population and transferring all owned tiles', () => {
@@ -60,6 +87,18 @@ describe('city-capture-system', () => {
     for (const coord of result.state.cities.athens.ownedTiles) {
       expect(result.state.map.tiles[hexKey(coord)].owner).toBe('player');
     }
+  });
+
+  it('reassigns legendary wonder projects to the new owner when a city is occupied', () => {
+    const state = makeExposedCityCaptureState({ population: 6, buildings: ['granary'] });
+    addLegendaryProject(state, 'ai-1', 'athens');
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(Object.keys(result.state.legendaryWonderProjects ?? {})).toEqual(['oracle-of-delphi:player:athens']);
+    expect(result.state.legendaryWonderProjects?.['oracle-of-delphi:player:athens']).toEqual(
+      expect.objectContaining({ ownerId: 'player', cityId: 'athens' }),
+    );
   });
 
   it('auto-razes a size-1 city instead of occupying it', () => {
@@ -81,5 +120,15 @@ describe('city-capture-system', () => {
     expect(result.goldAwarded).toBe(10 + Math.floor((40 + 16 + 30) / 2));
     expect(result.state.cities.athens).toBeUndefined();
     expect(result.state.civilizations['ai-1'].diplomacy.relationships.player).toBe(before - 40);
+  });
+
+  it('removes legendary wonder projects for a razed city', () => {
+    const state = makeExposedCityCaptureState({ population: 4, buildings: ['granary'] });
+    addLegendaryProject(state, 'ai-1', 'athens');
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
+
+    expect(result.state.cities.athens).toBeUndefined();
+    expect(result.state.legendaryWonderProjects).toEqual({});
   });
 });

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -1,8 +1,42 @@
 import { describe, it, expect } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { foundCity } from '@/systems/city-system';
 import { makeBreakawayFixture } from './helpers/breakaway-fixture';
-import { transferCapturedCityOwnership } from '@/systems/city-capture-system';
+import { resolveMajorCityCapture, transferCapturedCityOwnership } from '@/systems/city-capture-system';
 
 describe('city-capture-system', () => {
+  function makeExposedCityCaptureState({
+    population,
+    buildings,
+  }: {
+    population: number;
+    buildings: string[];
+  }): GameState {
+    const state = createNewGame(undefined, 'capture-empty-city', 'small');
+    state.civilizations.player.cities = [];
+    state.civilizations['ai-1'].cities = [];
+    state.civilizations.player.diplomacy.relationships['ai-1'] = 0;
+    state.civilizations['ai-1'].diplomacy.relationships.player = 0;
+
+    state.cities.athens = {
+      ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
+      id: 'athens',
+      name: 'Athens',
+      owner: 'ai-1',
+      position: { q: 1, r: 0 },
+      population,
+      buildings,
+      ownedTiles: [{ q: 1, r: 0 }, { q: 1, r: 1 }],
+    };
+    state.civilizations['ai-1'].cities = ['athens'];
+    state.map.tiles[hexKey({ q: 1, r: 0 })].owner = 'ai-1';
+    state.map.tiles[hexKey({ q: 1, r: 1 })].owner = 'ai-1';
+
+    return state;
+  }
+
   it('keeps instability pressure when the former owner reconquers its own breakaway city', () => {
     const { state, cityId } = makeBreakawayFixture({ breakawayStartedTurn: 12 });
 
@@ -11,5 +45,41 @@ describe('city-capture-system', () => {
     expect(result.cities[cityId].owner).toBe('player');
     expect(result.cities[cityId].unrestLevel).toBe(1);
     expect(result.cities[cityId].conquestTurn).toBeUndefined();
+  });
+
+  it('occupies a captured city by halving population and transferring all owned tiles', () => {
+    const state = makeExposedCityCaptureState({ population: 6, buildings: ['granary', 'library'] });
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(result.state.cities.athens.owner).toBe('player');
+    expect(result.state.cities.athens.population).toBe(3);
+    expect(result.state.cities.athens.occupation).toEqual(
+      expect.objectContaining({ originalOwnerId: 'ai-1', turnsRemaining: 10 }),
+    );
+    for (const coord of result.state.cities.athens.ownedTiles) {
+      expect(result.state.map.tiles[hexKey(coord)].owner).toBe('player');
+    }
+  });
+
+  it('auto-razes a size-1 city instead of occupying it', () => {
+    const state = makeExposedCityCaptureState({ population: 1, buildings: ['granary'] });
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(result.outcome).toBe('razed');
+    expect(result.state.cities.athens).toBeUndefined();
+    expect(result.goldAwarded).toBe(30);
+  });
+
+  it('awards salvage gold and applies a raze relationship penalty', () => {
+    const state = makeExposedCityCaptureState({ population: 4, buildings: ['granary', 'library', 'monument'] });
+    const before = state.civilizations['ai-1'].diplomacy.relationships.player;
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
+
+    expect(result.goldAwarded).toBe(10 + Math.floor((40 + 16 + 30) / 2));
+    expect(result.state.cities.athens).toBeUndefined();
+    expect(result.state.civilizations['ai-1'].diplomacy.relationships.player).toBe(before - 40);
   });
 });

--- a/tests/systems/city-occupation-system.test.ts
+++ b/tests/systems/city-occupation-system.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
+
+function makeOccupiedCityState(turnsRemaining: number): GameState {
+  const state = createNewGame(undefined, 'occupied-city', 'small');
+  const city: City = {
+    ...foundCity('player', { q: 1, r: 0 }, state.map),
+    id: 'athens',
+    name: 'Athens',
+    owner: 'player',
+    position: { q: 1, r: 0 },
+    population: 4,
+    occupation: { originalOwnerId: 'ai-1', turnsRemaining },
+  };
+  state.cities[city.id] = city;
+  state.civilizations.player.cities = [city.id];
+  return state;
+}
+
+describe('city-occupation-system', () => {
+  it('uses the stronger penalty while a city has 6 or more occupation turns remaining', () => {
+    const state = makeOccupiedCityState(8);
+
+    expect(getOccupiedCityYieldMultiplier(state.cities.athens)).toBe(0.5);
+  });
+
+  it('drops to the lighter penalty for the last five occupation turns', () => {
+    const state = makeOccupiedCityState(5);
+
+    expect(getOccupiedCityYieldMultiplier(state.cities.athens)).toBe(0.75);
+  });
+
+  it('decrements occupation each turn and clears it when integration completes', () => {
+    let state = makeOccupiedCityState(2);
+
+    state = tickOccupiedCities(state);
+    expect(state.cities.athens.occupation?.turnsRemaining).toBe(1);
+
+    state = tickOccupiedCities(state);
+    expect(state.cities.athens.occupation).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary\n- add a shared major-city capture resolver for occupy and raze outcomes\n- route AI adjacent exposed-city assaults through the shared resolver\n- add regression coverage for city capture outcomes and the AI exposed-city path\n\n## Testing\n- ./scripts/run-with-mise.sh yarn test --run tests/systems/city-capture-system.test.ts tests/ai/basic-ai.test.ts\n- scripts/check-src-rule-violations.sh src/systems/city-capture-system.ts src/ai/basic-ai.ts src/core/types.ts\n- ./scripts/run-with-mise.sh yarn build\n\nPart of #118.