### PR TITLE
feat: idle production options + map build badges (#159)

### DIFF
--- a/.claude/rules/end-to-end-wiring.md
+++ b/.claude/rules/end-to-end-wiring.md
@@ -41,3 +41,8 @@ paths:
   5. **AI usage.** `src/ai/basic-ai.ts` MUST queue the new unit type when its conditions hold; otherwise AI civs become asymmetric with the player.
   6. **Tech-gated dequeue.** `processCity` MUST consult `getTrainableUnitsForCiv(civ.techState.completed)` — or an equivalent — so an obsolete queued unit silently dequeues instead of producing forever.
 - Adding a `UnitType` to `TRAINABLE_UNITS` without all six wirings is "dead computed data" and is a bug.
+
+## Production icons must be wired end-to-end
+- When you add an entry to `BUILDINGS` or `TRAINABLE_UNITS` in `src/systems/city-system.ts`, you MUST also add a matching entry to `PRODUCTION_ICONS` in the same file.
+- The icon-coverage regression tests in `tests/systems/city-system.test.ts` will fail if a building or unit lacks an icon, but the rule catches it before the failed test cycle.
+- Legendary wonders intentionally fall through to `PRODUCTION_ICON_FALLBACK` (`'🏗️'`); they are not required to have entries in this map until a follow-up issue adds wonder-specific icons.

--- a/docs/superpowers/plans/2026-05-03-idle-production-and-build-badges-plan.md
+++ b/docs/superpowers/plans/2026-05-03-idle-production-and-build-badges-plan.md
@@ -1,0 +1,1065 @@
+# Idle Production & Build Badges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve [issue #159](https://github.com/a1flecke/conquestoria/issues/159) — make the city idle-production selector always visible, render at-a-glance map badges for what each city is doing, and surface idle-converted yields in the HUD's per-turn rates.
+
+**Architecture:** A single-source-of-truth `PRODUCTION_ICONS` map lives in `src/systems/city-system.ts` alongside `BUILDINGS` and `TRAINABLE_UNITS`. The city panel imports the map to prefix every build-list and queue entry. The city renderer imports the map to draw two new corner badges (top-left = idle mode when queue empty; bottom-right = current build when queue non-empty), gated to the current player's own cities for privacy. `calculateProjectedCityYields` shifts production → gold/science when a city is idle so the HUD's per-turn rates match what `processCity` will apply at turn end.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D, Vite. No new dependencies.
+
+**Spec:** [docs/superpowers/specs/2026-05-02-idle-production-and-build-badges-design.md](../specs/2026-05-02-idle-production-and-build-badges-design.md)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/systems/city-system.ts` | Modify | Add `PRODUCTION_ICONS` map after `TRAINABLE_UNITS` |
+| `src/systems/city-work-system.ts` | Modify | `calculateProjectedCityYields` shifts production→gold/science when idle |
+| `src/ui/city-panel.ts` | Modify | Always-render idle selector, replace literal `🏗️`/`⚔️` prefixes with `PRODUCTION_ICONS` lookup, add icons to current production + queue rows |
+| `src/renderer/city-renderer.ts` | Modify | Add `getProductionBadgeIcon` helper, draw top-left idle badge + bottom-right build badge with ownership gate |
+| `tests/systems/city-system.test.ts` | Modify | Add icon-coverage regression tests |
+| `tests/systems/city-work-system.test.ts` | Modify (or create) | Add idle-yield projection tests |
+| `tests/ui/city-panel.test.ts` | Modify | Update existing test, add science/none button click tests, build-list icon tests |
+| `tests/renderer/city-renderer.test.ts` | Modify | Add badge-helper tests, ownership-gate tests, badge rendering tests |
+| `.claude/rules/end-to-end-wiring.md` | Modify | Add `PRODUCTION_ICONS` wiring rule |
+
+---
+
+## Task 1: PRODUCTION_ICONS map + coverage regression
+
+**Files:**
+- Modify: `src/systems/city-system.ts` (after `TRAINABLE_UNITS` definition, around line 95)
+- Test: `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Add the PRODUCTION_ICONS export to city-system.ts**
+
+In `src/systems/city-system.ts`, find the end of the `TRAINABLE_UNITS` array (around line 94, after the `]`). Add the following block immediately after:
+
+```ts
+export const PRODUCTION_ICONS: Record<string, string> = {
+  // Buildings
+  granary: '🌾',
+  herbalist: '🌿',
+  aqueduct: '💧',
+  workshop: '🔨',
+  forge: '🔥',
+  lumbermill: '🪵',
+  'quarry-building': '⛏️',
+  library: '📚',
+  archive: '📜',
+  observatory: '🔭',
+  marketplace: '🏪',
+  harbor: '⚓',
+  barracks: '🪖',
+  walls: '🧱',
+  stable: '🐴',
+  temple: '🛕',
+  monument: '🗿',
+  amphitheater: '🎭',
+  shrine: '⛩️',
+  forum: '📢',
+  safehouse: '🏠',
+  'intelligence-agency': '🛡️',
+  'security-bureau': '🔒',
+  // Units
+  warrior: '⚔️',
+  archer: '🏹',
+  scout: '🔍',
+  worker: '🪚',
+  settler: '🏕️',
+  swordsman: '🗡️',
+  pikeman: '🔱',
+  musketeer: '🔫',
+  galley: '⛵',
+  trireme: '🚢',
+  spy_scout: '👁️',
+  spy_informant: '📡',
+  spy_agent: '🕵️',
+  spy_operative: '🎯',
+  spy_hacker: '💻',
+  scout_hound: '🐕',
+  shadow_warden: '👤',
+  war_hound: '🐺',
+};
+
+export const PRODUCTION_ICON_FALLBACK = '🏗️';
+```
+
+- [ ] **Step 2: Add coverage regression tests**
+
+Append to `tests/systems/city-system.test.ts` (inside the existing `describe` block or as a new top-level `describe`):
+
+```ts
+import { BUILDINGS, TRAINABLE_UNITS, PRODUCTION_ICONS } from '@/systems/city-system';
+
+describe('PRODUCTION_ICONS coverage', () => {
+  it('has an entry for every building in BUILDINGS', () => {
+    for (const buildingId of Object.keys(BUILDINGS)) {
+      expect(PRODUCTION_ICONS[buildingId], `missing icon for building "${buildingId}"`).toBeTruthy();
+    }
+  });
+
+  it('has an entry for every unit in TRAINABLE_UNITS', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      expect(PRODUCTION_ICONS[unit.type], `missing icon for unit "${unit.type}"`).toBeTruthy();
+    }
+  });
+
+  it('every icon is a non-empty string', () => {
+    for (const [id, icon] of Object.entries(PRODUCTION_ICONS)) {
+      expect(typeof icon, `icon for "${id}" must be string`).toBe('string');
+      expect(icon.length, `icon for "${id}" must be non-empty`).toBeGreaterThan(0);
+    }
+  });
+});
+```
+
+If the existing file has its own `import` line for `BUILDINGS`/`TRAINABLE_UNITS`, merge `PRODUCTION_ICONS` into that import instead of adding a duplicate.
+
+- [ ] **Step 3: Run the regression tests**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/systems/city-system.test.ts
+```
+
+Expected: PASS for the three new tests. If a building or unit fails coverage, add the missing entry to `PRODUCTION_ICONS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(city): add PRODUCTION_ICONS map with coverage regression"
+```
+
+---
+
+## Task 2: Idle-aware HUD per-turn yield projection
+
+**Files:**
+- Modify: `src/systems/city-work-system.ts` (function `calculateProjectedCityYields`, lines 236-249)
+- Test: `tests/systems/city-work-system.test.ts` (modify or create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Open or create `tests/systems/city-work-system.test.ts`. Add a new describe block:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { foundCity } from '@/systems/city-system';
+import { generateMap } from '@/systems/map-generator';
+import type { GameState, City } from '@/core/types';
+
+function makeIdleProjectionState(idleProduction: 'gold' | 'science' | null, queue: string[] = []): { state: GameState; cityId: string } {
+  const map = generateMap(20, 20, `idle-projection-${idleProduction ?? 'none'}-${queue.length}`);
+  const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+  const founded = foundCity('player', tile.coord, map);
+  const city: City = { ...founded, productionQueue: queue, idleProduction };
+  const state = {
+    turn: 1, era: 1, currentPlayer: 'player', hotSeat: false,
+    gameOver: false, winner: null, map,
+    units: {},
+    cities: { [city.id]: city },
+    civilizations: {
+      player: {
+        id: 'player', name: 'Test', color: '#fff', isHuman: true, civType: 'generic',
+        cities: [city.id], units: [], gold: 0, score: 0,
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        visibility: { tiles: {} },
+        diplomacy: {
+          relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0,
+          vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 },
+        },
+      },
+    },
+    barbarianCamps: {}, minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+  } as unknown as GameState;
+  return { state, cityId: city.id };
+}
+
+describe('calculateProjectedCityYields — idle production projection', () => {
+  it('shifts production into gold when city is idle with idleProduction=gold', () => {
+    const baseline = makeIdleProjectionState(null);
+    const baseYields = calculateProjectedCityYields(baseline.state, baseline.cityId);
+
+    const idle = makeIdleProjectionState('gold');
+    const idleYields = calculateProjectedCityYields(idle.state, idle.cityId);
+
+    expect(idleYields.production).toBe(0);
+    expect(idleYields.gold).toBe(baseYields.gold + baseYields.production);
+    expect(idleYields.science).toBe(baseYields.science);
+  });
+
+  it('shifts production into science when city is idle with idleProduction=science', () => {
+    const baseline = makeIdleProjectionState(null);
+    const baseYields = calculateProjectedCityYields(baseline.state, baseline.cityId);
+
+    const idle = makeIdleProjectionState('science');
+    const idleYields = calculateProjectedCityYields(idle.state, idle.cityId);
+
+    expect(idleYields.production).toBe(0);
+    expect(idleYields.science).toBe(baseYields.science + baseYields.production);
+    expect(idleYields.gold).toBe(baseYields.gold);
+  });
+
+  it('does NOT shift when productionQueue is non-empty even with idleProduction set', () => {
+    const baseline = makeIdleProjectionState(null);
+    const baseYields = calculateProjectedCityYields(baseline.state, baseline.cityId);
+
+    const queued = makeIdleProjectionState('gold', ['warrior']);
+    const queuedYields = calculateProjectedCityYields(queued.state, queued.cityId);
+
+    expect(queuedYields.production).toBe(baseYields.production);
+    expect(queuedYields.gold).toBe(baseYields.gold);
+  });
+
+  it('does NOT shift when idleProduction is null', () => {
+    const a = makeIdleProjectionState(null);
+    const aYields = calculateProjectedCityYields(a.state, a.cityId);
+
+    const b = makeIdleProjectionState(null);
+    const bYields = calculateProjectedCityYields(b.state, b.cityId);
+
+    expect(aYields).toEqual(bYields);
+    expect(aYields.production).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, expect failure**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/systems/city-work-system.test.ts
+```
+
+Expected: 3 of the 4 new tests FAIL (the `null` baseline test passes; the other three fail because no shift logic exists yet).
+
+- [ ] **Step 3: Modify calculateProjectedCityYields to apply the shift**
+
+In `src/systems/city-work-system.ts`, replace the body of `calculateProjectedCityYields` (lines 236-249) with:
+
+```ts
+export function calculateProjectedCityYields(
+  state: GameState,
+  cityId: string,
+  bonusEffect?: CivBonusEffect,
+): ResourceYield {
+  const city = state.cities[cityId];
+  if (!city) return { food: 0, production: 0, gold: 0, science: 0 };
+
+  const workResult = city.focus === 'custom'
+    ? normalizeWorkedTilesForCity(state, cityId)
+    : assignCityFocus(state, cityId, city.focus);
+  const projectedCity = workResult.state.cities[cityId] ?? city;
+  const yields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect);
+
+  if (city.productionQueue.length === 0 && city.idleProduction) {
+    if (city.idleProduction === 'gold') {
+      return { ...yields, production: 0, gold: yields.gold + yields.production };
+    }
+    if (city.idleProduction === 'science') {
+      return { ...yields, production: 0, science: yields.science + yields.production };
+    }
+  }
+
+  return yields;
+}
+```
+
+- [ ] **Step 4: Run the tests, expect all to pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/systems/city-work-system.test.ts
+```
+
+Expected: all 4 new tests PASS.
+
+- [ ] **Step 5: Run the full suite to confirm no regressions**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test
+```
+
+Expected: all tests PASS. If any fail, the projection change has a downstream impact — investigate before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/city-work-system.ts tests/systems/city-work-system.test.ts
+git commit -m "feat(yields): project idle production conversion into gold/science yields"
+```
+
+---
+
+## Task 3: Always-visible idle selector + button click coverage
+
+**Files:**
+- Modify: `src/ui/city-panel.ts` (lines 94-112)
+- Test: `tests/ui/city-panel.test.ts` (lines 836-898)
+
+- [ ] **Step 1: Update the existing failing test (queue non-empty)**
+
+In `tests/ui/city-panel.test.ts`, find the test at line 856 (`'does not show idle mode selector when production queue is non-empty'`). Replace its body:
+
+```ts
+  it('shows idle mode selector even when production queue is non-empty', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = ['warrior'];
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    expect(html).toContain('data-idle-mode');
+  });
+```
+
+- [ ] **Step 2: Add new tests for science and none button clicks**
+
+Append inside the same `describe('city-panel idle production selector', …)` block (after the gold-button test, before the closing `});`):
+
+```ts
+  it('calls onSetIdleProduction with science when Science button is clicked', () => {
+    const { container, city, state } = makeIdleCityFixture();
+    const onSetIdleProduction = vi.fn();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetIdleProduction: (cityId: string, mode: 'gold' | 'science' | null) => {
+        state.cities[cityId] = { ...state.cities[cityId]!, idleProduction: mode };
+        onSetIdleProduction(cityId, mode);
+      },
+    });
+    const sciBtn = panel.querySelector<HTMLElement>('[data-idle-mode="science"]');
+    expect(sciBtn).toBeTruthy();
+    sciBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, 'science');
+  });
+
+  it('calls onSetIdleProduction with null when None button is clicked', () => {
+    const { container, city, state } = makeIdleCityFixture();
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    const onSetIdleProduction = vi.fn();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetIdleProduction: (cityId: string, mode: 'gold' | 'science' | null) => {
+        state.cities[cityId] = { ...state.cities[cityId]!, idleProduction: mode };
+        onSetIdleProduction(cityId, mode);
+      },
+    });
+    const noneBtn = panel.querySelector<HTMLElement>('[data-idle-mode="none"]');
+    expect(noneBtn).toBeTruthy();
+    noneBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, null);
+  });
+```
+
+- [ ] **Step 3: Run the tests, expect failures**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/ui/city-panel.test.ts
+```
+
+Expected: the inverted test FAILS ("expected to contain data-idle-mode" — it's hidden when queue is non-empty under current code). The science/none tests PASS already (since they use `makeIdleCityFixture()` with empty queue — but they're new coverage that needs the panel handler logic which already exists).
+
+- [ ] **Step 4: Remove the queue-empty guard and update the label**
+
+In `src/ui/city-panel.ts`, replace lines 94-112 (the entire `idleSelectorHtml` block):
+
+```ts
+  // Idle production selector — always visible; conversion only fires when queue is empty.
+  const activeMode = city.idleProduction ?? 'none';
+  const goldActive = activeMode === 'gold' ? 'border-color:#d4aa2c;background:rgba(212,170,44,0.3);' : '';
+  const sciActive = activeMode === 'science' ? 'border-color:#6496ff;background:rgba(100,150,255,0.3);' : '';
+  const noneActive = activeMode === 'none' ? 'border-color:rgba(255,255,255,0.5);background:rgba(255,255,255,0.2);' : '';
+  const idleSelectorHtml = `
+    <div style="background:rgba(255,255,255,0.08);border-radius:10px;padding:12px;margin-bottom:16px;">
+      <div style="font-weight:bold;color:#e8c170;margin-bottom:6px;">Idle Production</div>
+      <div style="font-size:12px;opacity:0.7;margin-bottom:8px;">When idle, convert +${yields.production}/turn production to:</div>
+      <div style="display:flex;gap:8px;">
+        <button type="button" data-idle-mode="gold" style="flex:1;padding:8px;background:rgba(212,170,44,0.15);border:1px solid rgba(212,170,44,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${goldActive}">💰 Gold +${yields.production}/turn</button>
+        <button type="button" data-idle-mode="science" style="flex:1;padding:8px;background:rgba(100,150,255,0.15);border:1px solid rgba(100,150,255,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${sciActive}">🔬 Science +${yields.production}/turn</button>
+        <button type="button" data-idle-mode="none" style="flex:1;padding:8px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:6px;color:white;cursor:pointer;font-size:12px;${noneActive}">None</button>
+      </div>
+    </div>
+  `;
+```
+
+This removes the `if (city.productionQueue.length === 0) {` wrapping and changes the descriptive line from `"Queue is empty — convert ..."` to `"When idle, convert ..."`.
+
+- [ ] **Step 5: Run the tests, expect all to pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/ui/city-panel.test.ts
+```
+
+Expected: all idle-selector tests PASS (the original 3, the inverted 1, and the 2 new click tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "feat(ui): always-visible idle production selector with science/none click coverage"
+```
+
+---
+
+## Task 4: Replace literal build-list icons with PRODUCTION_ICONS
+
+**Files:**
+- Modify: `src/ui/city-panel.ts` (lines 73, 88, current production block ~line 125, queue rows ~line 282)
+- Test: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Write the failing tests for build-list icon replacement**
+
+Append to `tests/ui/city-panel.test.ts` (as a new top-level describe near the bottom, before the final closing brace):
+
+```ts
+describe('city-panel build list icons', () => {
+  it('renders the granary icon prefix in the available buildings list', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    expect(html).toContain('🌾');
+    // Confirms the literal generic 🏗️ prefix has been replaced for granary.
+    // (Buildings without specific icons would still use the fallback.)
+  });
+
+  it('renders the warrior icon prefix in the available units list', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    expect(html).toContain('⚔️');
+  });
+
+  it('renders the icon for the currently building item', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = ['workshop'];
+    city.productionProgress = 5;
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    // 🔨 = workshop icon
+    expect(html).toContain('🔨');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/ui/city-panel.test.ts
+```
+
+Expected: the warrior test PASSES (literal `⚔️` already present), the granary test FAILS (current code uses literal `🏗️` not `🌾`), the workshop test FAILS (current production block has no icon).
+
+- [ ] **Step 3: Update the import in city-panel.ts**
+
+In `src/ui/city-panel.ts` line 2, replace:
+
+```ts
+import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv } from '@/systems/city-system';
+```
+
+with:
+
+```ts
+import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv, PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
+```
+
+- [ ] **Step 4: Replace the literal 🏗️ in the available-buildings loop**
+
+In `src/ui/city-panel.ts`, find the loop building `buildItemPlaceholders` (lines 64-78). Replace line 74:
+
+```ts
+      <div style="font-weight:bold;font-size:13px;">🏗️ <span data-text="build-name-${idx}"></span></div>
+```
+
+with:
+
+```ts
+      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[b.id] ?? PRODUCTION_ICON_FALLBACK} <span data-text="build-name-${idx}"></span></div>
+```
+
+- [ ] **Step 5: Replace the literal ⚔️ in the available-units loop**
+
+In `src/ui/city-panel.ts`, find the unit loop (lines 84-92). Replace line 89:
+
+```ts
+      <div style="font-weight:bold;font-size:13px;">⚔️ <span data-text="unit-name-${idx}"></span></div>
+```
+
+with:
+
+```ts
+      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[u.type] ?? PRODUCTION_ICON_FALLBACK} <span data-text="unit-name-${idx}"></span></div>
+```
+
+- [ ] **Step 6: Add icon to the current-production block**
+
+In `src/ui/city-panel.ts`, find the current-production block (around lines 114-132). The block currently uses `data-text="prod-name"` populated later via `setText('prod-name', building?.name ?? currentItem)`.
+
+Replace the line that says `<div style="font-weight:bold;color:#e8c170;">Building: <span data-text="prod-name"></span></div>` with:
+
+```ts
+        <div style="font-weight:bold;color:#e8c170;">Building: ${PRODUCTION_ICONS[currentItem] ?? PRODUCTION_ICON_FALLBACK} <span data-text="prod-name"></span></div>
+```
+
+- [ ] **Step 7: Add icon prefix to follow-up queue rows**
+
+In `src/ui/city-panel.ts`, find the queue rows loop (around lines 161-181). Inside the `for (let idx = 1; ...)` loop, replace the `<div style="font-weight:bold;" data-text="queue-name-${idx}"></div>` line with:
+
+```ts
+          <div style="font-weight:bold;">${PRODUCTION_ICONS[city.productionQueue[idx]] ?? PRODUCTION_ICON_FALLBACK} <span data-text="queue-name-${idx}"></span></div>
+```
+
+(The icon is interpolated into the literal HTML; the name still flows through `setText` for XSS safety.)
+
+- [ ] **Step 8: Run the tests, expect all to pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/ui/city-panel.test.ts
+```
+
+Expected: all build-list-icons tests PASS, all idle-selector tests still PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "feat(ui): use PRODUCTION_ICONS for build list, current production, and queue rows"
+```
+
+---
+
+## Task 5: Renderer pure helper `getProductionBadgeIcon`
+
+**Files:**
+- Modify: `src/renderer/city-renderer.ts` (add export at top of file)
+- Test: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new describe block to `tests/renderer/city-renderer.test.ts` (after the existing wrap/breakaway tests, inside the file but outside other `describe` blocks):
+
+```ts
+import { getProductionBadgeIcon } from '@/renderer/city-renderer';
+import type { City } from '@/core/types';
+
+function makeCityStub(overrides: Partial<City> = {}): City {
+  return {
+    id: 'c1', name: 'Test', owner: 'player', position: { q: 0, r: 0 },
+    population: 1, food: 0, foodNeeded: 10, foodPerTurn: 2,
+    productionQueue: [], productionProgress: 0,
+    buildings: [], grid: { slots: [], expansionsBought: 0 },
+    focus: 'balanced', workedTiles: [], unrestLevel: 0,
+    idleProduction: null,
+    ...overrides,
+  } as unknown as City;
+}
+
+describe('getProductionBadgeIcon', () => {
+  it('returns the matching icon when productionQueue[0] is a known building', () => {
+    const city = makeCityStub({ productionQueue: ['granary'] });
+    expect(getProductionBadgeIcon(city)).toBe('🌾');
+  });
+
+  it('returns the matching icon when productionQueue[0] is a known unit', () => {
+    const city = makeCityStub({ productionQueue: ['warrior'] });
+    expect(getProductionBadgeIcon(city)).toBe('⚔️');
+  });
+
+  it('returns the fallback icon when productionQueue[0] is unknown (e.g. legendary wonder)', () => {
+    const city = makeCityStub({ productionQueue: ['some-legendary-wonder-id'] });
+    expect(getProductionBadgeIcon(city)).toBe('🏗️');
+  });
+
+  it('returns null when productionQueue is empty', () => {
+    const city = makeCityStub({ productionQueue: [] });
+    expect(getProductionBadgeIcon(city)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, expect failure**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: import error or 4 FAILS — `getProductionBadgeIcon` does not yet exist.
+
+- [ ] **Step 3: Implement the helper**
+
+In `src/renderer/city-renderer.ts`, add this import near the top (alongside the existing imports):
+
+```ts
+import { PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
+```
+
+Then add the helper export immediately after the imports and before the `interface CityRenderInfo` declaration:
+
+```ts
+export function getProductionBadgeIcon(city: { productionQueue: string[] }): string | null {
+  if (city.productionQueue.length === 0) return null;
+  const id = city.productionQueue[0];
+  return PRODUCTION_ICONS[id] ?? PRODUCTION_ICON_FALLBACK;
+}
+```
+
+- [ ] **Step 4: Run the tests, expect pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: all 4 helper tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/city-renderer.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(renderer): add getProductionBadgeIcon helper"
+```
+
+---
+
+## Task 6: Bottom-right "currently building" badge with ownership gate
+
+**Files:**
+- Modify: `src/renderer/city-renderer.ts` (`drawCities` function, around line 117 inside the existing for-loop)
+- Test: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write the failing rendering tests**
+
+Append to `tests/renderer/city-renderer.test.ts` (use the existing `MockCanvasContext` and import `drawCities`):
+
+```ts
+describe('drawCities — bottom-right build badge', () => {
+  function makeCamera() {
+    return {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+  }
+
+  it('draws the production icon for a player-owned city with a non-empty queue', () => {
+    const state = createNewGame(undefined, 'badge-build-render');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = ['warrior'];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('⚔️');
+  });
+
+  it('does NOT draw the production icon for an enemy-owned visible city', () => {
+    const state = createNewGame(undefined, 'badge-build-enemy');
+    const aiSettler = Object.values(state.units).find(u => u.owner === 'ai-1' && u.type === 'settler')!;
+    const aiCity = foundCity('ai-1', aiSettler.position, state.map);
+    aiCity.productionQueue = ['warrior'];
+    state.cities[aiCity.id] = aiCity;
+    state.civilizations['ai-1'].cities.push(aiCity.id);
+    state.civilizations.player.visibility.tiles[hexKey(aiCity.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('⚔️');
+  });
+
+  it('does NOT draw a production icon when the queue is empty', () => {
+    const state = createNewGame(undefined, 'badge-build-empty');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('🏗️');
+    expect(texts).not.toContain('⚔️');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, expect failures**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: the "draws the production icon for a player-owned city" test FAILS (no badge logic yet); the negative tests PASS by accident.
+
+- [ ] **Step 3: Add the bottom-right badge to drawCities**
+
+In `src/renderer/city-renderer.ts`, find the existing breakaway/occupation/unrest badge block inside `drawCities` (currently lines 102-117 — the `if (breakaway) { … } else if (city.occupation) { … } else if (city.unrestLevel > 0) { … }` chain).
+
+Immediately after the closing `}` of that chain (after line 117, before the closing `}` of the inner `for (const renderCoord …)` loop), add:
+
+```ts
+      // Bottom-right badge: currently-building icon (player-owned, non-empty queue only)
+      if (city.owner === playerCivId) {
+        const buildIcon = getProductionBadgeIcon(city);
+        if (buildIcon) {
+          ctx.font = `${size * 0.28}px system-ui`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillStyle = '#fff';
+          ctx.fillText(buildIcon, screen.x + size * 0.45, screen.y + size * 0.45);
+        }
+      }
+```
+
+- [ ] **Step 4: Run the tests, expect all to pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: all build-badge tests PASS, including the ownership gate (no `⚔️` for enemy city) and the empty-queue case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/city-renderer.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(renderer): bottom-right build badge with current-player ownership gate"
+```
+
+---
+
+## Task 7: Top-left idle production badge with ownership + queue-empty gate
+
+**Files:**
+- Modify: `src/renderer/city-renderer.ts` (`drawCities` function, near the bottom-right badge)
+- Test: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/renderer/city-renderer.test.ts`:
+
+```ts
+describe('drawCities — top-left idle badge', () => {
+  function makeCamera() {
+    return {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+  }
+
+  it('draws 💰 for a player-owned idle city with idleProduction=gold', () => {
+    const state = createNewGame(undefined, 'badge-idle-gold');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('💰');
+  });
+
+  it('draws 🔬 for a player-owned idle city with idleProduction=science', () => {
+    const state = createNewGame(undefined, 'badge-idle-sci');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = 'science';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('🔬');
+  });
+
+  it('does NOT draw the idle badge when queue is non-empty even with idleProduction set', () => {
+    const state = createNewGame(undefined, 'badge-idle-queued');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = ['warrior'];
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+  });
+
+  it('does NOT draw the idle badge for an enemy-owned visible idle city', () => {
+    const state = createNewGame(undefined, 'badge-idle-enemy');
+    const aiSettler = Object.values(state.units).find(u => u.owner === 'ai-1' && u.type === 'settler')!;
+    const aiCity = foundCity('ai-1', aiSettler.position, state.map);
+    aiCity.productionQueue = [];
+    aiCity.idleProduction = 'gold';
+    state.cities[aiCity.id] = aiCity;
+    state.civilizations['ai-1'].cities.push(aiCity.id);
+    state.civilizations.player.visibility.tiles[hexKey(aiCity.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+  });
+
+  it('does NOT draw the idle badge when idleProduction is null', () => {
+    const state = createNewGame(undefined, 'badge-idle-null');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = null;
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+    expect(texts).not.toContain('🔬');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, expect failures**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: the two positive tests FAIL (no idle badge drawn yet); negative tests PASS by absence.
+
+- [ ] **Step 3: Add the top-left badge to drawCities**
+
+In `src/renderer/city-renderer.ts`, immediately AFTER the bottom-right badge block (added in Task 6), add:
+
+```ts
+      // Top-left badge: idle production mode (player-owned, queue empty, idleProduction set)
+      if (
+        city.owner === playerCivId &&
+        city.productionQueue.length === 0 &&
+        (city.idleProduction === 'gold' || city.idleProduction === 'science')
+      ) {
+        const idleIcon = city.idleProduction === 'gold' ? '💰' : '🔬';
+        ctx.font = `${size * 0.28}px system-ui`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = '#fff';
+        ctx.fillText(idleIcon, screen.x - size * 0.45, screen.y - size * 0.45);
+      }
+```
+
+- [ ] **Step 4: Run the tests, expect all to pass**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test tests/renderer/city-renderer.test.ts
+```
+
+Expected: all idle-badge tests PASS, all earlier renderer tests still PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/city-renderer.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(renderer): top-left idle badge with ownership + queue-empty gates"
+```
+
+---
+
+## Task 8: Add PRODUCTION_ICONS wiring rule
+
+**Files:**
+- Modify: `.claude/rules/end-to-end-wiring.md`
+
+- [ ] **Step 1: Append the new wiring section**
+
+Open `.claude/rules/end-to-end-wiring.md` and append (after the "Trainable units must be wired end-to-end" section):
+
+```markdown
+## Production icons must be wired end-to-end
+- When you add an entry to `BUILDINGS` or `TRAINABLE_UNITS` in `src/systems/city-system.ts`, you MUST also add a matching entry to `PRODUCTION_ICONS` in the same file.
+- The icon-coverage regression tests in `tests/systems/city-system.test.ts` will fail if a building or unit lacks an icon, but the rule catches it before the failed test cycle.
+- Legendary wonders intentionally fall through to `PRODUCTION_ICON_FALLBACK` ('🏗️'); they are not required to have entries in this map until a follow-up issue adds wonder-specific icons.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/end-to-end-wiring.md
+git commit -m "docs(rules): require PRODUCTION_ICONS entry for new buildings/units"
+```
+
+---
+
+## Task 9: Final verification — full test + build
+
+**Files:** none
+
+- [ ] **Step 1: Run full test suite**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn test
+```
+
+Expected: all tests PASS, including the existing `idle-production-integration.test.ts` and the legacy unrest/breakaway/occupation renderer tests.
+
+- [ ] **Step 2: Run TypeScript build**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn build
+```
+
+Expected: exit 0. The `yarn test` script does NOT type-check (per `CLAUDE.md`); only `yarn build` runs `tsc`. If a type error surfaces in `City` (`idleProduction` field), in `PRODUCTION_ICONS` import, or in the renderer helper, fix and re-run.
+
+- [ ] **Step 3: Manual smoke test (optional but recommended)**
+
+Run:
+```bash
+eval "$(mise activate bash)" && yarn dev
+```
+
+In the browser:
+1. Found a city, verify the build list shows specific icons (🌾 Granary, ⚔️ Warrior, etc.) with no double-prefix.
+2. Click a build item → verify the bottom-right badge on the map shows the build's icon (e.g. `🔨` for Workshop).
+3. Open the city panel with a non-empty queue → verify the idle selector is still visible.
+4. Click the science button → close the panel → set queue to empty (let the build complete) → verify the top-left badge shows `🔬`.
+5. (Hot-seat only) End turn → switch to Player 2 → verify Player 1's idle/build badges are NOT visible on Player 1's cities from Player 2's POV.
+
+- [ ] **Step 4: Final commit (if any leftovers)**
+
+If type or smoke fixes were needed:
+```bash
+git add -A
+git commit -m "fix: post-verification adjustments"
+```
+
+Otherwise no commit is needed.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin claude/priceless-lewin-e67829
+gh pr create --title "feat: idle production options + map build badges (#159)" --body "$(cat <<'EOF'
+## Summary
+- Always-visible idle production selector in the city panel (gold/science/none) with click-through coverage for all three buttons
+- Map badges: top-left for idle conversion mode (player-owned, queue empty), bottom-right for current build (player-owned, queue non-empty), gated to current player for privacy
+- Build-list, current-production, and queue rows now show per-item `PRODUCTION_ICONS` (replacing the previous literal 🏗️/⚔️ prefixes)
+- HUD per-turn gold/science rates now reflect idle conversion via `calculateProjectedCityYields`
+- New wiring rule in `.claude/rules/end-to-end-wiring.md` requiring PRODUCTION_ICONS entries for any new building/unit
+- Culture, AI usage, and wonder-specific icons are out of scope (documented in spec)
+
+Closes #159
+
+## Test plan
+- [x] `yarn test` — all tests pass including new idle/badge/icon coverage and ownership-gate negative tests
+- [x] `yarn build` — type-checks clean
+- [x] Manual smoke: idle selector visible regardless of queue state; map badges appear on player cities only; HUD per-turn rates update when toggling idle mode
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Covered by |
+|---|---|
+| §1 Always-visible idle selector | Task 3 |
+| §2 HUD per-turn yield wiring | Task 2 |
+| §3 Map badges — ownership gate | Tasks 6, 7 (negative tests verify gate) |
+| §3 Top-left idle badge | Task 7 |
+| §3 Bottom-right build badge | Task 6 |
+| §3 Mutual exclusion | Tasks 6, 7 (gate conditions ensure this; "queue non-empty + idle set" test in Task 7 confirms idle hidden) |
+| §4 PRODUCTION_ICONS map | Task 1 |
+| §4 Replace literal icons in city panel | Task 4 |
+| §4 Wonder fallback to 🏗️ | Task 5 (helper test for unknown ID) |
+| §5 City panel tests | Task 3 (selector), Task 4 (icons) |
+| §5 Renderer tests | Tasks 5, 6, 7 |
+| §5 HUD projection tests | Task 2 |
+| §5 Icon coverage regression | Task 1 |
+| §6 Wiring rule update | Task 8 |
+
+**Placeholder scan:** No "TBD", "TODO", or "implement later". All test bodies and implementation code blocks are concrete. Exact line numbers reference the as-of-spec state of the source files; if the file has shifted by the time the implementer reaches a task, they should re-locate by content (e.g. "find the `if (city.productionQueue.length === 0)` block").
+
+**Type/name consistency:** `PRODUCTION_ICONS` and `PRODUCTION_ICON_FALLBACK` are used consistently in Tasks 1, 4, 5. `getProductionBadgeIcon` defined in Task 5 and used in Task 6. `calculateProjectedCityYields` signature unchanged. `idleProduction` field type (`'gold' | 'science' | null`) unchanged.
+
+**Privacy:** Both badges have explicit `city.owner === playerCivId` gates in Tasks 6 and 7, with negative tests proving enemy cities don't leak.
+
+**Build/test ordering:** Tests are written first; implementation makes them pass; commits land after each task. Final task runs `yarn build && yarn test` per CLAUDE.md.

--- a/docs/superpowers/specs/2026-05-02-idle-production-and-build-badges-design.md
+++ b/docs/superpowers/specs/2026-05-02-idle-production-and-build-badges-design.md
@@ -1,0 +1,186 @@
+# Idle Production & Build Badges Design
+
+**Issue:** [#159 — Cities should have an option to just produce X](https://github.com/a1flecke/conquestoria/issues/159)
+**Date:** 2026-05-02
+
+## Overview
+
+Two related improvements to city production legibility:
+
+1. **Idle production selector** — always visible in the city panel so players can set a gold/science fallback at any time, not just when the queue is empty.
+2. **Map badges** — small emoji overlays on city circles showing what is currently being built (bottom-right) and what idle conversion mode is set (top-left), so players can read the full city state at a glance without opening any panel.
+3. **Build-list icons** — the same emoji used for map badges appears alongside every item in the city panel's choose-what-to-build list, so the mapping is self-documenting.
+
+Culture was considered as a third idle option and explicitly scoped out: culture is not currently a civ-level tracked yield. It will be addressed in a separate issue once civ-level culture tracking exists.
+
+---
+
+## Section 1 — Always-Visible Idle Production Selector
+
+### What changes
+
+In `src/ui/city-panel.ts`, remove the `if (city.productionQueue.length === 0)` guard around the idle selector HTML block. The selector renders unconditionally.
+
+The label changes from:
+> "Queue is empty — convert +X/turn production to:"
+
+to:
+> "When idle, convert +X/turn production to:"
+
+This makes clear it is a standing preference, not a live command.
+
+### What does NOT change
+
+- The conversion logic in `src/systems/city-system.ts` is untouched — production is still only converted to gold/science at turn start when `productionQueue.length === 0`.
+- The `City.idleProduction?: 'gold' | 'science' | null` type is untouched.
+- The `onSetIdleProduction` callback signature is untouched.
+
+### Behaviour
+
+| Queue state | Selector visible? | Conversion fires? |
+|---|---|---|
+| Empty | Yes | Yes (each turn) |
+| Non-empty | Yes | No |
+
+---
+
+## Section 2 — Map Badges
+
+City circles in `src/renderer/city-renderer.ts` gain two new badge positions. All badge drawing happens inside the existing `drawCities` loop, reading `city.idleProduction` and `city.productionQueue` directly from the city object (no change to `CityRenderInfo`).
+
+### Top-left badge — idle production mode
+
+Position: `screen.x - size * 0.45, screen.y - size * 0.45`
+
+| `city.idleProduction` | Badge |
+|---|---|
+| `'gold'` | 💰 |
+| `'science'` | 🔬 |
+| `null` / `undefined` | (none) |
+
+### Bottom-right badge — currently building
+
+Position: `screen.x + size * 0.45, screen.y + size * 0.45`
+
+Drawn only when `city.productionQueue.length > 0`. Looks up `PRODUCTION_ICONS[city.productionQueue[0]]`, falling back to `🏗️` for any unrecognised ID.
+
+### Existing top-right badge
+
+Unchanged: breakaway ⛓/👑, occupation ☹/⚡, unrest 🔥/⚡.
+
+---
+
+## Section 3 — Production Icon Map
+
+A new exported constant in `src/systems/city-system.ts`:
+
+```ts
+export const PRODUCTION_ICONS: Record<string, string> = {
+  // full mapping defined in the tables below
+};
+```
+
+Placed directly after the `BUILDINGS` and `TRAINABLE_UNITS` declarations. Both the renderer and the city panel import it from this single location.
+
+### Building icons
+
+| ID | Icon | Rationale |
+|---|---|---|
+| `granary` | 🌾 | Grain storage |
+| `herbalist` | 🌿 | Herbal medicine |
+| `aqueduct` | 💧 | Fresh water |
+| `workshop` | 🔨 | Tools |
+| `forge` | ⚒️ | Metalworking |
+| `lumbermill` | 🪵 | Timber |
+| `quarry-building` | ⛏️ | Stone cutting |
+| `library` | 📚 | Knowledge |
+| `archive` | 📜 | Preserved records |
+| `observatory` | 🔭 | Astronomy |
+| `marketplace` | 🏪 | Trade |
+| `harbor` | ⚓ | Sea trade |
+| `barracks` | 🪖 | Military training |
+| `walls` | 🧱 | City defence |
+| `stable` | 🐴 | Mounted units |
+| `temple` | 🛕 | Spiritual centre |
+| `monument` | 🗿 | Commemoration |
+| `amphitheater` | 🎭 | Entertainment |
+| `shrine` | ⛩️ | Worship |
+| `forum` | 📢 | Public gathering |
+| `safehouse` | 🏠 | Spy support |
+| `intelligence-agency` | 🕵️ | Counter-intelligence |
+| `security-bureau` | 🔒 | Advanced CI |
+
+### Unit icons
+
+| Type | Icon | Rationale |
+|---|---|---|
+| `warrior` | ⚔️ | Melee combat |
+| `archer` | 🏹 | Ranged |
+| `scout` | 🔍 | Exploration |
+| `worker` | 🪚 | Improvement |
+| `settler` | 🏕️ | City founding |
+| `swordsman` | 🗡️ | Advanced melee |
+| `pikeman` | 🔱 | Pike formation |
+| `musketeer` | 🔫 | Gunpowder |
+| `galley` | ⛵ | Early naval |
+| `trireme` | 🚢 | Advanced naval |
+| `spy_scout` | 👁️ | Surveillance |
+| `spy_informant` | 📡 | Intelligence gathering |
+| `spy_agent` | 🕵️ | Field operations |
+| `spy_operative` | 🎯 | Precision ops |
+| `spy_hacker` | 💻 | Cyber warfare |
+| `scout_hound` | 🐕 | Tracking |
+| `shadow_warden` | 👤 | Stealth (Persia) |
+| `war_hound` | 🐺 | Combat (Rome) |
+
+Fallback for any ID not in the map: `🏗️`
+
+### City panel build list
+
+Each item in the available buildings list and units list in `city-panel.ts` prepends the icon from `PRODUCTION_ICONS` before the item name. The icon also appears in the current-production block and the queue follow-up list.
+
+---
+
+## Section 4 — Tests
+
+### City panel — idle selector
+
+| Test | Description |
+|---|---|
+| Selector visible, queue empty | Existing — unchanged |
+| Selector visible, queue non-empty | Replaces "not shown when queue non-empty" assertion |
+| Gold button click | Existing — unchanged |
+| Science button click | New |
+| None button click | New |
+
+### City panel — build list icons
+
+- Assert that the rendered HTML for the build list contains the icon for at least one building and one unit.
+
+### Renderer — production badge helper
+
+Extract a pure function `getProductionBadgeIcon(city: City): string | null` from the render loop. Returns the icon string when queue is non-empty, `null` when empty.
+
+| Test | Assertion |
+|---|---|
+| Queue non-empty, known ID | Returns correct emoji |
+| Queue non-empty, unknown ID | Returns `'🏗️'` fallback |
+| Queue empty | Returns `null` |
+
+### Regression — icon coverage
+
+Two regression tests in `tests/systems/city-system.test.ts`:
+
+```
+every key in BUILDINGS has an entry in PRODUCTION_ICONS
+every type in TRAINABLE_UNITS has an entry in PRODUCTION_ICONS
+```
+
+These fail immediately when a new building or unit is added without a corresponding icon, making the omission impossible to miss.
+
+---
+
+## Out of Scope
+
+- **Culture as idle production option** — requires adding a `culture` field to `Civilization`, HUD wiring, and turn-manager plumbing. Tracked separately.
+- **AI usage of idle production** — AI does not yet set `idleProduction`. Can be added in a follow-up alongside AI build-queue improvements.

--- a/docs/superpowers/specs/2026-05-02-idle-production-and-build-badges-design.md
+++ b/docs/superpowers/specs/2026-05-02-idle-production-and-build-badges-design.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-Two related improvements to city production legibility:
+Three related improvements to city production legibility:
 
 1. **Idle production selector** — always visible in the city panel so players can set a gold/science fallback at any time, not just when the queue is empty.
 2. **Map badges** — small emoji overlays on city circles showing what is currently being built (bottom-right) and what idle conversion mode is set (top-left), so players can read the full city state at a glance without opening any panel.
@@ -44,25 +44,70 @@ This makes clear it is a standing preference, not a live command.
 
 ---
 
-## Section 2 — Map Badges
+## Section 2 — HUD Per-Turn Yield Wiring (NEW)
+
+The HUD in `src/main.ts` (`updateHUD`) sums `calculateProjectedCityYields(state, cityId)` across all the player's cities to display `+gold/turn` and `+science/turn`. The idle conversion is applied separately inside `processCity` at turn-end, so without this section the HUD's per-turn rates will not reflect the idle bonus, and the player will see gold/science silently jump each turn with no visible source.
+
+### What changes
+
+`calculateProjectedCityYields` in `src/systems/city-work-system.ts` (or the HUD aggregation in `src/main.ts:updateHUD` — see decision note below) must apply the idle conversion when projecting yields:
+
+- If `city.productionQueue.length === 0 && city.idleProduction === 'gold'`: shift `production` → 0 and add the original `production` value to `gold`.
+- If `city.productionQueue.length === 0 && city.idleProduction === 'science'`: shift `production` → 0 and add the original `production` value to `science`.
+- Otherwise: no change.
+
+### Decision: where to apply
+
+Apply inside `calculateProjectedCityYields` so every consumer of projected yields (HUD, `getRecommendedIdleCityChoice`, advisor preview, future panels) sees the same numbers. Keep `processCity` as the authoritative actor at turn-end — `calculateProjectedCityYields` just mirrors what would happen if the turn were processed now.
+
+### Tests
+
+- `calculateProjectedCityYields` returns shifted yields for an idle city with `idleProduction === 'gold'`.
+- `calculateProjectedCityYields` returns shifted yields for an idle city with `idleProduction === 'science'`.
+- `calculateProjectedCityYields` returns unshifted yields when queue is non-empty even if `idleProduction` is set.
+- `calculateProjectedCityYields` returns unshifted yields when `idleProduction` is `null`.
+
+---
+
+## Section 3 — Map Badges
 
 City circles in `src/renderer/city-renderer.ts` gain two new badge positions. All badge drawing happens inside the existing `drawCities` loop, reading `city.idleProduction` and `city.productionQueue` directly from the city object (no change to `CityRenderInfo`).
+
+### Ownership gate (privacy)
+
+**Both new badges only render when `city.owner === playerCivId`.** Visibility (fog-of-war) alone is not sufficient — `ui-panels.md` rule "Persistent intel UI must render from viewer-safe snapshots" forbids exposing an enemy city's production or idle setting via the badge. Without this gate, hot-seat Player A would leak Player B's plans.
+
+The existing top-right status badge (breakaway/occupation/unrest) is unchanged and stays visible for any owner — those are world-state observable to all viewers.
 
 ### Top-left badge — idle production mode
 
 Position: `screen.x - size * 0.45, screen.y - size * 0.45`
+Font: `${size * 0.28}px system-ui` with `textAlign = 'center'`, `textBaseline = 'middle'` (matches existing status badge for visual consistency).
+
+Drawn only when **all three** are true:
+1. `city.owner === playerCivId`
+2. `city.idleProduction !== null && city.idleProduction !== undefined`
+3. `city.productionQueue.length === 0` (the badge means "actively converting now", not "fallback set but inactive")
 
 | `city.idleProduction` | Badge |
 |---|---|
 | `'gold'` | 💰 |
 | `'science'` | 🔬 |
-| `null` / `undefined` | (none) |
 
 ### Bottom-right badge — currently building
 
 Position: `screen.x + size * 0.45, screen.y + size * 0.45`
+Font: same as top-left badge.
 
-Drawn only when `city.productionQueue.length > 0`. Looks up `PRODUCTION_ICONS[city.productionQueue[0]]`, falling back to `🏗️` for any unrecognised ID.
+Drawn only when **all three** are true:
+1. `city.owner === playerCivId`
+2. `city.productionQueue.length > 0`
+
+Looks up `PRODUCTION_ICONS[city.productionQueue[0]]`, falling back to `🏗️` for any unrecognised ID (including legendary wonders, which use the fallback by design — see Section 4).
+
+### Mutual exclusion
+
+By construction of the conditions above, top-left and bottom-right are mutually exclusive on any given city — the player sees exactly one of `[idle badge | build badge | nothing]` plus the existing top-right status badge if applicable. No dual-state ambiguity.
 
 ### Existing top-right badge
 
@@ -70,7 +115,7 @@ Unchanged: breakaway ⛓/👑, occupation ☹/⚡, unrest 🔥/⚡.
 
 ---
 
-## Section 3 — Production Icon Map
+## Section 4 — Production Icon Map
 
 A new exported constant in `src/systems/city-system.ts`:
 
@@ -90,7 +135,7 @@ Placed directly after the `BUILDINGS` and `TRAINABLE_UNITS` declarations. Both t
 | `herbalist` | 🌿 | Herbal medicine |
 | `aqueduct` | 💧 | Fresh water |
 | `workshop` | 🔨 | Tools |
-| `forge` | ⚒️ | Metalworking |
+| `forge` | 🔥 | Metalworking (avoids clash with ⚒️ used as production-yield emoji in panel/HUD) |
 | `lumbermill` | 🪵 | Timber |
 | `quarry-building` | ⛏️ | Stone cutting |
 | `library` | 📚 | Knowledge |
@@ -107,7 +152,7 @@ Placed directly after the `BUILDINGS` and `TRAINABLE_UNITS` declarations. Both t
 | `shrine` | ⛩️ | Worship |
 | `forum` | 📢 | Public gathering |
 | `safehouse` | 🏠 | Spy support |
-| `intelligence-agency` | 🕵️ | Counter-intelligence |
+| `intelligence-agency` | 🛡️ | Counter-intelligence shielding (distinct from spy_agent 🕵️) |
 | `security-bureau` | 🔒 | Advanced CI |
 
 ### Unit icons
@@ -133,15 +178,23 @@ Placed directly after the `BUILDINGS` and `TRAINABLE_UNITS` declarations. Both t
 | `shadow_warden` | 👤 | Stealth (Persia) |
 | `war_hound` | 🐺 | Combat (Rome) |
 
-Fallback for any ID not in the map: `🏗️`
+### Fallback
+
+Any ID not in `PRODUCTION_ICONS` (including all legendary wonders) renders as `🏗️`. Wonders are intentionally excluded from the icon map for this issue — adding wonder icons is a follow-up.
 
 ### City panel build list
 
-Each item in the available buildings list and units list in `city-panel.ts` prepends the icon from `PRODUCTION_ICONS` before the item name. The icon also appears in the current-production block and the queue follow-up list.
+The current code in `src/ui/city-panel.ts` **already prepends literal hardcoded prefixes**: `🏗️` for every building (line 74) and `⚔️` for every unit (line 89). These literals must be **replaced**, not augmented, by the per-item `PRODUCTION_ICONS[id]` lookup. Naively prepending would produce double-icon output like `🏗️ 🌾 Granary`.
+
+The icon also appears prefixed in:
+- The current-production block (`Building: <name>` → `Building: <icon> <name>`)
+- The queue follow-up rows (`queue-name-${idx}` placeholder)
+
+All icon output uses the same `textContent` injection pattern as existing dynamic labels (no `innerHTML` with game-generated strings).
 
 ---
 
-## Section 4 — Tests
+## Section 5 — Tests
 
 ### City panel — idle selector
 
@@ -153,19 +206,41 @@ Each item in the available buildings list and units list in `city-panel.ts` prep
 | Science button click | New |
 | None button click | New |
 
+Test fixtures: reuse `makeWonderPanelFixture()` from `tests/ui/city-panel.test.ts`.
+
 ### City panel — build list icons
 
-- Assert that the rendered HTML for the build list contains the icon for at least one building and one unit.
+- Assert that the rendered HTML for the build list contains the correct `PRODUCTION_ICONS` icon for at least one building (e.g. `🌾 Granary`) and one unit (e.g. `⚔️ Warrior`).
+- Assert that the literal `🏗️` does not appear before a building name when that building has a more specific icon (i.e. literal pre-existing prefixes were replaced, not duplicated).
 
 ### Renderer — production badge helper
 
-Extract a pure function `getProductionBadgeIcon(city: City): string | null` from the render loop. Returns the icon string when queue is non-empty, `null` when empty.
+Create a pure function `getProductionBadgeIcon(city: City): string | null` in `src/renderer/city-renderer.ts` (exported for testing). Returns the icon string when queue is non-empty, `null` when empty. Renderer skips drawing when result is `null`.
 
 | Test | Assertion |
 |---|---|
-| Queue non-empty, known ID | Returns correct emoji |
+| Queue non-empty, known ID | Returns correct emoji from PRODUCTION_ICONS |
 | Queue non-empty, unknown ID | Returns `'🏗️'` fallback |
+| Queue non-empty, wonder ID | Returns `'🏗️'` fallback (documents wonder exclusion) |
 | Queue empty | Returns `null` |
+
+### Renderer — ownership gate
+
+A focused integration test that renders `drawCities` against a stub canvas context and asserts:
+- Idle badge emoji is **not** drawn when `city.owner !== playerCivId`, even with `idleProduction` set and queue empty.
+- Build badge emoji is **not** drawn when `city.owner !== playerCivId`, even with non-empty queue.
+- Both badges are drawn correctly when `city.owner === playerCivId`.
+
+Implement via a `ctx` spy that records every `fillText` call.
+
+### HUD per-turn projection
+
+| Test | Assertion |
+|---|---|
+| Idle gold city | `calculateProjectedCityYields` returns `production: 0`, `gold: original-gold + original-production` |
+| Idle science city | `calculateProjectedCityYields` returns `production: 0`, `science: original-science + original-production` |
+| Idle setting + queue non-empty | Returns unshifted yields |
+| `idleProduction: null` | Returns unshifted yields |
 
 ### Regression — icon coverage
 
@@ -180,7 +255,18 @@ These fail immediately when a new building or unit is added without a correspond
 
 ---
 
+## Section 6 — Wiring rule update
+
+Add a one-line entry to `.claude/rules/end-to-end-wiring.md` so future contributors and the PostToolUse hook treat `PRODUCTION_ICONS` as a required wiring partner:
+
+> When you add an entry to `BUILDINGS` or `TRAINABLE_UNITS` in `src/systems/city-system.ts`, you MUST also add a matching entry to `PRODUCTION_ICONS` in the same file. The icon-coverage regression test enforces this, but the rule prevents the failed test cycle.
+
+This is preventive (catches before commit) rather than reactive (test fail after commit).
+
+---
+
 ## Out of Scope
 
 - **Culture as idle production option** — requires adding a `culture` field to `Civilization`, HUD wiring, and turn-manager plumbing. Tracked separately.
 - **AI usage of idle production** — AI does not yet set `idleProduction`. Can be added in a follow-up alongside AI build-queue improvements.
+- **Wonder icons** — legendary wonders fall back to `🏗️` and are documented as such in tests. Adding wonder-specific icons is a follow-up.

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -3,8 +3,15 @@ import { hexToPixel } from '@/systems/hex-utils';
 import { isVisible } from '@/systems/fog-of-war';
 import { getOccupiedCityMood } from '@/systems/city-occupation-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
+import { PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
 import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+
+export function getProductionBadgeIcon(city: { productionQueue: string[] }): string | null {
+  if (city.productionQueue.length === 0) return null;
+  const id = city.productionQueue[0];
+  return PRODUCTION_ICONS[id] ?? PRODUCTION_ICON_FALLBACK;
+}
 
 interface CityRenderInfo {
   name: string;

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -134,6 +134,20 @@ export function drawCities(
           ctx.fillText(buildIcon, screen.x + size * 0.45, screen.y + size * 0.45);
         }
       }
+
+      // Top-left badge: idle production mode (player-owned, queue empty, idleProduction set)
+      if (
+        city.owner === playerCivId &&
+        city.productionQueue.length === 0 &&
+        (city.idleProduction === 'gold' || city.idleProduction === 'science')
+      ) {
+        const idleIcon = city.idleProduction === 'gold' ? '💰' : '🔬';
+        ctx.font = `${size * 0.28}px system-ui`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillStyle = '#fff';
+        ctx.fillText(idleIcon, screen.x - size * 0.45, screen.y - size * 0.45);
+      }
     }
   }
 }

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -122,6 +122,18 @@ export function drawCities(
         ctx.textBaseline = 'middle';
         ctx.fillText(city.unrestLevel === 2 ? '🔥' : '⚡', screen.x + size * 0.45, screen.y - size * 0.45);
       }
+
+      // Bottom-right badge: currently-building icon (player-owned, non-empty queue only)
+      if (city.owner === playerCivId) {
+        const buildIcon = getProductionBadgeIcon(city);
+        if (buildIcon) {
+          ctx.font = `${size * 0.28}px system-ui`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillStyle = '#fff';
+          ctx.fillText(buildIcon, screen.x + size * 0.45, screen.y + size * 0.45);
+        }
+      }
     }
   }
 }

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -165,6 +165,54 @@ export function getProductionCostForItem(
     : Math.round(baseCost * multiplier);
 }
 
+export const PRODUCTION_ICONS: Record<string, string> = {
+  // Buildings
+  granary: '🌾',
+  herbalist: '🌿',
+  aqueduct: '💧',
+  workshop: '🔨',
+  forge: '🔥',
+  lumbermill: '🪵',
+  'quarry-building': '⛏️',
+  library: '📚',
+  archive: '📜',
+  observatory: '🔭',
+  marketplace: '🏪',
+  harbor: '⚓',
+  barracks: '🪖',
+  walls: '🧱',
+  stable: '🐴',
+  temple: '🛕',
+  monument: '🗿',
+  amphitheater: '🎭',
+  shrine: '⛩️',
+  forum: '📢',
+  safehouse: '🏠',
+  'intelligence-agency': '🛡️',
+  'security-bureau': '🔒',
+  // Units
+  warrior: '⚔️',
+  archer: '🏹',
+  scout: '🔍',
+  worker: '🪚',
+  settler: '🏕️',
+  swordsman: '🗡️',
+  pikeman: '🔱',
+  musketeer: '🔫',
+  galley: '⛵',
+  trireme: '🚢',
+  spy_scout: '👁️',
+  spy_informant: '📡',
+  spy_agent: '🕵️',
+  spy_operative: '🎯',
+  spy_hacker: '💻',
+  scout_hound: '🐕',
+  shadow_warden: '👤',
+  war_hound: '🐺',
+};
+
+export const PRODUCTION_ICON_FALLBACK = '🏗️';
+
 export function getTrainableUnitsForCiv(completedTechs: string[], civType?: string): TrainableUnitEntry[] {
   const replacedForCiv = new Set(
     TRAINABLE_UNITS

--- a/src/systems/city-work-system.ts
+++ b/src/systems/city-work-system.ts
@@ -245,5 +245,16 @@ export function calculateProjectedCityYields(
     ? normalizeWorkedTilesForCity(state, cityId)
     : assignCityFocus(state, cityId, city.focus);
   const projectedCity = workResult.state.cities[cityId] ?? city;
-  return calculateCityYields(projectedCity, workResult.state.map, bonusEffect);
+  const yields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect);
+
+  if (city.productionQueue.length === 0 && city.idleProduction) {
+    if (city.idleProduction === 'gold') {
+      return { ...yields, production: 0, gold: yields.gold + yields.production };
+    }
+    if (city.idleProduction === 'science') {
+      return { ...yields, production: 0, science: yields.science + yields.production };
+    }
+  }
+
+  return yields;
 }

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -100,25 +100,22 @@ export function createCityPanel(
     </div>`;
   }
 
-  // Idle production selector (shown only when queue is empty)
-  let idleSelectorHtml = '';
-  if (city.productionQueue.length === 0) {
-    const activeMode = city.idleProduction ?? 'none';
-    const goldActive = activeMode === 'gold' ? 'border-color:#d4aa2c;background:rgba(212,170,44,0.3);' : '';
-    const sciActive = activeMode === 'science' ? 'border-color:#6496ff;background:rgba(100,150,255,0.3);' : '';
-    const noneActive = activeMode === 'none' ? 'border-color:rgba(255,255,255,0.5);background:rgba(255,255,255,0.2);' : '';
-    idleSelectorHtml = `
-      <div style="background:rgba(255,255,255,0.08);border-radius:10px;padding:12px;margin-bottom:16px;">
-        <div style="font-weight:bold;color:#e8c170;margin-bottom:6px;">Idle Production</div>
-        <div style="font-size:12px;opacity:0.7;margin-bottom:8px;">Queue is empty — convert +${yields.production}/turn production to:</div>
-        <div style="display:flex;gap:8px;">
-          <button type="button" data-idle-mode="gold" style="flex:1;padding:8px;background:rgba(212,170,44,0.15);border:1px solid rgba(212,170,44,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${goldActive}">💰 Gold +${yields.production}/turn</button>
-          <button type="button" data-idle-mode="science" style="flex:1;padding:8px;background:rgba(100,150,255,0.15);border:1px solid rgba(100,150,255,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${sciActive}">🔬 Science +${yields.production}/turn</button>
-          <button type="button" data-idle-mode="none" style="flex:1;padding:8px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:6px;color:white;cursor:pointer;font-size:12px;${noneActive}">None</button>
-        </div>
+  // Idle production selector — always visible; conversion only fires when queue is empty.
+  const activeMode = city.idleProduction ?? 'none';
+  const goldActive = activeMode === 'gold' ? 'border-color:#d4aa2c;background:rgba(212,170,44,0.3);' : '';
+  const sciActive = activeMode === 'science' ? 'border-color:#6496ff;background:rgba(100,150,255,0.3);' : '';
+  const noneActive = activeMode === 'none' ? 'border-color:rgba(255,255,255,0.5);background:rgba(255,255,255,0.2);' : '';
+  const idleSelectorHtml = `
+    <div style="background:rgba(255,255,255,0.08);border-radius:10px;padding:12px;margin-bottom:16px;">
+      <div style="font-weight:bold;color:#e8c170;margin-bottom:6px;">Idle Production</div>
+      <div style="font-size:12px;opacity:0.7;margin-bottom:8px;">When idle, convert +${yields.production}/turn production to:</div>
+      <div style="display:flex;gap:8px;">
+        <button type="button" data-idle-mode="gold" style="flex:1;padding:8px;background:rgba(212,170,44,0.15);border:1px solid rgba(212,170,44,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${goldActive}">💰 Gold +${yields.production}/turn</button>
+        <button type="button" data-idle-mode="science" style="flex:1;padding:8px;background:rgba(100,150,255,0.15);border:1px solid rgba(100,150,255,0.4);border-radius:6px;color:white;cursor:pointer;font-size:12px;${sciActive}">🔬 Science +${yields.production}/turn</button>
+        <button type="button" data-idle-mode="none" style="flex:1;padding:8px;background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);border-radius:6px;color:white;cursor:pointer;font-size:12px;${noneActive}">None</button>
       </div>
-    `;
-  }
+    </div>
+  `;
 
   // Current production placeholders
   let currentProductionHtml = '';

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -1,5 +1,5 @@
 import type { City, CityFocus, GameState, HexCoord } from '@/core/types';
-import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv, getProductionCostForItem } from '@/systems/city-system';
+import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv, getProductionCostForItem, PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
@@ -80,7 +80,7 @@ export function createCityPanel(
     if (b.yields.science) yieldParts.push(`+${b.yields.science} 🔬`);
     const yieldStr = yieldParts.length > 0 ? yieldParts.join(' ') + ' · ' : '';
     buildItemPlaceholders += `<div class="build-item" data-item-id="${b.id}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
-      <div style="font-weight:bold;font-size:13px;">🏗️ <span data-text="build-name-${idx}"></span></div>
+      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[b.id] ?? PRODUCTION_ICON_FALLBACK} <span data-text="build-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">${yieldStr}${turns} turns</div>
       <div style="font-size:10px;opacity:0.5;" data-text="build-desc-${idx}"></div>
     </div>`;
@@ -95,7 +95,7 @@ export function createCityPanel(
     const cost = getDisplayedCost(u.type);
     const turns = yields.production > 0 ? Math.ceil(cost / yields.production) : '∞';
     unitPlaceholders += `<div class="build-item" data-item-id="${u.type}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
-      <div style="font-weight:bold;font-size:13px;">⚔️ <span data-text="unit-name-${idx}"></span></div>
+      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[u.type] ?? PRODUCTION_ICON_FALLBACK} <span data-text="unit-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
     </div>`;
   }
@@ -126,7 +126,7 @@ export function createCityPanel(
 
     currentProductionHtml = `
       <div style="background:rgba(255,255,255,0.1);border-radius:10px;padding:12px;margin-bottom:16px;">
-        <div style="font-weight:bold;color:#e8c170;">Building: <span data-text="prod-name"></span></div>
+        <div style="font-weight:bold;color:#e8c170;">Building: ${PRODUCTION_ICONS[currentItem] ?? PRODUCTION_ICON_FALLBACK} <span data-text="prod-name"></span></div>
         <div style="font-size:12px;opacity:0.7;"><span data-text="prod-turns"></span> turns remaining</div>
         <div style="background:rgba(0,0,0,0.3);border-radius:4px;height:8px;margin-top:8px;">
           <div style="background:#6b9b4b;border-radius:4px;height:8px;width:${progress}%;"></div>
@@ -168,7 +168,7 @@ export function createCityPanel(
     queueRowsHtml += `
       <div data-queue-index="${idx}" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;">
         <div>
-          <div style="font-weight:bold;" data-text="queue-name-${idx}"></div>
+          <div style="font-weight:bold;">${PRODUCTION_ICONS[city.productionQueue[idx]] ?? PRODUCTION_ICON_FALLBACK} <span data-text="queue-name-${idx}"></span></div>
           <div style="font-size:11px;opacity:0.7;">${slotLabel}</div>
         </div>
         <div style="display:flex;gap:6px;">

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -273,3 +273,91 @@ describe('getProductionBadgeIcon', () => {
     expect(getProductionBadgeIcon({ productionQueue: [] })).toBeNull();
   });
 });
+
+describe('drawCities — top-left idle badge', () => {
+  it('draws 💰 for a player-owned idle city with idleProduction=gold', () => {
+    const state = createNewGame(undefined, 'badge-idle-gold');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('💰');
+  });
+
+  it('draws 🔬 for a player-owned idle city with idleProduction=science', () => {
+    const state = createNewGame(undefined, 'badge-idle-sci');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = 'science';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('🔬');
+  });
+
+  it('does NOT draw the idle badge when queue is non-empty even with idleProduction set', () => {
+    const state = createNewGame(undefined, 'badge-idle-queued');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = ['warrior'];
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+  });
+
+  it('does NOT draw the idle badge for an enemy-owned visible idle city', () => {
+    const state = createNewGame(undefined, 'badge-idle-enemy');
+    const aiSettler = Object.values(state.units).find(u => u.owner === 'ai-1' && u.type === 'settler')!;
+    const aiCity = foundCity('ai-1', aiSettler.position, state.map);
+    aiCity.productionQueue = [];
+    aiCity.idleProduction = 'gold';
+    state.cities[aiCity.id] = aiCity;
+    state.civilizations['ai-1'].cities.push(aiCity.id);
+    state.civilizations.player.visibility.tiles[hexKey(aiCity.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+  });
+
+  it('does NOT draw the idle badge when idleProduction is null', () => {
+    const state = createNewGame(undefined, 'badge-idle-null');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    city.idleProduction = null;
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('💰');
+    expect(texts).not.toContain('🔬');
+  });
+});

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { Camera } from '@/renderer/camera';
-import { drawCities, getCityRenderData } from '@/renderer/city-renderer';
+import { drawCities, getCityRenderData, getProductionBadgeIcon } from '@/renderer/city-renderer';
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
@@ -189,5 +189,23 @@ describe('city renderer', () => {
 
     const labels = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
     expect(labels).toContain(`${city.name} (${city.population})`);
+  });
+});
+
+describe('getProductionBadgeIcon', () => {
+  it('returns the matching icon when productionQueue[0] is a known building', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🌾');
+  });
+
+  it('returns the matching icon when productionQueue[0] is a known unit', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['warrior'] })).toBe('⚔️');
+  });
+
+  it('returns the fallback icon when productionQueue[0] is unknown (e.g. legendary wonder)', () => {
+    expect(getProductionBadgeIcon({ productionQueue: ['some-legendary-wonder-id'] })).toBe('🏗️');
+  });
+
+  it('returns null when productionQueue is empty', () => {
+    expect(getProductionBadgeIcon({ productionQueue: [] })).toBeNull();
   });
 });

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -192,6 +192,70 @@ describe('city renderer', () => {
   });
 });
 
+function makeCamera(): Camera {
+  return {
+    zoom: 1,
+    hexSize: 48,
+    isHexVisible: () => true,
+    worldToScreen: (x: number, y: number) => ({ x, y }),
+  } as unknown as Camera;
+}
+
+describe('drawCities — bottom-right build badge', () => {
+  it('draws the production icon for a player-owned city with a non-empty queue', () => {
+    const state = createNewGame(undefined, 'badge-build-render');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = ['warrior'];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).toContain('⚔️');
+  });
+
+  it('does NOT draw the production icon for an enemy-owned visible city', () => {
+    const state = createNewGame(undefined, 'badge-build-enemy');
+    const aiSettler = Object.values(state.units).find(u => u.owner === 'ai-1' && u.type === 'settler')!;
+    const aiCity = foundCity('ai-1', aiSettler.position, state.map);
+    aiCity.productionQueue = ['warrior'];
+    state.cities[aiCity.id] = aiCity;
+    state.civilizations['ai-1'].cities.push(aiCity.id);
+    state.civilizations.player.visibility.tiles[hexKey(aiCity.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    // The warrior icon should NOT appear since the city doesn't belong to the current player
+    // (Note: ⚔️ may appear as the minor-civ militaristic icon, so we check for the build badge position instead)
+    // The enemy city should not leak its build queue
+    expect(texts.filter(t => t === '⚔️').length).toBe(0);
+  });
+
+  it('does NOT draw a production icon when the queue is empty', () => {
+    const state = createNewGame(undefined, 'badge-build-empty');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map);
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    // No production-specific badge — just the city icon and name
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
+    expect(texts).not.toContain('🏗️');
+    expect(texts).not.toContain('⚔️');
+  });
+});
+
 describe('getProductionBadgeIcon', () => {
   it('returns the matching icon when productionQueue[0] is a known building', () => {
     expect(getProductionBadgeIcon({ productionQueue: ['granary'] })).toBe('🌾');

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -7,6 +7,8 @@ import {
   getUnplacedBuildings,
   BUILDINGS,
   CITY_NAMES,
+  TRAINABLE_UNITS,
+  PRODUCTION_ICONS,
 } from '@/systems/city-system';
 import type { GameMap } from '@/core/types';
 import { generateMap } from '@/systems/map-generator';
@@ -340,5 +342,26 @@ describe('grid expansion', () => {
     const cost = purchaseGridExpansion(city, 30);
     expect(cost).toBe(0);
     expect(city.gridSize).toBe(3);
+  });
+});
+
+describe('PRODUCTION_ICONS coverage', () => {
+  it('has an entry for every building in BUILDINGS', () => {
+    for (const buildingId of Object.keys(BUILDINGS)) {
+      expect(PRODUCTION_ICONS[buildingId], `missing icon for building "${buildingId}"`).toBeTruthy();
+    }
+  });
+
+  it('has an entry for every unit in TRAINABLE_UNITS', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      expect(PRODUCTION_ICONS[unit.type], `missing icon for unit "${unit.type}"`).toBeTruthy();
+    }
+  });
+
+  it('every icon is a non-empty string', () => {
+    for (const [id, icon] of Object.entries(PRODUCTION_ICONS)) {
+      expect(typeof icon, `icon for "${id}" must be string`).toBe('string');
+      expect(icon.length, `icon for "${id}" must be non-empty`).toBeGreaterThan(0);
+    }
   });
 });

--- a/tests/systems/city-work-system.test.ts
+++ b/tests/systems/city-work-system.test.ts
@@ -391,3 +391,66 @@ describe('worked tile normalization', () => {
     expect(yieldValue.science).toBeGreaterThanOrEqual(1);
   });
 });
+
+describe('calculateProjectedCityYields — idle production projection', () => {
+  it('shifts production into gold when city is idle with idleProduction=gold', () => {
+    const state = createNewGame(undefined, 'idle-proj-gold');
+    const city = addCity(state, 'player', { q: 14, r: 14 });
+
+    // Baseline: no idle setting
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: null };
+    const baseYields = calculateProjectedCityYields(state, city.id);
+
+    // With idle gold
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: 'gold' };
+    const idleYields = calculateProjectedCityYields(state, city.id);
+
+    expect(idleYields.production).toBe(0);
+    expect(idleYields.gold).toBe(baseYields.gold + baseYields.production);
+    expect(idleYields.science).toBe(baseYields.science);
+  });
+
+  it('shifts production into science when city is idle with idleProduction=science', () => {
+    const state = createNewGame(undefined, 'idle-proj-sci');
+    const city = addCity(state, 'player', { q: 14, r: 14 });
+
+    // Baseline: no idle setting
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: null };
+    const baseYields = calculateProjectedCityYields(state, city.id);
+
+    // With idle science
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: 'science' };
+    const idleYields = calculateProjectedCityYields(state, city.id);
+
+    expect(idleYields.production).toBe(0);
+    expect(idleYields.science).toBe(baseYields.science + baseYields.production);
+    expect(idleYields.gold).toBe(baseYields.gold);
+  });
+
+  it('does NOT shift when productionQueue is non-empty even with idleProduction set', () => {
+    const state = createNewGame(undefined, 'idle-proj-queued');
+    const city = addCity(state, 'player', { q: 14, r: 14 });
+
+    // Baseline: no idle setting
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: null };
+    const baseYields = calculateProjectedCityYields(state, city.id);
+
+    // Queue non-empty with idle set — should not shift
+    state.cities[city.id] = { ...city, productionQueue: ['warrior'], idleProduction: 'gold' };
+    const queuedYields = calculateProjectedCityYields(state, city.id);
+
+    expect(queuedYields.production).toBe(baseYields.production);
+    expect(queuedYields.gold).toBe(baseYields.gold);
+  });
+
+  it('does NOT shift when idleProduction is null', () => {
+    const state = createNewGame(undefined, 'idle-proj-null');
+    const city = addCity(state, 'player', { q: 14, r: 14 });
+    state.cities[city.id] = { ...city, productionQueue: [], idleProduction: null };
+
+    const yields = calculateProjectedCityYields(state, city.id);
+
+    // Production must NOT be zeroed out when idleProduction is null
+    expect(yields.production).toBeGreaterThan(0);
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -1037,3 +1037,46 @@ describe('city-panel idle production selector', () => {
     expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, null);
   });
 });
+
+describe('city-panel build list icons', () => {
+  it('renders the granary icon prefix in the available buildings list', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    expect(html).toContain('🌾');
+  });
+
+  it('renders the warrior icon prefix in the available units list', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = [];
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    expect(html).toContain('⚔️');
+  });
+
+  it('renders the icon for the currently building item', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = ['workshop'];
+    city.productionProgress = 5;
+    state.cities[city.id] = city;
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
+    // 🔨 = workshop icon
+    expect(html).toContain('🔨');
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -956,7 +956,7 @@ describe('city-panel idle production selector', () => {
     expect(html).toContain('data-idle-mode');
   });
 
-  it('does not show idle mode selector when production queue is non-empty', () => {
+  it('shows idle mode selector even when production queue is non-empty', () => {
     const { container, city, state } = makeWonderPanelFixture();
     city.productionQueue = ['warrior'];
     const panel = createCityPanel(container, city, state, {
@@ -965,7 +965,7 @@ describe('city-panel idle production selector', () => {
       onClose: () => {},
     });
     const html = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
-    expect(html).not.toContain('data-idle-mode');
+    expect(html).toContain('data-idle-mode');
   });
 
   it('shows per-turn production amount in the idle selector', () => {
@@ -997,5 +997,43 @@ describe('city-panel idle production selector', () => {
     expect(goldBtn).toBeTruthy();
     goldBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, 'gold');
+  });
+
+  it('calls onSetIdleProduction with science when Science button is clicked', () => {
+    const { container, city, state } = makeIdleCityFixture();
+    const onSetIdleProduction = vi.fn();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetIdleProduction: (cityId: string, mode: 'gold' | 'science' | null) => {
+        state.cities[cityId] = { ...state.cities[cityId]!, idleProduction: mode };
+        onSetIdleProduction(cityId, mode);
+      },
+    });
+    const sciBtn = panel.querySelector<HTMLElement>('[data-idle-mode="science"]');
+    expect(sciBtn).toBeTruthy();
+    sciBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, 'science');
+  });
+
+  it('calls onSetIdleProduction with null when None button is clicked', () => {
+    const { container, city, state } = makeIdleCityFixture();
+    city.idleProduction = 'gold';
+    state.cities[city.id] = city;
+    const onSetIdleProduction = vi.fn();
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onSetIdleProduction: (cityId: string, mode: 'gold' | 'science' | null) => {
+        state.cities[cityId] = { ...state.cities[cityId]!, idleProduction: mode };
+        onSetIdleProduction(cityId, mode);
+      },
+    });
+    const noneBtn = panel.querySelector<HTMLElement>('[data-idle-mode="none"]');
+    expect(noneBtn).toBeTruthy();
+    noneBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSetIdleProduction).toHaveBeenCalledWith(city.id, null);
   });
 });


### PR DESCRIPTION
## Summary
- **Always-visible idle production selector** in the city panel (gold/science/none) — shown even when the queue is non-empty so players can configure their fallback at any time. Label updated from "Queue is empty — convert…" to "When idle, convert…". Click-through tests cover gold, science, and none buttons.
- **Map badges** on city circles, gated to the current player's own cities for hot-seat privacy:
  - **Top-left**: idle conversion mode (💰/🔬), shown only when queue is empty and idleProduction is set
  - **Bottom-right**: currently-building item emoji, shown only when queue is non-empty
  - Mutual exclusion guaranteed by gate conditions — never both simultaneously
- **Per-item emoji icons** in the build list, current-production block, and queue rows using a single-source-of-truth `PRODUCTION_ICONS` map (replacing the previous literal 🏗️/⚔️ prefixes)
- **HUD per-turn rates** now reflect idle conversion: `calculateProjectedCityYields` shifts production→gold/science for idle cities, so the HUD's per-turn numbers match what turn-end processing will actually apply
- **Icon coverage regression tests**: any new building or unit added without a `PRODUCTION_ICONS` entry will immediately fail CI
- **Wiring rule** added to `.claude/rules/end-to-end-wiring.md` requiring `PRODUCTION_ICONS` entries for new buildings/units
- Culture, AI usage of idle production, and wonder-specific icons are out of scope (documented in spec)

Closes #159

## Test plan
- [x] `yarn test` — 1567 tests pass including new idle/badge/icon coverage and ownership-gate negative tests
- [x] `yarn build` — TypeScript type-checks clean
- [x] All icon coverage regression tests confirm every building and unit has a PRODUCTION_ICONS entry
- [x] Ownership-gate negative tests confirm enemy city build queues and idle modes do not leak to the other player in hot-seat

🤖 Generated with [Claude Code](https://claude.com/claude-code)