### PR TITLE
[codex] Streamline CI macOS app builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,18 +16,55 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  desktop-change-check:
+    runs-on: ubuntu-latest
+    outputs:
+      desktop_changed: ${{ steps.desktop-changes.outputs.desktop_changed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for desktop build inputs
+        id: desktop-changes
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "desktop_changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
+          desktop_changed=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              src-tauri/*|src-tauri/**|package.json|yarn.lock|.yarnrc.yml|.yarn/**|.github/workflows/deploy.yml)
+                desktop_changed=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "desktop_changed=$desktop_changed" >> "$GITHUB_OUTPUT"
+
   web-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
-        run: corepack enable && yarn install
+        run: yarn install --immutable
 
       - name: Build
         run: yarn build
@@ -44,13 +81,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
-        run: corepack enable && yarn install
+        run: yarn install --immutable
 
       - name: Run tests
         run: yarn test
@@ -61,13 +103,24 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
-        run: corepack enable && yarn install
+        run: yarn install --immutable
+
+      - name: Cache Playwright browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('yarn.lock') }}
 
       - name: Install Playwright browser
         run: yarn playwright install --with-deps chromium
@@ -81,49 +134,76 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependencies
-        run: corepack enable && yarn install
+        run: yarn install --immutable
 
       - name: Build Tauri frontend
         run: yarn build:tauri
 
   tauri-macos-build:
     runs-on: macos-latest
-    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+    needs: desktop-change-check
+    if: github.ref == 'refs/heads/main' || needs.desktop-change-check.outputs.desktop_changed == 'true'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Setup Rust
         run: |
           rustup toolchain install 1.95.0 --profile minimal
           rustup default 1.95.0
 
-      - name: Install dependencies
-        run: corepack enable && yarn install
+      - name: Configure ad-hoc signing
+        run: echo "APPLE_SIGNING_IDENTITY=-" >> "$GITHUB_ENV"
 
-      - name: Build macOS app and DMG
-        run: yarn tauri:build:mac
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+            src-tauri/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build macOS app
+        run: yarn tauri:build:mac-app
 
       - name: Check macOS artifacts
         run: yarn tauri:check:mac-artifacts
 
+      - name: Verify ad-hoc signed macOS app
+        run: codesign --verify --deep --strict --verbose=2 src-tauri/target/release/bundle/macos/Conquestoria.app
+
       - name: Upload macOS artifacts
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
         with:
           name: conquestoria-macos
-          path: |
-            src-tauri/target/release/bundle/macos/Conquestoria.app
-            src-tauri/target/release/bundle/dmg/*.dmg
+          path: src-tauri/target/release/bundle/macos/Conquestoria.app
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,7 @@
 node = "24.13.1"
 rust = "1.95.0"
 yarn = "latest"
+
+[tasks."macos:run"]
+description = "Build the ad-hoc signed macOS app bundle and launch it locally"
+run = "scripts/build-run-macos-app.sh"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "tauri:build:mac": "tauri build --bundles app,dmg",
+    "tauri:build:mac-app": "tauri build --bundles app",
     "tauri:check:mac-artifacts": "node scripts/check-tauri-macos-artifacts.mjs",
     "setup:hooks": "git config core.hooksPath .githooks",
     "test": "vitest run && bash tests/hooks/run.sh",

--- a/scripts/build-run-macos-app.sh
+++ b/scripts/build-run-macos-app.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+set -eu
+
+root_dir="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+app_path="$root_dir/src-tauri/target/release/bundle/macos/Conquestoria.app"
+open_app=1
+
+case "${1:-}" in
+  --no-open)
+    open_app=0
+    ;;
+  "")
+    ;;
+  *)
+    echo "Usage: mise run macos:run [--no-open]" >&2
+    exit 2
+    ;;
+esac
+
+cd "$root_dir"
+
+APPLE_SIGNING_IDENTITY=- yarn tauri:build:mac-app
+codesign --verify --deep --strict --verbose=2 "$app_path"
+xattr -cr "$app_path"
+
+if [ "$open_app" -eq 1 ]; then
+  open "$app_path"
+else
+  echo "Built macOS app: $app_path"
+fi

--- a/scripts/check-tauri-macos-artifacts.mjs
+++ b/scripts/check-tauri-macos-artifacts.mjs
@@ -1,23 +1,13 @@
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 const root = process.cwd();
 const appPath = join(root, 'src-tauri', 'target', 'release', 'bundle', 'macos', 'Conquestoria.app');
-const dmgDir = join(root, 'src-tauri', 'target', 'release', 'bundle', 'dmg');
 
 const failures = [];
 
 if (!existsSync(appPath)) {
   failures.push(`Missing app bundle: ${appPath}`);
-}
-
-let dmgFiles = [];
-if (existsSync(dmgDir)) {
-  dmgFiles = readdirSync(dmgDir).filter(file => file.endsWith('.dmg'));
-}
-
-if (dmgFiles.length === 0) {
-  failures.push(`Missing dmg artifact in: ${dmgDir}`);
 }
 
 if (failures.length > 0) {
@@ -26,4 +16,3 @@ if (failures.length > 0) {
 }
 
 console.log(`Found app bundle: ${appPath}`);
-console.log(`Found dmg artifact(s): ${dmgFiles.join(', ')}`);


### PR DESCRIPTION
## Summary
- Cache Yarn, Playwright, and Cargo work in CI to reduce repeated setup/build time.
- Skip the expensive macOS app build on PRs unless desktop/build inputs changed.
- Replace DMG-oriented macOS checks with an ad-hoc signed app build and local mise run macos:run helper.

## Impact
- Ordinary web/game PRs should avoid macOS runner minutes unless they touch Tauri or build configuration.
- main still builds and uploads a macOS app artifact.
- Local personal macOS testing is now one command: mise run macos:run.

## Validation
- git fetch origin main
- git merge --ff-only origin/main -> already up to date
- mise run macos:run --no-open
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); puts "YAML OK"'
- ./scripts/run-with-mise.sh yarn tauri:check:mac-artifacts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test -> 155 files, 1543 tests