### PR TITLE
fix: city-state conquest (#161)

### DIFF
--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -4,7 +4,8 @@ import { getMovementRange } from '@/systems/unit-system';
 
 export type SelectedUnitTapIntent =
   | { kind: 'move' }
-  | { kind: 'assault-city'; cityId: string };
+  | { kind: 'assault-city'; cityId: string }
+  | { kind: 'assault-minor-civ'; cityId: string; minorCivId: string };
 
 function buildUnitMaps(state: GameState): {
   unitPositions: Record<string, string>;
@@ -40,20 +41,23 @@ export function resolveSelectedUnitTapIntent(
     return { kind: 'move' };
   }
 
-  const cityAtTarget = Object.values(state.cities).find(city =>
-    hexKey(city.position) === targetKey
-    && city.owner !== state.currentPlayer
-    && !city.owner.startsWith('mc-'),
-  );
-  if (!cityAtTarget) {
-    return { kind: 'move' };
-  }
-
   const occupiedByOtherUnit = Object.values(state.units).some(other =>
     other.id !== unitId && hexKey(other.position) === targetKey,
   );
   if (occupiedByOtherUnit) {
     return { kind: 'move' };
+  }
+
+  const cityAtTarget = Object.values(state.cities).find(city =>
+    hexKey(city.position) === targetKey
+    && city.owner !== state.currentPlayer,
+  );
+  if (!cityAtTarget) {
+    return { kind: 'move' };
+  }
+
+  if (cityAtTarget.owner.startsWith('mc-')) {
+    return { kind: 'assault-minor-civ', cityId: cityAtTarget.id, minorCivId: cityAtTarget.owner };
   }
 
   return { kind: 'assault-city', cityId: cityAtTarget.id };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1683,9 +1683,16 @@ function handleHexTap(rawCoord: HexCoord): void {
         const mc = gameState.minorCivs[tapIntent.minorCivId];
         if (mc && !mc.isDestroyed) {
           const cityName = gameState.cities[tapIntent.cityId]?.name ?? 'City-State';
-          const attacker = gameState.units[selectedUnitId];
-          if (attacker) {
-            gameState.units[selectedUnitId] = { ...attacker, movementPointsLeft: 0, hasMoved: true };
+          // Move the unit onto the city hex (updates fog, position, movement cost).
+          executeUnitMove(gameState, selectedUnitId, coord, {
+            actor: 'player',
+            civId: gameState.currentPlayer,
+            bus,
+          });
+          // Conquering a city ends the unit's turn regardless of remaining movement.
+          const movedUnit = gameState.units[selectedUnitId];
+          if (movedUnit) {
+            gameState.units[selectedUnitId] = { ...movedUnit, movementPointsLeft: 0 };
           }
           conquestMinorCiv(gameState, tapIntent.minorCivId, gameState.currentPlayer, bus);
           showNotification(`${cityName} has been conquered!`, 'success');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1447,7 +1447,9 @@ function executeAttack(attackerId: string, defenderId: string, defender: Unit, t
 
     const cityAtTarget = Object.values(gameState.cities).find(c => hexKey(c.position) === targetKey);
     if (cityAtTarget && cityAtTarget.owner.startsWith('mc-')) {
+      const conqueredCityName = cityAtTarget.name;
       conquestMinorCiv(gameState, cityAtTarget.owner, gameState.currentPlayer, bus);
+      showNotification(`${conqueredCityName} has been conquered!`, 'success');
     }
     if (cityAtTarget && !cityAtTarget.owner.startsWith('mc-') && cityAtTarget.owner !== gameState.currentPlayer) {
       const assaultStatus = beginPlayerCityAssault(attackerId, cityAtTarget.id, attackerBonus);
@@ -1674,6 +1676,24 @@ function handleHexTap(rawCoord: HexCoord): void {
         if (assaultStatus === 'resolved') {
           selectNextUnit();
         }
+        return;
+      }
+
+      if (tapIntent.kind === 'assault-minor-civ') {
+        const mc = gameState.minorCivs[tapIntent.minorCivId];
+        if (mc && !mc.isDestroyed) {
+          const cityName = gameState.cities[tapIntent.cityId]?.name ?? 'City-State';
+          const attacker = gameState.units[selectedUnitId];
+          if (attacker) {
+            gameState.units[selectedUnitId] = { ...attacker, movementPointsLeft: 0, hasMoved: true };
+          }
+          conquestMinorCiv(gameState, tapIntent.minorCivId, gameState.currentPlayer, bus);
+          showNotification(`${cityName} has been conquered!`, 'success');
+        }
+        SFX.tap();
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        selectNextUnit();
         return;
       }
 

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -308,10 +308,14 @@ function processGarrison(state: GameState, mc: MinorCivState): void {
     } else {
       const city = state.cities[mc.cityId];
       if (city) {
-        const garrison = createUnit('warrior', mc.id, city.position);
-        state.units[garrison.id] = garrison;
-        mc.units.push(garrison.id);
-        mc.garrisonCooldown = 3;
+        const cityKey = hexKey(city.position);
+        const occupied = Object.values(state.units).some(u => hexKey(u.position) === cityKey);
+        if (!occupied) {
+          const garrison = createUnit('warrior', mc.id, city.position);
+          state.units[garrison.id] = garrison;
+          mc.units.push(garrison.id);
+          mc.garrisonCooldown = 3;
+        }
       }
     }
   }

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import type { GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
+import { createUnit } from '@/systems/unit-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 
 function makeTapAssaultFixture(): GameState {
@@ -43,5 +45,72 @@ describe('selected-unit-tap-intent', () => {
     const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
 
     expect(intent).toEqual({ kind: 'assault-city', cityId: 'enemyCity' });
+  });
+
+  it('returns assault-minor-civ for an ungarrisoned city-state city in movement range', () => {
+    const state = makeTapAssaultFixture();
+    // Replace the major enemy city at {q:1,r:0} with a city-state city.
+    delete state.cities.enemyCity;
+    state.civilizations['ai-1'].cities = [];
+
+    state.cities['mc-city'] = {
+      ...foundCity('mc-warriors', { q: 1, r: 0 }, state.map),
+      id: 'mc-city',
+      name: 'Warriors Haven',
+      owner: 'mc-warriors',
+      position: { q: 1, r: 0 },
+      population: 3,
+      ownedTiles: [{ q: 1, r: 0 }],
+    };
+    state.minorCivs['mc-warriors'] = {
+      id: 'mc-warriors',
+      definitionId: 'warriors',
+      cityId: 'mc-city',
+      units: [],
+      diplomacy: createDiplomacyState(Object.keys(state.civilizations), 'mc-warriors', 0),
+      activeQuests: {},
+      isDestroyed: false,
+      garrisonCooldown: 0,
+      lastEraUpgrade: 1,
+    };
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
+
+    expect(intent).toEqual({ kind: 'assault-minor-civ', cityId: 'mc-city', minorCivId: 'mc-warriors' });
+  });
+
+  it('returns move (not assault-minor-civ) when a garrison occupies the city-state hex', () => {
+    const state = makeTapAssaultFixture();
+    delete state.cities.enemyCity;
+    state.civilizations['ai-1'].cities = [];
+
+    state.cities['mc-city'] = {
+      ...foundCity('mc-warriors', { q: 1, r: 0 }, state.map),
+      id: 'mc-city',
+      name: 'Warriors Haven',
+      owner: 'mc-warriors',
+      position: { q: 1, r: 0 },
+      population: 3,
+      ownedTiles: [{ q: 1, r: 0 }],
+    };
+    // Use createUnit so all required Unit fields are populated correctly.
+    const garrison = createUnit('warrior', 'mc-warriors', { q: 1, r: 0 });
+    state.minorCivs['mc-warriors'] = {
+      id: 'mc-warriors',
+      definitionId: 'warriors',
+      cityId: 'mc-city',
+      units: [garrison.id],
+      diplomacy: createDiplomacyState(Object.keys(state.civilizations), 'mc-warriors', 0),
+      activeQuests: {},
+      isDestroyed: false,
+      garrisonCooldown: 0,
+      lastEraUpgrade: 1,
+    };
+    // Put the garrison on the city hex so occupiedByOtherUnit fires.
+    state.units[garrison.id] = garrison;
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
+
+    expect(intent).toEqual({ kind: 'move' });
   });
 });

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -5,6 +5,7 @@ import { hexDistance, hexKey } from '@/systems/hex-utils';
 import { EventBus } from '@/core/event-bus';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
+import { createUnit } from '@/systems/unit-system';
 
 const bus = new EventBus();
 
@@ -112,6 +113,50 @@ describe('minor civ turn processing', () => {
     // Next turn should spawn replacement
     const result2 = processMinorCivTurn(result, bus);
     expect(result2.minorCivs[mcId].units.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('skips garrison respawn when city hex is occupied by another unit', () => {
+    const state = createNewGame(undefined, 'mc-garrison-blocked', 'small');
+    const mcId = Object.keys(state.minorCivs)[0];
+    if (!mcId) return;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    if (!city) return;
+
+    // Kill the garrison
+    for (const uid of mc.units) {
+      delete state.units[uid];
+    }
+    mc.units = [];
+    mc.garrisonCooldown = 0;
+
+    // Place a player unit on the city hex
+    const occupier = createUnit('warrior', 'player', city.position);
+    state.units[occupier.id] = occupier;
+
+    const result = processMinorCivTurn(state, bus);
+
+    // Garrison must NOT have been spawned — hex is blocked
+    expect(result.minorCivs[mcId].units.length).toBe(0);
+  });
+
+  it('respawns garrison when city hex is free after cooldown', () => {
+    const state = createNewGame(undefined, 'mc-garrison-free', 'small');
+    const mcId = Object.keys(state.minorCivs)[0];
+    if (!mcId) return;
+    const mc = state.minorCivs[mcId];
+
+    // Kill the garrison
+    for (const uid of mc.units) {
+      delete state.units[uid];
+    }
+    mc.units = [];
+    mc.garrisonCooldown = 0;
+
+    const result = processMinorCivTurn(state, bus);
+
+    // Garrison should be respawned — hex is free
+    expect(result.minorCivs[mcId].units.length).toBeGreaterThanOrEqual(1);
   });
 
   it('applies ally bonus to allied major civ', () => {


### PR DESCRIPTION
## Summary

Fixes #161 — tapping an enemy city-state city with a unit in range either did nothing (ungarrisoned) or left the game in an irrecoverable state (garrison respawned on top of the player unit).

Three root causes, three fixes:

- **Bug 1 — intent resolver excluded city-states.** `resolveSelectedUnitTapIntent` had an explicit `!city.owner.startsWith('mc-')` guard that silently returned `move` for every city-state tap. Removed the guard; added a new `assault-minor-civ` intent variant (`{ kind, cityId, minorCivId }`) so callers can distinguish a city-state conquest from a regular move or major-city assault.

- **Bug 2 — no conquest handler for direct tap.** `handleHexTap` had no branch for `assault-minor-civ`. Added one: the unit walks onto the city hex via `executeUnitMove` (fog update, movement cost), movement is drained, `conquestMinorCiv` transfers ownership, and a success notification is shown. The `executeAttack` garrison-kill path already called `conquestMinorCiv` but was silent — added the notification there too.

- **Bug 3 — garrison respawned on occupied hex.** `processGarrison` spawned a new warrior every 3 turns without checking whether the city hex was already occupied, stacking units on the player who walked in. Added an occupancy check before spawning.

## Changes

| File | Change |
|------|--------|
| `src/input/selected-unit-tap-intent.ts` | New `assault-minor-civ` intent type; occupancy check promoted before city lookup; `mc-` filter removed |
| `src/main.ts` | `handleHexTap`: new `assault-minor-civ` branch with `executeUnitMove` + conquest; `executeAttack`: conquest notification |
| `src/systems/minor-civ-system.ts` | `processGarrison`: skip respawn when city hex is occupied |
| `tests/input/selected-unit-tap-intent.test.ts` | 2 new tests: ungarrisoned returns `assault-minor-civ`; garrisoned returns `move` |
| `tests/systems/minor-civ-system.test.ts` | 2 new tests: blocked respawn stays 0; free respawn increments to ≥1 |

## Test plan

- [ ] Tap an ungarrisoned city-state city with a unit in range → city transfers to player, unit moves to city hex, notification shown, unit's turn ends
- [ ] Tap a garrisoned city-state city → combat preview shown (garrison must die first)
- [ ] After killing the garrison → city auto-conquered, notification shown
- [ ] End turn with player unit on conquered city hex → no new garrison spawns on top
- [ ] End turn with city hex free (player moved away) → garrison respawns after cooldown as before
- [ ] yarn test && yarn build both exit 0

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)