### PR TITLE
feat(#190 #192 #193): button design system, pause menu, tech tree DAG overhaul

### DIFF
--- a/.claude/hooks/check-src-edit.sh
+++ b/.claude/hooks/check-src-edit.sh
@@ -68,6 +68,54 @@ if grep -nE 'innerHTML\s*=\s*`[^`]*\$\{' "$file_path" >/dev/null; then
 $lines"
 fi
 
+# --- bare createElement('button') without style in src/ui/ ---
+# Exceptions: ui-kit.ts (implementation) and primary-action-bar.ts (custom icon-bar design)
+case "$file_path" in
+  */src/ui/ui-kit.ts|*/src/ui/primary-action-bar.ts)
+    : # exempt
+    ;;
+  */src/ui/*.ts)
+    # For each line that creates a button, check that within the next 5 lines
+    # there is a style assignment or a createGameButton call on the same button variable.
+    # We use awk: when we see createElement('button'), read up to 5 subsequent lines
+    # and flag if none contains style\. or cssText or createGameButton.
+    bare_buttons="$(awk '
+      /createElement\('"'"'button'"'"'\)/ {
+        found_style = 0
+        lineno = NR
+        varname = $0
+        sub(/.*const ([a-zA-Z]+).*/, "\\1", varname)
+        # Check current line and next 5
+        buf[0] = $0
+        for (i = 1; i <= 5; i++) {
+          if ((getline line) > 0) {
+            buf[i] = line
+          } else {
+            buf[i] = ""
+          }
+        }
+        for (i = 0; i <= 5; i++) {
+          if (buf[i] ~ /style\.cssText|style\[|Object\.assign.*style|createGameButton/) {
+            found_style = 1
+            break
+          }
+        }
+        if (!found_style) {
+          print lineno ": " buf[0]
+        }
+        # Replay buffered lines (they may contain their own createElement calls)
+        for (i = 1; i <= 5; i++) {
+          if (buf[i] != "") print buf[i] | "cat >&2"
+        }
+      }
+    ' "$file_path" 2>/dev/null)"
+    if [ -n "$bare_buttons" ]; then
+      append "Bare createElement('button') without adjacent style assignment in src/ui/ — use createGameButton() from src/ui/ui-kit.ts (see .claude/rules/ui-panels.md#no-bare-buttons):
+$bare_buttons"
+    fi
+    ;;
+esac
+
 # --- dead return field (heuristic: literal 0/null followed by 'computed' comment) ---
 if grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" >/dev/null; then
   lines="$(grep -nE ':\s*(0|null|\[\])\s*,\s*//\s*calculated' "$file_path" | head -5)"

--- a/.claude/hooks/check-src-edit.sh
+++ b/.claude/hooks/check-src-edit.sh
@@ -75,43 +75,21 @@ case "$file_path" in
     : # exempt
     ;;
   */src/ui/*.ts)
-    # For each line that creates a button, check that within the next 5 lines
-    # there is a style assignment or a createGameButton call on the same button variable.
-    # We use awk: when we see createElement('button'), read up to 5 subsequent lines
-    # and flag if none contains style\. or cssText or createGameButton.
-    bare_buttons="$(awk '
-      /createElement\('"'"'button'"'"'\)/ {
-        found_style = 0
-        lineno = NR
-        varname = $0
-        sub(/.*const ([a-zA-Z]+).*/, "\\1", varname)
-        # Check current line and next 5
-        buf[0] = $0
-        for (i = 1; i <= 5; i++) {
-          if ((getline line) > 0) {
-            buf[i] = line
-          } else {
-            buf[i] = ""
-          }
-        }
-        for (i = 0; i <= 5; i++) {
-          if (buf[i] ~ /style\.cssText|style\[|Object\.assign.*style|createGameButton/) {
-            found_style = 1
-            break
-          }
-        }
-        if (!found_style) {
-          print lineno ": " buf[0]
-        }
-        # Replay buffered lines (they may contain their own createElement calls)
-        for (i = 1; i <= 5; i++) {
-          if (buf[i] != "") print buf[i] | "cat >&2"
-        }
-      }
-    ' "$file_path" 2>/dev/null)"
-    if [ -n "$bare_buttons" ]; then
+    # For each line that contains createElement('button'), check lines N..N+8
+    # for any style assignment (any .style. access, cssText, Object.assign with style,
+    # or a createGameButton call). If none found, flag the button as bare/unstyled.
+    bare_lines=""
+    while IFS= read -r line_num; do
+      block="$(sed -n "${line_num},$((line_num + 8))p" "$file_path" 2>/dev/null)"
+      if ! printf '%s' "$block" | grep -qE '\.style\.|cssText|createGameButton|Object\.assign'; then
+        src_line="$(sed -n "${line_num}p" "$file_path" 2>/dev/null)"
+        bare_lines="${bare_lines}${line_num}: ${src_line}
+"
+      fi
+    done < <(grep -nE "createElement\('button'\)" "$file_path" 2>/dev/null | cut -d: -f1)
+    if [ -n "$bare_lines" ]; then
       append "Bare createElement('button') without adjacent style assignment in src/ui/ — use createGameButton() from src/ui/ui-kit.ts (see .claude/rules/ui-panels.md#no-bare-buttons):
-$bare_buttons"
+${bare_lines}"
     fi
     ;;
 esac

--- a/.claude/rules/ui-panels.md
+++ b/.claude/rules/ui-panels.md
@@ -59,6 +59,13 @@ paths:
 - Recommendation sections may be selective. Browse/action sections may not become inaccessible because of recommendation ranking.
 - Persistent intel UI must render from viewer-safe snapshots, not from the richer source object if the player did not earn that detail.
 
+## No Bare Buttons
+- Every `document.createElement('button')` in `src/ui/` MUST receive a `style.cssText` or `Object.assign(button.style, {...})` that includes both `background` and `color` — or be constructed via `createGameButton()` from `src/ui/ui-kit.ts`.
+- `createGameButton(label, variant)` is the preferred path. Variants: `'primary'` (gold CTA), `'secondary'` (dark outlined), `'ghost'` (cancel/back), `'danger'` (destructive), `'close'` (panel ✕).
+- The only exceptions are `ui-kit.ts` itself and `primary-action-bar.ts` (which has a custom icon+label icon-bar design).
+- The `check-src-edit` hook flags new `createElement('button')` calls in `src/ui/` that lack adjacent style assignment — treat hook feedback as a required fix before continuing.
+- Buttons must set `min-height: 44px` for touch targets.
+
 ## Cities[0] Is Never The Answer (Extended)
 The "cycle through all cities" rule applies to EVERY surface that gives city-scoped advice, not just the main city panel. This includes:
 - Advisor triggers (`src/ui/advisor-system.ts`)

--- a/.claude/skills/button-styling.md
+++ b/.claude/skills/button-styling.md
@@ -1,0 +1,113 @@
+---
+name: button-styling
+description: Use when creating or editing any button in src/ui/. Enforces the createGameButton design system so all buttons have consistent visual styling and 44px touch targets.
+paths:
+  - "src/ui/**"
+---
+
+# Button Styling — Conquestoria Design System
+
+Every button in `src/ui/` must use `createGameButton()` from `src/ui/ui-kit.ts`. Do not call `document.createElement('button')` directly in UI files except inside `ui-kit.ts` itself or `primary-action-bar.ts` (which has a custom icon+label design).
+
+## Import
+
+```ts
+import { createGameButton } from '@/ui/ui-kit';
+```
+
+## API
+
+```ts
+createGameButton(
+  label: string,
+  variant: 'primary' | 'secondary' | 'ghost' | 'danger' | 'close',
+  options?: { disabled?: boolean; type?: 'button' | 'submit' }
+): HTMLButtonElement
+```
+
+After calling `createGameButton`, you can set `dataset.*`, `id`, and event listeners normally. Do not override `style` properties — they are set by the factory.
+
+## Variants
+
+### `'primary'` — Main CTA
+Gold background, dark bold text. For the most important action on the screen.
+
+Use for: Start Campaign, Confirm, Save, Research (tech panel), Occupy city.
+
+```ts
+const btn = createGameButton('Start Campaign', 'primary');
+btn.dataset.action = 'start-campaign';
+btn.addEventListener('click', () => callbacks.onStart());
+```
+
+### `'secondary'` — Secondary action
+Dark semi-transparent background, gold border, light text. For important but non-destructive actions that aren't the primary CTA.
+
+Use for: Choose Civilization, Open Tech Panel, Open City, Start Build, Return to Game.
+
+```ts
+const btn = createGameButton('Choose Civilization', 'secondary');
+btn.dataset.action = 'choose-civ';
+```
+
+### `'ghost'` — Cancel / Back
+Transparent background, muted border, lower-opacity text. Never the first button the player's eye lands on.
+
+Use for: Cancel, Back, any dismiss-without-committing action.
+
+```ts
+const btn = createGameButton('Cancel', 'ghost');
+```
+
+### `'danger'` — Destructive action
+Red background, white bold text. Reserve for actions that cannot be undone.
+
+Use for: Raze city, Delete unit, Discard & Start New Game, Move Anyway.
+
+```ts
+const btn = createGameButton('Raze City', 'danger');
+```
+
+### `'close'` — Panel ✕ button
+Transparent, no border, muted white. Small. For the top-right close button on panels.
+
+Use for: Panel close (✕) buttons anywhere in the game.
+
+```ts
+const close = createGameButton('✕', 'close');
+close.setAttribute('aria-label', 'Close panel');
+close.style.fontSize = '20px'; // font size override is OK for close buttons
+```
+
+## Disabled state
+
+Pass `{ disabled: true }` to get the greyed-out / non-interactive style:
+
+```ts
+const startBtn = createGameButton('Start Campaign', 'primary', { disabled: true });
+// Later, when ready:
+startBtn.disabled = false;
+startBtn.style.opacity = '1';
+startBtn.style.cursor = 'pointer';
+startBtn.style.pointerEvents = '';
+```
+
+Or create enabled and call `syncButtonDisabledState(btn, isDisabled)` if you need to toggle it.
+
+## Touch target contract
+
+All variants enforce `min-height: 44px; min-width: 44px`. Do not override these — they exist for mobile touch accuracy.
+
+## Common mistakes to avoid
+
+| Mistake | Fix |
+|---------|-----|
+| `document.createElement('button')` in a UI file | Use `createGameButton` |
+| Setting `button.style.cssText` after `createGameButton` | Append individual properties instead |
+| No `background` or `color` set | createGameButton handles this — don't skip it |
+| Using `'secondary'` for a destructive action | Use `'danger'` |
+| Using `'primary'` for cancel | Use `'ghost'` |
+
+## Hook enforcement
+
+The `check-src-edit` PostToolUse hook will flag any `createElement('button')` in `src/ui/` that lacks an adjacent style assignment. Fix the violation before continuing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Civilization-building strategy game. TypeScript + Canvas 2D + Vite.
 
 Detailed rules live in `.claude/rules/` and auto-apply based on the files you edit:
 - `.claude/rules/game-systems.md` — RNG, events-vs-state, diplomacy, unit types, **immutable turn processing**, **diplomacy lifecycle**, **no dead return fields**, **spawn occupancy**
-- `.claude/rules/ui-panels.md` — hot-seat `currentPlayer`, **cities[0] is never the answer**, **privacy and discovery**, **no silent destructive UI**, **panel rerender after interaction**, XSS-safe rendering
+- `.claude/rules/ui-panels.md` — hot-seat `currentPlayer`, **cities[0] is never the answer**, **privacy and discovery**, **no silent destructive UI**, **panel rerender after interaction**, XSS-safe rendering, **no bare buttons**
 - `.claude/rules/strategy-game-mechanics.md` — combat, tech gating, victory
 - `.claude/rules/end-to-end-wiring.md` — computed-data-must-render
 - `.claude/rules/spec-fidelity.md` — spec conjunctions, gating preservation, and visible-UI contract preservation
@@ -21,6 +21,11 @@ Detailed rules live in `.claude/rules/` and auto-apply based on the files you ed
 - `.claude/rules/hooks-and-tooling.md` — hook stdin/jq contract, exit codes, and required smoke tests
 
 A PostToolUse hook (`.claude/hooks/check-src-edit.sh`) greps every Write/Edit under `src/` for known rule violations and returns feedback in the same turn.
+
+## Skills
+
+Project-level skills live in `.claude/skills/` and are invoked by the Skill tool:
+- `.claude/skills/button-styling.md` — `createGameButton()` API reference; invoke before writing any button in `src/ui/`
 
 When planning interactive UI or queue work, use `docs/superpowers/plans/README.md` as the minimum checklist for player-visible state transitions, misleading derived labels, and replayable interaction coverage.
 

--- a/docs/superpowers/specs/2026-05-10-button-design-system.md
+++ b/docs/superpowers/specs/2026-05-10-button-design-system.md
@@ -1,0 +1,131 @@
+---
+# Button Design System
+**Issues:** #190 (solo campaign styling) + systemic audit  
+**Date:** 2026-05-10
+
+---
+
+## Problem
+
+11 buttons across 6 UI files have no visual styling — they render with browser-default gray chrome on a dark game background. This is a recurring pattern: every new UI file re-invents button construction and frequently omits `background` and `color`. There is no shared primitive, no hook check, and no rule to catch new violators before they ship.
+
+**Complete list of currently broken buttons:**
+
+| File | Button | Symptom |
+|------|--------|---------|
+| `foreign-city-entry-panel.ts:26` | `cancel` | Bare browser default |
+| `foreign-city-entry-panel.ts:35` | `confirm` | Bare browser default |
+| `worker-task-warning-panel.ts:25` | `cancel` | Bare browser default |
+| `worker-task-warning-panel.ts:34` | `confirm` | Bare browser default |
+| `required-choice-panel.ts:62` | `openTechButton` | Bare browser default |
+| `required-choice-panel.ts:90` | `openCityButton` | Bare browser default |
+| `wonder-panel.ts:130` | `startBuild` | Bare browser default |
+| `campaign-setup.ts:118` | `chooseCivButton` | Bare browser default |
+| `campaign-setup.ts:318` | `cancelButton` | Bare browser default |
+| `campaign-setup.ts:327` | `startButton` | Bare browser default |
+| `civ-select.ts:19` | `createButton` helper | Missing `background`/`color` |
+
+---
+
+## Design
+
+### 1. `src/ui/ui-kit.ts` — centralized button factory
+
+Single exported function:
+
+```ts
+export function createGameButton(
+  label: string,
+  variant: ButtonVariant,
+  options?: { disabled?: boolean; type?: 'button' | 'submit' }
+): HTMLButtonElement
+```
+
+**Variants:**
+
+| Variant | Background | Text | Border | Use case |
+|---------|-----------|------|--------|----------|
+| `'primary'` | `#e8c170` | `#1f1a12` bold | none | Main CTA: Start, Confirm, Save |
+| `'secondary'` | `rgba(255,255,255,0.08)` | `#f4f1e8` | `1px solid rgba(232,193,112,0.45)` | Secondary action: Choose Civ, Open Tech, Open City, Start Build |
+| `'ghost'` | `transparent` | `rgba(244,241,232,0.7)` | `1px solid rgba(255,255,255,0.2)` | Cancel / Back |
+| `'danger'` | `#b91c1c` | `white` bold | none | Destructive: Raze, Delete, Move Anyway |
+| `'close'` | `transparent` | `rgba(255,255,255,0.6)` | none | Panel ✕ buttons |
+
+All variants enforce:
+- `min-height: 44px` (touch target)
+- `min-width: 44px`
+- `padding: 10px 16px`
+- `border-radius: 8px`
+- `cursor: pointer`
+- `font: inherit`
+- `color` explicitly set (never inherited from browser)
+
+Disabled state: `opacity: 0.45`, `cursor: not-allowed`, `pointer-events: none`.
+
+### 2. Fix all 11 broken buttons
+
+Replace bare `createElement('button')` calls in the 6 affected files with `createGameButton`. Exact variant assignments:
+
+| Button | Variant |
+|--------|---------|
+| `foreign-city-entry-panel` cancel | `'ghost'` |
+| `foreign-city-entry-panel` confirm | `'secondary'` |
+| `worker-task-warning-panel` cancel | `'ghost'` |
+| `worker-task-warning-panel` confirm | `'danger'` |
+| `required-choice-panel` openTechButton | `'secondary'` |
+| `required-choice-panel` openCityButton | `'secondary'` |
+| `wonder-panel` startBuild | `'primary'` |
+| `campaign-setup` chooseCivButton | `'secondary'` |
+| `campaign-setup` cancelButton | `'ghost'` |
+| `campaign-setup` startButton | `'primary'` (disabled until civ chosen) |
+| `civ-select` createButton helper | replace with `createGameButton(label, 'ghost')` |
+
+### 3. Migration of existing per-file helpers
+
+`game-mode-select.ts` has a private `createActionButton` — migrate it to delegate to `createGameButton`. `civ-select.ts`'s `createButton` is replaced entirely.
+
+No other well-styled buttons need to change; they are already correct and may keep their inline styles for now (they're consistent with what `createGameButton` would produce).
+
+### 4. Tests
+
+In `tests/ui/ui-kit.test.ts`:
+- Assert all 5 variants produce a button with non-empty `background` and non-empty `color`
+- Assert `minHeight` is `'44px'`
+- Assert disabled buttons have `opacity: '0.45'` and `cursor: 'not-allowed'`
+
+In each panel's test file: smoke-assert that the specific formerly-broken buttons have `style.background` set and `style.color` set (not empty string).
+
+### 5. Rule update (`.claude/rules/ui-panels.md`)
+
+Add section **"No Bare Buttons"**:
+> Every `document.createElement('button')` in `src/ui/` must receive a `style.cssText` or `Object.assign(button.style, {...})` that includes at minimum `background` and `color`. Prefer `createGameButton()` from `src/ui/ui-kit.ts`. The `check-src-edit` hook blocks edits that introduce a new bare `createElement('button')` in `src/ui/` without an adjacent style assignment.
+
+### 6. Hook extension (`.claude/hooks/check-src-edit.sh`)
+
+Add a check that runs only on `src/ui/*.ts` files:
+- Grep for lines matching `createElement\('button'\)` 
+- For each match, check that within the next 5 lines there is either `style.cssText` or `createGameButton` — if not, report a violation
+- Exception: `ui-kit.ts` itself (where the implementation lives), `primary-action-bar.ts` (intentionally custom icon+label design)
+
+### 7. Project-level skill (`.claude/skills/button-styling.md`)
+
+Documents the `createGameButton` API, lists all variants with visual descriptions and use cases, and instructs to invoke before writing any button in `src/ui/`.
+
+---
+
+## What this does NOT change
+
+- Panel layouts, colors, or overall visual design
+- Buttons that already have correct styling (city-capture, unit-delete, council, tech-panel, etc.)
+- Any game logic
+
+---
+
+## Acceptance criteria
+
+- [ ] `src/ui/ui-kit.ts` exists and exports `createGameButton`
+- [ ] All 11 listed buttons pass a visual smoke test showing non-browser-default colors
+- [ ] `yarn test` passes (unit tests + hook smoke test for the new check)
+- [ ] `yarn build` clean
+- [ ] `check-src-edit` hook blocks a test input with a bare unstyled button in `src/ui/`
+- [ ] `.claude/skills/button-styling.md` exists and is referenced in CLAUDE.md rules index

--- a/docs/superpowers/specs/2026-05-10-button-design-system.md
+++ b/docs/superpowers/specs/2026-05-10-button-design-system.md
@@ -31,7 +31,7 @@
 
 ### 1. `src/ui/ui-kit.ts` — centralized button factory
 
-Single exported function:
+Two exported functions:
 
 ```ts
 export function createGameButton(
@@ -39,7 +39,11 @@ export function createGameButton(
   variant: ButtonVariant,
   options?: { disabled?: boolean; type?: 'button' | 'submit' }
 ): HTMLButtonElement
+
+export function setButtonDisabled(btn: HTMLButtonElement, disabled: boolean): void
 ```
+
+`setButtonDisabled` applies/removes the disabled visual state (opacity, cursor, pointer-events) without replacing the element. Use it when a button's enabled state changes after creation (e.g. Start Campaign becomes enabled once a civ is selected).
 
 **Variants:**
 
@@ -82,7 +86,11 @@ Replace bare `createElement('button')` calls in the 6 affected files with `creat
 
 ### 3. Migration of existing per-file helpers
 
-`game-mode-select.ts` has a private `createActionButton` — migrate it to delegate to `createGameButton`. `civ-select.ts`'s `createButton` is replaced entirely.
+`game-mode-select.ts` has two private helpers:
+- `createActionButton` (Back button) — migrate to `createGameButton(label, 'ghost')`.
+- `createModeButton` (Solo/Hot Seat mode tiles with 96px height, two-line label+description layout) — **do NOT migrate**; this is a selection tile, not a button variant. Keep as-is with a comment `// mode-tile: intentionally not a createGameButton variant`.
+
+`civ-select.ts`'s `createButton` helper is replaced entirely with `createGameButton(label, 'ghost')`.
 
 No other well-styled buttons need to change; they are already correct and may keep their inline styles for now (they're consistent with what `createGameButton` would produce).
 
@@ -102,10 +110,18 @@ Add section **"No Bare Buttons"**:
 
 ### 6. Hook extension (`.claude/hooks/check-src-edit.sh`)
 
-Add a check that runs only on `src/ui/*.ts` files:
-- Grep for lines matching `createElement\('button'\)` 
-- For each match, check that within the next 5 lines there is either `style.cssText` or `createGameButton` — if not, report a violation
-- Exception: `ui-kit.ts` itself (where the implementation lives), `primary-action-bar.ts` (intentionally custom icon+label design)
+Add a check that runs only on `src/ui/*.ts` files (exempt: `ui-kit.ts`, `primary-action-bar.ts`):
+- For each line containing `createElement('button')`, read lines N..N+8 using `sed`.
+- If none of those lines match `\.style\.|cssText|createGameButton|Object\.assign`, flag the button.
+- This approach (bash `while read` + `sed`) is safe: no awk `getline` stream consumption, handles multiple buttons at any spacing, and matches all style-setting patterns (individual property access, cssText, Object.assign, or createGameButton).
+
+### 7. Hook smoke test additions (`tests/hooks/check-src-edit.test.sh`)
+
+Add to the existing smoke test:
+- **Block**: `src/ui/bare.ts` containing `const btn = document.createElement('button');` with no style on following lines → exit 2.
+- **Allow**: `src/ui/styled.ts` containing `createElement('button')` followed by `btn.style.background = '#e8c170'` → exit 0.
+- **Allow**: `src/ui/kit.ts` containing `createElement('button')` → exit 0 (exempt because filename matches `ui-kit.ts`... use a fixture path like `src/ui/ui-kit.ts`).
+- **Allow**: `src/ui/game-btn.ts` containing `createGameButton('label', 'primary')` → exit 0.
 
 ### 7. Project-level skill (`.claude/skills/button-styling.md`)
 

--- a/docs/superpowers/specs/2026-05-10-pause-menu.md
+++ b/docs/superpowers/specs/2026-05-10-pause-menu.md
@@ -19,7 +19,7 @@ During active play the only visible affordances are the primary action bar (Coun
 
 ### Entry point: "☰" floating button in the game shell
 
-Add a `☰` button to `createGameShell`, positioned at `right: 132px` (immediately left of the existing 🗺️ at `right: 92px`). Requires adding `onOpenMenu: () => void` to `GameShellCallbacks` and `PrimaryActionBarCallbacks`.
+Add a `☰` button to `createGameShell`, positioned at `right: 132px` (immediately left of the existing 🗺️ at `right: 92px`). Requires adding `onOpenMenu: () => void` to `GameShellCallbacks` only — **not** `PrimaryActionBarCallbacks`. The menu button is a floating button added in `createGameShell`'s body, not part of the primary action bar that `createPrimaryActionBar` manages.
 
 Button style: matches existing floating buttons (same `cssText` pattern as `btn-notif-log`, `btn-icon-legend`).
 
@@ -38,7 +38,7 @@ Button style: matches existing floating buttons (same `cssText` pattern as `btn-
 
 Panel is a centered overlay (`z-index: 55`, above all game chrome). All three buttons use `createGameButton` from `ui-kit.ts`:
 - **Return to Game**: `'secondary'` variant — closes the panel, returns to active game
-- **Save Game**: `'secondary'` variant — opens `createSavePanel(container, callbacks, 'save')` from the existing save system; when save completes or is cancelled, returns to pause menu
+- **Save Game**: `'secondary'` variant — opens `createSavePanel(container, callbacks, 'save')` from the existing save system. `onSaveToSlot` callback calls `saveGame(slotId, name, gameState)` (note signature: `slotId` first, `name` second, `state` third), shows a "Game saved" notification, then re-renders the pause menu. The pause menu is NOT removed before opening the save panel — the save panel (z-index 60) layers above the pause menu (z-index 55). When save panel closes (after save or on back), the pause menu is revealed without needing to be re-created.
 - **New Game…**: `'secondary'` variant — triggers the "Save First?" confirmation sub-flow below
 
 ### "New Game → Save First?" confirmation sub-flow
@@ -74,7 +74,7 @@ onOpenMenu: () => {
     civName: gameState.civilizations[gameState.currentPlayer].name,
     onResume: () => {},
     onSave: async (slotId, name) => {
-      await saveGame(gameState, slotId, name);
+      await saveGame(slotId, name, gameState); // note: slotId, name, state order
       showNotification('Game saved.', 'info');
     },
     onNewGame: () => showGameModeSelection(),
@@ -82,6 +82,8 @@ onOpenMenu: () => {
   });
 },
 ```
+
+**Victory panel**: The victory panel's "New Game" button continues to call `showGameModeSelection()` directly without a save-first prompt. At game-over the game is complete — saving is not meaningful. This is intentional and not a gap.
 
 No changes to the existing `startGame()`, `autoSave()`, or `showGameModeSelection()` functions.
 

--- a/docs/superpowers/specs/2026-05-10-pause-menu.md
+++ b/docs/superpowers/specs/2026-05-10-pause-menu.md
@@ -1,0 +1,112 @@
+---
+# In-Game Pause Menu
+**Issue:** #192 — Missing ability to start a new game without closing/reopening  
+**Date:** 2026-05-10
+
+---
+
+## Problem
+
+`showGameModeSelection()` is only reachable from:
+1. The startup save panel (shown at app launch)
+2. The victory panel (shown only on win)
+
+During active play the only visible affordances are the primary action bar (Council, Tech, City, Intel, Diplo, Trade, End Turn) and three floating buttons (Next Unit, Notification Log, Icon Legend). None of these provide a path to "New Game" or "Save Game" — players must close the app or browser tab to escape an in-progress game.
+
+---
+
+## Design
+
+### Entry point: "☰" floating button in the game shell
+
+Add a `☰` button to `createGameShell`, positioned at `right: 132px` (immediately left of the existing 🗺️ at `right: 92px`). Requires adding `onOpenMenu: () => void` to `GameShellCallbacks` and `PrimaryActionBarCallbacks`.
+
+Button style: matches existing floating buttons (same `cssText` pattern as `btn-notif-log`, `btn-icon-legend`).
+
+### New file: `src/ui/pause-menu-panel.ts`
+
+```
+╔══════════════════════════════╗
+║  ⏸ Paused                    ║
+║  Turn 14 · Inca Empire       ║
+╠══════════════════════════════╣
+║  [Return to Game]            ║
+║  [Save Game]                 ║
+║  [New Game…]                 ║
+╚══════════════════════════════╝
+```
+
+Panel is a centered overlay (`z-index: 55`, above all game chrome). All three buttons use `createGameButton` from `ui-kit.ts`:
+- **Return to Game**: `'secondary'` variant — closes the panel, returns to active game
+- **Save Game**: `'secondary'` variant — opens `createSavePanel(container, callbacks, 'save')` from the existing save system; when save completes or is cancelled, returns to pause menu
+- **New Game…**: `'secondary'` variant — triggers the "Save First?" confirmation sub-flow below
+
+### "New Game → Save First?" confirmation sub-flow
+
+When the player taps "New Game…" from the pause menu, replace the pause menu body with a confirmation card (do not open a new overlay):
+
+```
+╔══════════════════════════════════╗
+║  Start a new game?               ║
+║  You have unsaved progress on    ║
+║  turn 14. Save before leaving?   ║
+╠══════════════════════════════════╣
+║  [Save & Start New Game]         ║  → autosave → showGameModeSelection()
+║  [Discard & Start New Game]      ║  → showGameModeSelection() directly
+║  [Cancel]                        ║  → back to pause menu main view
+╚══════════════════════════════════╝
+```
+
+- **Save & Start New Game** (`'primary'`): calls `autoSave(gameState)` (the existing autosave path already used on turn end), awaits completion, then closes the pause panel and calls `showGameModeSelection()`.
+- **Discard & Start New Game** (`'danger'`): closes the pause panel and calls `showGameModeSelection()` directly. Text is intentionally explicit ("Discard") so players understand the consequence.
+- **Cancel** (`'ghost'`): returns to the main pause menu view (swaps body content back, no new overlay).
+
+The current-turn number and civilization name shown in the panel header come from `state.turn` and `state.civilizations[state.currentPlayer].name`.
+
+### Wiring in `main.ts`
+
+Add `onOpenMenu` callback to the `createGameShell` call:
+
+```ts
+onOpenMenu: () => {
+  showPauseMenu(uiLayer, {
+    turn: gameState.turn,
+    civName: gameState.civilizations[gameState.currentPlayer].name,
+    onResume: () => {},
+    onSave: async (slotId, name) => {
+      await saveGame(gameState, slotId, name);
+      showNotification('Game saved.', 'info');
+    },
+    onNewGame: () => showGameModeSelection(),
+    autoSave: () => autoSave(gameState),
+  });
+},
+```
+
+No changes to the existing `startGame()`, `autoSave()`, or `showGameModeSelection()` functions.
+
+### Tests
+
+`tests/ui/pause-menu-panel.test.ts`:
+- Renders with correct turn number and civ name in header
+- "Return to Game" calls `onResume` and removes panel
+- "New Game…" swaps to the confirmation sub-view
+- "Save & Start New Game" calls `autoSave` then `onNewGame`
+- "Discard & Start New Game" calls `onNewGame` without `autoSave`
+- "Cancel" (in sub-view) returns to the main pause view without calling `onNewGame`
+- All buttons pass `createGameButton` styling contract (non-empty background/color)
+
+---
+
+## Acceptance criteria
+
+- [ ] `☰` button visible in the game shell during active play on both desktop and web
+- [ ] Pause menu opens, shows turn number and civ name
+- [ ] "Return to Game" dismisses the menu
+- [ ] "Save Game" opens save-to-slot flow and returns to pause menu on completion/cancel
+- [ ] "New Game…" shows the save-first confirmation
+- [ ] "Save & Start New Game" autosaves then navigates to game-mode-select
+- [ ] "Discard & Start New Game" navigates to game-mode-select without saving
+- [ ] "Cancel" in confirmation returns to pause menu main view
+- [ ] All buttons styled via `createGameButton` (no browser-default chrome)
+- [ ] `yarn test` and `yarn build` both clean

--- a/docs/superpowers/specs/2026-05-10-tech-tree-overhaul.md
+++ b/docs/superpowers/specs/2026-05-10-tech-tree-overhaul.md
@@ -19,9 +19,11 @@
 
 ### Phase 1 — Fix wrapping bug (Bug A)
 
-**Change**: In `createTechPanel`, the `body` container currently has `flex-wrap:wrap`. Remove `flex-wrap` from `body`. Set `mapWrap` to `overflow-x:auto` with the inner grid set to `min-width:max-content` so it scrolls horizontally rather than reflowing.
+**Scope**: Fix the inner era-grid only; leave `body`'s flex layout intact (it holds both `mapWrap` and the `inspector` side panel — removing flex-wrap from `body` would break inspector layout on narrow screens). Phase 3 replaces the whole structure anyway.
 
-This is a pure layout fix; no logic changes. Edge geometry recalculation already fires via `requestAnimationFrame` and will produce correct curves once reflow is prevented.
+**Change**: In `createTechPanel`'s `renderTree()`, the inner era-columns grid has `grid-auto-flow:column; grid-auto-columns:minmax(210px, max-content)`. Add `min-width:max-content` to this grid element and ensure `mapWrap` has `overflow-x:auto`. This allows the era columns to overflow horizontally and scroll rather than wrapping to a second row.
+
+This is a pure CSS change; no logic changes. Edge geometry recalculation already fires via `requestAnimationFrame` and produces correct curves once reflow is prevented.
 
 ### Phase 2 — Fix era visibility in focus mode (Bug B)
 
@@ -47,6 +49,8 @@ const visibleInFocus = (
 
 Era cap for focus zoom: `currentPlayerEra + 1`. Players in Era 1 see Era 1 (available + completed) and Era 2 (the preview layer). This gives forward-looking context without exposing unreachable content.
 
+The `isFocusNeighbor` path is intentionally uncapped — a tech that is a direct neighbor of the selected tech is always shown regardless of its era. This allows the selected-path highlight to draw a complete picture of a tech's immediate context even when its successors span era boundaries.
+
 The `'known'` and `'all'` zoom levels remain unchanged — players who want to see the full tree can switch to those.
 
 **Test**: A fresh tech state (no completed techs, no current research) in focus zoom must not include any node with `era > 2`.
@@ -59,18 +63,27 @@ This is the primary UX fix. Replace the era-column × track-row matrix with a pr
 
 Run after `buildTechProgressionView` produces `visibleNodes`:
 
-1. **Topological depth**: For each visible node, compute `depth = max(prerequisites' depths) + 1`. Root nodes (no prerequisites in the visible set) get `depth = 0`.
-2. **Track assignment**: Assign each track a fixed row index. Derive track order from `getDerivedTechTracks()` — the same stable order already used for the track list.
+1. **Topological depth**: Compute depth over the **full TECH_TREE** graph (not just visible nodes), so that visible nodes at any zoom level are placed correctly relative to the full dependency chain. For each tech in topological order: `depth = max(prerequisites' depths, default -1) + 1`. Root techs (no prerequisites) get `depth = 0`. This ensures an Era 2 tech is never placed in the same column as a true Era 1 root tech, even when some prerequisite nodes are filtered from view.
+2. **Track assignment**: Collect the set of tracks that have ≥1 visible node. Derive stable track order from `getDerivedTechTracks()` filtered to those present tracks. Assign row indices 0, 1, 2, … only to tracks with visible nodes — do not allocate rows for empty tracks.
 3. **Pixel coordinates**:
    - `x = depth * (CARD_WIDTH + CARD_GAP_H)` where `CARD_WIDTH = 200`, `CARD_GAP_H = 28`
-   - `y = trackIndex * (CARD_HEIGHT + CARD_GAP_V)` where `CARD_HEIGHT = 92`, `CARD_GAP_V = 16`
-4. **Collision resolution** (same-depth, same-track): If two nodes land at the same `(x, y)`, offset the second by `CARD_HEIGHT + CARD_GAP_V` (push it down within that track row). This handles multi-path tracks where two different prerequisites produce the same depth for a successor.
+   - `y = rowIndex * (CARD_HEIGHT + CARD_GAP_V)` where `CARD_HEIGHT = 92`, `CARD_GAP_V = 16`, and `rowIndex` is the track's assigned row
+4. **Collision resolution** (same-depth, same-track): Maintain a `slotCount: Map<string, number>` keyed by `"${depth}-${rowIndex}"`. Before placing each node, look up `slotIndex = slotCount.get(key) ?? 0`, then increment the counter. The final y is `rowIndex * (CARD_HEIGHT + CARD_GAP_V) + slotIndex * (CARD_HEIGHT + CARD_GAP_V)`. This correctly stacks 3+ colliding nodes downward, not just pairs.
 
 #### Render
 
-Replace `display:grid` with `position:relative` on the inner container. Render each tech card as `position:absolute; left:{x}px; top:{y}px`. The container's intrinsic size is `width: maxX + CARD_WIDTH; height: maxY + CARD_HEIGHT`.
+Remove the existing era-column `<section>` elements and their "Era N" header rows entirely. Replace with two sibling elements inside the tech tree wrapper:
 
-`mapWrap` scrolls both axes: `overflow:auto`. Horizontal scroll is primary; vertical scroll handles tall track lists.
+```
+techTreeWrapper (display:flex; flex-direction:row; align-items:flex-start)
+  ├── trackSidebar (width:48px; flex-shrink:0; position:relative)
+  │    └── one icon div per visible track, positioned absolutely at y = rowIndex*(CARD_HEIGHT+CARD_GAP_V)
+  └── mapWrap (flex:1; overflow:auto)
+       └── contentContainer (position:relative; width:maxX+CARD_WIDTH; height:maxY+CARD_HEIGHT)
+            └── cards (position:absolute; left:x; top:y each)
+```
+
+The `trackSidebar` height equals `contentContainer` height so icons align with cards. It does not scroll — `mapWrap` scrolls independently. Track icons always stay pinned on the left as the user scrolls right.
 
 #### Era boundary markers
 
@@ -120,7 +133,8 @@ On panel open, `mapWrap.scrollLeft` is set so the currently-researching (or most
 - **Phase 3**: All visible cards have `position.left` set; no two cards share the same `(x, y)` coordinates.
 - **Phase 3**: A tech with two prerequisites lands at `depth = max(prereqDepths) + 1`.
 - **Phase 3**: `mapWrap` does not have `flex-wrap:wrap` or equivalent (wrapping regression).
-- **Phase 3**: SVG edges connect from the right edge of a prerequisite card to the left edge of its successor card (x-ordering matches dependency direction).
+- **Phase 3**: For every prerequisite→successor pair, the prerequisite's computed depth is strictly less than the successor's computed depth (data-level; no pixel assertion needed — jsdom returns zero from getBoundingClientRect).
+- **Phase 3**: Tracks with no visible nodes are not assigned rows — the rendered row count equals the number of tracks that have ≥1 visible node.
 
 `tests/systems/tech-progression.test.ts` addition:
 - `buildTechProgressionView` in focus zoom with empty tech state returns no node with `era > 2`.

--- a/docs/superpowers/specs/2026-05-10-tech-tree-overhaul.md
+++ b/docs/superpowers/specs/2026-05-10-tech-tree-overhaul.md
@@ -1,0 +1,141 @@
+---
+# Tech Tree UI/UX Overhaul
+**Issue:** #193 — Tech tree laid out like a grid, shows future eras, lines wrap weird  
+**Date:** 2026-05-10
+
+---
+
+## Problems (three bugs, one root cause)
+
+**Bug A — Lines wrap weird**: `mapWrap`'s parent uses `flex-wrap:wrap`, so era columns reflow to a second row on narrower viewports. SVG bezier curves are calculated from DOM bounding rects post-layout, so a dependency line from Era 2 (top row, right) → Era 3 (second row, left) draws backwards or diagonally downward.
+
+**Bug B — Shows future eras in Era 1**: `visibleInFocus` marks a node visible if `revealed = true`, which happens when all prerequisites are in `completedOrPlannedOrAvailable`. Since every Era 1 starter has no prerequisites, they're immediately in `queueableIds`. Their Era 2 successors therefore get `revealed = true` from turn 1, and subsequent eras cascade similarly. Players see Era 4–5 nodes they cannot reach for many turns.
+
+**Bug C — "Still laid out like a grid"**: Nodes are arranged in an era-column × track-row matrix. The visual position of a node carries no information about its prerequisite relationships — two nodes in the same era column may have zero dependency on each other, yet appear adjacent. Players must read the connector lines to understand dependencies rather than reading spatial position.
+
+---
+
+## Design
+
+### Phase 1 — Fix wrapping bug (Bug A)
+
+**Change**: In `createTechPanel`, the `body` container currently has `flex-wrap:wrap`. Remove `flex-wrap` from `body`. Set `mapWrap` to `overflow-x:auto` with the inner grid set to `min-width:max-content` so it scrolls horizontally rather than reflowing.
+
+This is a pure layout fix; no logic changes. Edge geometry recalculation already fires via `requestAnimationFrame` and will produce correct curves once reflow is prevented.
+
+### Phase 2 — Fix era visibility in focus mode (Bug B)
+
+**Change in `buildTechProgressionView`**: Compute:
+
+```ts
+const currentPlayerEra = Math.max(
+  1,
+  ...state.completed.map(id => TECH_TREE.find(t => t.id === id)?.era ?? 1),
+  state.currentResearch ? (TECH_TREE.find(t => t.id === state.currentResearch)?.era ?? 1) : 1,
+);
+```
+
+In the `visibleInFocus` assignment, add an era cap:
+
+```ts
+const visibleInFocus = (
+  nodeState !== 'locked'
+  || isFocusNeighbor
+  || (revealed && tech.era <= currentPlayerEra + 1)
+);
+```
+
+Era cap for focus zoom: `currentPlayerEra + 1`. Players in Era 1 see Era 1 (available + completed) and Era 2 (the preview layer). This gives forward-looking context without exposing unreachable content.
+
+The `'known'` and `'all'` zoom levels remain unchanged — players who want to see the full tree can switch to those.
+
+**Test**: A fresh tech state (no completed techs, no current research) in focus zoom must not include any node with `era > 2`.
+
+### Phase 3 — Dependency-graph layout overhaul (Bug C)
+
+This is the primary UX fix. Replace the era-column × track-row matrix with a proper directed-acyclic-graph layout where **horizontal position = prerequisite depth** and **vertical position = track**.
+
+#### Layout algorithm
+
+Run after `buildTechProgressionView` produces `visibleNodes`:
+
+1. **Topological depth**: For each visible node, compute `depth = max(prerequisites' depths) + 1`. Root nodes (no prerequisites in the visible set) get `depth = 0`.
+2. **Track assignment**: Assign each track a fixed row index. Derive track order from `getDerivedTechTracks()` — the same stable order already used for the track list.
+3. **Pixel coordinates**:
+   - `x = depth * (CARD_WIDTH + CARD_GAP_H)` where `CARD_WIDTH = 200`, `CARD_GAP_H = 28`
+   - `y = trackIndex * (CARD_HEIGHT + CARD_GAP_V)` where `CARD_HEIGHT = 92`, `CARD_GAP_V = 16`
+4. **Collision resolution** (same-depth, same-track): If two nodes land at the same `(x, y)`, offset the second by `CARD_HEIGHT + CARD_GAP_V` (push it down within that track row). This handles multi-path tracks where two different prerequisites produce the same depth for a successor.
+
+#### Render
+
+Replace `display:grid` with `position:relative` on the inner container. Render each tech card as `position:absolute; left:{x}px; top:{y}px`. The container's intrinsic size is `width: maxX + CARD_WIDTH; height: maxY + CARD_HEIGHT`.
+
+`mapWrap` scrolls both axes: `overflow:auto`. Horizontal scroll is primary; vertical scroll handles tall track lists.
+
+#### Era boundary markers
+
+After positioning all cards, compute the min `x` coordinate for each era. Draw faint vertical lines (`position:absolute; width:1px; background:rgba(255,255,255,0.1)`) at each era boundary. Label the line with a small "Era N" pill at the top. These are informational overlays — they do not affect layout.
+
+#### Track headers (left sidebar)
+
+Add a fixed-width left strip (`width: 48px`, `position:sticky; left:0; z-index:2`) inside `mapWrap` that lists track icons down the Y axis, one icon per track row. The strip scrolls vertically with the content but stays pinned horizontally so track context is always visible.
+
+#### Visual hierarchy of node states
+
+| State | Opacity | Border | Additional treatment |
+|-------|---------|--------|----------------------|
+| `completed` | 1.0 | green `#6b9b4b` | Subtle checkmark overlay |
+| `current` | 1.0 | gold `#e8c170` pulsing | Progress bar inside card |
+| `queued` | 1.0 | blue `rgba(100,170,255,0.6)` | Queue position badge |
+| `available` | 1.0 | white `rgba(255,255,255,0.4)` | Slight glow (box-shadow) |
+| `next-layer` | 0.75 | amber `rgba(232,193,112,0.3)` | — |
+| `locked` (era ≤ current+1) | 0.45 | none | — |
+| `locked` (era > current+1) | *not shown in focus* | — | Hidden in focus zoom |
+
+The "available" frontier (all nodes with `state === 'available'`) is where the player's decision lies. These nodes are at full opacity with a subtle glow, naturally forming a vertical band across the visible tree at the current research frontier.
+
+#### Selected-path highlighting
+
+Clicking a tech card highlights its full prerequisite chain (all ancestor nodes) and its first successor chain (direct children with `state === 'next-layer'` or `available`) in a blue overlay color (`rgba(100,170,255,0.18)` background, `#64aaff` edge color). The SVG bezier edges for the selected path use `stroke-width:3` vs `1.5` for non-selected. Existing behavior is preserved; only the visual clarity improves.
+
+#### Scroll behavior on open
+
+On panel open, `mapWrap.scrollLeft` is set so the currently-researching (or most recently completed) tech is horizontally centered in the viewport. This ensures the player's current position in the tree is immediately visible without manual scrolling.
+
+#### What does NOT change
+
+- `buildTechProgressionView` data model (only `visibleInFocus` changes per Phase 2)
+- The queue section, inspector panel, and zoom controls above the tree
+- The "Focus / Known tree / All techs" zoom toggle buttons
+- Tech card content (name, status label, ETA, unlock text)
+- `TechProgressionNode` type shape
+
+---
+
+## Tests
+
+`tests/ui/tech-panel.test.ts` additions:
+- **Phase 2**: Fresh tech state in focus zoom has zero nodes with `era > 2`.
+- **Phase 2**: After completing an Era 2 tech, focus zoom allows nodes with `era <= 3`.
+- **Phase 3**: All visible cards have `position.left` set; no two cards share the same `(x, y)` coordinates.
+- **Phase 3**: A tech with two prerequisites lands at `depth = max(prereqDepths) + 1`.
+- **Phase 3**: `mapWrap` does not have `flex-wrap:wrap` or equivalent (wrapping regression).
+- **Phase 3**: SVG edges connect from the right edge of a prerequisite card to the left edge of its successor card (x-ordering matches dependency direction).
+
+`tests/systems/tech-progression.test.ts` addition:
+- `buildTechProgressionView` in focus zoom with empty tech state returns no node with `era > 2`.
+
+---
+
+## Acceptance criteria
+
+- [ ] Phase 1: No SVG lines draw backwards or diagonally downward when the panel is narrower than full-width
+- [ ] Phase 2: A new game in focus zoom shows Era 1 + Era 2 only; Era 3–5 nodes are absent
+- [ ] Phase 3: Tech cards are positioned by prerequisite depth; prerequisites are always to the left of their successors
+- [ ] Phase 3: Era boundaries appear as labeled vertical dividers
+- [ ] Phase 3: Track icons are visible in a left sidebar that stays pinned while scrolling horizontally
+- [ ] Phase 3: Available-frontier nodes have a visible glow distinguishing them from completed and locked nodes
+- [ ] Phase 3: Panel opens with the current research tech horizontally centered
+- [ ] Phase 3: Selected tech highlights its full ancestor + immediate successor chains
+- [ ] All existing tech-panel tests pass
+- [ ] `yarn test` and `yarn build` clean

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,6 +131,7 @@ import { initializeDesktopMenu } from '@/platform/desktop-menu';
 import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
 import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
+import { showPauseMenu } from '@/ui/pause-menu-panel';
 
 // --- App State ---
 let gameState: GameState;
@@ -199,6 +200,19 @@ function createUI(): void {
     onNextUnit: () => selectNextUnit(),
     onOpenNotificationLog: () => toggleNotificationLog(),
     onToggleIconLegend: () => toggleIconLegend(),
+    onOpenMenu: () => {
+      showPauseMenu(uiLayer, {
+        turn: gameState.turn,
+        civName: gameState.civilizations[gameState.currentPlayer].name,
+        onResume: () => {},
+        onSave: async (slotId, name) => {
+          await saveGame(slotId, name, gameState);
+          showNotification('Game saved.', 'info');
+        },
+        onNewGame: () => showGameModeSelection(),
+        autoSave: () => autoSave(gameState),
+      });
+    },
     iconLegendOverlay: createIconLegendOverlay(),
   });
 }

--- a/src/systems/tech-progression.ts
+++ b/src/systems/tech-progression.ts
@@ -166,6 +166,12 @@ export function buildTechProgressionView(
     collectPrerequisitePath(selectedTechId, selectedPathIds);
   }
 
+  const currentPlayerEra = Math.max(
+    1,
+    ...state.completed.map(id => TECH_TREE.find(t => t.id === id)?.era ?? 1),
+    state.currentResearch ? (TECH_TREE.find(t => t.id === state.currentResearch)?.era ?? 1) : 1,
+  );
+
   for (const tech of TECH_TREE) {
     const satisfiedPrerequisiteIds = tech.prerequisites.filter(prereq => planned.has(prereq));
     const missingPrerequisiteIds = tech.prerequisites.filter(prereq => !planned.has(prereq));
@@ -199,7 +205,11 @@ export function buildTechProgressionView(
     const isFocusChild = tech.prerequisites.includes(focusTechId ?? '') && revealed;
     const isFocusNeighbor = isFocusTech || isFocusChild || isFocusParent;
     const visibleInKnown = revealed;
-    const visibleInFocus = nodeState !== 'locked' || isFocusNeighbor || revealed;
+    const visibleInFocus = (
+      nodeState !== 'locked'
+      || isFocusNeighbor
+      || (revealed && tech.era <= currentPlayerEra + 1)
+    );
     const visibleByDefault = visibleInFocus;
     const queuedIndex = state.researchQueue.indexOf(tech.id);
     const turnsToResearch = state.currentResearch === tech.id

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -7,6 +7,7 @@ import { buildCustomCivId, customCivDefinitionsEqual, mergeCustomCivDefinitions 
 import { createDefaultSettings } from '@/core/game-state';
 import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
+import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
 
 export interface CampaignSetupCallbacks {
   onStartSolo: (config: SoloSetupConfig) => void;
@@ -115,10 +116,8 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   civSummary.textContent = 'No civilization selected yet';
   civSection.content.appendChild(civSummary);
 
-  const chooseCivButton = document.createElement('button');
-  chooseCivButton.type = 'button';
+  const chooseCivButton = createGameButton('Choose civilization', 'secondary');
   chooseCivButton.dataset.action = 'choose-civ';
-  chooseCivButton.textContent = 'Choose civilization';
   chooseCivButton.style.alignSelf = 'flex-start';
   civSection.content.appendChild(chooseCivButton);
 
@@ -249,8 +248,9 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     civSummary.textContent = selectedDefinition
       ? `Leading civilization: ${selectedDefinition.name}`
       : 'No civilization selected yet';
-    startButton.disabled = !selectedCivId || !gameTitle;
-    startButton.dataset.ready = startButton.disabled ? 'false' : 'true';
+    const isDisabled = !selectedCivId || !gameTitle;
+    setButtonDisabled(startButton, isDisabled);
+    startButton.dataset.ready = isDisabled ? 'false' : 'true';
   };
 
   const replaceSetupOverlay = (render: () => void): void => {
@@ -315,19 +315,14 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   const buttonRow = document.createElement('div');
   buttonRow.style.cssText = 'display:flex;gap:12px;';
 
-  const cancelButton = document.createElement('button');
-  cancelButton.type = 'button';
-  cancelButton.textContent = 'Cancel';
+  const cancelButton = createGameButton('Cancel', 'ghost');
   cancelButton.addEventListener('click', () => {
     panel.remove();
     callbacks.onCancel();
   });
   buttonRow.appendChild(cancelButton);
 
-  const startButton = document.createElement('button');
-  startButton.type = 'button';
-  startButton.textContent = 'Start Campaign';
-  startButton.disabled = true;
+  const startButton = createGameButton('Start Campaign', 'primary', { disabled: true });
   startButton.addEventListener('click', () => {
     if (!selectedCivId) {
       return;

--- a/src/ui/civ-select.ts
+++ b/src/ui/civ-select.ts
@@ -2,6 +2,7 @@ import type { CivDefinition } from '@/core/types';
 import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
 import { createRng } from '@/systems/map-generator';
 import { createSetupShell } from '@/ui/setup-shell';
+import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
 
 export interface CivSelectCallbacks {
   onSelect: (civId: string) => void;
@@ -14,20 +15,6 @@ export interface CivSelectOptions {
   headerText?: string;
   civDefinitions?: CivDefinition[];
   primaryActionText?: string;
-}
-
-function createButton(label: string): HTMLButtonElement {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.textContent = label;
-  button.style.minHeight = '44px';
-  button.style.minWidth = '44px';
-  button.style.padding = '10px 20px';
-  button.style.borderRadius = '8px';
-  button.style.border = '1px solid rgba(255,255,255,0.2)';
-  button.style.cursor = 'pointer';
-  button.style.fontSize = '13px';
-  return button;
 }
 
 export function createCivSelectPanel(
@@ -123,10 +110,9 @@ export function createCivSelectPanel(
         otherCard.setAttribute('aria-pressed', 'false');
       }
       card.style.borderColor = '#e8c170';
-       card.dataset.selected = 'true';
-       card.setAttribute('aria-pressed', 'true');
-      startButton.disabled = false;
-      startButton.style.opacity = '1';
+      card.dataset.selected = 'true';
+      card.setAttribute('aria-pressed', 'true');
+      setButtonDisabled(startButton, false);
     });
 
     cards.push(card);
@@ -143,10 +129,8 @@ export function createCivSelectPanel(
   shell.actions.appendChild(actionBar);
 
   if (callbacks.onCancel) {
-    const cancelButton = createButton('Back');
+    const cancelButton = createGameButton('Back', 'ghost');
     cancelButton.dataset.action = 'cancel-civ-select';
-    cancelButton.style.background = 'transparent';
-    cancelButton.style.color = '#f4f1e8';
     cancelButton.addEventListener('click', () => {
       panel.remove();
       callbacks.onCancel?.();
@@ -154,30 +138,19 @@ export function createCivSelectPanel(
     actionBar.appendChild(cancelButton);
   }
 
-  const randomButton = createButton('Surprise Me');
+  const randomButton = createGameButton('Surprise Me', 'secondary');
   randomButton.id = 'civ-random';
-  randomButton.style.background = 'rgba(255,255,255,0.1)';
-  randomButton.style.color = 'white';
   actionBar.appendChild(randomButton);
 
   if (callbacks.onCreateCustomCiv) {
-    const createCustomButton = createButton('Create Custom Civilization');
+    const createCustomButton = createGameButton('Create Custom Civilization', 'secondary');
     createCustomButton.dataset.action = 'create-custom-civ';
-    createCustomButton.style.background = 'rgba(74,144,217,0.2)';
-    createCustomButton.style.color = '#dbeafe';
     createCustomButton.addEventListener('click', () => callbacks.onCreateCustomCiv?.());
     actionBar.appendChild(createCustomButton);
   }
 
-  const startButton = createButton(primaryActionText);
+  const startButton = createGameButton(primaryActionText, 'primary', { disabled: true });
   startButton.id = 'civ-start';
-  startButton.style.background = 'rgba(232,193,112,0.3)';
-  startButton.style.border = '2px solid #e8c170';
-  startButton.style.color = '#e8c170';
-  startButton.style.fontSize = '14px';
-  startButton.style.fontWeight = 'bold';
-  startButton.style.opacity = '0.4';
-  startButton.disabled = true;
   actionBar.appendChild(startButton);
 
   randomButton.addEventListener('click', () => {
@@ -192,8 +165,7 @@ export function createCivSelectPanel(
       card.dataset.selected = selected ? 'true' : 'false';
       card.setAttribute('aria-pressed', selected ? 'true' : 'false');
     }
-    startButton.disabled = false;
-    startButton.style.opacity = '1';
+    setButtonDisabled(startButton, false);
   });
 
   startButton.addEventListener('click', () => {

--- a/src/ui/foreign-city-entry-panel.ts
+++ b/src/ui/foreign-city-entry-panel.ts
@@ -5,6 +5,8 @@ export interface ForeignCityEntryPanelConfig {
   onCancel: () => void;
 }
 
+import { createGameButton } from '@/ui/ui-kit';
+
 export function createForeignCityEntryPanel(
   container: HTMLElement,
   config: ForeignCityEntryPanelConfig,
@@ -23,8 +25,7 @@ export function createForeignCityEntryPanel(
   const buttonRow = document.createElement('div');
   buttonRow.style.cssText = 'display:flex;gap:8px;';
 
-  const cancel = document.createElement('button');
-  cancel.textContent = 'Cancel';
+  const cancel = createGameButton('Cancel', 'ghost');
   cancel.addEventListener('click', () => {
     if (closed) return;
     closed = true;
@@ -32,8 +33,7 @@ export function createForeignCityEntryPanel(
     config.onCancel();
   });
 
-  const confirm = document.createElement('button');
-  confirm.textContent = 'Continue';
+  const confirm = createGameButton('Continue', 'secondary');
   confirm.addEventListener('click', () => {
     if (closed) return;
     closed = true;

--- a/src/ui/game-mode-select.ts
+++ b/src/ui/game-mode-select.ts
@@ -1,4 +1,5 @@
 import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
+import { createGameButton } from '@/ui/ui-kit';
 
 export interface GameModeSelectCallbacks {
   initialTitle?: string;
@@ -48,21 +49,8 @@ function createModeButton(label: string, description: string, action: string): H
 }
 
 function createActionButton(label: string, action: string): HTMLButtonElement {
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.textContent = label;
+  const button = createGameButton(label, 'ghost');
   button.dataset.action = action;
-  Object.assign(button.style, {
-    minHeight: '44px',
-    minWidth: '44px',
-    padding: '10px 20px',
-    borderRadius: '8px',
-    border: '1px solid rgba(255,255,255,0.2)',
-    background: 'transparent',
-    color: '#f4f1e8',
-    cursor: 'pointer',
-    fontSize: '13px',
-  });
   return button;
 }
 

--- a/src/ui/game-shell.ts
+++ b/src/ui/game-shell.ts
@@ -4,6 +4,7 @@ export interface GameShellCallbacks extends PrimaryActionBarCallbacks {
   onNextUnit: () => void;
   onOpenNotificationLog: () => void;
   onToggleIconLegend: () => void;
+  onOpenMenu: () => void;
   iconLegendOverlay?: HTMLElement;
 }
 
@@ -47,6 +48,7 @@ export function createGameShell(container: HTMLElement, callbacks: GameShellCall
 
   shell.appendChild(createFloatingButton('btn-notif-log', '📜', 'View message log', 52, callbacks.onOpenNotificationLog));
   shell.appendChild(createFloatingButton('btn-icon-legend', '🗺️', 'Toggle icon legend', 92, callbacks.onToggleIconLegend));
+  shell.appendChild(createFloatingButton('btn-pause-menu', '☰', 'Pause menu', 132, callbacks.onOpenMenu));
 
   if (callbacks.iconLegendOverlay) {
     shell.appendChild(callbacks.iconLegendOverlay);

--- a/src/ui/pause-menu-panel.ts
+++ b/src/ui/pause-menu-panel.ts
@@ -1,0 +1,152 @@
+import { createSavePanel } from '@/ui/save-panel';
+import { createGameButton } from '@/ui/ui-kit';
+
+export interface PauseMenuCallbacks {
+  turn: number;
+  civName: string;
+  onResume: () => void;
+  onSave: (slotId: string, name: string) => Promise<void>;
+  onNewGame: () => void;
+  autoSave: () => Promise<void>;
+}
+
+function buildHeader(turn: number, civName: string): HTMLElement {
+  const header = document.createElement('div');
+  Object.assign(header.style, {
+    borderBottom: '1px solid rgba(255,255,255,0.15)',
+    paddingBottom: '12px',
+    marginBottom: '16px',
+  });
+
+  const title = document.createElement('h2');
+  title.textContent = '⏸ Paused';
+  Object.assign(title.style, { margin: '0 0 4px', fontSize: '18px', color: '#e8c170' });
+  header.appendChild(title);
+
+  const subtitle = document.createElement('p');
+  subtitle.textContent = `Turn ${turn} · ${civName}`;
+  Object.assign(subtitle.style, { margin: '0', fontSize: '13px', opacity: '0.7' });
+  header.appendChild(subtitle);
+
+  return header;
+}
+
+function buildMainView(
+  panel: HTMLElement,
+  body: HTMLElement,
+  container: HTMLElement,
+  callbacks: PauseMenuCallbacks,
+): void {
+  body.textContent = '';
+
+  const resumeBtn = createGameButton('Return to Game', 'secondary');
+  resumeBtn.style.width = '100%';
+  resumeBtn.style.marginBottom = '8px';
+  resumeBtn.addEventListener('click', () => {
+    panel.remove();
+    callbacks.onResume();
+  });
+  body.appendChild(resumeBtn);
+
+  const saveBtn = createGameButton('Save Game', 'secondary');
+  saveBtn.style.width = '100%';
+  saveBtn.style.marginBottom = '8px';
+  saveBtn.addEventListener('click', () => {
+    void createSavePanel(container, {
+      onNewGame: () => {},
+      onContinue: () => {},
+      onLoadSlot: () => {},
+      onSaveToSlot: async (slotId, name) => {
+        await callbacks.onSave(slotId, name);
+        document.getElementById('save-panel')?.remove();
+      },
+    }, 'save');
+  });
+  body.appendChild(saveBtn);
+
+  const newGameBtn = createGameButton('New Game…', 'secondary');
+  newGameBtn.style.width = '100%';
+  newGameBtn.addEventListener('click', () => buildConfirmView(panel, body, container, callbacks));
+  body.appendChild(newGameBtn);
+}
+
+function buildConfirmView(
+  panel: HTMLElement,
+  body: HTMLElement,
+  container: HTMLElement,
+  callbacks: PauseMenuCallbacks,
+): void {
+  body.textContent = '';
+
+  const question = document.createElement('p');
+  question.textContent = 'Start a new game?';
+  Object.assign(question.style, { margin: '0 0 6px', fontWeight: 'bold', fontSize: '15px' });
+  body.appendChild(question);
+
+  const detail = document.createElement('p');
+  detail.textContent = `You have unsaved progress on turn ${callbacks.turn}. Save before leaving?`;
+  Object.assign(detail.style, { margin: '0 0 16px', fontSize: '13px', opacity: '0.75' });
+  body.appendChild(detail);
+
+  const saveAndStart = createGameButton('Save & Start New Game', 'primary');
+  saveAndStart.style.width = '100%';
+  saveAndStart.style.marginBottom = '8px';
+  saveAndStart.addEventListener('click', async () => {
+    saveAndStart.disabled = true;
+    await callbacks.autoSave();
+    panel.remove();
+    callbacks.onNewGame();
+  });
+  body.appendChild(saveAndStart);
+
+  const discardAndStart = createGameButton('Discard & Start New Game', 'danger');
+  discardAndStart.style.width = '100%';
+  discardAndStart.style.marginBottom = '8px';
+  discardAndStart.addEventListener('click', () => {
+    panel.remove();
+    callbacks.onNewGame();
+  });
+  body.appendChild(discardAndStart);
+
+  const cancelBtn = createGameButton('Cancel', 'ghost');
+  cancelBtn.style.width = '100%';
+  cancelBtn.addEventListener('click', () => buildMainView(panel, body, container, callbacks));
+  body.appendChild(cancelBtn);
+}
+
+export function showPauseMenu(container: HTMLElement, callbacks: PauseMenuCallbacks): HTMLElement {
+  document.getElementById('pause-menu')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'pause-menu';
+  Object.assign(overlay.style, {
+    position: 'absolute',
+    inset: '0',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: '55',
+    background: 'rgba(0,0,0,0.5)',
+  });
+
+  const panel = document.createElement('div');
+  Object.assign(panel.style, {
+    background: 'rgba(18,18,30,0.97)',
+    border: '1px solid rgba(255,255,255,0.2)',
+    borderRadius: '12px',
+    padding: '20px',
+    width: '280px',
+    color: '#f4f1e8',
+  });
+
+  panel.appendChild(buildHeader(callbacks.turn, callbacks.civName));
+
+  const body = document.createElement('div');
+  panel.appendChild(body);
+  overlay.appendChild(panel);
+  container.appendChild(overlay);
+
+  buildMainView(overlay, body, container, callbacks);
+
+  return overlay;
+}

--- a/src/ui/required-choice-panel.ts
+++ b/src/ui/required-choice-panel.ts
@@ -1,3 +1,5 @@
+import { createGameButton } from '@/ui/ui-kit';
+
 export interface RequiredChoiceConfig {
   researchChoices: Array<{ techId: string; label: string; turns: number }>;
   cityChoices: Array<{ cityId: string; cityName: string; itemId: string; label: string; turns: number }>;
@@ -59,9 +61,7 @@ export function createRequiredChoicePanel(
     });
   }
 
-  const openTechButton = document.createElement('button');
-  openTechButton.type = 'button';
-  openTechButton.textContent = 'Open Tech Panel';
+  const openTechButton = createGameButton('Open Tech Panel', 'secondary');
   openTechButton.addEventListener('click', () => config.onOpenTech());
   researchSection.appendChild(openTechButton);
   panel.appendChild(researchSection);
@@ -87,9 +87,7 @@ export function createRequiredChoicePanel(
       buildButton.addEventListener('click', () => config.onChooseCityBuild(choice.cityId, choice.itemId));
       row.appendChild(buildButton);
 
-      const openCityButton = document.createElement('button');
-      openCityButton.type = 'button';
-      openCityButton.textContent = 'Open City';
+      const openCityButton = createGameButton('Open City', 'secondary');
       openCityButton.addEventListener('click', () => config.onOpenCity(choice.cityId));
       row.appendChild(openCityButton);
 

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -149,50 +149,27 @@ function createTechNode(
     onQueueResearch: (techId: string) => void;
   },
 ): HTMLButtonElement {
-  const item = document.createElement('button');
-  item.type = 'button';
-  item.className = 'tech-item';
-  item.dataset.techId = node.tech.id;
-  item.dataset.state = node.state;
-  item.dataset.techState = node.state;
-  item.dataset.track = node.track;
-  item.dataset.era = String(node.era);
-  if (opts.isFocused) item.dataset.focused = 'true';
-  if (opts.isSelected) item.dataset.selected = 'true';
-  if (opts.isPath) item.dataset.path = 'selected';
-
   let background = 'rgba(255,255,255,0.05)';
   let border = 'rgba(255,255,255,0.12)';
   let opacity = '0.62';
-  let cursor = 'pointer';
 
   if (node.state === 'completed') {
-    background = 'rgba(107,155,75,0.28)';
-    border = '#6b9b4b';
-    opacity = '1';
+    background = 'rgba(107,155,75,0.28)'; border = '#6b9b4b'; opacity = '1';
   } else if (node.state === 'current') {
-    background = 'rgba(232,193,112,0.22)';
-    border = '#e8c170';
-    opacity = '1';
+    background = 'rgba(232,193,112,0.22)'; border = '#e8c170'; opacity = '1';
   } else if (node.state === 'queued') {
-    background = 'rgba(100,170,255,0.18)';
-    border = 'rgba(100,170,255,0.55)';
-    opacity = '1';
+    background = 'rgba(100,170,255,0.18)'; border = 'rgba(100,170,255,0.55)'; opacity = '1';
   } else if (node.state === 'available') {
-    background = 'rgba(255,255,255,0.11)';
-    border = 'rgba(255,255,255,0.36)';
-    opacity = '1';
+    background = 'rgba(255,255,255,0.11)'; border = 'rgba(255,255,255,0.36)'; opacity = '1';
   } else if (node.state === 'next-layer') {
-    background = 'rgba(232,193,112,0.1)';
-    border = 'rgba(232,193,112,0.28)';
-    opacity = '0.88';
+    background = 'rgba(232,193,112,0.1)'; border = 'rgba(232,193,112,0.28)'; opacity = '0.88';
   }
-
   if (opts.isFocused || opts.isSelected) {
     border = '#f0d48a';
     background = node.state === 'completed' ? 'rgba(107,155,75,0.34)' : 'rgba(232,193,112,0.18)';
   }
 
+  const item = document.createElement('button');
   item.style.cssText = [
     `background:${background}`,
     `border:1px solid ${border}`,
@@ -207,6 +184,16 @@ function createTechNode(
     'text-align:left',
     'width:190px',
   ].join(';');
+  item.type = 'button';
+  item.className = 'tech-item';
+  item.dataset.techId = node.tech.id;
+  item.dataset.state = node.state;
+  item.dataset.techState = node.state;
+  item.dataset.track = node.track;
+  item.dataset.era = String(node.era);
+  if (opts.isFocused) item.dataset.focused = 'true';
+  if (opts.isSelected) item.dataset.selected = 'true';
+  if (opts.isPath) item.dataset.path = 'selected';
 
   const title = document.createElement('div');
   title.style.cssText = 'font-weight:bold;font-size:13px;line-height:1.2;';
@@ -464,10 +451,19 @@ export function createTechPanel(
   const body = document.createElement('div');
   body.style.cssText = 'display:flex;gap:14px;align-items:flex-start;flex-wrap:wrap;';
 
+  const techTreeWrapper = document.createElement('div');
+  techTreeWrapper.style.cssText = 'display:flex;flex-direction:row;align-items:flex-start;flex:1 1 620px;min-width:280px;overflow:hidden;';
+  body.appendChild(techTreeWrapper);
+
+  const trackSidebar = document.createElement('div');
+  trackSidebar.id = 'tech-track-sidebar';
+  trackSidebar.style.cssText = 'width:48px;flex-shrink:0;position:relative;overflow:hidden;';
+  techTreeWrapper.appendChild(trackSidebar);
+
   const mapWrap = document.createElement('div');
   mapWrap.dataset.layout = 'tech-dependency-map';
-  mapWrap.style.cssText = 'position:relative;flex:1 1 620px;min-width:280px;overflow:auto;padding-bottom:12px;';
-  body.appendChild(mapWrap);
+  mapWrap.style.cssText = 'flex:1;overflow:auto;position:relative;padding-bottom:12px;';
+  techTreeWrapper.appendChild(mapWrap);
 
   const inspector = document.createElement('aside');
   body.appendChild(inspector);
@@ -498,6 +494,7 @@ export function createTechPanel(
     }
   };
 
+  let hasScrolledToFocus = false;
   const renderTree = () => {
     renderZoomControls();
     mapWrap.textContent = '';
@@ -532,58 +529,124 @@ export function createTechPanel(
       path.setAttribute('fill', 'none');
       edgeLayer.appendChild(path);
     }
-    mapWrap.appendChild(edgeLayer);
+    // --- Phase 3: DAG layout ---
+    const CARD_W = 200;
+    const CARD_H = 92;
+    const GAP_H = 28;
+    const GAP_V = 16;
 
-    const grid = document.createElement('div');
-    grid.style.cssText = 'display:grid;grid-auto-flow:column;grid-auto-columns:minmax(210px, max-content);gap:14px;align-items:start;position:relative;z-index:1;';
-    mapWrap.appendChild(grid);
+    // 1. Topological depth over full TECH_TREE
+    const depthMap = new Map<string, number>();
+    const visited = new Set<string>();
+    const inProg = new Set<string>();
+    const topoOrder: string[] = [];
+    function topoVisit(techId: string): void {
+      if (visited.has(techId) || inProg.has(techId)) return;
+      inProg.add(techId);
+      const t = TECH_TREE.find(x => x.id === techId);
+      if (t) { for (const p of t.prerequisites) topoVisit(p); topoOrder.push(techId); }
+      inProg.delete(techId); visited.add(techId);
+    }
+    for (const t of TECH_TREE) topoVisit(t.id);
+    for (const techId of topoOrder) {
+      const t = TECH_TREE.find(x => x.id === techId)!;
+      const maxPrereq = t.prerequisites.length > 0 ? Math.max(...t.prerequisites.map(p => depthMap.get(p) ?? 0)) : -1;
+      depthMap.set(techId, maxPrereq + 1);
+    }
 
-    const eras = [...new Set(visibleNodes.map(node => node.era))].sort((a, b) => a - b);
-    for (const era of eras) {
-      const eraColumn = document.createElement('section');
-      eraColumn.dataset.era = String(era);
-      eraColumn.style.cssText = 'min-width:210px;';
+    // 2. Track row indices (only visible tracks)
+    const trackOrder = Object.keys(TRACK_ICONS) as Tech['track'][];
+    const visibleTracks = trackOrder.filter(tr => visibleNodes.some(n => n.track === tr));
+    const trackRow = new Map<string, number>();
+    visibleTracks.forEach((tr, i) => trackRow.set(tr, i));
 
-      const eraHeading = document.createElement('h3');
-      eraHeading.textContent = getEraLabel(era);
-      eraHeading.style.cssText = era === 5
-        ? 'font-size:11px;font-weight:bold;letter-spacing:0.06em;text-transform:uppercase;color:#e8c170;margin:0 0 8px;'
-        : 'font-size:11px;font-weight:bold;letter-spacing:0.04em;text-transform:uppercase;opacity:0.65;margin:0 0 8px;';
-      eraColumn.appendChild(eraHeading);
+    // 3. Pixel positions — sort by (depth, row) then pack downward per column
+    const sortedForLayout = [...visibleNodes].sort((a, b) => {
+      const da = depthMap.get(a.tech.id) ?? 0;
+      const db = depthMap.get(b.tech.id) ?? 0;
+      if (da !== db) return da - db;
+      return (trackRow.get(a.track) ?? 0) - (trackRow.get(b.track) ?? 0);
+    });
+    const colNextY = new Map<number, number>();
+    const nodePos = new Map<string, { x: number; y: number }>();
+    for (const node of sortedForLayout) {
+      const depth = depthMap.get(node.tech.id) ?? 0;
+      const row = trackRow.get(node.track) ?? 0;
+      const baseY = row * (CARD_H + GAP_V);
+      const prevY = colNextY.get(depth) ?? 0;
+      const y = Math.max(baseY, prevY);
+      colNextY.set(depth, y + CARD_H + GAP_V);
+      nodePos.set(node.tech.id, { x: depth * (CARD_W + GAP_H), y });
+    }
 
-      for (const track of progression.tracks) {
-        const trackNodes = visibleNodes.filter(node => node.era === era && node.track === track);
-        if (trackNodes.length === 0) {
-          continue;
-        }
+    const allPos = Array.from(nodePos.values());
+    const maxX = allPos.length > 0 ? Math.max(...allPos.map(p => p.x)) : 0;
+    const maxY = allPos.length > 0 ? Math.max(...allPos.map(p => p.y)) : 0;
+    const contentW = maxX + CARD_W;
+    const contentH = maxY + CARD_H;
 
-        const trackBlock = document.createElement('section');
-        trackBlock.className = 'tech-track';
-        trackBlock.dataset.track = track;
-        trackBlock.style.cssText = 'margin-bottom:12px;';
+    // 4. Content container
+    const contentContainer = document.createElement('div');
+    contentContainer.style.cssText = `position:relative;width:${contentW}px;height:${contentH}px;`;
+    contentContainer.appendChild(edgeLayer);
 
-        const trackHeading = document.createElement('div');
-        trackHeading.textContent = `${TRACK_ICONS[track]} ${titleCase(track)}`;
-        trackHeading.style.cssText = 'font-size:12px;color:#e0d6c8;margin:0 0 6px;';
-        trackBlock.appendChild(trackHeading);
+    // 5. Era boundary markers
+    const eraMinX = new Map<number, number>();
+    for (const node of visibleNodes) {
+      const pos = nodePos.get(node.tech.id);
+      if (!pos) continue;
+      const cur = eraMinX.get(node.era);
+      if (cur === undefined || pos.x < cur) eraMinX.set(node.era, pos.x);
+    }
+    for (const [era, x] of eraMinX) {
+      const marker = document.createElement('div');
+      marker.dataset.era = String(era);
+      marker.style.cssText = `position:absolute;left:${x > 0 ? x - GAP_H / 2 - 0.5 : 0}px;top:0;bottom:0;width:1px;background:rgba(255,255,255,0.1);z-index:0;`;
+      const label = document.createElement('div');
+      label.textContent = getEraLabel(era);
+      label.style.cssText = 'position:absolute;top:2px;left:4px;font-size:10px;white-space:nowrap;opacity:0.5;letter-spacing:0.05em;color:#e8c170;';
+      marker.appendChild(label);
+      contentContainer.appendChild(marker);
+    }
 
-        for (const node of trackNodes) {
-          trackBlock.appendChild(createTechNode(node, {
-            isFocused: progression.focusTechId === node.tech.id,
-            isSelected: selectedTechId === node.tech.id,
-            isPath: progression.selectedPathIds.has(node.tech.id),
-            onSelect: (techId) => {
-              selectedTechId = techId;
-              renderTree();
-            },
-            onQueueResearch: queueResearchAndReopen,
-          }));
-        }
+    // 6. Cards
+    for (const node of visibleNodes) {
+      const pos = nodePos.get(node.tech.id);
+      if (!pos) continue;
+      const card = createTechNode(node, {
+        isFocused: progression.focusTechId === node.tech.id,
+        isSelected: selectedTechId === node.tech.id,
+        isPath: progression.selectedPathIds.has(node.tech.id),
+        onSelect: (techId) => { selectedTechId = techId; renderTree(); },
+        onQueueResearch: queueResearchAndReopen,
+      });
+      card.style.position = 'absolute';
+      card.style.left = `${pos.x}px`;
+      card.style.top = `${pos.y}px`;
+      card.style.width = `${CARD_W}px`;
+      card.dataset.depth = String(depthMap.get(node.tech.id) ?? 0);
+      contentContainer.appendChild(card);
+    }
 
-        eraColumn.appendChild(trackBlock);
-      }
+    mapWrap.appendChild(contentContainer);
 
-      grid.appendChild(eraColumn);
+    // 7. Track sidebar icons — align with first card in each visible track
+    const trackMinY = new Map<string, number>();
+    for (const node of visibleNodes) {
+      const pos = nodePos.get(node.tech.id);
+      if (!pos) continue;
+      const cur = trackMinY.get(node.track);
+      if (cur === undefined || pos.y < cur) trackMinY.set(node.track, pos.y);
+    }
+    trackSidebar.textContent = '';
+    trackSidebar.style.height = `${contentH}px`;
+    for (const tr of visibleTracks) {
+      const minY = trackMinY.get(tr) ?? (trackRow.get(tr) ?? 0) * (CARD_H + GAP_V);
+      const icon = document.createElement('div');
+      icon.title = titleCase(tr);
+      icon.textContent = TRACK_ICONS[tr];
+      icon.style.cssText = `position:absolute;left:0;top:${minY + CARD_H / 2 - 12}px;width:48px;height:24px;display:flex;align-items:center;justify-content:center;font-size:18px;`;
+      trackSidebar.appendChild(icon);
     }
 
     const updateEdgeGeometry = () => {
@@ -627,7 +690,17 @@ export function createTechPanel(
 
     updateEdgeGeometry();
     if (typeof requestAnimationFrame === 'function') {
-      requestAnimationFrame(updateEdgeGeometry);
+      requestAnimationFrame(() => {
+        updateEdgeGeometry();
+        if (!hasScrolledToFocus) {
+          hasScrolledToFocus = true;
+          const focusPos = progression.focusTechId ? nodePos.get(progression.focusTechId) : undefined;
+          if (focusPos && mapWrap.clientWidth > 0) {
+            const target = focusPos.x - (mapWrap.clientWidth / 2 - CARD_W / 2);
+            if (target > 0) mapWrap.scrollLeft = target;
+          }
+        }
+      });
     }
 
     renderInspector(

--- a/src/ui/ui-kit.ts
+++ b/src/ui/ui-kit.ts
@@ -1,0 +1,72 @@
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'close';
+
+const VARIANT_STYLES: Record<ButtonVariant, Partial<CSSStyleDeclaration>> = {
+  primary: {
+    background: '#e8c170',
+    color: '#1f1a12',
+    fontWeight: 'bold',
+    border: 'none',
+  },
+  secondary: {
+    background: 'rgba(255,255,255,0.08)',
+    color: '#f4f1e8',
+    border: '1px solid rgba(232,193,112,0.45)',
+  },
+  ghost: {
+    background: 'transparent',
+    color: 'rgba(244,241,232,0.7)',
+    border: '1px solid rgba(255,255,255,0.2)',
+  },
+  danger: {
+    background: '#b91c1c',
+    color: 'white',
+    fontWeight: 'bold',
+    border: 'none',
+  },
+  close: {
+    background: 'transparent',
+    color: 'rgba(255,255,255,0.6)',
+    border: 'none',
+  },
+};
+
+export function createGameButton(
+  label: string,
+  variant: ButtonVariant,
+  options?: { disabled?: boolean; type?: 'button' | 'submit' },
+): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  btn.type = options?.type ?? 'button';
+
+  const variantStyle = VARIANT_STYLES[variant];
+  Object.assign(btn.style, {
+    minHeight: '44px',
+    minWidth: '44px',
+    padding: '10px 16px',
+    borderRadius: '8px',
+    cursor: 'pointer',
+    font: 'inherit',
+    opacity: '1',
+    ...variantStyle,
+  });
+
+  if (options?.disabled) {
+    setButtonDisabled(btn, true);
+  }
+
+  return btn;
+}
+
+export function setButtonDisabled(btn: HTMLButtonElement, disabled: boolean): void {
+  btn.disabled = disabled;
+  if (disabled) {
+    btn.style.opacity = '0.45';
+    btn.style.cursor = 'not-allowed';
+    btn.style.pointerEvents = 'none';
+  } else {
+    btn.style.opacity = '1';
+    btn.style.cursor = 'pointer';
+    btn.style.pointerEvents = '';
+  }
+}

--- a/src/ui/wonder-panel.ts
+++ b/src/ui/wonder-panel.ts
@@ -1,6 +1,7 @@
 import type { GameState, LegendaryWonderIntelEntry } from '@/core/types';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
+import { createGameButton } from '@/ui/ui-kit';
 
 export interface WonderPanelCallbacks {
   onStartBuild: (cityId: string, wonderId: string) => void;
@@ -127,8 +128,7 @@ function appendProjectCard(
   article.appendChild(race);
 
   if (project.phase === 'ready_to_build') {
-    const startBuild = document.createElement('button');
-    startBuild.textContent = 'Start Build';
+    const startBuild = createGameButton('Start Build', 'primary');
     startBuild.addEventListener('click', () => callbacks.onStartBuild(project.cityId, project.wonderId));
     article.appendChild(startBuild);
   }
@@ -279,8 +279,7 @@ export function createWonderPanel(
   appendProjectSection(panel, 'All ambitions in this city', 'all-city-wonders', laterProjects, state, callbacks);
   appendRivalIntelSection(panel, 'In progress elsewhere', 'rival-wonders', rivalIntel.slice(0, 3));
 
-  const close = document.createElement('button');
-  close.textContent = 'Close';
+  const close = createGameButton('Close', 'ghost');
   close.addEventListener('click', () => callbacks.onClose());
   panel.appendChild(close);
 

--- a/src/ui/worker-task-warning-panel.ts
+++ b/src/ui/worker-task-warning-panel.ts
@@ -4,6 +4,8 @@ export interface WorkerTaskWarningPanelConfig {
   onCancel: () => void;
 }
 
+import { createGameButton } from '@/ui/ui-kit';
+
 export function createWorkerTaskWarningPanel(
   container: HTMLElement,
   config: WorkerTaskWarningPanelConfig,
@@ -22,8 +24,7 @@ export function createWorkerTaskWarningPanel(
   const buttonRow = document.createElement('div');
   buttonRow.style.cssText = 'display:flex;gap:8px;';
 
-  const cancel = document.createElement('button');
-  cancel.textContent = 'Keep working';
+  const cancel = createGameButton('Keep working', 'ghost');
   cancel.addEventListener('click', () => {
     if (closed) return;
     closed = true;
@@ -31,8 +32,7 @@ export function createWorkerTaskWarningPanel(
     config.onCancel();
   });
 
-  const confirm = document.createElement('button');
-  confirm.textContent = 'Move anyway';
+  const confirm = createGameButton('Move anyway', 'danger');
   confirm.addEventListener('click', () => {
     if (closed) return;
     closed = true;

--- a/tests/hooks/check-src-edit.test.sh
+++ b/tests/hooks/check-src-edit.test.sh
@@ -92,4 +92,34 @@ if [ "$rc" != "0" ]; then
   echo "expected exit 0 for empty payload, got $rc ($out)"; fail=1
 fi
 
+# --- block: bare createElement('button') without adjacent style in src/ui/ ---
+cat > "$tmp/src/ui/bare.ts" <<'EOF'
+const btn = document.createElement('button');
+btn.textContent = 'Do it';
+btn.addEventListener('click', () => {});
+EOF
+expect_block "$tmp/src/ui/bare.ts" "bare button in src/ui"
+
+# --- allow: button with adjacent style assignment ---
+cat > "$tmp/src/ui/styled.ts" <<'EOF'
+const btn = document.createElement('button');
+btn.style.background = '#e8c170';
+btn.style.color = '#1f1a12';
+btn.textContent = 'OK';
+EOF
+expect_allow "$tmp/src/ui/styled.ts" "styled button in src/ui"
+
+# --- allow: createGameButton call (no bare createElement) ---
+cat > "$tmp/src/ui/game-btn.ts" <<'EOF'
+const btn = createGameButton('label', 'primary');
+EOF
+expect_allow "$tmp/src/ui/game-btn.ts" "createGameButton call (no createElement)"
+
+# --- allow: ui-kit.ts is exempt ---
+cat > "$tmp/src/ui/ui-kit.ts" <<'EOF'
+const btn = document.createElement('button');
+btn.textContent = label;
+EOF
+expect_allow "$tmp/src/ui/ui-kit.ts" "bare button in ui-kit.ts (exempt)"
+
 exit "$fail"

--- a/tests/systems/tech-progression.test.ts
+++ b/tests/systems/tech-progression.test.ts
@@ -120,6 +120,42 @@ describe('tech progression view model', () => {
     expect(view.selectedPathIds.has('astronomy')).toBe(false);
   });
 
+  // --- Phase 2: era cap ---
+
+  it('Phase 2: fresh focus zoom has no visible nodes beyond era 2', () => {
+    const view = buildTechProgressionView(createTechState(), { zoom: 'focus' });
+    for (const node of view.nodes) {
+      if (view.visibleIds.has(node.tech.id)) {
+        expect(node.era).toBeLessThanOrEqual(2);
+      }
+    }
+  });
+
+  it('Phase 2: completing an era-2 tech exposes era-3 revealed nodes in focus zoom', () => {
+    // bronze-working (era 2) → fortification (era 3) becomes revealed and era <= currentPlayerEra+1
+    const techState = {
+      ...createTechState(),
+      completed: ['stone-weapons', 'bronze-working'],
+    };
+    const view = buildTechProgressionView(techState, { zoom: 'focus' });
+    // currentPlayerEra = 2; era-3 revealed nodes must now be visible
+    expect(view.visibleIds.has('fortification')).toBe(true);
+    // No locked node with era > 3 should appear
+    for (const node of view.nodes) {
+      if (view.visibleIds.has(node.tech.id) && node.state === 'locked') {
+        expect(node.era).toBeLessThanOrEqual(3);
+      }
+    }
+  });
+
+  it('Phase 2: focus zoom excludes locked nodes beyond era cap even when revealed', () => {
+    // With currentPlayerEra=1, era-3 locked nodes must stay hidden in focus zoom
+    const techState = createTechState();
+    const view = buildTechProgressionView(techState, { zoom: 'focus' });
+    // fortification is era 3 and should NOT be visible with no completed techs
+    expect(view.visibleIds.has('fortification')).toBe(false);
+  });
+
   it('rejects queue reorders that would place a tech before its prerequisite', () => {
     const techState = {
       ...createTechState(),

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -456,4 +456,19 @@ describe('campaign-setup', () => {
 
     expect((container.querySelector('#civ-start') as HTMLButtonElement | null)?.textContent).toBe('Confirm Civilization');
   });
+
+  it('chooseCivButton, cancelButton, and startButton have styled background and color', () => {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    showCampaignSetup(container, { onStartSolo: vi.fn(), onCancel: vi.fn() });
+
+    const chooseCiv = container.querySelector<HTMLButtonElement>('[data-action="choose-civ"]')!;
+    const cancel = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Cancel') as HTMLButtonElement;
+    const start = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Start Campaign') as HTMLButtonElement;
+
+    for (const btn of [chooseCiv, cancel, start]) {
+      expect(btn.style.background, `${btn.textContent} background`).not.toBe('');
+      expect(btn.style.color, `${btn.textContent} color`).not.toBe('');
+    }
+  });
 });

--- a/tests/ui/foreign-city-entry-panel.test.ts
+++ b/tests/ui/foreign-city-entry-panel.test.ts
@@ -64,4 +64,15 @@ describe('foreign-city-entry-panel', () => {
     expect(onCancel).toHaveBeenCalledTimes(1);
     expect(document.querySelector('#foreign-city-entry-panel')).toBeNull();
   });
+
+  it('cancel and confirm buttons have styled background and color (not browser-default)', () => {
+    const panel = createForeignCityEntryPanel(document.body, {
+      cityName: 'Athens', defenderName: 'Greece', onConfirm: vi.fn(), onCancel: vi.fn(),
+    });
+    const buttons = Array.from(panel.querySelectorAll('button')) as HTMLButtonElement[];
+    for (const btn of buttons) {
+      expect(btn.style.background, `${btn.textContent} background`).not.toBe('');
+      expect(btn.style.color, `${btn.textContent} color`).not.toBe('');
+    }
+  });
 });

--- a/tests/ui/game-shell.test.ts
+++ b/tests/ui/game-shell.test.ts
@@ -20,6 +20,7 @@ describe('game-shell', () => {
       onNextUnit: () => {},
       onOpenNotificationLog: () => {},
       onToggleIconLegend: () => {},
+      onOpenMenu: () => {},
     });
 
     const shell = createGameShell(document.body, {
@@ -33,6 +34,7 @@ describe('game-shell', () => {
       onNextUnit: () => {},
       onOpenNotificationLog: () => {},
       onToggleIconLegend: () => {},
+      onOpenMenu: () => {},
     });
 
     expect(document.querySelectorAll('#bottom-bar')).toHaveLength(1);

--- a/tests/ui/pause-menu-panel.test.ts
+++ b/tests/ui/pause-menu-panel.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { showPauseMenu } from '@/ui/pause-menu-panel';
+
+function makeCallbacks(overrides: Partial<Parameters<typeof showPauseMenu>[1]> = {}): Parameters<typeof showPauseMenu>[1] {
+  return {
+    turn: 14,
+    civName: 'Inca Empire',
+    onResume: vi.fn(),
+    onSave: vi.fn(async () => {}),
+    onNewGame: vi.fn(),
+    autoSave: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
+function clickButton(label: string): void {
+  const btn = Array.from(document.querySelectorAll('button')).find(b => b.textContent === label) as HTMLButtonElement | undefined;
+  if (!btn) throw new Error(`No button found with text "${label}"`);
+  btn.click();
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('pause-menu-panel', () => {
+  it('renders with correct turn number and civ name in header', () => {
+    showPauseMenu(document.body, makeCallbacks());
+    expect(document.body.textContent).toContain('Turn 14');
+    expect(document.body.textContent).toContain('Inca Empire');
+  });
+
+  it('"Return to Game" calls onResume and removes panel', () => {
+    const callbacks = makeCallbacks();
+    showPauseMenu(document.body, callbacks);
+    clickButton('Return to Game');
+    expect(callbacks.onResume).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('pause-menu')).toBeNull();
+  });
+
+  it('"New Game…" swaps to the confirmation sub-view', () => {
+    showPauseMenu(document.body, makeCallbacks());
+    clickButton('New Game…');
+    expect(document.body.textContent).toContain('Save before leaving?');
+    expect(document.body.textContent).toContain('Turn 14');
+  });
+
+  it('"Save & Start New Game" calls autoSave then onNewGame', async () => {
+    const callbacks = makeCallbacks();
+    showPauseMenu(document.body, callbacks);
+    clickButton('New Game…');
+    clickButton('Save & Start New Game');
+    await vi.waitFor(() => expect(callbacks.autoSave).toHaveBeenCalledTimes(1));
+    expect(callbacks.onNewGame).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('pause-menu')).toBeNull();
+  });
+
+  it('"Discard & Start New Game" calls onNewGame without autoSave', () => {
+    const callbacks = makeCallbacks();
+    showPauseMenu(document.body, callbacks);
+    clickButton('New Game…');
+    clickButton('Discard & Start New Game');
+    expect(callbacks.autoSave).not.toHaveBeenCalled();
+    expect(callbacks.onNewGame).toHaveBeenCalledTimes(1);
+    expect(document.getElementById('pause-menu')).toBeNull();
+  });
+
+  it('"Cancel" in sub-view returns to main pause view without calling onNewGame', () => {
+    const callbacks = makeCallbacks();
+    showPauseMenu(document.body, callbacks);
+    clickButton('New Game…');
+    clickButton('Cancel');
+    expect(callbacks.onNewGame).not.toHaveBeenCalled();
+    expect(document.getElementById('pause-menu')).not.toBeNull();
+    expect(document.body.textContent).toContain('Return to Game');
+    expect(document.body.textContent).not.toContain('Save before leaving?');
+  });
+
+  it('replaces stale pause panels when reopened', () => {
+    showPauseMenu(document.body, makeCallbacks({ turn: 5, civName: 'Rome' }));
+    showPauseMenu(document.body, makeCallbacks({ turn: 8, civName: 'Egypt' }));
+    expect(document.querySelectorAll('#pause-menu')).toHaveLength(1);
+    expect(document.body.textContent).toContain('Turn 8');
+    expect(document.body.textContent).toContain('Egypt');
+  });
+
+  it('all buttons have styled background and color (no browser-default chrome)', () => {
+    showPauseMenu(document.body, makeCallbacks());
+    const buttons = Array.from(document.querySelectorAll('#pause-menu button')) as HTMLButtonElement[];
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      expect(btn.style.background, `${btn.textContent} background`).not.toBe('');
+      expect(btn.style.color, `${btn.textContent} color`).not.toBe('');
+    }
+  });
+});

--- a/tests/ui/required-choice-panel.test.ts
+++ b/tests/ui/required-choice-panel.test.ts
@@ -58,4 +58,21 @@ describe('required-choice-panel', () => {
     expect(document.getElementById('tech-panel')).toBeNull();
     expect(document.getElementById('city-panel')).toBeNull();
   });
+
+  it('Open Tech Panel and Open City buttons have styled background and color', () => {
+    const panel = createRequiredChoicePanel(document.body, {
+      researchChoices: [{ techId: 'fire', label: 'Fire', turns: 4 }],
+      cityChoices: [{ cityId: 'city-1', cityName: 'Roma', itemId: 'warrior', label: 'Warrior', turns: 3 }],
+      onChooseResearch: vi.fn(),
+      onChooseCityBuild: vi.fn(),
+      onOpenTech: vi.fn(),
+      onOpenCity: vi.fn(),
+    });
+    const openTech = Array.from(panel.querySelectorAll('button')).find(b => b.textContent === 'Open Tech Panel') as HTMLButtonElement;
+    const openCity = Array.from(panel.querySelectorAll('button')).find(b => b.textContent === 'Open City') as HTMLButtonElement;
+    expect(openTech.style.background).not.toBe('');
+    expect(openTech.style.color).not.toBe('');
+    expect(openCity.style.background).not.toBe('');
+    expect(openCity.style.color).not.toBe('');
+  });
 });

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -22,7 +22,8 @@ describe('tech-panel', () => {
     });
 
     expect(panel.textContent).toContain('Research');
-    expect(panel.querySelectorAll('.tech-track').length).toBeGreaterThan(3);
+    const visibleTracks = new Set(Array.from(panel.querySelectorAll('[data-track]')).map(el => (el as HTMLElement).dataset.track));
+    expect(visibleTracks.size).toBeGreaterThan(3);
     expect(panel.querySelector('[data-state="current"]')).toBeTruthy();
     expect(panel.querySelector('[data-state="available"]')).toBeTruthy();
   });
@@ -431,6 +432,139 @@ describe('tech-panel', () => {
     const upBtn = document.body.querySelector<HTMLButtonElement>('[data-queue-action="up"][data-queue-index="0"]');
     expect(upBtn).toBeTruthy();
     expect(upBtn!.disabled).toBe(true);
+  });
+
+  // --- Phase 2: era cap ---
+
+  it('Phase 2: focus zoom shows no nodes beyond era 2 with a fresh tech state', () => {
+    const state = createNewGame(undefined, 'tech-phase2-era-cap');
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    const cards = Array.from(panel.querySelectorAll('[data-tech-id]')) as HTMLElement[];
+    expect(cards.length).toBeGreaterThan(0);
+    for (const card of cards) {
+      expect(Number(card.dataset.era)).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('Phase 2: completing an era-2 tech opens era-3 nodes in focus zoom', () => {
+    const state = createNewGame(undefined, 'tech-phase2-era-unlock');
+    state.civilizations.player.techState.completed = ['stone-weapons', 'bronze-working'];
+
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    // fortification (era 3) requires bronze-working — should be visible after completing era-2 tech
+    expect(panel.querySelector('[data-tech-id="fortification"]')).toBeTruthy();
+    // No locked node with era > 3 should appear in focus zoom
+    const cards = Array.from(panel.querySelectorAll('[data-tech-id]')) as HTMLElement[];
+    for (const card of cards) {
+      const era = Number(card.dataset.era);
+      const techState = card.dataset.techState;
+      if (techState === 'locked') {
+        expect(era).toBeLessThanOrEqual(3);
+      }
+    }
+  });
+
+  // --- Phase 3: DAG layout ---
+
+  it('Phase 3: all visible cards have style.left set and no two share the same (left, top)', () => {
+    const state = createNewGame(undefined, 'tech-dag-unique-pos');
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    const cards = Array.from(panel.querySelectorAll('[data-tech-id]')) as HTMLElement[];
+    expect(cards.length).toBeGreaterThan(0);
+    const positions = new Set<string>();
+    for (const card of cards) {
+      expect(card.style.left).toBeTruthy();
+      expect(card.style.top).toBeTruthy();
+      const key = `${card.style.left},${card.style.top}`;
+      expect(positions.has(key)).toBe(false);
+      positions.add(key);
+    }
+  });
+
+  it('Phase 3: a tech with two prerequisites lands at depth = max(prereqDepths) + 1', () => {
+    // engineering: prerequisites [mathematics(depth=2), wheel(depth=1)] → expected depth=3
+    const state = createNewGame(undefined, 'tech-dag-depth');
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    panel.querySelector<HTMLButtonElement>('[data-zoom="all"]')?.click();
+    const engineeringCard = document.body.querySelector<HTMLElement>('[data-tech-id="engineering"]');
+    expect(engineeringCard).toBeTruthy();
+    expect(Number(engineeringCard!.dataset.depth)).toBe(3);
+  });
+
+  it('Phase 3: mapWrap uses absolute-positioned cards, not flex-wrap', () => {
+    const state = createNewGame(undefined, 'tech-dag-nowrap');
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    const mapWrap = panel.querySelector<HTMLElement>('[data-layout="tech-dependency-map"]');
+    expect(mapWrap).toBeTruthy();
+    expect(mapWrap!.style.flexWrap).not.toBe('wrap');
+    expect(mapWrap!.style.position).toBe('relative');
+  });
+
+  it('Phase 3: for every visible edge the prerequisite card left < successor card left', () => {
+    const state = createNewGame(undefined, 'tech-dag-edge-order');
+    state.civilizations.player.techState.currentResearch = 'fire';
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    const edges = Array.from(panel.querySelectorAll('[data-edge-from][data-edge-to]')) as HTMLElement[];
+    expect(edges.length).toBeGreaterThan(0);
+    for (const edge of edges) {
+      const fromId = (edge as HTMLElement).dataset.edgeFrom!;
+      const toId = (edge as HTMLElement).dataset.edgeTo!;
+      const fromCard = panel.querySelector<HTMLElement>(`[data-tech-id="${fromId}"]`);
+      const toCard = panel.querySelector<HTMLElement>(`[data-tech-id="${toId}"]`);
+      if (!fromCard || !toCard) continue;
+      const fromDepth = Number(fromCard.dataset.depth);
+      const toDepth = Number(toCard.dataset.depth);
+      expect(fromDepth).toBeLessThan(toDepth);
+    }
+  });
+
+  it('Phase 3: sidebar icon count equals the number of distinct tracks among visible cards', () => {
+    const state = createNewGame(undefined, 'tech-dag-sidebar-tracks');
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    const visibleTrackSet = new Set(
+      Array.from(panel.querySelectorAll('[data-tech-id]'))
+        .map(el => (el as HTMLElement).dataset.track)
+        .filter(Boolean),
+    );
+    const sidebar = panel.querySelector('#tech-track-sidebar');
+    expect(sidebar).toBeTruthy();
+    const sidebarIcons = Array.from(sidebar!.querySelectorAll('div'));
+    expect(sidebarIcons.length).toBe(visibleTrackSet.size);
   });
 
   it('↓ button on the last research queue item is disabled', () => {

--- a/tests/ui/ui-kit.test.ts
+++ b/tests/ui/ui-kit.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { createGameButton, setButtonDisabled, type ButtonVariant } from '@/ui/ui-kit';
+
+const ALL_VARIANTS: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'danger', 'close'];
+
+describe('createGameButton', () => {
+  it.each(ALL_VARIANTS)('%s variant has non-empty background and color', (variant) => {
+    const btn = createGameButton('Test', variant);
+    expect(btn.style.background).not.toBe('');
+    expect(btn.style.color).not.toBe('');
+  });
+
+  it.each(ALL_VARIANTS)('%s variant enforces 44px touch target', (variant) => {
+    const btn = createGameButton('Test', variant);
+    expect(btn.style.minHeight).toBe('44px');
+    expect(btn.style.minWidth).toBe('44px');
+  });
+
+  it('creates a button element with the given label', () => {
+    const btn = createGameButton('Start Campaign', 'primary');
+    expect(btn.tagName).toBe('BUTTON');
+    expect(btn.textContent).toBe('Start Campaign');
+  });
+
+  it('defaults to type=button to prevent accidental form submission', () => {
+    const btn = createGameButton('OK', 'primary');
+    expect(btn.type).toBe('button');
+  });
+
+  it('respects type override', () => {
+    const btn = createGameButton('Submit', 'primary', { type: 'submit' });
+    expect(btn.type).toBe('submit');
+  });
+
+  it('disabled option applies disabled visual state', () => {
+    const btn = createGameButton('Start', 'primary', { disabled: true });
+    expect(btn.disabled).toBe(true);
+    expect(btn.style.opacity).toBe('0.45');
+    expect(btn.style.cursor).toBe('not-allowed');
+  });
+
+  it('enabled by default', () => {
+    const btn = createGameButton('Start', 'primary');
+    expect(btn.disabled).toBe(false);
+    expect(btn.style.opacity).toBe('1');
+  });
+});
+
+describe('setButtonDisabled', () => {
+  it('disabling sets opacity 0.45, cursor not-allowed, pointer-events none', () => {
+    const btn = createGameButton('OK', 'primary');
+    setButtonDisabled(btn, true);
+    expect(btn.disabled).toBe(true);
+    expect(btn.style.opacity).toBe('0.45');
+    expect(btn.style.cursor).toBe('not-allowed');
+    expect(btn.style.pointerEvents).toBe('none');
+  });
+
+  it('re-enabling restores opacity 1, cursor pointer', () => {
+    const btn = createGameButton('OK', 'primary', { disabled: true });
+    setButtonDisabled(btn, false);
+    expect(btn.disabled).toBe(false);
+    expect(btn.style.opacity).toBe('1');
+    expect(btn.style.cursor).toBe('pointer');
+  });
+});

--- a/tests/ui/wonder-panel.test.ts
+++ b/tests/ui/wonder-panel.test.ts
@@ -330,4 +330,20 @@ describe('wonder-panel', () => {
     expect(rivalSection?.textContent).not.toContain('Quest steps:');
     expect(rivalSection?.textContent).not.toContain('Connect two cities');
   });
+
+  it('Start Build and Close buttons have styled background and color', () => {
+    const { container, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed = ['masonry', 'writing', 'calendar'];
+    state.wonderDiscoverers = { 'natural-1': ['player'] };
+    const seededState = initializeLegendaryWonderProjectsForCity(state, 'player', 'city-river');
+    const panel = createWonderPanel(container, seededState, 'city-river', {
+      onStartBuild: () => {},
+      onClose: () => {},
+    });
+    const allButtons = Array.from(panel.querySelectorAll('button')) as HTMLButtonElement[];
+    for (const btn of allButtons) {
+      expect(btn.style.background, `${btn.textContent} background`).not.toBe('');
+      expect(btn.style.color, `${btn.textContent} color`).not.toBe('');
+    }
+  });
 });

--- a/tests/ui/worker-task-warning-panel.test.ts
+++ b/tests/ui/worker-task-warning-panel.test.ts
@@ -61,4 +61,15 @@ describe('worker-task-warning-panel', () => {
     expect(document.querySelectorAll('#worker-task-warning-panel')).toHaveLength(1);
     expect(document.body.textContent).toContain('Mine');
   });
+
+  it('cancel and confirm buttons have styled background and color', () => {
+    const panel = createWorkerTaskWarningPanel(document.body, {
+      improvementName: 'Farm', onConfirm: vi.fn(), onCancel: vi.fn(),
+    });
+    const buttons = Array.from(panel.querySelectorAll('button')) as HTMLButtonElement[];
+    for (const btn of buttons) {
+      expect(btn.style.background, `${btn.textContent} background`).not.toBe('');
+      expect(btn.style.color, `${btn.textContent} color`).not.toBe('');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- **#190 Button Design System**: Centralized `createGameButton(label, variant)` factory in `src/ui/ui-kit.ts` with 5 variants (primary/secondary/ghost/danger/close), mandatory 44px touch targets, and `setButtonDisabled()`. Migrated 11 bare buttons across 6 UI files. Extended `check-src-edit.sh` hook to flag future regressions.
- **#192 Pause Menu**: `showPauseMenu()` panel (z-index 55) with Resume, Save Game (save-slot sub-panel at z-index 60), New Game… confirmation flow, and ☰ floating button wired into `game-shell.ts` and `main.ts`.
- **#193 Tech Tree UI/UX Overhaul**: Phase 2 era cap — focus zoom hides locked nodes beyond `currentPlayerEra + 1` while keeping focus neighbors visible. Phase 3 DAG layout — topological depth, collision-free `colNextY` absolute positioning, SVG bezier edges, era boundary markers, track sidebar with icons aligned to first card per track, scroll-to-focus.

## Test plan

- [x] `yarn test` — 1678 tests pass (163 files)
- [x] `yarn build` — TypeScript clean, Vite bundle builds
- [x] Hook smoke test: `check-src-edit.test.sh` covers bare-button block and `createGameButton` allow paths
- [x] New tests: `tests/ui/ui-kit.test.ts`, `tests/ui/pause-menu-panel.test.ts`
- [x] Extended tests: Phase 2 era-cap assertions in `tech-progression.test.ts`; Phase 3 DAG layout (unique positions, depth ordering, no flex-wrap, edge ordering, sidebar count) in `tech-panel.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)