### PR TITLE
Fix first-contact, city entry, and busy worker flows

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -985,7 +985,9 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     .map(id => newState.cities[id]?.position)
     .filter((p): p is HexCoord => p !== undefined);
   updateVisibility(newState.civilizations[civId].visibility, civUnits, newState.map, cityPositions);
-  syncCivilizationContactsFromVisibility(newState, civId);
+  for (const contact of syncCivilizationContactsFromVisibility(newState, civId)) {
+    bus.emit('civilization:first-contact', contact);
+  }
 
   return newState;
 }

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -290,7 +290,9 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
 
     // Update visibility
     updateVisibility(newState.civilizations[civId].visibility, civUnits, newState.map, cityPositions);
-    syncCivilizationContactsFromVisibility(newState, civId);
+    for (const contact of syncCivilizationContactsFromVisibility(newState, civId)) {
+      bus.emit('civilization:first-contact', contact);
+    }
 
     for (const [targetCivId, turnsRemaining] of Object.entries(currentCivState.satelliteSurveillanceTargets ?? {})) {
       if (turnsRemaining > 0) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -212,6 +212,11 @@ export interface UnitDefinition {
   spyDetectionChance?: number; // 0–1, probability per adjacent spy unit per turn
 }
 
+export interface WorkerTask {
+  action: BuildableImprovementType;
+  coord: HexCoord;
+}
+
 export interface Unit {
   id: string;
   type: UnitType;
@@ -224,6 +229,7 @@ export interface Unit {
   hasMoved: boolean;
   hasActed: boolean;         // used action this turn (build, found, etc.)
   chargesRemaining?: number; // workers default to 2; omitted on legacy saves
+  workerTask?: WorkerTask;    // active multi-turn improvement the worker is assigned to
   isResting: boolean;        // player explicitly chose to rest/heal this turn
   skippedTurn?: boolean;     // player chose to hold this unit out of unit cycling this turn
   automation?: {
@@ -1002,6 +1008,7 @@ export interface GameEvents {
   'fog:revealed': { tiles: HexCoord[] };
   'improvement:started': { unitId: string; coord: HexCoord; type: ImprovementType };
   'improvement:completed': { coord: HexCoord; type: ImprovementType };
+  'civilization:first-contact': { civA: string; civB: string };
   'barbarian:spawned': { campId: string; unitId: string };
   'barbarian:camp-destroyed': { campId: string; reward: number };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };

--- a/src/input/foreign-city-entry-flow.ts
+++ b/src/input/foreign-city-entry-flow.ts
@@ -1,0 +1,43 @@
+import type { EventBus } from '@/core/event-bus';
+import type { GameState } from '@/core/types';
+import { beginPlayerCityAssaultChoice, type PendingCityCaptureChoice } from '@/input/city-assault-flow';
+import { declareWar } from '@/systems/diplomacy-system';
+
+export function beginConfirmedForeignCityEntry(
+  state: GameState,
+  attackerId: string,
+  cityId: string,
+  bus?: EventBus,
+): { state: GameState; pending: PendingCityCaptureChoice } {
+  const city = state.cities[cityId];
+  if (!city) {
+    throw new Error(`Cannot enter missing city ${cityId}`);
+  }
+
+  let nextState = state;
+  const attackerCivId = state.currentPlayer;
+  const defenderId = city.owner;
+  const attacker = nextState.civilizations[attackerCivId];
+  const defender = nextState.civilizations[defenderId];
+  const alreadyAtWar = attacker?.diplomacy.atWarWith.includes(defenderId) ?? false;
+
+  if (attacker && defender && !alreadyAtWar) {
+    nextState = {
+      ...nextState,
+      civilizations: {
+        ...nextState.civilizations,
+        [attackerCivId]: {
+          ...attacker,
+          diplomacy: declareWar(attacker.diplomacy, defenderId, nextState.turn),
+        },
+        [defenderId]: {
+          ...defender,
+          diplomacy: declareWar(defender.diplomacy, attackerCivId, nextState.turn),
+        },
+      },
+    };
+    bus?.emit('diplomacy:war-declared', { attackerId: attackerCivId, defenderId });
+  }
+
+  return beginPlayerCityAssaultChoice(nextState, attackerId, cityId);
+}

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -6,7 +6,20 @@ import { getMovementRange } from '@/systems/unit-system';
 export type SelectedUnitTapIntent =
   | { kind: 'move' }
   | { kind: 'assault-city'; cityId: string }
-  | { kind: 'assault-minor-civ'; cityId: string; minorCivId: string };
+  | { kind: 'assault-minor-civ'; cityId: string; minorCivId: string }
+  | { kind: 'confirm-war-city'; cityId: string; defenderId: string };
+
+function hasTreaty(state: GameState, civA: string, civB: string, type: string): boolean {
+  const treaties = state.civilizations[civA]?.diplomacy?.treaties ?? [];
+  return treaties.some(treaty =>
+    treaty.type === type
+    && ((treaty.civA === civA && treaty.civB === civB) || (treaty.civA === civB && treaty.civB === civA)),
+  );
+}
+
+function canEnterForeignCityPeacefully(state: GameState, owner: string, targetOwner: string): boolean {
+  return hasTreaty(state, owner, targetOwner, 'alliance');
+}
 
 export function resolveSelectedUnitTapIntent(
   state: GameState,
@@ -43,6 +56,14 @@ export function resolveSelectedUnitTapIntent(
 
   if (cityAtTarget.owner.startsWith('mc-')) {
     return { kind: 'assault-minor-civ', cityId: cityAtTarget.id, minorCivId: cityAtTarget.owner };
+  }
+
+  if (canEnterForeignCityPeacefully(state, unit.owner, cityAtTarget.owner)) {
+    return { kind: 'move' };
+  }
+
+  if (!(state.civilizations[unit.owner]?.diplomacy.atWarWith.includes(cityAtTarget.owner) ?? false)) {
+    return { kind: 'confirm-war-city', cityId: cityAtTarget.id, defenderId: cityAtTarget.owner };
   }
 
   return { kind: 'assault-city', cityId: cityAtTarget.id };

--- a/src/input/worker-movement-flow.ts
+++ b/src/input/worker-movement-flow.ts
@@ -1,0 +1,18 @@
+import type { GameState, HexCoord } from '@/core/types';
+import {
+  abandonWorkerTask,
+  executeUnitMove,
+  type ExecuteUnitMoveOptions,
+  type ExecuteUnitMoveResult,
+} from '@/systems/unit-movement-system';
+
+export function confirmBusyWorkerMove(
+  state: GameState,
+  unitId: string,
+  to: HexCoord,
+  options: ExecuteUnitMoveOptions,
+): ExecuteUnitMoveResult & { state: GameState } {
+  abandonWorkerTask(state, unitId);
+  const result = executeUnitMove(state, unitId, to, options);
+  return { ...result, state };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,10 +17,12 @@ import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
 import { createCityCapturePanel } from '@/ui/city-capture-panel';
+import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
+import { createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { resolveCombat, getTerrainDefenseBonus, selectDefenderForAttack } from '@/systems/combat-system';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import { applyWorkerAction } from '@/systems/worker-action-system';
+import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
 import { updateVisibility, isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { autoSave, loadAutoSave, saveGame, loadGame, listSaves, loadSettings, saveSettings } from '@/storage/save-manager';
@@ -102,7 +104,7 @@ import {
 import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { canUpgradeUnit, applyUpgrade } from '@/systems/unit-upgrade-system';
-import { executeUnitMove } from '@/systems/unit-movement-system';
+import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
 import type { GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
 import {
   appendNotification,
@@ -115,6 +117,8 @@ import {
   routeCombatRewardEarned,
   routeCombatResolved,
   routeFactionTransition,
+  queueFirstContactPendingEvents,
+  routeFirstContact,
   routeLegendaryWonder,
   routePeaceMade,
   routePeaceRequested,
@@ -123,6 +127,8 @@ import {
 } from '@/ui/notification-routing';
 import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
 import { initializeDesktopMenu } from '@/platform/desktop-menu';
+import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
+import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 
 // --- App State ---
 let gameState: GameState;
@@ -1302,7 +1308,9 @@ function refreshCurrentPlayerVisibility(): void {
     .filter((position): position is HexCoord => position !== undefined);
 
   updateVisibility(civ.visibility, playerUnits, gameState.map, cityPositions);
-  syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer);
+  for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
+    bus.emit('civilization:first-contact', contact);
+  }
 }
 
 function getUnitTurnFlow() {
@@ -1372,7 +1380,9 @@ function foundCityAction(): void {
     .map(id => gameState.cities[id]?.position)
     .filter((p): p is HexCoord => p !== undefined);
   updateVisibility(currentCiv().visibility, playerUnits, gameState.map, cityPositions);
-  syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer);
+  for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
+    bus.emit('civilization:first-contact', contact);
+  }
 
   renderLoop.setGameState(gameState);
   updateHUD();
@@ -1802,6 +1812,36 @@ function handleHexTap(rawCoord: HexCoord): void {
         return;
       }
 
+      if (tapIntent.kind === 'confirm-war-city') {
+        const selectedId = selectedUnitId;
+        const city = gameState.cities[tapIntent.cityId];
+        const defender = gameState.civilizations[tapIntent.defenderId];
+        createForeignCityEntryPanel(uiLayer, {
+          cityName: city?.name ?? 'this city',
+          defenderName: defender?.name ?? tapIntent.defenderId,
+          onConfirm: () => {
+            const begun = beginConfirmedForeignCityEntry(gameState, selectedId, tapIntent.cityId, bus);
+            gameState = begun.state;
+            pendingCityCaptureChoice = begun.pending;
+            const captureCity = gameState.cities[tapIntent.cityId];
+            if (captureCity) {
+              createCityCapturePanel(uiLayer, {
+                cityName: captureCity.name,
+                occupiedPopulation: begun.pending.occupiedPopulation,
+                razeGold: begun.pending.razeGold,
+                onOccupy: () => finalizePendingCityCaptureChoice('occupy'),
+                onRaze: () => finalizePendingCityCaptureChoice('raze'),
+              });
+            }
+            SFX.tap();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+          },
+          onCancel: () => selectUnit(selectedId),
+        });
+        return;
+      }
+
       if (tapIntent.kind === 'assault-minor-civ') {
         const mc = gameState.minorCivs[tapIntent.minorCivId];
         if (mc && !mc.isDestroyed) {
@@ -1828,6 +1868,31 @@ function handleHexTap(rawCoord: HexCoord): void {
       }
 
       // Move unit
+      if (isWorkerBusy(gameState, selectedUnitId)) {
+        const selectedId = selectedUnitId;
+        const task = gameState.units[selectedId]?.workerTask;
+        createWorkerTaskWarningPanel(uiLayer, {
+          improvementName: task ? getImprovementDisplayName(task.action) : 'Improvement',
+          onCancel: () => selectUnit(selectedId),
+          onConfirm: () => {
+            confirmBusyWorkerMove(gameState, selectedId, coord, {
+              actor: 'player',
+              civId: gameState.currentPlayer,
+              bus,
+            });
+            SFX.tap();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+            if (gameState.units[selectedId]?.movementPointsLeft > 0) {
+              selectUnit(selectedId);
+            } else {
+              selectNextUnit();
+            }
+          },
+        });
+        return;
+      }
+
       executeUnitMove(gameState, selectedUnitId, coord, {
         actor: 'player',
         civId: gameState.currentPlayer,
@@ -1988,6 +2053,7 @@ function processImprovements(): void {
       tile.improvementTurnsLeft--;
       if (tile.improvementTurnsLeft === 0) {
         bus.emit('improvement:completed', { coord: tile.coord, type: tile.improvement });
+        gameState = clearCompletedWorkerTasksForImprovement(gameState, tile.coord);
         showNotification(`${getImprovementDisplayName(tile.improvement)} completed!`, 'success');
       }
     }
@@ -2282,6 +2348,11 @@ bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId 
 
 bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
   routeWarDeclared(gameState, attackerId, defenderId, appendToCivLog);
+});
+
+bus.on('civilization:first-contact', ({ civA, civB }) => {
+  routeFirstContact(gameState, civA, civB, appendToCivLog);
+  queueFirstContactPendingEvents(gameState, civA, civB);
 });
 
 bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {

--- a/src/systems/discovery-system.ts
+++ b/src/systems/discovery-system.ts
@@ -2,6 +2,11 @@ import type { GameState, HexCoord } from '@/core/types';
 import { hexKey } from './hex-utils';
 import { getVisibility } from './fog-of-war';
 
+export interface CivilizationContactTransition {
+  civA: string;
+  civB: string;
+}
+
 export function hasExploredCoord(state: GameState, viewerCivId: string, coord: HexCoord): boolean {
   const vis = state.civilizations[viewerCivId]?.visibility;
   if (!vis) return false;
@@ -23,14 +28,19 @@ export function hasDiscoveredCity(state: GameState, viewerCivId: string, cityId:
   return hasExploredCoord(state, viewerCivId, city.position);
 }
 
-export function recordCivilizationContact(state: GameState, civA: string, civB: string): void {
-  if (civA === civB) return;
+export function recordCivilizationContact(
+  state: GameState,
+  civA: string,
+  civB: string,
+): CivilizationContactTransition | null {
+  if (civA === civB) return null;
   const first = state.civilizations[civA];
   const second = state.civilizations[civB];
-  if (!first || !second) return;
+  if (!first || !second) return null;
 
   const firstKnown = first.knownCivilizations ?? ((first as GameState['civilizations'][string]).knownCivilizations = []);
   const secondKnown = second.knownCivilizations ?? ((second as GameState['civilizations'][string]).knownCivilizations = []);
+  const wasKnown = firstKnown.includes(civB) || secondKnown.includes(civA);
 
   if (!firstKnown.includes(civB)) {
     firstKnown.push(civB);
@@ -38,22 +48,30 @@ export function recordCivilizationContact(state: GameState, civA: string, civB: 
   if (!secondKnown.includes(civA)) {
     secondKnown.push(civA);
   }
+
+  return wasKnown ? null : { civA, civB };
 }
 
 export function refreshKnownCivilizations(state: GameState, civId: string): void {
   syncCivilizationContactsFromVisibility(state, civId);
 }
 
-export function syncCivilizationContactsFromVisibility(state: GameState, civId: string): void {
+export function syncCivilizationContactsFromVisibility(
+  state: GameState,
+  civId: string,
+): CivilizationContactTransition[] {
   const civ = state.civilizations[civId];
-  if (!civ) return;
+  if (!civ) return [];
 
+  const contacts: CivilizationContactTransition[] = [];
   for (const otherId of Object.keys(state.civilizations)) {
     if (otherId === civId) continue;
     if (hasMetCivilizationByCurrentEvidence(state, civId, otherId)) {
-      recordCivilizationContact(state, civId, otherId);
+      const contact = recordCivilizationContact(state, civId, otherId);
+      if (contact) contacts.push(contact);
     }
   }
+  return contacts;
 }
 
 export function hasMetCivilization(state: GameState, viewerCivId: string, targetCivId: string): boolean {

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -31,6 +31,31 @@ export interface ExecuteUnitMoveResult {
   };
 }
 
+export function isWorkerBusy(state: GameState, unitId: string): boolean {
+  const unit = state.units[unitId];
+  if (!unit || unit.type !== 'worker' || !unit.workerTask) return false;
+  const taskKey = hexKey(unit.workerTask.coord);
+  const tile = state.map.tiles[taskKey];
+  return hexKey(unit.position) === taskKey
+    && tile?.improvement === unit.workerTask.action
+    && tile.improvementTurnsLeft > 0;
+}
+
+export function abandonWorkerTask(state: GameState, unitId: string): void {
+  const unit = state.units[unitId];
+  if (!unit?.workerTask) return;
+  const key = hexKey(unit.workerTask.coord);
+  const tile = state.map.tiles[key];
+  if (tile?.improvement === unit.workerTask.action && tile.improvementTurnsLeft > 0) {
+    tile.improvement = 'none';
+    tile.improvementTurnsLeft = 0;
+  }
+  state.units = {
+    ...state.units,
+    [unitId]: { ...unit, workerTask: undefined },
+  };
+}
+
 function getCivUnits(state: GameState, civId: string) {
   return state.civilizations[civId]?.units
     .map(id => state.units[id])
@@ -74,7 +99,10 @@ export function executeUnitMove(
     const tile = state.map.tiles[hexKey(to)];
     cost = tile ? getMovementCost(tile.terrain) : 1;
   }
-  state.units[unitId] = moveUnit(unit, to, cost);
+  state.units = {
+    ...state.units,
+    [unitId]: moveUnit(unit, to, cost),
+  };
   options.bus?.emit('unit:move', { unitId, from, to });
 
   let villageOutcome: ExecuteUnitMoveResult['villageOutcome'];
@@ -105,7 +133,10 @@ export function executeUnitMove(
     state.map,
     getCivCityPositions(state, options.civId),
   );
-  syncCivilizationContactsFromVisibility(state, options.civId);
+  const contacts = syncCivilizationContactsFromVisibility(state, options.civId);
+  for (const contact of contacts) {
+    options.bus?.emit('civilization:first-contact', contact);
+  }
   if (revealedTiles.length > 0) {
     options.bus?.emit('fog:revealed', { tiles: revealedTiles });
   }

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -186,6 +186,9 @@ export function applyWorkerAction(
     hasActed: true,
     movementPointsLeft: 0,
     chargesRemaining: chargesAfter,
+    workerTask: isBuildableImprovement(action)
+      ? { action, coord: { ...tile.coord } }
+      : undefined,
   };
 
   let nextState: GameState = {
@@ -231,4 +234,30 @@ export function applyWorkerAction(
     forestProductionBonus,
     boostedCityId,
   };
+}
+
+export function clearCompletedWorkerTasksForImprovement(
+  state: GameState,
+  coord: HexCoord,
+): GameState {
+  const key = hexKey(coord);
+  const tile = state.map.tiles[key];
+  if (!tile || tile.improvementTurnsLeft > 0) return state;
+
+  let changed = false;
+  const nextUnits: GameState['units'] = {};
+  for (const [unitId, unit] of Object.entries(state.units)) {
+    if (
+      unit.workerTask
+      && hexKey(unit.workerTask.coord) === key
+      && unit.workerTask.action === tile.improvement
+    ) {
+      nextUnits[unitId] = { ...unit, workerTask: undefined };
+      changed = true;
+    } else {
+      nextUnits[unitId] = unit;
+    }
+  }
+
+  return changed ? { ...state, units: nextUnits } : state;
 }

--- a/src/ui/foreign-city-entry-panel.ts
+++ b/src/ui/foreign-city-entry-panel.ts
@@ -1,0 +1,48 @@
+export interface ForeignCityEntryPanelConfig {
+  cityName: string;
+  defenderName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function createForeignCityEntryPanel(
+  container: HTMLElement,
+  config: ForeignCityEntryPanelConfig,
+): HTMLElement {
+  container.querySelector('#foreign-city-entry-panel')?.remove();
+  let closed = false;
+  const panel = document.createElement('div');
+  panel.id = 'foreign-city-entry-panel';
+  panel.style.cssText = 'position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1000;background:rgba(18,18,18,0.96);border:1px solid rgba(255,255,255,0.25);border-radius:8px;padding:16px;max-width:360px;color:white;';
+
+  const title = document.createElement('h3');
+  title.textContent = `Enter ${config.cityName}?`;
+  const body = document.createElement('p');
+  body.textContent = `Entering this neutral city declares war on ${config.defenderName}.`;
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.cssText = 'display:flex;gap:8px;';
+
+  const cancel = document.createElement('button');
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => {
+    if (closed) return;
+    closed = true;
+    panel.remove();
+    config.onCancel();
+  });
+
+  const confirm = document.createElement('button');
+  confirm.textContent = 'Continue';
+  confirm.addEventListener('click', () => {
+    if (closed) return;
+    closed = true;
+    panel.remove();
+    config.onConfirm();
+  });
+
+  buttonRow.append(cancel, confirm);
+  panel.append(title, body, buttonRow);
+  container.appendChild(panel);
+  return panel;
+}

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -1,4 +1,5 @@
 import type { CombatResult, CombatRewardNotification, GameState } from '@/core/types';
+import { collectEvent } from '@/core/hotseat-events';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import type { NotificationEntry } from '@/ui/notification-log';
@@ -118,6 +119,30 @@ export function routePeaceRequested(
 ): void {
   const fromName = state.civilizations[fromCivId]?.name ?? 'Unknown';
   sink(toCivId, `${fromName} requests peace.`, 'info');
+}
+
+export function routeFirstContact(
+  state: GameState,
+  civA: string,
+  civB: string,
+  sink: NotificationSink,
+): void {
+  const aName = state.civilizations[civA]?.name ?? civA;
+  const bName = state.civilizations[civB]?.name ?? civB;
+  sink(civA, `You have encountered ${bName}.`, 'info');
+  sink(civB, `You have encountered ${aName}.`, 'info');
+}
+
+export function queueFirstContactPendingEvents(
+  state: GameState,
+  civA: string,
+  civB: string,
+): void {
+  state.pendingEvents ??= {};
+  const aName = state.civilizations[civA]?.name ?? civA;
+  const bName = state.civilizations[civB]?.name ?? civB;
+  collectEvent(state.pendingEvents, civA, { type: 'first-contact', message: `Encountered ${bName}.`, turn: state.turn });
+  collectEvent(state.pendingEvents, civB, { type: 'first-contact', message: `Encountered ${aName}.`, turn: state.turn });
 }
 
 // Routes to the defender's owner regardless of who is currently acting.

--- a/src/ui/worker-task-warning-panel.ts
+++ b/src/ui/worker-task-warning-panel.ts
@@ -1,0 +1,47 @@
+export interface WorkerTaskWarningPanelConfig {
+  improvementName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function createWorkerTaskWarningPanel(
+  container: HTMLElement,
+  config: WorkerTaskWarningPanelConfig,
+): HTMLElement {
+  container.querySelector('#worker-task-warning-panel')?.remove();
+  let closed = false;
+  const panel = document.createElement('div');
+  panel.id = 'worker-task-warning-panel';
+  panel.style.cssText = 'position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);z-index:1000;background:rgba(18,18,18,0.96);border:1px solid rgba(255,255,255,0.25);border-radius:8px;padding:16px;max-width:360px;color:white;';
+
+  const title = document.createElement('h3');
+  title.textContent = `${config.improvementName} in progress`;
+  const body = document.createElement('p');
+  body.textContent = 'Moving this worker now means work in progress will be lost.';
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.cssText = 'display:flex;gap:8px;';
+
+  const cancel = document.createElement('button');
+  cancel.textContent = 'Keep working';
+  cancel.addEventListener('click', () => {
+    if (closed) return;
+    closed = true;
+    panel.remove();
+    config.onCancel();
+  });
+
+  const confirm = document.createElement('button');
+  confirm.textContent = 'Move anyway';
+  confirm.addEventListener('click', () => {
+    if (closed) return;
+    closed = true;
+    panel.remove();
+    config.onConfirm();
+  });
+
+  buttonRow.append(cancel, confirm);
+  panel.append(title, body, buttonRow);
+  container.appendChild(panel);
+  return panel;
+}

--- a/tests/input/foreign-city-entry-flow.test.ts
+++ b/tests/input/foreign-city-entry-flow.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
+import { foundCity } from '@/systems/city-system';
+
+function makeForeignCityEntryState(): GameState {
+  const state = createNewGame(undefined, 'foreign-city-entry-flow', 'small');
+  state.currentPlayer = 'player';
+  const attacker = Object.values(state.units).find(unit => unit.owner === 'player' && unit.type === 'warrior')!;
+  state.units['unit-1'] = {
+    ...attacker,
+    id: 'unit-1',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    hasMoved: false,
+  };
+  state.civilizations.player.units = ['unit-1'];
+  state.cities.athens = {
+    ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
+    id: 'athens',
+    name: 'Athens',
+    owner: 'ai-1',
+    position: { q: 1, r: 0 },
+    population: 4,
+    ownedTiles: [{ q: 1, r: 0 }],
+  };
+  state.civilizations['ai-1'].cities = ['athens'];
+  state.civilizations.player.diplomacy.atWarWith = [];
+  state.civilizations['ai-1'].diplomacy.atWarWith = [];
+  return state;
+}
+
+describe('foreign-city-entry-flow', () => {
+  it('declares bilateral war and begins city assault only after confirmation', () => {
+    const state = makeForeignCityEntryState();
+    const bus = new EventBus();
+    const warDeclared = vi.fn();
+    bus.on('diplomacy:war-declared', warDeclared);
+
+    const result = beginConfirmedForeignCityEntry(state, 'unit-1', 'athens', bus);
+
+    expect(result.state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
+    expect(result.state.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
+    expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(result.pending.cityId).toBe('athens');
+    expect(warDeclared).toHaveBeenCalledWith({ attackerId: 'player', defenderId: 'ai-1' });
+  });
+
+  it('does not duplicate war declarations when already at war', () => {
+    const state = makeForeignCityEntryState();
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    const bus = new EventBus();
+    const warDeclared = vi.fn();
+    bus.on('diplomacy:war-declared', warDeclared);
+
+    const result = beginConfirmedForeignCityEntry(state, 'unit-1', 'athens', bus);
+
+    expect(result.state.civilizations.player.diplomacy.atWarWith).toEqual(['ai-1']);
+    expect(result.state.civilizations['ai-1'].diplomacy.atWarWith).toEqual(['player']);
+    expect(warDeclared).not.toHaveBeenCalled();
+  });
+});

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -39,12 +39,42 @@ function makeTapAssaultFixture(): GameState {
 }
 
 describe('selected-unit-tap-intent', () => {
-  it('returns assault-city for an ungarrisoned enemy major city in movement range', () => {
+  it('returns confirm-war-city for a neutral major city', () => {
     const state = makeTapAssaultFixture();
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
+
+    expect(intent).toEqual({ kind: 'confirm-war-city', cityId: 'enemyCity', defenderId: 'ai-1' });
+  });
+
+  it('returns assault-city for an at-war ungarrisoned major city', () => {
+    const state = makeTapAssaultFixture();
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
 
     const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
 
     expect(intent).toEqual({ kind: 'assault-city', cityId: 'enemyCity' });
+  });
+
+  it('returns move for an allied major city', () => {
+    const state = makeTapAssaultFixture();
+    state.civilizations.player.diplomacy.treaties.push({ type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: 10 });
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 }, [{ q: 1, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
+
+  it('still asks before entering a major city with only open borders', () => {
+    const state = makeTapAssaultFixture();
+    state.civilizations.player.diplomacy.treaties.push({ type: 'open_borders', civA: 'player', civB: 'ai-1', turnsRemaining: 10 });
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 1, r: 0 });
+
+    expect(intent).toEqual({ kind: 'confirm-war-city', cityId: 'enemyCity', defenderId: 'ai-1' });
   });
 
   it('returns assault-minor-civ for an ungarrisoned city-state city in movement range', () => {
@@ -116,6 +146,8 @@ describe('selected-unit-tap-intent', () => {
 
   it('returns assault-city when a friendly unit is stacked on the enemy city destination', () => {
     const state = makeTapAssaultFixture();
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
     const friendly = createUnit('worker', 'player', { q: 1, r: 0 });
     friendly.id = 'friendly-worker';
     state.units[friendly.id] = friendly;

--- a/tests/input/worker-movement-flow.test.ts
+++ b/tests/input/worker-movement-flow.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
+import { makeEdgeMoveState } from '../systems/unit-movement-system.test-helpers';
+
+describe('worker-movement-flow', () => {
+  it('abandons in-progress work and then moves the worker', () => {
+    const { state, unitId } = makeEdgeMoveState();
+    state.units[unitId] = {
+      ...state.units[unitId],
+      type: 'worker',
+      workerTask: { action: 'farm', coord: { q: 0, r: 1 } },
+    };
+    state.map.tiles['0,1'].improvement = 'farm';
+    state.map.tiles['0,1'].improvementTurnsLeft = 3;
+
+    const result = confirmBusyWorkerMove(state, unitId, { q: 1, r: 1 }, {
+      actor: 'player',
+      civId: 'player',
+      bus: new EventBus(),
+    });
+
+    expect(result.state.units[unitId].workerTask).toBeUndefined();
+    expect(result.state.units[unitId].position).toEqual({ q: 1, r: 1 });
+    expect(result.state.map.tiles['0,1']).toMatchObject({ improvement: 'none', improvementTurnsLeft: 0 });
+  });
+
+  it('is idempotent after the task has already been abandoned', () => {
+    const { state, unitId } = makeEdgeMoveState();
+    state.units[unitId] = {
+      ...state.units[unitId],
+      type: 'worker',
+      workerTask: { action: 'farm', coord: { q: 0, r: 1 } },
+    };
+    state.map.tiles['0,1'].improvement = 'farm';
+    state.map.tiles['0,1'].improvementTurnsLeft = 3;
+
+    confirmBusyWorkerMove(state, unitId, { q: 1, r: 1 }, { actor: 'player', civId: 'player' });
+
+    expect(() => confirmBusyWorkerMove(state, unitId, { q: 1, r: 2 }, { actor: 'player', civId: 'player' })).not.toThrow();
+    expect(state.map.tiles['0,1']).toMatchObject({ improvement: 'none', improvementTurnsLeft: 0 });
+  });
+});

--- a/tests/systems/discovery-system.test.ts
+++ b/tests/systems/discovery-system.test.ts
@@ -125,6 +125,55 @@ describe('discovery-system', () => {
     expect(state.civilizations.player.knownCivilizations).toContain('outsider');
   });
 
+  it('returns a first-contact transition only when contact is newly recorded', () => {
+    const { state } = makeBreakawayFixture({ includeThirdCiv: true });
+    state.cities['outsider-city'] = {
+      ...state.cities['city-border'],
+      id: 'outsider-city',
+      owner: 'outsider',
+      name: 'Outsider Camp',
+      position: { q: 6, r: 0 },
+      ownedTiles: [{ q: 6, r: 0 }],
+    };
+    state.civilizations.outsider.cities = ['outsider-city'];
+    state.map.tiles['6,0'] = {
+      ...state.map.tiles['4,0'],
+      coord: { q: 6, r: 0 },
+      owner: 'outsider',
+    };
+    state.civilizations.player.visibility.tiles['6,0'] = 'visible';
+    state.civilizations.player.knownCivilizations = [];
+    state.civilizations.outsider.knownCivilizations = [];
+
+    const first = syncCivilizationContactsFromVisibility(state, 'player');
+    const second = syncCivilizationContactsFromVisibility(state, 'player');
+
+    expect(first).toContainEqual({ civA: 'player', civB: 'outsider' });
+    expect(second).toEqual([]);
+  });
+
+  it('does not return first-contact when the other civ already knows the viewer', () => {
+    const { state } = makeBreakawayFixture({ includeThirdCiv: true });
+    state.units['unit-outsider'] = {
+      id: 'unit-outsider',
+      type: 'warrior',
+      owner: 'outsider',
+      position: { q: 2, r: 0 },
+      movementPointsLeft: 2,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    };
+    state.civilizations.outsider.units = ['unit-outsider'];
+    state.civilizations.outsider.knownCivilizations = ['player'];
+    state.civilizations.player.visibility.tiles['2,0'] = 'visible';
+
+    expect(syncCivilizationContactsFromVisibility(state, 'player')).toEqual([]);
+    expect(state.civilizations.player.knownCivilizations).toContain('outsider');
+  });
+
   it('does not lose first contact when visibility changes again before end turn', () => {
     const { state } = makeBreakawayFixture({ includeThirdCiv: true });
     state.map.tiles['0,0'] = {

--- a/tests/systems/unit-movement-system.test-helpers.ts
+++ b/tests/systems/unit-movement-system.test-helpers.ts
@@ -1,0 +1,94 @@
+import type { GameMap, GameState, Unit } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { hexKey } from '@/systems/hex-utils';
+
+function createWrappedGrasslandMap(width: number, height: number): GameMap {
+  const tiles: GameMap['tiles'] = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < height; r++) {
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: 'grassland',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+
+  return {
+    width,
+    height,
+    wrapsHorizontally: true,
+    tiles,
+    rivers: [],
+  };
+}
+
+export function makeEdgeMoveState(): { state: GameState; unitId: string } {
+  const map = createWrappedGrasslandMap(5, 4);
+  const unit: Unit = {
+    id: 'edge-warrior',
+    type: 'warrior',
+    owner: 'player',
+    position: { q: 0, r: 1 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+
+  const state = {
+    turn: 1,
+    era: 1,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map,
+    units: { [unit.id]: unit },
+    cities: {},
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'generic',
+        cities: [],
+        units: [unit.id],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} },
+        gold: 0,
+        visibility: { tiles: { '4,1': 'visible' } },
+        knownCivilizations: [],
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: false,
+      musicEnabled: false,
+      musicVolume: 0,
+      sfxVolume: 0,
+      tutorialEnabled: false,
+      advisorsEnabled: {},
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+  } as unknown as GameState;
+
+  return { state, unitId: unit.id };
+}

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -1,92 +1,9 @@
 import { EventBus } from '@/core/event-bus';
-import type { GameMap, GameState, Unit } from '@/core/types';
-import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
-import { executeUnitMove } from '@/systems/unit-movement-system';
+import { abandonWorkerTask, executeUnitMove } from '@/systems/unit-movement-system';
 import { makeAutoExploreFixture } from './helpers/auto-explore-fixture';
-
-function createWrappedGrasslandMap(width: number, height: number): GameMap {
-  const tiles: GameMap['tiles'] = {};
-  for (let q = 0; q < width; q++) {
-    for (let r = 0; r < height; r++) {
-      tiles[hexKey({ q, r })] = {
-        coord: { q, r },
-        terrain: 'grassland',
-        elevation: 'lowland',
-        resource: null,
-        improvement: 'none',
-        owner: null,
-        improvementTurnsLeft: 0,
-        hasRiver: false,
-        wonder: null,
-      };
-    }
-  }
-
-  return {
-    width,
-    height,
-    wrapsHorizontally: true,
-    tiles,
-    rivers: [],
-  };
-}
-
-function makeEdgeMoveState(): { state: GameState; unitId: string } {
-  const map = createWrappedGrasslandMap(5, 4);
-  const unit: Unit = {
-    id: 'edge-warrior',
-    type: 'warrior',
-    owner: 'player',
-    position: { q: 0, r: 1 },
-    movementPointsLeft: 2,
-    health: 100,
-    experience: 0,
-    hasMoved: false,
-    hasActed: false,
-    isResting: false,
-  };
-
-  const state = {
-    turn: 1,
-    era: 1,
-    currentPlayer: 'player',
-    gameOver: false,
-    winner: null,
-    map,
-    units: { [unit.id]: unit },
-    cities: {},
-    civilizations: {
-      player: {
-        id: 'player',
-        name: 'Player',
-        color: '#4a90d9',
-        isHuman: true,
-        civType: 'generic',
-        cities: [],
-        units: [unit.id],
-        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} },
-        gold: 0,
-        visibility: { tiles: { '4,1': 'visible' } },
-        knownCivilizations: [],
-        score: 0,
-        diplomacy: createDiplomacyState(['player'], 'player'),
-      },
-    },
-    barbarianCamps: {},
-    minorCivs: {},
-    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
-    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false, advisorsEnabled: {}, councilTalkLevel: 'normal' },
-    tribalVillages: {},
-    discoveredWonders: {},
-    wonderDiscoverers: {},
-    embargoes: [],
-    defensiveLeagues: [],
-  } as unknown as GameState;
-
-  return { state, unitId: unit.id };
-}
+import { makeEdgeMoveState } from './unit-movement-system.test-helpers';
 
 describe('unit-movement-system', () => {
   it('applies village rewards and removes the village when automation enters it', () => {
@@ -114,6 +31,22 @@ describe('unit-movement-system', () => {
 
     expect(result.revealedTiles.length).toBeGreaterThan(0);
     expect(state.civilizations.player.knownCivilizations).toContain(hiddenCivId);
+  });
+
+  it('emits first-contact when movement reveals a new civilization', () => {
+    const { state, unitId, hiddenCivId } = makeAutoExploreFixture({ foreignBorderNorth: true, safeFogNorth: true });
+    state.civilizations.traders.knownCivilizations = [];
+    const bus = new EventBus();
+    const contacts: Array<{ civA: string; civB: string }> = [];
+    bus.on('civilization:first-contact', event => contacts.push(event));
+
+    executeUnitMove(state, unitId, { q: 1, r: 0 }, {
+      actor: 'player',
+      civId: 'player',
+      bus,
+    });
+
+    expect(contacts).toEqual([{ civA: 'player', civB: hiddenCivId }]);
   });
 
   it('emits wonder discovery metadata when automation reveals a wonder tile', () => {
@@ -150,5 +83,21 @@ describe('unit-movement-system', () => {
     expect(fogRevealed).toHaveBeenCalledWith(expect.objectContaining({
       tiles: expect.arrayContaining([{ q: 0, r: 1 }]),
     }));
+  });
+
+  it('can abandon a busy worker task before moving', () => {
+    const { state, unitId } = makeEdgeMoveState();
+    state.units[unitId] = {
+      ...state.units[unitId],
+      type: 'worker',
+      workerTask: { action: 'farm', coord: { q: 0, r: 1 } },
+    };
+    state.map.tiles['0,1'].improvement = 'farm';
+    state.map.tiles['0,1'].improvementTurnsLeft = 3;
+
+    abandonWorkerTask(state, unitId);
+
+    expect(state.units[unitId].workerTask).toBeUndefined();
+    expect(state.map.tiles['0,1']).toMatchObject({ improvement: 'none', improvementTurnsLeft: 0 });
   });
 });

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { City, GameState, HexTile, Unit } from '@/core/types';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
-import { applyWorkerAction, getWorkerChargesRemaining } from '@/systems/worker-action-system';
+import { applyWorkerAction, clearCompletedWorkerTasksForImprovement, getWorkerChargesRemaining } from '@/systems/worker-action-system';
 
 function tile(overrides: Partial<HexTile>): HexTile {
   return {
@@ -160,6 +160,47 @@ describe('worker action system', () => {
       improvementTurnsLeft: 5,
     });
     expect(result.state.units['worker-1']?.chargesRemaining).toBe(1);
+  });
+
+  it('records an active worker task when an improvement starts', () => {
+    const start = state();
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.units['worker-1']?.workerTask).toEqual({
+      action: 'farm',
+      coord: { q: 0, r: 0 },
+    });
+  });
+
+  it('clears the active worker task when its improvement completes', () => {
+    const start = state();
+    start.units['worker-1'] = worker({
+      position: { q: 0, r: 0 },
+      workerTask: { action: 'farm', coord: { q: 0, r: 0 } },
+    });
+    start.map.tiles['0,0'].improvement = 'farm';
+    start.map.tiles['0,0'].improvementTurnsLeft = 0;
+
+    const result = clearCompletedWorkerTasksForImprovement(start, { q: 0, r: 0 });
+
+    expect(result.units['worker-1'].workerTask).toBeUndefined();
+  });
+
+  it('keeps a worker busy while the assigned improvement still has turns left', () => {
+    const start = state();
+    start.units['worker-1'] = worker({
+      position: { q: 0, r: 0 },
+      workerTask: { action: 'farm', coord: { q: 0, r: 0 } },
+    });
+    start.map.tiles['0,0'].improvement = 'farm';
+    start.map.tiles['0,0'].improvementTurnsLeft = 2;
+
+    const result = clearCompletedWorkerTasksForImprovement(start, { q: 0, r: 0 });
+
+    expect(result.units['worker-1'].workerTask).toEqual({ action: 'farm', coord: { q: 0, r: 0 } });
   });
 
   it('converts forest farm to plains and grants production to nearest owned city', () => {

--- a/tests/ui/foreign-city-entry-panel.test.ts
+++ b/tests/ui/foreign-city-entry-panel.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
+
+describe('foreign-city-entry-panel', () => {
+  beforeEach(() => {
+    document.body.textContent = '';
+  });
+
+  it('warns that entering a neutral city declares war and waits for confirmation', () => {
+    const onConfirm = vi.fn();
+    createForeignCityEntryPanel(document.body, {
+      cityName: 'Athens',
+      defenderName: 'Greece',
+      onConfirm,
+      onCancel: vi.fn(),
+    });
+
+    expect(document.body.textContent).toContain('declares war');
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('replaces stale prompts when reopened', () => {
+    createForeignCityEntryPanel(document.body, { cityName: 'Athens', defenderName: 'Greece', onConfirm: vi.fn(), onCancel: vi.fn() });
+    createForeignCityEntryPanel(document.body, { cityName: 'Thebes', defenderName: 'Egypt', onConfirm: vi.fn(), onCancel: vi.fn() });
+
+    expect(document.querySelectorAll('#foreign-city-entry-panel')).toHaveLength(1);
+    expect(document.body.textContent).toContain('Thebes');
+  });
+
+  it('calls confirm at most once even if stale button references are clicked again', () => {
+    const onConfirm = vi.fn();
+    const panel = createForeignCityEntryPanel(document.body, {
+      cityName: 'Athens',
+      defenderName: 'Greece',
+      onConfirm,
+      onCancel: vi.fn(),
+    });
+    const continueButton = Array.from(panel.querySelectorAll('button'))
+      .find(button => button.textContent === 'Continue')!;
+
+    continueButton.click();
+    continueButton.click();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('#foreign-city-entry-panel')).toBeNull();
+  });
+
+  it('calls cancel at most once even if stale button references are clicked again', () => {
+    const onCancel = vi.fn();
+    const panel = createForeignCityEntryPanel(document.body, {
+      cityName: 'Athens',
+      defenderName: 'Greece',
+      onConfirm: vi.fn(),
+      onCancel,
+    });
+    const cancelButton = Array.from(panel.querySelectorAll('button'))
+      .find(button => button.textContent === 'Cancel')!;
+
+    cancelButton.click();
+    cancelButton.click();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('#foreign-city-entry-panel')).toBeNull();
+  });
+});

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -4,8 +4,10 @@ import {
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeCombatResolved,
+  queueFirstContactPendingEvents,
   routeLegendaryWonder,
   routeFactionTransition,
+  routeFirstContact,
   routePeaceMade,
   routePeaceRequested,
   routeWarDeclared,
@@ -74,6 +76,31 @@ describe('notification routing', () => {
         message: expect.stringMatching(/Alice requests peace/i),
         type: 'info',
       }),
+    ]);
+  });
+
+  it('first-contact writes encounter messages to both civ logs', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+
+    routeFirstContact(state, 'p1', 'p2', sink);
+
+    expect(calls).toEqual([
+      expect.objectContaining({ civId: 'p1', message: expect.stringMatching(/encountered Bob/i), type: 'info' }),
+      expect.objectContaining({ civId: 'p2', message: expect.stringMatching(/encountered Alice/i), type: 'info' }),
+    ]);
+  });
+
+  it('first-contact queues hot-seat notable events for both players', () => {
+    const state = makeState({ pendingEvents: {} } as Partial<GameState>);
+
+    queueFirstContactPendingEvents(state, 'p1', 'p2');
+
+    expect(state.pendingEvents?.p1).toEqual([
+      expect.objectContaining({ type: 'first-contact', message: expect.stringMatching(/Encountered Bob/i), turn: state.turn }),
+    ]);
+    expect(state.pendingEvents?.p2).toEqual([
+      expect.objectContaining({ type: 'first-contact', message: expect.stringMatching(/Encountered Alice/i), turn: state.turn }),
     ]);
   });
 

--- a/tests/ui/worker-task-warning-panel.test.ts
+++ b/tests/ui/worker-task-warning-panel.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
+
+describe('worker-task-warning-panel', () => {
+  beforeEach(() => {
+    document.body.textContent = '';
+  });
+
+  it('warns that moving loses work in progress before confirming', () => {
+    const onConfirm = vi.fn();
+    createWorkerTaskWarningPanel(document.body, {
+      improvementName: 'Farm',
+      onConfirm,
+      onCancel: vi.fn(),
+    });
+
+    expect(document.body.textContent).toContain('work in progress will be lost');
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls confirm at most once', () => {
+    const onConfirm = vi.fn();
+    const panel = createWorkerTaskWarningPanel(document.body, {
+      improvementName: 'Farm',
+      onConfirm,
+      onCancel: vi.fn(),
+    });
+    const moveButton = Array.from(panel.querySelectorAll('button'))
+      .find(button => button.textContent === 'Move anyway')!;
+
+    moveButton.click();
+    moveButton.click();
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('#worker-task-warning-panel')).toBeNull();
+  });
+
+  it('calls cancel at most once', () => {
+    const onCancel = vi.fn();
+    const panel = createWorkerTaskWarningPanel(document.body, {
+      improvementName: 'Farm',
+      onConfirm: vi.fn(),
+      onCancel,
+    });
+    const keepWorkingButton = Array.from(panel.querySelectorAll('button'))
+      .find(button => button.textContent === 'Keep working')!;
+
+    keepWorkingButton.click();
+    keepWorkingButton.click();
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('#worker-task-warning-panel')).toBeNull();
+  });
+
+  it('replaces stale warning panels when reopened', () => {
+    createWorkerTaskWarningPanel(document.body, { improvementName: 'Farm', onConfirm: vi.fn(), onCancel: vi.fn() });
+    createWorkerTaskWarningPanel(document.body, { improvementName: 'Mine', onConfirm: vi.fn(), onCancel: vi.fn() });
+
+    expect(document.querySelectorAll('#worker-task-warning-panel')).toHaveLength(1);
+    expect(document.body.textContent).toContain('Mine');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #110 by emitting first-contact transitions from visibility refreshes and routing encounter logs plus hot-seat notable events.
- Fixes #115 by distinguishing neutral, at-war, allied, minor-civ, and open-borders city tap intent, with an act-of-war confirmation before neutral city entry.
- Fixes #117 by persisting active worker tasks, warning before abandoning in-progress work, and clearing completed task metadata.
- Confirms #111 and #116 are already closed as invalid on current main.
- Removes the implementation plan file for this effort.

## Testing
- scripts/check-src-rule-violations.sh src/ai/basic-ai.ts src/core/turn-manager.ts src/core/types.ts src/input/selected-unit-tap-intent.ts src/input/foreign-city-entry-flow.ts src/input/worker-movement-flow.ts src/main.ts src/systems/discovery-system.ts src/systems/unit-movement-system.ts src/systems/worker-action-system.ts src/ui/notification-routing.ts src/ui/foreign-city-entry-panel.ts src/ui/worker-task-warning-panel.ts
- ./scripts/run-with-mise.sh yarn test --run tests/systems/discovery-system.test.ts tests/systems/unit-movement-system.test.ts tests/core/turn-manager.test.ts tests/ai/basic-ai.test.ts tests/ui/notification-routing.test.ts tests/input/selected-unit-tap-intent.test.ts tests/input/city-assault-flow.test.ts tests/input/foreign-city-entry-flow.test.ts tests/input/worker-movement-flow.test.ts tests/ui/foreign-city-entry-panel.test.ts tests/ui/worker-task-warning-panel.test.ts tests/systems/worker-action-system.test.ts
- ./scripts/run-with-mise.sh yarn build