### PR TITLE
[codex] Prevent adjacent civilization starts

### DIFF
--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -238,7 +238,7 @@ export function findStartPositions(map: GameMap, count: number): HexCoord[] {
       tile.coord.r < map.height - 4
     ) {
       // Check that there's enough land nearby
-      const nearby = hexesInRange(tile.coord, 2);
+      const nearby = getCandidateNeighborhood(map, tile.coord, 2);
       const landCount = nearby.filter(n => {
         const t = map.tiles[hexKey(n)];
         return t && isLandTerrain(t.terrain);
@@ -251,10 +251,13 @@ export function findStartPositions(map: GameMap, count: number): HexCoord[] {
 
   if (candidates.length < count) {
     // Fallback: relax constraints
+    const candidateKeys = new Set(candidates.map(hexKey));
     for (const tile of Object.values(map.tiles)) {
-      if (isLandTerrain(tile.terrain)) {
-        candidates.push(tile.coord);
-      }
+      if (!isLandTerrain(tile.terrain)) continue;
+      const key = hexKey(tile.coord);
+      if (candidateKeys.has(key)) continue;
+      candidates.push(tile.coord);
+      candidateKeys.add(key);
     }
   }
 
@@ -277,22 +280,33 @@ export function findStartPositions(map: GameMap, count: number): HexCoord[] {
   positions.push(best);
   used.add(hexKey(best));
 
-  // Remaining positions: maximize minimum distance to existing positions
+  // Remaining positions: maximize minimum wrapped distance to existing positions.
+  const minimumDistance = getMinimumStartDistance(map);
   for (let i = 1; i < count; i++) {
-    let bestCandidate = candidates[0];
+    let bestCandidate: HexCoord | null = null;
     let bestMinDist = -1;
+    let bestFallbackCandidate: HexCoord | null = null;
+    let bestFallbackDist = -1;
 
     for (const c of candidates) {
       if (used.has(hexKey(c))) continue;
-      const minDist = Math.min(...positions.map(p => hexDistance(c, p)));
+      const minDist = getMinimumDistanceToExistingStarts(map, c, positions);
+      if (minDist > bestFallbackDist) {
+        bestFallbackDist = minDist;
+        bestFallbackCandidate = c;
+      }
+
+      if (minDist < minimumDistance) continue;
       if (minDist > bestMinDist) {
         bestMinDist = minDist;
         bestCandidate = c;
       }
     }
 
-    positions.push(bestCandidate);
-    used.add(hexKey(bestCandidate));
+    const selected = bestCandidate ?? bestFallbackCandidate;
+    if (!selected) break;
+    positions.push(selected);
+    used.add(hexKey(selected));
   }
 
   return positions;

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -1,5 +1,11 @@
 import type { GameMap, HexTile, HexCoord, TerrainType, Elevation } from '@/core/types';
-import { hexKey, hexDistance, hexesInRange } from './hex-utils';
+import {
+  hexKey,
+  hexDistance,
+  hexesInRange,
+  getWrappedHexesInRange,
+  wrappedHexDistance,
+} from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
 
 // Simple seeded PRNG (mulberry32)
@@ -189,6 +195,37 @@ function placeResources(tiles: Record<string, HexTile>, rng: () => number): void
 
 function isLandTerrain(terrain: TerrainType): boolean {
   return terrain !== 'ocean' && terrain !== 'coast' && terrain !== 'mountain' && terrain !== 'snow';
+}
+
+export const MIN_MAJOR_CIV_START_DISTANCE = 9;
+
+export function getMinimumStartDistance(_map: Pick<GameMap, 'width' | 'height'>): number {
+  return MIN_MAJOR_CIV_START_DISTANCE;
+}
+
+export function getStartPositionDistance(
+  map: Pick<GameMap, 'width' | 'wrapsHorizontally'>,
+  a: HexCoord,
+  b: HexCoord,
+): number {
+  return map.wrapsHorizontally
+    ? wrappedHexDistance(a, b, map.width)
+    : hexDistance(a, b);
+}
+
+function getCandidateNeighborhood(map: GameMap, coord: HexCoord, range: number): HexCoord[] {
+  return map.wrapsHorizontally
+    ? getWrappedHexesInRange(coord, range, map.width)
+    : hexesInRange(coord, range);
+}
+
+function getMinimumDistanceToExistingStarts(
+  map: GameMap,
+  coord: HexCoord,
+  positions: HexCoord[],
+): number {
+  if (positions.length === 0) return Infinity;
+  return Math.min(...positions.map(position => getStartPositionDistance(map, coord, position)));
 }
 
 export function findStartPositions(map: GameMap, count: number): HexCoord[] {

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -136,6 +136,17 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
   mapSection.content.appendChild(mapSizeCardRow);
 
+  const startSpacingNote = document.createElement('p');
+  startSpacingNote.dataset.role = 'start-spacing-note';
+  startSpacingNote.textContent = 'Balanced starts keep rival civilizations from beginning next door, including across the wrapped map edge.';
+  Object.assign(startSpacingNote.style, {
+    margin: '0',
+    fontSize: '12px',
+    opacity: '0.72',
+    lineHeight: '1.45',
+  });
+  mapSection.content.appendChild(startSpacingNote);
+
   const mapSizeField = createLabeledSelect('Map size', 'campaign-map-size');
   mapSizeField.wrapper.hidden = true;
   for (const size of ['small', 'medium', 'large'] as const) {

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -78,6 +78,12 @@ export function showHotSeatSetup(
       if (maxEl) maxEl.textContent = `Up to ${s.max} players`;
     }
 
+    const spacingNote = document.createElement('p');
+    spacingNote.dataset.role = 'hotseat-start-spacing-note';
+    spacingNote.textContent = 'Balanced starts keep rival civilizations from beginning next door, including across the wrapped map edge.';
+    spacingNote.style.cssText = 'font-size:12px;opacity:0.65;margin:16px 0 0;text-align:center;max-width:420px;line-height:1.45;';
+    panel.querySelector('.map-size-card')?.parentElement?.insertAdjacentElement('afterend', spacingNote);
+
     container.appendChild(panel);
 
     panel.querySelectorAll('.map-size-card').forEach(card => {

--- a/tests/core/game-state.test.ts
+++ b/tests/core/game-state.test.ts
@@ -1,5 +1,6 @@
 import { createNewGame, createHotSeatGame, MAP_DIMENSIONS } from '@/core/game-state';
-import type { CustomCivDefinition, HotSeatConfig } from '@/core/types';
+import type { CustomCivDefinition, GameState, HexCoord, HotSeatConfig } from '@/core/types';
+import { getMinimumStartDistance, getStartPositionDistance } from '@/systems/map-generator';
 
 const customCiv: CustomCivDefinition = {
   id: 'custom-sunfolk',
@@ -10,6 +11,23 @@ const customCiv: CustomCivDefinition = {
   primaryTrait: 'scholarly',
   temperamentTraits: ['diplomatic', 'trader'],
 };
+
+function getMajorSettlerStarts(state: GameState): HexCoord[] {
+  return Object.values(state.units)
+    .filter(unit => unit.type === 'settler' && !unit.owner.startsWith('mc-'))
+    .map(unit => unit.position);
+}
+
+function expectMajorStartsToRespectSpacing(state: GameState): void {
+  const starts = getMajorSettlerStarts(state);
+  const minimumDistance = getMinimumStartDistance(state.map);
+
+  for (let i = 0; i < starts.length; i++) {
+    for (let j = i + 1; j < starts.length; j++) {
+      expect(getStartPositionDistance(state.map, starts[i], starts[j])).toBeGreaterThanOrEqual(minimumDistance);
+    }
+  }
+}
 
 describe('createNewGame', () => {
   it('creates a valid initial game state', () => {
@@ -145,6 +163,18 @@ describe('createNewGame', () => {
     }
     expect(aiCivTypes.has('wakanda') || aiCivTypes.has('avalon')).toBe(true);
   });
+
+  it('spaces solo major civilizations by wrapped distance so rivals cannot start next door', () => {
+    const state = createNewGame({
+      civType: 'germany',
+      seed: 'issue-172-germany-greece-wrap',
+      mapSize: 'small',
+      opponentCount: 2,
+      gameTitle: 'Issue 172 Regression',
+    });
+
+    expectMajorStartsToRespectSpacing(state);
+  });
 });
 
 describe('minor civ integration', () => {
@@ -214,5 +244,19 @@ describe('createHotSeatGame', () => {
     const state = createHotSeatGame(config, 'hs-pending-diplomacy');
 
     expect(state.pendingDiplomacyRequests).toEqual([]);
+  });
+
+  it('spaces hot-seat major civilizations by wrapped distance at the selected map limit', () => {
+    const state = createHotSeatGame({
+      playerCount: 3,
+      mapSize: 'small',
+      players: [
+        { name: 'Germany', slotId: 'player-1', civType: 'germany', isHuman: true },
+        { name: 'Greece', slotId: 'player-2', civType: 'greece', isHuman: true },
+        { name: 'Rome', slotId: 'ai-1', civType: 'rome', isHuman: false },
+      ],
+    }, 'issue-172-hotseat-wrap');
+
+    expectMajorStartsToRespectSpacing(state);
   });
 });

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -7,6 +7,12 @@ import {
 import type { GameMap } from '@/core/types';
 import { hexKey, hexDistance } from '@/systems/hex-utils';
 
+const SUPPORTED_START_CASES = [
+  { width: 30, height: 30, count: 3, seed: 'issue-172-small-wrap' },
+  { width: 50, height: 50, count: 5, seed: 'issue-172-medium-wrap' },
+  { width: 80, height: 80, count: 8, seed: 'issue-172-large-wrap' },
+] as const;
+
 describe('generateMap', () => {
   let map: GameMap;
 
@@ -106,6 +112,21 @@ describe('findStartPositions', () => {
 
     expect(getStartPositionDistance(map, { q: 0, r: 12 }, { q: 29, r: 12 })).toBe(1);
     expect(getStartPositionDistance(map, { q: 1, r: 12 }, { q: 28, r: 12 })).toBe(3);
+  });
+
+  it('keeps generated start positions outside the wrapped minimum distance for supported map sizes', () => {
+    for (const setup of SUPPORTED_START_CASES) {
+      const map = generateMap(setup.width, setup.height, setup.seed);
+      const positions = findStartPositions(map, setup.count);
+      const minimumDistance = getMinimumStartDistance(map);
+
+      expect(positions).toHaveLength(setup.count);
+      for (let i = 0; i < positions.length; i++) {
+        for (let j = i + 1; j < positions.length; j++) {
+          expect(getStartPositionDistance(map, positions[i], positions[j])).toBeGreaterThanOrEqual(minimumDistance);
+        }
+      }
+    }
   });
 
   it('finds requested number of start positions on land', () => {

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -5,7 +5,7 @@ import {
   getStartPositionDistance,
 } from '@/systems/map-generator';
 import type { GameMap } from '@/core/types';
-import { hexKey, hexDistance } from '@/systems/hex-utils';
+import { hexKey } from '@/systems/hex-utils';
 
 const SUPPORTED_START_CASES = [
   { width: 30, height: 30, count: 3, seed: 'issue-172-small-wrap' },
@@ -146,7 +146,29 @@ describe('findStartPositions', () => {
   it('places start positions far apart', () => {
     const map = generateMap(30, 30, 'start-pos-seed');
     const positions = findStartPositions(map, 2);
-    const dist = hexDistance(positions[0], positions[1]);
+    const dist = getStartPositionDistance(map, positions[0], positions[1]);
     expect(dist).toBeGreaterThan(8);
+  });
+
+  it('keeps supported player counts safely spaced across representative seeds', () => {
+    const seeds = Array.from({ length: 20 }, (_, index) => `issue-172-seed-sweep-${index}`);
+
+    for (const setup of SUPPORTED_START_CASES) {
+      for (const seed of seeds) {
+        const map = generateMap(setup.width, setup.height, `${setup.seed}-${seed}`);
+        const positions = findStartPositions(map, setup.count);
+        const minimumDistance = getMinimumStartDistance(map);
+
+        expect(positions, `${setup.width}x${setup.height} ${seed}`).toHaveLength(setup.count);
+        for (let i = 0; i < positions.length; i++) {
+          for (let j = i + 1; j < positions.length; j++) {
+            expect(
+              getStartPositionDistance(map, positions[i], positions[j]),
+              `${setup.width}x${setup.height} ${seed} ${hexKey(positions[i])} -> ${hexKey(positions[j])}`,
+            ).toBeGreaterThanOrEqual(minimumDistance);
+          }
+        }
+      }
+    }
   });
 });

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -1,4 +1,9 @@
-import { generateMap, findStartPositions } from '@/systems/map-generator';
+import {
+  generateMap,
+  findStartPositions,
+  getMinimumStartDistance,
+  getStartPositionDistance,
+} from '@/systems/map-generator';
 import type { GameMap } from '@/core/types';
 import { hexKey, hexDistance } from '@/systems/hex-utils';
 
@@ -96,6 +101,13 @@ describe('new terrain types', () => {
 });
 
 describe('findStartPositions', () => {
+  it('treats horizontally wrapped edge starts as adjacent for spacing checks', () => {
+    const map = generateMap(30, 30, 'issue-172-distance-helper');
+
+    expect(getStartPositionDistance(map, { q: 0, r: 12 }, { q: 29, r: 12 })).toBe(1);
+    expect(getStartPositionDistance(map, { q: 1, r: 12 }, { q: 28, r: 12 })).toBe(3);
+  });
+
   it('finds requested number of start positions on land', () => {
     const map = generateMap(30, 30, 'start-pos-seed');
     const positions = findStartPositions(map, 2);

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -110,6 +110,8 @@ describe('campaign-setup', () => {
     expect(document.querySelector('[data-size="small"]')?.getAttribute('data-selected')).toBe('true');
     expect(Array.from(document.querySelectorAll('[data-opponent-count]')).map(card => card.getAttribute('data-opponent-count'))).toEqual(['1', '2']);
     expect(opponentsSelect.value).toBe('1');
+    expect(document.querySelector('[data-role="start-spacing-note"]')?.textContent)
+      .toContain('Balanced starts keep rival civilizations from beginning next door');
 
     click(document, '[data-size="large"]');
 

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -80,6 +80,19 @@ beforeEach(() => {
 });
 
 describe('hotseat-setup', () => {
+  it('explains that supported map sizes use balanced starts before player-count selection', () => {
+    showHotSeatSetup(
+      document.body,
+      {
+        onComplete: () => {},
+        onCancel: () => {},
+      },
+    );
+
+    expect(document.querySelector('[data-role="hotseat-start-spacing-note"]')?.textContent)
+      .toContain('Balanced starts keep rival civilizations from beginning next door');
+  });
+
   it('passes custom civ definitions into hot-seat setup selection flow for later players', () => {
     showHotSeatSetup(
       document.body,


### PR DESCRIPTION
## Summary
- Fix major civilization start placement to use horizontally wrapped hex distance when scoring candidate separation.
- Add regression coverage for wrapped edge adjacency, supported map sizes, solo game creation, and hot-seat game creation.
- Add setup copy that communicates balanced starts on solo and hot-seat setup screens.

## Root Cause
findStartPositions() used plain hexDistance() even though generated maps wrap horizontally. Starts near opposite q-edges could look far apart to generation while being adjacent in actual gameplay.

## Review Follow-up
During review, I also hardened the legacy start-position test to use wrapped distance and added a representative seed sweep across supported player counts.

## Test Plan
- git diff --check origin/main...HEAD
- scripts/check-src-rule-violations.sh src/systems/map-generator.ts src/ui/campaign-setup.ts src/ui/hotseat-setup.ts
- ./scripts/run-with-mise.sh yarn test --run tests/systems/map-generator.test.ts tests/core/game-state.test.ts tests/ui/campaign-setup.test.ts tests/ui/hotseat-setup.test.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test