### PR TITLE
[codex] Fix issue 109 production pacing

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -90,7 +90,16 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       totalScience += yields.science;
       totalGold += yields.gold;
       const effectiveProduction = isCityProductionLocked(city) ? 0 : yields.production;
-      const result = processCity(city, newState.map, yields.food, effectiveProduction, civDef?.bonusEffect, civ.techState.completed, civ.civType);
+      const result = processCity(
+        city,
+        newState.map,
+        yields.food,
+        effectiveProduction,
+        civDef?.bonusEffect,
+        civ.techState.completed,
+        civ.civType,
+        newState.era,
+      );
       totalGold += result.idleGoldBonus;
       totalScience += result.idleScienceBonus;
       const maturityResult = applyCityMaturity(result.city, civ.techState.completed);

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -18,7 +18,26 @@ export interface FoundCityOptions {
 export const BUILDINGS: Record<string, Building> = {
   // Food
   granary: { id: 'granary', name: 'Granary', category: 'food', yields: { food: 2, production: 0, gold: 0, science: 0 }, productionCost: 40, description: 'Stores food for growth', techRequired: 'granary-design', adjacencyBonuses: [] },
-  herbalist: { id: 'herbalist', name: 'Herbalist', category: 'food', yields: { food: 1, production: 0, gold: 0, science: 0 }, productionCost: 35, description: 'Herbal medicine boosts health', techRequired: null, adjacencyBonuses: [] },
+  herbalist: {
+    id: 'herbalist',
+    name: 'Herbalist',
+    category: 'food',
+    yields: { food: 1, production: 0, gold: 0, science: 0 },
+    productionCost: 16,
+    description: 'Herbal medicine boosts health',
+    techRequired: null,
+    adjacencyBonuses: [],
+    pacing: {
+      band: 'starter',
+      role: 'early-growth',
+      impact: 1,
+      scope: 'city',
+      snowball: 1.05,
+      urgency: 1.1,
+      situationality: 1,
+      unlockBreadth: 1,
+    },
+  },
   aqueduct: { id: 'aqueduct', name: 'Aqueduct', category: 'food', yields: { food: 2, production: 0, gold: 0, science: 0 }, productionCost: 80, description: 'Brings fresh water for growth', techRequired: 'engineering', adjacencyBonuses: [] },
 
   // Production
@@ -77,7 +96,7 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
   { type: 'archer', name: 'Archer', cost: 35, techRequired: 'archery' },
   { type: 'scout', name: 'Scout', cost: 6, pacing: { band: 'starter', role: 'early-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   { type: 'worker', name: 'Worker', cost: 12 },
-  { type: 'settler', name: 'Settler', cost: 50 },
+  { type: 'settler', name: 'Settler', cost: 24, pacing: { band: 'power-spike', role: 'expansion', impact: 1.25, scope: 'empire', snowball: 1.3, urgency: 1.05, situationality: 1, unlockBreadth: 1.2 } },
   { type: 'swordsman', name: 'Swordsman', cost: 50, techRequired: 'bronze-working' },
   { type: 'pikeman', name: 'Pikeman', cost: 70, techRequired: 'fortification' },
   { type: 'musketeer', name: 'Musketeer', cost: 90, techRequired: 'tactics' },
@@ -92,6 +111,55 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
   { type: 'shadow_warden', name: 'Shadow Warden', cost: 55, techRequired: 'lookouts', civTypeRequired: 'persia', replacesUnit: 'scout_hound' },
   { type: 'war_hound', name: 'War Hound', cost: 45, techRequired: 'lookouts', civTypeRequired: 'rome', replacesUnit: 'scout_hound' },
 ];
+
+export const SETTLER_COST_BY_ERA: Record<number, number> = {
+  1: 24,
+  2: 32,
+  3: 40,
+  4: 48,
+  5: 56,
+};
+
+function clampProductionEra(era: number | undefined): number {
+  const normalized = Math.max(1, Math.floor(era ?? 1));
+  return Math.min(5, normalized);
+}
+
+export function getSettlerProductionCost(era: number = 1): number {
+  return SETTLER_COST_BY_ERA[clampProductionEra(era)];
+}
+
+export function getCatalogProductionCost(itemId: string, era: number = 1): number {
+  const building = BUILDINGS[itemId];
+  if (building) return building.productionCost;
+
+  const unit = TRAINABLE_UNITS.find(candidate => candidate.type === itemId);
+  if (!unit) return 0;
+  if (unit.type === 'settler') return getSettlerProductionCost(era);
+  return unit.cost;
+}
+
+export function getProductionCostForItem(
+  itemId: string,
+  options: {
+    city?: Pick<City, 'buildings'>;
+    bonusEffect?: CivBonusEffect;
+    era?: number;
+  } = {},
+): number {
+  const baseCost = getCatalogProductionCost(itemId, options.era);
+  if (baseCost <= 0) return 0;
+
+  const unit = TRAINABLE_UNITS.find(candidate => candidate.type === itemId);
+  const multiplier = applyProductionBonus(itemId, options.bonusEffect);
+  const safehouseMultiplier = unit && options.city?.buildings.includes('safehouse') && isSpyUnitType(unit.type)
+    ? 0.75
+    : 1;
+
+  return safehouseMultiplier < 1
+    ? Math.ceil(baseCost * multiplier * safehouseMultiplier)
+    : Math.round(baseCost * multiplier);
+}
 
 export function getTrainableUnitsForCiv(completedTechs: string[], civType?: string): TrainableUnitEntry[] {
   const replacedForCiv = new Set(

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -42,13 +42,13 @@ export const BUILDINGS: Record<string, Building> = {
 
   // Production
   workshop: { id: 'workshop', name: 'Workshop', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 12, description: 'Tools boost production', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'early-production', impact: 1, scope: 'city', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1 } },
-  forge: { id: 'forge', name: 'Forge', category: 'production', yields: { food: 0, production: 3, gold: 0, science: 0 }, productionCost: 70, description: 'Metalworking facility', techRequired: 'engineering', adjacencyBonuses: [] },
-  lumbermill: { id: 'lumbermill', name: 'Lumbermill', category: 'production', yields: { food: 0, production: 2, gold: 1, science: 0 }, productionCost: 50, description: 'Processes timber efficiently', techRequired: 'state-workforce', adjacencyBonuses: [] },
-  'quarry-building': { id: 'quarry-building', name: 'Quarry', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 55, description: 'Cuts stone for construction', techRequired: 'state-workforce', adjacencyBonuses: [] },
+  forge: { id: 'forge', name: 'Forge', category: 'production', yields: { food: 0, production: 3, gold: 0, science: 0 }, productionCost: 70, description: 'Metalworking facility', techRequired: 'engineering', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'production-scaling', impact: 1.2, scope: 'city', snowball: 1.25, urgency: 1, situationality: 1, unlockBreadth: 1 } },
+  lumbermill: { id: 'lumbermill', name: 'Lumbermill', category: 'production', yields: { food: 0, production: 2, gold: 1, science: 0 }, productionCost: 50, description: 'Processes timber efficiently', techRequired: 'state-workforce', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'production-economy', impact: 1.1, scope: 'city', snowball: 1.15, urgency: 1, situationality: 1, unlockBreadth: 1 } },
+  'quarry-building': { id: 'quarry-building', name: 'Quarry', category: 'production', yields: { food: 0, production: 2, gold: 0, science: 0 }, productionCost: 55, description: 'Cuts stone for construction', techRequired: 'state-workforce', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'production-scaling', impact: 1.1, scope: 'city', snowball: 1.15, urgency: 1, situationality: 1, unlockBreadth: 1 } },
 
   // Science
   library: { id: 'library', name: 'Library', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 16, description: 'Knowledge repository', techRequired: 'writing', adjacencyBonuses: [] },
-  archive: { id: 'archive', name: 'Archive', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 75, description: 'Preserves ancient knowledge', techRequired: 'mathematics', adjacencyBonuses: [] },
+  archive: { id: 'archive', name: 'Archive', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 2 }, productionCost: 60, description: 'Preserves ancient knowledge', techRequired: 'mathematics', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'science-scaling', impact: 1.15, scope: 'city', snowball: 1.2, urgency: 1, situationality: 1, unlockBreadth: 1 } },
   observatory: { id: 'observatory', name: 'Observatory', category: 'science', yields: { food: 0, production: 0, gold: 0, science: 3 }, productionCost: 100, description: 'Studies the stars', techRequired: 'astronomy', adjacencyBonuses: [] },
 
   // Economy
@@ -62,54 +62,57 @@ export const BUILDINGS: Record<string, Building> = {
 
   // Culture
   temple: { id: 'temple', name: 'Temple', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 45, description: 'Spiritual center', techRequired: 'philosophy', adjacencyBonuses: [] },
-  monument: { id: 'monument', name: 'Monument', category: 'culture', yields: { food: 0, production: 0, gold: 1, science: 0 }, productionCost: 30, description: 'Commemorates your civilization', techRequired: 'code-of-laws', adjacencyBonuses: [] },
+  monument: { id: 'monument', name: 'Monument', category: 'culture', yields: { food: 0, production: 0, gold: 1, science: 0 }, productionCost: 30, description: 'Commemorates your civilization', techRequired: 'code-of-laws', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'early-culture', impact: 1.05, scope: 'city', snowball: 1.1, urgency: 1, situationality: 1, unlockBreadth: 1 } },
   amphitheater: { id: 'amphitheater', name: 'Amphitheater', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 1 }, productionCost: 85, description: 'Entertainment and culture', techRequired: 'drama-poetry', adjacencyBonuses: [] },
   shrine: { id: 'shrine', name: 'Shrine', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 8, description: 'Place of worship', techRequired: null, adjacencyBonuses: [], pacing: { band: 'starter', role: 'early-science', impact: 1, scope: 'city', snowball: 1.1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
-  forum: { id: 'forum', name: 'Forum', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 0 }, productionCost: 70, description: 'Public gathering place', techRequired: 'civil-service', adjacencyBonuses: [] },
+  forum: { id: 'forum', name: 'Forum', category: 'culture', yields: { food: 0, production: 0, gold: 2, science: 0 }, productionCost: 70, description: 'Public gathering place', techRequired: 'civil-service', adjacencyBonuses: [], pacing: { band: 'infrastructure', role: 'civic-economy', impact: 1.1, scope: 'city', snowball: 1.1, urgency: 1, situationality: 1, unlockBreadth: 1 } },
 
   // Espionage
   safehouse: {
     id: 'safehouse', name: 'Safehouse', category: 'espionage',
     yields: { food: 0, production: 0, gold: 0, science: 0 },
-    productionCost: 50,
+    productionCost: 36,
     description: 'Reduces spy unit training cost by 25%.',
     techRequired: 'espionage-scouting', adjacencyBonuses: [],
+    pacing: { band: 'power-spike', role: 'spy-cost-reduction', impact: 1.2, scope: 'city', snowball: 1.15, urgency: 1.05, situationality: 1.1, unlockBreadth: 1 },
   },
   'intelligence-agency': {
     id: 'intelligence-agency', name: 'Intelligence Agency', category: 'espionage',
     yields: { food: 0, production: 0, gold: 0, science: 0 },
-    productionCost: 80,
+    productionCost: 60,
     description: "Raises this city's counter-intelligence score by 20 each turn (max 100). Bonus halves when digital-surveillance era is reached.",
     techRequired: 'espionage-informants', adjacencyBonuses: [],
+    pacing: { band: 'infrastructure', role: 'counter-intelligence', impact: 1.15, scope: 'city', snowball: 1, urgency: 1.05, situationality: 1.1, unlockBreadth: 1 },
   },
   'security-bureau': {
     id: 'security-bureau', name: 'Security Bureau', category: 'espionage',
     yields: { food: 0, production: 0, gold: 0, science: 0 },
-    productionCost: 120,
+    productionCost: 100,
     description: 'Raises CI by 30 each turn and makes captured spies 50% less likely to be turned. Bonus halves at cyber-warfare era.',
     techRequired: 'counter-intelligence', adjacencyBonuses: [],
+    pacing: { band: 'infrastructure', role: 'advanced-counter-intelligence', impact: 1.2, scope: 'city', snowball: 1, urgency: 1, situationality: 1.1, unlockBreadth: 1 },
   },
 };
 
 export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pacing'] }> = [
   { type: 'warrior', name: 'Warrior', cost: 8, pacing: { band: 'starter', role: 'early-military', impact: 1, scope: 'military', snowball: 1, urgency: 1.2, situationality: 1, unlockBreadth: 1 } },
-  { type: 'archer', name: 'Archer', cost: 35, techRequired: 'archery' },
+  { type: 'archer', name: 'Archer', cost: 35, techRequired: 'archery', pacing: { band: 'power-spike', role: 'ranged-breakpoint', impact: 1.15, scope: 'military', snowball: 1, urgency: 1.05, situationality: 1, unlockBreadth: 1 } },
   { type: 'scout', name: 'Scout', cost: 6, pacing: { band: 'starter', role: 'early-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
   { type: 'worker', name: 'Worker', cost: 12 },
   { type: 'settler', name: 'Settler', cost: 24, pacing: { band: 'power-spike', role: 'expansion', impact: 1.25, scope: 'empire', snowball: 1.3, urgency: 1.05, situationality: 1, unlockBreadth: 1.2 } },
-  { type: 'swordsman', name: 'Swordsman', cost: 50, techRequired: 'bronze-working' },
-  { type: 'pikeman', name: 'Pikeman', cost: 70, techRequired: 'fortification' },
+  { type: 'swordsman', name: 'Swordsman', cost: 50, techRequired: 'bronze-working', pacing: { band: 'power-spike', role: 'melee-breakpoint', impact: 1.2, scope: 'military', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1 } },
+  { type: 'pikeman', name: 'Pikeman', cost: 70, techRequired: 'fortification', pacing: { band: 'power-spike', role: 'anti-cavalry-breakpoint', impact: 1.15, scope: 'military', snowball: 1, urgency: 1, situationality: 1.05, unlockBreadth: 1 } },
   { type: 'musketeer', name: 'Musketeer', cost: 90, techRequired: 'tactics' },
   { type: 'galley', name: 'Galley', cost: 40, techRequired: 'galleys' },
-  { type: 'trireme', name: 'Trireme', cost: 70, techRequired: 'triremes' },
-  { type: 'spy_scout', name: 'Scout Agent', cost: 30, techRequired: 'espionage-scouting', obsoletedByTech: 'espionage-informants' },
-  { type: 'spy_informant', name: 'Informant', cost: 50, techRequired: 'espionage-informants', obsoletedByTech: 'spy-networks' },
-  { type: 'spy_agent', name: 'Field Agent', cost: 70, techRequired: 'spy-networks', obsoletedByTech: 'cryptography' },
+  { type: 'trireme', name: 'Trireme', cost: 70, techRequired: 'triremes', pacing: { band: 'power-spike', role: 'naval-breakpoint', impact: 1.15, scope: 'military', snowball: 1, urgency: 1, situationality: 1.1, unlockBreadth: 1 } },
+  { type: 'spy_scout', name: 'Scout Agent', cost: 30, techRequired: 'espionage-scouting', obsoletedByTech: 'espionage-informants', pacing: { band: 'power-spike', role: 'first-spy-unit', impact: 1.15, scope: 'military', snowball: 1.1, urgency: 1.1, situationality: 1.1, unlockBreadth: 1.1 } },
+  { type: 'spy_informant', name: 'Informant', cost: 50, techRequired: 'espionage-informants', obsoletedByTech: 'spy-networks', pacing: { band: 'power-spike', role: 'spy-capability-breakpoint', impact: 1.15, scope: 'military', snowball: 1.1, urgency: 1.05, situationality: 1.1, unlockBreadth: 1.1 } },
+  { type: 'spy_agent', name: 'Field Agent', cost: 70, techRequired: 'spy-networks', obsoletedByTech: 'cryptography', pacing: { band: 'power-spike', role: 'spy-capability-breakpoint', impact: 1.2, scope: 'military', snowball: 1.1, urgency: 1, situationality: 1.1, unlockBreadth: 1.1 } },
   { type: 'spy_operative', name: 'Operative', cost: 90, techRequired: 'cryptography', obsoletedByTech: 'cyber-warfare' },
   { type: 'spy_hacker', name: 'Cyber Operative', cost: 110, techRequired: 'cyber-warfare' },
-  { type: 'scout_hound', name: 'Scout Hound', cost: 55, techRequired: 'lookouts' },
-  { type: 'shadow_warden', name: 'Shadow Warden', cost: 55, techRequired: 'lookouts', civTypeRequired: 'persia', replacesUnit: 'scout_hound' },
-  { type: 'war_hound', name: 'War Hound', cost: 45, techRequired: 'lookouts', civTypeRequired: 'rome', replacesUnit: 'scout_hound' },
+  { type: 'scout_hound', name: 'Scout Hound', cost: 36, techRequired: 'lookouts', pacing: { band: 'power-spike', role: 'spy-detection', impact: 1.15, scope: 'military', snowball: 1, urgency: 1.05, situationality: 1.15, unlockBreadth: 1 } },
+  { type: 'shadow_warden', name: 'Shadow Warden', cost: 36, techRequired: 'lookouts', civTypeRequired: 'persia', replacesUnit: 'scout_hound', pacing: { band: 'power-spike', role: 'unique-spy-detection', impact: 1.2, scope: 'military', snowball: 1, urgency: 1.05, situationality: 1.15, unlockBreadth: 1 } },
+  { type: 'war_hound', name: 'War Hound', cost: 32, techRequired: 'lookouts', civTypeRequired: 'rome', replacesUnit: 'scout_hound', pacing: { band: 'power-spike', role: 'unique-spy-detection-combat', impact: 1.1, scope: 'military', snowball: 1, urgency: 1.05, situationality: 1.1, unlockBreadth: 1 } },
 ];
 
 export const SETTLER_COST_BY_ERA: Record<number, number> = {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -291,6 +291,7 @@ export function processCity(
   bonusEffect?: CivBonusEffect,
   completedTechs: string[] = [],
   civType?: string,
+  era: number = 1,
 ): CityProcessResult {
   let grew = false;
   let completedBuilding: string | null = null;
@@ -337,8 +338,7 @@ export function processCity(
 
     // Check if it's a building
     const building = BUILDINGS[currentItem];
-    const buildingCostMult = building ? applyProductionBonus(currentItem, bonusEffect) : 1;
-    if (building && newProgress >= Math.round(building.productionCost * buildingCostMult)) {
+    if (building && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
       if (!newBuildings.includes(building.id)) {
         newBuildings.push(building.id);
         completedBuilding = building.id;
@@ -349,19 +349,10 @@ export function processCity(
 
     // Check if it's a unit
     const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    if (unitDef) {
-      const unitCostMult = applyProductionBonus(currentItem, bonusEffect);
-      const safehouseMult = (city.buildings.includes('safehouse') && isSpyUnitType(unitDef.type as UnitType))
-        ? 0.75
-        : 1;
-      const effectiveCost = safehouseMult < 1
-        ? Math.ceil(unitDef.cost * unitCostMult * safehouseMult)
-        : Math.round(unitDef.cost * unitCostMult);
-      if (newProgress >= effectiveCost) {
-        newQueue.shift();
-        newProgress = 0;
-        completedUnit = unitDef.type;
-      }
+    if (unitDef && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
+      newQueue.shift();
+      newProgress = 0;
+      completedUnit = unitDef.type;
     }
   }
 

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -124,7 +124,8 @@ export const SETTLER_COST_BY_ERA: Record<number, number> = {
 };
 
 function clampProductionEra(era: number | undefined): number {
-  const normalized = Math.max(1, Math.floor(era ?? 1));
+  const numericEra = typeof era === 'number' && Number.isFinite(era) ? era : 1;
+  const normalized = Math.max(1, Math.floor(numericEra));
   return Math.min(5, normalized);
 }
 

--- a/src/systems/pacing-audit.ts
+++ b/src/systems/pacing-audit.ts
@@ -1,5 +1,6 @@
-import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import { BUILDINGS, TRAINABLE_UNITS, getCatalogProductionCost } from '@/systems/city-system';
 import {
+  getProductionOutputProfileForEra,
   getTargetTurnWindow,
   estimateTurnsToComplete,
   resolveBuildingPacingBand,
@@ -53,11 +54,13 @@ function buildAuditSignals(
   };
 }
 
-export function buildPacingAudit(): PacingAuditRow[] {
+export function buildPacingAudit(options: { era?: number } = {}): PacingAuditRow[] {
   return [
     ...Object.values(BUILDINGS).map(building => {
       const era = getUnlockEra(building.techRequired);
       const band = resolveBuildingPacingBand(building);
+      const outputPerTurn = getProductionOutputProfileForEra(era);
+      const currentCost = getCatalogProductionCost(building.id, era);
       const target = getTargetTurnWindow({
         era,
         band,
@@ -69,16 +72,19 @@ export function buildPacingAudit(): PacingAuditRow[] {
         contentType: 'building' as const,
         era,
         band,
-        currentCost: building.productionCost,
+        currentCost,
         target,
-        ...buildAuditSignals(building.productionCost, 4, target),
+        ...buildAuditSignals(currentCost, outputPerTurn, target),
       };
     }),
     ...TRAINABLE_UNITS.map(unit => {
       const era = getUnlockEra(unit.techRequired);
+      const auditEra = unit.type === 'settler' ? options.era ?? era : era;
       const band = resolveUnitPacingBand(unit);
+      const outputPerTurn = getProductionOutputProfileForEra(auditEra);
+      const currentCost = getCatalogProductionCost(unit.type, auditEra);
       const target = getTargetTurnWindow({
-        era,
+        era: auditEra,
         band,
         contentType: 'unit',
       });
@@ -86,11 +92,11 @@ export function buildPacingAudit(): PacingAuditRow[] {
         id: unit.type,
         label: unit.name,
         contentType: 'unit' as const,
-        era,
+        era: auditEra,
         band,
-        currentCost: unit.cost,
+        currentCost,
         target,
-        ...buildAuditSignals(unit.cost, 4, target),
+        ...buildAuditSignals(currentCost, outputPerTurn, target),
       };
     }),
     ...TECH_TREE.map(tech => {

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -19,7 +19,8 @@ const PRODUCTION_OUTPUT_BY_ERA: Record<number, number> = {
 };
 
 export function getProductionOutputProfileForEra(era: number): number {
-  const normalized = Math.max(1, Math.floor(era));
+  const numericEra = Number.isFinite(era) ? era : 1;
+  const normalized = Math.max(1, Math.floor(numericEra));
   return PRODUCTION_OUTPUT_BY_ERA[Math.min(5, normalized)];
 }
 

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -10,6 +10,19 @@ const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number,
   marquee: { early: [10, 12], late: [10, 16] },
 };
 
+const PRODUCTION_OUTPUT_BY_ERA: Record<number, number> = {
+  1: 4,
+  2: 6,
+  3: 8,
+  4: 10,
+  5: 12,
+};
+
+export function getProductionOutputProfileForEra(era: number): number {
+  const normalized = Math.max(1, Math.floor(era));
+  return PRODUCTION_OUTPUT_BY_ERA[Math.min(5, normalized)];
+}
+
 export function getTargetTurnWindow(input: { era: number; band: PacingBand; contentType: PacingContentType }): { min: number; max: number } {
   const [min, max] = input.era <= 1 ? BAND_WINDOWS[input.band].early : BAND_WINDOWS[input.band].late;
   return { min, max };

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -1,8 +1,9 @@
 import type { City, GameState, TechState } from '@/core/types';
-import { BUILDINGS, getAvailableBuildings, TRAINABLE_UNITS } from '@/systems/city-system';
+import { BUILDINGS, getAvailableBuildings, getProductionCostForItem, getTrainableUnitsForCiv } from '@/systems/city-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { getAvailableTechs } from '@/systems/tech-system';
 import { resolveBuildingPacingBand, resolveUnitPacingBand } from '@/systems/pacing-model';
+import { resolveCivDefinition } from '@/systems/civ-registry';
 
 const MAX_CITY_QUEUE_ITEMS = 4;
 const MAX_RESEARCH_QUEUE_ITEMS = 3;
@@ -94,7 +95,7 @@ export function getIdleCityIds(state: GameState, civId: string): string[] {
     .filter(city => !city.idleProduction)
     .filter(city => {
       const buildableBuildings = getAvailableBuildings(city, completedTechs).length > 0;
-      const buildableUnits = TRAINABLE_UNITS.some(unit => !unit.techRequired || completedTechs.includes(unit.techRequired));
+      const buildableUnits = getTrainableUnitsForCiv(completedTechs, civ.civType).length > 0;
       return buildableBuildings || buildableUnits;
     })
     .map(city => city.id);
@@ -123,24 +124,30 @@ export function getRecommendedIdleCityChoice(
   }
 
   const completedTechs = civ.techState.completed ?? [];
-  const productionPerTurn = Math.max(1, calculateProjectedCityYields(state, cityId).production);
+  const bonusEffect = resolveCivDefinition(state, civ.civType)?.bonusEffect;
+  const productionPerTurn = Math.max(1, calculateProjectedCityYields(state, cityId, bonusEffect).production);
   const candidates = [
-    ...getAvailableBuildings(city, completedTechs).map(building => ({
-      itemId: building.id,
-      label: building.name,
-      cost: building.productionCost,
-      turns: Math.ceil(building.productionCost / productionPerTurn),
-      priority: resolveBuildingPacingBand(building) === 'starter' ? 0 : 1,
-    })),
-    ...TRAINABLE_UNITS
-      .filter(unit => !unit.techRequired || completedTechs.includes(unit.techRequired))
-      .map(unit => ({
-        itemId: unit.type,
-        label: unit.name,
-        cost: unit.cost,
-        turns: Math.ceil(unit.cost / productionPerTurn),
-        priority: resolveUnitPacingBand(unit) === 'starter' ? 0 : 1,
-      })),
+    ...getAvailableBuildings(city, completedTechs).map(building => {
+      const cost = getProductionCostForItem(building.id, { city, bonusEffect, era: state.era });
+      return {
+        itemId: building.id,
+        label: building.name,
+        cost,
+        turns: Math.ceil(cost / productionPerTurn),
+        priority: resolveBuildingPacingBand(building) === 'starter' ? 0 : 1,
+      };
+    }),
+    ...getTrainableUnitsForCiv(completedTechs, civ.civType)
+      .map(unit => {
+        const cost = getProductionCostForItem(unit.type, { city, bonusEffect, era: state.era });
+        return {
+          itemId: unit.type,
+          label: unit.name,
+          cost,
+          turns: Math.ceil(cost / productionPerTurn),
+          priority: resolveUnitPacingBand(unit) === 'starter' ? 0 : 1,
+        };
+      }),
   ];
 
   const best = candidates

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -88,19 +88,19 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
   scout_hound: {
     type: 'scout_hound', name: 'Scout Hound', movementPoints: 3,
     visionRange: 3, strength: 8, canFoundCity: false,
-    canBuildImprovements: false, productionCost: 55,
+    canBuildImprovements: false, productionCost: 36,
     spyDetectionChance: 0.35,
   },
   shadow_warden: {
     type: 'shadow_warden', name: 'Shadow Warden', movementPoints: 3,
     visionRange: 4, strength: 6, canFoundCity: false,
-    canBuildImprovements: false, productionCost: 55,
+    canBuildImprovements: false, productionCost: 36,
     spyDetectionChance: 0.50,
   },
   war_hound: {
     type: 'war_hound', name: 'War Hound', movementPoints: 4,
     visionRange: 3, strength: 12, canFoundCity: false,
-    canBuildImprovements: false, productionCost: 45,
+    canBuildImprovements: false, productionCost: 32,
     spyDetectionChance: 0.30,
   },
 };

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -13,22 +13,22 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
   settler: {
     type: 'settler', name: 'Settler', movementPoints: 2,
     visionRange: 2, strength: 0, canFoundCity: true,
-    canBuildImprovements: false, productionCost: 50,
+    canBuildImprovements: false, productionCost: 24,
   },
   worker: {
     type: 'worker', name: 'Worker', movementPoints: 2,
     visionRange: 2, strength: 0, canFoundCity: false,
-    canBuildImprovements: true, productionCost: 30,
+    canBuildImprovements: true, productionCost: 12,
   },
   scout: {
     type: 'scout', name: 'Scout', movementPoints: 3,
     visionRange: 3, strength: 5, canFoundCity: false,
-    canBuildImprovements: false, productionCost: 20,
+    canBuildImprovements: false, productionCost: 6,
   },
   warrior: {
     type: 'warrior', name: 'Warrior', movementPoints: 2,
     visionRange: 2, strength: 10, canFoundCity: false,
-    canBuildImprovements: false, productionCost: 25,
+    canBuildImprovements: false, productionCost: 8,
   },
   archer: {
     type: 'archer', name: 'Archer', movementPoints: 2,

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -1,10 +1,9 @@
 import type { Unit, UnitType, City } from '@/core/types';
-import { TRAINABLE_UNITS } from './city-system';
-import { UNIT_DEFINITIONS } from './unit-system';
+import { TRAINABLE_UNITS, getCatalogProductionCost } from './city-system';
 
 export function getUpgradeCost(targetType: UnitType): number {
-  const entry = TRAINABLE_UNITS.find(u => u.type === targetType);
-  return entry ? Math.ceil(entry.cost * 0.5) : 0;
+  const cost = getCatalogProductionCost(targetType, 1);
+  return cost > 0 ? Math.ceil(cost * 0.5) : 0;
 }
 
 export function canUpgradeUnit(

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -1,10 +1,11 @@
 import type { City, CityFocus, GameState, HexCoord } from '@/core/types';
-import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv } from '@/systems/city-system';
+import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv, getProductionCostForItem } from '@/systems/city-system';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createCityGrid } from './city-grid';
 
 export interface CityPanelCallbacks {
@@ -45,7 +46,14 @@ export function createCityPanel(
   const occupiedMood = getOccupiedCityMood(city);
   const occupiedStatus = city.occupation ? `Occupied: ${city.occupation.turnsRemaining} turns to integrate` : '';
   const occupiedMoodText = occupiedMood === 2 ? 'Very Unhappy' : occupiedMood === 1 ? 'Unhappy' : '';
-  const availableBuildings = getAvailableBuildings(city, state.civilizations[state.currentPlayer].techState.completed);
+  const currentCiv = state.civilizations[state.currentPlayer];
+  const civDef = resolveCivDefinition(state, currentCiv.civType);
+  const getDisplayedCost = (itemId: string): number => getProductionCostForItem(itemId, {
+    city,
+    bonusEffect: civDef?.bonusEffect,
+    era: state.era,
+  });
+  const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed);
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
 
   // Build placeholders for dynamic data; style attributes with pure numbers (progress%) are safe
@@ -63,7 +71,8 @@ export function createCityPanel(
   let buildItemPlaceholders = '';
   for (let idx = 0; idx < availableBuildings.length; idx++) {
     const b = availableBuildings[idx];
-    const turns = yields.production > 0 ? Math.ceil(b.productionCost / yields.production) : '∞';
+    const cost = getDisplayedCost(b.id);
+    const turns = yields.production > 0 ? Math.ceil(cost / yields.production) : '∞';
     const yieldParts: string[] = [];
     if (b.yields.food) yieldParts.push(`+${b.yields.food} 🌾`);
     if (b.yields.production) yieldParts.push(`+${b.yields.production} ⚒️`);
@@ -77,17 +86,17 @@ export function createCityPanel(
     </div>`;
   }
 
-  const currentCiv = state.civilizations[state.currentPlayer];
   const completedTechs = currentCiv.techState.completed;
   const availableUnits = getTrainableUnitsForCiv(completedTechs, currentCiv.civType);
 
   let unitPlaceholders = '';
   for (let idx = 0; idx < availableUnits.length; idx++) {
     const u = availableUnits[idx];
-    const turns = yields.production > 0 ? Math.ceil(u.cost / yields.production) : '∞';
+    const cost = getDisplayedCost(u.type);
+    const turns = yields.production > 0 ? Math.ceil(cost / yields.production) : '∞';
     unitPlaceholders += `<div class="build-item" data-item-id="${u.type}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
       <div style="font-weight:bold;font-size:13px;">⚔️ <span data-text="unit-name-${idx}"></span></div>
-      <div style="font-size:11px;opacity:0.7;">Cost: ${u.cost} · ${turns} turns</div>
+      <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
     </div>`;
   }
 
@@ -115,9 +124,7 @@ export function createCityPanel(
   let currentProductionHtml = '';
   if (city.productionQueue.length > 0) {
     const currentItem = city.productionQueue[0];
-    const building = BUILDINGS[currentItem];
-    const unit = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    const totalCost = building?.productionCost ?? unit?.cost ?? 0;
+    const totalCost = getDisplayedCost(currentItem);
     const progress = totalCost > 0 ? Math.round((city.productionProgress / totalCost) * 100) : 0;
 
     currentProductionHtml = `
@@ -135,15 +142,11 @@ export function createCityPanel(
   const followUpTimings: Array<{ startTurns: number; finishTurns: number } | null> = [];
   if (city.productionQueue.length > 1 && yields.production > 0) {
     const currentItem0 = city.productionQueue[0];
-    const currentBuilding0 = BUILDINGS[currentItem0];
-    const currentUnit0 = TRAINABLE_UNITS.find(u => u.type === currentItem0);
-    const currentCost0 = currentBuilding0?.productionCost ?? currentUnit0?.cost ?? 0;
+    const currentCost0 = getDisplayedCost(currentItem0);
     let elapsed = Math.ceil(Math.max(0, currentCost0 - city.productionProgress) / yields.production);
     for (let i = 1; i < city.productionQueue.length; i++) {
       const followId = city.productionQueue[i];
-      const followBuilding = BUILDINGS[followId];
-      const followUnit = TRAINABLE_UNITS.find(u => u.type === followId);
-      const followCost = followBuilding?.productionCost ?? followUnit?.cost ?? 0;
+      const followCost = getDisplayedCost(followId);
       const duration = Math.ceil(followCost / yields.production);
       followUpTimings.push({ startTurns: elapsed, finishTurns: elapsed + duration });
       elapsed += duration;
@@ -253,9 +256,9 @@ export function createCityPanel(
     const currentItem = city.productionQueue[0];
     const building = BUILDINGS[currentItem];
     const unit = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    const totalCost = building?.productionCost ?? unit?.cost ?? 0;
+    const totalCost = getDisplayedCost(currentItem);
     const turnsLeft = yields.production > 0 ? Math.ceil((totalCost - city.productionProgress) / yields.production) : '∞';
-    setText('prod-name', building?.name ?? currentItem);
+    setText('prod-name', building?.name ?? unit?.name ?? currentItem);
     setText('prod-turns', String(turnsLeft));
   }
 

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -238,6 +238,33 @@ describe('processCity', () => {
     expect(result.idleGoldBonus).toBe(0);
     expect(result.idleScienceBonus).toBe(0);
   });
+
+  it('completes Herbalist at the retuned opening cost', () => {
+    const map = generateMap(30, 30, 'herbalist-opening-cost');
+    const city = foundCity('player', { q: 15, r: 15 }, map);
+    const queued = { ...city, productionQueue: ['herbalist'], productionProgress: 12 };
+
+    const result = processCity(queued, map, 0, 4, undefined, [], undefined, 1);
+
+    expect(result.completedBuilding).toBe('herbalist');
+    expect(result.city.buildings).toContain('herbalist');
+    expect(result.city.productionQueue).toEqual([]);
+  });
+
+  it('uses the current era cost when completing a Settler', () => {
+    const map = generateMap(30, 30, 'settler-era-cost');
+    const city = foundCity('player', { q: 15, r: 15 }, map);
+    const queued = { ...city, productionQueue: ['settler'], productionProgress: 39 };
+
+    const era3Result = processCity(queued, map, 0, 1, undefined, [], undefined, 3);
+    const era4Result = processCity(queued, map, 0, 1, undefined, [], undefined, 4);
+
+    expect(era3Result.completedUnit).toBe('settler');
+    expect(era3Result.city.productionQueue).toEqual([]);
+    expect(era4Result.completedUnit).toBeNull();
+    expect(era4Result.city.productionQueue).toEqual(['settler']);
+    expect(era4Result.city.productionProgress).toBe(40);
+  });
 });
 
 describe('expanded buildings', () => {

--- a/tests/systems/pacing-audit.test.ts
+++ b/tests/systems/pacing-audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildPacingAudit } from '@/systems/pacing-audit';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 
 describe('pacing-audit', () => {
   it('returns audit rows for current techs, units, and buildings', () => {
@@ -31,5 +32,36 @@ describe('pacing-audit', () => {
     expect(rows.find(row => row.id === 'granary')?.band).toBe('infrastructure');
     expect(rows.find(row => row.id === 'settler')?.band).toBe('power-spike');
     expect(rows.find(row => row.id === 'banking')?.band).toBe('power-spike');
+  });
+
+  it('audits every current building and trainable unit exactly once', () => {
+    const productionRows = buildPacingAudit({ era: 1 })
+      .filter(row => row.contentType === 'building' || row.contentType === 'unit');
+    const actualIds = productionRows.map(row => row.id).sort();
+    const expectedIds = [
+      ...Object.keys(BUILDINGS),
+      ...TRAINABLE_UNITS.map(unit => unit.type),
+    ].sort();
+
+    expect(actualIds).toEqual(expectedIds);
+  });
+
+  it('reports Settler cost using the requested audit era', () => {
+    const era1Settler = buildPacingAudit({ era: 1 }).find(row => row.id === 'settler');
+    const era4Settler = buildPacingAudit({ era: 4 }).find(row => row.id === 'settler');
+
+    expect(era1Settler?.currentCost).toBe(24);
+    expect(era1Settler?.estimatedTurns).toBe(6);
+    expect(era4Settler?.currentCost).toBe(48);
+    expect(era4Settler?.estimatedTurns).toBe(5);
+  });
+
+  it('has no slower-than-target building or unit outliers after the catalog audit pass', () => {
+    const slowOutliers = buildPacingAudit({ era: 1 })
+      .filter(row => row.contentType === 'building' || row.contentType === 'unit')
+      .filter(row => row.estimatedTurns > row.target.max)
+      .map(row => `${row.id}:${row.estimatedTurns}/${row.target.max}`);
+
+    expect(slowOutliers).toEqual([]);
   });
 });

--- a/tests/systems/pacing-model.test.ts
+++ b/tests/systems/pacing-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { estimateTurnsToComplete, getTargetTurnWindow } from '@/systems/pacing-model';
+import { estimateTurnsToComplete, getProductionOutputProfileForEra, getTargetTurnWindow } from '@/systems/pacing-model';
 
 describe('pacing-model', () => {
   it('gives Era 1 starter items a 2-4 turn target window', () => {
@@ -9,5 +9,9 @@ describe('pacing-model', () => {
   it('rounds ETA values up by turn', () => {
     expect(estimateTurnsToComplete({ cost: 12, outputPerTurn: 4 })).toBe(3);
     expect(estimateTurnsToComplete({ cost: 13, outputPerTurn: 4 })).toBe(4);
+  });
+
+  it('uses Era 1 production assumptions when the era is invalid', () => {
+    expect(getProductionOutputProfileForEra(Number.NaN)).toBe(4);
   });
 });

--- a/tests/systems/planning-system.test.ts
+++ b/tests/systems/planning-system.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { foundCity } from '@/systems/city-system';
+import { BUILDINGS, foundCity, TRAINABLE_UNITS } from '@/systems/city-system';
 import { generateMap } from '@/systems/map-generator';
 import { createTechState } from '@/systems/tech-system';
 import {
@@ -101,6 +101,37 @@ describe('planning-system city queues', () => {
 
     expect(choice).not.toBeNull();
     expect(choice?.itemId).not.toBe('herbalist');
+  });
+
+  it('prices recommended Settler production with the current era cost table', () => {
+    const state = createNewGame(undefined, 'idle-settler-era-seed', 'small');
+    const playerId = state.currentPlayer;
+    state.era = 4;
+    const settlerId = state.civilizations[playerId].units.find(unitId => state.units[unitId]?.type === 'settler');
+    expect(settlerId).toBeDefined();
+
+    const city = {
+      ...foundCity(playerId, state.units[settlerId!].position, state.map),
+      buildings: Object.keys(BUILDINGS),
+    };
+    state.cities[city.id] = city;
+    state.civilizations[playerId].cities.push(city.id);
+
+    const originalUnits = [...TRAINABLE_UNITS];
+    const settlerEntry = TRAINABLE_UNITS.find(unit => unit.type === 'settler');
+    expect(settlerEntry).toBeDefined();
+    TRAINABLE_UNITS.splice(0, TRAINABLE_UNITS.length, settlerEntry!);
+
+    try {
+      const choice = getRecommendedIdleCityChoice(state, playerId, city.id);
+
+      expect(choice).toMatchObject({
+        itemId: 'settler',
+        cost: 48,
+      });
+    } finally {
+      TRAINABLE_UNITS.splice(0, TRAINABLE_UNITS.length, ...originalUnits);
+    }
   });
 });
 

--- a/tests/systems/production-costs.test.ts
+++ b/tests/systems/production-costs.test.ts
@@ -24,6 +24,10 @@ describe('production cost catalog', () => {
     expect(getSettlerProductionCost(99)).toBe(56);
   });
 
+  it('treats invalid Settler era input as Era 1 instead of returning undefined', () => {
+    expect(getSettlerProductionCost(Number.NaN)).toBe(24);
+  });
+
   it('uses the current era for Settler catalog cost and raw cost for other units', () => {
     expect(getCatalogProductionCost('settler', 1)).toBe(24);
     expect(getCatalogProductionCost('settler', 4)).toBe(48);

--- a/tests/systems/production-costs.test.ts
+++ b/tests/systems/production-costs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUILDINGS,
+  TRAINABLE_UNITS,
+  getCatalogProductionCost,
+  getProductionCostForItem,
+  getSettlerProductionCost,
+} from '@/systems/city-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+describe('production cost catalog', () => {
+  it('keeps Herbalist in the Era 1 starter window for a new capital', () => {
+    expect(BUILDINGS.herbalist.productionCost).toBe(16);
+    expect(BUILDINGS.herbalist.pacing?.band).toBe('starter');
+    expect(getCatalogProductionCost('herbalist', 1)).toBe(16);
+  });
+
+  it('scales Settler cost upward by era as cities get more complex', () => {
+    expect(getSettlerProductionCost(1)).toBe(24);
+    expect(getSettlerProductionCost(2)).toBe(32);
+    expect(getSettlerProductionCost(3)).toBe(40);
+    expect(getSettlerProductionCost(4)).toBe(48);
+    expect(getSettlerProductionCost(5)).toBe(56);
+    expect(getSettlerProductionCost(99)).toBe(56);
+  });
+
+  it('uses the current era for Settler catalog cost and raw cost for other units', () => {
+    expect(getCatalogProductionCost('settler', 1)).toBe(24);
+    expect(getCatalogProductionCost('settler', 4)).toBe(48);
+    expect(getCatalogProductionCost('worker', 4)).toBe(12);
+  });
+
+  it('applies Safehouse discounts only to spy units after resolving the canonical base cost', () => {
+    const cityWithSafehouse = { buildings: ['safehouse'] };
+    const cityWithoutSafehouse = { buildings: [] };
+
+    expect(getProductionCostForItem('spy_scout', { city: cityWithSafehouse, era: 1 })).toBe(23);
+    expect(getProductionCostForItem('spy_scout', { city: cityWithoutSafehouse, era: 1 })).toBe(30);
+    expect(getProductionCostForItem('settler', { city: cityWithSafehouse, era: 2 })).toBe(32);
+  });
+
+  it('keeps trainable unit costs aligned with unit definitions', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      expect(UNIT_DEFINITIONS[unit.type].productionCost).toBe(unit.cost);
+    }
+  });
+});

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -48,9 +48,13 @@ describe('canUpgradeUnit', () => {
 });
 
 describe('getUpgradeCost', () => {
-  it('returns half of the target unit production cost', () => {
+  it('returns half of the target unit production cost from the canonical catalog', () => {
     const cost = getUpgradeCost('spy_informant');
-    expect(cost).toBe(25); // spy_informant costs 50 in TRAINABLE_UNITS, half = 25
+    expect(cost).toBe(25);
+  });
+
+  it('uses the retuned worker production cost for upgrade math', () => {
+    expect(getUpgradeCost('worker')).toBe(6);
   });
 });
 

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -186,6 +186,76 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('data-queue-action="remove"');
   });
 
+  it('shows retuned Era 1 Settler and Herbalist ETA from canonical costs', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.population = 1;
+    city.focus = 'production';
+    city.buildings = ['forge'];
+    city.workedTiles = [];
+    city.ownedTiles = [city.position];
+    state.era = 1;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Herbalist');
+    expect(rendered).toContain('4 turns');
+    expect(rendered).toContain('Settler');
+    expect(rendered).toContain('Cost: 24');
+    expect(rendered).toContain('6 turns');
+  });
+
+  it('shows higher Settler cost and ETA after the era advances', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.population = 1;
+    city.focus = 'production';
+    city.buildings = ['forge'];
+    city.workedTiles = [];
+    city.ownedTiles = [city.position];
+    state.era = 3;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Settler');
+    expect(rendered).toContain('Cost: 40');
+    expect(rendered).toContain('10 turns');
+  });
+
+  it('recalculates queue timing with era-aware Settler cost', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.population = 1;
+    city.focus = 'production';
+    city.buildings = ['forge'];
+    city.workedTiles = [];
+    city.ownedTiles = [city.position];
+    city.productionQueue = ['herbalist', 'settler'];
+    city.productionProgress = 8;
+    state.era = 2;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onMoveQueueItem: () => {},
+      onRemoveQueueItem: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Herbalist');
+    expect(rendered).toContain('Settler');
+    expect(rendered).toContain('Starts in 2 turns');
+    expect(rendered).toContain('Done in 10 turns');
+  });
+
   it('renders Overview, Buildings/Core, and Worked Land And Water sections in the Grid tab', () => {
     const { container, city, state } = makeWonderPanelFixture();
     city.focus = 'balanced';


### PR DESCRIPTION
Fixes #109

Summary:
- Retunes opening Herbalist and Settler production pacing.
- Adds canonical production-cost helpers for era-aware Settlers, bonuses, and Safehouse spy discounts.
- Wires costs through turn processing, city panel ETA rendering, pacing audit, upgrade math, and idle-city recommendations.
- Audits current building/unit pacing and retunes outliers.

Checks:
- scripts/check-src-rule-violations.sh src/systems/city-system.ts src/systems/unit-system.ts src/systems/unit-upgrade-system.ts src/systems/pacing-model.ts src/systems/pacing-audit.ts src/systems/planning-system.ts src/core/turn-manager.ts src/ui/city-panel.ts
- ./scripts/run-with-mise.sh yarn vitest run tests/systems/production-costs.test.ts tests/systems/pacing-model.test.ts tests/systems/planning-system.test.ts tests/systems/pacing-audit.test.ts tests/systems/city-system.test.ts tests/systems/unit-upgrade.test.ts tests/systems/unit-system.test.ts tests/systems/detection-system.test.ts tests/ui/city-panel.test.ts tests/ui/pacing-debug-panel.test.ts tests/integration/pacing-simulation.test.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test