### PR TITLE
[codex] Add basic worker tile improvements

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -162,7 +162,9 @@ export interface TribalVillage {
 
 export type VisibilityState = 'unexplored' | 'fog' | 'visible';
 
-export type ImprovementType = 'farm' | 'mine' | 'none';
+export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill' | 'none';
+export type BuildableImprovementType = Exclude<ImprovementType, 'none'>;
+export type WorkerActionType = BuildableImprovementType | 'drain_swamp';
 
 export interface HexTile {
   coord: HexCoord;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -223,6 +223,7 @@ export interface Unit {
   experience: number;
   hasMoved: boolean;
   hasActed: boolean;         // used action this turn (build, found, etc.)
+  chargesRemaining?: number; // workers default to 2; omitted on legacy saves
   isResting: boolean;        // player explicitly chose to rest/heal this turn
   automation?: {
     mode: 'auto-explore';

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
+import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
@@ -1839,7 +1840,7 @@ function handleHexLongPress(rawCoord: HexCoord): void {
   }
 
   const wonderInfo = tile.wonder ? ` · ⭐ ${getWonderDefinition(tile.wonder)?.name ?? tile.wonder}` : '';
-  showNotification(`${tile.terrain} · ${tile.elevation}${tile.improvement !== 'none' ? ' · ' + tile.improvement : ''}${tile.resource ? ' · ' + tile.resource : ''}${wonderInfo}`);
+  showNotification(`${tile.terrain} · ${tile.elevation}${tile.improvement !== 'none' ? ' · ' + getImprovementDisplayName(tile.improvement) : ''}${tile.resource ? ' · ' + tile.resource : ''}${wonderInfo}`);
 }
 
 async function endTurn(): Promise<void> {
@@ -1920,7 +1921,7 @@ function processImprovements(): void {
       tile.improvementTurnsLeft--;
       if (tile.improvementTurnsLeft === 0) {
         bus.emit('improvement:completed', { coord: tile.coord, type: tile.improvement });
-        showNotification(`${tile.improvement} completed!`, 'success');
+        showNotification(`${getImprovementDisplayName(tile.improvement)} completed!`, 'success');
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { resolveCombat, getTerrainDefenseBonus } from '@/systems/combat-system';
-import { canBuildImprovement, IMPROVEMENT_BUILD_TURNS } from '@/systems/improvement-system';
+import { applyWorkerAction } from '@/systems/worker-action-system';
 import { updateVisibility, isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { autoSave, loadAutoSave, saveGame, loadGame, listSaves, loadSettings, saveSettings } from '@/storage/save-manager';
@@ -100,7 +100,7 @@ import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { canUpgradeUnit, applyUpgrade } from '@/systems/unit-upgrade-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
-import type { GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect } from '@/core/types';
+import type { GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
 import {
   appendNotification,
   createNotificationLog,
@@ -1072,8 +1072,7 @@ function selectUnit(unitId: string): void {
     renderSelectedUnitInfo(panel, gameState, unitId, {
       onClose: () => deselectUnit(),
       onFoundCity: () => foundCityAction(),
-      onBuildFarm: () => buildImprovementAction('farm'),
-      onBuildMine: () => buildImprovementAction('mine'),
+      onWorkerAction: action => performWorkerAction(action),
       onRest: () => restAction(),
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
       onOpenStack: (coord) => {
@@ -1341,21 +1340,31 @@ function foundCityAction(): void {
   updateHUD();
 }
 
-function buildImprovementAction(type: 'farm' | 'mine'): void {
+function performWorkerAction(action: WorkerActionType): void {
   if (!selectedUnitId) return;
-  const unit = gameState.units[selectedUnitId];
-  if (!unit || unit.type !== 'worker') return;
 
-  const tile = gameState.map.tiles[hexKey(unit.position)];
-  if (!tile || !canBuildImprovement(tile, type)) return;
+  const result = applyWorkerAction(gameState, selectedUnitId, action);
+  if (!result.ok) return;
 
-  tile.improvement = type;
-  tile.improvementTurnsLeft = IMPROVEMENT_BUILD_TURNS[type];
-  gameState.units[selectedUnitId].hasActed = true;
+  gameState = result.state;
+  for (const event of result.events) {
+    if (event.type === 'improvement:started') {
+      bus.emit('improvement:started', event.payload);
+    } else {
+      bus.emit('unit:destroyed', event.payload);
+    }
+  }
 
-  deselectUnit();
-  showNotification(`Building ${type}... (${IMPROVEMENT_BUILD_TURNS[type]} turns)`, 'info');
   renderLoop.setGameState(gameState);
+  updateHUD();
+
+  if (result.workerConsumed || result.workerLost || !gameState.units[selectedUnitId]) {
+    deselectUnit();
+  } else {
+    selectUnit(selectedUnitId);
+  }
+
+  showNotification(result.message, result.workerLost ? 'warning' : 'info');
 }
 
 function ensurePlayerWarState(targetCivId: string): void {

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -209,7 +209,13 @@ function drawHex(
     ctx.font = `${size * 0.5}px system-ui`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    const icon = tile.improvement === 'farm' ? '🌾' : '⛏️';
+    const icons: Record<string, string> = {
+      farm: '🌾',
+      mine: '⛏️',
+      lumber_camp: '🪵',
+      watermill: '💧',
+    };
+    const icon = icons[tile.improvement] ?? '◆';
     ctx.fillText(icon, cx, cy);
   }
 

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -111,7 +111,12 @@ export function getImprovementYieldBonus(type: ImprovementType): ResourceYield {
   return { ...IMPROVEMENT_DEFINITIONS[type].yieldBonus };
 }
 
+export function getImprovementDisplayName(type: ImprovementType): string {
+  if (type === 'none') return 'None';
+  return IMPROVEMENT_DEFINITIONS[type].name;
+}
+
 export function getWorkerActionLabel(action: WorkerActionType): string {
   if (action === 'drain_swamp') return 'Drain Swamp (20% worker risk)';
-  return `Build ${IMPROVEMENT_DEFINITIONS[action].name}`;
+  return `Build ${getImprovementDisplayName(action)}`;
 }

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -1,29 +1,117 @@
-import type { HexTile, ImprovementType, ResourceYield } from '@/core/types';
+import type {
+  BuildableImprovementType,
+  HexTile,
+  ImprovementType,
+  ResourceYield,
+  TerrainType,
+  WorkerActionType,
+} from '@/core/types';
+
+export interface ImprovementDefinition {
+  type: BuildableImprovementType;
+  name: string;
+  buildTurns: number;
+  validTerrains: TerrainType[];
+  requiresRiver: boolean;
+  requiredTech: string | null;
+  yieldBonus: ResourceYield;
+  preservesTerrain: boolean;
+}
+
+export const IMPROVEMENT_DEFINITIONS: Record<BuildableImprovementType, ImprovementDefinition> = {
+  farm: {
+    type: 'farm',
+    name: 'Farm',
+    buildTurns: 4,
+    validTerrains: ['grassland', 'plains', 'desert', 'forest', 'jungle'],
+    requiresRiver: false,
+    requiredTech: null,
+    yieldBonus: { food: 2, production: 0, gold: 0, science: 0 },
+    preservesTerrain: false,
+  },
+  mine: {
+    type: 'mine',
+    name: 'Mine',
+    buildTurns: 5,
+    validTerrains: ['hills', 'plains', 'mountain', 'volcanic'],
+    requiresRiver: false,
+    requiredTech: null,
+    yieldBonus: { food: 0, production: 2, gold: 1, science: 0 },
+    preservesTerrain: true,
+  },
+  lumber_camp: {
+    type: 'lumber_camp',
+    name: 'Lumber Camp',
+    buildTurns: 5,
+    validTerrains: ['forest', 'jungle'],
+    requiresRiver: false,
+    requiredTech: null,
+    yieldBonus: { food: 0, production: 2, gold: 0, science: 0 },
+    preservesTerrain: true,
+  },
+  watermill: {
+    type: 'watermill',
+    name: 'Watermill',
+    buildTurns: 5,
+    validTerrains: ['grassland', 'plains', 'forest', 'jungle', 'swamp'],
+    requiresRiver: true,
+    requiredTech: null,
+    yieldBonus: { food: 1, production: 1, gold: 0, science: 0 },
+    preservesTerrain: true,
+  },
+};
 
 export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
-  farm: 4,
-  mine: 5,
+  farm: IMPROVEMENT_DEFINITIONS.farm.buildTurns,
+  mine: IMPROVEMENT_DEFINITIONS.mine.buildTurns,
+  lumber_camp: IMPROVEMENT_DEFINITIONS.lumber_camp.buildTurns,
+  watermill: IMPROVEMENT_DEFINITIONS.watermill.buildTurns,
   none: 0,
 };
 
-const VALID_TERRAIN: Record<ImprovementType, string[]> = {
-  farm: ['grassland', 'plains', 'desert', 'forest', 'jungle'],
-  mine: ['hills', 'plains', 'mountain', 'volcanic'],
-  none: [],
-};
+const NO_YIELD: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
 
-const YIELD_BONUSES: Record<ImprovementType, ResourceYield> = {
-  farm: { food: 2, production: 0, gold: 0, science: 0 },
-  mine: { food: 0, production: 2, gold: 1, science: 0 },
-  none: { food: 0, production: 0, gold: 0, science: 0 },
-};
-
-export function canBuildImprovement(tile: HexTile, type: ImprovementType): boolean {
-  if (type === 'none') return false;
+export function canBuildImprovement(
+  tile: HexTile,
+  type: BuildableImprovementType,
+  completedTechs: string[] = [],
+  ownerId?: string,
+): boolean {
+  const definition = IMPROVEMENT_DEFINITIONS[type];
+  if (!definition) return false;
+  if (ownerId && tile.owner !== ownerId) return false;
   if (tile.improvement !== 'none') return false;
-  return VALID_TERRAIN[type].includes(tile.terrain);
+  if (!definition.validTerrains.includes(tile.terrain)) return false;
+  if (definition.requiresRiver && !tile.hasRiver) return false;
+  if (definition.requiredTech && !completedTechs.includes(definition.requiredTech)) return false;
+  return true;
+}
+
+export function canDrainSwamp(tile: HexTile, ownerId?: string): boolean {
+  if (ownerId && tile.owner !== ownerId) return false;
+  return tile.terrain === 'swamp' && tile.improvement === 'none';
+}
+
+export function getAvailableWorkerActions(
+  tile: HexTile | undefined,
+  completedTechs: string[] = [],
+  ownerId?: string,
+): WorkerActionType[] {
+  if (!tile) return [];
+  const actions: WorkerActionType[] = [];
+  for (const type of Object.keys(IMPROVEMENT_DEFINITIONS) as BuildableImprovementType[]) {
+    if (canBuildImprovement(tile, type, completedTechs, ownerId)) actions.push(type);
+  }
+  if (canDrainSwamp(tile, ownerId)) actions.push('drain_swamp');
+  return actions;
 }
 
 export function getImprovementYieldBonus(type: ImprovementType): ResourceYield {
-  return { ...YIELD_BONUSES[type] };
+  if (type === 'none') return { ...NO_YIELD };
+  return { ...IMPROVEMENT_DEFINITIONS[type].yieldBonus };
+}
+
+export function getWorkerActionLabel(action: WorkerActionType): string {
+  if (action === 'drain_swamp') return 'Drain Swamp (20% worker risk)';
+  return `Build ${IMPROVEMENT_DEFINITIONS[action].name}`;
 }

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -128,6 +128,7 @@ export function createUnit(
     experience: 0,
     hasMoved: false,
     hasActed: false,
+    chargesRemaining: type === 'worker' ? 2 : undefined,
     isResting: false,
   };
 }
@@ -199,7 +200,7 @@ export function restUnit(unit: Unit): Unit {
 
 export const UNIT_DESCRIPTIONS: Record<UnitType, string> = {
   settler: 'Civilian unit that can found new cities',
-  worker: 'Civilian unit that builds tile improvements',
+  worker: 'Civilian unit that builds tile improvements. Workers have 2 action charges by default and are used up after spending the last charge.',
   scout: 'Fast exploration unit with extended vision',
   warrior: 'Basic melee fighter — your first line of defense',
   archer: 'Ranged unit that attacks from a distance',

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -1,0 +1,226 @@
+import type {
+  BuildableImprovementType,
+  City,
+  GameEvents,
+  GameState,
+  HexCoord,
+  TerrainType,
+  Unit,
+  WorkerActionType,
+} from '@/core/types';
+import { createRng } from './map-generator';
+import { hexDistance, hexKey } from './hex-utils';
+import {
+  IMPROVEMENT_BUILD_TURNS,
+  canBuildImprovement,
+  canDrainSwamp,
+  getWorkerActionLabel,
+} from './improvement-system';
+
+export const DEFAULT_WORKER_CHARGES = 2;
+export const MAX_WORKER_CHARGES = 5;
+export const FOREST_FARM_PRODUCTION_BONUS = 20;
+export const SWAMP_DRAIN_WORKER_LOSS_CHANCE = 0.2;
+
+type WorkerActionEvent =
+  | { type: 'improvement:started'; payload: GameEvents['improvement:started'] }
+  | { type: 'unit:destroyed'; payload: GameEvents['unit:destroyed'] };
+
+export type WorkerActionFailureReason =
+  | 'missing-unit'
+  | 'not-worker'
+  | 'missing-tile'
+  | 'invalid-action'
+  | 'already-acted';
+
+export interface WorkerActionOptions {
+  rng?: () => number;
+}
+
+export type WorkerActionResult =
+  | {
+      ok: true;
+      state: GameState;
+      action: WorkerActionType;
+      message: string;
+      events: WorkerActionEvent[];
+      workerConsumed: boolean;
+      workerLost: boolean;
+      chargesRemaining: number;
+      forestProductionBonus: number;
+      boostedCityId: string | null;
+    }
+  | {
+      ok: false;
+      state: GameState;
+      reason: WorkerActionFailureReason;
+      events: [];
+    };
+
+function isBuildableImprovement(action: WorkerActionType): action is BuildableImprovementType {
+  return action !== 'drain_swamp';
+}
+
+export function getWorkerChargesRemaining(unit: Unit): number {
+  if (unit.type !== 'worker') return 0;
+  return Math.min(MAX_WORKER_CHARGES, unit.chargesRemaining ?? DEFAULT_WORKER_CHARGES);
+}
+
+function findNearestOwnedCity(state: GameState, owner: string, coord: HexCoord): City | null {
+  const cities = Object.values(state.cities)
+    .filter(candidate => candidate.owner === owner)
+    .sort((left, right) => {
+      const distanceDiff = hexDistance(left.position, coord) - hexDistance(right.position, coord);
+      return distanceDiff !== 0 ? distanceDiff : left.id.localeCompare(right.id);
+    });
+  return cities[0] ?? null;
+}
+
+function removeUnit(state: GameState, unit: Unit): GameState {
+  const { [unit.id]: _removed, ...remainingUnits } = state.units;
+  const civ = state.civilizations[unit.owner];
+  if (!civ) return { ...state, units: remainingUnits };
+
+  return {
+    ...state,
+    units: remainingUnits,
+    civilizations: {
+      ...state.civilizations,
+      [unit.owner]: {
+        ...civ,
+        units: civ.units.filter(unitId => unitId !== unit.id),
+      },
+    },
+  };
+}
+
+function defaultDrainRng(state: GameState, unit: Unit, action: WorkerActionType): () => number {
+  const seed = `${state.gameId ?? 'game'}-${state.turn}-${unit.id}-${hexKey(unit.position)}-${action}-${getWorkerChargesRemaining(unit)}`;
+  return createRng(seed);
+}
+
+export function applyWorkerAction(
+  state: GameState,
+  unitId: string,
+  action: WorkerActionType,
+  options: WorkerActionOptions = {},
+): WorkerActionResult {
+  const unit = state.units[unitId];
+  if (!unit) return { ok: false, state, reason: 'missing-unit', events: [] };
+  if (unit.type !== 'worker') return { ok: false, state, reason: 'not-worker', events: [] };
+  if (unit.hasActed) return { ok: false, state, reason: 'already-acted', events: [] };
+
+  const key = hexKey(unit.position);
+  const tile = state.map.tiles[key];
+  if (!tile) return { ok: false, state, reason: 'missing-tile', events: [] };
+
+  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  if (isBuildableImprovement(action)) {
+    if (!canBuildImprovement(tile, action, completedTechs, unit.owner)) {
+      return { ok: false, state, reason: 'invalid-action', events: [] };
+    }
+  } else if (!canDrainSwamp(tile, unit.owner)) {
+    return { ok: false, state, reason: 'invalid-action', events: [] };
+  }
+
+  const chargesBefore = getWorkerChargesRemaining(unit);
+  const chargesAfter = Math.max(0, chargesBefore - 1);
+  const events: WorkerActionEvent[] = [];
+  let nextTerrain: TerrainType = tile.terrain;
+  let nextImprovement = tile.improvement;
+  let nextImprovementTurnsLeft = tile.improvementTurnsLeft;
+  let workerLost = false;
+  let forestProductionBonus = 0;
+  let boostedCityId: string | null = null;
+
+  if (isBuildableImprovement(action)) {
+    nextImprovement = action;
+    nextImprovementTurnsLeft = IMPROVEMENT_BUILD_TURNS[action];
+    events.push({
+      type: 'improvement:started',
+      payload: { unitId, coord: { ...tile.coord }, type: action },
+    });
+
+    if (action === 'farm' && (tile.terrain === 'forest' || tile.terrain === 'jungle')) {
+      nextTerrain = 'plains';
+      const boostedCity = findNearestOwnedCity(state, unit.owner, tile.coord);
+      if (boostedCity) {
+        forestProductionBonus = FOREST_FARM_PRODUCTION_BONUS;
+        boostedCityId = boostedCity.id;
+      }
+    }
+  } else {
+    nextTerrain = 'grassland';
+    nextImprovement = 'none';
+    nextImprovementTurnsLeft = 0;
+    const rng = options.rng ?? defaultDrainRng(state, unit, action);
+    workerLost = rng() < SWAMP_DRAIN_WORKER_LOSS_CHANCE;
+  }
+
+  const nextTile = {
+    ...tile,
+    terrain: nextTerrain,
+    improvement: nextImprovement,
+    improvementTurnsLeft: nextImprovementTurnsLeft,
+  };
+
+  const nextCities = { ...state.cities };
+  if (boostedCityId) {
+    const boostedCity = nextCities[boostedCityId];
+    nextCities[boostedCityId] = {
+      ...boostedCity,
+      productionProgress: boostedCity.productionProgress + forestProductionBonus,
+    };
+  }
+
+  const updatedUnit = {
+    ...unit,
+    hasActed: true,
+    movementPointsLeft: 0,
+    chargesRemaining: chargesAfter,
+  };
+
+  let nextState: GameState = {
+    ...state,
+    map: {
+      ...state.map,
+      tiles: {
+        ...state.map.tiles,
+        [key]: nextTile,
+      },
+    },
+    cities: nextCities,
+    units: {
+      ...state.units,
+      [unitId]: updatedUnit,
+    },
+  };
+
+  const workerConsumed = chargesAfter === 0;
+  if (workerConsumed || workerLost) {
+    nextState = removeUnit(nextState, updatedUnit);
+    events.push({
+      type: 'unit:destroyed',
+      payload: { unitId, position: { ...unit.position } },
+    });
+  }
+
+  const messageParts = [getWorkerActionLabel(action)];
+  if (forestProductionBonus > 0) messageParts.push(`+${forestProductionBonus} production in ${nextCities[boostedCityId!].name}`);
+  if (workerLost) messageParts.push('worker lost draining swamp');
+  else if (workerConsumed) messageParts.push('worker used up');
+  else messageParts.push(`${chargesAfter}/${DEFAULT_WORKER_CHARGES} charges left`);
+
+  return {
+    ok: true,
+    state: nextState,
+    action,
+    message: messageParts.join(' - '),
+    events,
+    workerConsumed,
+    workerLost,
+    chargesRemaining: chargesAfter,
+    forestProductionBonus,
+    boostedCityId,
+  };
+}

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -31,6 +31,7 @@ export type WorkerActionFailureReason =
   | 'not-worker'
   | 'missing-tile'
   | 'invalid-action'
+  | 'no-charges'
   | 'already-acted';
 
 export interface WorkerActionOptions {
@@ -109,6 +110,8 @@ export function applyWorkerAction(
   if (!unit) return { ok: false, state, reason: 'missing-unit', events: [] };
   if (unit.type !== 'worker') return { ok: false, state, reason: 'not-worker', events: [] };
   if (unit.hasActed) return { ok: false, state, reason: 'already-acted', events: [] };
+  const chargesBefore = getWorkerChargesRemaining(unit);
+  if (chargesBefore <= 0) return { ok: false, state, reason: 'no-charges', events: [] };
 
   const key = hexKey(unit.position);
   const tile = state.map.tiles[key];
@@ -123,7 +126,6 @@ export function applyWorkerAction(
     return { ok: false, state, reason: 'invalid-action', events: [] };
   }
 
-  const chargesBefore = getWorkerChargesRemaining(unit);
   const chargesAfter = Math.max(0, chargesBefore - 1);
   const events: WorkerActionEvent[] = [];
   let nextTerrain: TerrainType = tile.terrain;

--- a/src/ui/advisor-system.ts
+++ b/src/ui/advisor-system.ts
@@ -37,7 +37,7 @@ const ADVISOR_MESSAGES: AdvisorMessage[] = [
     id: 'build_improvement',
     advisor: 'builder',
     icon: '🏗️',
-    message: "Your Worker can build Farms and Mines on nearby tiles. Select the Worker and choose an improvement to boost your city's output.",
+    message: "Your Worker can build Farms, Mines, Lumber Camps, and Watermills, or drain swamps on nearby tiles. Select the Worker and choose an improvement to boost your city's output.",
     trigger: (state) => Object.values(state.units).some(u => u.owner === state.currentPlayer && u.type === 'worker'),
     tutorialStep: 'build_improvement',
   },

--- a/src/ui/city-grid.ts
+++ b/src/ui/city-grid.ts
@@ -63,7 +63,7 @@ interface CityManagementOptions {
 }
 
 function titleCase(value: string): string {
-  return value.replace(/-/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+  return value.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
 }
 
 function formatYield(yieldValue: ResourceYield): string {
@@ -334,11 +334,7 @@ function renderWorkedLandSection(root: HTMLElement, city: City, options: CityMan
 
   const help = document.createElement('p');
   help.style.cssText = 'font-size:11px;color:rgba(255,255,255,0.55);margin:0;line-height:1.4;';
-  const farmBonus = getImprovementYieldBonus('farm');
-  const mineBonus = getImprovementYieldBonus('mine');
-  const farmText = formatYield(farmBonus);
-  const mineText = formatYield(mineBonus);
-  help.textContent = `Workers build Farms (${farmText}) and Mines (${mineText}) on nearby tiles. Assign citizens to worked tiles each turn to collect their yields.`;
+  help.textContent = 'Workers have 2 charges by default. They build Farms (+2 food), Mines (+2 production, +1 gold), Lumber Camps (+2 production on forest/jungle), and Watermills (+1 food, +1 production on river land).';
   section.appendChild(help);
 
   const workedKeys = new Set((city.workedTiles ?? []).map(coord => hexKey(coord)));
@@ -461,7 +457,7 @@ export function createCityGrid(
     introTitle.style.color = '#e8c170';
     introTitle.textContent = 'Grid View';
     intro.appendChild(introTitle);
-    intro.appendChild(document.createTextNode(' - Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos. Workers can also build improvements (Farms, Mines) on surrounding tiles to boost your city\'s output.'));
+    intro.appendChild(document.createTextNode(' - Tap empty slots to place buildings, tap built slots to learn what they do, and use adjacency to make clever little combos. Workers can also build improvements (Farms, Mines, Lumber Camps, Watermills) or drain swamps on surrounding tiles to boost your city\'s output.'));
     if (suggestedBuilding) {
       const suggested = document.createElement('div');
       suggested.style.cssText = 'color:#e8c170;margin-top:4px;';

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -1,15 +1,15 @@
-import type { GameState, DisguiseType, HexCoord } from '@/core/types';
+import type { GameState, DisguiseType, HexCoord, WorkerActionType } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
 import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
-import { canBuildImprovement } from '@/systems/improvement-system';
+import { getAvailableWorkerActions, getWorkerActionLabel } from '@/systems/improvement-system';
+import { DEFAULT_WORKER_CHARGES, getWorkerChargesRemaining } from '@/systems/worker-action-system';
 import { hexKey } from '@/systems/hex-utils';
 
 export interface SelectedUnitInfoCallbacks {
   onClose?: () => void;
   onFoundCity?: () => void;
-  onBuildFarm?: () => void;
-  onBuildMine?: () => void;
+  onWorkerAction?: (action: WorkerActionType) => void;
   onRest?: () => void;
   onCancelAutoExplore?: () => void;
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
@@ -112,11 +112,26 @@ export function renderSelectedUnitInfo(
   }
 
   if (def.canBuildImprovements) {
-    if (tile && canBuildImprovement(tile, 'farm') && callbacks.onBuildFarm) {
-      actionsDiv.appendChild(makeButton('Build Farm', '#6b9b4b', callbacks.onBuildFarm));
-    }
-    if (tile && canBuildImprovement(tile, 'mine') && callbacks.onBuildMine) {
-      actionsDiv.appendChild(makeButton('Build Mine', '#8b7355', callbacks.onBuildMine));
+    const charges = getWorkerChargesRemaining(unit);
+    const chargeDiv = document.createElement('div');
+    chargeDiv.style.cssText = 'font-size:10px;opacity:0.75;margin-top:6px;';
+    chargeDiv.textContent = `Worker Charges: ${charges}/${DEFAULT_WORKER_CHARGES}`;
+    wrapper.appendChild(chargeDiv);
+
+    if (charges > 0 && !unit.hasActed && callbacks.onWorkerAction) {
+      const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+      for (const action of getAvailableWorkerActions(tile, completedTechs, unit.owner)) {
+        const color = action === 'farm'
+          ? '#6b9b4b'
+          : action === 'mine'
+            ? '#8b7355'
+            : action === 'lumber_camp'
+              ? '#476f3a'
+              : action === 'watermill'
+                ? '#3f7f8f'
+                : '#64748b';
+        actionsDiv.appendChild(makeButton(getWorkerActionLabel(action), color, () => callbacks.onWorkerAction!(action)));
+      }
     }
   }
 

--- a/src/ui/tutorial.ts
+++ b/src/ui/tutorial.ts
@@ -31,7 +31,7 @@ const TUTORIAL_MESSAGES: TutorialMessage[] = [
   {
     step: 'build_improvement',
     advisor: 'builder',
-    message: 'Your Worker can build Farms and Mines on nearby tiles. Select the Worker and choose an improvement to boost your city\'s output.',
+    message: 'Your Worker can build Farms, Mines, Lumber Camps, and Watermills, or drain swamps on nearby tiles. Select the Worker and choose an improvement to boost your city\'s output.',
     trigger: (state) => Object.values(state.units).some(u => u.owner === state.currentPlayer && u.type === 'worker'),
   },
   {

--- a/tests/systems/city-work-system.test.ts
+++ b/tests/systems/city-work-system.test.ts
@@ -100,6 +100,47 @@ describe('city focus assignment', () => {
     expect(state.cities[city.id].workedTiles).toEqual([]);
   });
 
+  it('calculates lumber camp worked-tile yield', () => {
+    const state = createNewGame(undefined, 'city-work-lumber-camp-yield');
+    addCity(state, 'player', { q: 15, r: 15 });
+    state.map.tiles['1,1'] = {
+      coord: { q: 1, r: 1 },
+      terrain: 'forest',
+      elevation: 'lowland',
+      resource: null,
+      improvement: 'lumber_camp',
+      owner: 'player',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+    };
+
+    const yields = calculateWorkedTileYield(state, { q: 1, r: 1 });
+
+    expect(yields.production).toBeGreaterThanOrEqual(3);
+  });
+
+  it('calculates watermill worked-tile yield', () => {
+    const state = createNewGame(undefined, 'city-work-watermill-yield');
+    addCity(state, 'player', { q: 15, r: 15 });
+    state.map.tiles['1,1'] = {
+      coord: { q: 1, r: 1 },
+      terrain: 'plains',
+      elevation: 'lowland',
+      resource: null,
+      improvement: 'watermill',
+      owner: 'player',
+      improvementTurnsLeft: 0,
+      hasRiver: true,
+      wonder: null,
+    };
+
+    const yields = calculateWorkedTileYield(state, { q: 1, r: 1 });
+
+    expect(yields.food).toBeGreaterThanOrEqual(2);
+    expect(yields.production).toBeGreaterThanOrEqual(2);
+  });
+
   it('assigns food focus to the highest-food unclaimed tiles up to population', () => {
     const state = createNewGame(undefined, 'city-work-food-focus');
     const city = addCity(state, 'player', { q: 15, r: 15 });

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -1,4 +1,8 @@
-import { canBuildImprovement, getImprovementYieldBonus } from '@/systems/improvement-system';
+import {
+  canBuildImprovement,
+  getAvailableWorkerActions,
+  getImprovementYieldBonus,
+} from '@/systems/improvement-system';
 import type { HexTile } from '@/core/types';
 
 describe('canBuildImprovement', () => {
@@ -66,5 +70,63 @@ describe('new terrain improvements', () => {
   it('can build mine on volcanic', () => {
     const tile = { terrain: 'volcanic', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false } as any;
     expect(canBuildImprovement(tile, 'mine')).toBe(true);
+  });
+});
+
+describe('lumber camp and watermill eligibility', () => {
+  function tile(overrides: Partial<HexTile>): HexTile {
+    return {
+      coord: { q: 0, r: 0 },
+      terrain: 'grassland',
+      elevation: 'lowland',
+      resource: null,
+      improvement: 'none',
+      owner: 'p1',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      ...overrides,
+    };
+  }
+
+  it('allows lumber camp on unimproved forest and jungle while preserving the terrain', () => {
+    expect(canBuildImprovement(tile({ terrain: 'forest' }), 'lumber_camp')).toBe(true);
+    expect(canBuildImprovement(tile({ terrain: 'jungle' }), 'lumber_camp')).toBe(true);
+  });
+
+  it('does not allow lumber camp on plains, swamp, or already improved forest', () => {
+    expect(canBuildImprovement(tile({ terrain: 'plains' }), 'lumber_camp')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'swamp' }), 'lumber_camp')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'forest', improvement: 'farm' }), 'lumber_camp')).toBe(false);
+  });
+
+  it('allows watermill only on valid unimproved river land', () => {
+    expect(canBuildImprovement(tile({ terrain: 'plains', hasRiver: true }), 'watermill')).toBe(true);
+    expect(canBuildImprovement(tile({ terrain: 'forest', hasRiver: true }), 'watermill')).toBe(true);
+    expect(canBuildImprovement(tile({ terrain: 'swamp', hasRiver: true }), 'watermill')).toBe(true);
+  });
+
+  it('does not allow watermill without river, on mountain, on coast, or on improved land', () => {
+    expect(canBuildImprovement(tile({ terrain: 'plains', hasRiver: false }), 'watermill')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'mountain', elevation: 'mountain', hasRiver: true }), 'watermill')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'coast', hasRiver: true }), 'watermill')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'plains', hasRiver: true, improvement: 'mine' }), 'watermill')).toBe(false);
+  });
+
+  it('rejects improvement actions on unowned or enemy-owned tiles when an owner is supplied', () => {
+    expect(canBuildImprovement(tile({ terrain: 'forest', owner: null }), 'lumber_camp', [], 'p1')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'forest', owner: 'enemy' }), 'lumber_camp', [], 'p1')).toBe(false);
+    expect(canBuildImprovement(tile({ terrain: 'forest', owner: 'p1' }), 'lumber_camp', [], 'p1')).toBe(true);
+  });
+
+  it('returns no worker actions for unowned or enemy-owned valid terrain', () => {
+    expect(getAvailableWorkerActions(tile({ terrain: 'forest', owner: null }), [], 'p1')).toEqual([]);
+    expect(getAvailableWorkerActions(tile({ terrain: 'forest', owner: 'enemy' }), [], 'p1')).toEqual([]);
+    expect(getAvailableWorkerActions(tile({ terrain: 'forest', owner: 'p1' }), [], 'p1')).toContain('lumber_camp');
+  });
+
+  it('returns expected yields for lumber camp and watermill', () => {
+    expect(getImprovementYieldBonus('lumber_camp')).toEqual({ food: 0, production: 2, gold: 0, science: 0 });
+    expect(getImprovementYieldBonus('watermill')).toEqual({ food: 1, production: 1, gold: 0, science: 0 });
   });
 });

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -1,6 +1,7 @@
 import {
   canBuildImprovement,
   getAvailableWorkerActions,
+  getImprovementDisplayName,
   getImprovementYieldBonus,
 } from '@/systems/improvement-system';
 import type { HexTile } from '@/core/types';
@@ -53,6 +54,12 @@ describe('getImprovementYieldBonus', () => {
   it('none gives no bonus', () => {
     const bonus = getImprovementYieldBonus('none');
     expect(bonus.food + bonus.production + bonus.gold + bonus.science).toBe(0);
+  });
+
+  it('formats improvement names for player-facing text', () => {
+    expect(getImprovementDisplayName('lumber_camp')).toBe('Lumber Camp');
+    expect(getImprovementDisplayName('watermill')).toBe('Watermill');
+    expect(getImprovementDisplayName('none')).toBe('None');
   });
 });
 

--- a/tests/systems/resource-system.test.ts
+++ b/tests/systems/resource-system.test.ts
@@ -90,6 +90,49 @@ describe('calculateCityYields', () => {
     expect(yields.food).toBe(3);
     expect(yields.gold).toBe(2);
   });
+
+  it('includes completed lumber camp production in city yields', () => {
+    const map = generateMap(10, 10, 'lumber-yield');
+    const center = { q: 2, r: 2 };
+    const worked = { q: 2, r: 3 };
+    map.tiles['2,2'] = {
+      coord: center, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    map.tiles['2,3'] = {
+      coord: worked, terrain: 'forest', elevation: 'lowland', resource: null,
+      improvement: 'lumber_camp', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    const city = foundCity('player', center, map);
+    city.population = 1;
+    city.workedTiles = [worked];
+
+    const yields = calculateCityYields(city, map);
+
+    expect(yields.production).toBeGreaterThanOrEqual(3);
+  });
+
+  it('includes completed watermill food and production in city yields', () => {
+    const map = generateMap(10, 10, 'watermill-yield');
+    const center = { q: 2, r: 2 };
+    const worked = { q: 2, r: 3 };
+    map.tiles['2,2'] = {
+      coord: center, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    map.tiles['2,3'] = {
+      coord: worked, terrain: 'plains', elevation: 'lowland', resource: null,
+      improvement: 'watermill', owner: 'player', improvementTurnsLeft: 0, hasRiver: true, wonder: null,
+    };
+    const city = foundCity('player', center, map);
+    city.population = 1;
+    city.workedTiles = [worked];
+
+    const yields = calculateCityYields(city, map);
+
+    expect(yields.food).toBeGreaterThanOrEqual(3);
+    expect(yields.production).toBeGreaterThanOrEqual(2);
+  });
 });
 
 describe('adjacency yields in city calculation', () => {

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -75,6 +75,12 @@ describe('createUnit', () => {
     expect(unit.health).toBe(100);
   });
 
+  it('creates workers with two default charges', () => {
+    const worker = createUnit('worker', 'player', { q: 0, r: 0 });
+
+    expect(worker.chargesRemaining).toBe(2);
+  });
+
   it('applies a persistent viking movement bonus', () => {
     const unit = createUnit(
       'warrior',

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import type { City, GameState, HexTile, Unit } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { applyWorkerAction, getWorkerChargesRemaining } from '@/systems/worker-action-system';
+
+function tile(overrides: Partial<HexTile>): HexTile {
+  return {
+    coord: { q: 0, r: 0 },
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: 'player',
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    ...overrides,
+  };
+}
+
+function city(overrides: Partial<City>): City {
+  return {
+    id: 'city-1',
+    name: 'Capital',
+    owner: 'player',
+    position: { q: 0, r: 1 },
+    population: 1,
+    food: 0,
+    foodNeeded: 20,
+    buildings: [],
+    productionQueue: ['worker'],
+    productionProgress: 0,
+    ownedTiles: [{ q: 0, r: 0 }],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    grid: Array.from({ length: 7 }, () => Array.from({ length: 7 }, () => null)),
+    gridSize: 3,
+    unrestLevel: 0,
+    unrestTurns: 0,
+    ...overrides,
+  };
+}
+
+function worker(overrides: Partial<Unit>): Unit {
+  return {
+    id: 'worker-1',
+    type: 'worker',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+    chargesRemaining: 2,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 3,
+    era: 1,
+    gameId: 'test-game',
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: {
+      width: 5,
+      height: 5,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': tile({ coord: { q: 0, r: 0 } }),
+      },
+    },
+    units: { 'worker-1': worker({}) },
+    cities: { 'city-1': city({}) },
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'generic',
+        cities: ['city-1'],
+        units: ['worker-1'],
+        techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
+        gold: 0,
+        visibility: { tiles: {} },
+        knownCivilizations: [],
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'welcome', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: true,
+      musicEnabled: true,
+      musicVolume: 0.5,
+      sfxVolume: 0.7,
+      tutorialEnabled: false,
+      advisorsEnabled: {} as any,
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    legendaryWonderHistory: { destroyedStrongholds: [], discoveredSites: [] },
+    legendaryWonderIntel: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    pendingDiplomacyRequests: [],
+    ...overrides,
+  };
+}
+
+describe('worker action system', () => {
+  it('treats legacy workers without chargesRemaining as two-charge workers', () => {
+    expect(getWorkerChargesRemaining(worker({ chargesRemaining: undefined }))).toBe(2);
+  });
+
+  it('builds lumber camp, keeps forest, and consumes one charge', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'forest' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'lumber_camp');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({
+      terrain: 'forest',
+      improvement: 'lumber_camp',
+      improvementTurnsLeft: 5,
+    });
+    expect(result.state.units['worker-1']?.chargesRemaining).toBe(1);
+    expect(result.events).toContainEqual({
+      type: 'improvement:started',
+      payload: { unitId: 'worker-1', coord: { q: 0, r: 0 }, type: 'lumber_camp' },
+    });
+  });
+
+  it('builds watermill only on river land and consumes one charge', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'plains', hasRiver: true });
+
+    const result = applyWorkerAction(start, 'worker-1', 'watermill');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({
+      terrain: 'plains',
+      improvement: 'watermill',
+      improvementTurnsLeft: 5,
+    });
+    expect(result.state.units['worker-1']?.chargesRemaining).toBe(1);
+  });
+
+  it('converts forest farm to plains and grants production to nearest owned city', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'forest' });
+    start.cities['city-2'] = city({
+      id: 'city-2',
+      name: 'Far City',
+      position: { q: 4, r: 4 },
+      ownedTiles: [{ q: 0, r: 0 }],
+      productionProgress: 0,
+    });
+    start.civilizations.player.cities = ['city-1', 'city-2'];
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({
+      terrain: 'plains',
+      improvement: 'farm',
+      improvementTurnsLeft: 4,
+    });
+    expect(result.state.cities['city-1'].productionProgress).toBe(20);
+    expect(result.state.cities['city-2'].productionProgress).toBe(0);
+  });
+
+  it('does not grant forest production burst when farming grassland', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'grassland' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0'].terrain).toBe('grassland');
+    expect(result.state.cities['city-1'].productionProgress).toBe(0);
+  });
+
+  it('rejects worker actions on unowned tiles', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'forest', owner: null });
+
+    const result = applyWorkerAction(start, 'worker-1', 'lumber_camp');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('invalid-action');
+    expect(result.state.map.tiles['0,0']).toMatchObject({ terrain: 'forest', improvement: 'none' });
+  });
+
+  it('rejects worker actions on enemy-owned tiles', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'forest', owner: 'enemy' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('invalid-action');
+    expect(result.state.cities['city-1'].productionProgress).toBe(0);
+  });
+
+  it('drains swamp to grassland without placing an improvement when the worker survives', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'swamp' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'drain_swamp', { rng: () => 0.95 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({
+      terrain: 'grassland',
+      improvement: 'none',
+      improvementTurnsLeft: 0,
+    });
+    expect(result.state.units['worker-1']?.chargesRemaining).toBe(1);
+  });
+
+  it('drains swamp and removes the worker on a dangerous roll', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'swamp' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'drain_swamp', { rng: () => 0.05 });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0'].terrain).toBe('grassland');
+    expect(result.state.units['worker-1']).toBeUndefined();
+    expect(result.state.civilizations.player.units).not.toContain('worker-1');
+    expect(result.workerLost).toBe(true);
+  });
+
+  it('removes a worker after spending its final charge', () => {
+    const start = state();
+    start.units['worker-1'] = worker({ chargesRemaining: 1 });
+    start.map.tiles['0,0'] = tile({ terrain: 'forest' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'lumber_camp');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.units['worker-1']).toBeUndefined();
+    expect(result.state.civilizations.player.units).not.toContain('worker-1');
+    expect(result.workerConsumed).toBe(true);
+  });
+
+  it('rejects repeat-click mutation after the worker has already been removed', () => {
+    const start = state({
+      units: {},
+      civilizations: {
+        ...state().civilizations,
+        player: { ...state().civilizations.player, units: [] },
+      },
+    });
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('missing-unit');
+  });
+});

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -267,6 +267,20 @@ describe('worker action system', () => {
     expect(result.workerConsumed).toBe(true);
   });
 
+  it('rejects actions from workers with no charges left', () => {
+    const start = state();
+    start.units['worker-1'] = worker({ chargesRemaining: 0 });
+    start.map.tiles['0,0'] = tile({ terrain: 'forest' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'lumber_camp');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('no-charges');
+    expect(result.state.map.tiles['0,0']).toMatchObject({ terrain: 'forest', improvement: 'none' });
+    expect(result.state.units['worker-1']).toBeDefined();
+  });
+
   it('rejects repeat-click mutation after the worker has already been removed', () => {
     const start = state({
       units: {},

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -38,6 +38,7 @@ function city(overrides: Partial<City>): City {
     gridSize: 3,
     unrestLevel: 0,
     unrestTurns: 0,
+    spyUnrestBonus: 0,
     ...overrides,
   };
 }

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -372,6 +372,36 @@ describe('city-panel navigation', () => {
     expect(collectText(panel)).toContain('Mine (+2 production, +1 gold)');
   });
 
+  it('shows lumber camp label without underscores in worked-land tile row', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const forestTile = { q: city.position.q + 1, r: city.position.r };
+    state.map.tiles[hexKey(forestTile)] = {
+      ...state.map.tiles[hexKey(forestTile)],
+      coord: forestTile,
+      terrain: 'forest',
+      elevation: 'lowland',
+      improvement: 'lumber_camp',
+      improvementTurnsLeft: 0,
+      owner: city.owner,
+      hasRiver: false,
+      wonder: null,
+      resource: null,
+    };
+    city.ownedTiles = [city.position, forestTile];
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetCityFocus: () => {},
+      onToggleWorkedTile: () => {},
+    });
+
+    clickElement(panel.querySelector('[id="tab-grid"]'));
+    expect(collectText(panel)).toContain('Lumber Camp (+2 production)');
+    expect(collectText(panel)).not.toContain('Lumber_camp');
+  });
+
   it('shows help text in the Worked Land And Water section explaining improvements', () => {
     const { container, city, state } = makeWonderPanelFixture();
     const panel = createCityPanel(container, city, state, {
@@ -383,8 +413,11 @@ describe('city-panel navigation', () => {
     });
     clickElement(panel.querySelector('[id="tab-grid"]'));
     const rendered = collectText(panel);
-    expect(rendered).toContain('Workers build Farms (+2 food)');
-    expect(rendered).toContain('Mines (+2 production, +1 gold)');
+    expect(rendered).toContain('Farms');
+    expect(rendered).toContain('Mines');
+    expect(rendered).toContain('Lumber Camps');
+    expect(rendered).toContain('Watermills');
+    expect(rendered).toContain('2 charges');
   });
 
   it('shows claimed overlap tiles as unavailable', () => {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -101,6 +101,56 @@ function makeSpyState(techs: string[], spyStatus: string = 'idle'): GameState {
   } as unknown as GameState;
 }
 
+function makeWorkerState(tileOverrides: Record<string, unknown>, unitOverrides: Record<string, unknown> = {}): GameState {
+  return {
+    turn: 1,
+    era: 1,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: {
+      width: 10,
+      height: 10,
+      tiles: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'forest',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          owner: 'player',
+          improvementTurnsLeft: 0,
+          hasRiver: false,
+          wonder: null,
+          ...tileOverrides,
+        },
+      },
+      wrapsHorizontally: false,
+      rivers: [],
+    },
+    units: {
+      'worker-1': {
+        id: 'worker-1',
+        type: 'worker',
+        owner: 'player',
+        position: { q: 0, r: 0 },
+        movementPointsLeft: 2,
+        health: 100,
+        experience: 0,
+        hasMoved: false,
+        hasActed: false,
+        isResting: false,
+        chargesRemaining: 2,
+        ...unitOverrides,
+      },
+    },
+    cities: {},
+    civilizations: {
+      player: { color: '#fff', techState: { completed: [] } },
+    },
+  } as unknown as GameState;
+}
+
 describe('renderSelectedUnitInfo — spy disguise buttons', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);
@@ -235,5 +285,123 @@ describe('renderSelectedUnitInfo - unit stack switch', () => {
     findButtons(container).find(button => button.textContent === 'Switch unit')?.click();
 
     expect(opened).toEqual({ q: 4, r: 2 });
+  });
+});
+
+describe('renderSelectedUnitInfo - worker actions', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows worker charges and valid forest actions', () => {
+    const state = makeWorkerState({ terrain: 'forest' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(text).toContain('Worker Charges: 2/2');
+    expect(buttons).toContain('Build Farm');
+    expect(buttons).toContain('Build Lumber Camp');
+    expect(buttons).not.toContain('Build Watermill');
+    expect(buttons).not.toContain('Drain Swamp (20% worker risk)');
+  });
+
+  it('shows watermill only on valid river land', () => {
+    const state = makeWorkerState({ terrain: 'plains', hasRiver: true });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(buttons).toContain('Build Farm');
+    expect(buttons).toContain('Build Mine');
+    expect(buttons).toContain('Build Watermill');
+  });
+
+  it('shows Drain Swamp only on unimproved swamp', () => {
+    const state = makeWorkerState({ terrain: 'swamp' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(buttons).toContain('Drain Swamp (20% worker risk)');
+    expect(buttons).not.toContain('Build Farm');
+  });
+
+  it('communicates swamp danger before the player clicks', () => {
+    const state = makeWorkerState({ terrain: 'swamp' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('20% worker risk');
+  });
+
+  it('shows no worker actions on unowned or enemy-owned terrain', () => {
+    for (const [terrain, owner] of [['forest', null], ['forest', 'enemy'], ['swamp', null], ['swamp', 'enemy']] as const) {
+      const state = makeWorkerState({ terrain, owner });
+      const container = new MockElement('div');
+
+      renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+        onWorkerAction: () => {},
+      });
+
+      const buttons = findButtons(container).map(button => button.textContent);
+      expect(collectAllText(container).join(' ')).toContain('Worker Charges: 2/2');
+      expect(buttons).not.toContain('Build Farm');
+      expect(buttons).not.toContain('Build Lumber Camp');
+      expect(buttons).not.toContain('Drain Swamp (20% worker risk)');
+    }
+  });
+
+  it('hides worker actions after the worker has already acted', () => {
+    const state = makeWorkerState({ terrain: 'forest' }, { hasActed: true });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(buttons).not.toContain('Build Farm');
+    expect(buttons).not.toContain('Build Lumber Camp');
+  });
+
+  it('hides worker actions on already improved tiles', () => {
+    const state = makeWorkerState({ terrain: 'swamp', improvement: 'farm' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(buttons).not.toContain('Drain Swamp (20% worker risk)');
+    expect(buttons).not.toContain('Build Farm');
+  });
+
+  it('fires onWorkerAction with the clicked action id', () => {
+    const state = makeWorkerState({ terrain: 'forest' });
+    const container = new MockElement('div');
+    let clicked: unknown = null;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: action => { clicked = action; },
+    });
+
+    findButtons(container).find(button => button.textContent === 'Build Lumber Camp')?.click();
+
+    expect(clicked).toBe('lumber_camp');
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -378,6 +378,21 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     expect(buttons).not.toContain('Build Lumber Camp');
   });
 
+  it('hides worker actions when the worker has no charges left', () => {
+    const state = makeWorkerState({ terrain: 'forest' }, { chargesRemaining: 0 });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(text).toContain('Worker Charges: 0/2');
+    expect(buttons).not.toContain('Build Farm');
+    expect(buttons).not.toContain('Build Lumber Camp');
+  });
+
   it('hides worker actions on already improved tiles', () => {
     const state = makeWorkerState({ terrain: 'swamp', improvement: 'farm' });
     const container = new MockElement('div');


### PR DESCRIPTION
## Summary
- Adds lumber camps, watermills, swamp draining, forest-to-farm clearing, and two-charge worker consumption through a shared worker action system.
- Updates selected-unit UI, map rendering, city-grid labels/help text, advisor/tutorial copy, and player-facing improvement display names.
- Adds regression coverage for ownership gates, zero-charge workers, swamp risk visibility, stale worker action buttons, new improvement yields, and worked-tile display labels.

## Gameplay impact
Workers now spend finite charges on tile actions. Lumber camps preserve forest/jungle while adding production, watermills work on river land with food and production, farms clear forest/jungle into plains with a one-time production burst to the nearest owned city, and swamp draining carries a visible 20% worker-loss risk.

## Fixes
Closes #155.

## Test Plan
- scripts/check-src-rule-violations.sh src/systems/worker-action-system.ts src/systems/improvement-system.ts src/ui/selected-unit-info.ts src/main.ts
- ./scripts/run-with-mise.sh yarn exec vitest run tests/systems/worker-action-system.test.ts tests/ui/selected-unit-info.test.ts tests/systems/improvement-system.test.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test