### PR TITLE
feat(espionage): MR8 — per-era spy types + universal unit upgrade system

### DIFF
--- a/docs/superpowers/plans/espionage-overhaul/mr-08-era-types-unit-upgrade.md
+++ b/docs/superpowers/plans/espionage-overhaul/mr-08-era-types-unit-upgrade.md
@@ -2,21 +2,23 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** All obsolete units (including spy units) can be upgraded to the current era's equivalent at half production cost in a home city. Obsolete embedded/infiltrated spy units auto-expire cleanly with a notification.
+**Goal:** All obsolete units (including spy units) can be upgraded to the current era's equivalent at half cost in a home city. Obsolete embedded/infiltrated/on-mission spy units auto-expire cleanly with a notification.
 
 **Prerequisite MRs:** MR 1–7 (spy unit types and obsolescence fields already in place from MR 1)
+
+**Cost model:** Upgrades cost gold (half the target unit's production cost from `TRAINABLE_UNITS`). The codebase has no per-civ floating production stockpile — `civ.gold` is the correct deduction target. The button label says "gold", not "prod".
 
 ---
 
 ## Task 11: Unit Upgrade System (all unit types)
 
-**User value:** Obsolete units can be upgraded to the current era's equivalent at half production cost in a home city. Takes 1 turn. Heals unit to full health.
+**User value:** Obsolete units can be upgraded to the next era equivalent at half gold cost when standing on a home city tile. The unit consumes its action for the turn and heals to full health on upgrade.
 
 **Files:**
 - Create: `src/systems/unit-upgrade-system.ts`
-- Modify: `src/core/turn-manager.ts`
-- Modify: `src/ui/city-panel.ts`
 - Modify: `src/ui/selected-unit-info.ts`
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/main.ts`
 - Create: `tests/systems/unit-upgrade.test.ts`
 
 - [ ] **Step 1: Write failing tests**
@@ -26,7 +28,6 @@ Create `tests/systems/unit-upgrade.test.ts`:
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { canUpgradeUnit, getUpgradeCost, applyUpgrade } from '@/systems/unit-upgrade-system';
-import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import type { Unit } from '@/core/types';
 
 function makeUnit(type: string, position = { q: 0, r: 0 }): Unit {
@@ -60,18 +61,18 @@ describe('canUpgradeUnit', () => {
 describe('getUpgradeCost', () => {
   it('returns half of the target unit production cost', () => {
     const cost = getUpgradeCost('spy_informant');
-    expect(cost).toBe(25); // spy_informant costs 50, half = 25
+    expect(cost).toBe(25); // spy_informant costs 50 in TRAINABLE_UNITS, half = 25
   });
 });
 
 describe('applyUpgrade', () => {
-  it('changes unit type and heals to full health', () => {
+  it('changes unit type, heals to full health, and consumes action', () => {
     const unit = makeUnit('spy_scout');
-    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
-    const upgraded = applyUpgrade(unit, 'spy_informant', city);
+    const upgraded = applyUpgrade(unit, 'spy_informant');
     expect(upgraded.type).toBe('spy_informant');
     expect(upgraded.health).toBe(100);
     expect(upgraded.hasActed).toBe(true);
+    expect(upgraded.movementPointsLeft).toBe(0);
   });
 });
 ```
@@ -79,7 +80,7 @@ describe('applyUpgrade', () => {
 - [ ] **Step 2: Run to verify failure**
 
 ```bash
-yarn test tests/systems/unit-upgrade.test.ts
+scripts/run-with-mise.sh yarn test tests/systems/unit-upgrade.test.ts
 ```
 
 - [ ] **Step 3: Create `src/systems/unit-upgrade-system.ts`**
@@ -88,12 +89,6 @@ yarn test tests/systems/unit-upgrade.test.ts
 import type { Unit, UnitType, City } from '@/core/types';
 import { TRAINABLE_UNITS } from './city-system';
 import { UNIT_DEFINITIONS } from './unit-system';
-
-export interface UpgradeRequest {
-  unitId: string;
-  targetType: UnitType;
-  cityId: string;
-}
 
 export function getUpgradeCost(targetType: UnitType): number {
   const entry = TRAINABLE_UNITS.find(u => u.type === targetType);
@@ -115,8 +110,8 @@ export function canUpgradeUnit(
   if (!currentEntry?.obsoletedByTech || !completedTechs.includes(currentEntry.obsoletedByTech)) {
     return { canUpgrade: false, targetType: null, cost: 0 };
   }
-  // Find the next unit in this upgrade chain: requires the same tech that obsoleted us,
-  // and is not itself obsolete. Parentheses are critical here — && binds tighter than ||.
+  // Find next unit in this upgrade chain: requires the same tech that obsoleted us,
+  // and is not itself already obsoleted by a further tech.
   const nextEntry = TRAINABLE_UNITS.find(u =>
     u.techRequired === currentEntry.obsoletedByTech &&
     (!u.obsoletedByTech || !completedTechs.includes(u.obsoletedByTech))
@@ -125,16 +120,14 @@ export function canUpgradeUnit(
   return { canUpgrade: true, targetType: nextEntry.type, cost: getUpgradeCost(nextEntry.type) };
 }
 
-export function applyUpgrade(
-  unit: Unit,
-  targetType: UnitType,
-  city: City,
-): Unit {
+// Returns a new Unit with the upgraded type, full health, and action consumed.
+// Caller is responsible for deducting civ.gold by getUpgradeCost(targetType).
+export function applyUpgrade(unit: Unit, targetType: UnitType): Unit {
   return {
     ...unit,
     type: targetType,
     health: 100,
-    movementPointsLeft: UNIT_DEFINITIONS[targetType].movementPoints,
+    movementPointsLeft: 0,
     hasActed: true,
   };
 }
@@ -143,48 +136,185 @@ export function applyUpgrade(
 - [ ] **Step 4: Run tests to verify they pass**
 
 ```bash
-yarn test tests/systems/unit-upgrade.test.ts
+scripts/run-with-mise.sh yarn test tests/systems/unit-upgrade.test.ts
 ```
 
-- [ ] **Step 5: Add upgrade prompt to `src/ui/selected-unit-info.ts`**
+- [ ] **Step 5: Add upgrade button to `src/ui/selected-unit-info.ts`**
 
-Add `onUpgradeUnit?: (unitId: string, cityId: string) => void` to `SelectedUnitInfoCallbacks`.
+**5a — Interface change:** Add `onUpgradeUnit?: (unitId: string, cityId: string) => void` to `SelectedUnitInfoCallbacks`.
 
-In `renderSelectedUnitInfo`, for units on a home city tile, check `canUpgradeUnit`. If upgradeable, show:
+**5b — Add import:** At the top of `selected-unit-info.ts`, add:
 
 ```typescript
-const upgradeable = checkUpgrade(unit, state);
-if (upgradeable && callbacks.onUpgradeUnit) {
-  const btn = makeButton(
-    `Upgrade → ${upgradeable.targetTypeName} (${upgradeable.cost} prod, 1 turn)`,
-    '#7c3aed',
-    () => callbacks.onUpgradeUnit!(unitId, upgradeable.cityId),
+import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system'; // already imported — no change needed
+```
+
+`UNIT_DEFINITIONS` is already imported. Only add the `canUpgradeUnit` import.
+
+**5c — Render upgrade button:** After the embed block (near end of `renderSelectedUnitInfo`, before `actionsDiv` is appended to wrapper), add:
+
+```typescript
+// Upgrade button — only when unit is on an owned city tile and upgrade is available
+if (callbacks.onUpgradeUnit) {
+  // Find the home city this unit is standing on
+  const homeCity = Object.values(state.cities).find(
+    c => c.owner === unit.owner &&
+         c.position.q === unit.position.q &&
+         c.position.r === unit.position.r,
   );
-  actionsDiv.appendChild(btn);
+  if (homeCity) {
+    const completedTechs = state.civilizations[unit.owner]?.techState?.completed ?? [];
+    const upgrade = canUpgradeUnit(unit, homeCity.id, state.cities, completedTechs);
+    if (upgrade.canUpgrade && upgrade.targetType) {
+      const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+      const btn = makeButton(
+        `Upgrade → ${targetName} (${upgrade.cost} gold)`,
+        '#7c3aed',
+        () => callbacks.onUpgradeUnit!(unitId, homeCity.id),
+      );
+      actionsDiv.appendChild(btn);
+    }
+  }
 }
 ```
 
-Helper `checkUpgrade` finds the city the unit is currently standing on (owned by the same player) and calls `canUpgradeUnit`.
+- [ ] **Step 6: Wire `onUpgradeUnit` in `src/main.ts`**
 
-- [ ] **Step 6: Add upgrade prompt to `src/ui/city-panel.ts`**
+In `main.ts`, inside the `renderSelectedUnitInfo` call (around line 995), add `onUpgradeUnit` to the callbacks object:
 
-In the city panel, show units currently in the city that are eligible for upgrade. For each such unit, show:
+```typescript
+onUpgradeUnit: (uid, cityId) => {
+  const unit = gameState.units[uid];
+  if (!unit || unit.owner !== gameState.currentPlayer) return;
+  const civ = gameState.civilizations[gameState.currentPlayer];
+  const completedTechs = civ?.techState?.completed ?? [];
+  const upgrade = canUpgradeUnit(unit, cityId, gameState.cities, completedTechs);
+  if (!upgrade.canUpgrade || !upgrade.targetType) return;
+  if (civ.gold < upgrade.cost) {
+    showNotification('Not enough gold to upgrade!', 'warning');
+    return;
+  }
+  gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
+  gameState.units[uid] = applyUpgrade(unit, upgrade.targetType);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  selectUnit(uid);
+  const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+  showNotification(`Upgraded to ${targetName}!`, 'success');
+},
 ```
-[Unit Name] — Upgrade to [Target] for [N] production
-```
-with an Upgrade button.
 
-- [ ] **Step 7: Run full test suite**
+Add the required imports to the top of `main.ts` (they may already be partially imported — only add what's missing):
+
+```typescript
+import { canUpgradeUnit, applyUpgrade } from '@/systems/unit-upgrade-system';
+```
+
+`UNIT_DEFINITIONS` is already imported in main.ts via the existing unit-system imports — verify with `grep UNIT_DEFINITIONS src/main.ts`. If not present, add it.
+
+- [ ] **Step 7: Add upgrade section to `src/ui/city-panel.ts`**
+
+**7a — Interface change:** Add `onUpgradeUnit?: (unitId: string) => void` to `CityPanelCallbacks`.
+
+**7b — Add imports at top of `city-panel.ts`:**
+
+```typescript
+import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+```
+
+**7c — Build upgrade section using DOM API** (not innerHTML, per XSS rules). Add this block after the `container.appendChild(panel)` call (around line 228) and before the `rerenderPanel` definition:
+
+```typescript
+// Upgradeable units section — units standing on this city that can be upgraded
+const completedTechs = state.civilizations[state.currentPlayer]?.techState?.completed ?? [];
+const upgradeableUnits = Object.values(state.units).filter(u =>
+  u.owner === city.owner &&
+  u.position.q === city.position.q &&
+  u.position.r === city.position.r &&
+  canUpgradeUnit(u, city.id, state.cities, completedTechs).canUpgrade,
+);
+
+if (upgradeableUnits.length > 0 && callbacks.onUpgradeUnit) {
+  const upgradeSection = document.createElement('div');
+  upgradeSection.style.cssText = 'margin-top:16px;';
+
+  const header = document.createElement('div');
+  header.style.cssText = 'font-size:12px;font-weight:bold;color:#a78bfa;margin-bottom:8px;';
+  header.textContent = 'Upgradeable Units';
+  upgradeSection.appendChild(header);
+
+  for (const u of upgradeableUnits) {
+    const upgrade = canUpgradeUnit(u, city.id, state.cities, completedTechs);
+    if (!upgrade.canUpgrade || !upgrade.targetType) continue;
+
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;margin-bottom:6px;';
+
+    const info = document.createElement('span');
+    info.style.cssText = 'font-size:12px;';
+    const currentName = UNIT_DEFINITIONS[u.type]?.name ?? u.type;
+    const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+    info.textContent = `${currentName} → ${targetName} (${upgrade.cost} gold)`;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = 'Upgrade';
+    btn.style.cssText = 'padding:4px 10px;border-radius:6px;background:#7c3aed;border:none;color:white;cursor:pointer;font-size:11px;';
+    btn.addEventListener('click', () => callbacks.onUpgradeUnit!(u.id));
+
+    row.appendChild(info);
+    row.appendChild(btn);
+    upgradeSection.appendChild(row);
+  }
+
+  // Insert before the close/nav buttons by appending to the list view
+  const listViewEl = panel.querySelector('#city-list-view');
+  listViewEl ? listViewEl.appendChild(upgradeSection) : panel.appendChild(upgradeSection);
+}
+```
+
+**7d — Wire `onUpgradeUnit` in `main.ts`** where `createCityPanel` is called. Add to the callbacks object:
+
+```typescript
+onUpgradeUnit: (unitId) => {
+  const unit = gameState.units[unitId];
+  if (!unit || unit.owner !== gameState.currentPlayer) return;
+  const civ = gameState.civilizations[gameState.currentPlayer];
+  const completedTechs = civ?.techState?.completed ?? [];
+  // Find the city the unit is on (the panel already knows which city, but we derive it cleanly)
+  const homeCity = Object.values(gameState.cities).find(
+    c => c.owner === unit.owner &&
+         c.position.q === unit.position.q &&
+         c.position.r === unit.position.r,
+  );
+  if (!homeCity) return;
+  const upgrade = canUpgradeUnit(unit, homeCity.id, gameState.cities, completedTechs);
+  if (!upgrade.canUpgrade || !upgrade.targetType) return;
+  if (civ.gold < upgrade.cost) {
+    showNotification('Not enough gold to upgrade!', 'warning');
+    return;
+  }
+  gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
+  gameState.units[unitId] = applyUpgrade(unit, upgrade.targetType);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
+},
+```
+
+- [ ] **Step 8: Run full test suite**
 
 ```bash
-yarn test
+scripts/run-with-mise.sh yarn test
 ```
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Commit**
 
 ```bash
-git add src/systems/unit-upgrade-system.ts src/core/turn-manager.ts src/ui/city-panel.ts src/ui/selected-unit-info.ts tests/systems/unit-upgrade.test.ts
-git commit -m "feat(espionage): unit upgrade system — obsolete units upgradeable at half cost in home city"
+git add src/systems/unit-upgrade-system.ts src/ui/city-panel.ts src/ui/selected-unit-info.ts src/main.ts tests/systems/unit-upgrade.test.ts
+git commit -m "feat(espionage): unit upgrade system — obsolete units upgradeable at half gold cost in home city"
 ```
 
 ---
@@ -193,18 +323,76 @@ git commit -m "feat(espionage): unit upgrade system — obsolete units upgradeab
 
 **Files:**
 - Modify: `src/core/turn-manager.ts`
-- Modify: `src/systems/espionage-system.ts`
+- Modify: `src/core/types.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/systems/unit-upgrade.test.ts`
 
-- [ ] **Step 1: Write failing test**
+- [ ] **Step 1: Write failing tests**
 
 Add to `tests/systems/unit-upgrade.test.ts`:
 
 ```typescript
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
+import type { GameState, Spy } from '@/core/types';
+
+// Minimal GameState for obsolescence tests. processTurn requires a valid civilizations map,
+// a map with tiles, and the standard espionage shape.
+function makeObsolescenceState(overrides: {
+  unitOnMap?: boolean;
+  spyStatus?: 'embedded' | 'stationed' | 'on_mission';
+} = {}): GameState {
+  const civId = 'player';
+  // Spy_scout is obsoleted by 'espionage-informants'. Set research so tech completes this turn.
+  const spy: Spy = {
+    id: 'spy1',
+    name: 'Agent Fox',
+    owner: civId,
+    unitType: 'spy_scout',
+    status: overrides.spyStatus ?? 'embedded',
+    experience: 0,
+    cooldownTurns: 0,
+    infiltrationCityId: overrides.spyStatus === 'stationed' ? 'enemy-city' : undefined,
+    missionHistory: [],
+    promotions: [],
+  };
+  return {
+    turn: 1,
+    currentPlayer: civId,
+    map: { tiles: {}, width: 1, height: 1 },
+    cities: {},
+    units: overrides.unitOnMap
+      ? { u1: { id: 'u1', type: 'spy_scout', owner: civId, position: { q: 0, r: 0 }, health: 100, movementPointsLeft: 2, hasActed: false, hasMoved: false } }
+      : {},
+    civilizations: {
+      [civId]: {
+        id: civId, name: 'Player', color: '#fff', civType: 'default',
+        gold: 0, goldPerTurn: 0,
+        units: overrides.unitOnMap ? ['u1'] : [],
+        cities: [],
+        techState: {
+          completed: ['espionage-scouting'],
+          currentResearch: 'espionage-informants',
+          researchProgress: 9999, // will complete this turn
+          queue: [],
+        },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], vassalage: { overlord: null, vassals: [] } },
+        visibility: { tiles: {} },
+      },
+    },
+    espionage: {
+      [civId]: {
+        maxSpies: 2,
+        spies: { spy1: spy },
+        counterIntelligence: {},
+      },
+    },
+  } as unknown as GameState;
+}
+
 describe('obsolescence notifications', () => {
-  it('emits unit:obsolete for map units when tech completes', () => {
-    // Build a state with a spy_scout unit and espionage-informants completing this turn
-    // processTurn should emit unit:obsolete for the spy_scout
-    const state = makeStateWithSpyScoutAndTechCompleting();
+  it('emits unit:obsolete for map spy_scout units when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ unitOnMap: true });
     const bus = new EventBus();
     const events: unknown[] = [];
     bus.on('unit:obsolete', e => events.push(e));
@@ -212,10 +400,24 @@ describe('obsolescence notifications', () => {
     expect(events.length).toBeGreaterThan(0);
   });
 
-  it('silently removes embedded spy when its era tech completes', () => {
-    // Build state where spy_scout is embedded and espionage-informants completes
-    // After processTurn, the spy record should be gone, no diplomatic penalty
-    const state = makeStateWithEmbeddedSpyScoutAndTechCompleting();
+  it('silently removes embedded spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'embedded' });
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    const spies = Object.values(next.espionage?.['player']?.spies ?? {});
+    expect(spies.filter(s => s.unitType === 'spy_scout')).toHaveLength(0);
+  });
+
+  it('silently removes stationed spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'stationed' });
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    const spies = Object.values(next.espionage?.['player']?.spies ?? {});
+    expect(spies.filter(s => s.unitType === 'spy_scout')).toHaveLength(0);
+  });
+
+  it('silently removes on_mission spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'on_mission' });
     const bus = new EventBus();
     const next = processTurn(state, bus);
     const spies = Object.values(next.espionage?.['player']?.spies ?? {});
@@ -224,60 +426,89 @@ describe('obsolescence notifications', () => {
 });
 ```
 
-- [ ] **Step 2: Implement obsolescence scan in `src/core/turn-manager.ts`**
+- [ ] **Step 2: Run to verify failure**
 
-When a tech completes, scan `state.units` for units owned by that civ of the obsoleted type. The tech completion is already emitted as `tech:completed`. Add a handler in `processTurn`:
+```bash
+scripts/run-with-mise.sh yarn test tests/systems/unit-upgrade.test.ts
+```
+
+- [ ] **Step 3: Add new event types to `src/core/types.ts`**
+
+Locate the espionage events in `GameEventMap` (around line 1039–1042, near `'espionage:spy-promoted'`). Add:
 
 ```typescript
-bus.on('tech:completed', ({ civId: completedCivId, techId }) => {
+'unit:obsolete': { civId: string; unitId: string; unitType: UnitType };
+'espionage:spy-expired': { civId: string; spyId: string; spyName: string; unitType: UnitType };
+```
+
+- [ ] **Step 4: Add inline obsolescence scan to `src/core/turn-manager.ts`**
+
+**Do NOT use `bus.on('tech:completed', ...)` inside `processTurn` — registering a listener inside a function that also emits that event causes a new subscription on every turn call.**
+
+Instead, add a synchronous inline block immediately after the existing `bus.emit('tech:completed', ...)` at line 152. The full block (with surrounding context) looks like:
+
+```typescript
+if (researchResult.completedTech) {
+  const techId = researchResult.completedTech;
+  bus.emit('tech:completed', { civId, techId });
+
+  // Inline obsolescence scan — runs once per completed tech, no bus listener needed
   const obsoletedTypes = TRAINABLE_UNITS
     .filter(u => u.obsoletedByTech === techId)
     .map(u => u.type);
-  if (obsoletedTypes.length === 0) return;
 
-  // Map units
-  for (const [unitId, unit] of Object.entries(newState.units)) {
-    if (unit.owner !== completedCivId) continue;
-    if (!obsoletedTypes.includes(unit.type)) continue;
-    bus.emit('unit:obsolete', { civId: completedCivId, unitId, unitType: unit.type });
-  }
+  if (obsoletedTypes.length > 0) {
+    // Map units owned by this civ
+    for (const [unitId, unit] of Object.entries(newState.units)) {
+      if (unit.owner !== civId) continue;
+      if (!obsoletedTypes.includes(unit.type as any)) continue;
+      bus.emit('unit:obsolete', { civId, unitId, unitType: unit.type as any });
+    }
 
-  // Embedded/infiltrated spy units
-  const civEsp = newState.espionage?.[completedCivId];
-  if (civEsp) {
-    for (const [spyId, spy] of Object.entries(civEsp.spies)) {
-      if (!obsoletedTypes.includes(spy.unitType)) continue;
-      if (spy.status === 'embedded' || spy.status === 'stationed') {
-        // Silently expire: remove spy record, notify owning player
-        const { [spyId]: _removed, ...remainingSpies } = newState.espionage![completedCivId].spies;
-        newState.espionage![completedCivId] = { ...newState.espionage![completedCivId], spies: remainingSpies };
-        bus.emit('espionage:spy-expired', { civId: completedCivId, spyId, spyName: spy.name, unitType: spy.unitType });
+    // Off-map spy records: embedded, stationed, or on_mission
+    const civEsp = newState.espionage?.[civId];
+    if (civEsp) {
+      for (const [spyId, spy] of Object.entries(civEsp.spies)) {
+        if (!obsoletedTypes.includes(spy.unitType as any)) continue;
+        if (spy.status !== 'embedded' && spy.status !== 'stationed' && spy.status !== 'on_mission') continue;
+        const { [spyId]: _removed, ...remainingSpies } = newState.espionage![civId].spies;
+        newState.espionage![civId] = { ...newState.espionage![civId], spies: remainingSpies };
+        bus.emit('espionage:spy-expired', { civId, spyId, spyName: spy.name, unitType: spy.unitType });
       }
     }
   }
-});
+}
 ```
 
-Add `'unit:obsolete'` and `'espionage:spy-expired'` to `GameEventMap` in `types.ts`.
+Also add `TRAINABLE_UNITS` to the imports at the top of `turn-manager.ts` if not already present:
 
-In `main.ts`, show notification for expired spies:
+```typescript
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+```
+
+Verify with `grep "TRAINABLE_UNITS" src/core/turn-manager.ts` first.
+
+- [ ] **Step 5: Wire notification in `src/main.ts`**
+
+Add a new `bus.on` handler near the other espionage handlers (around line 2114):
+
 ```typescript
 bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
   if (civId === gameState.currentPlayer) {
-    showNotification(`${spyName}'s network has been dissolved (${unitType} era ended). No diplomatic penalty.`, 'info');
+    showNotification(`${spyName}'s network dissolved — ${unitType} era ended. No diplomatic penalty.`, 'info');
   }
 });
 ```
 
-- [ ] **Step 3: Run full test suite**
+- [ ] **Step 6: Run full test suite**
 
 ```bash
-yarn test
+scripts/run-with-mise.sh yarn test
 ```
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
-git add src/core/turn-manager.ts src/core/types.ts tests/systems/unit-upgrade.test.ts
-git commit -m "feat(espionage): obsolescence notifications — unit:obsolete event; embedded spies auto-expire cleanly"
+git add src/core/turn-manager.ts src/core/types.ts src/main.ts tests/systems/unit-upgrade.test.ts
+git commit -m "feat(espionage): obsolescence notifications — unit:obsolete event; off-map spies auto-expire on era tech"
 ```

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -160,14 +160,14 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       if (obsoletedTypes.length > 0) {
         for (const [unitId, unit] of Object.entries(newState.units)) {
           if (unit.owner !== civId) continue;
-          if (!obsoletedTypes.includes(unit.type as any)) continue;
-          bus.emit('unit:obsolete', { civId, unitId, unitType: unit.type as any });
+          if (!obsoletedTypes.includes(unit.type)) continue;
+          bus.emit('unit:obsolete', { civId, unitId, unitType: unit.type });
         }
 
         const civEsp = newState.espionage?.[civId];
         if (civEsp) {
           for (const [spyId, spy] of Object.entries(civEsp.spies)) {
-            if (!obsoletedTypes.includes(spy.unitType as any)) continue;
+            if (!obsoletedTypes.includes(spy.unitType)) continue;
             if (spy.status !== 'embedded' && spy.status !== 'stationed' && spy.status !== 'on_mission') continue;
             const { [spyId]: _removed, ...remainingSpies } = newState.espionage![civId].spies;
             newState.espionage![civId] = { ...newState.espionage![civId], spies: remainingSpies };

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -1,7 +1,7 @@
 import type { AdvisorType, GameState } from './types';
 import { EventBus } from './event-bus';
 import { resetUnitTurn, createUnit, healUnit, moveUnit } from '@/systems/unit-system';
-import { processCity } from '@/systems/city-system';
+import { processCity, TRAINABLE_UNITS } from '@/systems/city-system';
 import { applyCityMaturity } from '@/systems/city-maturity-system';
 import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
 import { processResearch, getTechById } from '@/systems/tech-system';
@@ -149,7 +149,32 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     const researchResult = processResearch(civ.techState, effectiveScience);
     newState.civilizations[civId].techState = researchResult.state;
     if (researchResult.completedTech) {
-      bus.emit('tech:completed', { civId, techId: researchResult.completedTech });
+      const techId = researchResult.completedTech;
+      bus.emit('tech:completed', { civId, techId });
+
+      // Inline obsolescence scan — runs once synchronously per completed tech
+      const obsoletedTypes = TRAINABLE_UNITS
+        .filter(u => u.obsoletedByTech === techId)
+        .map(u => u.type);
+
+      if (obsoletedTypes.length > 0) {
+        for (const [unitId, unit] of Object.entries(newState.units)) {
+          if (unit.owner !== civId) continue;
+          if (!obsoletedTypes.includes(unit.type as any)) continue;
+          bus.emit('unit:obsolete', { civId, unitId, unitType: unit.type as any });
+        }
+
+        const civEsp = newState.espionage?.[civId];
+        if (civEsp) {
+          for (const [spyId, spy] of Object.entries(civEsp.spies)) {
+            if (!obsoletedTypes.includes(spy.unitType as any)) continue;
+            if (spy.status !== 'embedded' && spy.status !== 'stationed' && spy.status !== 'on_mission') continue;
+            const { [spyId]: _removed, ...remainingSpies } = newState.espionage![civId].spies;
+            newState.espionage![civId] = { ...newState.espionage![civId], spies: remainingSpies };
+            bus.emit('espionage:spy-expired', { civId, spyId, spyName: spy.name, unitType: spy.unitType });
+          }
+        }
+      }
     }
 
     // Update gold

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1041,4 +1041,6 @@ export interface GameEvents {
   'espionage:documents-forged': { civA: string; civB: string; relationshipPenalty: number };
   'espionage:spy-executed': { executingCivId: string; spyOwner: string; spyId: string; spyName: string };
   'espionage:intel-extracted': { captorId: string; intel: InterrogationIntel[] };
+  'unit:obsolete': { civId: string; unitId: string; unitType: UnitType };
+  'espionage:spy-expired': { civId: string; spyId: string; spyName: string; unitType: UnitType };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,7 @@ import {
 } from '@/systems/espionage-system';
 import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
+import { canUpgradeUnit, applyUpgrade } from '@/systems/unit-upgrade-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import type { GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect } from '@/core/types';
 import {
@@ -547,6 +548,29 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       const nextIdx = (currentIdx + 1) % cities.length;
       const nextCity = gameState.cities[cities[nextIdx]];
       if (nextCity) openCityPanelForCity(nextCity);
+    },
+    onUpgradeUnit: (unitId) => {
+      const unit = gameState.units[unitId];
+      if (!unit || unit.owner !== gameState.currentPlayer) return;
+      const civ = gameState.civilizations[gameState.currentPlayer];
+      const completedTechs = civ?.techState?.completed ?? [];
+      const homeCity = Object.values(gameState.cities).find(
+        c => c.owner === unit.owner &&
+             c.position.q === unit.position.q &&
+             c.position.r === unit.position.r,
+      );
+      if (!homeCity) return;
+      const upgrade = canUpgradeUnit(unit, homeCity.id, gameState.cities, completedTechs);
+      if (!upgrade.canUpgrade || !upgrade.targetType) return;
+      if (civ.gold < upgrade.cost) {
+        showNotification('Not enough gold to upgrade!', 'warning');
+        return;
+      }
+      gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
+      gameState.units[unitId] = applyUpgrade(unit, upgrade.targetType);
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
     },
   });
 }
@@ -1114,6 +1138,24 @@ function selectUnit(unitId: string): void {
         renderLoop.setGameState(gameState);
         updateHUD();
         showNotification(`Spy embedded in ${city.name}. Counter-intelligence boosted.`, 'info');
+      },
+      onUpgradeUnit: (uid, cityId) => {
+        const unit = gameState.units[uid];
+        if (!unit || unit.owner !== gameState.currentPlayer) return;
+        const civ = gameState.civilizations[gameState.currentPlayer];
+        const completedTechs = civ?.techState?.completed ?? [];
+        const upgrade = canUpgradeUnit(unit, cityId, gameState.cities, completedTechs);
+        if (!upgrade.canUpgrade || !upgrade.targetType) return;
+        if (civ.gold < upgrade.cost) {
+          showNotification('Not enough gold to upgrade!', 'warning');
+          return;
+        }
+        gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
+        gameState.units[uid] = applyUpgrade(unit, upgrade.targetType);
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        selectUnit(uid);
+        showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
       },
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,7 @@ import {
   expelSpy,
   executeSpy,
   startInterrogation,
+  isSpyUnitType,
   missionRequiresPlacedSpy,
   recallSpy,
   resolveMissionResult,
@@ -464,6 +465,27 @@ function openDiplomacyPanel(): void {
   });
 }
 
+// Deduct gold, upgrade unit type, sync spy record unitType if applicable, refresh render.
+// Caller must validate eligibility and afford-ability before calling.
+function executeUpgrade(unitId: string, targetType: import('@/core/types').UnitType, cost: number): void {
+  const unit = gameState.units[unitId];
+  if (!unit) return;
+  const civ = gameState.civilizations[gameState.currentPlayer];
+  gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - cost };
+  gameState.units[unitId] = applyUpgrade(unit, targetType);
+  if (isSpyUnitType(unit.type)) {
+    const civEsp = gameState.espionage?.[gameState.currentPlayer];
+    if (civEsp?.spies[unitId]) {
+      gameState.espionage![gameState.currentPlayer] = {
+        ...civEsp,
+        spies: { ...civEsp.spies, [unitId]: { ...civEsp.spies[unitId], unitType: targetType } },
+      };
+    }
+  }
+  renderLoop.setGameState(gameState);
+  updateHUD();
+}
+
 function openCityPanelForCity(city: import('@/core/types').City): void {
   if (city.owner !== gameState.currentPlayer) return;
   const playerCities = currentCiv().cities;
@@ -566,10 +588,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
         showNotification('Not enough gold to upgrade!', 'warning');
         return;
       }
-      gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
-      gameState.units[unitId] = applyUpgrade(unit, upgrade.targetType);
-      renderLoop.setGameState(gameState);
-      updateHUD();
+      executeUpgrade(unitId, upgrade.targetType, upgrade.cost);
       showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
     },
   });
@@ -1150,10 +1169,7 @@ function selectUnit(unitId: string): void {
           showNotification('Not enough gold to upgrade!', 'warning');
           return;
         }
-        gameState.civilizations[gameState.currentPlayer] = { ...civ, gold: civ.gold - upgrade.cost };
-        gameState.units[uid] = applyUpgrade(unit, upgrade.targetType);
-        renderLoop.setGameState(gameState);
-        updateHUD();
+        executeUpgrade(uid, upgrade.targetType, upgrade.cost);
         selectUnit(uid);
         showNotification(`Upgraded to ${UNIT_DEFINITIONS[upgrade.targetType].name}!`, 'success');
       },
@@ -2196,6 +2212,13 @@ bus.on('espionage:spy-executed', ({ executingCivId, spyOwner, spyName }) => {
       `${spyName} was executed by ${gameState.civilizations[executingCivId]?.name ?? 'an enemy'}.`,
       'warning',
     );
+  }
+});
+
+bus.on('unit:obsolete', ({ civId, unitType }) => {
+  if (civId === gameState.currentPlayer) {
+    const name = UNIT_DEFINITIONS[unitType]?.name ?? unitType;
+    showNotification(`Your ${name} is now obsolete — upgrade it in your home city.`, 'info');
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2199,6 +2199,12 @@ bus.on('espionage:spy-executed', ({ executingCivId, spyOwner, spyName }) => {
   }
 });
 
+bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
+  if (civId === gameState.currentPlayer) {
+    showNotification(`${spyName}'s network dissolved — ${unitType} era ended. No diplomatic penalty.`, 'info');
+  }
+});
+
 bus.on('espionage:spy-auto-exfiltrated', ({ civId, cityId }) => {
   if (civId === gameState.currentPlayer) {
     const city = gameState.cities[cityId];

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -12,6 +12,7 @@ export function canUpgradeUnit(
   cityId: string,
   cities: Record<string, City>,
   completedTechs: string[],
+  civGold?: number,
 ): { canUpgrade: boolean; targetType: UnitType | null; cost: number } {
   const city = cities[cityId];
   if (!city || city.owner !== unit.owner) return { canUpgrade: false, targetType: null, cost: 0 };
@@ -29,7 +30,9 @@ export function canUpgradeUnit(
     (!u.obsoletedByTech || !completedTechs.includes(u.obsoletedByTech))
   );
   if (!nextEntry) return { canUpgrade: false, targetType: null, cost: 0 };
-  return { canUpgrade: true, targetType: nextEntry.type, cost: getUpgradeCost(nextEntry.type) };
+  const cost = getUpgradeCost(nextEntry.type);
+  if (civGold !== undefined && civGold < cost) return { canUpgrade: false, targetType: null, cost };
+  return { canUpgrade: true, targetType: nextEntry.type, cost };
 }
 
 // Returns a new Unit with the upgraded type, full health, and action consumed.

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -1,0 +1,45 @@
+import type { Unit, UnitType, City } from '@/core/types';
+import { TRAINABLE_UNITS } from './city-system';
+import { UNIT_DEFINITIONS } from './unit-system';
+
+export function getUpgradeCost(targetType: UnitType): number {
+  const entry = TRAINABLE_UNITS.find(u => u.type === targetType);
+  return entry ? Math.ceil(entry.cost * 0.5) : 0;
+}
+
+export function canUpgradeUnit(
+  unit: Unit,
+  cityId: string,
+  cities: Record<string, City>,
+  completedTechs: string[],
+): { canUpgrade: boolean; targetType: UnitType | null; cost: number } {
+  const city = cities[cityId];
+  if (!city || city.owner !== unit.owner) return { canUpgrade: false, targetType: null, cost: 0 };
+  if (unit.position.q !== city.position.q || unit.position.r !== city.position.r) {
+    return { canUpgrade: false, targetType: null, cost: 0 };
+  }
+  const currentEntry = TRAINABLE_UNITS.find(u => u.type === unit.type);
+  if (!currentEntry?.obsoletedByTech || !completedTechs.includes(currentEntry.obsoletedByTech)) {
+    return { canUpgrade: false, targetType: null, cost: 0 };
+  }
+  // Find next unit in this upgrade chain: requires the same tech that obsoleted us,
+  // and is not itself already obsoleted by a further tech.
+  const nextEntry = TRAINABLE_UNITS.find(u =>
+    u.techRequired === currentEntry.obsoletedByTech &&
+    (!u.obsoletedByTech || !completedTechs.includes(u.obsoletedByTech))
+  );
+  if (!nextEntry) return { canUpgrade: false, targetType: null, cost: 0 };
+  return { canUpgrade: true, targetType: nextEntry.type, cost: getUpgradeCost(nextEntry.type) };
+}
+
+// Returns a new Unit with the upgraded type, full health, and action consumed.
+// Caller is responsible for deducting civ.gold by getUpgradeCost(targetType).
+export function applyUpgrade(unit: Unit, targetType: UnitType): Unit {
+  return {
+    ...unit,
+    type: targetType,
+    health: 100,
+    movementPointsLeft: 0,
+    hasActed: true,
+  };
+}

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -230,57 +230,6 @@ export function createCityPanel(
 
   container.appendChild(panel);
 
-  // Upgradeable units section — units standing on this city tile that can be upgraded
-  // completedTechs is already declared above (line ~79); reuse it here
-  const upgradeableUnits = Object.values(state.units).filter(u =>
-    u.owner === city.owner &&
-    u.position.q === city.position.q &&
-    u.position.r === city.position.r &&
-    canUpgradeUnit(u, city.id, state.cities, completedTechs).canUpgrade,
-  );
-
-  if (upgradeableUnits.length > 0 && callbacks.onUpgradeUnit) {
-    const upgradeSection = document.createElement('div');
-    upgradeSection.style.cssText = 'margin-top:16px;';
-
-    const header = document.createElement('div');
-    header.style.cssText = 'font-size:12px;font-weight:bold;color:#a78bfa;margin-bottom:8px;';
-    header.textContent = 'Upgradeable Units';
-    upgradeSection.appendChild(header);
-
-    for (const u of upgradeableUnits) {
-      const upgrade = canUpgradeUnit(u, city.id, state.cities, completedTechs);
-      if (!upgrade.canUpgrade || !upgrade.targetType) continue;
-
-      const row = document.createElement('div');
-      row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;margin-bottom:6px;';
-
-      const info = document.createElement('span');
-      info.style.cssText = 'font-size:12px;';
-      const currentName = UNIT_DEFINITIONS[u.type]?.name ?? u.type;
-      const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
-      const cost = getUpgradeCost(upgrade.targetType);
-      info.textContent = `${currentName} → ${targetName} (${cost} gold)`;
-
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.textContent = 'Upgrade';
-      btn.style.cssText = 'padding:4px 10px;border-radius:6px;background:#7c3aed;border:none;color:white;cursor:pointer;font-size:11px;';
-      btn.addEventListener('click', () => callbacks.onUpgradeUnit!(u.id));
-
-      row.appendChild(info);
-      row.appendChild(btn);
-      upgradeSection.appendChild(row);
-    }
-
-    const listViewEl = panel.querySelector('#city-list-view');
-    if (listViewEl) {
-      listViewEl.appendChild(upgradeSection);
-    } else {
-      panel.appendChild(upgradeSection);
-    }
-  }
-
   const rerenderPanel = (nextState: GameState | void = state, nextTab: CityPanelTab = 'list') => {
     const renderState = nextState ?? state;
     const refreshedCity = renderState.cities[city.id];
@@ -403,6 +352,63 @@ export function createCityPanel(
 
   if (initialTab === 'grid') {
     activateGridTab();
+  }
+
+  // Upgradeable units section — computed and rendered after rerenderPanel is defined
+  // so click handlers can call rerenderPanel() to refresh after upgrade.
+  if (callbacks.onUpgradeUnit) {
+    const civGold = state.civilizations[city.owner]?.gold ?? 0;
+    const upgradeEntries = Object.values(state.units)
+      .map(u => ({ u, upgrade: canUpgradeUnit(u, city.id, state.cities, completedTechs, civGold) }))
+      .filter(({ u, upgrade }) =>
+        u.owner === city.owner &&
+        u.position.q === city.position.q &&
+        u.position.r === city.position.r &&
+        upgrade.canUpgrade,
+      );
+
+    if (upgradeEntries.length > 0) {
+      const upgradeSection = document.createElement('div');
+      upgradeSection.style.cssText = 'margin-top:16px;';
+
+      const header = document.createElement('div');
+      header.style.cssText = 'font-size:12px;font-weight:bold;color:#a78bfa;margin-bottom:8px;';
+      header.textContent = 'Upgradeable Units';
+      upgradeSection.appendChild(header);
+
+      for (const { u, upgrade } of upgradeEntries) {
+        if (!upgrade.targetType) continue;
+
+        const row = document.createElement('div');
+        row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;margin-bottom:6px;';
+
+        const info = document.createElement('span');
+        info.style.cssText = 'font-size:12px;';
+        const currentName = UNIT_DEFINITIONS[u.type]?.name ?? u.type;
+        const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+        info.textContent = `${currentName} → ${targetName} (${upgrade.cost} gold)`;
+
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Upgrade';
+        btn.style.cssText = 'padding:4px 10px;border-radius:6px;background:#7c3aed;border:none;color:white;cursor:pointer;font-size:11px;';
+        btn.addEventListener('click', () => {
+          callbacks.onUpgradeUnit!(u.id);
+          rerenderPanel();
+        });
+
+        row.appendChild(info);
+        row.appendChild(btn);
+        upgradeSection.appendChild(row);
+      }
+
+      const listViewEl = panel.querySelector('#city-list-view');
+      if (listViewEl) {
+        listViewEl.appendChild(upgradeSection);
+      } else {
+        panel.appendChild(upgradeSection);
+      }
+    }
   }
 
   return panel;

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -1,5 +1,7 @@
 import type { City, CityFocus, GameState, HexCoord } from '@/core/types';
 import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
@@ -15,6 +17,7 @@ export interface CityPanelCallbacks {
   onClose: () => void;
   onPrevCity?: () => void;
   onNextCity?: () => void;
+  onUpgradeUnit?: (unitId: string) => void;
 }
 
 type CityPanelTab = 'list' | 'grid';
@@ -226,6 +229,57 @@ export function createCityPanel(
   });
 
   container.appendChild(panel);
+
+  // Upgradeable units section — units standing on this city tile that can be upgraded
+  // completedTechs is already declared above (line ~79); reuse it here
+  const upgradeableUnits = Object.values(state.units).filter(u =>
+    u.owner === city.owner &&
+    u.position.q === city.position.q &&
+    u.position.r === city.position.r &&
+    canUpgradeUnit(u, city.id, state.cities, completedTechs).canUpgrade,
+  );
+
+  if (upgradeableUnits.length > 0 && callbacks.onUpgradeUnit) {
+    const upgradeSection = document.createElement('div');
+    upgradeSection.style.cssText = 'margin-top:16px;';
+
+    const header = document.createElement('div');
+    header.style.cssText = 'font-size:12px;font-weight:bold;color:#a78bfa;margin-bottom:8px;';
+    header.textContent = 'Upgradeable Units';
+    upgradeSection.appendChild(header);
+
+    for (const u of upgradeableUnits) {
+      const upgrade = canUpgradeUnit(u, city.id, state.cities, completedTechs);
+      if (!upgrade.canUpgrade || !upgrade.targetType) continue;
+
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;margin-bottom:6px;';
+
+      const info = document.createElement('span');
+      info.style.cssText = 'font-size:12px;';
+      const currentName = UNIT_DEFINITIONS[u.type]?.name ?? u.type;
+      const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+      const cost = getUpgradeCost(upgrade.targetType);
+      info.textContent = `${currentName} → ${targetName} (${cost} gold)`;
+
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = 'Upgrade';
+      btn.style.cssText = 'padding:4px 10px;border-radius:6px;background:#7c3aed;border:none;color:white;cursor:pointer;font-size:11px;';
+      btn.addEventListener('click', () => callbacks.onUpgradeUnit!(u.id));
+
+      row.appendChild(info);
+      row.appendChild(btn);
+      upgradeSection.appendChild(row);
+    }
+
+    const listViewEl = panel.querySelector('#city-list-view');
+    if (listViewEl) {
+      listViewEl.appendChild(upgradeSection);
+    } else {
+      panel.appendChild(upgradeSection);
+    }
+  }
 
   const rerenderPanel = (nextState: GameState | void = state, nextTab: CityPanelTab = 'list') => {
     const renderState = nextState ?? state;

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -174,7 +174,7 @@ export function renderSelectedUnitInfo(
     }
   }
 
-  if (callbacks.onUpgradeUnit) {
+  if (callbacks.onUpgradeUnit && !unit.hasActed) {
     const homeCity = Object.values(state.cities).find(
       c => c.owner === unit.owner &&
            c.position.q === unit.position.q &&
@@ -182,7 +182,8 @@ export function renderSelectedUnitInfo(
     );
     if (homeCity) {
       const completedTechs = state.civilizations[unit.owner]?.techState?.completed ?? [];
-      const upgrade = canUpgradeUnit(unit, homeCity.id, state.cities, completedTechs);
+      const civGold = state.civilizations[unit.owner]?.gold ?? 0;
+      const upgrade = canUpgradeUnit(unit, homeCity.id, state.cities, completedTechs, civGold);
       if (upgrade.canUpgrade && upgrade.targetType) {
         const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
         const btn = makeButton(

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -1,6 +1,7 @@
 import type { GameState, DisguiseType } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
+import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
 import { canBuildImprovement } from '@/systems/improvement-system';
 import { hexKey } from '@/systems/hex-utils';
 
@@ -14,6 +15,7 @@ export interface SelectedUnitInfoCallbacks {
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
   onInfiltrate?: (unitId: string) => void;
   onEmbed?: (unitId: string) => void;
+  onUpgradeUnit?: (unitId: string, cityId: string) => void;
 }
 
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
@@ -169,6 +171,27 @@ export function renderSelectedUnitInfo(
     );
     if (ownCityHere && spyRecord?.status === 'idle' && !unit.hasActed) {
       actionsDiv.appendChild(makeButton('Embed (counter-espionage)', '#374151', () => callbacks.onEmbed!(unitId)));
+    }
+  }
+
+  if (callbacks.onUpgradeUnit) {
+    const homeCity = Object.values(state.cities).find(
+      c => c.owner === unit.owner &&
+           c.position.q === unit.position.q &&
+           c.position.r === unit.position.r,
+    );
+    if (homeCity) {
+      const completedTechs = state.civilizations[unit.owner]?.techState?.completed ?? [];
+      const upgrade = canUpgradeUnit(unit, homeCity.id, state.cities, completedTechs);
+      if (upgrade.canUpgrade && upgrade.targetType) {
+        const targetName = UNIT_DEFINITIONS[upgrade.targetType].name;
+        const btn = makeButton(
+          `Upgrade → ${targetName} (${upgrade.cost} gold)`,
+          '#7c3aed',
+          () => callbacks.onUpgradeUnit!(unitId, homeCity.id),
+        );
+        actionsDiv.appendChild(btn);
+      }
     }
   }
 

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { canUpgradeUnit, getUpgradeCost, applyUpgrade } from '@/systems/unit-upgrade-system';
-import type { Unit } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
+import type { GameState, Spy, Unit } from '@/core/types';
 
 function makeUnit(type: string, position = { q: 0, r: 0 }): Unit {
   return { id: 'u1', type: type as any, owner: 'player', position, health: 70, movementPointsLeft: 2, hasActed: false, hasMoved: false };
@@ -45,5 +47,102 @@ describe('applyUpgrade', () => {
     expect(upgraded.health).toBe(100);
     expect(upgraded.hasActed).toBe(true);
     expect(upgraded.movementPointsLeft).toBe(0);
+  });
+});
+
+// ─── Obsolescence helpers ───────────────────────────────────────────────────
+
+function makeTestSpy(overrides: Partial<Spy> = {}): Spy {
+  return {
+    id: 'spy1', owner: 'player', name: 'Agent Fox',
+    unitType: 'spy_scout', targetCivId: null, targetCityId: null,
+    position: null, status: 'embedded', experience: 0,
+    currentMission: null, cooldownTurns: 0, promotionAvailable: false,
+    ...overrides,
+  };
+}
+
+// Minimal GameState where espionage-informants completes this turn.
+// researchProgress = 80 = cost, so 80 + 0 >= 80 → completes with 0 science.
+function makeObsolescenceState(overrides: {
+  unitOnMap?: boolean;
+  spyStatus?: 'embedded' | 'stationed' | 'on_mission';
+} = {}): GameState {
+  const civId = 'player';
+  const spy = makeTestSpy({ status: overrides.spyStatus ?? 'embedded' });
+  const mapUnit = {
+    id: 'u1', type: 'spy_scout' as const, owner: civId,
+    position: { q: 0, r: 0 }, health: 100, movementPointsLeft: 2,
+    hasActed: false, hasMoved: false,
+  };
+  return {
+    turn: 1, era: 1, currentPlayer: civId, hotSeat: false,
+    gameOver: false, winner: null,
+    map: { width: 5, height: 5, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: overrides.unitOnMap ? { u1: mapUnit } : {},
+    cities: {},
+    civilizations: {
+      [civId]: {
+        id: civId, name: 'Rome', color: '#c00', isHuman: true, civType: 'rome',
+        cities: [], units: overrides.unitOnMap ? ['u1'] : [],
+        techState: {
+          completed: ['espionage-scouting'],
+          currentResearch: 'espionage-informants',
+          researchProgress: 80, // at cost threshold — completes with 0 science
+          researchQueue: [],
+          trackPriorities: {} as any,
+        },
+        gold: 0,
+        visibility: { tiles: {} },
+        score: 0,
+        diplomacy: {
+          relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0,
+          vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 },
+        },
+      },
+    },
+    espionage: {
+      [civId]: { spies: { spy1: spy }, maxSpies: 2, counterIntelligence: {} },
+    },
+    barbarianCamps: {}, minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+  } as unknown as GameState;
+}
+
+describe('obsolescence notifications', () => {
+  it('emits unit:obsolete for map spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ unitOnMap: true });
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('unit:obsolete', e => events.push(e));
+    processTurn(state, bus);
+    expect(events.length).toBeGreaterThan(0);
+  });
+
+  it('silently removes embedded spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'embedded' });
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    const spies = Object.values(next.espionage?.['player']?.spies ?? {});
+    expect(spies.filter(s => s.unitType === 'spy_scout')).toHaveLength(0);
+  });
+
+  it('silently removes stationed spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'stationed' });
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    const spies = Object.values(next.espionage?.['player']?.spies ?? {});
+    expect(spies.filter(s => s.unitType === 'spy_scout')).toHaveLength(0);
+  });
+
+  it('silently removes on_mission spy_scout when espionage-informants completes', () => {
+    const state = makeObsolescenceState({ spyStatus: 'on_mission' });
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    const spies = Object.values(next.espionage?.['player']?.spies ?? {});
+    expect(spies.filter(s => s.unitType === 'spy_scout')).toHaveLength(0);
   });
 });

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { canUpgradeUnit, getUpgradeCost, applyUpgrade } from '@/systems/unit-upgrade-system';
+import type { Unit } from '@/core/types';
+
+function makeUnit(type: string, position = { q: 0, r: 0 }): Unit {
+  return { id: 'u1', type: type as any, owner: 'player', position, health: 70, movementPointsLeft: 2, hasActed: false, hasMoved: false };
+}
+
+describe('canUpgradeUnit', () => {
+  it('spy_scout upgrades to spy_informant when espionage-informants researched', () => {
+    const unit = makeUnit('spy_scout', { q: 0, r: 0 });
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
+    const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting', 'espionage-informants']);
+    expect(result.canUpgrade).toBe(true);
+    expect(result.targetType).toBe('spy_informant');
+  });
+
+  it('spy_scout does not upgrade when espionage-informants not researched', () => {
+    const unit = makeUnit('spy_scout', { q: 0, r: 0 });
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
+    const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting']);
+    expect(result.canUpgrade).toBe(false);
+  });
+
+  it('cannot upgrade unit not standing on the city tile', () => {
+    const unit = makeUnit('spy_scout', { q: 5, r: 5 });
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
+    const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting', 'espionage-informants']);
+    expect(result.canUpgrade).toBe(false);
+  });
+});
+
+describe('getUpgradeCost', () => {
+  it('returns half of the target unit production cost', () => {
+    const cost = getUpgradeCost('spy_informant');
+    expect(cost).toBe(25); // spy_informant costs 50 in TRAINABLE_UNITS, half = 25
+  });
+});
+
+describe('applyUpgrade', () => {
+  it('changes unit type, heals to full health, and consumes action', () => {
+    const unit = makeUnit('spy_scout');
+    const upgraded = applyUpgrade(unit, 'spy_informant');
+    expect(upgraded.type).toBe('spy_informant');
+    expect(upgraded.health).toBe(100);
+    expect(upgraded.hasActed).toBe(true);
+    expect(upgraded.movementPointsLeft).toBe(0);
+  });
+});

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -5,7 +5,7 @@ import { processTurn } from '@/core/turn-manager';
 import type { GameState, Spy, Unit } from '@/core/types';
 
 function makeUnit(type: string, position = { q: 0, r: 0 }): Unit {
-  return { id: 'u1', type: type as any, owner: 'player', position, health: 70, movementPointsLeft: 2, hasActed: false, hasMoved: false };
+  return { id: 'u1', type: type as any, owner: 'player', position, health: 70, movementPointsLeft: 2, hasActed: false, hasMoved: false, experience: 0, isResting: false };
 }
 
 describe('canUpgradeUnit', () => {
@@ -30,6 +30,21 @@ describe('canUpgradeUnit', () => {
     const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting', 'espionage-informants']);
     expect(result.canUpgrade).toBe(false);
   });
+
+  it('reports canUpgrade:false when civGold is below cost', () => {
+    const unit = makeUnit('spy_scout', { q: 0, r: 0 });
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
+    const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting', 'espionage-informants'], 10);
+    expect(result.canUpgrade).toBe(false);
+  });
+
+  it('reports canUpgrade:true when civGold exactly meets cost', () => {
+    const unit = makeUnit('spy_scout', { q: 0, r: 0 });
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 } } as any;
+    const result = canUpgradeUnit(unit, 'c1', { 'c1': city }, ['espionage-scouting', 'espionage-informants'], 25);
+    expect(result.canUpgrade).toBe(true);
+    expect(result.cost).toBe(25);
+  });
 });
 
 describe('getUpgradeCost', () => {
@@ -47,6 +62,14 @@ describe('applyUpgrade', () => {
     expect(upgraded.health).toBe(100);
     expect(upgraded.hasActed).toBe(true);
     expect(upgraded.movementPointsLeft).toBe(0);
+  });
+
+  it('preserves identity fields (id, owner, position) so spy record can sync by unitId', () => {
+    const unit = makeUnit('spy_scout', { q: 3, r: 4 });
+    const upgraded = applyUpgrade(unit, 'spy_informant');
+    expect(upgraded.id).toBe(unit.id);
+    expect(upgraded.owner).toBe(unit.owner);
+    expect(upgraded.position).toEqual({ q: 3, r: 4 });
   });
 });
 
@@ -73,7 +96,7 @@ function makeObsolescenceState(overrides: {
   const mapUnit = {
     id: 'u1', type: 'spy_scout' as const, owner: civId,
     position: { q: 0, r: 0 }, health: 100, movementPointsLeft: 2,
-    hasActed: false, hasMoved: false,
+    hasActed: false, hasMoved: false, experience: 0, isResting: false,
   };
   return {
     turn: 1, era: 1, currentPlayer: civId, hotSeat: false,


### PR DESCRIPTION
## Summary

- **New `unit-upgrade-system.ts`**: `canUpgradeUnit` / `getUpgradeCost` / `applyUpgrade` — finds the next unit in the upgrade chain when the obsoleting tech is researched, enforces position + ownership + tech + gold gates
- **Obsolescence notifications**: `turn-manager.ts` emits `unit:obsolete` for on-map units and silently removes expired embedded/stationed/on-mission spies when their era tech completes; `main.ts` shows player-facing notification
- **Upgrade UI**: upgrade buttons surface in both the selected-unit panel and city panel; clicking deducts gold, upgrades unit type, syncs spy record `unitType` so exfiltration recreates the right unit, and refreshes render
- **Gold gate at system layer**: `canUpgradeUnit` accepts optional `civGold` — buttons are hidden when the player can't afford the upgrade, not just blocked on click

## Test plan

- [x] `canUpgradeUnit` — upgrades with tech, blocked without tech, blocked off-tile, blocked when gold < cost, allowed at exact cost
- [x] `getUpgradeCost` — returns half of target unit's production cost
- [x] `applyUpgrade` — new type, full health, hasActed=true, movementPoints=0, identity fields preserved
- [x] Obsolescence: `unit:obsolete` fires for on-map spy_scout; embedded/stationed/on_mission spies removed silently
- [x] `yarn test` — 1271 passing
- [x] `yarn build` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)