### PR TITLE
[codex] Preserve major city captures and critical instability notices

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1038,6 +1038,7 @@ export interface GameEvents {
   'faction:breakaway-started': { cityId: string; oldOwner: string; breakawayId: string };
   'faction:breakaway-established': { civId: string; originOwnerId: string };
   'faction:breakaway-reabsorbed': { civId: string; ownerId: string; cityId: string };
+  'faction:critical-status': { cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string };
   'espionage:spy-promoted': { civId: string; spyId: string; promotion: SpyPromotion };
   'espionage:advisor-assassinated': { targetCivId: string; advisorType: AdvisorType; disabledUntilTurn: number };
   'espionage:documents-forged': { civA: string; civB: string; relationshipPenalty: number };

--- a/src/input/city-assault-flow.ts
+++ b/src/input/city-assault-flow.ts
@@ -10,6 +10,12 @@ export interface PendingCityCaptureChoice {
   razeGold: number;
 }
 
+export function shouldPromptForPlayerCityCapture(
+  city: { population: number },
+): boolean {
+  return city.population >= 1;
+}
+
 export function beginPlayerCityAssaultChoice(
   state: GameState,
   attackerId: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,12 @@ import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
-import { type PendingCityCaptureChoice, beginPlayerCityAssaultChoice, finalizePlayerCityAssaultChoice } from '@/input/city-assault-flow';
+import {
+  type PendingCityCaptureChoice,
+  beginPlayerCityAssaultChoice,
+  finalizePlayerCityAssaultChoice,
+  shouldPromptForPlayerCityCapture,
+} from '@/input/city-assault-flow';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 import {
   initializeLegendaryWonderProjectsForCity,
@@ -102,6 +107,7 @@ import {
 import {
   routeBarbarianSpawned,
   routeCombatResolved,
+  routeFactionTransition,
   routeLegendaryWonder,
   routePeaceMade,
   routePeaceRequested,
@@ -1376,13 +1382,12 @@ function beginPlayerCityAssault(
   const begun = beginPlayerCityAssaultChoice(gameState, attackerId, cityId);
   gameState = begun.state;
 
-  if (city.population <= 1) {
-    pendingCityCaptureChoice = begun.pending;
+  pendingCityCaptureChoice = begun.pending;
+  if (!shouldPromptForPlayerCityCapture(city)) {
     finalizePendingCityCaptureChoice('raze', attackerBonus);
     return 'resolved';
   }
 
-  pendingCityCaptureChoice = begun.pending;
   createCityCapturePanel(uiLayer, {
     cityName: city.name,
     occupiedPopulation: begun.pending.occupiedPopulation,
@@ -2195,6 +2200,37 @@ bus.on('barbarian:spawned', ({ campId, unitId }) => {
 });
 
 registerMinorCivNotificationListeners(bus, () => gameState, { appendToCivLog });
+
+function appendFactionNotice(civId: string, message: string, type: NotificationEntry['type']): void {
+  appendToCivLog(civId, message, type);
+  if (gameState.pendingEvents) {
+    collectEvent(gameState.pendingEvents, civId, { type: 'faction:critical', message, turn: gameState.turn });
+  }
+}
+
+bus.on('faction:unrest-started', event => {
+  routeFactionTransition(gameState, { type: 'faction:unrest-started', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:revolt-started', event => {
+  routeFactionTransition(gameState, { type: 'faction:revolt-started', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:unrest-resolved', event => {
+  routeFactionTransition(gameState, { type: 'faction:unrest-resolved', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:breakaway-started', event => {
+  routeFactionTransition(gameState, { type: 'faction:breakaway-started', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:breakaway-established', event => {
+  routeFactionTransition(gameState, { type: 'faction:breakaway-established', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:critical-status', event => {
+  routeFactionTransition(gameState, { type: 'faction:critical-status', ...event }, appendFactionNotice);
+});
 
 bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {
   const label = wasDisguised ? 'A disguised unit' : 'An enemy spy';

--- a/src/systems/breakaway-system.ts
+++ b/src/systems/breakaway-system.ts
@@ -140,6 +140,12 @@ export function processBreakawayTurn(state: GameState, bus: EventBus): GameState
       continue;
     }
     if (state.turn < civ.breakaway.establishesOnTurn) {
+      bus.emit('faction:critical-status', {
+        cityId: civ.breakaway.originCityId,
+        owner: civ.breakaway.originOwnerId,
+        status: 'breakaway',
+        breakawayId: civId,
+      });
       continue;
     }
 

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -75,7 +75,7 @@ export function resolveMajorCityCapture(
     return { state, outcome: 'razed', goldAwarded: 0 };
   }
 
-  const forcedDisposition: MajorCityCaptureDisposition = city.population <= 1 ? 'raze' : disposition;
+  const forcedDisposition: MajorCityCaptureDisposition = disposition;
 
   if (forcedDisposition === 'occupy' && previousOwner?.breakaway?.originOwnerId === newOwnerId) {
     const reconquered = reconquerBreakawayCity(state, newOwnerId, previousOwnerId, cityId);

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -86,7 +86,7 @@ export function isCityProductionLocked(city: City): boolean {
 
 // --- Rebel spawning ---
 
-function spawnRebelUnits(city: City, state: GameState, seed: string): void {
+function spawnRebelUnits(city: City, state: GameState, seed: string): GameState['units'] {
   const rng = createRng(seed);
   const offsets: HexCoord[] = [
     { q: 1, r: 0 }, { q: -1, r: 0 }, { q: 0, r: 1 },
@@ -94,74 +94,158 @@ function spawnRebelUnits(city: City, state: GameState, seed: string): void {
   ];
   const unitType: UnitType = city.population >= 4 ? 'swordsman' : 'warrior';
   const spawnCount = 1 + Math.floor(rng() * 2); // 1-2 rebels
+  const occupied = new Set(Object.values(state.units).map(unit => `${unit.position.q},${unit.position.r}`));
+  const available = offsets
+    .map(offset => ({ q: city.position.q + offset.q, r: city.position.r + offset.r }))
+    .filter(pos => {
+      const key = `${pos.q},${pos.r}`;
+      return state.map.tiles[key] !== undefined && !occupied.has(key);
+    });
 
+  let units = { ...state.units };
   for (let i = 0; i < spawnCount; i++) {
-    const offset = offsets[Math.floor(rng() * offsets.length)];
-    const pos: HexCoord = { q: city.position.q + offset.q, r: city.position.r + offset.r };
-    const key = `${pos.q},${pos.r}`;
-    if (!state.map.tiles[key]) continue; // off-map, skip
+    if (available.length === 0) break;
+    const index = Math.floor(rng() * available.length);
+    const [pos] = available.splice(index, 1);
+    if (!pos) continue;
     const rebel = createUnit(unitType, 'rebels', pos);
-    state.units[rebel.id] = rebel;
+    units = { ...units, [rebel.id]: rebel };
+    occupied.add(`${pos.q},${pos.r}`);
   }
+  return units;
 }
 
 // --- Main faction tick ---
 
+function clearEraOneUnrest(state: GameState): GameState {
+  let mutated = false;
+  const cities = { ...state.cities };
+
+  for (const [cityId, city] of Object.entries(state.cities)) {
+    if (city.unrestLevel === 0 && city.unrestTurns === 0 && city.spyUnrestBonus === 0) {
+      continue;
+    }
+    cities[cityId] = {
+      ...city,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    };
+    mutated = true;
+  }
+
+  return mutated ? { ...state, cities } : state;
+}
+
 export function processFactionTurn(state: GameState, bus: EventBus): GameState {
-  for (const cityId of Object.keys(state.cities)) {
-    const city = state.cities[cityId];
+  if (state.era <= 1) {
+    return clearEraOneUnrest(state);
+  }
+
+  let nextState = state;
+
+  for (const cityId of Object.keys(nextState.cities)) {
+    const city = nextState.cities[cityId];
     if (!city) continue;
 
     // Clear expired conquestTurn
     if (city.conquestTurn !== undefined &&
-        (state.turn - city.conquestTurn) >= CONQUEST_UNREST_DURATION) {
-      state.cities[cityId] = { ...state.cities[cityId], conquestTurn: undefined };
+        (nextState.turn - city.conquestTurn) >= CONQUEST_UNREST_DURATION) {
+      nextState = {
+        ...nextState,
+        cities: {
+          ...nextState.cities,
+          [cityId]: { ...city, conquestTurn: undefined },
+        },
+      };
     }
 
-    const pressure = computeUnrestPressure(cityId, state);
-    let updated = { ...state.cities[cityId] };
+    const currentCity = nextState.cities[cityId];
+    if (!currentCity) continue;
+    const initialCriticalStatus = currentCity.unrestLevel === 1
+      ? 'unrest'
+      : currentCity.unrestLevel === 2
+        ? 'revolt'
+        : null;
+    const pressure = computeUnrestPressure(cityId, nextState);
+    let updated = { ...currentCity };
 
     if (updated.unrestLevel === 0) {
       if (pressure > UNREST_TRIGGER_PRESSURE) {
         updated = { ...updated, unrestLevel: 1, unrestTurns: 0 };
-        state.cities[cityId] = updated;
+        nextState = {
+          ...nextState,
+          cities: { ...nextState.cities, [cityId]: updated },
+        };
         bus.emit('faction:unrest-started', { cityId, owner: city.owner });
       }
     } else if (updated.unrestLevel === 1) {
-      const garrisoned = canGarrisonCity(cityId, state);
+      const garrisoned = canGarrisonCity(cityId, nextState);
       if (pressure <= UNREST_TRIGGER_PRESSURE || garrisoned) {
         updated = { ...updated, unrestLevel: 0, unrestTurns: 0 };
-        state.cities[cityId] = updated;
+        nextState = {
+          ...nextState,
+          cities: { ...nextState.cities, [cityId]: updated },
+        };
         bus.emit('faction:unrest-resolved', { cityId, owner: city.owner });
       } else {
         updated = { ...updated, unrestTurns: updated.unrestTurns + 1 };
         if (updated.unrestTurns >= REVOLT_UNREST_TURNS) {
           updated = { ...updated, unrestLevel: 2, unrestTurns: 0 };
-          state.cities[cityId] = updated;
-          spawnRebelUnits(updated, state, `revolt-${cityId}-${state.turn}`);
+          nextState = {
+            ...nextState,
+            cities: { ...nextState.cities, [cityId]: updated },
+          };
+          nextState = {
+            ...nextState,
+            units: spawnRebelUnits(updated, nextState, `revolt-${cityId}-${nextState.turn}`),
+          };
           bus.emit('faction:revolt-started', { cityId, owner: city.owner });
         } else {
-          state.cities[cityId] = updated;
+          nextState = {
+            ...nextState,
+            cities: { ...nextState.cities, [cityId]: updated },
+          };
         }
       }
     } else if (updated.unrestLevel === 2) {
       // Revolt: resolve when rebels nearby are defeated AND pressure drops or city garrisoned
-      const nearbyRebels = Object.values(state.units).filter(
+      const nearbyRebels = Object.values(nextState.units).filter(
         u => u.owner === 'rebels' && hexDistance(u.position, city.position) <= 3,
       );
       if (nearbyRebels.length === 0 && pressure <= UNREST_TRIGGER_PRESSURE) {
         updated = { ...updated, unrestLevel: 0, unrestTurns: 0 };
-        state.cities[cityId] = updated;
+        nextState = {
+          ...nextState,
+          cities: { ...nextState.cities, [cityId]: updated },
+        };
         bus.emit('faction:unrest-resolved', { cityId, owner: city.owner });
       } else {
         updated = { ...updated, unrestTurns: updated.unrestTurns + 1 };
-        state.cities[cityId] = updated;
+        nextState = {
+          ...nextState,
+          cities: { ...nextState.cities, [cityId]: updated },
+        };
         if (updated.unrestTurns >= 10) {
-          state = createBreakawayFromCity(state, cityId, bus);
+          nextState = createBreakawayFromCity(nextState, cityId, bus);
         }
       }
     }
+
+    const finalCity = nextState.cities[cityId];
+    const finalCriticalStatus = finalCity?.unrestLevel === 1
+      ? 'unrest'
+      : finalCity?.unrestLevel === 2
+        ? 'revolt'
+        : null;
+    if (initialCriticalStatus && finalCriticalStatus === initialCriticalStatus && finalCity) {
+      bus.emit('faction:critical-status', {
+        cityId,
+        owner: finalCity.owner,
+        status: finalCriticalStatus,
+      });
+    }
   }
 
-  return state;
+  return nextState;
 }

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -5,6 +5,78 @@ import type { NotificationEntry } from '@/ui/notification-log';
 
 export type NotificationSink = (civId: string, message: string, type: NotificationEntry['type']) => void;
 
+type FactionTransitionEvent =
+  | { type: 'faction:unrest-started'; cityId: string; owner: string }
+  | { type: 'faction:revolt-started'; cityId: string; owner: string }
+  | { type: 'faction:unrest-resolved'; cityId: string; owner: string }
+  | { type: 'faction:breakaway-started'; cityId: string; oldOwner: string; breakawayId: string }
+  | { type: 'faction:breakaway-established'; civId: string; originOwnerId: string }
+  | { type: 'faction:critical-status'; cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string };
+
+export function routeFactionTransition(
+  state: GameState,
+  event: FactionTransitionEvent,
+  sink: NotificationSink,
+): void {
+  if (event.type === 'faction:unrest-started') {
+    const city = state.cities[event.cityId];
+    sink(event.owner, `${city?.name ?? 'A city'} is slipping into unrest. Stabilize it before revolt spreads.`, 'warning');
+    return;
+  }
+
+  if (event.type === 'faction:revolt-started') {
+    const city = state.cities[event.cityId];
+    sink(event.owner, `${city?.name ?? 'A city'} is in open revolt. Defeat nearby rebels and reduce pressure.`, 'warning');
+    return;
+  }
+
+  if (event.type === 'faction:unrest-resolved') {
+    const city = state.cities[event.cityId];
+    sink(event.owner, `${city?.name ?? 'A city'} has stabilized.`, 'success');
+    return;
+  }
+
+  if (event.type === 'faction:breakaway-started') {
+    const city = state.cities[event.cityId];
+    const breakaway = state.civilizations[event.breakawayId];
+    const turnsLeft = breakaway?.breakaway
+      ? Math.max(0, breakaway.breakaway.establishesOnTurn - state.turn)
+      : 0;
+    sink(
+      event.oldOwner,
+      `${city?.name ?? 'A city'} has broken away. Recapture or reabsorb it before it becomes established${turnsLeft > 0 ? ` in ${turnsLeft} turns` : ''}.`,
+      'warning',
+    );
+    return;
+  }
+
+  if (event.type === 'faction:critical-status') {
+    const city = state.cities[event.cityId];
+    if (event.status === 'unrest') {
+      sink(event.owner, `${city?.name ?? 'A city'} remains in unrest. Stabilize it before revolt spreads.`, 'warning');
+      return;
+    }
+    if (event.status === 'revolt') {
+      sink(event.owner, `${city?.name ?? 'A city'} remains in open revolt. Defeat nearby rebels and reduce pressure.`, 'warning');
+      return;
+    }
+    const breakaway = event.breakawayId ? state.civilizations[event.breakawayId] : undefined;
+    const turnsLeft = breakaway?.breakaway
+      ? Math.max(0, breakaway.breakaway.establishesOnTurn - state.turn)
+      : 0;
+    sink(
+      event.owner,
+      `${city?.name ?? 'A city'} is still in secession${turnsLeft > 0 ? ` (${turnsLeft} turns before establishment)` : ''}.`,
+      'warning',
+    );
+    return;
+  }
+
+  const civ = state.civilizations[event.civId];
+  const city = civ?.breakaway ? state.cities[civ.breakaway.originCityId] : undefined;
+  sink(event.originOwnerId, `${city?.name ?? civ?.name ?? 'A breakaway state'} is now an established civilization.`, 'warning');
+}
+
 // Writes to both parties' logs from their own perspective.
 export function routeWarDeclared(
   state: GameState,

--- a/tests/input/city-assault-flow.test.ts
+++ b/tests/input/city-assault-flow.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import type { GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
-import { beginPlayerCityAssaultChoice, finalizePlayerCityAssaultChoice } from '@/input/city-assault-flow';
+import {
+  beginPlayerCityAssaultChoice,
+  finalizePlayerCityAssaultChoice,
+  shouldPromptForPlayerCityCapture,
+} from '@/input/city-assault-flow';
 
 function makePlayerAssaultState({ population }: { population: number }): GameState {
   const state = createNewGame(undefined, 'player-assault', 'small');
@@ -60,5 +64,21 @@ describe('city-assault-flow', () => {
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
     expect(result.state.units['unit-1'].movementPointsLeft).toBe(0);
     expect(result.state.cities.athens).toBeUndefined();
+  });
+
+  it('keeps population-1 player captures on the choice path so major cities can be occupied', () => {
+    const state = makePlayerAssaultState({ population: 1 });
+
+    expect(shouldPromptForPlayerCityCapture(state.cities.athens)).toBe(true);
+
+    const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
+
+    expect(begun.pending.occupiedPopulation).toBe(1);
+    expect(result.outcome).toBe('occupied');
+    expect(result.state.cities.athens).toMatchObject({
+      owner: 'player',
+      population: 1,
+    });
   });
 });

--- a/tests/systems/breakaway-system.test.ts
+++ b/tests/systems/breakaway-system.test.ts
@@ -29,9 +29,29 @@ describe('breakaway-system', () => {
   it('promotes a surviving breakaway state into an established civilization after 50 turns', () => {
     const { state, breakawayId } = makeBreakawayFixture({ breakawayStartedTurn: 12, turn: 62 });
     const bus = new EventBus();
+    const criticalEvents: string[] = [];
+    const establishedEvents: string[] = [];
+    bus.on('faction:critical-status', event => criticalEvents.push(event.cityId));
+    bus.on('faction:breakaway-established', event => establishedEvents.push(event.civId));
 
     const result = processBreakawayTurn(state, bus);
+
     expect(result.civilizations[breakawayId].breakaway?.status).toBe('established');
+    expect(establishedEvents).toEqual([breakawayId]);
+    expect(criticalEvents).toEqual([]);
+  });
+
+  it('emits a recurring critical status while a breakaway secession is unresolved', () => {
+    const { state, breakawayId, cityId } = makeBreakawayFixture({ breakawayStartedTurn: 12, turn: 20 });
+    const bus = new EventBus();
+    const events: Array<{ cityId: string; owner: string; status: string; breakawayId?: string }> = [];
+    bus.on('faction:critical-status', event => events.push(event));
+
+    processBreakawayTurn(state, bus);
+
+    expect(events).toEqual([
+      { cityId, owner: 'player', status: 'breakaway', breakawayId },
+    ]);
   });
 
   it('requires both relationship and gold to reabsorb a breakaway state', () => {

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -101,14 +101,30 @@ describe('city-capture-system', () => {
     );
   });
 
-  it('auto-razes a size-1 city instead of occupying it', () => {
+  it('razes a population-1 major city when the conqueror chooses raze', () => {
     const state = makeExposedCityCaptureState({ population: 1, buildings: ['granary'] });
 
-    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
 
     expect(result.outcome).toBe('razed');
     expect(result.state.cities.athens).toBeUndefined();
     expect(result.goldAwarded).toBe(30);
+  });
+
+  it('occupies a population-1 major city when the conqueror chooses occupy', () => {
+    const state = makeExposedCityCaptureState({ population: 1, buildings: ['granary'] });
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(result.outcome).toBe('occupied');
+    expect(result.state.cities.athens).toEqual(
+      expect.objectContaining({
+        owner: 'player',
+        population: 1,
+        occupation: expect.objectContaining({ originalOwnerId: 'ai-1', turnsRemaining: 10 }),
+      }),
+    );
+    expect(result.goldAwarded).toBe(0);
   });
 
   it('awards salvage gold and applies a raze relationship penalty', () => {

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -46,6 +46,7 @@ function makeState({
   spyUnrestBonus = 0,
   atWarCount = 0,
   unitPositions = [] as HexCoord[],
+  era = 2,
 }: {
   cityCount?: number;
   cityPosition?: HexCoord;
@@ -56,6 +57,7 @@ function makeState({
   spyUnrestBonus?: number;
   atWarCount?: number;
   unitPositions?: HexCoord[];
+  era?: number;
 } = {}): GameState {
   const civId = 'player';
   const city: City = makeCity('city-1', civId, cityPosition, {
@@ -95,7 +97,7 @@ function makeState({
 
   return {
     turn: 10,
-    era: 2,
+    era,
     currentPlayer: civId,
     gameOver: false,
     winner: null,
@@ -238,6 +240,109 @@ describe('faction-system', () => {
     expect(events).toEqual([{ type: 'unrest-started', cityId: 'city-1' }]);
   });
 
+  it('does not start unrest in Era 1 even when pressure is critical', () => {
+    const state = makeState({
+      era: 1,
+      cityCount: 21,
+      conquestTurn: 0,
+      spyUnrestBonus: 30,
+      atWarCount: 3,
+    });
+
+    const events: string[] = [];
+    bus.on('faction:unrest-started', payload => events.push(payload.cityId));
+    bus.on('faction:revolt-started', payload => events.push(payload.cityId));
+    bus.on('faction:breakaway-started', payload => events.push(payload.cityId));
+
+    const result = processFactionTurn(state, bus);
+
+    expect(result.cities['city-1'].unrestLevel).toBe(0);
+    expect(result.cities['city-1'].unrestTurns).toBe(0);
+    expect(events).toEqual([]);
+  });
+
+  it('clears existing unrest state in Era 1 instead of preserving penalties from saves', () => {
+    const state = makeState({
+      era: 1,
+      unrestLevel: 2,
+      unrestTurns: 7,
+      spyUnrestBonus: 15,
+    });
+
+    const events: string[] = [];
+    bus.on('faction:critical-status', payload => events.push(payload.cityId));
+    bus.on('faction:unrest-resolved', payload => events.push(payload.cityId));
+
+    const result = processFactionTurn(state, bus);
+
+    expect(result.cities['city-1']).toMatchObject({
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    });
+    expect(events).toEqual([]);
+  });
+
+  it('emits a recurring critical status for an ongoing unrest city', () => {
+    const state = makeState({
+      cityCount: 21,
+      unrestLevel: 1,
+      unrestTurns: 1,
+      spyUnrestBonus: 20,
+      atWarCount: 2,
+    });
+
+    const events: Array<{ cityId: string; owner: string; status: string }> = [];
+    bus.on('faction:critical-status', event => events.push(event));
+
+    processFactionTurn(state, bus);
+
+    expect(events).toEqual([
+      { cityId: 'city-1', owner: 'player', status: 'unrest' },
+    ]);
+  });
+
+  it('does not emit recurring critical status when unrest stabilizes that turn', () => {
+    const state = makeState({
+      cityCount: 1,
+      unrestLevel: 1,
+      unrestTurns: 3,
+      spyUnrestBonus: 0,
+    });
+
+    const criticalEvents: string[] = [];
+    const resolvedEvents: string[] = [];
+    bus.on('faction:critical-status', payload => criticalEvents.push(payload.cityId));
+    bus.on('faction:unrest-resolved', payload => resolvedEvents.push(payload.cityId));
+
+    const result = processFactionTurn(state, bus);
+
+    expect(result.cities['city-1'].unrestLevel).toBe(0);
+    expect(resolvedEvents).toEqual(['city-1']);
+    expect(criticalEvents).toEqual([]);
+  });
+
+  it('emits recurring critical status for a revolt only when it remains unresolved', () => {
+    const state = makeState({
+      cityCount: 21,
+      cityPosition: { q: 3, r: 3 },
+      unrestLevel: 2,
+      unrestTurns: 0,
+      spyUnrestBonus: 20,
+      atWarCount: 2,
+    });
+
+    const events: Array<{ cityId: string; owner: string; status: string }> = [];
+    bus.on('faction:critical-status', event => events.push(event));
+
+    const result = processFactionTurn(state, bus);
+
+    expect(result.cities['city-1'].unrestLevel).toBe(2);
+    expect(events).toEqual([
+      { cityId: 'city-1', owner: 'player', status: 'revolt' },
+    ]);
+  });
+
   it('escalates unrest to revolt after enough turns and spawns rebel units', () => {
     const cityPos = { q: 5, r: 5 };
     const state = makeState({
@@ -247,14 +352,6 @@ describe('faction-system', () => {
       unrestTurns: 4,
       spyUnrestBonus: 7,
       atWarCount: 1,
-      unitPositions: [
-        { q: 6, r: 5 },
-        { q: 4, r: 5 },
-        { q: 5, r: 6 },
-        { q: 5, r: 4 },
-        { q: 6, r: 4 },
-        { q: 4, r: 6 },
-      ],
     });
 
     for (const coord of [
@@ -305,12 +402,15 @@ describe('faction-system', () => {
     });
 
     const events: string[] = [];
+    const criticalEvents: string[] = [];
     bus.on('faction:unrest-resolved', payload => events.push(payload.cityId));
+    bus.on('faction:critical-status', payload => criticalEvents.push(payload.cityId));
 
     const result = processFactionTurn(state, bus);
 
     expect(result.cities['city-1'].unrestLevel).toBe(0);
     expect(events).toEqual(['city-1']);
+    expect(criticalEvents).toEqual([]);
   });
 
   it('does not resolve revolt from a garrison alone while pressure remains high', () => {

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -4,6 +4,7 @@ import {
   routeBarbarianSpawned,
   routeCombatResolved,
   routeLegendaryWonder,
+  routeFactionTransition,
   routePeaceMade,
   routePeaceRequested,
   routeWarDeclared,
@@ -144,6 +145,74 @@ describe('notification routing', () => {
     );
     expect(calls).toHaveLength(1);
     expect(calls[0]!.civId).toBe('p2');
+  });
+
+  it('routes breakaway-started as a critical warning to the origin owner', () => {
+    const state = makeState({
+      turn: 34,
+      cities: {
+        paris: { id: 'paris', name: 'Paris', owner: 'breakaway-paris', position: { q: 4, r: 2 } },
+      } as any,
+      civilizations: {
+        p1: { id: 'p1', name: 'France', diplomacy: { relationships: {}, atWarWith: [] }, visibility: { tiles: {} } },
+        'breakaway-paris': {
+          id: 'breakaway-paris',
+          name: 'Paris Secession',
+          diplomacy: { relationships: {}, atWarWith: [] },
+          visibility: { tiles: {} },
+          breakaway: { originOwnerId: 'p1', originCityId: 'paris', startedTurn: 34, establishesOnTurn: 84, status: 'secession' },
+        },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+
+    routeFactionTransition(
+      state,
+      { type: 'faction:breakaway-started', cityId: 'paris', oldOwner: 'p1', breakawayId: 'breakaway-paris' },
+      sink,
+    );
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        civId: 'p1',
+        message: expect.stringMatching(/Paris.*broken away/i),
+        type: 'warning',
+      }),
+    ]);
+  });
+
+  it('routes recurring breakaway critical status to the origin owner', () => {
+    const state = makeState({
+      turn: 35,
+      cities: {
+        paris: { id: 'paris', name: 'Paris', owner: 'breakaway-paris', position: { q: 4, r: 2 } },
+      } as any,
+      civilizations: {
+        p1: { id: 'p1', name: 'France', diplomacy: { relationships: {}, atWarWith: [] }, visibility: { tiles: {} } },
+        'breakaway-paris': {
+          id: 'breakaway-paris',
+          name: 'Paris Secession',
+          diplomacy: { relationships: {}, atWarWith: [] },
+          visibility: { tiles: {} },
+          breakaway: { originOwnerId: 'p1', originCityId: 'paris', startedTurn: 34, establishesOnTurn: 84, status: 'secession' },
+        },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+
+    routeFactionTransition(
+      state,
+      { type: 'faction:critical-status', cityId: 'paris', owner: 'p1', status: 'breakaway', breakawayId: 'breakaway-paris' },
+      sink,
+    );
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        civId: 'p1',
+        message: expect.stringMatching(/Paris.*still in secession/i),
+        type: 'warning',
+      }),
+    ]);
   });
 
   it('legendary-wonder-ready targets the builder only', () => {


### PR DESCRIPTION
## Summary

- Removes forced auto-raze behavior for population-1 major city captures, including the live player capture path.
- Enforces the Era 1 rule that cities cannot carry unrest penalties by clearing stale unrest state during faction processing.
- Adds player-facing faction critical notices for unrest, revolt, and breakaway states, with recurring warnings emitted only after unresolved states remain active.

## Why

Paris-style major city loss could still happen silently through the player assault flow because population-1 captures bypassed the capture choice panel. Existing Era 1 unrest could also survive from saved or fixture state and continue applying penalties. Recurring critical warnings were emitted before resolution, causing contradictory same-turn messages like still in unrest plus stabilized.

## Validation

- ./scripts/run-with-mise.sh yarn test --run tests/input/city-assault-flow.test.ts tests/systems/city-capture-system.test.ts tests/systems/faction-system.test.ts tests/systems/breakaway-system.test.ts tests/ui/notification-routing.test.ts
- scripts/check-src-rule-violations.sh src/input/city-assault-flow.ts src/main.ts src/systems/city-capture-system.ts src/systems/faction-system.ts src/systems/breakaway-system.ts src/ui/notification-routing.ts src/core/types.ts
- ./scripts/run-with-mise.sh yarn build
- git diff --check

Fixes #160 and #162.