### PR TITLE
feat(ui): add player city capture choices

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '24.13.1'
 
       - name: Install dependencies
         run: corepack enable && yarn install
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '24.13.1'
 
       - name: Install dependencies
         run: corepack enable && yarn install

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "lts"
+node = "24.13.1"
 yarn = "latest"

--- a/src/input/city-assault-flow.ts
+++ b/src/input/city-assault-flow.ts
@@ -1,0 +1,55 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { moveUnit } from '@/systems/unit-system';
+import { computeRazeGold, resolveMajorCityCapture, type MajorCityCaptureDisposition } from '@/systems/city-capture-system';
+
+export interface PendingCityCaptureChoice {
+  attackerId: string;
+  cityId: string;
+  targetCoord: HexCoord;
+  occupiedPopulation: number;
+  razeGold: number;
+}
+
+export function beginPlayerCityAssaultChoice(
+  state: GameState,
+  attackerId: string,
+  cityId: string,
+): { state: GameState; pending: PendingCityCaptureChoice } {
+  const attacker = state.units[attackerId];
+  const city = state.cities[cityId];
+  if (!attacker || !city) {
+    throw new Error('Cannot begin city assault without attacker and city');
+  }
+
+  const movedAttacker = {
+    ...moveUnit(attacker, city.position, 1),
+    movementPointsLeft: 0,
+    hasMoved: true,
+  };
+
+  return {
+    state: {
+      ...state,
+      units: {
+        ...state.units,
+        [attackerId]: movedAttacker,
+      },
+    },
+    pending: {
+      attackerId,
+      cityId,
+      targetCoord: city.position,
+      occupiedPopulation: Math.max(1, Math.floor(city.population / 2)),
+      razeGold: computeRazeGold(city),
+    },
+  };
+}
+
+export function finalizePlayerCityAssaultChoice(
+  state: GameState,
+  pending: PendingCityCaptureChoice,
+  disposition: MajorCityCaptureDisposition,
+  turn: number,
+): { state: GameState; outcome: 'occupied' | 'razed'; goldAwarded: number } {
+  return resolveMajorCityCapture(state, pending.cityId, state.currentPlayer, disposition, turn);
+}

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -1,0 +1,60 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { getMovementRange } from '@/systems/unit-system';
+
+export type SelectedUnitTapIntent =
+  | { kind: 'move' }
+  | { kind: 'assault-city'; cityId: string };
+
+function buildUnitMaps(state: GameState): {
+  unitPositions: Record<string, string>;
+  unitOwners: Record<string, string>;
+} {
+  const unitPositions: Record<string, string> = {};
+  const unitOwners: Record<string, string> = {};
+
+  for (const unit of Object.values(state.units)) {
+    unitPositions[hexKey(unit.position)] = unit.id;
+    unitOwners[unit.id] = unit.owner;
+  }
+
+  return { unitPositions, unitOwners };
+}
+
+export function resolveSelectedUnitTapIntent(
+  state: GameState,
+  unitId: string,
+  targetCoord: HexCoord,
+  movementRangeOverride?: HexCoord[],
+): SelectedUnitTapIntent {
+  const unit = state.units[unitId];
+  if (!unit) return { kind: 'move' };
+
+  const movementRange = movementRangeOverride ?? (() => {
+    const { unitPositions, unitOwners } = buildUnitMaps(state);
+    return getMovementRange(unit, state.map, unitPositions, unitOwners);
+  })();
+
+  const targetKey = hexKey(targetCoord);
+  if (!movementRange.some(coord => hexKey(coord) === targetKey)) {
+    return { kind: 'move' };
+  }
+
+  const cityAtTarget = Object.values(state.cities).find(city =>
+    hexKey(city.position) === targetKey
+    && city.owner !== state.currentPlayer
+    && !city.owner.startsWith('mc-'),
+  );
+  if (!cityAtTarget) {
+    return { kind: 'move' };
+  }
+
+  const occupiedByOtherUnit = Object.values(state.units).some(other =>
+    other.id !== unitId && hexKey(other.position) === targetKey,
+  );
+  if (occupiedByOtherUnit) {
+    return { kind: 'move' };
+  }
+
+  return { kind: 'assault-city', cityId: cityAtTarget.id };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedI
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
+import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { resolveCombat, getTerrainDefenseBonus } from '@/systems/combat-system';
 import { canBuildImprovement, IMPROVEMENT_BUILD_TURNS } from '@/systems/improvement-system';
@@ -53,7 +54,8 @@ import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
-import { transferCapturedCityOwnership } from '@/systems/city-capture-system';
+import { type PendingCityCaptureChoice, beginPlayerCityAssaultChoice, finalizePlayerCityAssaultChoice } from '@/input/city-assault-flow';
+import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 import {
   initializeLegendaryWonderProjectsForCity,
   startLegendaryWonderBuild,
@@ -69,7 +71,7 @@ import {
 import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
-import type { GameState, HexCoord, Unit, DiplomaticAction } from '@/core/types';
+import type { GameState, HexCoord, Unit, DiplomaticAction, CivBonusEffect } from '@/core/types';
 import {
   appendNotification,
   createNotificationLog,
@@ -94,6 +96,7 @@ let inputInitialized = false;
 let councilPanelOpen = false;
 let persistedSettings: GameState['settings'] | undefined;
 let pacingDebugOpen = false;
+let pendingCityCaptureChoice: PendingCityCaptureChoice | null = null;
 
 function mergePersistedSettings(loadedSettings?: GameState['settings']): GameState['settings'] {
   const baseSettings = loadedSettings ?? persistedSettings ?? createDefaultSettings('small');
@@ -966,6 +969,81 @@ function buildImprovementAction(type: 'farm' | 'mine'): void {
   renderLoop.setGameState(gameState);
 }
 
+function ensurePlayerWarState(targetCivId: string): void {
+  const targetCiv = gameState.civilizations[targetCivId];
+  if (!targetCiv || targetCivId.startsWith('mc-') || targetCivId === 'barbarian') return;
+
+  const cp = gameState.currentPlayer;
+  const alreadyAtWar = currentCiv().diplomacy?.atWarWith.includes(targetCivId) ?? false;
+  if (alreadyAtWar) return;
+
+  currentCiv().diplomacy = declareWar(currentCiv().diplomacy, targetCivId, gameState.turn);
+  targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, gameState.turn);
+  bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId });
+}
+
+function finalizePendingCityCaptureChoice(
+  disposition: 'occupy' | 'raze',
+  attackerBonus?: CivBonusEffect,
+): void {
+  if (!pendingCityCaptureChoice) return;
+
+  const pending = pendingCityCaptureChoice;
+  const cityBeforeResolution = gameState.cities[pending.cityId];
+  const previousOwner = cityBeforeResolution?.owner ?? '';
+  const cityName = cityBeforeResolution?.name ?? pending.cityId;
+  const result = finalizePlayerCityAssaultChoice(gameState, pending, disposition, gameState.turn);
+
+  pendingCityCaptureChoice = null;
+  document.getElementById('city-capture-panel')?.remove();
+  gameState = result.state;
+
+  if (result.outcome === 'occupied') {
+    const capturingCiv = currentCiv();
+    if (capturingCiv && attackerBonus?.type === 'naval_raiding') {
+      capturingCiv.gold += 30;
+      showNotification('Viking raid spoils! +30 gold', 'success');
+    }
+    showNotification(`We have captured ${cityName}!`, 'success');
+    bus.emit('city:captured', { cityId: pending.cityId, newOwner: gameState.currentPlayer, previousOwner });
+  } else {
+    showNotification(`${cityName} was razed! +${result.goldAwarded} gold`, 'success');
+  }
+
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  selectNextUnit();
+}
+
+function beginPlayerCityAssault(
+  attackerId: string,
+  cityId: string,
+  attackerBonus?: CivBonusEffect,
+): 'pending' | 'resolved' {
+  const city = gameState.cities[cityId];
+  if (!city) return 'resolved';
+
+  ensurePlayerWarState(city.owner);
+  const begun = beginPlayerCityAssaultChoice(gameState, attackerId, cityId);
+  gameState = begun.state;
+
+  if (city.population <= 1) {
+    pendingCityCaptureChoice = begun.pending;
+    finalizePendingCityCaptureChoice('raze', attackerBonus);
+    return 'resolved';
+  }
+
+  pendingCityCaptureChoice = begun.pending;
+  createCityCapturePanel(uiLayer, {
+    cityName: city.name,
+    occupiedPopulation: begun.pending.occupiedPopulation,
+    razeGold: begun.pending.razeGold,
+    onOccupy: () => finalizePendingCityCaptureChoice('occupy', attackerBonus),
+    onRaze: () => finalizePendingCityCaptureChoice('raze', attackerBonus),
+  });
+  return 'pending';
+}
+
 function executeAttack(attackerId: string, defenderId: string, defender: Unit, targetKey: string): void {
   const attacker = gameState.units[attackerId];
   if (!attacker) return;
@@ -973,15 +1051,7 @@ function executeAttack(attackerId: string, defenderId: string, defender: Unit, t
   const defOwnerCiv = defender.owner;
   const isBarbarian = defOwnerCiv === 'barbarian' || defOwnerCiv.startsWith('mc-');
   if (!isBarbarian && gameState.civilizations[defOwnerCiv]) {
-    const cp = gameState.currentPlayer;
-    const alreadyAtWar = currentCiv().diplomacy?.atWarWith.includes(defOwnerCiv) ?? false;
-    if (!alreadyAtWar) {
-      currentCiv().diplomacy = declareWar(currentCiv().diplomacy, defOwnerCiv, gameState.turn);
-      gameState.civilizations[defOwnerCiv].diplomacy = declareWar(
-        gameState.civilizations[defOwnerCiv].diplomacy, cp, gameState.turn,
-      );
-      bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: defOwnerCiv });
-    }
+    ensurePlayerWarState(defOwnerCiv);
   }
 
   const seed = gameState.turn * 16807 + attacker.id.charCodeAt(0) + defender.id.charCodeAt(0);
@@ -1031,18 +1101,14 @@ function executeAttack(attackerId: string, defenderId: string, defender: Unit, t
       conquestMinorCiv(gameState, cityAtTarget.owner, gameState.currentPlayer, bus);
     }
     if (cityAtTarget && !cityAtTarget.owner.startsWith('mc-') && cityAtTarget.owner !== gameState.currentPlayer) {
-      const previousOwner = cityAtTarget.owner;
-      gameState = transferCapturedCityOwnership(gameState, cityAtTarget.id, gameState.currentPlayer, gameState.turn);
-      const capturingCiv = currentCiv();
-      if (capturingCiv && !capturingCiv.cities.includes(cityAtTarget.id)) {
-        capturingCiv.cities.push(cityAtTarget.id);
+      const assaultStatus = beginPlayerCityAssault(attackerId, cityAtTarget.id, attackerBonus);
+      SFX.combat();
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      if (assaultStatus === 'resolved') {
+        selectNextUnit();
       }
-      if (capturingCiv && attackerBonus?.type === 'naval_raiding') {
-        capturingCiv.gold += 30;
-        showNotification('Viking raid spoils! +30 gold', 'success');
-      }
-      showNotification(`We have captured ${cityAtTarget.name}!`, 'success');
-      bus.emit('city:captured', { cityId: cityAtTarget.id, newOwner: gameState.currentPlayer, previousOwner });
+      return;
     }
   } else {
     if (gameState.units[defenderId]) {
@@ -1068,6 +1134,10 @@ function restAction(): void {
 }
 
 function handleHexTap(rawCoord: HexCoord): void {
+  if (pendingCityCaptureChoice) {
+    return;
+  }
+
   const coord = gameState.map.wrapsHorizontally
     ? wrapHexCoord(rawCoord, gameState.map.width)
     : rawCoord;
@@ -1246,6 +1316,18 @@ function handleHexTap(rawCoord: HexCoord): void {
         return; // Wait for button press
       }
     } else {
+      const tapIntent = resolveSelectedUnitTapIntent(gameState, selectedUnitId, coord, movementRange);
+      if (tapIntent.kind === 'assault-city') {
+        const assaultStatus = beginPlayerCityAssault(selectedUnitId, tapIntent.cityId);
+        SFX.tap();
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        if (assaultStatus === 'resolved') {
+          selectNextUnit();
+        }
+        return;
+      }
+
       // Move unit
       executeUnitMove(gameState, selectedUnitId, coord, {
         actor: 'player',

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -1,6 +1,7 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { hexToPixel } from '@/systems/hex-utils';
 import { isVisible } from '@/systems/fog-of-war';
+import { getOccupiedCityMood } from '@/systems/city-occupation-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
@@ -103,6 +104,11 @@ export function drawCities(
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(breakaway.status === 'secession' ? '⛓' : '👑', screen.x + size * 0.45, screen.y - size * 0.45);
+      } else if (city.occupation) {
+        ctx.font = `${size * 0.28}px system-ui`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(getOccupiedCityMood(city) === 2 ? '☹' : '⚡', screen.x + size * 0.45, screen.y - size * 0.45);
       } else if (city.unrestLevel > 0) {
         ctx.font = `${size * 0.28}px system-ui`;
         ctx.textAlign = 'center';

--- a/src/systems/city-occupation-system.ts
+++ b/src/systems/city-occupation-system.ts
@@ -1,13 +1,16 @@
 import type { City, GameState } from '@/core/types';
 
-export function getOccupiedCityYieldMultiplier(city: City): 0.5 | 0.75 | 1 {
+export function getOccupiedCityMood(city: City): 0 | 1 | 2 {
   const turnsRemaining = city.occupation?.turnsRemaining ?? 0;
-  if (turnsRemaining >= 6) {
-    return 0.5;
-  }
-  if (turnsRemaining >= 1) {
-    return 0.75;
-  }
+  if (turnsRemaining >= 6) return 2;
+  if (turnsRemaining >= 1) return 1;
+  return 0;
+}
+
+export function getOccupiedCityYieldMultiplier(city: City): 0.5 | 0.75 | 1 {
+  const mood = getOccupiedCityMood(city);
+  if (mood === 2) return 0.5;
+  if (mood === 1) return 0.75;
   return 1;
 }
 

--- a/src/ui/city-capture-panel.ts
+++ b/src/ui/city-capture-panel.ts
@@ -1,0 +1,66 @@
+export interface CityCapturePanelOptions {
+  cityName: string;
+  occupiedPopulation: number;
+  razeGold: number;
+  onOccupy: () => void;
+  onRaze: () => void;
+}
+
+export function createCityCapturePanel(
+  container: HTMLElement,
+  options: CityCapturePanelOptions,
+): HTMLElement {
+  document.getElementById('city-capture-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'city-capture-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(10,10,20,0.92);z-index:70;display:flex;align-items:center;justify-content:center;padding:24px;';
+
+  const card = document.createElement('div');
+  card.style.cssText = 'max-width:420px;width:100%;background:rgba(34,24,20,0.98);border:1px solid rgba(232,193,112,0.35);border-radius:18px;padding:20px;color:#f5e7c9;box-shadow:0 24px 60px rgba(0,0,0,0.35);';
+
+  const title = document.createElement('h2');
+  title.style.cssText = 'margin:0 0 8px;font-size:22px;color:#e8c170;';
+  title.textContent = options.cityName;
+  card.appendChild(title);
+
+  const subtitle = document.createElement('div');
+  subtitle.style.cssText = 'font-size:13px;opacity:0.8;margin-bottom:16px;';
+  subtitle.textContent = 'Choose the fate of the conquered city.';
+  card.appendChild(subtitle);
+
+  const occupy = document.createElement('div');
+  occupy.style.cssText = 'background:rgba(255,255,255,0.06);border-radius:12px;padding:12px;margin-bottom:10px;';
+  occupy.textContent = `Occupy: Population ${options.occupiedPopulation}, 10 turns to integrate`;
+  card.appendChild(occupy);
+
+  const raze = document.createElement('div');
+  raze.style.cssText = 'background:rgba(255,255,255,0.06);border-radius:12px;padding:12px;margin-bottom:18px;';
+  raze.textContent = `Raze: Gain ${options.razeGold} gold immediately`;
+  card.appendChild(raze);
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.cssText = 'display:flex;gap:10px;';
+
+  const occupyButton = document.createElement('button');
+  occupyButton.type = 'button';
+  occupyButton.dataset.action = 'occupy';
+  occupyButton.style.cssText = 'flex:1;padding:12px 14px;border:none;border-radius:10px;background:#7d9d4e;color:#111;font-weight:700;cursor:pointer;';
+  occupyButton.textContent = 'Occupy';
+  occupyButton.addEventListener('click', options.onOccupy);
+
+  const razeButton = document.createElement('button');
+  razeButton.type = 'button';
+  razeButton.dataset.action = 'raze';
+  razeButton.style.cssText = 'flex:1;padding:12px 14px;border:none;border-radius:10px;background:#b24a36;color:#fff;font-weight:700;cursor:pointer;';
+  razeButton.textContent = 'Raze';
+  razeButton.addEventListener('click', options.onRaze);
+
+  buttonRow.appendChild(occupyButton);
+  buttonRow.appendChild(razeButton);
+  card.appendChild(buttonRow);
+  panel.appendChild(card);
+  container.appendChild(panel);
+
+  return panel;
+}

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -1,5 +1,7 @@
 import type { City, GameState } from '@/core/types';
 import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import { getUnrestYieldMultiplier } from '@/systems/faction-system';
+import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateCityYields } from '@/systems/resource-system';
 import { createCityGrid } from './city-grid';
 
@@ -23,7 +25,17 @@ export function createCityPanel(
   panel.id = 'city-panel';
   panel.style.cssText = 'position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(15,15,25,0.95);z-index:30;overflow-y:auto;padding:16px;padding-bottom:80px;';
 
-  const yields = calculateCityYields(city, state.map);
+  const baseYields = calculateCityYields(city, state.map);
+  const yieldMultiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city));
+  const yields = {
+    food: Math.floor(baseYields.food * yieldMultiplier),
+    production: Math.floor(baseYields.production * yieldMultiplier),
+    gold: Math.floor(baseYields.gold * yieldMultiplier),
+    science: Math.floor(baseYields.science * yieldMultiplier),
+  };
+  const occupiedMood = getOccupiedCityMood(city);
+  const occupiedStatus = city.occupation ? `Occupied: ${city.occupation.turnsRemaining} turns to integrate` : '';
+  const occupiedMoodText = occupiedMood === 2 ? 'Very Unhappy' : occupiedMood === 1 ? 'Unhappy' : '';
   const availableBuildings = getAvailableBuildings(city, state.civilizations[state.currentPlayer].techState.completed);
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
 
@@ -118,6 +130,8 @@ export function createCityPanel(
       <div>
         <h2 style="font-size:18px;color:#e8c170;margin:0;"><span data-text="city-name"></span></h2>
         <div style="font-size:12px;opacity:0.7;">Population: <span data-text="city-pop"></span></div>
+        ${city.occupation ? '<div style="font-size:12px;color:#e8c170;" data-text="occupied-status"></div>' : ''}
+        ${occupiedMoodText ? '<div style="font-size:12px;color:#d9a25c;" data-text="occupied-mood"></div>' : ''}
       </div>
       <div style="display:flex;align-items:center;gap:8px;">
         ${navHtml}
@@ -161,6 +175,12 @@ export function createCityPanel(
 
   setText('city-name', city.name);
   setText('city-pop', String(city.population));
+  if (city.occupation) {
+    setText('occupied-status', occupiedStatus);
+  }
+  if (occupiedMoodText) {
+    setText('occupied-mood', occupiedMoodText);
+  }
   setText('yield-food', String(yields.food));
   setText('yield-prod', String(yields.production));
   setText('yield-gold', String(yields.gold));

--- a/tests/input/city-assault-flow.test.ts
+++ b/tests/input/city-assault-flow.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { beginPlayerCityAssaultChoice, finalizePlayerCityAssaultChoice } from '@/input/city-assault-flow';
+
+function makePlayerAssaultState({ population }: { population: number }): GameState {
+  const state = createNewGame(undefined, 'player-assault', 'small');
+  state.currentPlayer = 'player';
+  const attacker = Object.values(state.units).find(unit => unit.owner === 'player' && unit.type === 'warrior');
+  if (!attacker) {
+    throw new Error('missing player attacker');
+  }
+
+  state.units['unit-1'] = {
+    ...attacker,
+    id: 'unit-1',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    hasMoved: false,
+  };
+  state.civilizations.player.units = ['unit-1'];
+
+  state.cities.athens = {
+    ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
+    id: 'athens',
+    name: 'Athens',
+    owner: 'ai-1',
+    position: { q: 1, r: 0 },
+    population,
+    ownedTiles: [{ q: 1, r: 0 }],
+  };
+  state.civilizations['ai-1'].cities = ['athens'];
+
+  return state;
+}
+
+describe('city-assault-flow', () => {
+  it('begins a pending player choice by moving onto a size-2 city and finalizes occupy in place', () => {
+    const state = makePlayerAssaultState({ population: 4 });
+
+    const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
+
+    expect(begun.pending.occupiedPopulation).toBe(2);
+    expect(begun.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(begun.state.units['unit-1'].movementPointsLeft).toBe(0);
+    expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(result.state.units['unit-1'].movementPointsLeft).toBe(0);
+    expect(result.state.cities.athens.owner).toBe('player');
+  });
+
+  it('begins a pending player choice by moving onto a size-2 city and finalizes raze in place', () => {
+    const state = makePlayerAssaultState({ population: 4 });
+
+    const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'raze', begun.state.turn);
+
+    expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(result.state.units['unit-1'].movementPointsLeft).toBe(0);
+    expect(result.state.cities.athens).toBeUndefined();
+  });
+});

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
+
+function makeTapAssaultFixture(): GameState {
+  const state = createNewGame(undefined, 'tap-assault', 'small');
+  state.currentPlayer = 'player';
+  const attacker = Object.values(state.units).find(unit => unit.owner === 'player' && unit.type === 'warrior');
+  if (!attacker) {
+    throw new Error('missing player attacker');
+  }
+
+  state.units['unit-1'] = {
+    ...attacker,
+    id: 'unit-1',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    hasMoved: false,
+  };
+  state.civilizations.player.units = ['unit-1'];
+
+  state.cities.enemyCity = {
+    ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
+    id: 'enemyCity',
+    name: 'Enemy City',
+    owner: 'ai-1',
+    position: { q: 1, r: 0 },
+    population: 4,
+    ownedTiles: [{ q: 1, r: 0 }],
+  };
+  state.civilizations['ai-1'].cities = ['enemyCity'];
+
+  return state;
+}
+
+describe('selected-unit-tap-intent', () => {
+  it('returns assault-city for an ungarrisoned enemy major city in movement range', () => {
+    const state = makeTapAssaultFixture();
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
+
+    expect(intent).toEqual({ kind: 'assault-city', cityId: 'enemyCity' });
+  });
+});

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -3,6 +3,7 @@ import type { Camera } from '@/renderer/camera';
 import { drawCities, getCityRenderData } from '@/renderer/city-renderer';
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
 import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 
 class MockCanvasContext {
@@ -140,6 +141,30 @@ describe('city renderer', () => {
 
     const overlayTexts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
     expect(overlayTexts).toContain('⛓');
+  });
+
+  it('renders an occupied-city badge separately from ordinary unrest', () => {
+    const state = createNewGame(undefined, 'occupied-render', 'small');
+    const settler = Object.values(state.units).find(unit => unit.owner === 'player' && unit.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.id = 'occupied-city';
+    city.occupation = { originalOwnerId: 'ai-1', turnsRemaining: 9 };
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const camera = {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+
+    drawCities(ctx, state, camera, 'player');
+
+    const overlayTexts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
+    expect(overlayTexts).toContain('☹');
   });
 
   it('renders wrapped ghost cities at the horizontal seam when only the mirrored copy is on screen', () => {

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -12,6 +12,7 @@ vi.mock('@/storage/db', () => ({
 
 import { loadGame, migrateLegacyNamingState, saveGame } from '@/storage/save-manager';
 import type { CustomCivDefinition, GameState } from '@/core/types';
+import { foundCity } from '@/systems/city-system';
 
 // --- Minimal in-memory localStorage mock ---
 function makeLocalStorageMock() {
@@ -143,6 +144,24 @@ describe('save persistence (#38)', () => {
 
     expect(roundTrip.completedLegendaryWonders['oracle-of-delphi'].ownerId).toBe('player');
     expect(roundTrip.completedLegendaryWonders['oracle-of-delphi'].turnCompleted).toBe(40);
+  });
+
+  it('round-trips occupied city state through save and load', async () => {
+    const state = createNewGame(undefined, 'occupied-save', 'small');
+    state.cities.athens = {
+      ...foundCity('player', { q: 1, r: 0 }, state.map),
+      id: 'athens',
+      name: 'Athens',
+      owner: 'player',
+      position: { q: 1, r: 0 },
+      occupation: { originalOwnerId: 'ai-1', turnsRemaining: 6 },
+    };
+    state.civilizations.player.cities = ['athens'];
+
+    await saveGame('slot-occupied-city', 'Occupied City', state);
+    const loaded = await loadGame('slot-occupied-city');
+
+    expect(loaded?.cities.athens.occupation).toEqual(state.cities.athens.occupation);
   });
 
   it('round-trips legendary wonder history through JSON serialization', () => {

--- a/tests/systems/city-occupation-system.test.ts
+++ b/tests/systems/city-occupation-system.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import type { City, GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
-import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
+import { getOccupiedCityMood, getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 
 function makeOccupiedCityState(turnsRemaining: number): GameState {
   const state = createNewGame(undefined, 'occupied-city', 'small');
@@ -21,6 +21,18 @@ function makeOccupiedCityState(turnsRemaining: number): GameState {
 }
 
 describe('city-occupation-system', () => {
+  it('reports very unhappy mood while six or more occupation turns remain', () => {
+    const state = makeOccupiedCityState(8);
+
+    expect(getOccupiedCityMood(state.cities.athens)).toBe(2);
+  });
+
+  it('reports unhappy mood during the final five occupation turns', () => {
+    const state = makeOccupiedCityState(5);
+
+    expect(getOccupiedCityMood(state.cities.athens)).toBe(1);
+  });
+
   it('uses the stronger penalty while a city has 6 or more occupation turns remaining', () => {
     const state = makeOccupiedCityState(8);
 
@@ -41,5 +53,22 @@ describe('city-occupation-system', () => {
 
     state = tickOccupiedCities(state);
     expect(state.cities.athens.occupation).toBeUndefined();
+  });
+
+  it('decays occupied-city mood over ten turns and then clears occupation', () => {
+    const state = makeOccupiedCityState(10);
+
+    let afterFive = state;
+    for (let i = 0; i < 5; i++) {
+      afterFive = tickOccupiedCities(afterFive);
+    }
+
+    let afterTen = state;
+    for (let i = 0; i < 10; i++) {
+      afterTen = tickOccupiedCities(afterTen);
+    }
+
+    expect(getOccupiedCityMood(afterFive.cities.athens)).toBe(1);
+    expect(afterTen.cities.athens.occupation).toBeUndefined();
   });
 });

--- a/tests/ui/city-capture-panel.test.ts
+++ b/tests/ui/city-capture-panel.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCityCapturePanel } from '@/ui/city-capture-panel';
+
+class MockElement {
+  children: MockElement[] = [];
+  style = { cssText: '' };
+  dataset: Record<string, string> = {};
+  id = '';
+  textContent = '';
+  type = '';
+  private listeners = new Map<string, Array<() => void>>();
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+
+  addEventListener(event: string, handler: () => void): void {
+    this.listeners.set(event, [...(this.listeners.get(event) ?? []), handler]);
+  }
+
+  click(): void {
+    for (const handler of this.listeners.get('click') ?? []) {
+      handler();
+    }
+  }
+
+  remove(): void {}
+
+  querySelector<T extends MockElement = MockElement>(selector: string): T | null {
+    const action = selector === '[data-action="occupy"]'
+      ? 'occupy'
+      : selector === '[data-action="raze"]'
+        ? 'raze'
+        : null;
+    if (!action) return null;
+
+    const search = (node: MockElement): MockElement | null => {
+      if (node.dataset.action === action) return node;
+      for (const child of node.children) {
+        const match = search(child);
+        if (match) return match;
+      }
+      return null;
+    };
+
+    return search(this) as T | null;
+  }
+}
+
+class MockDocument {
+  createElement(): MockElement {
+    return new MockElement();
+  }
+
+  getElementById(): MockElement | null {
+    return null;
+  }
+}
+
+function collectText(node: MockElement): string {
+  return [node.textContent, ...node.children.map(collectText)].join(' ').trim();
+}
+
+describe('city-capture-panel', () => {
+  it('uses a minimal document shim in the non-DOM panel test environment', () => {
+    if (typeof document === 'undefined') {
+      (globalThis as typeof globalThis & { document?: Document }).document = new MockDocument() as unknown as Document;
+    }
+  });
+
+  it('shows occupy and raze outcomes for a newly conquered city', () => {
+    const container = document.createElement('div');
+    const panel = createCityCapturePanel(container, {
+      cityName: 'Athens',
+      occupiedPopulation: 3,
+      razeGold: 53,
+      onOccupy: () => {},
+      onRaze: () => {},
+    });
+
+    const rendered = collectText(panel as unknown as MockElement);
+    expect(rendered).toContain('Occupy');
+    expect(rendered).toContain('Raze');
+    expect(rendered).toContain('Population 3');
+    expect(rendered).toContain('53 gold');
+  });
+
+  it('calls the selected callback exactly once', () => {
+    const container = document.createElement('div');
+    const onOccupy = vi.fn();
+    const onRaze = vi.fn();
+    const panel = createCityCapturePanel(container, {
+      cityName: 'Athens',
+      occupiedPopulation: 3,
+      razeGold: 53,
+      onOccupy,
+      onRaze,
+    });
+
+    (panel as unknown as MockElement).querySelector('[data-action="occupy"]')?.click();
+
+    expect(onOccupy).toHaveBeenCalledTimes(1);
+    expect(onRaze).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -100,6 +100,40 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('turns');
   });
 
+  it('shows occupied-city integration countdown', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.occupation = { originalOwnerId: 'ai-1', turnsRemaining: 7 };
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
+
+    expect(rendered).toContain('Occupied');
+    expect(rendered).toContain('7 turns');
+  });
+
+  it('shows occupation-reduced yields and build eta', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.population = 4;
+    city.buildings = ['granary'];
+    city.productionQueue = ['library'];
+    city.productionProgress = 0;
+    city.occupation = { originalOwnerId: 'ai-1', turnsRemaining: 8 };
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
+
+    expect(rendered).toContain('Very Unhappy');
+    expect(rendered).toContain('turns remaining');
+  });
+
   it('renders production queue rows with move and remove controls', () => {
     const { container, city, state } = makeMultiCityFixture();
     city.productionQueue = ['warrior', 'shrine', 'worker'];


### PR DESCRIPTION
## Summary
- add the player city assault intent and pending capture-choice flow for empty enemy major cities
- add the blocking occupy-or-raze panel plus occupied-city status in the city panel and city renderer
- pin local and CI Node to 24.13.1 so the build stops failing on the GitHub lts/* runner regression

## Testing
- ./scripts/run-with-mise.sh yarn test
- ./scripts/run-with-mise.sh yarn build
- scripts/check-src-rule-violations.sh src/systems/city-occupation-system.ts src/input/city-assault-flow.ts src/input/selected-unit-tap-intent.ts src/core/turn-manager.ts src/main.ts src/ui/city-capture-panel.ts src/ui/city-panel.ts src/renderer/city-renderer.ts src/storage/save-manager.ts

Part of #118