### PR TITLE
feat(city): auto-place completed buildings

### DIFF
--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -2,6 +2,7 @@ import type { City, Building, HexCoord, GameMap, UnitType, CivBonusEffect, Train
 import { hexKey, hexesInRange, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
+import { findOptimalSlot } from './adjacency-system';
 
 let nextCityId = 1;
 export const CITY_NAMES = DEFAULT_CITY_NAMES;
@@ -146,6 +147,27 @@ export function purchaseGridExpansion(_city: City, _currentGold: number): number
   return 0;
 }
 
+export function placeBuildingInGrid(city: City, buildingId: string): City {
+  if (city.grid.flat().includes(buildingId)) return city;
+  const slot = findOptimalSlot(city.grid, city.gridSize, buildingId);
+  if (!slot) return city;
+
+  const grid = city.grid.map(row => row.slice());
+  if (grid[slot.row]?.[slot.col]) return city;
+  grid[slot.row][slot.col] = buildingId;
+  return { ...city, grid };
+}
+
+export function getUnplacedBuildings(city: City): string[] {
+  const placed = new Set(city.grid.flat().filter((entry): entry is string => Boolean(entry)));
+  const seen = new Set<string>();
+  return city.buildings.filter(buildingId => {
+    if (seen.has(buildingId)) return false;
+    seen.add(buildingId);
+    return !placed.has(buildingId);
+  });
+}
+
 export interface CityProcessResult {
   city: City;
   grew: boolean;
@@ -208,10 +230,12 @@ export function processCity(
     const building = BUILDINGS[currentItem];
     const buildingCostMult = building ? applyProductionBonus(currentItem, bonusEffect) : 1;
     if (building && newProgress >= Math.round(building.productionCost * buildingCostMult)) {
-      newBuildings.push(building.id);
+      if (!newBuildings.includes(building.id)) {
+        newBuildings.push(building.id);
+        completedBuilding = building.id;
+      }
       newQueue.shift();
       newProgress = 0;
-      completedBuilding = building.id;
     }
 
     // Check if it's a unit
@@ -224,16 +248,22 @@ export function processCity(
     }
   }
 
+  let nextCity: City = {
+    ...city,
+    food: newFood,
+    foodNeeded: newFoodNeeded,
+    population: newPop,
+    productionProgress: newProgress,
+    productionQueue: newQueue,
+    buildings: newBuildings,
+  };
+
+  if (completedBuilding) {
+    nextCity = placeBuildingInGrid(nextCity, completedBuilding);
+  }
+
   return {
-    city: {
-      ...city,
-      food: newFood,
-      foodNeeded: newFoodNeeded,
-      population: newPop,
-      productionProgress: newProgress,
-      productionQueue: newQueue,
-      buildings: newBuildings,
-    },
+    city: nextCity,
     grew,
     completedBuilding,
     completedUnit,

--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -1,6 +1,6 @@
 import type { City, CityFocus, GameMap, GameState, HexCoord, HexTile, ResourceYield } from '@/core/types';
 import { hexKey, hexesInRange } from '@/systems/hex-utils';
-import { BUILDINGS } from '@/systems/city-system';
+import { BUILDINGS, getUnplacedBuildings } from '@/systems/city-system';
 import { calculateAdjacencyBonuses, findOptimalSlot } from '@/systems/adjacency-system';
 import { TERRAIN_YIELDS } from '@/systems/resource-system';
 import {
@@ -125,19 +125,201 @@ function renderOverviewSection(root: HTMLElement, city: City, options: CityManag
   root.appendChild(section);
 }
 
-function renderBuildingsCoreSection(root: HTMLElement, city: City): void {
+const EDGE_SLOTS: Record<string, number> = {
+  '0,1': 0,
+  '0,2': 1,
+  '0,3': 2,
+  '1,0': 3,
+  '1,4': 4,
+  '2,0': 5,
+  '2,4': 6,
+  '3,0': 7,
+  '3,4': 8,
+  '4,1': 9,
+  '4,2': 10,
+  '4,3': 11,
+  '0,0': 12,
+  '0,4': 13,
+  '4,0': 14,
+  '4,4': 15,
+};
+
+function getOwnedTileMap(city: City, map: GameMap): Record<string, HexTile> {
+  const ownedTileMap: Record<string, HexTile> = {};
+  const surroundingHexes = hexesInRange(city.position, 1);
+  for (let index = 0; index < surroundingHexes.length && index < 8; index++) {
+    const key = hexKey(surroundingHexes[index]);
+    if (map.tiles[key]) ownedTileMap[`edge-${index}`] = map.tiles[key];
+  }
+  return ownedTileMap;
+}
+
+function appendTextSpan(parent: HTMLElement, text: string, style?: string): void {
+  const span = document.createElement('span');
+  if (style) span.style.cssText = style;
+  span.textContent = text;
+  parent.appendChild(span);
+}
+
+function appendBuildingDetail(detail: HTMLElement, buildingId: string): void {
+  const building = BUILDINGS[buildingId];
+  if (!building) return;
+
+  const yields: string[] = [];
+  if (building.yields.food > 0) yields.push(`+${building.yields.food} food`);
+  if (building.yields.production > 0) yields.push(`+${building.yields.production} production`);
+  if (building.yields.gold > 0) yields.push(`+${building.yields.gold} gold`);
+  if (building.yields.science > 0) yields.push(`+${building.yields.science} science`);
+  const yieldText = yields.length > 0 ? yields.join(', ') : 'no direct yields';
+
+  detail.textContent = '';
+  const strong = document.createElement('strong');
+  strong.style.color = '#e8c170';
+  strong.textContent = building.name;
+  detail.appendChild(strong);
+  detail.appendChild(document.createTextNode(`: ${building.description} - ${yieldText}`));
+}
+
+function renderBuildingBoard(
+  root: HTMLElement,
+  city: City,
+  map: GameMap,
+  callbacks: CityGridCallbacks,
+  suggestedBuilding?: string,
+): void {
+  const adjBonuses = calculateAdjacencyBonuses(city.grid, city.gridSize);
+  const suggestedSlot = suggestedBuilding
+    ? findOptimalSlot(city.grid, city.gridSize, suggestedBuilding)
+    : null;
+  const renderGridSize = city.grid.length || 7;
+  const gridCenter = Math.floor(renderGridSize / 2);
+  const gridMaxWidth = Math.min(420, renderGridSize * 56);
+  const ownedTileMap = getOwnedTileMap(city, map);
+
+  const grid = document.createElement('div');
+  grid.dataset.buildingGrid = 'core';
+  grid.style.cssText = `display:grid;grid-template-columns:repeat(${renderGridSize},minmax(0,1fr));gap:3px;max-width:${gridMaxWidth}px;margin:0 auto;`;
+
+  const detail = document.createElement('div');
+  detail.id = 'grid-detail';
+  detail.style.cssText = 'margin-top:8px;font-size:11px;color:rgba(255,255,255,0.6);min-height:24px;padding:0 4px;';
+
+  for (let row = 0; row < renderGridSize; row++) {
+    for (let col = 0; col < renderGridSize; col++) {
+      const buildingId = city.grid[row]?.[col];
+      const isUnlocked = isSlotUnlocked(row, col, city.gridSize, renderGridSize);
+      const isSuggested = suggestedSlot && suggestedSlot.row === row && suggestedSlot.col === col;
+      const cell = document.createElement('button');
+      cell.type = 'button';
+      cell.style.cssText = [
+        'aspect-ratio:1',
+        'border-radius:6px',
+        'display:flex',
+        'align-items:center',
+        'justify-content:center',
+        'flex-direction:column',
+        'font-size:10px',
+        'cursor:pointer',
+      ].join(';');
+
+      if (!isUnlocked) {
+        const distanceFromCenter = Math.max(Math.abs(row - gridCenter), Math.abs(col - gridCenter));
+        const popNeeded = distanceFromCenter > 2 ? 6 : 3;
+        const buyCost = popNeeded === 3 ? 50 : 150;
+        cell.className = 'grid-locked';
+        cell.style.cssText += ';background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.05);color:rgba(255,255,255,0.35);';
+        appendTextSpan(cell, 'Locked');
+        appendTextSpan(cell, `Pop ${popNeeded}`, 'margin-top:2px;');
+        appendTextSpan(cell, `Gold ${buyCost}`, 'font-size:8px;');
+        cell.addEventListener('click', () => callbacks.onBuyExpansion());
+      } else if (buildingId) {
+        const building = BUILDINGS[buildingId];
+        const bonus = adjBonuses[`${row},${col}`];
+        const bgColor = buildingId === 'city-center' ? 'rgba(232,193,112,0.3)' : 'rgba(107,155,75,0.2)';
+        const borderColor = buildingId === 'city-center' ? '#e8c170' : 'rgba(107,155,75,0.5)';
+        cell.className = 'grid-building';
+        cell.dataset.building = buildingId;
+        cell.dataset.buildingCell = buildingId;
+        cell.style.cssText += `;background:${bgColor};border:2px solid ${borderColor};`;
+        appendTextSpan(cell, BUILDING_ICONS[buildingId] ?? 'Build', 'font-size:18px;');
+        appendTextSpan(cell, building?.name ?? titleCase(buildingId), 'font-size:7px;margin-top:1px;');
+        if (bonus && bonus.food + bonus.production + bonus.gold + bonus.science > 0) {
+          const parts: string[] = [];
+          if (bonus.food > 0) parts.push(`+${bonus.food} food`);
+          if (bonus.production > 0) parts.push(`+${bonus.production} production`);
+          if (bonus.gold > 0) parts.push(`+${bonus.gold} gold`);
+          if (bonus.science > 0) parts.push(`+${bonus.science} science`);
+          appendTextSpan(cell, parts.join(' '), 'font-size:7px;color:#e8c170;');
+        }
+        cell.addEventListener('click', () => appendBuildingDetail(detail, buildingId));
+      } else {
+        const edgeIdx = EDGE_SLOTS[`${row},${col}`];
+        const edgeTile = edgeIdx !== undefined ? ownedTileMap[`edge-${edgeIdx}`] : null;
+        const border = isSuggested
+          ? 'border:2px dashed #e8c170;'
+          : 'border:2px dashed rgba(255,255,255,0.15);';
+        const bg = edgeTile
+          ? 'background:rgba(255,255,255,0.04);'
+          : 'background:rgba(255,255,255,0.06);';
+        cell.className = 'grid-slot';
+        cell.dataset.row = String(row);
+        cell.dataset.col = String(col);
+        cell.style.cssText += `;${bg}${border}`;
+        if (edgeTile && (row !== gridCenter || col !== gridCenter)) {
+          const terrainYield = TERRAIN_YIELDS[edgeTile.terrain];
+          const yieldParts: string[] = [];
+          if (terrainYield?.food) yieldParts.push(`${terrainYield.food} food`);
+          if (terrainYield?.production) yieldParts.push(`${terrainYield.production} production`);
+          if (edgeTile.hasRiver) yieldParts.push('+1 gold');
+          appendTextSpan(cell, TERRAIN_ICONS[edgeTile.terrain] ?? '?', 'font-size:14px;');
+          appendTextSpan(cell, titleCase(edgeTile.terrain), 'font-size:7px;color:rgba(255,255,255,0.5);');
+          if (yieldParts.length > 0) appendTextSpan(cell, yieldParts.join(' '), 'font-size:7px;color:rgba(255,255,255,0.4);');
+        } else {
+          appendTextSpan(cell, '+', 'font-size:14px;color:rgba(255,255,255,0.25);');
+        }
+        if (isSuggested) appendTextSpan(cell, 'suggested', 'font-size:7px;color:#e8c170;');
+        cell.addEventListener('click', () => callbacks.onSlotTap(row, col));
+      }
+
+      grid.appendChild(cell);
+    }
+  }
+
+  root.appendChild(grid);
+  root.appendChild(detail);
+}
+
+function renderBuildingsCoreSection(
+  root: HTMLElement,
+  city: City,
+  map: GameMap,
+  callbacks: CityGridCallbacks,
+  suggestedBuilding?: string,
+): void {
   const section = document.createElement('section');
-  section.style.cssText = 'display:flex;flex-direction:column;gap:6px;';
+  section.style.cssText = 'display:flex;flex-direction:column;gap:8px;';
   const heading = document.createElement('h3');
   heading.textContent = 'Buildings/Core';
   section.appendChild(heading);
 
-  const placedBuildingIds = city.grid.flat().filter((buildingId): buildingId is string => Boolean(buildingId));
-  const summary = document.createElement('div');
-  summary.textContent = placedBuildingIds.length > 0
-    ? placedBuildingIds.map(buildingId => BUILDINGS[buildingId]?.name ?? titleCase(buildingId)).join(', ')
-    : 'City Center';
-  section.appendChild(summary);
+  renderBuildingBoard(section, city, map, callbacks, suggestedBuilding);
+
+  const unplaced = getUnplacedBuildings(city);
+  if (unplaced.length > 0) {
+    const unplacedSection = document.createElement('section');
+    unplacedSection.dataset.unplacedBuildings = 'true';
+    unplacedSection.style.cssText = 'display:flex;flex-direction:column;gap:4px;font-size:12px;';
+    const unplacedHeading = document.createElement('h4');
+    unplacedHeading.textContent = 'Unplaced buildings';
+    unplacedSection.appendChild(unplacedHeading);
+    for (const buildingId of unplaced) {
+      const row = document.createElement('div');
+      row.textContent = BUILDINGS[buildingId]?.name ?? titleCase(buildingId);
+      unplacedSection.appendChild(row);
+    }
+    section.appendChild(unplacedSection);
+  }
+
   root.appendChild(section);
 }
 
@@ -238,116 +420,6 @@ export function createCityGrid(
   panel.id = 'city-grid';
   panel.style.cssText = 'padding:16px;';
 
-  const adjBonuses = calculateAdjacencyBonuses(city.grid, city.gridSize);
-  const suggestedSlot = suggestedBuilding
-    ? findOptimalSlot(city.grid, city.gridSize, suggestedBuilding)
-    : null;
-  const renderGridSize = city.grid.length || 7;
-  const gridCenter = Math.floor(renderGridSize / 2);
-  const gridMaxWidth = Math.min(420, renderGridSize * 56);
-
-  // Get terrain for edge slots from owned tiles
-  const ownedTileMap: Record<string, HexTile> = {};
-  const surroundingHexes = hexesInRange(city.position, 1);
-  for (let i = 0; i < surroundingHexes.length && i < 8; i++) {
-    const key = hexKey(surroundingHexes[i]);
-    if (map.tiles[key]) {
-      ownedTileMap[`edge-${i}`] = map.tiles[key];
-    }
-  }
-
-  let html = `
-  <div style="font-size:12px;color:rgba(255,255,255,0.7);margin-bottom:10px;padding:0 4px;line-height:1.4;">
-    <strong style="color:#e8c170;">Grid View</strong> — Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos. Edge slots show the terrain they sit on so the board explains itself.
-    ${suggestedBuilding ? `<div style="color:#e8c170;margin-top:4px;">Suggested: <strong>${suggestedBuilding}</strong></div>` : ''}
-  </div>
-  <div style="display:grid;grid-template-columns:repeat(${renderGridSize},minmax(0,1fr));gap:3px;max-width:${gridMaxWidth}px;margin:0 auto;">`;
-
-  const edgeSlots: Record<string, number> = {
-    '0,1': 0, '0,2': 1, '0,3': 2,
-    '1,0': 3, '1,4': 4,
-    '2,0': 5, '2,4': 6,
-    '3,0': 7, '3,4': 8,
-    '4,1': 9, '4,2': 10, '4,3': 11,
-    '0,0': 12, '0,4': 13, '4,0': 14, '4,4': 15,
-  };
-
-  for (let r = 0; r < renderGridSize; r++) {
-    for (let c = 0; c < renderGridSize; c++) {
-      const building = city.grid[r]?.[c];
-      const isUnlocked = isSlotUnlocked(r, c, city.gridSize, renderGridSize);
-      const isSuggested = suggestedSlot && suggestedSlot.row === r && suggestedSlot.col === c;
-      const adjKey = `${r},${c}`;
-      const bonus = adjBonuses[adjKey];
-
-      if (!isUnlocked) {
-        const distanceFromCenter = Math.max(Math.abs(r - gridCenter), Math.abs(c - gridCenter));
-        const popNeeded = distanceFromCenter > 2 ? 6 : 3;
-        const buyCost = popNeeded === 3 ? 50 : 150;
-        html += `<div class="grid-locked" style="aspect-ratio:1;background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.05);border-radius:6px;display:flex;align-items:center;justify-content:center;flex-direction:column;font-size:10px;color:rgba(255,255,255,0.15);cursor:pointer;">
-          <span>🔒</span>
-          <span style="margin-top:2px;">Pop ${popNeeded}</span>
-          <span style="font-size:8px;">💰${buyCost}</span>
-        </div>`;
-      } else if (building) {
-        const icon = BUILDING_ICONS[building] ?? '🏗️';
-        const bDef = BUILDINGS[building];
-        const name = bDef?.name ?? building;
-        let bonusText = '';
-        if (bonus && (bonus.food + bonus.production + bonus.gold + bonus.science > 0)) {
-          const parts: string[] = [];
-          if (bonus.food > 0) parts.push(`+${bonus.food}🍞`);
-          if (bonus.production > 0) parts.push(`+${bonus.production}⚒️`);
-          if (bonus.gold > 0) parts.push(`+${bonus.gold}💰`);
-          if (bonus.science > 0) parts.push(`+${bonus.science}🔬`);
-          bonusText = `<span style="font-size:7px;color:#e8c170;">${parts.join(' ')}</span>`;
-        }
-        const bgColor = building === 'city-center' ? 'rgba(232,193,112,0.3)' : 'rgba(107,155,75,0.2)';
-        const borderColor = building === 'city-center' ? '#e8c170' : 'rgba(107,155,75,0.5)';
-        html += `<div class="grid-building" data-building="${building}" style="aspect-ratio:1;background:${bgColor};border:2px solid ${borderColor};border-radius:6px;display:flex;align-items:center;justify-content:center;flex-direction:column;font-size:10px;cursor:pointer;">
-          <span style="font-size:18px;">${icon}</span>
-          <span style="font-size:7px;margin-top:1px;">${name}</span>
-          ${bonusText}
-        </div>`;
-      } else {
-        const edgeKey = `${r},${c}`;
-        const edgeIdx = edgeSlots[edgeKey];
-        const edgeTile = edgeIdx !== undefined ? ownedTileMap[`edge-${edgeIdx}`] : null;
-
-        let terrainInfo = '';
-        if (edgeTile && (r !== gridCenter || c !== gridCenter)) {
-          const tIcon = TERRAIN_ICONS[edgeTile.terrain] ?? '?';
-          const tYield = TERRAIN_YIELDS[edgeTile.terrain];
-          const yieldParts: string[] = [];
-          if (tYield?.food) yieldParts.push(`${tYield.food}🍞`);
-          if (tYield?.production) yieldParts.push(`${tYield.production}⚒️`);
-          if (edgeTile.hasRiver) yieldParts.push('+1💰');
-          terrainInfo = `<span style="font-size:14px;">${tIcon}</span>
-            <span style="font-size:7px;color:rgba(255,255,255,0.5);">${edgeTile.terrain}</span>
-            <span style="font-size:7px;color:rgba(255,255,255,0.4);">${yieldParts.join(' ')}</span>`;
-        } else {
-          terrainInfo = '<span style="font-size:14px;color:rgba(255,255,255,0.25);">+</span>';
-        }
-
-        const border = isSuggested
-          ? 'border:2px dashed #e8c170;animation:pulse 1.5s infinite;'
-          : 'border:2px dashed rgba(255,255,255,0.15);';
-        const bg = edgeTile
-          ? 'background:rgba(255,255,255,0.04);'
-          : 'background:rgba(255,255,255,0.06);';
-
-        html += `<div class="grid-slot" data-row="${r}" data-col="${c}" style="aspect-ratio:1;${bg}${border}border-radius:6px;display:flex;align-items:center;justify-content:center;flex-direction:column;cursor:pointer;font-size:10px;">
-          ${terrainInfo}
-          ${isSuggested ? '<span style="font-size:7px;color:#e8c170;">✨ suggested</span>' : ''}
-        </div>`;
-      }
-    }
-  }
-
-  html += '</div>';
-  html += '<div id="grid-detail" style="margin-top:8px;font-size:11px;color:rgba(255,255,255,0.6);min-height:24px;padding:0 4px;"></div>';
-  html += '<style>@keyframes pulse { 0%,100% { opacity:1; } 50% { opacity:0.6; } }</style>';
-
   if (managementOptions) {
     const managementRoot = document.createElement('div');
     managementRoot.style.cssText = [
@@ -360,57 +432,27 @@ export function createCityGrid(
     const displayedWorkView = getDisplayedCityWorkView(managementOptions.state, city);
     const displayedOptions = { ...managementOptions, state: displayedWorkView.state };
     renderOverviewSection(managementRoot, displayedWorkView.city, displayedOptions);
-    renderBuildingsCoreSection(managementRoot, displayedWorkView.city);
+    renderBuildingsCoreSection(managementRoot, displayedWorkView.city, map, callbacks, suggestedBuilding);
     renderWorkedLandSection(managementRoot, displayedWorkView.city, displayedOptions);
-
-    const boardRoot = document.createElement('div');
-    boardRoot.innerHTML = html;
     panel.appendChild(managementRoot);
-    panel.appendChild(boardRoot);
   } else {
-    panel.innerHTML = html;
+    const intro = document.createElement('div');
+    intro.style.cssText = 'font-size:12px;color:rgba(255,255,255,0.7);margin-bottom:10px;padding:0 4px;line-height:1.4;';
+    const introTitle = document.createElement('strong');
+    introTitle.style.color = '#e8c170';
+    introTitle.textContent = 'Grid View';
+    intro.appendChild(introTitle);
+    intro.appendChild(document.createTextNode(' - Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos.'));
+    if (suggestedBuilding) {
+      const suggested = document.createElement('div');
+      suggested.style.cssText = 'color:#e8c170;margin-top:4px;';
+      suggested.textContent = `Suggested: ${suggestedBuilding}`;
+      intro.appendChild(suggested);
+    }
+    panel.appendChild(intro);
+    renderBuildingBoard(panel, city, map, callbacks, suggestedBuilding);
   }
   container.appendChild(panel);
-
-  // Click handlers for occupied building slots — show info inline
-  panel.querySelectorAll('.grid-building').forEach(el => {
-    el.addEventListener('click', () => {
-      const buildingId = (el as HTMLElement).dataset.building!;
-      const bDef = BUILDINGS[buildingId];
-      if (!bDef) return;
-      const yields: string[] = [];
-      if (bDef.yields.food > 0) yields.push(`+${bDef.yields.food} food`);
-      if (bDef.yields.production > 0) yields.push(`+${bDef.yields.production} production`);
-      if (bDef.yields.gold > 0) yields.push(`+${bDef.yields.gold} gold`);
-      if (bDef.yields.science > 0) yields.push(`+${bDef.yields.science} science`);
-      const yieldText = yields.length > 0 ? yields.join(', ') : 'no direct yields';
-      const detailEl = panel.querySelector('#grid-detail');
-      if (detailEl) {
-        detailEl.textContent = '';
-        const strong = document.createElement('strong');
-        strong.style.color = '#e8c170';
-        strong.textContent = bDef.name;
-        detailEl.appendChild(strong);
-        detailEl.appendChild(document.createTextNode(`: ${bDef.description} — ${yieldText}`));
-      }
-    });
-  });
-
-  // Click handlers for empty slots
-  panel.querySelectorAll('.grid-slot').forEach(el => {
-    el.addEventListener('click', () => {
-      const row = parseInt((el as HTMLElement).dataset.row!);
-      const col = parseInt((el as HTMLElement).dataset.col!);
-      callbacks.onSlotTap(row, col);
-    });
-  });
-
-  // Click handlers for locked slots (gold purchase)
-  panel.querySelectorAll('.grid-locked').forEach(el => {
-    el.addEventListener('click', () => {
-      callbacks.onBuyExpansion();
-    });
-  });
 
   return panel;
 }

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -4,6 +4,7 @@ import {
   processCity,
   checkGridExpansion,
   purchaseGridExpansion,
+  getUnplacedBuildings,
   BUILDINGS,
   CITY_NAMES,
 } from '@/systems/city-system';
@@ -131,6 +132,58 @@ describe('processCity', () => {
     const result = processCity(focused, map, 30, 0);
     expect(result.city.focus).toBe('food');
     expect(result.city.workedTiles).toEqual([]);
+  });
+
+  it('auto-places a newly completed Barracks into an unlocked building grid slot', () => {
+    const map = generateMap(30, 30, 'auto-place-barracks');
+    const city = foundCity('player', { q: 15, r: 15 }, map);
+    const queued = { ...city, productionQueue: ['barracks'], productionProgress: 9 };
+
+    const result = processCity(queued, map, 0, 1);
+
+    expect(result.completedBuilding).toBe('barracks');
+    expect(result.city.buildings).toEqual(['barracks']);
+    expect(result.city.grid.flat()).toContain('barracks');
+    expect(getUnplacedBuildings(result.city)).not.toContain('barracks');
+  });
+
+  it('keeps completed buildings unplaced when every unlocked slot is full', () => {
+    const map = generateMap(30, 30, 'unplaced-barracks');
+    const city = foundCity('player', { q: 15, r: 15 }, map);
+    const fullGrid = city.grid.map(row => row.slice());
+    for (let row = 2; row <= 4; row++) {
+      for (let col = 2; col <= 4; col++) {
+        if (row !== 3 || col !== 3) fullGrid[row][col] = 'shrine';
+      }
+    }
+    const queued = { ...city, grid: fullGrid, productionQueue: ['barracks'], productionProgress: 9 };
+
+    const result = processCity(queued, map, 0, 1);
+
+    expect(result.completedBuilding).toBe('barracks');
+    expect(result.city.buildings).toContain('barracks');
+    expect(result.city.grid.flat()).not.toContain('barracks');
+    expect(getUnplacedBuildings(result.city)).toEqual(['barracks']);
+  });
+
+  it('does not duplicate an already built building from a stale production queue', () => {
+    const map = generateMap(30, 30, 'dedupe-built-barracks');
+    const city = foundCity('player', { q: 15, r: 15 }, map);
+    const grid = city.grid.map(row => row.slice());
+    grid[3][2] = 'barracks';
+    const queued = {
+      ...city,
+      buildings: ['barracks'],
+      grid,
+      productionQueue: ['barracks'],
+      productionProgress: 9,
+    };
+
+    const result = processCity(queued, map, 0, 1);
+
+    expect(result.city.buildings.filter(buildingId => buildingId === 'barracks')).toHaveLength(1);
+    expect(result.city.grid.flat().filter(buildingId => buildingId === 'barracks')).toHaveLength(1);
+    expect(getUnplacedBuildings(result.city)).toEqual([]);
   });
 });
 

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest';
 import { createCityPanel } from '@/ui/city-panel';
+import { createEmptyCityGrid } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { hexKey } from '@/systems/hex-utils';
 import { collectText, makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
@@ -205,6 +206,79 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('Worked Land And Water');
     expect(rendered).toContain('Worked 1/');
     expect(rendered).toContain('Balanced focus');
+  });
+
+  it('shows a placed completed Barracks in exactly one Buildings/Core grid', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['barracks'];
+    city.grid = createEmptyCityGrid();
+    city.grid[3][2] = 'barracks';
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    const gridView = activeCityGrid(container);
+    const boards = gridView.querySelectorAll('[data-building-grid="core"]');
+    expect(boards).toHaveLength(1);
+    const barracksCell = gridView.querySelector<HTMLElement>('[data-building-cell="barracks"]');
+    expect(barracksCell).toBeTruthy();
+    expect(barracksCell!.textContent).toContain('Barracks');
+    expect(gridView.querySelector('[data-unplaced-buildings]')).toBeNull();
+  });
+
+  it('shows unplaced buildings instead of hiding them', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['barracks'];
+    city.grid = createEmptyCityGrid();
+    city.grid = city.grid.map(row => row.map(value => value === 'barracks' ? null : value));
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    const gridView = activeCityGrid(container);
+    expect(gridView.querySelector('[data-building-cell="barracks"]')).toBeNull();
+    const unplaced = gridView.querySelector<HTMLElement>('[data-unplaced-buildings]');
+    expect(unplaced).toBeTruthy();
+    expect(unplaced!.textContent).toContain('Unplaced buildings');
+    expect(unplaced!.textContent).toContain('Barracks');
+  });
+
+  it('keeps building details and the single grid after reopening the Grid tab', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['barracks'];
+    city.grid = createEmptyCityGrid();
+    city.grid[3][2] = 'barracks';
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    clickElement(activeCityGrid(container).querySelector('[data-building-cell="barracks"]'));
+    expect(collectText(activeCityGrid(container))).toContain('A training ground');
+
+    clickElement(panel.querySelector('[id="tab-list"]'));
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+
+    const gridView = activeCityGrid(container);
+    expect(gridView.querySelectorAll('[data-building-grid="core"]')).toHaveLength(1);
+    expect(gridView.querySelector<HTMLElement>('[data-building-cell="barracks"]')?.textContent).toContain('Barracks');
   });
 
   it('shows surplus unassigned citizens when population exceeds available worked tiles', () => {


### PR DESCRIPTION
## Summary
- Auto-place newly completed buildings into the city building grid using existing adjacency slot scoring.
- Surface completed buildings as unplaced when no unlocked grid slot is available.
- Move the managed Grid tab building board into Buildings/Core and cover placed/unplaced Barracks regressions.

## Test Plan
- `scripts/check-src-rule-violations.sh src/systems/city-system.ts src/ui/city-grid.ts`
- `./scripts/run-with-mise.sh yarn test --run tests/systems/city-system.test.ts tests/ui/city-panel.test.ts tests/ui/city-grid.test.ts`
- `./scripts/run-with-mise.sh yarn build`