### PR TITLE
[codex] Add unit stacking selection UX

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -5,6 +5,7 @@ import { foundCity, getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { resolveCombat } from '@/systems/combat-system';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
 import { updateVisibility } from '@/systems/fog-of-war';
@@ -343,19 +344,17 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     .map(id => newState.units[id])
     .filter((u): u is Unit => u !== undefined && u.type !== 'settler' && u.type !== 'worker');
 
-  const unitPositions: Record<string, string> = {};
-  for (const [id, unit] of Object.entries(newState.units)) {
-    unitPositions[hexKey(unit.position)] = id;
-  }
-
   for (const unit of militaryUnits) {
     if (unit.movementPointsLeft <= 0) continue;
+
+    const occupancy = buildUnitOccupancy(newState.units);
 
     // Check for nearby enemies to attack
     const neighbors = hexNeighbors(unit.position);
     let attacked = false;
     for (const neighbor of neighbors) {
-      const occupantId = unitPositions[hexKey(neighbor)];
+      const occupantId = (occupancy.unitIdsByHex[hexKey(neighbor)] ?? [])
+        .find(id => newState.units[id]?.owner !== civId);
       if (occupantId) {
         const occupant = newState.units[occupantId];
         if (occupant && occupant.owner !== civId) {
@@ -421,8 +420,6 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
         movementPointsLeft: 0,
         hasMoved: true,
       };
-      delete unitPositions[hexKey(unit.position)];
-      unitPositions[hexKey(exposedEnemyCity.position)] = unit.id;
       const captureResult = resolveMajorCityCapture(
         newState,
         exposedEnemyCity.id,
@@ -436,7 +433,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     }
 
     // Explore: move toward unexplored territory
-    const range = getMovementRange(unit, newState.map, unitPositions);
+    const range = getMovementRange(unit, newState.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
     if (range.length > 0) {
       const unexplored = range.filter(
         coord => civ.visibility.tiles[hexKey(coord)] !== 'visible',
@@ -445,8 +442,6 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       const moveSeed = newState.turn * 16807 + unit.id.charCodeAt(0);
       const target = candidates[moveSeed % candidates.length];
       newState.units[unit.id] = moveUnit(unit, target, 1);
-      delete unitPositions[hexKey(unit.position)];
-      unitPositions[hexKey(target)] = unit.id;
     }
   }
 

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -29,7 +29,7 @@ export function resolveSelectedUnitTapIntent(
 
   const occupancy = buildUnitOccupancy(state.units);
   const relationship = getStackRelationship(occupancy, unit, targetCoord);
-  if (relationship.occupantIds.length > 0) {
+  if (relationship.hasHostileBlocker) {
     return { kind: 'move' };
   }
 

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -1,26 +1,12 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
+import { buildUnitOccupancy, getStackRelationship } from '@/systems/unit-occupancy';
 import { getMovementRange } from '@/systems/unit-system';
 
 export type SelectedUnitTapIntent =
   | { kind: 'move' }
   | { kind: 'assault-city'; cityId: string }
   | { kind: 'assault-minor-civ'; cityId: string; minorCivId: string };
-
-function buildUnitMaps(state: GameState): {
-  unitPositions: Record<string, string>;
-  unitOwners: Record<string, string>;
-} {
-  const unitPositions: Record<string, string> = {};
-  const unitOwners: Record<string, string> = {};
-
-  for (const unit of Object.values(state.units)) {
-    unitPositions[hexKey(unit.position)] = unit.id;
-    unitOwners[unit.id] = unit.owner;
-  }
-
-  return { unitPositions, unitOwners };
-}
 
 export function resolveSelectedUnitTapIntent(
   state: GameState,
@@ -32,8 +18,8 @@ export function resolveSelectedUnitTapIntent(
   if (!unit) return { kind: 'move' };
 
   const movementRange = movementRangeOverride ?? (() => {
-    const { unitPositions, unitOwners } = buildUnitMaps(state);
-    return getMovementRange(unit, state.map, unitPositions, unitOwners);
+    const occupancy = buildUnitOccupancy(state.units);
+    return getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
   })();
 
   const targetKey = hexKey(targetCoord);
@@ -41,10 +27,9 @@ export function resolveSelectedUnitTapIntent(
     return { kind: 'move' };
   }
 
-  const occupiedByOtherUnit = Object.values(state.units).some(other =>
-    other.id !== unitId && hexKey(other.position) === targetKey,
-  );
-  if (occupiedByOtherUnit) {
+  const occupancy = buildUnitOccupancy(state.units);
+  const relationship = getStackRelationship(occupancy, unit, targetCoord);
+  if (relationship.occupantIds.length > 0) {
     return { kind: 'move' };
   }
 

--- a/src/input/unit-stack-selection.ts
+++ b/src/input/unit-stack-selection.ts
@@ -1,0 +1,30 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+
+export type FriendlyUnitStackTap =
+  | { kind: 'none' }
+  | { kind: 'select-unit'; unitId: string }
+  | { kind: 'open-stack-picker'; unitIds: string[] };
+
+export function getFriendlyUnitIdsAtHex(
+  state: GameState,
+  coord: HexCoord,
+): string[] {
+  const key = hexKey(coord);
+  return Object.values(state.units)
+    .filter(unit => unit.owner === state.currentPlayer && hexKey(unit.position) === key)
+    .map(unit => unit.id)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function resolveFriendlyUnitStackTap(
+  state: GameState,
+  coord: HexCoord,
+  selectedUnitId: string | null,
+): FriendlyUnitStackTap {
+  const unitIds = getFriendlyUnitIdsAtHex(state, coord);
+  if (unitIds.length === 0) return { kind: 'none' };
+  if (unitIds.length > 1) return { kind: 'open-stack-picker', unitIds };
+  if (selectedUnitId && unitIds[0] === selectedUnitId) return { kind: 'select-unit', unitId: unitIds[0] };
+  return { kind: 'select-unit', unitId: unitIds[0] };
+}

--- a/src/input/unit-stack-selection.ts
+++ b/src/input/unit-stack-selection.ts
@@ -6,6 +6,11 @@ export type FriendlyUnitStackTap =
   | { kind: 'select-unit'; unitId: string }
   | { kind: 'open-stack-picker'; unitIds: string[] };
 
+export interface FriendlyUnitStackTapCallbacks {
+  onSelectUnit: (unitId: string) => void;
+  onOpenStackPicker: (coord: HexCoord, unitIds: string[]) => void;
+}
+
 export function getFriendlyUnitIdsAtHex(
   state: GameState,
   coord: HexCoord,
@@ -27,4 +32,22 @@ export function resolveFriendlyUnitStackTap(
   if (unitIds.length > 1) return { kind: 'open-stack-picker', unitIds };
   if (selectedUnitId && unitIds[0] === selectedUnitId) return { kind: 'select-unit', unitId: unitIds[0] };
   return { kind: 'select-unit', unitId: unitIds[0] };
+}
+
+export function handleFriendlyUnitStackTap(
+  state: GameState,
+  coord: HexCoord,
+  selectedUnitId: string | null,
+  callbacks: FriendlyUnitStackTapCallbacks,
+): boolean {
+  const friendlyTap = resolveFriendlyUnitStackTap(state, coord, selectedUnitId);
+  if (friendlyTap.kind === 'open-stack-picker') {
+    callbacks.onOpenStackPicker(coord, friendlyTap.unitIds);
+    return true;
+  }
+  if (friendlyTap.kind === 'select-unit') {
+    callbacks.onSelectUnit(friendlyTap.unitId);
+    return true;
+  }
+  return false;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import { createCouncilPanel } from '@/ui/council-panel';
 import { createGameShell } from '@/ui/game-shell';
 import { createContextMenu } from '@/ui/context-menu';
 import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
+import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
 import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
 import { showCampaignSetup } from '@/ui/campaign-setup';
@@ -63,6 +64,7 @@ import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
+import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import {
   type PendingCityCaptureChoice,
   beginPlayerCityAssaultChoice,
@@ -70,6 +72,7 @@ import {
   shouldPromptForPlayerCityCapture,
 } from '@/input/city-assault-flow';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
+import { getFriendlyUnitIdsAtHex, resolveFriendlyUnitStackTap } from '@/input/unit-stack-selection';
 import {
   initializeLegendaryWonderProjectsForCity,
   startLegendaryWonderBuild,
@@ -1019,25 +1022,44 @@ function getPersistedSettingsOverrides(): Partial<GameState['settings']> {
   };
 }
 
+function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
+  const panel = document.getElementById('info-panel');
+  if (!panel) return;
+
+  renderUnitStackPanel(panel, gameState, coord, unitIds, {
+    onSelectUnit: (unitId) => selectUnit(unitId),
+    onOpenCity: (cityId) => {
+      const city = gameState.cities[cityId];
+      if (!city) return;
+      document.getElementById('tech-panel')?.remove();
+      document.getElementById('city-panel')?.remove();
+      document.getElementById('espionage-panel')?.remove();
+      document.getElementById('diplomacy-panel')?.remove();
+      document.getElementById('marketplace-panel')?.remove();
+      document.getElementById('council-panel')?.remove();
+      deselectUnit();
+      openCityPanelForCity(city);
+    },
+    onClose: () => deselectUnit(),
+  }, { selectedUnitId });
+}
+
 function selectUnit(unitId: string): void {
   selectedUnitId = unitId;
   const unit = gameState.units[unitId];
   if (!unit || unit.owner !== gameState.currentPlayer) return;
 
-  // Calculate movement range
-  const unitPositions: Record<string, string> = {};
-  const unitOwners: Record<string, string> = {};
-  for (const [id, u] of Object.entries(gameState.units)) {
-    unitPositions[hexKey(u.position)] = id;
-    unitOwners[id] = u.owner;
-  }
-  movementRange = getMovementRange(unit, gameState.map, unitPositions, unitOwners);
+  const occupancy = buildUnitOccupancy(gameState.units);
+  movementRange = getMovementRange(unit, gameState.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
 
   // Classify hexes as move or attack and send to renderer
   const highlights: HexHighlight[] = movementRange.map(coord => {
     const k = hexKey(coord);
-    const occupantId = unitPositions[k];
-    if (occupantId && unitOwners[occupantId] !== gameState.currentPlayer) {
+    const occupantIds = occupancy.unitIdsByHex[k] ?? [];
+    const hasEnemy = occupantIds.some(occupantId =>
+      occupantId !== unit.id && occupancy.ownersByUnitId[occupantId] !== gameState.currentPlayer,
+    );
+    if (hasEnemy) {
       return { coord, type: 'attack' as const };
     }
     return { coord, type: 'move' as const };
@@ -1054,6 +1076,10 @@ function selectUnit(unitId: string): void {
       onBuildMine: () => buildImprovementAction('mine'),
       onRest: () => restAction(),
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
+      onOpenStack: (coord) => {
+        const unitIds = getFriendlyUnitIdsAtHex(gameState, coord);
+        if (unitIds.length > 1) openUnitStackPicker(coord, unitIds);
+      },
       onSetDisguise: (uid, disguise) => {
         const unit = gameState.units[uid];
         if (!unit || unit.hasActed) return;
@@ -1505,18 +1531,26 @@ function handleHexTap(rawCoord: HexCoord): void {
     : rawCoord;
   const key = hexKey(coord);
 
-  // Check if tapping a unit
+  const selectedUnitCanMoveToTappedHex = selectedUnitId && movementRange.some(h => hexKey(h) === key);
+  if (!selectedUnitCanMoveToTappedHex) {
+    const friendlyTap = resolveFriendlyUnitStackTap(gameState, coord, selectedUnitId);
+    if (friendlyTap.kind === 'open-stack-picker') {
+      openUnitStackPicker(coord, friendlyTap.unitIds);
+      return;
+    }
+    if (friendlyTap.kind === 'select-unit') {
+      selectUnit(friendlyTap.unitId);
+      return;
+    }
+  }
+
   const unitAtHex = Object.entries(gameState.units).find(
-    ([_, u]) => hexKey(u.position) === key && (
-      u.owner === gameState.currentPlayer || !isForestConcealedUnit(gameState, gameState.currentPlayer, u)
-    )
+    ([_, u]) => hexKey(u.position) === key
+      && u.owner !== gameState.currentPlayer
+      && !isForestConcealedUnit(gameState, gameState.currentPlayer, u),
   );
 
   if (unitAtHex) {
-    if (unitAtHex[1].owner === gameState.currentPlayer) {
-      selectUnit(unitAtHex[0]);
-      return;
-    }
     // Show enemy unit info (if no unit selected for attack)
     if (!selectedUnitId) {
       const enemyUnit = unitAtHex[1];

--- a/src/main.ts
+++ b/src/main.ts
@@ -64,7 +64,7 @@ import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
-import { buildUnitOccupancy } from '@/systems/unit-occupancy';
+import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupancy';
 import {
   type PendingCityCaptureChoice,
   beginPlayerCityAssaultChoice,
@@ -72,7 +72,7 @@ import {
   shouldPromptForPlayerCityCapture,
 } from '@/input/city-assault-flow';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
-import { getFriendlyUnitIdsAtHex, resolveFriendlyUnitStackTap } from '@/input/unit-stack-selection';
+import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
 import {
   initializeLegendaryWonderProjectsForCity,
   startLegendaryWonderBuild,
@@ -1077,8 +1077,10 @@ function selectUnit(unitId: string): void {
       onRest: () => restAction(),
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
       onOpenStack: (coord) => {
-        const unitIds = getFriendlyUnitIdsAtHex(gameState, coord);
-        if (unitIds.length > 1) openUnitStackPicker(coord, unitIds);
+        handleFriendlyUnitStackTap(gameState, coord, selectedUnitId, {
+          onSelectUnit: selectUnit,
+          onOpenStackPicker: openUnitStackPicker,
+        });
       },
       onSetDisguise: (uid, disguise) => {
         const unit = gameState.units[uid];
@@ -1483,20 +1485,26 @@ function executeAttack(attackerId: string, defenderId: string, defender: Unit, t
     }
 
     const cityAtTarget = Object.values(gameState.cities).find(c => hexKey(c.position) === targetKey);
-    if (cityAtTarget && cityAtTarget.owner.startsWith('mc-')) {
-      const conqueredCityName = cityAtTarget.name;
-      conquestMinorCiv(gameState, cityAtTarget.owner, gameState.currentPlayer, bus);
-      showNotification(`${conqueredCityName} has been conquered!`, 'success');
-    }
-    if (cityAtTarget && !cityAtTarget.owner.startsWith('mc-') && cityAtTarget.owner !== gameState.currentPlayer) {
-      const assaultStatus = beginPlayerCityAssault(attackerId, cityAtTarget.id, attackerBonus);
-      SFX.combat();
-      renderLoop.setGameState(gameState);
-      updateHUD();
-      if (assaultStatus === 'resolved') {
-        selectNextUnit();
+    if (cityAtTarget) {
+      const occupancy = buildUnitOccupancy(gameState.units);
+      const remainingHostileDefenders = hasHostileUnitAtCoord(occupancy, cityAtTarget.position, gameState.currentPlayer);
+      if (!remainingHostileDefenders) {
+        if (cityAtTarget.owner.startsWith('mc-')) {
+          const conqueredCityName = cityAtTarget.name;
+          conquestMinorCiv(gameState, cityAtTarget.owner, gameState.currentPlayer, bus);
+          showNotification(`${conqueredCityName} has been conquered!`, 'success');
+        }
+        if (!cityAtTarget.owner.startsWith('mc-') && cityAtTarget.owner !== gameState.currentPlayer) {
+          const assaultStatus = beginPlayerCityAssault(attackerId, cityAtTarget.id, attackerBonus);
+          SFX.combat();
+          renderLoop.setGameState(gameState);
+          updateHUD();
+          if (assaultStatus === 'resolved') {
+            selectNextUnit();
+          }
+          return;
+        }
       }
-      return;
     }
   } else {
     if (gameState.units[defenderId]) {
@@ -1533,13 +1541,10 @@ function handleHexTap(rawCoord: HexCoord): void {
 
   const selectedUnitCanMoveToTappedHex = selectedUnitId && movementRange.some(h => hexKey(h) === key);
   if (!selectedUnitCanMoveToTappedHex) {
-    const friendlyTap = resolveFriendlyUnitStackTap(gameState, coord, selectedUnitId);
-    if (friendlyTap.kind === 'open-stack-picker') {
-      openUnitStackPicker(coord, friendlyTap.unitIds);
-      return;
-    }
-    if (friendlyTap.kind === 'select-unit') {
-      selectUnit(friendlyTap.unitId);
+    if (handleFriendlyUnitStackTap(gameState, coord, selectedUnitId, {
+      onSelectUnit: selectUnit,
+      onOpenStackPicker: openUnitStackPicker,
+    })) {
       return;
     }
   }

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -28,6 +28,25 @@ const OWNER_COLORS: Record<string, string> = {
   barbarian: '#8b4513',
 };
 
+const STACK_OFFSETS = [
+  { x: 0, y: 0 },
+  { x: -0.18, y: -0.1 },
+  { x: 0.18, y: 0.1 },
+];
+
+function groupUnitsByHex(units: Unit[]): Record<string, Unit[]> {
+  const groups: Record<string, Unit[]> = {};
+  for (const unit of units) {
+    const key = `${unit.position.q},${unit.position.r}`;
+    groups[key] ??= [];
+    groups[key].push(unit);
+  }
+  for (const group of Object.values(groups)) {
+    group.sort((a, b) => a.id.localeCompare(b.id));
+  }
+  return groups;
+}
+
 export function drawUnits(
   ctx: CanvasRenderingContext2D,
   units: Record<string, Unit>,
@@ -37,15 +56,15 @@ export function drawUnits(
   currentPlayer: string,
   colorLookup?: Record<string, string>,
 ): void {
-  for (const unit of Object.values(units)) {
-    // Only draw units visible to the player
-    if (!isVisible(playerVisibility, unit.position)) continue;
-    if (isForestConcealedUnit(state, currentPlayer, unit)) continue;
-    const ownerColor = colorLookup?.[unit.owner] ?? OWNER_COLORS[unit.owner] ?? '#888';
+  const visibleUnits = Object.values(units).filter(unit =>
+    isVisible(playerVisibility, unit.position) && !isForestConcealedUnit(state, currentPlayer, unit),
+  );
 
+  for (const stack of Object.values(groupUnitsByHex(visibleUnits))) {
+    const anchor = stack[0].position;
     const renderCoords = state.map.wrapsHorizontally
-      ? getHorizontalWrapRenderCoords(unit.position, state.map.width, camera)
-      : [unit.position];
+      ? getHorizontalWrapRenderCoords(anchor, state.map.width, camera)
+      : [anchor];
 
     for (const renderCoord of renderCoords) {
       if (!camera.isHexVisible(renderCoord)) continue;
@@ -53,35 +72,53 @@ export function drawUnits(
       const pixel = hexToPixel(renderCoord, camera.hexSize);
       const screen = camera.worldToScreen(pixel.x, pixel.y);
       const size = camera.hexSize * camera.zoom;
+      const unitsToDraw = stack.slice(0, 3);
 
-      // Unit background circle
-      ctx.beginPath();
-      ctx.arc(screen.x, screen.y, size * 0.35, 0, Math.PI * 2);
-      ctx.fillStyle = ownerColor;
-      ctx.fill();
-      ctx.strokeStyle = 'rgba(255,255,255,0.6)';
-      ctx.lineWidth = 1.5;
-      ctx.stroke();
+      for (let index = 0; index < unitsToDraw.length; index++) {
+        const unit = unitsToDraw[index];
+        const offset = stack.length === 1 ? STACK_OFFSETS[0] : STACK_OFFSETS[index];
+        const unitX = screen.x + offset.x * size;
+        const unitY = screen.y + offset.y * size;
+        const ownerColor = colorLookup?.[unit.owner] ?? OWNER_COLORS[unit.owner] ?? '#888';
 
-      // Unit icon
-      ctx.font = `${size * 0.4}px system-ui`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(UNIT_ICONS[unit.type] ?? '?', screen.x, screen.y);
+        ctx.beginPath();
+        ctx.arc(unitX, unitY, size * (stack.length === 1 ? 0.35 : 0.25), 0, Math.PI * 2);
+        ctx.fillStyle = ownerColor;
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+        ctx.lineWidth = 1.5;
+        ctx.stroke();
 
-      // Health bar (if damaged)
-      if (unit.health < 100) {
-        const barWidth = size * 0.6;
-        const barHeight = size * 0.08;
-        const barX = screen.x - barWidth / 2;
-        const barY = screen.y + size * 0.4;
+        ctx.font = `${size * (stack.length === 1 ? 0.4 : 0.28)}px system-ui`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(UNIT_ICONS[unit.type] ?? '?', unitX, unitY);
 
-        ctx.fillStyle = 'rgba(0,0,0,0.5)';
-        ctx.fillRect(barX, barY, barWidth, barHeight);
+        if (unit.health < 100) {
+          const barWidth = size * 0.42;
+          const barHeight = size * 0.06;
+          const barX = unitX - barWidth / 2;
+          const barY = unitY + size * 0.28;
 
-        const healthRatio = unit.health / 100;
-        ctx.fillStyle = healthRatio > 0.5 ? '#4caf50' : healthRatio > 0.25 ? '#ff9800' : '#f44336';
-        ctx.fillRect(barX, barY, barWidth * healthRatio, barHeight);
+          ctx.fillStyle = 'rgba(0,0,0,0.5)';
+          ctx.fillRect(barX, barY, barWidth, barHeight);
+
+          const healthRatio = unit.health / 100;
+          ctx.fillStyle = healthRatio > 0.5 ? '#4caf50' : healthRatio > 0.25 ? '#ff9800' : '#f44336';
+          ctx.fillRect(barX, barY, barWidth * healthRatio, barHeight);
+        }
+      }
+
+      if (stack.length > 1) {
+        ctx.beginPath();
+        ctx.arc(screen.x + size * 0.34, screen.y - size * 0.34, size * 0.16, 0, Math.PI * 2);
+        ctx.fillStyle = 'rgba(0,0,0,0.82)';
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+        ctx.stroke();
+        ctx.font = `${size * 0.18}px system-ui`;
+        ctx.fillStyle = 'white';
+        ctx.fillText(String(stack.length), screen.x + size * 0.34, screen.y - size * 0.34);
       }
     }
   }

--- a/src/systems/auto-explore-system.ts
+++ b/src/systems/auto-explore-system.ts
@@ -3,6 +3,7 @@ import type { GameState, HexCoord } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey, hexNeighbors, getWrappedHexNeighbors } from '@/systems/hex-utils';
 import { isThreatenedByVisibleHostiles } from '@/systems/movement-safety';
+import { buildUnitOccupancy, getStackRelationship } from '@/systems/unit-occupancy';
 import { getMovementCost, getMovementRange } from '@/systems/unit-system';
 import { executeUnitMove, type ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
 
@@ -12,19 +13,11 @@ export interface AutoExploreOrder {
   reason: string;
 }
 
-function getOccupants(state: GameState): { positions: Record<string, string>; owners: Record<string, string> } {
-  const positions: Record<string, string> = {};
-  const owners: Record<string, string> = {};
-  for (const unit of Object.values(state.units)) {
-    positions[hexKey(unit.position)] = unit.id;
-    owners[unit.id] = unit.owner;
-  }
-  return { positions, owners };
-}
-
-function isDestinationEmpty(state: GameState, unitId: string, coord: HexCoord): boolean {
-  const key = hexKey(coord);
-  return !Object.values(state.units).some(unit => unit.id !== unitId && hexKey(unit.position) === key);
+function canAutoExploreEnter(state: GameState, unitId: string, coord: HexCoord): boolean {
+  const unit = state.units[unitId];
+  if (!unit) return false;
+  const occupancy = buildUnitOccupancy(state.units);
+  return !getStackRelationship(occupancy, unit, coord).hasHostileBlocker;
 }
 
 function countUnexploredNeighbors(state: GameState, viewerId: string, coord: HexCoord): number {
@@ -53,7 +46,7 @@ function rankCandidate(state: GameState, unitId: string, coord: HexCoord): { sco
   }
 
   const tile = state.map.tiles[hexKey(coord)];
-  if (!tile || getMovementCost(tile.terrain) > unit.movementPointsLeft || !isDestinationEmpty(state, unitId, coord)) {
+  if (!tile || getMovementCost(tile.terrain) > unit.movementPointsLeft || !canAutoExploreEnter(state, unitId, coord)) {
     return null;
   }
 
@@ -79,8 +72,8 @@ export function chooseAutoExploreMove(state: GameState, unitId: string): AutoExp
     return null;
   }
 
-  const { positions, owners } = getOccupants(state);
-  const best = getMovementRange(unit, state.map, positions, owners)
+  const occupancy = buildUnitOccupancy(state.units);
+  const best = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId)
     .map(coord => ({ coord, rank: rankCandidate(state, unitId, coord) }))
     .filter((entry): entry is { coord: HexCoord; rank: { score: number; reason: string } } => entry.rank !== null)
     .sort((a, b) => b.rank.score - a.rank.score)[0];
@@ -108,7 +101,11 @@ export function applyAutoExploreOrder(
 
   const order = chooseAutoExploreMove(state, unitId);
   if (!order) {
-    delete state.units[unitId].automation;
+    const { automation: _automation, ...unitWithoutAutomation } = state.units[unitId];
+    state.units = {
+      ...state.units,
+      [unitId]: unitWithoutAutomation,
+    };
     return null;
   }
 
@@ -117,13 +114,19 @@ export function applyAutoExploreOrder(
     civId: unit.owner,
     bus: options.bus,
   });
-  state.units[unitId] = {
-    ...state.units[unitId],
-    automation: {
-      mode: 'auto-explore',
-      startedTurn: unit.automation.startedTurn,
-      lastTargets: [...unit.automation.lastTargets, hexKey(order.to)].slice(-4),
-    },
-  };
+  const movedUnit = state.units[unitId];
+  if (movedUnit) {
+    state.units = {
+      ...state.units,
+      [unitId]: {
+        ...movedUnit,
+        automation: {
+          mode: 'auto-explore',
+          startedTurn: unit.automation.startedTurn,
+          lastTargets: [...unit.automation.lastTargets, hexKey(order.to)].slice(-4),
+        },
+      },
+    };
+  }
   return result;
 }

--- a/src/systems/unit-occupancy.ts
+++ b/src/systems/unit-occupancy.ts
@@ -1,0 +1,77 @@
+import type { HexCoord, Unit } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export interface UnitOccupancyIndex {
+  unitIdsByHex: Record<string, string[]>;
+  ownersByUnitId: Record<string, string>;
+}
+
+export interface StackRelationship {
+  occupantIds: string[];
+  friendlyUnitIds: string[];
+  hostileUnitIds: string[];
+  hasFriendlyStack: boolean;
+  hasHostileBlocker: boolean;
+}
+
+export function buildUnitOccupancy(units: Record<string, Unit>): UnitOccupancyIndex {
+  const unitIdsByHex: Record<string, string[]> = {};
+  const ownersByUnitId: Record<string, string> = {};
+
+  for (const [unitId, unit] of Object.entries(units)) {
+    const key = hexKey(unit.position);
+    unitIdsByHex[key] ??= [];
+    unitIdsByHex[key].push(unitId);
+    ownersByUnitId[unitId] = unit.owner;
+  }
+
+  for (const ids of Object.values(unitIdsByHex)) {
+    ids.sort((a, b) => a.localeCompare(b));
+  }
+
+  return { unitIdsByHex, ownersByUnitId };
+}
+
+export function getUnitIdsAtCoord(index: UnitOccupancyIndex, coord: HexCoord): string[] {
+  return [...(index.unitIdsByHex[hexKey(coord)] ?? [])];
+}
+
+export function getStackRelationship(
+  index: UnitOccupancyIndex,
+  movingUnit: Unit,
+  coord: HexCoord,
+): StackRelationship {
+  const occupantIds = getUnitIdsAtCoord(index, coord).filter(id => id !== movingUnit.id);
+  const friendlyUnitIds = occupantIds.filter(id => index.ownersByUnitId[id] === movingUnit.owner);
+  const hostileUnitIds = occupantIds.filter(id => index.ownersByUnitId[id] !== movingUnit.owner);
+
+  return {
+    occupantIds,
+    friendlyUnitIds,
+    hostileUnitIds,
+    hasFriendlyStack: friendlyUnitIds.length > 0,
+    hasHostileBlocker: hostileUnitIds.length > 0,
+  };
+}
+
+function isReady(unit: Unit): boolean {
+  return unit.movementPointsLeft > 0 && !unit.hasActed;
+}
+
+export function sortUnitsForStackPicker(units: Unit[], currentUnitId: string | null = null): Unit[] {
+  return [...units].sort((a, b) => {
+    const readyDelta = Number(isReady(b)) - Number(isReady(a));
+    if (readyDelta !== 0) return readyDelta;
+
+    if (currentUnitId) {
+      const currentDelta = Number(b.id === currentUnitId) - Number(a.id === currentUnitId);
+      if (currentDelta !== 0) return currentDelta;
+    }
+
+    const nameDelta = UNIT_DEFINITIONS[a.type].name.localeCompare(UNIT_DEFINITIONS[b.type].name);
+    if (nameDelta !== 0) return nameDelta;
+
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/src/systems/unit-occupancy.ts
+++ b/src/systems/unit-occupancy.ts
@@ -55,6 +55,14 @@ export function getStackRelationship(
   };
 }
 
+export function hasHostileUnitAtCoord(
+  index: UnitOccupancyIndex,
+  coord: HexCoord,
+  ownerId: string,
+): boolean {
+  return getUnitIdsAtCoord(index, coord).some(unitId => index.ownersByUnitId[unitId] !== ownerId);
+}
+
 function isReady(unit: Unit): boolean {
   return unit.movementPointsLeft > 0 && !unit.hasActed;
 }

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -241,10 +241,15 @@ function isPassable(terrain: string): boolean {
   return getMovementCost(terrain) < Infinity;
 }
 
+function normalizeOccupants(value: string | string[] | undefined): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
 export function getMovementRange(
   unit: Unit,
   map: GameMap,
-  unitPositions: Record<string, string>, // hexKey -> unitId (for blocking)
+  unitPositions: Record<string, string | string[]>, // hexKey -> unitId(s) for occupancy
   unitOwners?: Record<string, string>, // unitId -> owner (to distinguish friend/foe)
 ): HexCoord[] {
   const reachable: HexCoord[] = [];
@@ -270,19 +275,17 @@ export function getMovementRange(
       const remaining = current.remaining - cost;
       if (remaining < 0) continue;
 
-      // Check for unit blocking
-      const occupant = unitPositions[key];
-      if (occupant && occupant !== unit.id) {
-        const occupantOwner = unitOwners?.[occupant];
-        if (!occupantOwner || occupantOwner === unit.owner) continue; // block friendlies
-        // Enemy tile is reachable (for attack) but can't pathfind through
-        const prevRemaining = visited.get(key) ?? -1;
-        if (remaining > prevRemaining) {
-          visited.set(key, remaining);
-          reachable.push(neighbor);
-          // Don't add to queue — can't move through enemies
+      const occupants = normalizeOccupants(unitPositions[key]).filter(id => id !== unit.id);
+      if (occupants.length > 0) {
+        const hostileOccupants = occupants.filter(id => unitOwners?.[id] !== unit.owner);
+        if (hostileOccupants.length > 0) {
+          const prevRemaining = visited.get(key) ?? -1;
+          if (remaining > prevRemaining) {
+            visited.set(key, remaining);
+            reachable.push(neighbor);
+          }
+          continue;
         }
-        continue;
       }
 
       const prevRemaining = visited.get(key) ?? -1;

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -1,4 +1,4 @@
-import type { GameState, DisguiseType } from '@/core/types';
+import type { GameState, DisguiseType, HexCoord } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
 import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
@@ -16,6 +16,7 @@ export interface SelectedUnitInfoCallbacks {
   onInfiltrate?: (unitId: string) => void;
   onEmbed?: (unitId: string) => void;
   onUpgradeUnit?: (unitId: string, cityId: string) => void;
+  onOpenStack?: (coord: HexCoord) => void;
 }
 
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
@@ -76,6 +77,20 @@ export function renderSelectedUnitInfo(
 
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
+
+  const friendlyUnitsHere = Object.values(state.units).filter(other =>
+    other.owner === unit.owner && hexKey(other.position) === hexKey(unit.position),
+  );
+  if (friendlyUnitsHere.length > 1 && callbacks.onOpenStack) {
+    const stackRow = document.createElement('div');
+    stackRow.style.cssText = 'margin-top:8px;display:flex;justify-content:space-between;align-items:center;gap:8px;font-size:11px;color:#e8c170;';
+    const stackText = document.createElement('span');
+    stackText.textContent = `Stack: ${friendlyUnitsHere.length} units here`;
+    const switchButton = makeButton('Switch unit', '#374151', () => callbacks.onOpenStack?.({ ...unit.position }));
+    stackRow.appendChild(stackText);
+    stackRow.appendChild(switchButton);
+    wrapper.appendChild(stackRow);
+  }
 
   if (unit.automation?.mode === 'auto-explore') {
     const statusRow = document.createElement('div');

--- a/src/ui/unit-stack-panel.ts
+++ b/src/ui/unit-stack-panel.ts
@@ -1,0 +1,117 @@
+import type { GameState, HexCoord, Unit } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { sortUnitsForStackPicker } from '@/systems/unit-occupancy';
+import { canHeal, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS } from '@/systems/unit-system';
+
+export interface UnitStackPanelCallbacks {
+  onSelectUnit: (unitId: string) => void;
+  onOpenCity?: (cityId: string) => void;
+  onClose?: () => void;
+}
+
+export interface UnitStackPanelOptions {
+  selectedUnitId?: string | null;
+}
+
+function unitStatus(unit: Unit): string {
+  if (unit.automation?.mode === 'auto-explore') return 'Auto-explore';
+  if (unit.hasActed || unit.movementPointsLeft <= 0) return 'Spent';
+
+  const def = UNIT_DEFINITIONS[unit.type];
+  if (def.canFoundCity) return 'Ready · Can found';
+  if (def.canBuildImprovements) return 'Ready · Can build';
+  if (canHeal(unit)) return 'Ready · Can rest';
+  return 'Ready';
+}
+
+function findFriendlyCityAtCoord(state: GameState, coord: HexCoord) {
+  const key = hexKey(coord);
+  return Object.values(state.cities).find(city =>
+    city.owner === state.currentPlayer && hexKey(city.position) === key,
+  );
+}
+
+function makeButton(): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.style.cssText = 'width:100%;padding:8px;border-radius:8px;border:1px solid rgba(255,255,255,0.16);background:rgba(255,255,255,0.08);color:white;text-align:left;cursor:pointer;';
+  return button;
+}
+
+export function renderUnitStackPanel(
+  container: HTMLElement,
+  state: GameState,
+  coord: HexCoord,
+  unitIds: string[],
+  callbacks: UnitStackPanelCallbacks,
+  options: UnitStackPanelOptions = {},
+): void {
+  const units = sortUnitsForStackPicker(
+    unitIds.map(unitId => state.units[unitId]).filter((unit): unit is Unit => Boolean(unit)),
+    options.selectedUnitId ?? null,
+  );
+  const city = findFriendlyCityAtCoord(state, coord);
+
+  container.style.display = 'block';
+  container.replaceChildren();
+
+  const wrapper = document.createElement('div');
+  wrapper.dataset.unitStackPanel = 'true';
+  wrapper.style.cssText = 'background:rgba(0,0,0,0.88);border-radius:12px;padding:12px 16px;border-left:4px solid #e8c170;display:flex;flex-direction:column;gap:8px;';
+
+  const topRow = document.createElement('div');
+  topRow.style.cssText = 'display:flex;justify-content:space-between;align-items:center;gap:8px;';
+
+  const title = document.createElement('strong');
+  title.textContent = `${units.length} units at ${city?.name ?? `${coord.q},${coord.r}`}`;
+  topRow.appendChild(title);
+
+  const closeButton = document.createElement('button');
+  closeButton.type = 'button';
+  closeButton.textContent = 'x';
+  closeButton.setAttribute('aria-label', 'Close unit stack');
+  closeButton.style.cssText = 'cursor:pointer;font-size:18px;opacity:0.7;background:none;border:none;color:white;';
+  closeButton.addEventListener('click', () => callbacks.onClose?.());
+  topRow.appendChild(closeButton);
+  wrapper.appendChild(topRow);
+
+  if (city && callbacks.onOpenCity) {
+    const cityButton = makeButton();
+    cityButton.dataset.stackAction = 'open-city';
+    cityButton.textContent = `Open ${city.name}`;
+    cityButton.addEventListener('click', () => callbacks.onOpenCity?.(city.id));
+    wrapper.appendChild(cityButton);
+  }
+
+  for (const unit of units) {
+    const def = UNIT_DEFINITIONS[unit.type];
+    const row = makeButton();
+    row.dataset.unitStackItem = 'true';
+    row.dataset.unitId = unit.id;
+    row.dataset.selected = String(unit.id === options.selectedUnitId);
+    row.setAttribute('aria-pressed', String(unit.id === options.selectedUnitId));
+
+    const nameLine = document.createElement('div');
+    nameLine.style.cssText = 'display:flex;justify-content:space-between;gap:8px;font-size:12px;font-weight:700;';
+
+    const name = document.createElement('span');
+    name.textContent = `${unit.id === options.selectedUnitId ? 'Selected · ' : ''}${def.name}`;
+
+    const stats = document.createElement('span');
+    stats.textContent = `HP ${unit.health}/100 · Moves ${unit.movementPointsLeft}/${def.movementPoints}`;
+
+    nameLine.appendChild(name);
+    nameLine.appendChild(stats);
+
+    const statusLine = document.createElement('div');
+    statusLine.style.cssText = 'font-size:10px;opacity:0.72;margin-top:3px;';
+    statusLine.textContent = `${unitStatus(unit)} · ${UNIT_DESCRIPTIONS[unit.type] ?? ''}`;
+
+    row.appendChild(nameLine);
+    row.appendChild(statusLine);
+    row.addEventListener('click', () => callbacks.onSelectUnit(unit.id));
+    wrapper.appendChild(row);
+  }
+
+  container.appendChild(wrapper);
+}

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -114,8 +114,22 @@ describe('selected-unit-tap-intent', () => {
     expect(intent).toEqual({ kind: 'move' });
   });
 
-  it('returns move when the selected unit taps a friendly stack destination in range', () => {
+  it('returns assault-city when a friendly unit is stacked on the enemy city destination', () => {
     const state = makeTapAssaultFixture();
+    const friendly = createUnit('worker', 'player', { q: 1, r: 0 });
+    friendly.id = 'friendly-worker';
+    state.units[friendly.id] = friendly;
+    state.civilizations.player.units.push(friendly.id);
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'assault-city', cityId: 'enemyCity' });
+  });
+
+  it('returns move when the selected unit taps a friendly stack destination with no enemy city', () => {
+    const state = makeTapAssaultFixture();
+    delete state.cities.enemyCity;
+    state.civilizations['ai-1'].cities = [];
     const friendly = createUnit('worker', 'player', { q: 1, r: 0 });
     friendly.id = 'friendly-worker';
     state.units[friendly.id] = friendly;

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -113,4 +113,28 @@ describe('selected-unit-tap-intent', () => {
 
     expect(intent).toEqual({ kind: 'move' });
   });
+
+  it('returns move when the selected unit taps a friendly stack destination in range', () => {
+    const state = makeTapAssaultFixture();
+    const friendly = createUnit('worker', 'player', { q: 1, r: 0 });
+    friendly.id = 'friendly-worker';
+    state.units[friendly.id] = friendly;
+    state.civilizations.player.units.push(friendly.id);
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
+
+  it('keeps hostile garrisoned cities out of direct city assault intent', () => {
+    const state = makeTapAssaultFixture();
+    const garrison = createUnit('warrior', 'ai-1', { q: 1, r: 0 });
+    garrison.id = 'enemy-garrison';
+    state.units[garrison.id] = garrison;
+    state.civilizations['ai-1'].units.push(garrison.id);
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
 });

--- a/tests/input/unit-stack-selection-ui-flow.test.ts
+++ b/tests/input/unit-stack-selection-ui-flow.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import type { GameState, Unit } from '@/core/types';
+import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
+import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
+import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
+
+function unit(id: string, type: Unit['type']): Unit {
+  return {
+    id,
+    type,
+    owner: 'player',
+    position: { q: 2, r: 1 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+}
+
+function stackedState(): GameState {
+  return {
+    currentPlayer: 'player',
+    turn: 1,
+    era: 1,
+    map: {
+      width: 10,
+      height: 10,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: { '2,1': { coord: { q: 2, r: 1 }, terrain: 'plains', resources: [], visible: true, explored: true } },
+    },
+    units: {
+      warrior: unit('warrior', 'warrior'),
+      worker: unit('worker', 'worker'),
+    },
+    cities: {},
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        units: ['warrior', 'worker'],
+        cities: [],
+        techState: { completed: [] },
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('unit stack selection live UI flow', () => {
+  it('opens the stack picker from a friendly stack tap and updates selected unit info after row click', () => {
+    const state = stackedState();
+    const stackPanel = document.createElement('div');
+    const infoPanel = document.createElement('div');
+    let selectedUnitId = 'warrior';
+
+    const selectUnit = (unitId: string) => {
+      selectedUnitId = unitId;
+      renderSelectedUnitInfo(infoPanel, state, selectedUnitId, {
+        onOpenStack: coord => {
+          handleFriendlyUnitStackTap(state, coord, selectedUnitId, {
+            onSelectUnit: selectUnit,
+            onOpenStackPicker: (pickerCoord, unitIds) => {
+              renderUnitStackPanel(stackPanel, state, pickerCoord, unitIds, {
+                onSelectUnit: selectUnit,
+              }, { selectedUnitId });
+            },
+          });
+        },
+      });
+    };
+
+    selectUnit(selectedUnitId);
+
+    const handled = handleFriendlyUnitStackTap(state, { q: 2, r: 1 }, selectedUnitId, {
+      onSelectUnit: selectUnit,
+      onOpenStackPicker: (coord, unitIds) => {
+        renderUnitStackPanel(stackPanel, state, coord, unitIds, {
+          onSelectUnit: selectUnit,
+        }, { selectedUnitId });
+      },
+    });
+
+    expect(handled).toBe(true);
+    expect(stackPanel.textContent).toContain('2 units at 2,1');
+
+    (stackPanel.querySelector('[data-unit-id="worker"]') as HTMLButtonElement).click();
+
+    expect(selectedUnitId).toBe('worker');
+    expect(infoPanel.textContent).toContain('Worker');
+    expect(infoPanel.textContent).toContain('Stack: 2 units here');
+  });
+});

--- a/tests/input/unit-stack-selection.test.ts
+++ b/tests/input/unit-stack-selection.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState, Unit } from '@/core/types';
+import { resolveFriendlyUnitStackTap } from '@/input/unit-stack-selection';
+
+function unit(id: string, owner: string, q: number, r: number): Unit {
+  return {
+    id,
+    owner,
+    type: 'warrior',
+    position: { q, r },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+}
+
+function state(units: Record<string, Unit>): GameState {
+  return {
+    currentPlayer: 'player',
+    units,
+    cities: {},
+    map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+  } as unknown as GameState;
+}
+
+describe('unit stack selection tap resolution', () => {
+  it('selects a single friendly unit directly', () => {
+    expect(resolveFriendlyUnitStackTap(state({
+      warrior: unit('warrior', 'player', 1, 1),
+    }), { q: 1, r: 1 }, null)).toEqual({
+      kind: 'select-unit',
+      unitId: 'warrior',
+    });
+  });
+
+  it('opens the stack picker for multiple friendly units', () => {
+    expect(resolveFriendlyUnitStackTap(state({
+      warrior: unit('warrior', 'player', 1, 1),
+      worker: unit('worker', 'player', 1, 1),
+    }), { q: 1, r: 1 }, null)).toEqual({
+      kind: 'open-stack-picker',
+      unitIds: ['warrior', 'worker'],
+    });
+  });
+
+  it('opens the stack picker when the selected unit taps its own stack tile', () => {
+    expect(resolveFriendlyUnitStackTap(state({
+      warrior: unit('warrior', 'player', 1, 1),
+      worker: unit('worker', 'player', 1, 1),
+    }), { q: 1, r: 1 }, 'warrior')).toEqual({
+      kind: 'open-stack-picker',
+      unitIds: ['warrior', 'worker'],
+    });
+  });
+
+  it('ignores enemy-only units for friendly stack selection', () => {
+    expect(resolveFriendlyUnitStackTap(state({
+      enemy: unit('enemy', 'ai-1', 1, 1),
+    }), { q: 1, r: 1 }, null)).toEqual({ kind: 'none' });
+  });
+});

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -54,4 +54,50 @@ describe('unit renderer wrap parity', () => {
 
     expect(ctx.fillText).toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
   });
+
+  it('draws a count badge when multiple visible units share a tile', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      warrior: {
+        id: 'warrior',
+        owner: 'player',
+        type: 'warrior',
+        position: { q: 1, r: 1 },
+        movementPointsLeft: 2,
+        health: 100,
+        experience: 0,
+        hasMoved: false,
+        hasActed: false,
+        isResting: false,
+      },
+      worker: {
+        id: 'worker',
+        owner: 'player',
+        type: 'worker',
+        position: { q: 1, r: 1 },
+        movementPointsLeft: 2,
+        health: 100,
+        experience: 0,
+        hasMoved: false,
+        hasActed: false,
+        isResting: false,
+      },
+    };
+    const visibility: VisibilityMap = { tiles: { '1,1': 'visible' } };
+    const state = {
+      map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    } as unknown as GameState;
+    const camera = {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+
+    drawUnits(ctx, units, camera, visibility, state, 'player', { player: '#4a90d9' });
+
+    expect(ctx.fillText).toHaveBeenCalledWith('2', expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith('👷', expect.any(Number), expect.any(Number));
+  });
 });

--- a/tests/systems/unit-occupancy.test.ts
+++ b/tests/systems/unit-occupancy.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import type { Unit } from '@/core/types';
+import {
+  buildUnitOccupancy,
+  getUnitIdsAtCoord,
+  getStackRelationship,
+  sortUnitsForStackPicker,
+} from '@/systems/unit-occupancy';
+
+function unit(id: string, owner: string, q: number, r: number, overrides: Partial<Unit> = {}): Unit {
+  return {
+    id,
+    owner,
+    type: 'warrior',
+    position: { q, r },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+    ...overrides,
+  };
+}
+
+describe('unit occupancy', () => {
+  it('groups multiple units on the same hex in stable id order', () => {
+    const occupancy = buildUnitOccupancy({
+      'unit-b': unit('unit-b', 'player', 2, 1),
+      'unit-a': unit('unit-a', 'player', 2, 1),
+      'unit-c': unit('unit-c', 'player', 3, 1),
+    });
+
+    expect(getUnitIdsAtCoord(occupancy, { q: 2, r: 1 })).toEqual(['unit-a', 'unit-b']);
+    expect(getUnitIdsAtCoord(occupancy, { q: 3, r: 1 })).toEqual(['unit-c']);
+  });
+
+  it('classifies same-owner occupants as stackable for the moving unit', () => {
+    const units = {
+      mover: unit('mover', 'player', 1, 1),
+      friend: unit('friend', 'player', 2, 1),
+    };
+    const occupancy = buildUnitOccupancy(units);
+
+    expect(getStackRelationship(occupancy, units.mover, { q: 2, r: 1 })).toEqual({
+      occupantIds: ['friend'],
+      friendlyUnitIds: ['friend'],
+      hostileUnitIds: [],
+      hasFriendlyStack: true,
+      hasHostileBlocker: false,
+    });
+  });
+
+  it('classifies different-owner occupants as hostile blockers', () => {
+    const units = {
+      mover: unit('mover', 'player', 1, 1),
+      enemy: unit('enemy', 'ai-1', 2, 1),
+    };
+    const occupancy = buildUnitOccupancy(units);
+
+    expect(getStackRelationship(occupancy, units.mover, { q: 2, r: 1 })).toEqual({
+      occupantIds: ['enemy'],
+      friendlyUnitIds: [],
+      hostileUnitIds: ['enemy'],
+      hasFriendlyStack: false,
+      hasHostileBlocker: true,
+    });
+  });
+
+  it('sorts stack picker rows by ready state, current unit, name, then id', () => {
+    const units = [
+      unit('worker-2', 'player', 0, 0, { type: 'worker', movementPointsLeft: 0 }),
+      unit('scout-1', 'player', 0, 0, { type: 'scout', movementPointsLeft: 3 }),
+      unit('warrior-1', 'player', 0, 0, { type: 'warrior', movementPointsLeft: 2 }),
+    ];
+
+    expect(sortUnitsForStackPicker(units, 'warrior-1').map(u => u.id)).toEqual([
+      'warrior-1',
+      'scout-1',
+      'worker-2',
+    ]);
+  });
+});

--- a/tests/systems/unit-occupancy.test.ts
+++ b/tests/systems/unit-occupancy.test.ts
@@ -4,6 +4,7 @@ import {
   buildUnitOccupancy,
   getUnitIdsAtCoord,
   getStackRelationship,
+  hasHostileUnitAtCoord,
   sortUnitsForStackPicker,
 } from '@/systems/unit-occupancy';
 
@@ -65,6 +66,23 @@ describe('unit occupancy', () => {
       hasFriendlyStack: false,
       hasHostileBlocker: true,
     });
+  });
+
+  it('detects remaining hostile defenders while ignoring friendly stacks', () => {
+    const afterFirstDefenderDies = buildUnitOccupancy({
+      attacker: unit('attacker', 'player', 1, 1),
+      friendly: unit('friendly', 'player', 2, 1),
+      'enemy-2': unit('enemy-2', 'ai-1', 2, 1),
+    });
+
+    expect(hasHostileUnitAtCoord(afterFirstDefenderDies, { q: 2, r: 1 }, 'player')).toBe(true);
+
+    const afterAllDefendersDie = buildUnitOccupancy({
+      attacker: unit('attacker', 'player', 1, 1),
+      friendly: unit('friendly', 'player', 2, 1),
+    });
+
+    expect(hasHostileUnitAtCoord(afterAllDefendersDie, { q: 2, r: 1 }, 'player')).toBe(false);
   });
 
   it('sorts stack picker rows by ready state, current unit, name, then id', () => {

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -37,6 +37,34 @@ function createWrappedGrasslandMap(width: number, height: number): GameMap {
   };
 }
 
+function createStackCorridorMap(): GameMap {
+  const tiles: GameMap['tiles'] = {};
+  for (let q = 0; q < 5; q++) {
+    for (let r = 0; r < 3; r++) {
+      const isCorridor = r === 1 && q >= 1 && q <= 3;
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: isCorridor ? 'grassland' : 'mountain',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+
+  return {
+    width: 5,
+    height: 3,
+    wrapsHorizontally: false,
+    tiles,
+    rivers: [],
+  };
+}
+
 describe('createUnit', () => {
   it('creates a unit with full movement points', () => {
     const unit = createUnit('warrior', 'p1', { q: 5, r: 5 });
@@ -103,30 +131,46 @@ describe('getMovementRange', () => {
     expect(keys).toContain(enemyKey);
   });
 
-  it('excludes friendly-occupied tiles from range', () => {
-    const landTile = Object.values(map.tiles).find(
-      t => t.terrain === 'grassland' || t.terrain === 'plains'
-    )!;
-    const unit = createUnit('warrior', 'p1', landTile.coord);
-    const neighborTiles = Object.values(map.tiles).filter(t =>
-      (t.terrain === 'grassland' || t.terrain === 'plains') &&
-      Math.abs(t.coord.q - landTile.coord.q) + Math.abs(t.coord.r - landTile.coord.r) <= 2
-    );
-    const friendlyTile = neighborTiles.find(t => hexKey(t.coord) !== hexKey(landTile.coord));
-    if (!friendlyTile) return;
+  it('includes same-owner occupied tiles as stackable movement destinations', () => {
+    const map = createWrappedGrasslandMap(5, 3);
+    const unit = createUnit('warrior', 'p1', { q: 1, r: 1 });
+    const friendly = createUnit('worker', 'p1', { q: 2, r: 1 });
+    friendly.id = 'friendly-worker';
 
-    const friendlyKey = hexKey(friendlyTile.coord);
-    const unitPositions: Record<string, string> = {
-      [hexKey(landTile.coord)]: unit.id,
-      [friendlyKey]: 'friendly1',
-    };
-    const unitOwners: Record<string, string> = {
+    const range = getMovementRange(unit, map, {
+      [hexKey(unit.position)]: [unit.id],
+      [hexKey(friendly.position)]: [friendly.id],
+    }, {
       [unit.id]: 'p1',
-      'friendly1': 'p1',
-    };
-    const range = getMovementRange(unit, map, unitPositions, unitOwners);
-    const keys = range.map(h => hexKey(h));
-    expect(keys).not.toContain(friendlyKey);
+      [friendly.id]: 'p1',
+    });
+
+    expect(range.map(hexKey)).toContain('2,1');
+  });
+
+  it('can path through same-owner stacks but not through hostile stacks', () => {
+    const map = createStackCorridorMap();
+    const unit = createUnit('scout', 'p1', { q: 1, r: 1 });
+
+    const friendlyRange = getMovementRange(unit, map, {
+      [hexKey(unit.position)]: [unit.id],
+      '2,1': ['friendly-warrior'],
+    }, {
+      [unit.id]: 'p1',
+      'friendly-warrior': 'p1',
+    });
+
+    const hostileRange = getMovementRange(unit, map, {
+      [hexKey(unit.position)]: [unit.id],
+      '2,1': ['enemy-warrior'],
+    }, {
+      [unit.id]: 'p1',
+      'enemy-warrior': 'ai-1',
+    });
+
+    expect(friendlyRange.map(hexKey)).toContain('3,1');
+    expect(hostileRange.map(hexKey)).toContain('2,1');
+    expect(hostileRange.map(hexKey)).not.toContain('3,1');
   });
 
   it('does not include impassable tiles', () => {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -166,3 +166,74 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
     expect(called).toEqual(['unit-1', 'archer']);
   });
 });
+
+describe('renderSelectedUnitInfo - unit stack switch', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('renders a switch action when another friendly unit shares the selected unit tile', () => {
+    const state = makeSpyState([]);
+    state.units['unit-1'] = {
+      ...state.units['unit-1'],
+      type: 'warrior',
+      position: { q: 4, r: 2 },
+    } as any;
+    state.units['unit-2'] = {
+      ...state.units['unit-1'],
+      id: 'unit-2',
+      type: 'worker',
+      owner: 'player',
+      position: { q: 4, r: 2 },
+    } as any;
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onOpenStack: () => {},
+    });
+
+    expect(collectAllText(container).join(' ')).toContain('Stack: 2 units here');
+    expect(findButtons(container).some(button => button.textContent === 'Switch unit')).toBe(true);
+  });
+
+  it('does not render switch action for a single selected unit', () => {
+    const state = makeSpyState([]);
+    state.units['unit-1'] = {
+      ...state.units['unit-1'],
+      type: 'warrior',
+      position: { q: 4, r: 2 },
+    } as any;
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onOpenStack: () => {},
+    });
+
+    expect(collectAllText(container).join(' ')).not.toContain('Stack:');
+  });
+
+  it('fires onOpenStack with the selected unit coordinate', () => {
+    const state = makeSpyState([]);
+    state.units['unit-1'] = {
+      ...state.units['unit-1'],
+      type: 'warrior',
+      position: { q: 4, r: 2 },
+    } as any;
+    state.units['unit-2'] = {
+      ...state.units['unit-1'],
+      id: 'unit-2',
+      type: 'worker',
+      owner: 'player',
+      position: { q: 4, r: 2 },
+    } as any;
+    let opened: { q: number; r: number } | null = null;
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
+      onOpenStack: coord => { opened = coord; },
+    });
+
+    findButtons(container).find(button => button.textContent === 'Switch unit')?.click();
+
+    expect(opened).toEqual({ q: 4, r: 2 });
+  });
+});

--- a/tests/ui/unit-stack-panel.test.ts
+++ b/tests/ui/unit-stack-panel.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import type { GameState, Unit } from '@/core/types';
+import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
+
+function unit(id: string, type: Unit['type'], overrides: Partial<Unit> = {}): Unit {
+  return {
+    id,
+    type,
+    owner: 'player',
+    position: { q: 2, r: 1 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+    ...overrides,
+  };
+}
+
+function stateWithStack(): GameState {
+  return {
+    currentPlayer: 'player',
+    turn: 3,
+    era: 1,
+    map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    units: {
+      warrior: unit('warrior', 'warrior'),
+      worker: unit('worker', 'worker', { movementPointsLeft: 0 }),
+      scout: unit('scout', 'scout', { movementPointsLeft: 3 }),
+    },
+    cities: {
+      city: {
+        id: 'city',
+        name: 'Roma',
+        owner: 'player',
+        position: { q: 2, r: 1 },
+        population: 2,
+        food: 0,
+        foodNeeded: 10,
+        buildings: [],
+        productionQueue: [],
+        productionProgress: 0,
+        ownedTiles: [{ q: 2, r: 1 }],
+        grid: [],
+        gridSize: 3,
+        unrestLevel: 0,
+        unrestTurns: 0,
+        spyUnrestBonus: 0,
+      },
+    },
+    civilizations: {
+      player: { id: 'player', name: 'Player', color: '#4a90d9', units: ['warrior', 'worker', 'scout'], cities: ['city'] },
+    },
+  } as unknown as GameState;
+}
+
+describe('unit stack panel', () => {
+  it('renders every stacked unit and keeps spent units reachable', () => {
+    const container = document.createElement('div');
+
+    renderUnitStackPanel(container, stateWithStack(), { q: 2, r: 1 }, ['warrior', 'worker', 'scout'], {
+      onSelectUnit: () => {},
+    }, { selectedUnitId: 'warrior' });
+
+    const rows = Array.from(container.querySelectorAll('[data-unit-stack-item]'));
+    expect(rows.map(row => row.getAttribute('data-unit-id'))).toEqual(['warrior', 'scout', 'worker']);
+    expect(container.textContent).toContain('3 units at Roma');
+    expect(container.textContent).toContain('Warrior');
+    expect(container.textContent).toContain('Scout');
+    expect(container.textContent).toContain('Worker');
+    expect(container.textContent).toContain('Spent');
+  });
+
+  it('fires onSelectUnit with the clicked unit id', () => {
+    const container = document.createElement('div');
+    let selected: string | null = null;
+
+    renderUnitStackPanel(container, stateWithStack(), { q: 2, r: 1 }, ['warrior', 'worker', 'scout'], {
+      onSelectUnit: unitId => { selected = unitId; },
+    });
+
+    (container.querySelector('[data-unit-id="worker"]') as HTMLButtonElement).click();
+
+    expect(selected).toBe('worker');
+  });
+
+  it('renders a friendly city action for city stacks', () => {
+    const container = document.createElement('div');
+    let openedCity: string | null = null;
+
+    renderUnitStackPanel(container, stateWithStack(), { q: 2, r: 1 }, ['warrior', 'worker'], {
+      onSelectUnit: () => {},
+      onOpenCity: cityId => { openedCity = cityId; },
+    });
+
+    const cityButton = container.querySelector('[data-stack-action="open-city"]') as HTMLButtonElement;
+    expect(cityButton.textContent).toContain('Open Roma');
+    cityButton.click();
+    expect(openedCity).toBe('city');
+  });
+});


### PR DESCRIPTION
## Summary

Adds friendly unit stacking support for issue #151, including shared unit occupancy helpers, stack-aware movement/auto-explore/AI behavior, visible stack rendering, selected-unit stack switching, and a unit stack picker panel.

## Review fixes

- Prevents city capture or assault from proceeding after only one defender dies when other hostile defenders remain stacked on the city hex.
- Allows enemy-city assault intent when the only units stacked on the target are friendly units.
- Adds click-through UI regression coverage for opening the stack picker and updating the selected-unit panel after selecting another unit.

## Player impact

Players can now identify and select the intended friendly unit when multiple units share a hex, including from the map and from the selected-unit info panel. Stacked units remain visible and lower-priority or spent units stay reachable from the picker.

## Validation

- scripts/check-src-rule-violations.sh src/systems/unit-occupancy.ts src/input/selected-unit-tap-intent.ts src/input/unit-stack-selection.ts src/main.ts
- ./scripts/run-with-mise.sh yarn test
- ./scripts/run-with-mise.sh yarn build
- git diff --check