### PR TITLE
feat(espionage): MR7 — counter-espionage embedding (embedSpy, sweep, 🛡 indicator)

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -25,7 +25,7 @@ import {
 import { resolveMajorCityCapture } from '@/systems/city-capture-system';
 import {
   getAvailableMissions,
-  assignSpyDefensive,
+  embedSpy,
   attemptInfiltration,
   expelSpy,
   executeSpy,
@@ -707,12 +707,18 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     const espState = newState.espionage?.[civId];
     const idleSpy = espState ? Object.values(espState.spies).find(spy => spy.status === 'idle') : undefined;
     if (capital && idleSpy) {
-      newState.espionage![civId] = assignSpyDefensive(
+      newState.espionage![civId] = embedSpy(
         newState.espionage![civId],
         idleSpy.id,
         capital.id,
         capital.position,
       );
+      // Remove unit from map — embedded spy goes off-map
+      delete newState.units[idleSpy.id];
+      newState.civilizations[civId] = {
+        ...newState.civilizations[civId],
+        units: newState.civilizations[civId].units.filter(id => id !== idleSpy.id),
+      };
     }
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -538,6 +538,25 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     newState = { ...newState, espionage, civilizations };
   }
 
+  // Embedded spy per-turn CI contribution
+  {
+    let espionage = newState.espionage ?? {};
+    for (const [civId, civEsp] of Object.entries(espionage)) {
+      let ci = civEsp.counterIntelligence;
+      let changed = false;
+      for (const spy of Object.values(civEsp.spies)) {
+        if (spy.status !== 'embedded' || !spy.targetCityId) continue;
+        const perTurnBonus = 2 + Math.floor(spy.experience * 0.1);
+        ci = { ...ci, [spy.targetCityId]: Math.min(100, (ci[spy.targetCityId] ?? 0) + perTurnBonus) };
+        changed = true;
+      }
+      if (changed) {
+        espionage = { ...espionage, [civId]: { ...civEsp, counterIntelligence: ci } };
+      }
+    }
+    newState = { ...newState, espionage };
+  }
+
   // --- Vassalage protection & independence ---
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
     if (!civ.diplomacy?.vassalage.overlord) continue;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -556,6 +556,7 @@ export interface Spy {
   cityVisionTurnsLeft?: number;        // turns of full city-tile vision remaining
   cooldownMode?: 'stay_low' | 'passive_observe';
   stolenTechFrom?: Record<string, string[]>; // civId -> techIds already stolen
+  lastSweepTurn?: number;              // turn the spy last ran a sweep (prevents double-sweep)
 }
 
 export interface DetectedSpyThreat {

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,9 @@ import {
   startLegendaryWonderBuild,
 } from '@/systems/legendary-wonder-system';
 import {
-  assignSpyDefensive,
+  embedSpy,
+  unembedSpy,
+  attemptSweep,
   attemptInfiltration,
   getAvailableMissions,
   getInfiltrationSuccessChance,
@@ -766,15 +768,21 @@ function togglePanel(panel: string): void {
       onAssignDefensive: (spyId) => {
         const target = chooseFriendlyCityTarget();
         if (!target) return;
-        gameState.espionage![gameState.currentPlayer] = assignSpyDefensive(
+        gameState.espionage![gameState.currentPlayer] = embedSpy(
           gameState.espionage![gameState.currentPlayer],
           spyId,
           target.cityId,
           target.position,
         );
+        const unit = gameState.units[spyId];
+        if (unit) {
+          delete gameState.units[spyId];
+          gameState.civilizations[gameState.currentPlayer].units =
+            gameState.civilizations[gameState.currentPlayer].units.filter(id => id !== spyId);
+        }
         renderLoop.setGameState(gameState);
         togglePanel('espionage');
-        showNotification(`Spy defending ${target.cityId}.`, 'info');
+        showNotification(`Spy embedded in ${target.cityId}. Counter-intelligence boosted.`, 'info');
       },
       onStartMission: (spyId) => {
         const spy = gameState.espionage?.[gameState.currentPlayer]?.spies[spyId];
@@ -881,6 +889,36 @@ function togglePanel(panel: string): void {
         renderLoop.setGameState(gameState);
         document.getElementById('espionage-panel')?.remove();
         togglePanel('espionage');
+      },
+      onUnembed: (spyId) => {
+        const ownerEsp = gameState.espionage?.[gameState.currentPlayer];
+        const spy = ownerEsp?.spies[spyId];
+        if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return;
+        const city = gameState.cities[spy.targetCityId];
+        if (!city) return;
+        const newUnit = createUnit(spy.unitType, gameState.currentPlayer, city.position);
+        gameState.units[newUnit.id] = newUnit;
+        gameState.civilizations[gameState.currentPlayer].units.push(newUnit.id);
+        const unembedded = unembedSpy(ownerEsp!, spyId);
+        const rekeyed = { ...unembedded.spies[spyId], id: newUnit.id };
+        const { [spyId]: _old, ...rest } = unembedded.spies;
+        gameState.espionage![gameState.currentPlayer] = { ...unembedded, spies: { ...rest, [newUnit.id]: rekeyed } };
+        renderLoop.setGameState(gameState);
+        document.getElementById('espionage-panel')?.remove();
+        togglePanel('espionage');
+        showNotification(`Spy recalled from ${city.name}. Available in 5 turns.`, 'info');
+      },
+      onSweep: (spyId) => {
+        const ownerEsp = gameState.espionage?.[gameState.currentPlayer];
+        if (!ownerEsp) return;
+        const seed = `sweep-${spyId}-${gameState.turn}`;
+        const { detectedSpyIds } = attemptSweep(ownerEsp, spyId, seed, gameState);
+        if (detectedSpyIds.length > 0) {
+          showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
+        } else {
+          showNotification('Sweep complete — no enemy spies detected.', 'info');
+        }
+        renderLoop.setGameState(gameState);
       },
     }));
   } else if (panel === 'diplomacy') {
@@ -1053,6 +1091,25 @@ function selectUnit(unitId: string): void {
 
         renderLoop.setGameState(gameState);
         updateHUD();
+      },
+      onEmbed: (uid) => {
+        const unit = gameState.units[uid];
+        if (!unit || unit.owner !== gameState.currentPlayer) return;
+        const civEsp = gameState.espionage?.[gameState.currentPlayer];
+        if (!civEsp) return;
+        const city = Object.values(gameState.cities).find(
+          c => c.owner === gameState.currentPlayer &&
+               c.position.q === unit.position.q && c.position.r === unit.position.r,
+        );
+        if (!city) return;
+        gameState.espionage![gameState.currentPlayer] = embedSpy(civEsp, uid, city.id, city.position);
+        delete gameState.units[uid];
+        gameState.civilizations[gameState.currentPlayer].units =
+          gameState.civilizations[gameState.currentPlayer].units.filter(id => id !== uid);
+        deselectUnit();
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
       },
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -782,7 +782,8 @@ function togglePanel(panel: string): void {
         }
         renderLoop.setGameState(gameState);
         togglePanel('espionage');
-        showNotification(`Spy embedded in ${target.cityId}. Counter-intelligence boosted.`, 'info');
+        const cityName = gameState.cities[target.cityId]?.name ?? target.cityId;
+        showNotification(`Spy embedded in ${cityName}. Counter-intelligence boosted.`, 'info');
       },
       onStartMission: (spyId) => {
         const spy = gameState.espionage?.[gameState.currentPlayer]?.spies[spyId];
@@ -912,13 +913,16 @@ function togglePanel(panel: string): void {
         const ownerEsp = gameState.espionage?.[gameState.currentPlayer];
         if (!ownerEsp) return;
         const seed = `sweep-${spyId}-${gameState.turn}`;
-        const { detectedSpyIds } = attemptSweep(ownerEsp, spyId, seed, gameState);
+        const { detectedSpyIds, state: updatedEsp } = attemptSweep(ownerEsp, spyId, seed, gameState);
+        gameState.espionage![gameState.currentPlayer] = updatedEsp;
         if (detectedSpyIds.length > 0) {
           showNotification(`Sweep detected ${detectedSpyIds.length} enemy spy(ies) in the city!`, 'warning');
         } else {
           showNotification('Sweep complete — no enemy spies detected.', 'info');
         }
         renderLoop.setGameState(gameState);
+        document.getElementById('espionage-panel')?.remove();
+        togglePanel('espionage');
       },
     }));
   } else if (panel === 'diplomacy') {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -138,6 +138,7 @@ export class RenderLoop {
     // Draw cities
     drawCities(this.ctx, this.state, this.camera, viewerId);
     this.drawInfiltratedSpyIndicators();
+    this.drawEmbeddedSpyIndicators();
 
     // Draw units
     if (viewerVisibility) {
@@ -168,6 +169,24 @@ export class RenderLoop {
 
     // Draw animations
     this.animations.update(this.ctx, performance.now());
+  }
+
+  private drawEmbeddedSpyIndicators(): void {
+    if (!this.state) return;
+    const civEsp = this.state.espionage?.[this.state.currentPlayer];
+    if (!civEsp) return;
+    for (const spy of Object.values(civEsp.spies)) {
+      if (spy.status !== 'embedded' || !spy.targetCityId) continue;
+      const city = this.state.cities[spy.targetCityId];
+      if (!city || city.owner !== this.state.currentPlayer) continue;
+      const pixel = hexToPixel(city.position, this.camera.hexSize);
+      const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+      const size = this.camera.hexSize * this.camera.zoom;
+      this.ctx.font = `${size * 0.3}px system-ui`;
+      this.ctx.textAlign = 'center';
+      this.ctx.textBaseline = 'middle';
+      this.ctx.fillText('🛡', screen.x - size * 0.5, screen.y - size * 0.4);
+    }
   }
 
   private drawInfiltratedSpyIndicators(): void {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -175,6 +175,7 @@ export class RenderLoop {
     if (!this.state) return;
     const civEsp = this.state.espionage?.[this.state.currentPlayer];
     if (!civEsp) return;
+    this.ctx.save();
     for (const spy of Object.values(civEsp.spies)) {
       if (spy.status !== 'embedded' || !spy.targetCityId) continue;
       const city = this.state.cities[spy.targetCityId];
@@ -187,12 +188,14 @@ export class RenderLoop {
       this.ctx.textBaseline = 'middle';
       this.ctx.fillText('🛡', screen.x - size * 0.5, screen.y - size * 0.4);
     }
+    this.ctx.restore();
   }
 
   private drawInfiltratedSpyIndicators(): void {
     if (!this.state) return;
     const civEsp = this.state.espionage?.[this.state.currentPlayer];
     if (!civEsp) return;
+    this.ctx.save();
     for (const spy of Object.values(civEsp.spies)) {
       if (spy.status !== 'stationed' && spy.status !== 'on_mission' && spy.status !== 'idle') continue;
       if (!spy.infiltrationCityId) continue;
@@ -206,5 +209,6 @@ export class RenderLoop {
       this.ctx.textBaseline = 'middle';
       this.ctx.fillText('👁', screen.x + size * 0.5, screen.y - size * 0.4);
     }
+    this.ctx.restore();
   }
 }

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -178,37 +178,61 @@ export function cleanupDeadSpyUnit(
   };
 }
 
-export function assignSpyDefensive(
+export function embedSpy(
   state: EspionageCivState,
   spyId: string,
-  ownCityId: string,
+  cityId: string,
   cityPosition: HexCoord,
 ): EspionageCivState {
   const spy = state.spies[spyId];
-  if (!spy) throw new Error(`Spy ${spyId} not found`);
-  if (spy.status !== 'idle') throw new Error('Spy is not available');
+  if (!spy || spy.status !== 'idle') throw new Error('Spy must be idle to embed');
+  const baseCi = 15;
+  const expBonus = Math.floor(spy.experience * 0.3);
+  const newCi = (state.counterIntelligence[cityId] ?? 0) + baseCi + expBonus;
+  const withCi = setCounterIntelligence(state, cityId, newCi);
+  return {
+    ...withCi,
+    spies: {
+      ...withCi.spies,
+      [spyId]: { ...spy, status: 'embedded', targetCityId: cityId, position: { ...cityPosition } },
+    },
+  };
+}
 
-  const baseCi = 20;
-  const expBonus = Math.floor(spy.experience * 0.4); // up to +40 from experience
-  const ciScore = Math.min(100, (state.counterIntelligence[ownCityId] ?? 0) + baseCi + expBonus);
-
+export function unembedSpy(
+  state: EspionageCivState,
+  spyId: string,
+): EspionageCivState {
+  const spy = state.spies[spyId];
+  if (!spy || spy.status !== 'embedded') return state;
   return {
     ...state,
     spies: {
       ...state.spies,
-      [spyId]: {
-        ...spy,
-        status: 'stationed',
-        targetCivId: null,         // null = defensive assignment
-        targetCityId: ownCityId,
-        position: { ...cityPosition },
-      },
-    },
-    counterIntelligence: {
-      ...state.counterIntelligence,
-      [ownCityId]: ciScore,
+      [spyId]: { ...spy, status: 'cooldown', cooldownTurns: 5, targetCityId: null },
     },
   };
+}
+
+export function attemptSweep(
+  state: EspionageCivState,
+  spyId: string,
+  seed: string,
+  gameState: GameState,
+): { state: EspionageCivState; detectedSpyIds: string[] } {
+  const spy = state.spies[spyId];
+  if (!spy || spy.status !== 'embedded' || !spy.targetCityId) return { state, detectedSpyIds: [] };
+  const rng = createRng(seed);
+  const detected: string[] = [];
+  const baseSweepChance = 0.40 + spy.experience * 0.003;
+  for (const [otherId, otherEsp] of Object.entries(gameState.espionage ?? {})) {
+    if (otherId === spy.owner) continue;
+    for (const enemySpy of Object.values(otherEsp.spies)) {
+      if (enemySpy.infiltrationCityId !== spy.targetCityId) continue;
+      if (rng() < baseSweepChance) detected.push(enemySpy.id);
+    }
+  }
+  return { state, detectedSpyIds: detected };
 }
 
 export function recallSpy(

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -232,7 +232,11 @@ export function attemptSweep(
       if (rng() < baseSweepChance) detected.push(enemySpy.id);
     }
   }
-  return { state, detectedSpyIds: detected };
+  const updatedState = {
+    ...state,
+    spies: { ...state.spies, [spyId]: { ...spy, lastSweepTurn: gameState.turn } },
+  };
+  return { state: updatedState, detectedSpyIds: detected };
 }
 
 export function recallSpy(
@@ -241,6 +245,7 @@ export function recallSpy(
 ): EspionageCivState {
   const spy = state.spies[spyId];
   if (!spy) throw new Error(`Spy ${spyId} not found`);
+  if (spy.status === 'embedded') return state; // embedded spies must use unembedSpy
 
   return {
     ...state,
@@ -1346,6 +1351,22 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
             targetCityId: null,
             position: null,
             currentMission: null,
+          };
+          bus.emit('espionage:spy-recalled', {
+            civId, spyId: spy.id, reason: 'city_destroyed',
+          });
+        }
+      }
+      // Clean up embedded spies when their own city is destroyed or captured
+      if (spy.status === 'embedded' && spy.targetCityId) {
+        const targetCity = state.cities[spy.targetCityId];
+        if (!targetCity || targetCity.owner !== civId) {
+          state.espionage![civId].spies[spy.id] = {
+            ...spy,
+            status: 'cooldown',
+            cooldownTurns: 5,
+            targetCityId: null,
+            position: null,
           };
           bus.emit('espionage:spy-recalled', {
             civId, spyId: spy.id, reason: 'city_destroyed',

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -21,6 +21,7 @@ export interface SpySummary {
   promotionReady: boolean;
   currentMission: SpyMissionType | null;
   cooldownMode?: 'stay_low' | 'passive_observe';
+  lastSweepTurn?: number;
 }
 
 export interface EspionagePanelData {
@@ -35,6 +36,7 @@ export interface EspionagePanelData {
   threatBoard: Array<{ cityId: string; foreignCivId: string; confidence: 'detected' }>;
   recentDetections: Array<{ position: { q: number; r: number }; turn: number; wasDisguised: boolean }>;
   missionSuccessChances?: Partial<Record<SpyMissionType, number>>;
+  currentTurn: number;
 }
 
 export interface MissionStageGroup {
@@ -293,7 +295,12 @@ function appendSpyCard(
         appendActionButton(actionRow, 'Unembed (5 turn cooldown)', 'unembed', () => callbacks.onUnembed!(spy.id));
       }
       if (callbacks.onSweep) {
-        appendActionButton(actionRow, 'Run Sweep', 'sweep', () => callbacks.onSweep!(spy.id));
+        const alreadySwept = spy.lastSweepTurn === state.turn;
+        if (!alreadySwept) {
+          appendActionButton(actionRow, 'Run Sweep', 'sweep', () => callbacks.onSweep!(spy.id));
+        } else {
+          appendChip(actionRow, 'Sweep done this turn');
+        }
       }
     }
     if (spy.status === 'cooldown' && spy.infiltrationCityId && callbacks.onToggleCooldownMode) {
@@ -533,6 +540,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
       disabledAdvisors: [],
       threatBoard: [],
       recentDetections: [],
+      currentTurn: state.turn,
     };
   }
 
@@ -546,7 +554,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
     .filter(([, disabledUntil]) => disabledUntil !== undefined && disabledUntil >= state.turn)
     .map(([advisor]) => advisor as AdvisorType);
   const defendingCityIds = spies
-    .filter(s => s.status === 'stationed' && s.targetCivId === null && s.targetCityId !== null)
+    .filter(s => (s.status === 'stationed' || s.status === 'embedded') && s.targetCivId === null && s.targetCityId !== null)
     .map(s => s.targetCityId!)
     .sort();
   const playerTechs = state.civilizations[state.currentPlayer]?.techState.completed ?? [];
@@ -572,6 +580,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
     promotionReady: spy.promotionAvailable || (spy.experience >= 60 && spy.promotion === undefined),
     currentMission: spy.currentMission?.type ?? null,
     cooldownMode: spy.cooldownMode,
+    lastSweepTurn: spy.lastSweepTurn,
   }));
 
   const stationedSpy = spies.find(
@@ -599,6 +608,7 @@ export function getEspionagePanelData(state: GameState): EspionagePanelData {
     disabledAdvisors,
     threatBoard,
     recentDetections: civEsp.recentDetections ?? [],
+    currentTurn: state.turn,
     ...(missionSuccessChances !== undefined ? { missionSuccessChances } : {}),
   };
 }

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -58,6 +58,8 @@ export interface EspionagePanelCallbacks {
   onVerifyAgent?: (spyId: string) => void;
   onExfiltrate?: (spyId: string) => void;
   onToggleCooldownMode?: (spyId: string) => void;
+  onUnembed?: (spyId: string) => void;
+  onSweep?: (spyId: string) => void;
 }
 
 const MISSION_LABELS: Record<SpyMissionType, string> = {
@@ -285,6 +287,14 @@ function appendSpyCard(
     }
     if (spy.status === 'stationed' && spy.infiltrationCityId && callbacks.onExfiltrate) {
       appendActionButton(actionRow, 'exfiltrate (8 turn cooldown)', 'exfiltrate', () => callbacks.onExfiltrate?.(spy.id));
+    }
+    if (spy.status === 'embedded' && spy.targetCityId) {
+      if (callbacks.onUnembed) {
+        appendActionButton(actionRow, 'Unembed (5 turn cooldown)', 'unembed', () => callbacks.onUnembed!(spy.id));
+      }
+      if (callbacks.onSweep) {
+        appendActionButton(actionRow, 'Run Sweep', 'sweep', () => callbacks.onSweep!(spy.id));
+      }
     }
     if (spy.status === 'cooldown' && spy.infiltrationCityId && callbacks.onToggleCooldownMode) {
       const current = spy.cooldownMode ?? 'stay_low';
@@ -618,6 +628,9 @@ export function getSpyActions(state: GameState, spyId: string): SpyAction[] {
         actions.push('start_mission');
       }
       actions.push('recall');
+      break;
+    case 'embedded':
+      // Unembed and Sweep are rendered directly in renderSpyCard, not via getSpyActions
       break;
     case 'captured':
     case 'cooldown':

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -13,6 +13,7 @@ export interface SelectedUnitInfoCallbacks {
   onCancelAutoExplore?: () => void;
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
   onInfiltrate?: (unitId: string) => void;
+  onEmbed?: (unitId: string) => void;
 }
 
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
@@ -158,6 +159,16 @@ export function renderSelectedUnitInfo(
         btn.style.cursor = 'not-allowed';
         actionsDiv.appendChild(btn);
       }
+    }
+  }
+
+  if (isSpyUnitType(unit.type) && callbacks.onEmbed) {
+    const spyRecord = state.espionage?.[unit.owner]?.spies[unitId];
+    const ownCityHere = Object.values(state.cities).some(
+      c => c.owner === unit.owner && c.position.q === unit.position.q && c.position.r === unit.position.r,
+    );
+    if (ownCityHere && spyRecord?.status === 'idle') {
+      actionsDiv.appendChild(makeButton('Embed (counter-espionage)', '#374151', () => callbacks.onEmbed!(unitId)));
     }
   }
 

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -167,7 +167,7 @@ export function renderSelectedUnitInfo(
     const ownCityHere = Object.values(state.cities).some(
       c => c.owner === unit.owner && c.position.q === unit.position.q && c.position.r === unit.position.r,
     );
-    if (ownCityHere && spyRecord?.status === 'idle') {
+    if (ownCityHere && spyRecord?.status === 'idle' && !unit.hasActed) {
       actionsDiv.appendChild(makeButton('Embed (counter-espionage)', '#374151', () => callbacks.onEmbed!(unitId)));
     }
   }

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1202,7 +1202,7 @@ describe('processAITurn', () => {
 
     const spies = Object.values(newState.espionage!['ai-1'].spies);
     expect(spies).toHaveLength(1);
-    expect(spies[0].status).toBe('stationed');
+    expect(spies[0].status).toBe('embedded');
     expect(spies[0].targetCivId).toBeNull();
     expect(spies[0].targetCityId).toBe('city-ai');
     expect(newState.espionage!['ai-1'].counterIntelligence['city-ai']).toBeGreaterThan(0);
@@ -1298,7 +1298,8 @@ describe('processAITurn', () => {
         },
       },
       maxSpies: 1,
-      counterIntelligence: {},
+      // Pre-set CI so shouldAiStationDefensiveSpy returns false (CI > 0 → no embed needed)
+      counterIntelligence: { 'city-ai': 20 },
     };
 
     const result = processAITurn(state, 'ai-1', bus);

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1,7 +1,7 @@
 import { processTurn } from '@/core/turn-manager';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
-import type { CustomCivDefinition, GameState } from '@/core/types';
+import type { CustomCivDefinition, GameState, UnitType } from '@/core/types';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { foundCity } from '@/systems/city-system';
 import { getAvailableTechs } from '@/systems/tech-system';
@@ -469,5 +469,44 @@ describe('processTurn', () => {
     const roundTrip = JSON.parse(JSON.stringify(state)) as GameState;
     expect(resolveCivDefinition(roundTrip, 'custom-sunfolk')?.name).toBe('Sunfolk');
     expect(() => processTurn(roundTrip, new EventBus())).not.toThrow();
+  });
+
+  it('per-turn CI accumulates for an embedded spy each turn', () => {
+    const state = createNewGame(undefined, 'ci-embed-test', 'small');
+    const bus = new EventBus();
+
+    // Player starts with a settler, not a city — found one so targetCityId is valid
+    const city = foundCity('player', { q: 1, r: 0 }, state.map);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities = [city.id];
+
+    const cityId = city.id;
+    const startCi = 10;
+    state.espionage!['player'] = {
+      ...state.espionage!['player']!,
+      counterIntelligence: { [cityId]: startCi },
+      spies: {
+        'test-spy-embed': {
+          id: 'test-spy-embed',
+          owner: 'player',
+          name: 'Test Spy',
+          targetCivId: null,
+          targetCityId: cityId,
+          position: null,
+          status: 'embedded',
+          experience: 0,
+          currentMission: null,
+          cooldownTurns: 0,
+          promotionAvailable: false,
+          unitType: 'spy_scout' as UnitType,
+          stolenTechFrom: {},
+        },
+      },
+    };
+
+    const result = processTurn(state, bus);
+
+    const afterCi = result.espionage!['player']!.counterIntelligence[cityId] ?? 0;
+    expect(afterCi).toBe(startCi + 2); // perTurnBonus = 2 + floor(0 * 0.1) = 2
   });
 });

--- a/tests/systems/espionage-capture.test.ts
+++ b/tests/systems/espionage-capture.test.ts
@@ -3,8 +3,9 @@ import {
   expelSpy, executeSpy, startInterrogation, processInterrogation,
   getSpyCaptureRelationshipPenalty,
   createEspionageCivState, createSpyFromUnit,
-  embedSpy, unembedSpy, attemptSweep,
+  embedSpy, unembedSpy, attemptSweep, processEspionageTurn,
 } from '@/systems/espionage-system';
+import { EventBus } from '@/core/event-bus';
 import type { GameState } from '@/core/types';
 
 describe('relational penalty by distance', () => {
@@ -184,9 +185,13 @@ describe('attemptSweep', () => {
     expect(detectedSpyIds).toHaveLength(0);
   });
 
-  it('can detect an enemy spy stationed in the embedded city', () => {
+  it('detects an enemy spy in the embedded city when experience is high', () => {
     let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
     ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    ownerEsp = {
+      ...ownerEsp,
+      spies: { 'spy-own': { ...ownerEsp.spies['spy-own'], experience: 100 } },
+    };
     ownerEsp = embedSpy(ownerEsp, 'spy-own', 'city-1', { q: 0, r: 0 });
 
     let enemyEsp = { ...createEspionageCivState(), maxSpies: 1 };
@@ -197,8 +202,22 @@ describe('attemptSweep', () => {
     };
 
     const fakeGameState = { espionage: { player: ownerEsp, ai: enemyEsp } } as unknown as GameState;
-    const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', 'sweep-high', fakeGameState);
-    expect(Array.isArray(detectedSpyIds)).toBe(true);
+    // With experience=100, sweepChance=0.70; across 20 seeds detection is near-certain
+    let detected = false;
+    for (let i = 0; i < 20; i++) {
+      const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', `sweep-high-${i}`, fakeGameState);
+      if (detectedSpyIds.includes('spy-enemy')) { detected = true; break; }
+    }
+    expect(detected).toBe(true);
+  });
+
+  it('records lastSweepTurn on the sweeping spy', () => {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    ownerEsp = embedSpy(ownerEsp, 'spy-own', 'city-1', { q: 0, r: 0 });
+    const fakeGameState = { turn: 7, espionage: { player: ownerEsp } } as unknown as GameState;
+    const { state: updatedEsp } = attemptSweep(ownerEsp, 'spy-own', 'sweep-seed', fakeGameState);
+    expect(updatedEsp.spies['spy-own'].lastSweepTurn).toBe(7);
   });
 
   it('does not detect enemy spy in a different city', () => {
@@ -339,5 +358,72 @@ describe('intel extraction', () => {
     // With 6 intel types at 0.08–0.60 chance each per turn x 3 turns,
     // statistically at least 1 intel item should be extracted with our fixed seeds
     expect(typeof totalExtracted).toBe('number'); // always accumulates (even 0 is a valid run)
+  });
+});
+
+describe('processEspionageTurn embedded spy cleanup', () => {
+  function makeEmbedCleanupState(cityExists: boolean, cityOwner: string): GameState {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-1', 'player', 'spy_scout', 'seed'));
+    ownerEsp = embedSpy(ownerEsp, 'spy-1', 'city-1', { q: 0, r: 0 });
+    return {
+      turn: 3,
+      era: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 5, tiles: {}, wrapsHorizontally: false, rivers: [] },
+      units: {},
+      cities: cityExists
+        ? {
+          'city-1': {
+            id: 'city-1', name: 'Rome', owner: cityOwner,
+            position: { q: 0, r: 0 }, population: 2, food: 0, foodNeeded: 10,
+            buildings: [], productionQueue: [], productionProgress: 0,
+            ownedTiles: [], grid: [[null]], gridSize: 3,
+            unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+          },
+        }
+        : {},
+      civilizations: {
+        player: {
+          id: 'player', name: 'Rome', color: '#f00',
+          isHuman: true, civType: 'rome',
+          cities: cityExists ? ['city-1'] : [], units: [],
+          techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+          gold: 0, visibility: { tiles: {} }, score: 0,
+          diplomacy: {
+            relationships: {}, treaties: [], events: [], atWarWith: [],
+            treacheryScore: 0,
+            vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 },
+          },
+        },
+      },
+      barbarianCamps: {},
+      minorCivs: {},
+      gameOver: false, winner: null,
+      tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+      settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+      tribalVillages: {},
+      discoveredWonders: {},
+      wonderDiscoverers: {},
+      espionage: { player: ownerEsp },
+    } as unknown as GameState;
+  }
+
+  it('keeps embedded spy when own city still exists and is owned by same civ', () => {
+    const state = makeEmbedCleanupState(true, 'player');
+    const result = processEspionageTurn(state, new EventBus());
+    expect(result.espionage!['player'].spies['spy-1'].status).toBe('embedded');
+  });
+
+  it('moves embedded spy to cooldown when target city is destroyed', () => {
+    const state = makeEmbedCleanupState(false, 'player');
+    const result = processEspionageTurn(state, new EventBus());
+    expect(result.espionage!['player'].spies['spy-1'].status).toBe('cooldown');
+  });
+
+  it('moves embedded spy to cooldown when target city is captured by enemy', () => {
+    const state = makeEmbedCleanupState(true, 'enemy');
+    const result = processEspionageTurn(state, new EventBus());
+    expect(result.espionage!['player'].spies['spy-1'].status).toBe('cooldown');
   });
 });

--- a/tests/systems/espionage-capture.test.ts
+++ b/tests/systems/espionage-capture.test.ts
@@ -3,6 +3,7 @@ import {
   expelSpy, executeSpy, startInterrogation, processInterrogation,
   getSpyCaptureRelationshipPenalty,
   createEspionageCivState, createSpyFromUnit,
+  embedSpy, unembedSpy, attemptSweep,
 } from '@/systems/espionage-system';
 import type { GameState } from '@/core/types';
 
@@ -118,6 +119,103 @@ describe('interrogation', () => {
       complete = result.complete;
     }
     expect(complete).toBe(true);
+  });
+});
+
+describe('embedSpy', () => {
+  it('sets spy status to embedded and sets targetCityId', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: civEsp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed'));
+    const result = embedSpy(civEsp, 'unit-1', 'city-1', { q: 0, r: 0 });
+    expect(result.spies['unit-1'].status).toBe('embedded');
+    expect(result.spies['unit-1'].targetCityId).toBe('city-1');
+  });
+
+  it('embedding boosts CI score for the city', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: civEsp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed'));
+    const before = civEsp.counterIntelligence['city-1'] ?? 0;
+    const result = embedSpy(civEsp, 'unit-1', 'city-1', { q: 0, r: 0 });
+    expect(result.counterIntelligence['city-1']).toBeGreaterThan(before);
+  });
+
+  it('throws if spy is not idle', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: civEsp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed'));
+    civEsp = embedSpy(civEsp, 'unit-1', 'city-1', { q: 0, r: 0 });
+    expect(() => embedSpy(civEsp, 'unit-1', 'city-1', { q: 0, r: 0 })).toThrow();
+  });
+});
+
+describe('unembedSpy', () => {
+  it('sets status to cooldown with cooldownTurns 5', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: civEsp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed'));
+    civEsp = embedSpy(civEsp, 'unit-1', 'city-1', { q: 0, r: 0 });
+    const result = unembedSpy(civEsp, 'unit-1');
+    expect(result.spies['unit-1'].status).toBe('cooldown');
+    expect(result.spies['unit-1'].cooldownTurns).toBe(5);
+    expect(result.spies['unit-1'].targetCityId).toBeNull();
+  });
+
+  it('is a no-op if spy is not embedded', () => {
+    let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: civEsp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed'));
+    const result = unembedSpy(civEsp, 'unit-1');
+    expect(result.spies['unit-1'].status).toBe('idle');
+  });
+});
+
+describe('attemptSweep', () => {
+  it('returns empty array when no enemy spies are in the city', () => {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    ownerEsp = embedSpy(ownerEsp, 'spy-own', 'city-1', { q: 0, r: 0 });
+    const fakeGameState = { espionage: { player: ownerEsp } } as unknown as GameState;
+    const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', 'sweep-seed', fakeGameState);
+    expect(detectedSpyIds).toHaveLength(0);
+  });
+
+  it('returns empty array if spy is not embedded', () => {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    const fakeGameState = { espionage: { player: ownerEsp } } as unknown as GameState;
+    const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', 'sweep-seed', fakeGameState);
+    expect(detectedSpyIds).toHaveLength(0);
+  });
+
+  it('can detect an enemy spy stationed in the embedded city', () => {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    ownerEsp = embedSpy(ownerEsp, 'spy-own', 'city-1', { q: 0, r: 0 });
+
+    let enemyEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: enemyEsp } = createSpyFromUnit(enemyEsp, 'spy-enemy', 'ai', 'spy_scout', 'seed2'));
+    enemyEsp = {
+      ...enemyEsp,
+      spies: { 'spy-enemy': { ...enemyEsp.spies['spy-enemy'], infiltrationCityId: 'city-1', status: 'stationed' as const } },
+    };
+
+    const fakeGameState = { espionage: { player: ownerEsp, ai: enemyEsp } } as unknown as GameState;
+    const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', 'sweep-high', fakeGameState);
+    expect(Array.isArray(detectedSpyIds)).toBe(true);
+  });
+
+  it('does not detect enemy spy in a different city', () => {
+    let ownerEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: ownerEsp } = createSpyFromUnit(ownerEsp, 'spy-own', 'player', 'spy_scout', 'seed'));
+    ownerEsp = embedSpy(ownerEsp, 'spy-own', 'city-1', { q: 0, r: 0 });
+
+    let enemyEsp = { ...createEspionageCivState(), maxSpies: 1 };
+    ({ state: enemyEsp } = createSpyFromUnit(enemyEsp, 'spy-enemy', 'ai', 'spy_scout', 'seed2'));
+    enemyEsp = {
+      ...enemyEsp,
+      spies: { 'spy-enemy': { ...enemyEsp.spies['spy-enemy'], infiltrationCityId: 'city-2', status: 'stationed' as const } },
+    };
+
+    const fakeGameState = { espionage: { player: ownerEsp, ai: enemyEsp } } as unknown as GameState;
+    const { detectedSpyIds } = attemptSweep(ownerEsp, 'spy-own', 'sweep-seed', fakeGameState);
+    expect(detectedSpyIds).toHaveLength(0);
   });
 });
 

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -9,7 +9,7 @@ import { TECH_TREE } from '@/systems/tech-definitions';
 import {
   createEspionageCivState,
   createSpyFromUnit,
-  assignSpyDefensive,
+  embedSpy,
   recallSpy,
   getSpySuccessChance,
   getMissionDuration,
@@ -181,13 +181,13 @@ describe('espionage-system', () => {
     });
   });
 
-  describe('assignSpyDefensive', () => {
-    it('assigns spy to own city for counter-intelligence', () => {
+  describe('embedSpy', () => {
+    it('embeds spy in own city for counter-intelligence', () => {
       const spy = makeTestSpy('spy-1', 'player');
       const s1 = addSpy(createEspionageCivState(), spy);
-      const s2 = assignSpyDefensive(s1, spy.id, 'city-player-1', { q: 0, r: 0 });
+      const s2 = embedSpy(s1, spy.id, 'city-player-1', { q: 0, r: 0 });
       const assigned = s2.spies[spy.id];
-      expect(assigned.status).toBe('stationed');
+      expect(assigned.status).toBe('embedded');
       expect(assigned.targetCivId).toBeNull();
       expect(assigned.targetCityId).toBe('city-player-1');
       expect(s2.counterIntelligence['city-player-1']).toBeGreaterThan(0);
@@ -196,9 +196,9 @@ describe('espionage-system', () => {
     it('increases counter-intelligence score based on spy experience', () => {
       const spy = makeTestSpy('spy-1', 'player', { experience: 50 });
       const s1 = addSpy(createEspionageCivState(), spy);
-      const s2 = assignSpyDefensive(s1, spy.id, 'city-player-1', { q: 0, r: 0 });
+      const s2 = embedSpy(s1, spy.id, 'city-player-1', { q: 0, r: 0 });
       const ciScore = s2.counterIntelligence['city-player-1'];
-      expect(ciScore).toBeGreaterThan(20); // base 20 + experience bonus
+      expect(ciScore).toBeGreaterThan(15); // base 15 + experience bonus
     });
   });
 


### PR DESCRIPTION
## Summary

- Replaces `assignSpyDefensive` (unit stayed on map, `stationed` status) with `embedSpy`: spy is removed from the map and enters a new `'embedded'` status inside an **own city**, boosting its counter-intelligence score
- Embedded spies accumulate CI passively each turn (+2 base, +0.1×experience) via a new `processTurn` block
- New `unembedSpy` action recalls the spy with a 5-turn cooldown
- New `attemptSweep` action detects enemy spies infiltrating the embedded city (40–70% chance by experience)
- 🛡 shield icon rendered on map tiles where own spy is embedded
- AI updated to call `embedSpy` instead of `assignSpyDefensive`

## Code-review fixes (post-implementation)

All 10 issues from the inline review were addressed in a follow-up commit:

| # | Issue | Fix |
|---|-------|-----|
| 1 | Embedded spy not cleaned up on city capture | `processEspionageTurn` cleanup handles `embedded` → cooldown when city destroyed or captured |
| 2 | `defendingCityIds` excluded embedded spies | Filter now includes `embedded` status |
| 3 | Notification showed raw city ID | Resolves city name from `gameState.cities` |
| 4 | Embed button ignored `hasActed` | Added `!unit.hasActed` guard |
| 5 | Sweep detection test only checked `Array.isArray` | Replaced with experience=100 spy + 20-seed loop asserting actual detection |
| 6 | No per-turn sweep gate | `attemptSweep` records `lastSweepTurn`; panel shows "Sweep done this turn" chip; `onSweep` writes returned state back |
| 7 | No test for per-turn CI accumulation | Added turn-manager integration test using `foundCity` |
| 8 | No test for embedded spy city-capture cleanup | Three-case test: city still owned, destroyed, captured by enemy |
| 9 | Canvas state not saved/restored | `ctx.save()`/`ctx.restore()` wraps both indicator functions |
| 10 | `recallSpy` on embedded spy would ghost it | Guard returns unchanged state for `embedded` status |

## Test plan

- [ ] `yarn test` — 1253 tests, all passing
- [ ] `yarn build` — clean TypeScript compile, no errors
- [ ] Embed a spy via the espionage panel → unit disappears from map, 🛡 appears on city tile
- [ ] Embed a spy via the selected-unit-info panel (idle spy on own city) → same result
- [ ] Verify CI score for the city increases each turn while spy is embedded
- [ ] Run Sweep → notification shows detection count or "no spies detected"; button replaced by "Sweep done this turn" chip until next turn
- [ ] Unembed → spy reappears at city with 5-turn cooldown
- [ ] Capture the city where a spy is embedded → spy enters cooldown on next turn
- [ ] Try recallSpy on an embedded spy via the Recall button → no ghost (button should not be visible for embedded spies, and system-level guard prevents it)
- [ ] AI civs with espionage tech embed spies defensively when CI is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)