### PR TITLE
feat(espionage): MR9 — Safehouse, Intelligence Agency, Security Bureau

### DIFF
--- a/docs/superpowers/plans/espionage-overhaul/mr-09-espionage-buildings.md
+++ b/docs/superpowers/plans/espionage-overhaul/mr-09-espionage-buildings.md
@@ -4,7 +4,7 @@
 
 **Goal:** Three espionage-category buildings boost spy training, counter-intelligence, and captive handling. CI bonuses from older-era buildings fade when later-era security techs are researched (era adaptation mechanic).
 
-**Prerequisite MRs:** MR 1–7 (`setCounterIntelligence` module-private helper defined in MR 7)
+**Prerequisite MRs:** MR 1–7 (`setCounterIntelligence` is **exported** from `espionage-system.ts` — `applyBuildingCI` lives in the same file so it can call `setCounterIntelligence` directly with no additional import)
 
 **Buildings:**
 
@@ -21,6 +21,7 @@
 **Files:**
 - Modify: `src/systems/city-system.ts`
 - Modify: `src/systems/espionage-system.ts`
+- Modify: `src/core/turn-manager.ts`
 - Create: `tests/systems/espionage-buildings.test.ts`
 
 - [ ] **Step 1: Write failing tests**
@@ -29,24 +30,23 @@ Create `tests/systems/espionage-buildings.test.ts`:
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { processCity, BUILDING_DEFINITIONS } from '@/systems/city-system';
-import { applyBuildingCI } from '@/systems/espionage-system';
-import { createEspionageCivState } from '@/systems/espionage-system';
+import { processCity, BUILDINGS } from '@/systems/city-system';
+import { applyBuildingCI, createEspionageCivState } from '@/systems/espionage-system';
 
 describe('espionage building definitions', () => {
   it('safehouse is defined with espionage category', () => {
-    expect(BUILDING_DEFINITIONS['safehouse']).toBeDefined();
-    expect(BUILDING_DEFINITIONS['safehouse'].category).toBe('espionage');
+    expect(BUILDINGS['safehouse']).toBeDefined();
+    expect(BUILDINGS['safehouse'].category).toBe('espionage');
   });
 
   it('intelligence-agency is defined with espionage category', () => {
-    expect(BUILDING_DEFINITIONS['intelligence-agency']).toBeDefined();
-    expect(BUILDING_DEFINITIONS['intelligence-agency'].techRequired).toBe('espionage-informants');
+    expect(BUILDINGS['intelligence-agency']).toBeDefined();
+    expect(BUILDINGS['intelligence-agency'].techRequired).toBe('espionage-informants');
   });
 
   it('security-bureau is defined with espionage category', () => {
-    expect(BUILDING_DEFINITIONS['security-bureau']).toBeDefined();
-    expect(BUILDING_DEFINITIONS['security-bureau'].techRequired).toBe('counter-intelligence');
+    expect(BUILDINGS['security-bureau']).toBeDefined();
+    expect(BUILDINGS['security-bureau'].techRequired).toBe('counter-intelligence');
   });
 });
 
@@ -65,6 +65,13 @@ describe('applyBuildingCI', () => {
     expect(result.counterIntelligence['c1']).toBe(10);
   });
 
+  it('city without intelligence-agency gets no CI from that building', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: [] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBeUndefined();
+  });
+
   it('security-bureau gives +30 CI per turn', () => {
     const civEsp = createEspionageCivState();
     const city = { id: 'c1', buildings: ['security-bureau'] } as any;
@@ -79,10 +86,72 @@ describe('applyBuildingCI', () => {
     expect(result.counterIntelligence['c1']).toBe(15);
   });
 
-  it('safehouse reduces spy training cost by 25%', () => {
-    const city = { id: 'c1', buildings: ['safehouse'] } as any;
-    // processCity with spy_scout in queue should cost ~23 instead of 30
-    // (test the applyProductionBonus integration)
+  it('city without security-bureau gets no CI from that building', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: [] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBeUndefined();
+  });
+
+  it('both buildings stack CI', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(50); // 20 + 30
+  });
+
+  it('CI is capped at 100', () => {
+    const civEsp = { ...createEspionageCivState(), counterIntelligence: { c1: 90 } };
+    const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(100);
+  });
+});
+
+describe('safehouse spy training cost reduction', () => {
+  const baseCity = {
+    id: 'c1',
+    food: 0, foodNeeded: 10, population: 1,
+    productionProgress: 0,
+    productionQueue: ['spy_scout'],
+    buildings: ['safehouse'],
+    ownedTiles: [],
+    buildingGrid: {},
+  } as any;
+
+  const baseMap = { tiles: {}, width: 10, height: 10, wrap: false } as any;
+
+  it('safehouse reduces spy_scout training cost by 25% (30 → 23)', () => {
+    // spy_scout costs 30; with safehouse 25% discount: ceil(30 * 0.75) = 23
+    const city = { ...baseCity, productionProgress: 22 };
+    const result = processCity(city, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    // Progress 22 < 23 — not complete yet
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, productionProgress: 23 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result2.completedUnit).toBe('spy_scout');
+  });
+
+  it('safehouse does NOT reduce training cost for non-spy units', () => {
+    // warrior costs 8; safehouse discount should not apply
+    const city = { ...baseCity, productionQueue: ['warrior'], productionProgress: 7 };
+    const result = processCity(city, baseMap, 0, 0, undefined, []);
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, productionQueue: ['warrior'], productionProgress: 8 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, []);
+    expect(result2.completedUnit).toBe('warrior');
+  });
+
+  it('without safehouse spy_scout requires full 30 production', () => {
+    const city = { ...baseCity, buildings: [], productionProgress: 29 };
+    const result = processCity(city, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, buildings: [], productionProgress: 30 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result2.completedUnit).toBe('spy_scout');
   });
 });
 ```
@@ -90,58 +159,80 @@ describe('applyBuildingCI', () => {
 - [ ] **Step 2: Run to verify failure**
 
 ```bash
-yarn test tests/systems/espionage-buildings.test.ts
+bash scripts/run-with-mise.sh yarn test tests/systems/espionage-buildings.test.ts
 ```
 
 - [ ] **Step 3: Add building definitions to `src/systems/city-system.ts`**
 
-In `BUILDING_DEFINITIONS`, add:
+In `BUILDINGS`, add an `// Espionage` section after the Culture section (after the closing `forum` entry, before the `};` that closes the object):
 
 ```typescript
-safehouse: {
-  id: 'safehouse', name: 'Safehouse', category: 'espionage',
-  yields: { food: 0, production: 0, gold: 0, science: 0 },
-  productionCost: 50,
-  description: 'Reduces spy unit training cost by 25%.',
-  techRequired: 'espionage-scouting', adjacencyBonuses: [],
-},
-'intelligence-agency': {
-  id: 'intelligence-agency', name: 'Intelligence Agency', category: 'espionage',
-  yields: { food: 0, production: 0, gold: 0, science: 0 },
-  productionCost: 80,
-  description: 'Raises this city\'s counter-intelligence score by 20 each turn (max 100). Bonus halves when digital-surveillance era is reached.',
-  techRequired: 'espionage-informants', adjacencyBonuses: [],
-},
-'security-bureau': {
-  id: 'security-bureau', name: 'Security Bureau', category: 'espionage',
-  yields: { food: 0, production: 0, gold: 0, science: 0 },
-  productionCost: 120,
-  description: 'Raises CI by 30 each turn and makes captured spies 50% less likely to be turned. Bonus halves at cyber-warfare era.',
-  techRequired: 'counter-intelligence', adjacencyBonuses: [],
-},
+  // Espionage
+  safehouse: {
+    id: 'safehouse', name: 'Safehouse', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 50,
+    description: 'Reduces spy unit training cost by 25%.',
+    techRequired: 'espionage-scouting', adjacencyBonuses: [],
+  },
+  'intelligence-agency': {
+    id: 'intelligence-agency', name: 'Intelligence Agency', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 80,
+    description: "Raises this city's counter-intelligence score by 20 each turn (max 100). Bonus halves when digital-surveillance era is reached.",
+    techRequired: 'espionage-informants', adjacencyBonuses: [],
+  },
+  'security-bureau': {
+    id: 'security-bureau', name: 'Security Bureau', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 120,
+    description: 'Raises CI by 30 each turn and makes captured spies 50% less likely to be turned. Bonus halves at cyber-warfare era.',
+    techRequired: 'counter-intelligence', adjacencyBonuses: [],
+  },
 ```
 
 - [ ] **Step 4: Wire Safehouse 25% spy training cost reduction in `src/systems/city-system.ts`**
 
-In `processCity`, in the unit production cost calculation, check if the city has a safehouse and the unit being trained is a spy type:
+First add an import for `isSpyUnitType` at the top of `city-system.ts` (alongside the existing imports):
 
 ```typescript
-let effectiveCost = unitDef.cost;
-if (city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType)) {
-  effectiveCost = Math.ceil(effectiveCost * 0.75);
-}
+import { isSpyUnitType } from './espionage-system';
 ```
 
-Import `isSpyUnitType` from `espionage-system.ts`.
+Then in `processCity`, find the existing unit cost block (the lines that check `unitDef` and compare to `Math.round(unitDef.cost * unitCostMult)`):
+
+**Before:**
+```typescript
+    const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
+    const unitCostMult = unitDef ? applyProductionBonus(currentItem, bonusEffect) : 1;
+    if (unitDef && newProgress >= Math.round(unitDef.cost * unitCostMult)) {
+      newQueue.shift();
+      newProgress = 0;
+      completedUnit = unitDef.type;
+    }
+```
+
+**After:**
+```typescript
+    const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
+    const unitCostMult = unitDef ? applyProductionBonus(currentItem, bonusEffect) : 1;
+    const safehouseMult = (unitDef && city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType))
+      ? 0.75
+      : 1;
+    if (unitDef && newProgress >= Math.ceil(unitDef.cost * unitCostMult * safehouseMult)) {
+      newQueue.shift();
+      newProgress = 0;
+      completedUnit = unitDef.type;
+    }
+```
+
+Use `Math.ceil` so that 30 × 0.75 = 22.5 rounds up to 23, matching the test.
 
 - [ ] **Step 5: Add `applyBuildingCI` to `src/systems/espionage-system.ts`**
 
-```typescript
-const ERA_CI_FADE_TRIGGERS: Record<string, string[]> = {
-  'digital-surveillance': ['intelligence-agency'],
-  'cyber-warfare': ['security-bureau'],
-};
+Add after the `setCounterIntelligence` export (currently around line 755):
 
+```typescript
 export function applyBuildingCI(
   cityId: string,
   city: { buildings: string[] },
@@ -163,41 +254,88 @@ export function applyBuildingCI(
 }
 ```
 
+`setCounterIntelligence` is already exported from this file — call it directly, no additional import needed.
+
 - [ ] **Step 6: Wire `applyBuildingCI` in `src/core/turn-manager.ts`**
 
-In the espionage turn processing loop, after the embedded spy CI contribution block:
+Extend the existing espionage import line (line 40) to include `applyBuildingCI`:
 
 ```typescript
-import { applyBuildingCI } from '@/systems/espionage-system';
-
-// For each city owned by this civ, apply building CI bonuses
-for (const cityId of civ.cities) {
-  const city = newState.cities[cityId];
-  if (!city || !newState.espionage?.[civId]) continue;
-  newState.espionage![civId] = applyBuildingCI(cityId, city, newState.espionage![civId], civ.techState.completed);
-}
+import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 ```
 
-- [ ] **Step 7: Wire Security Bureau's turning resistance**
-
-In `processEspionageTurn`, before calling `turnCapturedSpy`, check if the captured spy's target city has a security bureau. If so, skip the turning (return early from that branch):
+Then add a new block **immediately after** the embedded-spy per-turn CI block (the `{ let espionage = newState.espionage ?? {}; ... newState = { ...newState, espionage }; }` block that ends around line 583). Use the same spread pattern — never mutate `newState.espionage![civId]` directly:
 
 ```typescript
-const targetCity = gameState.cities[spy.targetCityId ?? ''];
-const hasSecurityBureau = targetCity?.buildings.includes('security-bureau') ?? false;
-if (hasSecurityBureau && rng() < 0.5) {
-  // Security bureau blocks the turning attempt
-  continue;
-}
+  // Building CI bonuses per turn (Intelligence Agency + Security Bureau)
+  {
+    let espionage = newState.espionage ?? {};
+    for (const [civId, civ] of Object.entries(newState.civilizations)) {
+      if (!espionage[civId]) continue;
+      for (const cityId of civ.cities) {
+        const city = newState.cities[cityId];
+        if (!city) continue;
+        const updated = applyBuildingCI(cityId, city, espionage[civId], civ.techState.completed);
+        if (updated !== espionage[civId]) {
+          espionage = { ...espionage, [civId]: updated };
+        }
+      }
+    }
+    newState = { ...newState, espionage };
+  }
 ```
+
+- [ ] **Step 7: Wire Security Bureau's turning resistance in `src/systems/espionage-system.ts`**
+
+In `processEspionageTurn` (around line 1059), find the captured spy turning block:
+
+```typescript
+      if (spy.status === 'captured' && !spy.turnedBy && captorId && canTurnCapturedSpy) {
+        state.espionage = turnCapturedSpy(state.espionage!, captorId, civId, spy.id, state.turn);
+        bus.emit('espionage:spy-detected', {
+          detectingCivId: captorId,
+          spyOwner: civId,
+          spyId: spy.id,
+          cityId: spy.targetCityId ?? '',
+        });
+      }
+```
+
+Replace with:
+
+```typescript
+      if (spy.status === 'captured' && !spy.turnedBy && captorId && canTurnCapturedSpy) {
+        const targetCity = spy.targetCityId ? state.cities[spy.targetCityId] : null;
+        const hasSecurityBureau = targetCity?.buildings.includes('security-bureau') ?? false;
+        if (hasSecurityBureau) {
+          const turnRng = createRng(`sec-bureau-${spy.id}-${state.turn}`);
+          if (turnRng() < 0.5) continue; // Security bureau blocks 50% of turning attempts
+        }
+        state.espionage = turnCapturedSpy(state.espionage!, captorId, civId, spy.id, state.turn);
+        bus.emit('espionage:spy-detected', {
+          detectingCivId: captorId,
+          spyOwner: civId,
+          spyId: spy.id,
+          cityId: spy.targetCityId ?? '',
+        });
+      }
+```
+
+`createRng` is already imported at the top of `espionage-system.ts`. Use `state.cities` (the function parameter name) — not `gameState`.
 
 - [ ] **Step 8: Run full test suite**
 
 ```bash
-yarn test
+bash scripts/run-with-mise.sh yarn test
 ```
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 9: Type-check**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+
+- [ ] **Step 10: Commit**
 
 ```bash
 git add src/systems/city-system.ts src/systems/espionage-system.ts src/core/turn-manager.ts tests/systems/espionage-buildings.test.ts

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -37,7 +37,7 @@ import { createRng } from '@/systems/map-generator';
 import { processMinorCivTurn, checkEraAdvancement, processMinorCivEraUpgrade, checkCampEvolution } from '@/systems/minor-civ-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyProductionBonus } from '@/systems/city-system';
-import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation } from '@/systems/espionage-system';
+import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
@@ -577,6 +577,23 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       }
       if (changed) {
         espionage = { ...espionage, [civId]: { ...civEsp, counterIntelligence: ci } };
+      }
+    }
+    newState = { ...newState, espionage };
+  }
+
+  // Building CI bonuses per turn (Intelligence Agency + Security Bureau)
+  {
+    let espionage = newState.espionage ?? {};
+    for (const [civId, civ] of Object.entries(newState.civilizations)) {
+      if (!espionage[civId]) continue;
+      for (const cityId of civ.cities) {
+        const city = newState.cities[cityId];
+        if (!city) continue;
+        const updated = applyBuildingCI(cityId, city, espionage[civId], civ.techState.completed);
+        if (updated !== espionage[civId]) {
+          espionage = { ...espionage, [civId]: updated };
+        }
       }
     }
     newState = { ...newState, espionage };

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -264,14 +264,19 @@ export function processCity(
 
     // Check if it's a unit
     const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    const unitCostMult = unitDef ? applyProductionBonus(currentItem, bonusEffect) : 1;
-    const safehouseMult = (unitDef && city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType))
-      ? 0.75
-      : 1;
-    if (unitDef && newProgress >= Math.ceil(unitDef.cost * unitCostMult * safehouseMult)) {
-      newQueue.shift();
-      newProgress = 0;
-      completedUnit = unitDef.type;
+    if (unitDef) {
+      const unitCostMult = applyProductionBonus(currentItem, bonusEffect);
+      const safehouseMult = (city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType))
+        ? 0.75
+        : 1;
+      const effectiveCost = safehouseMult < 1
+        ? Math.ceil(unitDef.cost * unitCostMult * safehouseMult)
+        : Math.round(unitDef.cost * unitCostMult);
+      if (newProgress >= effectiveCost) {
+        newQueue.shift();
+        newProgress = 0;
+        completedUnit = unitDef.type;
+      }
     }
   }
 

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1,4 +1,5 @@
 import type { City, Building, HexCoord, GameMap, UnitType, CivBonusEffect, TrainableUnitEntry } from '@/core/types';
+import { isSpyUnitType } from './espionage-system';
 import { hexKey, hexesInRange, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
@@ -46,6 +47,29 @@ export const BUILDINGS: Record<string, Building> = {
   amphitheater: { id: 'amphitheater', name: 'Amphitheater', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 1 }, productionCost: 85, description: 'Entertainment and culture', techRequired: 'drama-poetry', adjacencyBonuses: [] },
   shrine: { id: 'shrine', name: 'Shrine', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 8, description: 'Place of worship', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'early-science', impact: 1, scope: 'city', snowball: 1.1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   forum: { id: 'forum', name: 'Forum', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 0 }, productionCost: 70, description: 'Public gathering place', techRequired: 'civil-service', adjacencyBonuses: [] },
+
+  // Espionage
+  safehouse: {
+    id: 'safehouse', name: 'Safehouse', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 50,
+    description: 'Reduces spy unit training cost by 25%.',
+    techRequired: 'espionage-scouting', adjacencyBonuses: [],
+  },
+  'intelligence-agency': {
+    id: 'intelligence-agency', name: 'Intelligence Agency', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 80,
+    description: "Raises this city's counter-intelligence score by 20 each turn (max 100). Bonus halves when digital-surveillance era is reached.",
+    techRequired: 'espionage-informants', adjacencyBonuses: [],
+  },
+  'security-bureau': {
+    id: 'security-bureau', name: 'Security Bureau', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 120,
+    description: 'Raises CI by 30 each turn and makes captured spies 50% less likely to be turned. Bonus halves at cyber-warfare era.',
+    techRequired: 'counter-intelligence', adjacencyBonuses: [],
+  },
 };
 
 export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pacing'] }> = [
@@ -241,7 +265,10 @@ export function processCity(
     // Check if it's a unit
     const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
     const unitCostMult = unitDef ? applyProductionBonus(currentItem, bonusEffect) : 1;
-    if (unitDef && newProgress >= Math.round(unitDef.cost * unitCostMult)) {
+    const safehouseMult = (unitDef && city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType))
+      ? 0.75
+      : 1;
+    if (unitDef && newProgress >= Math.ceil(unitDef.cost * unitCostMult * safehouseMult)) {
       newQueue.shift();
       newProgress = 0;
       completedUnit = unitDef.type;

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -771,7 +771,7 @@ export function applyBuildingCI(
   }
   if (ciBonus === 0) return civEsp;
   const current = civEsp.counterIntelligence[cityId] ?? 0;
-  return setCounterIntelligence(civEsp, cityId, Math.min(100, current + ciBonus));
+  return setCounterIntelligence(civEsp, cityId, current + ciBonus);
 }
 
 export function getSpyCaptureRelationshipPenalty(distanceToNearestCity: number): number {

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -754,6 +754,26 @@ export function setCounterIntelligence(
   };
 }
 
+export function applyBuildingCI(
+  cityId: string,
+  city: { buildings: string[] },
+  civEsp: EspionageCivState,
+  completedTechs: string[],
+): EspionageCivState {
+  let ciBonus = 0;
+  if (city.buildings.includes('intelligence-agency')) {
+    const faded = completedTechs.includes('digital-surveillance');
+    ciBonus += faded ? 10 : 20;
+  }
+  if (city.buildings.includes('security-bureau')) {
+    const faded = completedTechs.includes('cyber-warfare');
+    ciBonus += faded ? 15 : 30;
+  }
+  if (ciBonus === 0) return civEsp;
+  const current = civEsp.counterIntelligence[cityId] ?? 0;
+  return setCounterIntelligence(civEsp, cityId, Math.min(100, current + ciBonus));
+}
+
 export function getSpyCaptureRelationshipPenalty(distanceToNearestCity: number): number {
   if (distanceToNearestCity > 5) return 0;
   if (distanceToNearestCity > 1) return -10;
@@ -1058,6 +1078,12 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
       const captorTechs = captorId ? state.civilizations[captorId]?.techState.completed ?? [] : [];
       const canTurnCapturedSpy = captorTechs.includes('counter-intelligence') || captorTechs.includes('digital-surveillance');
       if (spy.status === 'captured' && !spy.turnedBy && captorId && canTurnCapturedSpy) {
+        const targetCity = spy.targetCityId ? state.cities[spy.targetCityId] : null;
+        const hasSecurityBureau = targetCity?.buildings.includes('security-bureau') ?? false;
+        if (hasSecurityBureau) {
+          const turnRng = createRng(`sec-bureau-${spy.id}-${state.turn}`);
+          if (turnRng() < 0.5) continue; // Security bureau blocks 50% of turning attempts
+        }
         state.espionage = turnCapturedSpy(state.espionage!, captorId, civId, spy.id, state.turn);
         bus.emit('espionage:spy-detected', {
           detectingCivId: captorId,

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -195,7 +195,7 @@ describe('expanded buildings', () => {
   it('all buildings have a category', () => {
     for (const building of Object.values(BUILDINGS)) {
       expect(building.category).toBeDefined();
-      expect(['production', 'food', 'science', 'economy', 'military', 'culture']).toContain(building.category);
+      expect(['production', 'food', 'science', 'economy', 'military', 'culture', 'espionage']).toContain(building.category);
     }
   });
 

--- a/tests/systems/espionage-buildings.test.ts
+++ b/tests/systems/espionage-buildings.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { processCity, BUILDINGS } from '@/systems/city-system';
+import { applyBuildingCI, createEspionageCivState } from '@/systems/espionage-system';
+
+describe('espionage building definitions', () => {
+  it('safehouse is defined with espionage category', () => {
+    expect(BUILDINGS['safehouse']).toBeDefined();
+    expect(BUILDINGS['safehouse'].category).toBe('espionage');
+  });
+
+  it('intelligence-agency is defined with espionage category', () => {
+    expect(BUILDINGS['intelligence-agency']).toBeDefined();
+    expect(BUILDINGS['intelligence-agency'].techRequired).toBe('espionage-informants');
+  });
+
+  it('security-bureau is defined with espionage category', () => {
+    expect(BUILDINGS['security-bureau']).toBeDefined();
+    expect(BUILDINGS['security-bureau'].techRequired).toBe('counter-intelligence');
+  });
+});
+
+describe('applyBuildingCI', () => {
+  it('intelligence-agency gives +20 CI per turn', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['intelligence-agency'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(20);
+  });
+
+  it('intelligence-agency CI halved (to +10) when digital-surveillance researched', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['intelligence-agency'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, ['digital-surveillance']);
+    expect(result.counterIntelligence['c1']).toBe(10);
+  });
+
+  it('city without intelligence-agency gets no CI from that building', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: [] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBeUndefined();
+  });
+
+  it('security-bureau gives +30 CI per turn', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(30);
+  });
+
+  it('security-bureau CI halved (to +15) when cyber-warfare researched', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, ['cyber-warfare']);
+    expect(result.counterIntelligence['c1']).toBe(15);
+  });
+
+  it('city without security-bureau gets no CI from that building', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: [] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBeUndefined();
+  });
+
+  it('both buildings stack CI', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(50); // 20 + 30
+  });
+
+  it('CI is capped at 100', () => {
+    const civEsp = { ...createEspionageCivState(), counterIntelligence: { c1: 90 } };
+    const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, []);
+    expect(result.counterIntelligence['c1']).toBe(100);
+  });
+});
+
+describe('safehouse spy training cost reduction', () => {
+  const baseCity = {
+    id: 'c1',
+    food: 0, foodNeeded: 10, population: 1,
+    productionProgress: 0,
+    productionQueue: ['spy_scout'],
+    buildings: ['safehouse'],
+    ownedTiles: [],
+    buildingGrid: {},
+  } as any;
+
+  const baseMap = { tiles: {}, width: 10, height: 10, wrap: false } as any;
+
+  it('safehouse reduces spy_scout training cost by 25% (30 → 23)', () => {
+    // spy_scout costs 30; with safehouse 25% discount: ceil(30 * 0.75) = 23
+    const city = { ...baseCity, productionProgress: 22 };
+    const result = processCity(city, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, productionProgress: 23 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result2.completedUnit).toBe('spy_scout');
+  });
+
+  it('safehouse does NOT reduce training cost for non-spy units', () => {
+    // warrior costs 8; safehouse discount should not apply
+    const city = { ...baseCity, productionQueue: ['warrior'], productionProgress: 7 };
+    const result = processCity(city, baseMap, 0, 0, undefined, []);
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, productionQueue: ['warrior'], productionProgress: 8 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, []);
+    expect(result2.completedUnit).toBe('warrior');
+  });
+
+  it('without safehouse spy_scout requires full 30 production', () => {
+    const city = { ...baseCity, buildings: [], productionProgress: 29 };
+    const result = processCity(city, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result.completedUnit).toBeNull();
+
+    const city2 = { ...baseCity, buildings: [], productionProgress: 30 };
+    const result2 = processCity(city2, baseMap, 0, 0, undefined, ['espionage-scouting']);
+    expect(result2.completedUnit).toBe('spy_scout');
+  });
+});

--- a/tests/systems/espionage-buildings.test.ts
+++ b/tests/systems/espionage-buildings.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { processCity, BUILDINGS } from '@/systems/city-system';
-import { applyBuildingCI, createEspionageCivState } from '@/systems/espionage-system';
+import { applyBuildingCI, createEspionageCivState, processEspionageTurn } from '@/systems/espionage-system';
+import { createRng } from '@/systems/map-generator';
+import { EventBus } from '@/core/event-bus';
+import type { GameState, Spy } from '@/core/types';
 
 describe('espionage building definitions', () => {
   it('safehouse is defined with espionage category', () => {
@@ -120,5 +123,145 @@ describe('safehouse spy training cost reduction', () => {
     const city2 = { ...baseCity, buildings: [], productionProgress: 30 };
     const result2 = processCity(city2, baseMap, 0, 0, undefined, ['espionage-scouting']);
     expect(result2.completedUnit).toBe('spy_scout');
+  });
+});
+
+// ─── Security bureau turning-resistance tests ─────────────────────────────────
+// The security bureau blocks 50% of turning attempts for captured spies.
+// Seed format: `sec-bureau-${spy.id}-${state.turn}`.
+// Deterministic values (precomputed from mulberry32):
+//   'sec-bureau-spy1-1' => 0.0535 (< 0.5  → BLOCK)
+//   'sec-bureau-spy1-2' => 0.9923 (>= 0.5 → ALLOW)
+
+function makeSpyTurningState(spyId: string, turn: number, hasSecurityBureau: boolean): GameState {
+  const spy: Spy = {
+    id: spyId,
+    owner: 'attacker',
+    name: 'Agent Shadow',
+    unitType: 'spy_scout',
+    targetCivId: 'defender',
+    targetCityId: 'city-1',
+    position: null,
+    status: 'captured',
+    experience: 0,
+    currentMission: null,
+    cooldownTurns: 0,
+    promotion: undefined,
+    promotionAvailable: false,
+    feedsFalseIntel: false,
+    disguiseAs: null,
+    infiltrationCityId: null,
+    cityVisionTurnsLeft: 0,
+    stolenTechFrom: {},
+  };
+
+  const defenderEsp = createEspionageCivState();
+  const attackerEsp = {
+    ...createEspionageCivState(),
+    spies: { [spyId]: spy },
+  };
+
+  return {
+    turn,
+    era: 1,
+    currentPlayer: 'attacker',
+    gameOver: false,
+    winner: null,
+    map: { width: 5, height: 5, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'Rome', owner: 'defender',
+        position: { q: 0, r: 0 }, population: 2, food: 0, foodNeeded: 10,
+        buildings: hasSecurityBureau ? ['security-bureau'] : [],
+        productionQueue: [], productionProgress: 0,
+        ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'city',
+        grid: [[null]], gridSize: 3,
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      },
+    },
+    civilizations: {
+      attacker: {
+        id: 'attacker', name: 'Attacker', color: '#ff0000',
+        isHuman: false, civType: 'rome',
+        cities: [], units: [],
+        techState: { completed: ['espionage-scouting'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, score: 0,
+        diplomacy: { relationships: { defender: -50 }, treaties: [], events: [], atWarWith: ['defender'], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
+      },
+      defender: {
+        id: 'defender', name: 'Defender', color: '#0000ff',
+        isHuman: false, civType: 'egypt',
+        cities: ['city-1'], units: [],
+        techState: { completed: ['counter-intelligence'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, score: 0,
+        diplomacy: { relationships: { attacker: -50 }, treaties: [], events: [], atWarWith: ['attacker'], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
+      },
+    },
+    espionage: {
+      attacker: attackerEsp,
+      defender: defenderEsp,
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+  } as GameState;
+}
+
+describe('security bureau — turning resistance (50% block)', () => {
+  it('seed sec-bureau-spy1-1 produces value < 0.5 (block path)', () => {
+    // Verify the seed math is deterministic and matches what processEspionageTurn uses
+    const val = createRng('sec-bureau-spy1-1')();
+    expect(val).toBeCloseTo(0.0535, 3);
+    expect(val).toBeLessThan(0.5); // should BLOCK turning
+  });
+
+  it('seed sec-bureau-spy1-2 produces value >= 0.5 (allow path)', () => {
+    const val = createRng('sec-bureau-spy1-2')();
+    expect(val).toBeCloseTo(0.9923, 3);
+    expect(val).toBeGreaterThanOrEqual(0.5); // should ALLOW turning
+  });
+
+  it('security bureau blocks turning when RNG < 0.5 (turn 1 → block)', () => {
+    // spy1, turn 1: RNG = 0.0535 < 0.5 → turning should be blocked
+    const state = makeSpyTurningState('spy1', 1, /* hasSecurityBureau */ true);
+    const bus = new EventBus();
+    const emitted: string[] = [];
+    bus.on('espionage:spy-detected', () => emitted.push('detected'));
+
+    const result = processEspionageTurn(state, bus);
+    // Spy should still be captured (not turned into a stationed double agent)
+    expect(result.espionage!['attacker'].spies['spy1'].status).toBe('captured');
+    expect(result.espionage!['attacker'].spies['spy1'].feedsFalseIntel).toBe(false);
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('security bureau allows turning when RNG >= 0.5 (turn 2 → allow)', () => {
+    // spy1, turn 2: RNG = 0.9923 >= 0.5 → turning should succeed
+    const state = makeSpyTurningState('spy1', 2, /* hasSecurityBureau */ true);
+    const bus = new EventBus();
+    const emitted: string[] = [];
+    bus.on('espionage:spy-detected', () => emitted.push('detected'));
+
+    const result = processEspionageTurn(state, bus);
+    // Spy should be turned (status = stationed, feedsFalseIntel = true)
+    expect(result.espionage!['attacker'].spies['spy1'].status).toBe('stationed');
+    expect(result.espionage!['attacker'].spies['spy1'].feedsFalseIntel).toBe(true);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('without security bureau, captured spy is always turned (no RNG gate)', () => {
+    // turn 1 without security bureau: the RNG check is skipped entirely → always turns
+    const state = makeSpyTurningState('spy1', 1, /* hasSecurityBureau */ false);
+    const bus = new EventBus();
+    const result = processEspionageTurn(state, bus);
+    expect(result.espionage!['attacker'].spies['spy1'].status).toBe('stationed');
+    expect(result.espionage!['attacker'].spies['spy1'].feedsFalseIntel).toBe(true);
   });
 });

--- a/tests/systems/espionage-buildings.test.ts
+++ b/tests/systems/espionage-buildings.test.ts
@@ -72,6 +72,13 @@ describe('applyBuildingCI', () => {
     expect(result.counterIntelligence['c1']).toBe(50); // 20 + 30
   });
 
+  it('both buildings faded simultaneously with both era techs', () => {
+    const civEsp = createEspionageCivState();
+    const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
+    const result = applyBuildingCI('c1', city, civEsp, ['digital-surveillance', 'cyber-warfare']);
+    expect(result.counterIntelligence['c1']).toBe(25); // 10 + 15
+  });
+
   it('CI is capped at 100', () => {
     const civEsp = { ...createEspionageCivState(), counterIntelligence: { c1: 90 } };
     const city = { id: 'c1', buildings: ['intelligence-agency', 'security-bureau'] } as any;
@@ -88,7 +95,7 @@ describe('safehouse spy training cost reduction', () => {
     productionQueue: ['spy_scout'],
     buildings: ['safehouse'],
     ownedTiles: [],
-    buildingGrid: {},
+    grid: [[null]],
   } as any;
 
   const baseMap = { tiles: {}, width: 10, height: 10, wrap: false } as any;


### PR DESCRIPTION
## Summary

- Adds three espionage-category buildings to the build queue: **Safehouse** (50 prod, era 1), **Intelligence Agency** (80 prod, era 2), **Security Bureau** (120 prod, era 4)
- Safehouse applies a 25% training cost discount to spy units only (Math.ceil so 30 → 23); all other unit rounding preserved
- Intelligence Agency contributes +20 CI/turn to its city (halved to +10 once `digital-surveillance` is researched); Security Bureau contributes +30 CI/turn (halved to +15 once `cyber-warfare` is researched); both are wired into the per-turn espionage loop via a new immutable-spread block in `turn-manager.ts`
- Security Bureau also blocks 50% of captured-spy turning attempts, using seeded RNG (`createRng`) for determinism

## Test Plan

- [ ] 1291 tests pass (`bash scripts/run-with-mise.sh yarn test`)
- [ ] TypeScript build clean (`bash scripts/run-with-mise.sh yarn build`)
- [ ] 20 new tests in `tests/systems/espionage-buildings.test.ts`: building definitions, CI stacking/capping/fading (incl. both techs simultaneously), safehouse discount + negative cases, security bureau turning resistance (seed verification + integration + no-bureau control)

🤖 Generated with [Claude Code](https://claude.com/claude-code)