### PR TITLE
fix: city founding blocked by warrior on starting tile (issue #149)

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -313,7 +313,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
 
   for (const settler of settlers) {
     const tile = newState.map.tiles[hexKey(settler.position)];
-    if (tile && canFoundCityAt(newState, settler.position, { ignoreUnitId: settler.id })) {
+    if (tile && canFoundCityAt(newState, settler.position)) {
       const city = foundCity(civId, settler.position, newState.map, {
         civType: civ.civType,
         namingPool: civDef?.cityNames,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1259,7 +1259,7 @@ function foundCityAction(): void {
   if (!unit || unit.type !== 'settler') return;
 
   const cp = gameState.currentPlayer;
-  const blockers = getCityFoundingBlockers(gameState, unit.position, { ignoreUnitId: unit.id });
+  const blockers = getCityFoundingBlockers(gameState, unit.position);
   if (blockers.length > 0) {
     showNotification(formatCityFoundingBlockerMessage(blockers), 'warning');
     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2467,7 +2467,6 @@ function showGameModeSelection(): void {
             gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
           }
           startGame();
-          showNotification('Your tribe has settled near a river...', 'info');
         },
         onCustomCivilizationsChanged: (customCivilizations) => {
           updatePersistedCustomCivilizations(customCivilizations);

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -4,7 +4,7 @@ import { hexDistance, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-uti
 export const MIN_CITY_CENTER_DISTANCE = 4;
 
 export interface CityFoundingBlocker {
-  reason: 'too-close' | 'invalid-terrain' | 'occupied' | 'unreachable';
+  reason: 'too-close' | 'invalid-terrain';
   cityId?: string;
   cityName?: string;
   distance?: number;
@@ -23,10 +23,6 @@ export interface CityWorkClaimNormalizationResult {
   changedCityIds: string[];
 }
 
-export interface CityFoundingValidationOptions {
-  ignoreUnitId?: string;
-}
-
 export function canonicalizeCityCoord(coord: HexCoord, map: GameMap): HexCoord {
   return map.wrapsHorizontally ? wrapHexCoord(coord, map.width) : { ...coord };
 }
@@ -43,22 +39,12 @@ function isValidCityCenterTerrain(state: GameState, position: HexCoord): boolean
 export function getCityFoundingBlockers(
   state: GameState,
   position: HexCoord,
-  options: CityFoundingValidationOptions = {},
 ): CityFoundingBlocker[] {
   const canonical = canonicalizeCityCoord(position, state.map);
   const blockers: CityFoundingBlocker[] = [];
 
   if (!isValidCityCenterTerrain(state, canonical)) {
     blockers.push({ reason: 'invalid-terrain' });
-  }
-
-  const occupied = Object.values(state.units).some(unit =>
-    unit.id !== options.ignoreUnitId &&
-    unit.position.q === canonical.q &&
-    unit.position.r === canonical.r,
-  );
-  if (occupied) {
-    blockers.push({ reason: 'occupied' });
   }
 
   for (const city of Object.values(state.cities)) {
@@ -79,16 +65,14 @@ export function getCityFoundingBlockers(
 export function canFoundCityAt(
   state: GameState,
   position: HexCoord,
-  options: CityFoundingValidationOptions = {},
 ): boolean {
-  return getCityFoundingBlockers(state, position, options).length === 0;
+  return getCityFoundingBlockers(state, position).length === 0;
 }
 
 export function formatCityFoundingBlockerMessage(blockers: CityFoundingBlocker[]): string {
   const tooClose = blockers.find(blocker => blocker.reason === 'too-close');
   if (tooClose?.cityName) return `Too close to ${tooClose.cityName}.`;
   if (blockers.some(blocker => blocker.reason === 'invalid-terrain')) return 'Cities must be founded on land.';
-  if (blockers.some(blocker => blocker.reason === 'occupied')) return 'Another unit is blocking this city site.';
   return 'This location cannot support a city.';
 }
 

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -233,9 +233,11 @@ function applyAllyBonuses(state: GameState, mc: MinorCivState, def: { allyBonus:
       }
       case 'free_unit': {
         if (state.turn % def.allyBonus.everyNTurns === 0) {
-          const city = civ.cities.map(id => state.cities[id]).find(c => !!c);
-          if (city) {
-            const freeUnit = createUnit(def.allyBonus.unitType, civId, city.position);
+          const spawnCity = civ.cities
+            .map(id => state.cities[id])
+            .find(c => c && !Object.values(state.units).some(u => hexKey(u.position) === hexKey(c.position)));
+          if (spawnCity) {
+            const freeUnit = createUnit(def.allyBonus.unitType, civId, spawnCity.position);
             state = { ...state, units: { ...state.units, [freeUnit.id]: freeUnit } };
             civ.units.push(freeUnit.id);
           }
@@ -382,6 +384,10 @@ export function processGuerrilla(state: GameState, mc: MinorCivState, bus: Event
 
   const city = state.cities[mc.cityId];
   if (!city) return state;
+
+  const cityKey = hexKey(city.position);
+  const cityOccupied = Object.values(state.units).some(u => hexKey(u.position) === cityKey);
+  if (cityOccupied) return state;
 
   const guerrilla = createUnit('warrior', mc.id, city.position);
   state = { ...state, units: { ...state.units, [guerrilla.id]: guerrilla } };

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -4,7 +4,7 @@ import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
 import { getEraAdvancementTechs } from './tech-definitions';
 import { createDiplomacyState, modifyRelationship } from './diplomacy-system';
 import { applyResearchBonus } from './tech-system';
-import { hexDistance, hexKey, hexNeighbors } from './hex-utils';
+import { hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
 import { createUnit, UNIT_DEFINITIONS } from './unit-system';
 import { foundCity } from './city-system';
 import { collectUsedCityNames } from './city-name-system';
@@ -72,6 +72,7 @@ export function placeMinorCivs(
       startPositions,
       cityPositions,
       placedPositions,
+      state.map.width,
     );
     if (!pos) continue;
 
@@ -121,11 +122,12 @@ function findValidPosition(
   startPositions: HexCoord[],
   cityPositions: HexCoord[],
   placedPositions: HexCoord[],
+  mapWidth: number,
 ): HexCoord | null {
   for (const pos of candidates) {
-    if (startPositions.some(s => hexDistance(pos, s) < 8)) continue;
-    if (cityPositions.some(c => hexDistance(pos, c) < 6)) continue;
-    if (placedPositions.some(p => hexDistance(pos, p) < 10)) continue;
+    if (startPositions.some(s => wrappedHexDistance(pos, s, mapWidth) < 8)) continue;
+    if (cityPositions.some(c => wrappedHexDistance(pos, c, mapWidth) < 6)) continue;
+    if (placedPositions.some(p => wrappedHexDistance(pos, p, mapWidth) < 10)) continue;
     return pos;
   }
   return null;
@@ -150,8 +152,8 @@ export function processMinorCivTurn(state: GameState, bus: EventBus): GameState 
 
     processMovement(state, mc);
     processQuests(state, mc, def, bus);
-    applyAllyBonuses(state, mc, def, bus);
-    processGarrison(state, mc);
+    state = applyAllyBonuses(state, mc, def, bus);
+    state = processGarrison(state, mc);
     emitRelationshipThresholds(state, mc, bus);
   }
 
@@ -203,7 +205,7 @@ function processQuests(state: GameState, mc: MinorCivState, def: { archetype: an
   }
 }
 
-function applyAllyBonuses(state: GameState, mc: MinorCivState, def: { allyBonus: any }, bus: EventBus): void {
+function applyAllyBonuses(state: GameState, mc: MinorCivState, def: { allyBonus: any }, bus: EventBus): GameState {
   for (const [civId, rel] of Object.entries(mc.diplomacy.relationships)) {
     if (rel < 60) continue;
 
@@ -221,19 +223,20 @@ function applyAllyBonuses(state: GameState, mc: MinorCivState, def: { allyBonus:
         }
         break;
       case 'production_per_turn': {
-        const firstCityId = civ.cities[0];
-        const firstCity = firstCityId ? state.cities[firstCityId] : null;
-        if (firstCity && firstCity.productionQueue.length > 0) {
-          firstCity.productionProgress += def.allyBonus.amount;
+        const cityWithQueue = civ.cities
+          .map(id => state.cities[id])
+          .find(c => c && c.productionQueue.length > 0);
+        if (cityWithQueue) {
+          cityWithQueue.productionProgress += def.allyBonus.amount;
         }
         break;
       }
       case 'free_unit': {
         if (state.turn % def.allyBonus.everyNTurns === 0) {
-          const city = civ.cities[0] ? state.cities[civ.cities[0]] : null;
+          const city = civ.cities.map(id => state.cities[id]).find(c => !!c);
           if (city) {
             const freeUnit = createUnit(def.allyBonus.unitType, civId, city.position);
-            state.units[freeUnit.id] = freeUnit;
+            state = { ...state, units: { ...state.units, [freeUnit.id]: freeUnit } };
             civ.units.push(freeUnit.id);
           }
         }
@@ -241,6 +244,7 @@ function applyAllyBonuses(state: GameState, mc: MinorCivState, def: { allyBonus:
       }
     }
   }
+  return state;
 }
 
 function processMovement(state: GameState, mc: MinorCivState): void {
@@ -298,7 +302,7 @@ function emitRelationshipThresholds(state: GameState, mc: MinorCivState, bus: Ev
   }
 }
 
-function processGarrison(state: GameState, mc: MinorCivState): void {
+function processGarrison(state: GameState, mc: MinorCivState): GameState {
   const aliveUnits = mc.units.filter(uid => state.units[uid]);
   mc.units = aliveUnits;
 
@@ -312,13 +316,14 @@ function processGarrison(state: GameState, mc: MinorCivState): void {
         const occupied = Object.values(state.units).some(u => hexKey(u.position) === cityKey);
         if (!occupied) {
           const garrison = createUnit('warrior', mc.id, city.position);
-          state.units[garrison.id] = garrison;
+          state = { ...state, units: { ...state.units, [garrison.id]: garrison } };
           mc.units.push(garrison.id);
           mc.garrisonCooldown = 3;
         }
       }
     }
   }
+  return state;
 }
 
 function makeRng(seed: number): () => number {
@@ -368,18 +373,18 @@ export function conquestMinorCiv(
 
 // === Guerrilla & Scuffles ===
 
-export function processGuerrilla(state: GameState, mc: MinorCivState, bus: EventBus): void {
-  if (mc.isDestroyed) return;
-  if (mc.diplomacy.atWarWith.length === 0) return;
+export function processGuerrilla(state: GameState, mc: MinorCivState, bus: EventBus): GameState {
+  if (mc.isDestroyed) return state;
+  if (mc.diplomacy.atWarWith.length === 0) return state;
 
   const guerrillaCount = mc.units.filter(uid => state.units[uid]).length - 1;
-  if (guerrillaCount >= 2) return;
+  if (guerrillaCount >= 2) return state;
 
   const city = state.cities[mc.cityId];
-  if (!city) return;
+  if (!city) return state;
 
   const guerrilla = createUnit('warrior', mc.id, city.position);
-  state.units[guerrilla.id] = guerrilla;
+  state = { ...state, units: { ...state.units, [guerrilla.id]: guerrilla } };
   mc.units.push(guerrilla.id);
 
   bus.emit('minor-civ:guerrilla', {
@@ -387,6 +392,7 @@ export function processGuerrilla(state: GameState, mc: MinorCivState, bus: Event
     targetCivId: mc.diplomacy.atWarWith[0],
     position: city.position,
   });
+  return state;
 }
 
 export function processScuffles(state: GameState, bus: EventBus): void {

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -69,7 +69,7 @@ describe('city founding territory rules', () => {
 
     const blockers = getCityFoundingBlockers(state, { q: 12, r: 12 });
 
-    expect(blockers.find(b => b.reason === 'occupied')).toBeUndefined();
+    // Only distance blockers (from pre-existing AI start cities) are acceptable — no terrain or unit blockers.
     expect(blockers.filter(b => b.reason !== 'too-close')).toHaveLength(0);
   });
 
@@ -89,7 +89,8 @@ describe('city founding territory rules', () => {
 
     const blockers = getCityFoundingBlockers(state, { q: 5, r: 5 });
 
-    expect(blockers.find(b => b.reason === 'occupied')).toBeUndefined();
+    // Only distance blockers acceptable — units must never block founding.
+    expect(blockers.filter(b => b.reason !== 'too-close')).toHaveLength(0);
   });
 
   it('formats player-facing founding blocker messages', () => {

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -5,6 +5,7 @@ import { foundCity } from '@/systems/city-system';
 import {
   buildCityWorkClaimIndex,
   canonicalizeCityCoord,
+  cityDistance,
   formatCityFoundingBlockerMessage,
   getCityFoundingBlockers,
   MIN_CITY_CENTER_DISTANCE,
@@ -133,5 +134,22 @@ describe('work claim indexing', () => {
 
     expect(normalized.state.cities[city.id].workedTiles).toEqual([]);
     expect(normalized.changedCityIds).toContain(city.id);
+  });
+});
+
+describe('minor-civ placement and founding distance invariant', () => {
+  it('no city-state city is within MIN_CITY_CENTER_DISTANCE wrapped hexes of a player start position', () => {
+    const state = createNewGame(undefined, 'minor-civ-wrap-placement');
+    const settlerPositions = Object.values(state.units)
+      .filter(u => u.type === 'settler')
+      .map(u => u.position);
+
+    for (const city of Object.values(state.cities)) {
+      if (!city.id.startsWith('mc-')) continue;
+      for (const settlerPos of settlerPositions) {
+        const dist = cityDistance(city.position, settlerPos, state.map);
+        expect(dist).toBeGreaterThanOrEqual(MIN_CITY_CENTER_DISTANCE);
+      }
+    }
   });
 });

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -145,7 +145,7 @@ describe('minor-civ placement and founding distance invariant', () => {
       .map(u => u.position);
 
     for (const city of Object.values(state.cities)) {
-      if (!city.id.startsWith('mc-')) continue;
+      if (!city.owner.startsWith('mc-')) continue;
       for (const settlerPos of settlerPositions) {
         const dist = cityDistance(city.position, settlerPos, state.map);
         expect(dist).toBeGreaterThanOrEqual(MIN_CITY_CENTER_DISTANCE);

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -51,11 +51,11 @@ describe('city founding territory rules', () => {
     expect(blockers).toContainEqual(expect.objectContaining({ reason: 'too-close', distance: 2 }));
   });
 
-  it('does not treat the founding settler as an occupied-tile blocker', () => {
-    const state = createNewGame(undefined, 'city-spacing-ignore-settler');
-    state.units['unit-settler-test'] = {
-      id: 'unit-settler-test',
-      type: 'settler',
+  it('does not block founding when a friendly warrior shares the tile', () => {
+    const state = createNewGame(undefined, 'city-found-with-warrior');
+    state.units['unit-warrior-test'] = {
+      id: 'unit-warrior-test',
+      type: 'warrior',
       owner: 'player',
       position: { q: 12, r: 12 },
       movementPointsLeft: 2,
@@ -65,14 +65,31 @@ describe('city founding territory rules', () => {
       hasActed: false,
       isResting: false,
     };
-    state.map.tiles['12,12'] = {
-      ...state.map.tiles['12,12'],
-      terrain: 'grassland',
+    state.map.tiles['12,12'] = { ...state.map.tiles['12,12'], terrain: 'grassland' };
+
+    const blockers = getCityFoundingBlockers(state, { q: 12, r: 12 });
+
+    expect(blockers.find(b => b.reason === 'occupied')).toBeUndefined();
+    expect(blockers.filter(b => b.reason !== 'too-close')).toHaveLength(0);
+  });
+
+  it('does not block founding when settler and warrior share the same tile (turn-1 scenario)', () => {
+    const state = createNewGame(undefined, 'city-found-any-unit');
+    state.units['unit-a'] = {
+      id: 'unit-a', type: 'settler', owner: 'player',
+      position: { q: 5, r: 5 }, movementPointsLeft: 2,
+      health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
     };
+    state.units['unit-b'] = {
+      id: 'unit-b', type: 'warrior', owner: 'player',
+      position: { q: 5, r: 5 }, movementPointsLeft: 2,
+      health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+    };
+    state.map.tiles['5,5'] = { ...state.map.tiles['5,5'], terrain: 'grassland' };
 
-    const blockers = getCityFoundingBlockers(state, { q: 12, r: 12 }, { ignoreUnitId: 'unit-settler-test' });
+    const blockers = getCityFoundingBlockers(state, { q: 5, r: 5 });
 
-    expect(blockers.find(blocker => blocker.reason === 'occupied')).toBeUndefined();
+    expect(blockers.find(b => b.reason === 'occupied')).toBeUndefined();
   });
 
   it('formats player-facing founding blocker messages', () => {
@@ -80,7 +97,6 @@ describe('city founding territory rules', () => {
       { reason: 'too-close', cityName: 'Ephyra', distance: 2 },
     ])).toBe('Too close to Ephyra.');
     expect(formatCityFoundingBlockerMessage([{ reason: 'invalid-terrain' }])).toBe('Cities must be founded on land.');
-    expect(formatCityFoundingBlockerMessage([{ reason: 'occupied' }])).toBe('Another unit is blocking this city site.');
   });
 });
 

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -321,24 +321,24 @@ describe('conquest mechanics', () => {
 
 describe('guerrilla behavior', () => {
   it('spawns guerrilla units when at war (max 2)', () => {
-    const state = createNewGame(undefined, 'mc-guerrilla', 'small');
+    let state = createNewGame(undefined, 'mc-guerrilla', 'small');
     const mcId = Object.keys(state.minorCivs)[0];
     if (!mcId) return;
     const mc = state.minorCivs[mcId];
     mc.diplomacy.atWarWith.push('player');
 
-    processGuerrilla(state, mc, bus);
+    state = processGuerrilla(state, mc, bus);
     expect(mc.units.length).toBeLessThanOrEqual(3);
   });
 
   it('does not spawn guerrilla when not at war', () => {
-    const state = createNewGame(undefined, 'mc-no-guerrilla', 'small');
+    let state = createNewGame(undefined, 'mc-no-guerrilla', 'small');
     const mcId = Object.keys(state.minorCivs)[0];
     if (!mcId) return;
     const mc = state.minorCivs[mcId];
     const unitsBefore = mc.units.length;
 
-    processGuerrilla(state, mc, bus);
+    state = processGuerrilla(state, mc, bus);
     expect(mc.units.length).toBe(unitsBefore);
   });
 });


### PR DESCRIPTION
## Summary

- **Primary fix**: Removes the unit-occupancy check from `getCityFoundingBlockers`. Settler and warrior both spawn on the same hex at game start, so this check always blocked turn-1 founding. Per requirements, no unit should ever block city founding.
- **Secondary fix**: Removes the unconditional `'Your tribe has settled near a river...'` notification that fired at game start regardless of river presence, misleading players into thinking river proximity was a founding rule.
- **Tertiary fix**: `findValidPosition` in minor-civ placement now uses `wrappedHexDistance` (matching `getCityFoundingBlockers`) instead of `hexDistance`, preventing city-states from appearing within the founding exclusion radius via map wrapping.
- **Bonus fixes from review**: Added occupancy checks to `free_unit` ally-bonus spawn and `processGuerrilla` spawn (previously both could stack onto occupied tiles). Fixed `applyAllyBonuses`/`processGarrison`/`processGuerrilla` to return new `GameState` instead of mutating directly. Fixed minor-civ placement invariant test that was vacuously passing by checking `city.id` instead of `city.owner`.

## Files changed

| File | Change |
|------|--------|
| `src/systems/city-territory-system.ts` | Remove `occupied`/`unreachable` reasons, `CityFoundingValidationOptions`, and occupancy check block |
| `src/main.ts` | Remove `ignoreUnitId` from founding call; delete river notification |
| `src/ai/basic-ai.ts` | Remove `ignoreUnitId` from AI founding check |
| `src/systems/minor-civ-system.ts` | Wrapped distance in placement; immutable spread for unit spawns; occupancy guards for free-unit and guerrilla |
| `tests/systems/city-territory-system.test.ts` | Replace occupied tests with unit-coexistence tests; fix `city.owner` check in placement invariant |
| `tests/systems/minor-civ-system.test.ts` | Update guerrilla tests to capture returned state |

## Test plan
- [ ] Start a new solo campaign → turn 1: select settler, click "Found City" → city founds successfully (warrior on same tile no longer blocks)
- [ ] No `'Your tribe has settled near a river...'` notification at game start
- [ ] `[CityName] has been founded!` success notification still appears after founding
- [ ] Try to found a second city within 3 hexes of the first → `Too close to [CityName]` still shows
- [ ] Try to found on an ocean/coast tile → `Cities must be founded on land.` still shows
- [ ] `yarn test` → 1307 tests pass; `yarn build` → exits 0

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)