### PR TITLE
fix(diplomacy): require acceptance for peace requests

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -14,7 +14,7 @@ import { chooseTech, chooseProduction } from './ai-strategy';
 import { evaluateDiplomacy, evaluateMinorCivDiplomacy, evaluateVassalage, evaluateEmbargoResponse, evaluateLeagueResponse } from './ai-diplomacy';
 import {
   declareWar,
-  makePeace,
+  enqueuePeaceRequest,
   proposeTreaty,
   modifyRelationship,
   offerVassalage,
@@ -570,15 +570,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
           bus.emit('diplomacy:war-declared', { attackerId: civId, defenderId: decision.targetCiv });
           break;
         case 'request_peace':
-          newState.civilizations[civId].diplomacy = makePeace(
-            civ.diplomacy, decision.targetCiv, newState.turn,
-          );
-          if (newState.civilizations[decision.targetCiv]?.diplomacy) {
-            newState.civilizations[decision.targetCiv].diplomacy = makePeace(
-              newState.civilizations[decision.targetCiv].diplomacy, civId, newState.turn,
-            );
-          }
-          bus.emit('diplomacy:peace-made', { civA: civId, civB: decision.targetCiv });
+          newState = enqueuePeaceRequest(newState, civId, decision.targetCiv);
           break;
         case 'non_aggression_pact':
         case 'trade_agreement':

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -557,10 +557,14 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     );
 
     for (const decision of decisions) {
+      const currentDiplomacy = newState.civilizations[civId]?.diplomacy;
+      if (!currentDiplomacy) {
+        continue;
+      }
       switch (decision.action) {
         case 'declare_war':
           newState.civilizations[civId].diplomacy = declareWar(
-            civ.diplomacy, decision.targetCiv, newState.turn,
+            currentDiplomacy, decision.targetCiv, newState.turn,
           );
           if (newState.civilizations[decision.targetCiv]?.diplomacy) {
             newState.civilizations[decision.targetCiv].diplomacy = declareWar(
@@ -570,14 +574,14 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
           bus.emit('diplomacy:war-declared', { attackerId: civId, defenderId: decision.targetCiv });
           break;
         case 'request_peace':
-          newState = enqueuePeaceRequest(newState, civId, decision.targetCiv);
+          newState = enqueuePeaceRequest(newState, civId, decision.targetCiv, bus);
           break;
         case 'non_aggression_pact':
         case 'trade_agreement':
         case 'open_borders':
         case 'alliance':
           newState.civilizations[civId].diplomacy = proposeTreaty(
-            civ.diplomacy, civId, decision.targetCiv, decision.action,
+            currentDiplomacy, civId, decision.targetCiv, decision.action,
             decision.action === 'non_aggression_pact' ? 10 : -1, newState.turn,
           );
           if (newState.civilizations[decision.targetCiv]?.diplomacy) {

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -237,6 +237,7 @@ export function createNewGame(
     legendaryWonderIntel: {},
     embargoes: [],
     defensiveLeagues: [],
+    pendingDiplomacyRequests: [],
     settings,
   };
 
@@ -347,6 +348,7 @@ export function createHotSeatGame(config: HotSeatConfig, seed?: string, gameTitl
     legendaryWonderIntel: {},
     embargoes: [],
     defensiveLeagues: [],
+    pendingDiplomacyRequests: [],
     settings,
   };
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -470,6 +470,14 @@ export interface DefensiveLeague {
   formedTurn: number;
 }
 
+export interface PendingDiplomaticRequest {
+  id: string;
+  type: 'peace';
+  fromCivId: string;
+  toCivId: string;
+  turnIssued: number;
+}
+
 // --- Espionage ---
 
 export type SpyStatus =
@@ -913,6 +921,7 @@ export interface GameState {
   espionage?: EspionageState;
   embargoes: Embargo[];
   defensiveLeagues: DefensiveLeague[];
+  pendingDiplomacyRequests?: PendingDiplomaticRequest[];
 }
 
 export interface GameSettings {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -979,6 +979,7 @@ export interface GameEvents {
   'grid:slot-unlocked': { cityId: string; newGridSize: number };
   'grid:building-placed': { cityId: string; buildingId: string; row: number; col: number };
   'diplomacy:war-declared': { attackerId: string; defenderId: string };
+  'diplomacy:peace-requested': { fromCivId: string; toCivId: string };
   'diplomacy:peace-made': { civA: string; civB: string };
   'diplomacy:treaty-proposed': { fromCiv: string; toCiv: string; treaty: TreatyType };
   'diplomacy:treaty-accepted': { civA: string; civB: string; treaty: TreatyType };

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,14 @@ import { showCampaignSetup } from '@/ui/campaign-setup';
 import { showGameModeSelect } from '@/ui/game-mode-select';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
 import { resolveCivDefinition } from '@/systems/civ-registry';
-import { applyDiplomaticAction, declareWar, makePeace, modifyRelationship } from '@/systems/diplomacy-system';
+import {
+  acceptDiplomaticRequest,
+  applyDiplomaticAction,
+  declareWar,
+  makePeace,
+  modifyRelationship,
+  rejectDiplomaticRequest,
+} from '@/systems/diplomacy-system';
 import { calculateCityYields } from '@/systems/resource-system';
 import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import { visitVillage } from '@/systems/village-system';
@@ -364,7 +371,30 @@ function toggleNotificationLog(): void {
 function handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): void {
   const cp = gameState.currentPlayer;
   gameState = applyDiplomaticAction(gameState, cp, targetCivId, action, bus);
-  showNotification(`Diplomatic action: ${action.replace(/_/g, ' ')}`, 'info');
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  if (action === 'request_peace') {
+    showNotification('Peace requested.', 'info');
+  } else {
+    showNotification(`Diplomatic action: ${action.replace(/_/g, ' ')}`, 'info');
+  }
+}
+
+function handleAcceptPeaceRequest(requestId: string): void {
+  gameState = acceptDiplomaticRequest(gameState, gameState.currentPlayer, requestId, bus);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  showNotification('Peace accepted.', 'success');
+}
+
+function handleRejectPeaceRequest(requestId: string): void {
+  gameState = rejectDiplomaticRequest(gameState, gameState.currentPlayer, requestId);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  showNotification('Peace request rejected.', 'info');
 }
 
 function handleGiftGold(mcId: string): void {
@@ -406,6 +436,18 @@ function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
   }
   renderLoop.setGameState(gameState);
   updateHUD();
+}
+
+function openDiplomacyPanel(): void {
+  document.getElementById('diplomacy-panel')?.remove();
+  createDiplomacyPanel(uiLayer, gameState, {
+    onAction: handleDiplomaticAction,
+    onAcceptPeaceRequest: handleAcceptPeaceRequest,
+    onRejectPeaceRequest: handleRejectPeaceRequest,
+    onGiftGold: handleGiftGold,
+    onMinorCivWarPeace: handleMinorCivWarPeace,
+    onClose: () => {},
+  });
 }
 
 function openCityPanelForCity(city: import('@/core/types').City): void {
@@ -752,12 +794,7 @@ function togglePanel(panel: string): void {
       },
     }));
   } else if (panel === 'diplomacy') {
-    createDiplomacyPanel(uiLayer, gameState, {
-      onAction: handleDiplomaticAction,
-      onGiftGold: handleGiftGold,
-      onMinorCivWarPeace: handleMinorCivWarPeace,
-      onClose: () => {},
-    });
+    openDiplomacyPanel();
   } else if (panel === 'marketplace') {
     createMarketplacePanel(uiLayer, gameState, {
       onClose: () => {},
@@ -1575,6 +1612,16 @@ bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId 
 
 bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
   routeWarDeclared(gameState, attackerId, defenderId, appendToCivLog);
+});
+
+bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {
+  const fromName = gameState.civilizations[fromCivId]?.name ?? 'Unknown';
+  const toName = gameState.civilizations[toCivId]?.name ?? 'Unknown';
+  appendToCivLog(toCivId, `${fromName} requests peace.`, 'info');
+  appendToCivLog(fromCivId, `Peace requested from ${toName}.`, 'info');
+  if (toCivId === gameState.currentPlayer) {
+    showNotification(`${fromName} requests peace.`, 'info');
+  }
 });
 
 bus.on('diplomacy:peace-made', ({ civA, civB }) => {

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -45,7 +45,9 @@ function migrateLegacyPlanningState(state: GameState): GameState {
 }
 
 function normalizeLoadedState(state: GameState): GameState {
-  return migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)));
+  const normalized = migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)));
+  normalized.pendingDiplomacyRequests ??= [];
+  return normalized;
 }
 
 function getCityNamingInfo(state: GameState, ownerId: string): { civType: string; civName: string; namingPool?: string[] } {

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -332,7 +332,7 @@ export function applyDiplomaticAction(
         },
       };
     case 'request_peace':
-      return enqueuePeaceRequest(state, actorId, targetCivId);
+      return enqueuePeaceRequest(state, actorId, targetCivId, bus);
     case 'non_aggression_pact':
     case 'trade_agreement':
     case 'open_borders':
@@ -409,16 +409,41 @@ function isSamePeaceRequest(
     && request.toCivId === toCivId;
 }
 
+function isPeaceRequestPair(
+  request: PendingDiplomaticRequest,
+  civA: string,
+  civB: string,
+): boolean {
+  return request.type === 'peace'
+    && (
+      (request.fromCivId === civA && request.toCivId === civB)
+      || (request.fromCivId === civB && request.toCivId === civA)
+    );
+}
+
+export function getPendingPeaceRequestForPair(
+  state: GameState,
+  civA: string,
+  civB: string,
+): PendingDiplomaticRequest | undefined {
+  return (state.pendingDiplomacyRequests ?? []).find(request => isPeaceRequestPair(request, civA, civB));
+}
+
 export function enqueuePeaceRequest(
   state: GameState,
   fromCivId: string,
   toCivId: string,
+  bus?: EventBus,
 ): GameState {
   const requests = state.pendingDiplomacyRequests ?? [];
-  if (requests.some(request => isSamePeaceRequest(request, fromCivId, toCivId))) {
+  if (
+    requests.some(request => isSamePeaceRequest(request, fromCivId, toCivId))
+    || getPendingPeaceRequestForPair(state, fromCivId, toCivId)
+  ) {
     return state;
   }
 
+  bus?.emit('diplomacy:peace-requested', { fromCivId, toCivId });
   return {
     ...state,
     pendingDiplomacyRequests: [
@@ -436,11 +461,12 @@ export function enqueuePeaceRequest(
 
 export function acceptDiplomaticRequest(
   state: GameState,
+  actingCivId: string,
   requestId: string,
   bus: EventBus,
 ): GameState {
   const request = (state.pendingDiplomacyRequests ?? []).find(candidate => candidate.id === requestId);
-  if (!request || request.type !== 'peace') {
+  if (!request || request.type !== 'peace' || request.toCivId !== actingCivId) {
     return state;
   }
 
@@ -456,7 +482,9 @@ export function acceptDiplomaticRequest(
   bus.emit('diplomacy:peace-made', { civA: request.fromCivId, civB: request.toCivId });
   return {
     ...state,
-    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
+    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(
+      candidate => !isPeaceRequestPair(candidate, request.fromCivId, request.toCivId),
+    ),
     civilizations: {
       ...state.civilizations,
       [request.fromCivId]: {
@@ -473,15 +501,17 @@ export function acceptDiplomaticRequest(
 
 export function rejectDiplomaticRequest(
   state: GameState,
+  actingCivId: string,
   requestId: string,
 ): GameState {
-  if (!(state.pendingDiplomacyRequests ?? []).some(request => request.id === requestId)) {
+  const request = (state.pendingDiplomacyRequests ?? []).find(candidate => candidate.id === requestId);
+  if (!request || request.toCivId !== actingCivId) {
     return state;
   }
 
   return {
     ...state,
-    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(request => request.id !== requestId),
+    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
   };
 }
 

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -6,6 +6,7 @@ import type {
   TreatyType,
   DefensiveLeague,
   Embargo,
+  PendingDiplomaticRequest,
   TradeRoute,
 } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
@@ -331,21 +332,7 @@ export function applyDiplomaticAction(
         },
       };
     case 'request_peace':
-      bus.emit('diplomacy:peace-made', { civA: actorId, civB: targetCivId });
-      return {
-        ...state,
-        civilizations: {
-          ...state.civilizations,
-          [actorId]: {
-            ...actor,
-            diplomacy: makePeace(actor.diplomacy, targetCivId, state.turn),
-          },
-          [targetCivId]: {
-            ...target,
-            diplomacy: makePeace(target.diplomacy, actorId, state.turn),
-          },
-        },
-      };
+      return enqueuePeaceRequest(state, actorId, targetCivId);
     case 'non_aggression_pact':
     case 'trade_agreement':
     case 'open_borders':
@@ -406,6 +393,96 @@ export function applyDiplomaticAction(
     default:
       return state;
   }
+}
+
+function buildPendingPeaceRequestId(fromCivId: string, toCivId: string, turn: number): string {
+  return `peace:${fromCivId}:${toCivId}:${turn}`;
+}
+
+function isSamePeaceRequest(
+  request: PendingDiplomaticRequest,
+  fromCivId: string,
+  toCivId: string,
+): boolean {
+  return request.type === 'peace'
+    && request.fromCivId === fromCivId
+    && request.toCivId === toCivId;
+}
+
+export function enqueuePeaceRequest(
+  state: GameState,
+  fromCivId: string,
+  toCivId: string,
+): GameState {
+  const requests = state.pendingDiplomacyRequests ?? [];
+  if (requests.some(request => isSamePeaceRequest(request, fromCivId, toCivId))) {
+    return state;
+  }
+
+  return {
+    ...state,
+    pendingDiplomacyRequests: [
+      ...requests,
+      {
+        id: buildPendingPeaceRequestId(fromCivId, toCivId, state.turn),
+        type: 'peace',
+        fromCivId,
+        toCivId,
+        turnIssued: state.turn,
+      },
+    ],
+  };
+}
+
+export function acceptDiplomaticRequest(
+  state: GameState,
+  requestId: string,
+  bus: EventBus,
+): GameState {
+  const request = (state.pendingDiplomacyRequests ?? []).find(candidate => candidate.id === requestId);
+  if (!request || request.type !== 'peace') {
+    return state;
+  }
+
+  const actor = state.civilizations[request.fromCivId];
+  const target = state.civilizations[request.toCivId];
+  if (!actor || !target) {
+    return {
+      ...state,
+      pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
+    };
+  }
+
+  bus.emit('diplomacy:peace-made', { civA: request.fromCivId, civB: request.toCivId });
+  return {
+    ...state,
+    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
+    civilizations: {
+      ...state.civilizations,
+      [request.fromCivId]: {
+        ...actor,
+        diplomacy: makePeace(actor.diplomacy, request.toCivId, state.turn),
+      },
+      [request.toCivId]: {
+        ...target,
+        diplomacy: makePeace(target.diplomacy, request.fromCivId, state.turn),
+      },
+    },
+  };
+}
+
+export function rejectDiplomaticRequest(
+  state: GameState,
+  requestId: string,
+): GameState {
+  if (!(state.pendingDiplomacyRequests ?? []).some(request => request.id === requestId)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(request => request.id !== requestId),
+  };
 }
 
 // --- Defensive Leagues (real implementations in league section below) ---

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -1,5 +1,11 @@
 import type { GameState, DiplomaticAction } from '@/core/types';
-import { canReabsorbBreakaway, getRelationship, isAtWar, getAvailableActions } from '@/systems/diplomacy-system';
+import {
+  canReabsorbBreakaway,
+  getRelationship,
+  isAtWar,
+  getAvailableActions,
+  getPendingPeaceRequestForPair,
+} from '@/systems/diplomacy-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { hasDiscoveredMinorCiv, hasMetCivilization } from '@/systems/discovery-system';
@@ -8,6 +14,8 @@ import { getQuestDescriptionForPlayer } from '@/systems/quest-system';
 
 export interface DiplomacyPanelCallbacks {
   onAction: (targetCivId: string, action: DiplomaticAction) => void;
+  onAcceptPeaceRequest?: (requestId: string) => void;
+  onRejectPeaceRequest?: (requestId: string) => void;
   onGiftGold?: (mcId: string) => void;
   onMinorCivWarPeace?: (mcId: string, currentlyAtWar: boolean) => void;
   onClose: () => void;
@@ -25,6 +33,8 @@ interface CivRowData {
   statusText: string;
   treaties: Array<{ label: string; turns: number }>;
   actions: Array<{ action: DiplomaticAction; isHostile: boolean }>;
+  peaceRequestState: 'none' | 'incoming' | 'outgoing';
+  peaceRequestId: string | null;
 }
 
 interface MinorCivRowData {
@@ -63,6 +73,11 @@ export function createDiplomacyPanel(
     const civDef = resolveCivDefinition(state, civ.civType ?? '');
     const relationship = getRelationship(playerDiplomacy, civId);
     const atWar = isAtWar(playerDiplomacy, civId);
+    const pendingPeaceRequest = getPendingPeaceRequestForPair(state, state.currentPlayer, civId);
+    const peaceRequestState = !pendingPeaceRequest ? 'none'
+      : pendingPeaceRequest.toCivId === state.currentPlayer ? 'incoming'
+      : pendingPeaceRequest.fromCivId === state.currentPlayer ? 'outgoing'
+      : 'none';
     const actions = hasMet
       ? getAvailableActions(
           playerDiplomacy, civId, playerCiv.techState.completed, state.era,
@@ -113,7 +128,11 @@ export function createDiplomacyPanel(
       barColor: hasMet ? barColor : '#888',
       statusText: hasMet ? statusText : 'Unknown rival',
       treaties,
-      actions: rowActions.map(action => ({ action, isHostile: action === 'declare_war' })),
+      actions: rowActions
+        .filter(action => !(action === 'request_peace' && peaceRequestState !== 'none'))
+        .map(action => ({ action, isHostile: action === 'declare_war' })),
+      peaceRequestState,
+      peaceRequestId: pendingPeaceRequest?.id ?? null,
     });
     civIdx++;
   }
@@ -164,6 +183,12 @@ export function createDiplomacyPanel(
     }
 
     let actionsHtml = '<div style="display:flex;flex-wrap:wrap;gap:6px;">';
+    if (row.peaceRequestState === 'incoming' && row.peaceRequestId) {
+      actionsHtml += `<button class="diplo-accept-peace" data-request-id="${row.peaceRequestId}" data-action="accept-peace-request" style="padding:6px 12px;background:rgba(74,155,74,0.3);border:1px solid #4a9b4a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Accept Peace</button>`;
+      actionsHtml += `<button class="diplo-reject-peace" data-request-id="${row.peaceRequestId}" data-action="reject-peace-request" style="padding:6px 12px;background:rgba(217,148,74,0.25);border:1px solid #d9944a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Reject Peace</button>`;
+    } else if (row.peaceRequestState === 'outgoing') {
+      actionsHtml += '<span data-role="peace-requested-pill" style="display:inline-block;padding:6px 12px;background:rgba(232,193,112,0.2);border:1px solid rgba(232,193,112,0.5);border-radius:6px;color:#e8c170;font-size:11px;">Peace Requested</span>';
+    }
     row.actions.forEach((a, aIdx) => {
       const btnColor = a.isHostile ? 'rgba(217,74,74,0.3)' : 'rgba(255,255,255,0.1)';
       const borderColor = a.isHostile ? '#d94a4a' : 'rgba(255,255,255,0.2)';
@@ -265,8 +290,24 @@ export function createDiplomacyPanel(
     btn.addEventListener('click', () => {
       const civId = (btn as HTMLElement).dataset.civId!;
       const action = (btn as HTMLElement).dataset.action! as DiplomaticAction;
-      callbacks.onAction(civId, action);
       panel.remove();
+      callbacks.onAction(civId, action);
+    });
+  });
+
+  panel.querySelectorAll('.diplo-accept-peace').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const requestId = (btn as HTMLElement).dataset.requestId!;
+      panel.remove();
+      callbacks.onAcceptPeaceRequest?.(requestId);
+    });
+  });
+
+  panel.querySelectorAll('.diplo-reject-peace').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const requestId = (btn as HTMLElement).dataset.requestId!;
+      panel.remove();
+      callbacks.onRejectPeaceRequest?.(requestId);
     });
   });
 

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -450,6 +450,17 @@ function makeAdjacentExposedCityState({ population }: { population: number }): G
   return state;
 }
 
+function makeAiPeaceRequestState(): GameState {
+  const state = createNewGame(undefined, 'ai-peace-request', 'small');
+  state.currentPlayer = 'ai-1';
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  state.civilizations.player.diplomacy.relationships['ai-1'] = 10;
+  state.civilizations['ai-1'].diplomacy.relationships.player = 10;
+  state.pendingDiplomacyRequests = [];
+  return state;
+}
+
 function makeLegendaryWonderAiFixture(options: { duplicateLostRace?: boolean } = {}): GameState {
   const state = {
     turn: 40,
@@ -1011,6 +1022,16 @@ function makeAiBarbarianCampAttackState(): GameState {
 }
 
 describe('processAITurn', () => {
+  it('does not auto-force peace on a human player', () => {
+    const state = makeAiPeaceRequestState();
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+    expect(result.pendingDiplomacyRequests).toContainEqual(
+      expect.objectContaining({ fromCivId: 'ai-1', toCivId: 'player', type: 'peace' }),
+    );
+  });
+
   it('assaults and occupies an exposed enemy city', () => {
     const state = makeAdjacentExposedCityState({ population: 5 });
     const bus = new EventBus();

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1032,6 +1032,25 @@ describe('processAITurn', () => {
     );
   });
 
+  it('does not enqueue a duplicate reciprocal peace request when one already exists', () => {
+    const state = makeAiPeaceRequestState();
+    state.pendingDiplomacyRequests = [
+      {
+        id: 'peace:player:ai-1:1',
+        type: 'peace',
+        fromCivId: 'player',
+        toCivId: 'ai-1',
+        turnIssued: state.turn,
+      },
+    ];
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.pendingDiplomacyRequests).toHaveLength(1);
+    expect(result.pendingDiplomacyRequests?.[0]?.fromCivId).toBe('player');
+    expect(result.pendingDiplomacyRequests?.[0]?.toCivId).toBe('ai-1');
+  });
+
   it('assaults and occupies an exposed enemy city', () => {
     const state = makeAdjacentExposedCityState({ population: 5 });
     const bus = new EventBus();

--- a/tests/core/game-state.test.ts
+++ b/tests/core/game-state.test.ts
@@ -110,6 +110,12 @@ describe('createNewGame', () => {
     expect(state.settings.councilTalkLevel).toBe('quiet');
   });
 
+  it('initializes pending diplomacy requests for new solo games', () => {
+    const state = createNewGame(undefined, 'pending-diplomacy-seed');
+
+    expect(state.pendingDiplomacyRequests).toEqual([]);
+  });
+
   it('createNewGame can start from a saved custom civ registry', () => {
     const state = createNewGame({
       civType: 'custom-sunfolk',
@@ -202,5 +208,11 @@ describe('createHotSeatGame', () => {
     const state = createHotSeatGame(config, 'hs-title', 'Friends Campaign');
     expect(state.gameTitle).toBe('Friends Campaign');
     expect(state.gameId).toMatch(/^game-/);
+  });
+
+  it('initializes pending diplomacy requests for hot seat games', () => {
+    const state = createHotSeatGame(config, 'hs-pending-diplomacy');
+
+    expect(state.pendingDiplomacyRequests).toEqual([]);
   });
 });

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -164,6 +164,18 @@ describe('save persistence (#38)', () => {
     expect(loaded?.cities.athens.occupation).toEqual(state.cities.athens.occupation);
   });
 
+  it('round-trips pending diplomacy requests through save and load', async () => {
+    const state = createNewGame(undefined, 'pending-peace-save', 'small');
+    state.pendingDiplomacyRequests = [
+      { id: 'req-1', type: 'peace', fromCivId: 'ai-1', toCivId: 'player', turnIssued: state.turn },
+    ];
+
+    await saveGame('slot-pending-peace', 'Pending Peace', state);
+    const loaded = await loadGame('slot-pending-peace');
+
+    expect(loaded?.pendingDiplomacyRequests).toEqual(state.pendingDiplomacyRequests);
+  });
+
   it('round-trips legendary wonder history through JSON serialization', () => {
     const state = {
       legendaryWonderHistory: {

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -176,6 +176,16 @@ describe('save persistence (#38)', () => {
     expect(loaded?.pendingDiplomacyRequests).toEqual(state.pendingDiplomacyRequests);
   });
 
+  it('normalizes older saves without pending diplomacy requests', async () => {
+    const state = createNewGame(undefined, 'legacy-pending-peace-save', 'small');
+    delete (state as Partial<GameState>).pendingDiplomacyRequests;
+
+    await saveGame('slot-legacy-pending-peace', 'Legacy Pending Peace', state);
+    const loaded = await loadGame('slot-legacy-pending-peace');
+
+    expect(loaded?.pendingDiplomacyRequests).toEqual([]);
+  });
+
   it('round-trips legendary wonder history through JSON serialization', () => {
     const state = {
       legendaryWonderHistory: {

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+  acceptDiplomaticRequest,
   applyDiplomaticAction,
   createDiplomacyState,
+  enqueuePeaceRequest,
   getRelationship,
+  getPendingPeaceRequestForPair,
   modifyRelationship,
   declareWar,
   makePeace,
@@ -12,6 +15,7 @@ import {
   decayEvents,
   getAvailableActions,
   isAtWar,
+  rejectDiplomaticRequest,
 } from '@/systems/diplomacy-system';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
@@ -180,6 +184,65 @@ describe('diplomacy-system', () => {
       expect(result.pendingDiplomacyRequests).toContainEqual(
         expect.objectContaining({ fromCivId: 'ai-1', toCivId: 'player', type: 'peace' }),
       );
+    });
+
+    it('deduplicates pending peace requests across both directions for the same civ pair', () => {
+      const state = makeWarState();
+
+      const first = enqueuePeaceRequest(state, 'ai-1', 'player');
+      const second = enqueuePeaceRequest(first, 'player', 'ai-1');
+
+      expect(second.pendingDiplomacyRequests).toHaveLength(1);
+      expect(getPendingPeaceRequestForPair(second, 'player', 'ai-1')).toEqual(first.pendingDiplomacyRequests?.[0]);
+    });
+
+    it('accepts a peace request only for the addressed civ and clears pair requests', () => {
+      const state = makeWarState();
+      const bus = new EventBus();
+      const first = enqueuePeaceRequest(state, 'ai-1', 'player');
+      const pairRequestId = first.pendingDiplomacyRequests?.[0]?.id;
+      if (!pairRequestId) {
+        throw new Error('expected pending peace request');
+      }
+
+      const wrongActorResult = acceptDiplomaticRequest(first, 'ai-1', pairRequestId, bus);
+      expect(wrongActorResult).toBe(first);
+
+      const second = {
+        ...first,
+        pendingDiplomacyRequests: [
+          ...(first.pendingDiplomacyRequests ?? []),
+          {
+            id: 'peace:player:ai-1:10',
+            type: 'peace' as const,
+            fromCivId: 'player',
+            toCivId: 'ai-1',
+            turnIssued: first.turn,
+          },
+        ],
+      };
+
+      const accepted = acceptDiplomaticRequest(second, 'player', pairRequestId, bus);
+      expect(accepted.pendingDiplomacyRequests).toEqual([]);
+      expect(accepted.civilizations.player.diplomacy.atWarWith).not.toContain('ai-1');
+      expect(accepted.civilizations['ai-1'].diplomacy.atWarWith).not.toContain('player');
+    });
+
+    it('rejects a peace request only for the addressed civ and keeps war active', () => {
+      const state = makeWarState();
+      const requested = enqueuePeaceRequest(state, 'ai-1', 'player');
+      const requestId = requested.pendingDiplomacyRequests?.[0]?.id;
+      if (!requestId) {
+        throw new Error('expected pending peace request');
+      }
+
+      const wrongActorResult = rejectDiplomaticRequest(requested, 'ai-1', requestId);
+      expect(wrongActorResult).toBe(requested);
+
+      const rejected = rejectDiplomaticRequest(requested, 'player', requestId);
+      expect(rejected.pendingDiplomacyRequests).toEqual([]);
+      expect(rejected.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+      expect(rejected.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
     });
 
     it('applies Narnias treaty relationship bonus symmetrically when a treaty is signed', () => {

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -14,7 +14,19 @@ import {
   isAtWar,
 } from '@/systems/diplomacy-system';
 import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
 import { makeBreakawayFixture } from './helpers/breakaway-fixture';
+
+function makeWarState(): GameState {
+  const state = createNewGame(undefined, 'peace-request-test', 'small');
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  state.civilizations.player.diplomacy.relationships['ai-1'] = -25;
+  state.civilizations['ai-1'].diplomacy.relationships.player = -25;
+  state.pendingDiplomacyRequests = [];
+  return state;
+}
 
 describe('diplomacy-system', () => {
   const civIds = ['player', 'ai-egypt', 'ai-rome'];
@@ -159,6 +171,17 @@ describe('diplomacy-system', () => {
   });
 
   describe('applyDiplomaticAction', () => {
+    it('request_peace enqueues a proposal instead of clearing war state', () => {
+      const state = makeWarState();
+
+      const result = applyDiplomaticAction(state, 'ai-1', 'player', 'request_peace', new EventBus());
+
+      expect(result.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+      expect(result.pendingDiplomacyRequests).toContainEqual(
+        expect.objectContaining({ fromCivId: 'ai-1', toCivId: 'player', type: 'peace' }),
+      );
+    });
+
     it('applies Narnias treaty relationship bonus symmetrically when a treaty is signed', () => {
       const bus = new EventBus();
       const state = {

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -1,5 +1,13 @@
+// @vitest-environment jsdom
+
 import { describe, it, expect } from 'vitest';
 import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
+import {
+  acceptDiplomaticRequest,
+  enqueuePeaceRequest,
+  rejectDiplomaticRequest,
+} from '@/systems/diplomacy-system';
+import { EventBus } from '@/core/event-bus';
 import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
 import { makeDiplomacyFixture } from './helpers/diplomacy-fixture';
 
@@ -217,5 +225,79 @@ describe('diplomacy-panel breakaway rows', () => {
 
     const rendered = (panel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? panel.textContent ?? '';
     expect(rendered).toContain(presentation.name);
+  });
+
+  it('shows Peace Requested instead of Request Peace for an outbound proposal', () => {
+    const { container, state: baseState } = makeDiplomacyFixture({
+      currentPlayer: 'player',
+      includeThirdCiv: true,
+    });
+    let state = baseState;
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    state = enqueuePeaceRequest(state, 'player', 'outsider');
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Peace Requested');
+    expect(panel.textContent).not.toContain('request peace');
+  });
+
+  it('shows Accept Peace and Reject Peace for an incoming proposal', () => {
+    const { container, state: baseState } = makeDiplomacyFixture({
+      currentPlayer: 'player',
+      includeThirdCiv: true,
+    });
+    let state = baseState;
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    state = enqueuePeaceRequest(state, 'outsider', 'player');
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onAcceptPeaceRequest: () => {},
+      onRejectPeaceRequest: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Accept Peace');
+    expect(panel.textContent).toContain('Reject Peace');
+    expect(panel.textContent).not.toContain('request peace');
+  });
+
+  it('updates the open panel immediately after accepting an incoming proposal', () => {
+    const { container, state } = makeDiplomacyFixture({
+      currentPlayer: 'player',
+      includeThirdCiv: true,
+    });
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    let nextState = enqueuePeaceRequest(state, 'outsider', 'player');
+    const bus = new EventBus();
+
+    const render = () => createDiplomacyPanel(container, nextState, {
+      onAction: () => {},
+      onAcceptPeaceRequest: (requestId) => {
+        nextState = acceptDiplomaticRequest(nextState, 'player', requestId, bus);
+        render();
+      },
+      onRejectPeaceRequest: (requestId) => {
+        nextState = rejectDiplomaticRequest(nextState, 'player', requestId);
+        render();
+      },
+      onClose: () => {},
+    });
+
+    let panel = render();
+    (panel.querySelector('[data-action="accept-peace-request"]') as HTMLButtonElement).click();
+    panel = container.querySelector('#diplomacy-panel') as HTMLElement;
+
+    expect(panel.textContent).not.toContain('Accept Peace');
+    expect(panel.textContent).not.toContain('Reject Peace');
+    expect(panel.textContent).not.toContain('Peace Requested');
+    expect(panel.textContent).toContain('declare war');
   });
 });

--- a/tests/ui/helpers/diplomacy-fixture.ts
+++ b/tests/ui/helpers/diplomacy-fixture.ts
@@ -54,6 +54,15 @@ class MockDocument {
   }
 }
 
+function ensureDocument(): Document {
+  if (typeof document !== 'undefined' && typeof document.createElement === 'function') {
+    return document;
+  }
+  const mockDocument = new MockDocument() as unknown as Document;
+  (globalThis as typeof globalThis & { document?: Document }).document = mockDocument;
+  return mockDocument;
+}
+
 export function makeDiplomacyFixture({
   currentPlayer = 'player',
   includeBreakaway = true,
@@ -67,13 +76,14 @@ export function makeDiplomacyFixture({
   relationship?: number;
   gold?: number;
 } = {}): { container: HTMLElement; state: GameState } {
-  (globalThis as typeof globalThis & { document?: Document }).document = new MockDocument() as unknown as Document;
+  const activeDocument = ensureDocument();
 
   const base = includeBreakaway
     ? makeBreakawayFixture({ turn: 10, breakawayStartedTurn: 10, includeThirdCiv })
     : makeBreakawayFixture();
   const state = base.state;
   state.currentPlayer = currentPlayer;
+  state.pendingDiplomacyRequests = [];
 
   if (currentPlayer === 'player-2') {
     state.civilizations['player-2'] = {
@@ -99,7 +109,7 @@ export function makeDiplomacyFixture({
   }
 
   return {
-    container: new MockElement() as unknown as HTMLElement,
+    container: activeDocument.createElement('div'),
     state,
   };
 }


### PR DESCRIPTION
## Summary
- add persisted pending peace-request state to game creation and save/load normalization
- change request_peace to enqueue a proposal instead of immediately forcing both sides to peace
- route AI peace decisions through the shared enqueue path and lock in the backend behavior with diplomacy, AI, game-state, and persistence regressions

## Testing
- ./scripts/run-with-mise.sh yarn test --run tests/systems/diplomacy-system.test.ts tests/ai/basic-ai.test.ts tests/core/game-state.test.ts tests/storage/save-persistence.test.ts
- scripts/check-src-rule-violations.sh src/core/types.ts src/core/game-state.ts src/storage/save-manager.ts src/systems/diplomacy-system.ts src/ai/basic-ai.ts
- ./scripts/run-with-mise.sh yarn build

Part of #118