### PR TITLE
fix(#140) + feat(#150): disable invalid Found City button; add Fortify unit mechanic

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -232,6 +232,7 @@ export interface Unit {
   workerTask?: WorkerTask;    // active multi-turn improvement the worker is assigned to
   isResting: boolean;        // player explicitly chose to rest/heal this turn
   skippedTurn?: boolean;     // player chose to hold this unit out of unit cycling this turn
+  isFortified?: boolean;    // unit is in defensive stance; excluded from unmoved-unit cycling, +25% defense
   automation?: {
     mode: 'auto-explore';
     lastTargets: string[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
 import { initializeDesktopMenu } from '@/platform/desktop-menu';
 import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
 import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
+import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 
 // --- App State ---
 let gameState: GameState;
@@ -1085,6 +1086,20 @@ function selectUnit(unitId: string): void {
       onRest: () => restAction(),
       onSkipTurn: uid => getUnitTurnFlow().skipUnitAction(uid),
       onDeleteUnit: uid => getUnitTurnFlow().showDeleteUnitConfirmation(uid),
+      onFortify: uid => {
+        const unit = gameState.units[uid];
+        if (!unit || unit.owner !== gameState.currentPlayer) return;
+        if (unit.isFortified) {
+          gameState = unfortifyUnitInState(gameState, gameState.currentPlayer, uid);
+          showNotification('Unit unfortified.', 'info');
+        } else {
+          gameState = fortifyUnitInState(gameState, gameState.currentPlayer, uid);
+          showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+        }
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        selectUnit(uid);
+      },
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
       onOpenStack: (coord) => {
         handleFriendlyUnitStackTap(gameState, coord, selectedUnitId, {

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -107,6 +107,24 @@ export function drawUnits(
           ctx.fillStyle = healthRatio > 0.5 ? '#4caf50' : healthRatio > 0.25 ? '#ff9800' : '#f44336';
           ctx.fillRect(barX, barY, barWidth * healthRatio, barHeight);
         }
+
+        if (unit.isFortified) {
+          const badgeR = size * 0.16;
+          const badgeX = unitX - size * 0.34;
+          const badgeY = unitY - size * 0.34;
+          ctx.beginPath();
+          ctx.arc(badgeX, badgeY, badgeR, 0, Math.PI * 2);
+          ctx.fillStyle = 'rgba(200,150,0,0.9)';
+          ctx.fill();
+          ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+          ctx.lineWidth = 1;
+          ctx.stroke();
+          ctx.font = `${size * 0.18}px system-ui`;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillStyle = 'white';
+          ctx.fillText('F', badgeX, badgeY);
+        }
       }
 
       if (stack.length > 1) {

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -82,6 +82,10 @@ export function resolveCombat(
     }
   }
 
+  if (defender.isFortified) {
+    defStrength *= 1.25;
+  }
+
   if (
     context?.attackerBonus?.type === 'coastal_science'
     && (attacker.type === 'galley' || attacker.type === 'trireme')

--- a/src/systems/unit-lifecycle-system.ts
+++ b/src/systems/unit-lifecycle-system.ts
@@ -61,3 +61,39 @@ export function getUnmovedUnitsForEndTurn(state: GameState, civId: string): Unit
   const roster = new Set(civ.units);
   return getUnmovedUnits(state.units, civId).filter(unit => roster.has(unit.id));
 }
+
+export function fortifyUnitInState(state: GameState, civId: string, unitId: string): GameState {
+  const unit = state.units[unitId];
+  if (!unit || unit.owner !== civId) {
+    return state;
+  }
+
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [unitId]: {
+        ...unit,
+        isFortified: true,
+        hasActed: true,
+        movementPointsLeft: 0,
+      },
+    },
+  };
+}
+
+export function unfortifyUnitInState(state: GameState, civId: string, unitId: string): GameState {
+  const unit = state.units[unitId];
+  if (!unit || unit.owner !== civId) {
+    return state;
+  }
+
+  const { isFortified: _removed, ...rest } = unit;
+  return {
+    ...state,
+    units: {
+      ...state.units,
+      [unitId]: rest,
+    },
+  };
+}

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -143,6 +143,7 @@ export function moveUnit(unit: Unit, to: HexCoord, cost: number): Unit {
     position: { ...to },
     movementPointsLeft: unit.movementPointsLeft - cost,
     hasMoved: true,
+    isFortified: undefined,
   };
 }
 
@@ -225,7 +226,7 @@ export function getUnmovedUnits(
   civId: string,
 ): Unit[] {
   return Object.values(units).filter(
-    u => u.owner === civId && !u.hasMoved && !u.hasActed && !u.skippedTurn,
+    u => u.owner === civId && !u.hasMoved && !u.hasActed && !u.skippedTurn && !u.isFortified,
   );
 }
 

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -6,6 +6,7 @@ import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
 import { getAvailableWorkerActions, getWorkerActionLabel } from '@/systems/improvement-system';
 import { DEFAULT_WORKER_CHARGES, getWorkerChargesRemaining } from '@/systems/worker-action-system';
 import { hexKey } from '@/systems/hex-utils';
+import { canFoundCityAt, formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 
 export interface SelectedUnitInfoCallbacks {
   onClose?: () => void;
@@ -14,6 +15,7 @@ export interface SelectedUnitInfoCallbacks {
   onRest?: () => void;
   onSkipTurn?: (unitId: string) => void;
   onDeleteUnit?: (unitId: string) => void;
+  onFortify?: (unitId: string) => void;
   onCancelAutoExplore?: () => void;
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
   onInfiltrate?: (unitId: string) => void;
@@ -129,7 +131,17 @@ export function renderSelectedUnitInfo(
   actionsDiv.style.cssText = 'margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;';
 
   if (def.canFoundCity && callbacks.onFoundCity) {
-    actionsDiv.appendChild(makeButton('Found City', '#e8c170', callbacks.onFoundCity));
+    if (canFoundCityAt(state, unit.position)) {
+      actionsDiv.appendChild(makeButton('Found City', '#e8c170', callbacks.onFoundCity));
+    } else {
+      const blockers = getCityFoundingBlockers(state, unit.position);
+      const btn = makeButton('Found City', '#e8c170');
+      btn.disabled = true;
+      btn.style.opacity = '0.5';
+      btn.style.cursor = 'not-allowed';
+      btn.title = formatCityFoundingBlockerMessage(blockers);
+      actionsDiv.appendChild(btn);
+    }
   }
 
   if (def.canBuildImprovements) {
@@ -168,6 +180,14 @@ export function renderSelectedUnitInfo(
 
   if (callbacks.onDeleteUnit) {
     actionsDiv.appendChild(makeButton('Delete Unit', '#b91c1c', () => callbacks.onDeleteUnit!(unitId)));
+  }
+
+  if (def.strength > 0 && callbacks.onFortify) {
+    if (unit.isFortified) {
+      actionsDiv.appendChild(makeButton('Unfortify', '#6b7a8a', () => callbacks.onFortify!(unitId)));
+    } else if (!unit.hasActed) {
+      actionsDiv.appendChild(makeButton('Fortify', '#3b5268', () => callbacks.onFortify!(unitId)));
+    }
   }
 
   if (isSpyUnitType(unit.type) && !unit.hasActed && callbacks.onSetDisguise) {

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -101,3 +101,54 @@ describe('unit renderer wrap parity', () => {
     expect(ctx.fillText).toHaveBeenCalledWith('👷', expect.any(Number), expect.any(Number));
   });
 });
+
+describe('fortified unit badge', () => {
+  function makeCamera(): Camera {
+    return {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+  }
+
+  function makeState(): GameState {
+    return {
+      map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    } as unknown as GameState;
+  }
+
+  it('draws an F badge for a fortified unit', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      'unit-1': {
+        id: 'unit-1', owner: 'player', type: 'warrior',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+        isFortified: true,
+      } as unknown as Unit,
+    };
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+    drawUnits(ctx, units, makeCamera(), visibility, makeState(), 'player', { player: '#4a90d9' });
+
+    expect(ctx.fillText).toHaveBeenCalledWith('F', expect.any(Number), expect.any(Number));
+  });
+
+  it('does not draw an F badge for a non-fortified unit', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      'unit-1': {
+        id: 'unit-1', owner: 'player', type: 'warrior',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+      } as unknown as Unit,
+    };
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+    drawUnits(ctx, units, makeCamera(), visibility, makeState(), 'player', { player: '#4a90d9' });
+
+    const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
+    expect(fillTextCalls.some(([text]) => text === 'F')).toBe(false);
+  });
+});

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -128,3 +128,34 @@ describe('new terrain defense bonuses', () => {
     expect(getTerrainDefenseBonus('swamp')).toBe(0);
   });
 });
+
+describe('fortify defense bonus', () => {
+  let fortifyMap: GameMap;
+
+  beforeAll(() => {
+    fortifyMap = generateMap(30, 30, 'fortify-combat-test');
+  });
+
+  it('fortified defender takes less damage than an identical non-fortified defender', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 });
+    const defender = createUnit('warrior', 'p2', { q: 11, r: 10 });
+    const defenderFortified = { ...defender, isFortified: true };
+
+    // Same seed → deterministic; only variable is isFortified
+    const resultBase = resolveCombat(attacker, defender, fortifyMap, 42);
+    const resultFortified = resolveCombat(attacker, defenderFortified, fortifyMap, 42);
+
+    expect(resultFortified.defenderDamage).toBeLessThan(resultBase.defenderDamage);
+  });
+
+  it('non-fortified combat produces identical results with the same seed', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 });
+    const defender = createUnit('warrior', 'p2', { q: 11, r: 10 });
+
+    const r1 = resolveCombat(attacker, defender, fortifyMap, 99);
+    const r2 = resolveCombat(attacker, defender, fortifyMap, 99);
+
+    expect(r1.defenderDamage).toBe(r2.defenderDamage);
+    expect(r1.attackerDamage).toBe(r2.attackerDamage);
+  });
+});

--- a/tests/systems/unit-lifecycle-system.test.ts
+++ b/tests/systems/unit-lifecycle-system.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { createUnit } from '@/systems/unit-system';
+import { createUnit, moveUnit, resetUnitTurn } from '@/systems/unit-system';
 import {
   getUnmovedUnitsForEndTurn,
   removePlayerUnitFromState,
   skipUnitForTurn,
   skipUnitInState,
+  fortifyUnitInState,
+  unfortifyUnitInState,
 } from '@/systems/unit-lifecycle-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
 
@@ -98,6 +100,33 @@ describe('unit-lifecycle-system', () => {
     expect(next.espionage?.[playerId]?.spies[spyUnit.id]).toBeUndefined();
   });
 
+  it('excludes fortified units from getUnmovedUnitsForEndTurn', () => {
+    const state = createNewGame(undefined, 'fortify-unmoved-test', 'small');
+    const playerId = state.currentPlayer;
+    const unitId = state.civilizations[playerId].units[0];
+
+    state.units[unitId] = { ...state.units[unitId], isFortified: true };
+
+    const unmoved = getUnmovedUnitsForEndTurn(state, playerId).map(u => u.id);
+    expect(unmoved).not.toContain(unitId);
+  });
+
+  it('clears isFortified when a unit moves', () => {
+    const unit = createUnit('warrior', 'player', { q: 0, r: 0 });
+    const fortifiedUnit = { ...unit, isFortified: true };
+    const moved = moveUnit(fortifiedUnit, { q: 1, r: 0 }, 1);
+    expect(moved.isFortified).toBeUndefined();
+  });
+
+  it('preserves isFortified through resetUnitTurn (fortification persists across turns)', () => {
+    const unit = createUnit('warrior', 'player', { q: 0, r: 0 });
+    const fortifiedAndActed = { ...unit, isFortified: true, hasActed: true, movementPointsLeft: 0 };
+    const reset = resetUnitTurn(fortifiedAndActed);
+    expect(reset.isFortified).toBe(true);
+    expect(reset.hasActed).toBe(false);
+    expect(reset.movementPointsLeft).toBeGreaterThan(0);
+  });
+
   it('returns only current-player units that still need orders at end turn', () => {
     const state = createNewGame(undefined, 'issue-154-unmoved', 'small');
     const playerId = state.currentPlayer;
@@ -119,5 +148,54 @@ describe('unit-lifecycle-system', () => {
     expect(warningUnits).not.toContain(firstUnitId);
     expect(warningUnits).not.toContain(secondUnitId);
     expect(warningUnits).not.toContain(enemyUnitId);
+  });
+});
+
+describe('fortifyUnitInState / unfortifyUnitInState', () => {
+  it('fortifyUnitInState sets isFortified, consumes the action, and zeroes movement', () => {
+    const state = createNewGame(undefined, 'fortify-state-test', 'small');
+    const playerId = state.currentPlayer;
+    const unitId = state.civilizations[playerId].units[0];
+    const original = state.units[unitId];
+
+    const next = fortifyUnitInState(state, playerId, unitId);
+
+    expect(next.units[unitId].isFortified).toBe(true);
+    expect(next.units[unitId].hasActed).toBe(true);
+    expect(next.units[unitId].movementPointsLeft).toBe(0);
+    // original state untouched
+    expect(original.isFortified).toBeUndefined();
+  });
+
+  it('fortifyUnitInState returns the same state object for an enemy unit', () => {
+    const state = createNewGame(undefined, 'fortify-enemy-test', 'small');
+    const playerId = state.currentPlayer;
+    const enemyUnitId = state.civilizations['ai-1'].units[0];
+
+    const next = fortifyUnitInState(state, playerId, enemyUnitId);
+
+    expect(next).toBe(state);
+  });
+
+  it('unfortifyUnitInState clears isFortified without changing other fields', () => {
+    const state = createNewGame(undefined, 'unfortify-test', 'small');
+    const playerId = state.currentPlayer;
+    const unitId = state.civilizations[playerId].units[0];
+    state.units[unitId] = { ...state.units[unitId], isFortified: true };
+
+    const next = unfortifyUnitInState(state, playerId, unitId);
+
+    expect(next.units[unitId].isFortified).toBeUndefined();
+    expect(next.units[unitId].id).toBe(unitId);
+  });
+
+  it('unfortifyUnitInState returns the same state object for an enemy unit', () => {
+    const state = createNewGame(undefined, 'unfortify-enemy-test', 'small');
+    const playerId = state.currentPlayer;
+    const enemyUnitId = state.civilizations['ai-1'].units[0];
+
+    const next = unfortifyUnitInState(state, playerId, enemyUnitId);
+
+    expect(next).toBe(state);
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -536,3 +536,170 @@ describe('renderSelectedUnitInfo - veterancy', () => {
     expect(text).toContain('25 XP to Elite');
   });
 });
+
+describe('renderSelectedUnitInfo - found city button', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  function makeSettlerState(cityOverrides: Record<string, unknown> = {}): GameState {
+    return {
+      turn: 1, era: 1, currentPlayer: 'player', gameOver: false, winner: null,
+      map: {
+        width: 20, height: 20, wrapsHorizontally: false, rivers: [],
+        tiles: {
+          '5,5': { coord: { q: 5, r: 5 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+        },
+      },
+      units: {
+        'settler-1': { id: 'settler-1', type: 'settler', owner: 'player', position: { q: 5, r: 5 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+      },
+      cities: { ...cityOverrides },
+      civilizations: { player: { color: '#fff', techState: { completed: [] } } },
+      espionage: undefined,
+    } as unknown as GameState;
+  }
+
+  it('enables Found City button and fires callback when location is valid', () => {
+    const state = makeSettlerState();
+    const container = new MockElement('div');
+    let called = false;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'settler-1', {
+      onFoundCity: () => { called = true; },
+    });
+
+    const btn = findButtons(container).find(b => b.textContent === 'Found City');
+    expect(btn).toBeDefined();
+    btn!.click();
+    expect(called).toBe(true);
+  });
+
+  it('renders Found City as disabled and does not fire callback when too close to another city', () => {
+    // City at (5,6) is distance 1 from settler at (5,5) — less than MIN_CITY_CENTER_DISTANCE (4)
+    const state = makeSettlerState({
+      'city-1': { id: 'city-1', name: 'Rome', owner: 'player', position: { q: 5, r: 6 } },
+    });
+    const container = new MockElement('div');
+    let called = false;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'settler-1', {
+      onFoundCity: () => { called = true; },
+    });
+
+    const btn = findButtons(container).find(b => b.textContent === 'Found City');
+    expect(btn).toBeDefined(); // button still renders — visible but unavailable
+    btn!.click();
+    expect(called).toBe(false); // no click handler on disabled button
+  });
+
+  it('renders Found City as disabled and does not fire callback on invalid terrain (no tile)', () => {
+    // No tile at settler position → invalid terrain
+    const state = makeSettlerState();
+    state.map.tiles = {}; // remove all tiles
+    const container = new MockElement('div');
+    let called = false;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'settler-1', {
+      onFoundCity: () => { called = true; },
+    });
+
+    const btn = findButtons(container).find(b => b.textContent === 'Found City');
+    expect(btn).toBeDefined();
+    btn!.click();
+    expect(called).toBe(false);
+  });
+});
+
+describe('renderSelectedUnitInfo - fortify button', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  function makeWarriorState(unitOverrides: Record<string, unknown> = {}): GameState {
+    return {
+      turn: 1, era: 1, currentPlayer: 'player', gameOver: false, winner: null,
+      map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+      units: {
+        'warrior-1': { id: 'warrior-1', type: 'warrior', owner: 'player', position: { q: 0, r: 0 }, health: 100, experience: 0, movementPointsLeft: 2, hasMoved: false, hasActed: false, isResting: false, ...unitOverrides },
+      },
+      cities: {},
+      civilizations: { player: { color: '#fff', techState: { completed: [] } } },
+    } as unknown as GameState;
+  }
+
+  it('renders Fortify button for a military unit that has not yet acted', () => {
+    const state = makeWarriorState();
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: () => {},
+    });
+
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns).toContain('Fortify');
+    expect(btns).not.toContain('Unfortify');
+  });
+
+  it('renders Unfortify button when unit is already fortified', () => {
+    const state = makeWarriorState({ isFortified: true });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: () => {},
+    });
+
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns).toContain('Unfortify');
+    expect(btns).not.toContain('Fortify');
+  });
+
+  it('does not render Fortify button for a non-combat unit (settler)', () => {
+    const state = makeWarriorState({ type: 'settler' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: () => {},
+    });
+
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns).not.toContain('Fortify');
+    expect(btns).not.toContain('Unfortify');
+  });
+
+  it('hides Fortify button when unit has already acted this turn', () => {
+    const state = makeWarriorState({ hasActed: true });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: () => {},
+    });
+
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns).not.toContain('Fortify');
+  });
+
+  it('fires onFortify with the unit id when Fortify is clicked', () => {
+    const state = makeWarriorState();
+    const container = new MockElement('div');
+    let fortifiedId: string | null = null;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: (uid) => { fortifiedId = uid; },
+    });
+
+    findButtons(container).find(b => b.textContent === 'Fortify')?.click();
+    expect(fortifiedId).toBe('warrior-1');
+  });
+
+  it('fires onFortify with the unit id when Unfortify is clicked', () => {
+    const state = makeWarriorState({ isFortified: true });
+    const container = new MockElement('div');
+    let fortifiedId: string | null = null;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'warrior-1', {
+      onFortify: (uid) => { fortifiedId = uid; },
+    });
+
+    findButtons(container).find(b => b.textContent === 'Unfortify')?.click();
+    expect(fortifiedId).toBe('warrior-1');
+  });
+});


### PR DESCRIPTION
## Summary

- **Closes #140** — `Found City` button is now disabled (greyed out, `cursor: not-allowed`, tooltip explaining the blocker) when `canFoundCityAt` returns false. Previously the button was always enabled and only produced an error after the player clicked it.
- **Closes #150** — Military units (any unit with `strength > 0`) can Fortify for a +25% defense bonus. Fortified units are excluded from the end-of-turn unmoved-unit cycling queue. Moving a unit auto-unfortifies it. A gold `F` badge renders in the unit token's top-left corner.

## What changed

| File | Change |
|------|--------|
| `src/core/types.ts` | Added `isFortified?: boolean` to `Unit` |
| `src/systems/unit-system.ts` | `moveUnit` clears `isFortified`; `getUnmovedUnits` excludes fortified units |
| `src/systems/unit-lifecycle-system.ts` | Added `fortifyUnitInState` / `unfortifyUnitInState` |
| `src/systems/combat-system.ts` | `defender.isFortified` multiplies `defStrength × 1.25` |
| `src/ui/selected-unit-info.ts` | Disabled Found City button (with tooltip); Fortify/Unfortify button for combat units |
| `src/renderer/unit-renderer.ts` | Gold `F` badge at top-left of fortified unit tokens |
| `src/main.ts` | Wired `onFortify` callback; imports `fortifyUnitInState` / `unfortifyUnitInState` |

## Test plan

- [ ] Select a settler already next to a city — "Found City" button appears grey with a tooltip explaining the blocker, clicking does nothing
- [ ] Move settler 4+ hexes away — "Found City" button becomes active and clickable
- [ ] On invalid terrain (ocean/coast/mountain) the button also renders as disabled
- [ ] Select a warrior, click "Fortify" — gold `F` badge appears on the unit token, notification shows "+25% defense", unit is no longer cycled by end-of-turn
- [ ] Attack a fortified warrior with an equal warrior — fortified unit survives longer
- [ ] Click "Unfortify" — badge disappears, unit returns to normal cycling
- [ ] Move a fortified unit — badge disappears automatically (moving breaks fortification)
- [ ] End a turn with fortified units — they do not appear in the "unmoved units" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)