### PR TITLE
fix(map): wrap visibility across horizontal seam

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -291,7 +291,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       .filter(mc => !mc.isDestroyed)
       .map(mc => newState.cities[mc.cityId]?.position)
       .filter(Boolean) as HexCoord[];
-    revealMinorCivCities(civ.visibility, mcCityPositions);
+    revealMinorCivCities(newState.civilizations[civId].visibility, mcCityPositions, newState.map);
 
     // Shared vision for friendly minor civs
     for (const mc of Object.values(newState.minorCivs)) {
@@ -302,7 +302,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
           newState.cities[mc.cityId]?.position,
           ...mc.units.map(uid => newState.units[uid]?.position),
         ].filter(Boolean) as HexCoord[];
-        applySharedVision(civ.visibility, mcPositions, newState.map);
+        applySharedVision(newState.civilizations[civId].visibility, mcPositions, newState.map);
       }
     }
 

--- a/src/systems/fog-of-war.ts
+++ b/src/systems/fog-of-war.ts
@@ -1,5 +1,5 @@
 import type { VisibilityMap, VisibilityState, HexCoord, Unit, GameMap, GameState } from '@/core/types';
-import { hexKey, hexesInRange, hexDistance } from './hex-utils';
+import { hexKey, hexesInRange, hexDistance, getWrappedHexesInRange, wrapHexCoord, wrappedHexDistance } from './hex-utils';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { getWonderVisionBonus } from './wonder-system';
 import { resolveCivDefinition } from './civ-registry';
@@ -24,6 +24,21 @@ export function isUnexplored(vis: VisibilityMap, coord: HexCoord): boolean {
   return getVisibility(vis, coord) === 'unexplored';
 }
 
+function getVisibilityRange(center: HexCoord, range: number, map?: GameMap): HexCoord[] {
+  if (map?.wrapsHorizontally) {
+    return getWrappedHexesInRange(center, range, map.width);
+  }
+  return hexesInRange(center, range);
+}
+
+function canonicalVisibilityCoord(coord: HexCoord, map?: GameMap): HexCoord {
+  return map?.wrapsHorizontally ? wrapHexCoord(coord, map.width) : coord;
+}
+
+function visibilityDistance(a: HexCoord, b: HexCoord, map: GameMap): number {
+  return map.wrapsHorizontally ? wrappedHexDistance(a, b, map.width) : hexDistance(a, b);
+}
+
 /**
  * Recalculates visibility for a player based on their units and cities.
  * Returns newly revealed tiles (were unexplored, now visible).
@@ -44,13 +59,14 @@ export function updateVisibility(
   const newlyRevealed: HexCoord[] = [];
 
   const revealTile = (coord: HexCoord) => {
-    const key = hexKey(coord);
+    const canonical = canonicalVisibilityCoord(coord, map);
+    const key = hexKey(canonical);
     if (!map.tiles[key]) return; // off map
 
     const prev = vis.tiles[key];
     vis.tiles[key] = 'visible';
     if (!prev || prev === 'unexplored') {
-      newlyRevealed.push(coord);
+      newlyRevealed.push(canonical);
     }
   };
 
@@ -60,11 +76,12 @@ export function updateVisibility(
     const visionRange = def.visionRange;
 
     // Check if unit is on elevated terrain for bonus
-    const unitTile = map.tiles[hexKey(unit.position)];
+    const unitPosition = canonicalVisibilityCoord(unit.position, map);
+    const unitTile = map.tiles[hexKey(unitPosition)];
     const bonus = unitTile ? getTerrainVisionBonus(unitTile.terrain) : 0;
     const wonderBonus = unitTile?.wonder ? getWonderVisionBonus(unitTile.wonder) : 0;
 
-    const visible = hexesInRange(unit.position, visionRange + bonus + wonderBonus);
+    const visible = getVisibilityRange(unitPosition, visionRange + bonus + wonderBonus, map);
     for (const coord of visible) {
       revealTile(coord);
     }
@@ -72,7 +89,7 @@ export function updateVisibility(
 
   // Reveal around each city (vision range 2)
   for (const cityPos of cityPositions) {
-    const visible = hexesInRange(cityPos, 2);
+    const visible = getVisibilityRange(canonicalVisibilityCoord(cityPos, map), 2, map);
     for (const coord of visible) {
       revealTile(coord);
     }
@@ -90,12 +107,14 @@ export function getTerrainVisionBonus(terrain: string): number {
 export function revealMinorCivCities(
   vis: VisibilityMap,
   mcCityPositions: HexCoord[],
+  map?: GameMap,
 ): void {
   for (const cityPos of mcCityPositions) {
-    const key = hexKey(cityPos);
+    const cityCoord = canonicalVisibilityCoord(cityPos, map);
+    const key = hexKey(cityCoord);
     if (vis.tiles[key] === 'visible') continue;
 
-    const nearby = hexesInRange(cityPos, 2);
+    const nearby = getVisibilityRange(cityCoord, 2, map);
     const anyExplored = nearby.some(h => {
       const k = hexKey(h);
       return vis.tiles[k] === 'fog' || vis.tiles[k] === 'visible';
@@ -113,7 +132,7 @@ export function applySharedVision(
   map: GameMap,
 ): void {
   for (const pos of positions) {
-    const range = hexesInRange(pos, 2);
+    const range = getVisibilityRange(canonicalVisibilityCoord(pos, map), 2, map);
     for (const hex of range) {
       const key = hexKey(hex);
       if (map.tiles[key]) {
@@ -155,7 +174,8 @@ export function isForestConcealedUnit(
     return false;
   }
 
-  const tile = state.map.tiles[hexKey(unit.position)];
+  const unitPosition = canonicalVisibilityCoord(unit.position, state.map);
+  const tile = state.map.tiles[hexKey(unitPosition)];
   if (tile?.terrain !== 'forest') {
     return false;
   }
@@ -168,7 +188,11 @@ export function isForestConcealedUnit(
   const hasAdjacentUnit = viewer.units
     .map(unitId => state.units[unitId])
     .filter(Boolean)
-    .some(viewerUnit => hexDistance(viewerUnit!.position, unit.position) <= 1);
+    .some(viewerUnit => visibilityDistance(
+      canonicalVisibilityCoord(viewerUnit!.position, state.map),
+      unitPosition,
+      state.map,
+    ) <= 1);
   if (hasAdjacentUnit) {
     return false;
   }
@@ -176,6 +200,10 @@ export function isForestConcealedUnit(
   const hasAdjacentCity = viewer.cities
     .map(cityId => state.cities[cityId])
     .filter(Boolean)
-    .some(city => hexDistance(city!.position, unit.position) <= 1);
+    .some(city => visibilityDistance(
+      canonicalVisibilityCoord(city!.position, state.map),
+      unitPosition,
+      state.map,
+    ) <= 1);
   return !hasAdjacentCity;
 }

--- a/src/systems/hex-utils.ts
+++ b/src/systems/hex-utils.ts
@@ -129,6 +129,15 @@ export function getWrappedHexNeighbors(coord: HexCoord, mapWidth: number): HexCo
   return Array.from(deduped.values());
 }
 
+export function getWrappedHexesInRange(center: HexCoord, range: number, mapWidth: number): HexCoord[] {
+  const deduped = new Map<string, HexCoord>();
+  for (const coord of hexesInRange(center, range)) {
+    const wrapped = wrapHexCoord(coord, mapWidth);
+    deduped.set(hexKey(wrapped), wrapped);
+  }
+  return Array.from(deduped.values());
+}
+
 export function wrappedHexDistance(a: HexCoord, b: HexCoord, mapWidth: number): number {
   return Math.min(
     hexDistance(a, b),

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -4,6 +4,8 @@ import { EventBus } from '@/core/event-bus';
 import type { CustomCivDefinition, GameState, UnitType } from '@/core/types';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { foundCity } from '@/systems/city-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { createVisibilityMap, getVisibility } from '@/systems/fog-of-war';
 import { getAvailableTechs } from '@/systems/tech-system';
 import { hexKey } from '@/systems/hex-utils';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
@@ -22,6 +24,33 @@ const customCiv: CustomCivDefinition = {
   primaryTrait: 'scholarly',
   temperamentTraits: ['diplomatic', 'trader'],
 };
+
+function createWrappedGrasslandMap(width: number, height: number): GameState['map'] {
+  const tiles: GameState['map']['tiles'] = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < height; r++) {
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: 'grassland',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+
+  return {
+    width,
+    height,
+    wrapsHorizontally: true,
+    tiles,
+    rivers: [],
+  };
+}
 
 describe('processTurn', () => {
   it('increments the turn counter', () => {
@@ -99,6 +128,43 @@ describe('processTurn', () => {
 
     const result = processTurn(state, bus);
     expect(Object.keys(result.minorCivs).length).toBeGreaterThan(0);
+  });
+
+  it('persists wrapped minor-civ proximity reveal on the returned turn state', () => {
+    const state = createNewGame(undefined, 'minor-civ-wrap-visibility', 'small');
+    state.map = createWrappedGrasslandMap(5, 4);
+    state.units = {};
+    state.cities = {};
+    state.minorCivs = {};
+
+    for (const civ of Object.values(state.civilizations)) {
+      civ.units = [];
+      civ.cities = [];
+      civ.visibility = createVisibilityMap();
+    }
+
+    state.civilizations.player.visibility.tiles['4,1'] = 'fog';
+
+    const minorCity = foundCity('mc-geneva', { q: 0, r: 1 }, state.map);
+    minorCity.id = 'city-geneva';
+    minorCity.name = 'Geneva';
+    minorCity.owner = 'mc-geneva';
+    state.cities[minorCity.id] = minorCity;
+    state.minorCivs['mc-geneva'] = {
+      id: 'mc-geneva',
+      definitionId: 'geneva',
+      cityId: minorCity.id,
+      units: [],
+      diplomacy: createDiplomacyState(['player', 'mc-geneva'], 'mc-geneva'),
+      activeQuests: {},
+      isDestroyed: false,
+      garrisonCooldown: 0,
+      lastEraUpgrade: 0,
+    };
+
+    const result = processTurn(state, new EventBus());
+
+    expect(getVisibility(result.civilizations.player.visibility, { q: 0, r: 1 })).toBe('visible');
   });
 
   it('advances research progress when a city exists and tech is selected', () => {

--- a/tests/systems/fog-of-war.test.ts
+++ b/tests/systems/fog-of-war.test.ts
@@ -1,7 +1,49 @@
-import { createVisibilityMap, updateVisibility, isVisible, isFog, isUnexplored, getTerrainVisionBonus, revealMinorCivCities, applySharedVision, applySatelliteSurveillance, isForestConcealedUnit } from '@/systems/fog-of-war';
-import type { VisibilityMap, GameMap, Unit, GameState } from '@/core/types';
+import { createVisibilityMap, updateVisibility, isVisible, isFog, isUnexplored, getTerrainVisionBonus, revealMinorCivCities, applySharedVision, applySatelliteSurveillance, isForestConcealedUnit, getVisibility } from '@/systems/fog-of-war';
+import type { VisibilityMap, GameMap, Unit, GameState, HexCoord } from '@/core/types';
 import { generateMap } from '@/systems/map-generator';
 import { hexKey } from '@/systems/hex-utils';
+
+function createWrappedGrasslandMap(width: number, height: number): GameMap {
+  const tiles: GameMap['tiles'] = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < height; r++) {
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: 'grassland',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+
+  return {
+    width,
+    height,
+    wrapsHorizontally: true,
+    tiles,
+    rivers: [],
+  };
+}
+
+function makeWarrior(position: HexCoord): Unit {
+  return {
+    id: 'edge-warrior',
+    type: 'warrior',
+    owner: 'player',
+    position,
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+}
 
 describe('fog-of-war', () => {
   let map: GameMap;
@@ -67,6 +109,77 @@ describe('fog-of-war', () => {
     // Old position should be fog (seen before but no longer visible)
     expect(isFog(vis, { q: 15, r: 15 })).toBe(true);
     expect(isVisible(vis, { q: 15, r: 15 })).toBe(false);
+  });
+});
+
+describe('wrapped fog-of-war', () => {
+  it('reveals canonical wrapped tiles around a unit on the west map edge', () => {
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+    const unit = makeWarrior({ q: 0, r: 1 });
+
+    const revealed = updateVisibility(vis, [unit], map);
+
+    expect(getVisibility(vis, { q: 4, r: 1 })).toBe('visible');
+    expect(getVisibility(vis, { q: 4, r: 2 })).toBe('visible');
+    expect(revealed.map(hexKey)).toContain('4,1');
+    expect(Object.keys(vis.tiles).some(key => key.startsWith('-'))).toBe(false);
+  });
+
+  it('reveals canonical wrapped tiles around a unit on the east map edge', () => {
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+    const unit = makeWarrior({ q: 4, r: 1 });
+
+    updateVisibility(vis, [unit], map);
+
+    expect(getVisibility(vis, { q: 0, r: 1 })).toBe('visible');
+    expect(getVisibility(vis, { q: 0, r: 0 })).toBe('visible');
+    expect(Object.keys(vis.tiles).some(key => Number(key.split(',')[0]) >= map.width)).toBe(false);
+  });
+
+  it('uses wrapped range for city vision', () => {
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+
+    updateVisibility(vis, [], map, [{ q: 0, r: 1 }]);
+
+    expect(getVisibility(vis, { q: 4, r: 1 })).toBe('visible');
+    expect(getVisibility(vis, { q: 4, r: 2 })).toBe('visible');
+  });
+
+  it('uses wrapped range for shared vision', () => {
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+
+    applySharedVision(vis, [{ q: 0, r: 1 }], map);
+
+    expect(getVisibility(vis, { q: 4, r: 1 })).toBe('visible');
+    expect(getVisibility(vis, { q: 4, r: 2 })).toBe('visible');
+  });
+
+  it('treats explored wrapped neighbors as nearby when revealing minor-civ cities', () => {
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+    vis.tiles['4,1'] = 'fog';
+
+    revealMinorCivCities(vis, [{ q: 0, r: 1 }], map);
+
+    expect(getVisibility(vis, { q: 0, r: 1 })).toBe('visible');
+  });
+
+  it('matches movement wrapping: a wrapped reachable tile is also visible', async () => {
+    const { getMovementRange } = await import('@/systems/unit-system');
+    const map = createWrappedGrasslandMap(5, 4);
+    const vis = createVisibilityMap();
+    const unit = makeWarrior({ q: 0, r: 1 });
+    const wrappedNeighbor = { q: 4, r: 1 };
+
+    const movementRange = getMovementRange(unit, map, {}, {});
+    updateVisibility(vis, [unit], map);
+
+    expect(movementRange.map(hexKey)).toContain(hexKey(wrappedNeighbor));
+    expect(getVisibility(vis, wrappedNeighbor)).toBe('visible');
   });
 });
 
@@ -232,6 +345,71 @@ describe('forest concealment', () => {
     expect(isForestConcealedUnit(state, 'player', state.units.hidden)).toBe(true);
 
     state.units.scout.position = { q: 4, r: 5 };
+    expect(isForestConcealedUnit(state, 'player', state.units.hidden)).toBe(false);
+  });
+
+  it('treats wrapped-edge adjacent contact as enough to reveal concealed forest units', () => {
+    const state = {
+      turn: 1,
+      era: 1,
+      currentPlayer: 'player',
+      gameOver: false,
+      winner: null,
+      map: createWrappedGrasslandMap(5, 4),
+      units: {
+        hidden: { id: 'hidden', type: 'warrior', owner: 'ai-1', position: { q: 4, r: 1 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+        scout: { id: 'scout', type: 'scout', owner: 'player', position: { q: 0, r: 1 }, movementPointsLeft: 3, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+      },
+      cities: {},
+      civilizations: {
+        player: { id: 'player', civType: 'egypt', units: ['scout'], cities: [], visibility: createVisibilityMap(), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, score: 0, isHuman: true, name: 'Player', color: '#4a90d9', diplomacy: {} as any },
+        'ai-1': { id: 'ai-1', civType: 'lothlorien', units: ['hidden'], cities: [], visibility: createVisibilityMap(), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, score: 0, isHuman: false, name: 'Lothlorien', color: '#4d7c0f', diplomacy: {} as any },
+      },
+      barbarianCamps: {},
+      minorCivs: {},
+      tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+      settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+      tribalVillages: {},
+      discoveredWonders: {},
+      wonderDiscoverers: {},
+      embargoes: [],
+      defensiveLeagues: [],
+    } as GameState;
+    state.map.tiles['4,1'] = { ...state.map.tiles['4,1'], terrain: 'forest' };
+
+    expect(isForestConcealedUnit(state, 'player', state.units.hidden)).toBe(false);
+  });
+
+  it('treats wrapped-edge adjacent cities as enough to reveal concealed forest units', () => {
+    const state = {
+      turn: 1,
+      era: 1,
+      currentPlayer: 'player',
+      gameOver: false,
+      winner: null,
+      map: createWrappedGrasslandMap(5, 4),
+      units: {
+        hidden: { id: 'hidden', type: 'warrior', owner: 'ai-1', position: { q: 4, r: 1 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+      },
+      cities: {
+        'city-player': { id: 'city-player', name: 'Edge City', owner: 'player', position: { q: 0, r: 1 }, population: 1, food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 },
+      },
+      civilizations: {
+        player: { id: 'player', civType: 'egypt', units: [], cities: ['city-player'], visibility: createVisibilityMap(), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, score: 0, isHuman: true, name: 'Player', color: '#4a90d9', diplomacy: {} as any },
+        'ai-1': { id: 'ai-1', civType: 'lothlorien', units: ['hidden'], cities: [], visibility: createVisibilityMap(), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, score: 0, isHuman: false, name: 'Lothlorien', color: '#4d7c0f', diplomacy: {} as any },
+      },
+      barbarianCamps: {},
+      minorCivs: {},
+      tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+      settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+      tribalVillages: {},
+      discoveredWonders: {},
+      wonderDiscoverers: {},
+      embargoes: [],
+      defensiveLeagues: [],
+    } as GameState;
+    state.map.tiles['4,1'] = { ...state.map.tiles['4,1'], terrain: 'forest' };
+
     expect(isForestConcealedUnit(state, 'player', state.units.hidden)).toBe(false);
   });
 });

--- a/tests/systems/hex-utils.test.ts
+++ b/tests/systems/hex-utils.test.ts
@@ -4,6 +4,7 @@ import {
   hexNeighbors,
   hexDistance,
   getWrappedHexNeighbors,
+  getWrappedHexesInRange,
   hexRing,
   hexesInRange,
   pixelToHex,
@@ -125,5 +126,23 @@ describe('wrapped hex helpers', () => {
   it('uses the wrapped distance across horizontal seams', () => {
     expect(wrappedHexDistance({ q: 0, r: 0 }, { q: 4, r: 0 }, 5)).toBe(1);
     expect(wrappedHexDistance({ q: 0, r: 0 }, { q: 3, r: 0 }, 5)).toBe(2);
+  });
+
+  it('wraps every coordinate in a range through the horizontal seam', () => {
+    const range = getWrappedHexesInRange({ q: 0, r: 1 }, 1, 5);
+
+    expect(range).toContainEqual({ q: 4, r: 1 });
+    expect(range).toContainEqual({ q: 4, r: 2 });
+    expect(range).toContainEqual({ q: 0, r: 1 });
+    expect(range).toContainEqual({ q: 1, r: 0 });
+  });
+
+  it('deduplicates wrapped range coordinates using canonical keys', () => {
+    const range = getWrappedHexesInRange({ q: 0, r: 1 }, 3, 5);
+    const keys = range.map(hexKey);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys.every(key => Number(key.split(',')[0]) >= 0)).toBe(true);
+    expect(keys.every(key => Number(key.split(',')[0]) < 5)).toBe(true);
   });
 });

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -1,6 +1,92 @@
 import { EventBus } from '@/core/event-bus';
+import type { GameMap, GameState, Unit } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey } from '@/systems/hex-utils';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import { makeAutoExploreFixture } from './helpers/auto-explore-fixture';
+
+function createWrappedGrasslandMap(width: number, height: number): GameMap {
+  const tiles: GameMap['tiles'] = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < height; r++) {
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: 'grassland',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+
+  return {
+    width,
+    height,
+    wrapsHorizontally: true,
+    tiles,
+    rivers: [],
+  };
+}
+
+function makeEdgeMoveState(): { state: GameState; unitId: string } {
+  const map = createWrappedGrasslandMap(5, 4);
+  const unit: Unit = {
+    id: 'edge-warrior',
+    type: 'warrior',
+    owner: 'player',
+    position: { q: 0, r: 1 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+
+  const state = {
+    turn: 1,
+    era: 1,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map,
+    units: { [unit.id]: unit },
+    cities: {},
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'generic',
+        cities: [],
+        units: [unit.id],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} },
+        gold: 0,
+        visibility: { tiles: { '4,1': 'visible' } },
+        knownCivilizations: [],
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {}, councilTalkLevel: 'normal' },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+  } as unknown as GameState;
+
+  return { state, unitId: unit.id };
+}
 
 describe('unit-movement-system', () => {
   it('applies village rewards and removes the village when automation enters it', () => {
@@ -42,5 +128,27 @@ describe('unit-movement-system', () => {
     expect(result.discoveredWonders).toEqual([
       expect.objectContaining({ wonderId: 'grand_canyon' }),
     ]);
+  });
+
+  it('returns canonical wrapped revealed tiles after moving through the seam', () => {
+    const { state, unitId } = makeEdgeMoveState();
+    const bus = new EventBus();
+    const fogRevealed = vi.fn();
+    bus.on('fog:revealed', fogRevealed);
+
+    const result = executeUnitMove(state, unitId, { q: 4, r: 1 }, {
+      actor: 'player',
+      civId: 'player',
+      bus,
+    });
+    const revealedKeys = result.revealedTiles.map(hexKey);
+
+    expect(result.to).toEqual({ q: 4, r: 1 });
+    expect(revealedKeys).toContain('0,1');
+    expect(revealedKeys.some(key => Number(key.split(',')[0]) < 0 || Number(key.split(',')[0]) >= state.map.width)).toBe(false);
+    expect(getVisibility(state.civilizations.player.visibility, { q: 0, r: 1 })).toBe('visible');
+    expect(fogRevealed).toHaveBeenCalledWith(expect.objectContaining({
+      tiles: expect.arrayContaining([{ q: 0, r: 1 }]),
+    }));
   });
 });


### PR DESCRIPTION
## Summary
- Fixes #113 by canonicalizing fog-of-war reveal coordinates on horizontally wrapping maps.
- Adds wrapped range visibility support for units, cities, minor-civ proximity reveal, shared vision, and forest concealment adjacency checks.
- Pins turn-manager minor-civ/shared-vision updates to the current newState visibility object after possible state reassignment.

## Review notes
- Added the real movement execution regression for executeUnitMove, including canonical revealedTiles, fog:revealed, and visibility state assertions.
- Added turn-manager coverage for wrapped minor-civ proximity reveal on the returned state.
- Added extra wrapped-edge forest concealment regressions for adjacent units and cities discovered during review.

## Verification
- scripts/check-src-rule-violations.sh src/systems/hex-utils.ts src/systems/fog-of-war.ts src/core/turn-manager.ts
- ./scripts/run-with-mise.sh yarn exec vitest run tests/systems/hex-utils.test.ts tests/systems/fog-of-war.test.ts tests/core/turn-manager.test.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/systems/discovery-system.test.ts tests/renderer/fog-renderer.test.ts tests/renderer/render-loop-wrap.test.ts
- ./scripts/run-with-mise.sh yarn test
- ./scripts/run-with-mise.sh yarn build