### PR TITLE
[codex] Make village tech rewards rare

### DIFF
--- a/src/systems/village-system.ts
+++ b/src/systems/village-system.ts
@@ -1,4 +1,4 @@
-import type { GameMap, HexCoord, GameState, Unit, TribalVillage, VillageOutcomeType } from '@/core/types';
+import type { GameMap, HexCoord, GameState, TechState, Unit, TribalVillage, VillageOutcomeType } from '@/core/types';
 import { hexKey, hexDistance, hexNeighbors } from './hex-utils';
 import { createUnit } from './unit-system';
 import { TECH_TREE, applyResearchBonus } from './tech-system';
@@ -54,11 +54,26 @@ export function placeVillages(
 export function rollVillageOutcome(roll: number): VillageOutcomeType {
   if (roll < 0.25) return 'gold';
   if (roll < 0.45) return 'food';
-  if (roll < 0.60) return 'science';
-  if (roll < 0.75) return 'free_unit';
+  if (roll < 0.69) return 'science';
+  if (roll < 0.84) return 'free_unit';
   if (roll < 0.85) return 'free_tech';
   if (roll < 0.95) return 'ambush';
   return 'illness';
+}
+
+function getCurrentResearchTech(techState: TechState) {
+  return techState.currentResearch
+    ? TECH_TREE.find(tech => tech.id === techState.currentResearch)
+    : undefined;
+}
+
+function capVillageResearchBonus(techState: TechState, amount: number): number {
+  const tech = getCurrentResearchTech(techState);
+  if (!tech) return amount;
+
+  const remaining = tech.cost - techState.researchProgress;
+  if (remaining <= 1) return amount;
+  return Math.min(amount, remaining - 1);
 }
 
 export function visitVillage(
@@ -114,11 +129,20 @@ export function visitVillage(
       break;
     }
     case 'science': {
-      const amount = Math.round((10 + Math.floor(rng() * 16)) * rewardMultiplier); // 10-25
+      const amount = Math.round((4 + Math.floor(rng() * 5)) * rewardMultiplier); // 4-8
       if (civ?.techState.currentResearch) {
-        const bonusResult = applyResearchBonus(civ.techState, amount);
+        const tech = getCurrentResearchTech(civ.techState);
+        const cappedAmount = capVillageResearchBonus(civ.techState, amount);
+        const bonusResult = applyResearchBonus(civ.techState, cappedAmount);
         civ.techState = bonusResult.state;
-        message = `The villagers share ancient knowledge! +${amount} research.`;
+        if (bonusResult.completedTech && tech) {
+          message = `The villagers helped us finish ${tech.name}! +${cappedAmount} research.`;
+        } else if (tech) {
+          message = `The villagers taught us a little bit about ${tech.name}. `
+            + `We are getting closer to understanding ${tech.name}. +${cappedAmount} research.`;
+        } else {
+          message = `The villagers share ancient knowledge! +${cappedAmount} research.`;
+        }
       } else {
         // Fallback: gold
         const fallbackGold = Math.round(25 * rewardMultiplier);
@@ -130,7 +154,7 @@ export function visitVillage(
     case 'free_unit': {
       const unitType: 'scout' | 'warrior' = rng() < 0.5 ? 'scout' : 'warrior';
       const newUnit = createUnit(unitType, unit.owner, village.position);
-      state.units[newUnit.id] = newUnit;
+      state.units = { ...state.units, [newUnit.id]: newUnit };
       if (civ) civ.units.push(newUnit.id);
       message = `A ${unitType} joins your cause!`;
       break;
@@ -143,10 +167,15 @@ export function visitVillage(
       );
       if (availableTechs.length > 0) {
         const tech = availableTechs[Math.floor(rng() * availableTechs.length)];
-        civ.techState.completed.push(tech.id);
         if (civ.techState.currentResearch === tech.id) {
-          civ.techState.currentResearch = null;
-          civ.techState.researchProgress = 0;
+          const remainingCost = Math.max(0, tech.cost - civ.techState.researchProgress);
+          civ.techState = applyResearchBonus(civ.techState, remainingCost).state;
+        } else {
+          civ.techState = {
+            ...civ.techState,
+            completed: [...civ.techState.completed, tech.id],
+            researchQueue: civ.techState.researchQueue.filter(techId => techId !== tech.id),
+          };
         }
         message = `The villagers taught us ${tech.name}!`;
       } else {
@@ -166,7 +195,7 @@ export function visitVillage(
       const spawnCount = Math.min(1 + Math.floor(rng() * 2), passable.length); // 1-2
       for (let i = 0; i < spawnCount; i++) {
         const barbarian = createUnit('warrior', 'barbarian', passable[i]);
-        state.units[barbarian.id] = barbarian;
+        state.units = { ...state.units, [barbarian.id]: barbarian };
       }
       message = spawnCount > 0
         ? 'It was a trap! Barbarian warriors ambush you!'

--- a/tests/systems/village-system.test.ts
+++ b/tests/systems/village-system.test.ts
@@ -3,6 +3,7 @@ import { placeVillages, visitVillage, rollVillageOutcome } from '@/systems/villa
 import { generateMap, findStartPositions } from '@/systems/map-generator';
 import { createNewGame } from '@/core/game-state';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
+import { TECH_TREE, getTechById } from '@/systems/tech-system';
 import type { GameState } from '@/core/types';
 
 function makeMap(size: 'small' | 'medium' | 'large') {
@@ -160,8 +161,58 @@ describe('visitVillage', () => {
     unit.position = { q: 5, r: 5 };
     const unitCountBefore = Object.keys(state.units).length;
 
-    visitVillage(state, 'v1', unit, () => 0.65); // 0.65 = free_unit
+    visitVillage(state, 'v1', unit, () => 0.7); // 0.7 = free_unit
     expect(Object.keys(state.units).length).toBeGreaterThan(unitCountBefore);
+  });
+
+  it('science outcome teaches partial progress instead of completing a fresh starter tech', () => {
+    const state = makeGameState();
+    state.civilizations.player.techState.currentResearch = 'fire';
+    state.civilizations.player.techState.researchProgress = 0;
+    state.tribalVillages = {
+      'v1': { id: 'v1', position: { q: 5, r: 5 } },
+    };
+    const unit = Object.values(state.units).find(u => u.owner === 'player')!;
+    unit.position = { q: 5, r: 5 };
+    const fire = getTechById('fire')!;
+    const rolls = [0.5, 0.999];
+
+    const result = visitVillage(state, 'v1', unit, () => rolls.shift() ?? 0);
+
+    expect(result.outcome).toBe('science');
+    expect(state.civilizations.player.techState.completed).not.toContain('fire');
+    expect(state.civilizations.player.techState.researchProgress).toBe(fire.cost - 1);
+    expect(result.message).toContain('getting closer to understanding Fire');
+  });
+
+  it('free tech outcome advances into queued research when completing current research', () => {
+    const state = makeGameState();
+    const otherStarterTechs = TECH_TREE
+      .filter(tech => tech.prerequisites.length === 0 && tech.id !== 'fire')
+      .map(tech => tech.id);
+    state.civilizations.player.techState.completed = otherStarterTechs;
+    state.civilizations.player.techState.currentResearch = 'fire';
+    state.civilizations.player.techState.researchQueue = ['writing'];
+    state.civilizations.player.techState.researchProgress = 3;
+    state.tribalVillages = {
+      'v1': { id: 'v1', position: { q: 5, r: 5 } },
+    };
+    const unit = Object.values(state.units).find(u => u.owner === 'player')!;
+    unit.position = { q: 5, r: 5 };
+    const availableTechs = TECH_TREE.filter(tech =>
+      !state.civilizations.player.techState.completed.includes(tech.id)
+      && tech.prerequisites.every(prerequisite => state.civilizations.player.techState.completed.includes(prerequisite)),
+    );
+    const fireIndex = availableTechs.findIndex(tech => tech.id === 'fire');
+    const rolls = [0.84, (fireIndex + 0.1) / availableTechs.length];
+
+    const result = visitVillage(state, 'v1', unit, () => rolls.shift() ?? 0);
+
+    expect(result.outcome).toBe('free_tech');
+    expect(state.civilizations.player.techState.completed).toContain('fire');
+    expect(state.civilizations.player.techState.currentResearch).toBe('writing');
+    expect(state.civilizations.player.techState.researchQueue).toEqual([]);
+    expect(state.civilizations.player.techState.researchProgress).toBe(0);
   });
 });
 
@@ -174,16 +225,18 @@ describe('rollVillageOutcome', () => {
     expect(rollVillageOutcome(0.3)).toBe('food');
   });
 
-  it('returns science for rng 0.45-0.60', () => {
+  it('returns science for rng 0.45-0.69', () => {
     expect(rollVillageOutcome(0.5)).toBe('science');
+    expect(rollVillageOutcome(0.68)).toBe('science');
   });
 
-  it('returns free_unit for rng 0.60-0.75', () => {
-    expect(rollVillageOutcome(0.65)).toBe('free_unit');
+  it('returns free_unit for rng 0.69-0.84', () => {
+    expect(rollVillageOutcome(0.7)).toBe('free_unit');
+    expect(rollVillageOutcome(0.83)).toBe('free_unit');
   });
 
-  it('returns free_tech for rng 0.75-0.85', () => {
-    expect(rollVillageOutcome(0.8)).toBe('free_tech');
+  it('returns free_tech for rng 0.84-0.85', () => {
+    expect(rollVillageOutcome(0.84)).toBe('free_tech');
   });
 
   it('returns ambush for rng 0.85-0.95', () => {
@@ -192,5 +245,17 @@ describe('rollVillageOutcome', () => {
 
   it('returns illness for rng >= 0.95', () => {
     expect(rollVillageOutcome(0.96)).toBe('illness');
+  });
+
+  it('keeps full tech rare while making research hints common', () => {
+    const outcomes = Array.from(
+      { length: 1000 },
+      (_, i) => rollVillageOutcome((i + 0.5) / 1000),
+    );
+    const fullTechCount = outcomes.filter(outcome => outcome === 'free_tech').length;
+    const scienceCount = outcomes.filter(outcome => outcome === 'science').length;
+
+    expect(fullTechCount).toBeLessThanOrEqual(15);
+    expect(scienceCount).toBeGreaterThanOrEqual(230);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #153 by making tribal village full-tech rewards rare and shifting more outcomes toward smaller research hints.

## What changed

- Reduced the direct `free_tech` village outcome from 10% to 1%.
- Increased the `science` hint outcome and changed it to grant a smaller capped research bump.
- Prevented science village rewards from completing a fresh starter tech outright.
- Preserved normal research queue behavior when the rare full-tech reward completes the current research.
- Removed two direct `state.units[...] = ...` writes in `village-system.ts` so the changed source file passes repo rule checks.

## Root cause

Village outcomes gave `free_tech` a broad 10% band, and the regular science outcome could also complete low-cost starter techs because it granted 10-25 research against techs that can cost 8-10.

## Verification

- `./scripts/run-with-mise.sh yarn test --run tests/systems/village-system.test.ts`
- `scripts/check-src-rule-violations.sh src/systems/village-system.ts`
- `./scripts/run-with-mise.sh yarn build`