### PR TITLE
fix(city-grid): surface improvement info inline so players understand farms and mines

### DIFF
--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -3,6 +3,7 @@ import { hexKey, hexesInRange } from '@/systems/hex-utils';
 import { BUILDINGS, getUnplacedBuildings } from '@/systems/city-system';
 import { calculateAdjacencyBonuses, findOptimalSlot } from '@/systems/adjacency-system';
 import { TERRAIN_YIELDS } from '@/systems/resource-system';
+import { getImprovementYieldBonus } from '@/systems/improvement-system';
 import {
   assignCityFocus,
   calculateProjectedCityYields,
@@ -376,7 +377,16 @@ function renderWorkedLandSection(root: HTMLElement, city: City, options: CityMan
 
     const text = document.createElement('div');
     const labels = [titleCase(tile.terrain), formatYield(entry.yield)];
-    if (tile.improvement !== 'none' && tile.improvementTurnsLeft === 0) labels.push(titleCase(tile.improvement));
+    if (tile.improvement !== 'none' && tile.improvementTurnsLeft === 0) {
+      const bonus = getImprovementYieldBonus(tile.improvement);
+      const bonusParts: string[] = [];
+      if (bonus.food) bonusParts.push(`+${bonus.food} food`);
+      if (bonus.production) bonusParts.push(`+${bonus.production} production`);
+      if (bonus.gold) bonusParts.push(`+${bonus.gold} gold`);
+      if (bonus.science) bonusParts.push(`+${bonus.science} science`);
+      const bonusText = bonusParts.length > 0 ? ` (${bonusParts.join(', ')})` : '';
+      labels.push(`${titleCase(tile.improvement)}${bonusText}`);
+    }
     if (entry.isWater) labels.push('Water work: fishing/trapping');
     const blockedByCapacity = !worked && entry.available && !hasOpenCitizen;
     if (entry.claim) {

--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -457,7 +457,7 @@ export function createCityGrid(
     introTitle.style.color = '#e8c170';
     introTitle.textContent = 'Grid View';
     intro.appendChild(introTitle);
-    intro.appendChild(document.createTextNode(' - Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos.'));
+    intro.appendChild(document.createTextNode(' - Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos. Workers can also build improvements (Farms, Mines) on surrounding tiles to boost your city\'s output.'));
     if (suggestedBuilding) {
       const suggested = document.createElement('div');
       suggested.style.cssText = 'color:#e8c170;margin-top:4px;';

--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -334,7 +334,11 @@ function renderWorkedLandSection(root: HTMLElement, city: City, options: CityMan
 
   const help = document.createElement('p');
   help.style.cssText = 'font-size:11px;color:rgba(255,255,255,0.55);margin:0;line-height:1.4;';
-  help.textContent = 'Workers build Farms (+2 food) and Mines (+2 production, +1 gold) on nearby tiles. Assign citizens to worked tiles each turn to collect their yields.';
+  const farmBonus = getImprovementYieldBonus('farm');
+  const mineBonus = getImprovementYieldBonus('mine');
+  const farmText = formatYield(farmBonus);
+  const mineText = formatYield(mineBonus);
+  help.textContent = `Workers build Farms (${farmText}) and Mines (${mineText}) on nearby tiles. Assign citizens to worked tiles each turn to collect their yields.`;
   section.appendChild(help);
 
   const workedKeys = new Set((city.workedTiles ?? []).map(coord => hexKey(coord)));

--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -332,6 +332,11 @@ function renderWorkedLandSection(root: HTMLElement, city: City, options: CityMan
   heading.textContent = 'Worked Land And Water';
   section.appendChild(heading);
 
+  const help = document.createElement('p');
+  help.style.cssText = 'font-size:11px;color:rgba(255,255,255,0.55);margin:0;line-height:1.4;';
+  help.textContent = 'Workers build Farms (+2 food) and Mines (+2 production, +1 gold) on nearby tiles. Assign citizens to worked tiles each turn to collect their yields.';
+  section.appendChild(help);
+
   const workedKeys = new Set((city.workedTiles ?? []).map(coord => hexKey(coord)));
   const workedCount = Math.min(city.population, workedKeys.size);
   const unassigned = Math.max(0, city.population - workedCount);

--- a/tests/ui/city-grid.test.ts
+++ b/tests/ui/city-grid.test.ts
@@ -6,6 +6,28 @@ import { generateMap } from '@/systems/map-generator';
 import { createCityGrid } from '@/ui/city-grid';
 
 describe('city-grid view', () => {
+  it('mentions improvements in the Grid View intro text', () => {
+    const previousDocument = globalThis.document;
+    const dom = new JSDOM('<!doctype html><div id="root"></div>', { url: 'http://localhost/' });
+    globalThis.document = dom.window.document;
+
+    try {
+      const map = generateMap(30, 30, 'city-grid-intro-test');
+      const city = foundCity('player', { q: 15, r: 15 }, map);
+      const container = document.createElement('div');
+
+      const panel = createCityGrid(container, city, map, {
+        onSlotTap: () => {},
+        onBuyExpansion: () => {},
+        onClose: () => {},
+      });
+
+      expect(panel.textContent).toContain('improvements');
+    } finally {
+      globalThis.document = previousDocument;
+    }
+  });
+
   it('renders the full 7x7 city grid with the city center in the visual center', () => {
     const previousDocument = globalThis.document;
     const dom = new JSDOM('<!doctype html><div id="root"></div>', { url: 'http://localhost/' });

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -343,6 +343,35 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('Water work: fishing/trapping');
   });
 
+  it('shows mine yield bonus in worked-land tile row', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const hillTile = { q: city.position.q + 1, r: city.position.r };
+    state.map.tiles[hexKey(hillTile)] = {
+      ...state.map.tiles[hexKey(hillTile)],
+      coord: hillTile,
+      terrain: 'hills',
+      elevation: 'highland',
+      improvement: 'mine',
+      improvementTurnsLeft: 0,
+      owner: city.owner,
+      hasRiver: false,
+      wonder: null,
+      resource: null,
+    };
+    city.ownedTiles = [city.position, hillTile];
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    expect(collectText(panel)).toContain('Mine (+2 production, +1 gold)');
+  });
+
   it('shows help text in the Worked Land And Water section explaining improvements', () => {
     const { container, city, state } = makeWonderPanelFixture();
     const panel = createCityPanel(container, city, state, {
@@ -354,8 +383,8 @@ describe('city-panel navigation', () => {
     });
     clickElement(panel.querySelector('[id="tab-grid"]'));
     const rendered = collectText(panel);
-    expect(rendered).toContain('Workers build Farms');
-    expect(rendered).toContain('Mines');
+    expect(rendered).toContain('Workers build Farms (+2 food)');
+    expect(rendered).toContain('Mines (+2 production, +1 gold)');
   });
 
   it('shows claimed overlap tiles as unavailable', () => {

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -339,7 +339,7 @@ describe('city-panel navigation', () => {
 
     clickElement(panel.querySelector('[id="tab-grid"]'));
     const rendered = collectText(panel);
-    expect(rendered).toContain('Farm');
+    expect(rendered).toContain('Farm (+2 food)');
     expect(rendered).toContain('Water work: fishing/trapping');
   });
 

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -343,6 +343,21 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('Water work: fishing/trapping');
   });
 
+  it('shows help text in the Worked Land And Water section explaining improvements', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Workers build Farms');
+    expect(rendered).toContain('Mines');
+  });
+
   it('shows claimed overlap tiles as unavailable', () => {
     const { container, city, state } = makeWonderPanelFixture();
     const claimed = { q: city.position.q + 1, r: city.position.r };


### PR DESCRIPTION
Closes #114.

## Summary
- **Tile row yield bonus** — completed improvements now show their bonus explicitly: `Farm (+2 food)` / `Mine (+2 production, +1 gold)` instead of just the name. Yield values are derived live from `getImprovementYieldBonus` so they stay accurate if yields are rebalanced.
- **Worked Land help text** — a brief paragraph below the section heading explains that Workers build Farms and Mines, and that citizens must be assigned to collect yields. Yield values are again derived from `getImprovementYieldBonus` — no hardcoded strings.
- **Grid View intro text** — the building-board intro now mentions that Workers can build improvements on surrounding tiles.

## Test Plan
- [ ] Farm tile row shows `Farm (+2 food)` in the Worked Land section
- [ ] Mine tile row shows `Mine (+2 production, +1 gold)` in the Worked Land section
- [ ] Help paragraph containing `Workers build Farms (+2 food)` and `Mines (+2 production, +1 gold)` appears in the Grid tab
- [ ] Grid View intro text contains the word `improvements`
- [ ] Full suite: 1336 tests passing, `yarn build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)