### PR TITLE
refactor(ui): route peace request notifications

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -90,6 +90,7 @@ import {
   routeCombatResolved,
   routeLegendaryWonder,
   routePeaceMade,
+  routePeaceRequested,
   routeWarDeclared,
   type NotificationSink,
 } from '@/ui/notification-routing';
@@ -1615,11 +1616,9 @@ bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
 });
 
 bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {
-  const fromName = gameState.civilizations[fromCivId]?.name ?? 'Unknown';
-  const toName = gameState.civilizations[toCivId]?.name ?? 'Unknown';
-  appendToCivLog(toCivId, `${fromName} requests peace.`, 'info');
-  appendToCivLog(fromCivId, `Peace requested from ${toName}.`, 'info');
+  routePeaceRequested(gameState, fromCivId, toCivId, appendToCivLog);
   if (toCivId === gameState.currentPlayer) {
+    const fromName = gameState.civilizations[fromCivId]?.name ?? 'Unknown';
     showNotification(`${fromName} requests peace.`, 'info');
   }
 });

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -36,6 +36,18 @@ export function routePeaceMade(
   sink(civB, `Peace with ${a}!`, 'success');
 }
 
+// Writes only to the recipient civ's log because the requester already
+// gets direct action feedback from the initiating UI/AI path.
+export function routePeaceRequested(
+  state: GameState,
+  fromCivId: string,
+  toCivId: string,
+  sink: NotificationSink,
+): void {
+  const fromName = state.civilizations[fromCivId]?.name ?? 'Unknown';
+  sink(toCivId, `${fromName} requests peace.`, 'info');
+}
+
 // Routes to the defender's owner regardless of who is currently acting.
 export function routeCombatResolved(
   state: GameState,

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -5,6 +5,7 @@ import {
   routeCombatResolved,
   routeLegendaryWonder,
   routePeaceMade,
+  routePeaceRequested,
   routeWarDeclared,
   type NotificationSink,
 } from '@/ui/notification-routing';
@@ -57,6 +58,21 @@ describe('notification routing', () => {
     expect(calls.map(c => c.civId).sort()).toEqual(['p1', 'p2']);
     expect(calls.every(c => c.type === 'success')).toBe(true);
     expect(calls.find(c => c.civId === 'p3')).toBeUndefined();
+  });
+
+  it('peace-requested writes only to the recipient civ', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+
+    routePeaceRequested(state, 'p1', 'p2', sink);
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        civId: 'p2',
+        message: expect.stringMatching(/Alice requests peace/i),
+        type: 'info',
+      }),
+    ]);
   });
 
   it('combat-resolved writes to the defender owner log even when current player is a third civ', () => {


### PR DESCRIPTION
## Summary
- route peace-request notifications through shared notification-routing helper
- notify only the addressed civilization in the civ log, keeping requester feedback in the initiating flow
- add regression coverage for recipient-only peace-request routing

## Testing
- ./scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts tests/ui/diplomacy-panel.test.ts
- scripts/check-src-rule-violations.sh src/ui/notification-routing.ts src/main.ts
- ./scripts/run-with-mise.sh yarn build