### PR TITLE
fix(pacing): retune opening research costs

### DIFF
--- a/docs/superpowers/plans/2026-05-14-tech-research-pacing.md
+++ b/docs/superpowers/plans/2026-05-14-tech-research-pacing.md
@@ -1,0 +1,1068 @@
+# Tech Research Pacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issue #133 by making early tech research costs use a production-style pacing model so first real unlocks, especially Bronze Working, complete in fun live turn ranges.
+
+**Architecture:** Add research-specific pacing helpers to `src/systems/pacing-model.ts`, then wire tech audit rows through those helpers without changing turn processing or hiding live ETA math. Retune the targeted opening tech costs in `src/systems/tech-definitions.ts`, and prove the player-visible tech panel still displays actual live-science ETA rather than model-profile ETA.
+
+**Tech Stack:** TypeScript, Vitest, jsdom for UI tests, Vite build, repo wrapper `./scripts/run-with-mise.sh`, rule check script `scripts/check-src-rule-violations.sh`
+
+**Model Target:** GPT-5.4, medium reasoning effort.
+
+---
+
+## Scope Check
+
+This plan implements one vertical slice from `docs/superpowers/specs/2026-05-13-tech-research-pacing-design.md`: tech research pacing. It does not change production, queue semantics, turn processing, save format, tech prerequisites, or tech panel layout. The only UI-facing behavior under this plan is that existing ETA text reflects the retuned costs using live science per turn.
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `src/systems/pacing-model.ts` | Add research output profiles, opening-tier classifiers, metadata multiplier, recommended tech window, and recommended tech cost helpers. |
+| `tests/systems/pacing-model.test.ts` | Unit-test research profiles, structural opening-tier helpers, multiplier behavior, recommended windows, and recommended readable costs. |
+| `src/systems/pacing-audit.ts` | Use the research pacing helpers for tech audit rows and expose tech audit profile plus live-baseline turn fields. |
+| `tests/systems/pacing-audit.test.ts` | Prove current Bronze Working starts as a slow outlier, then prove retuned opening-baseline tech rows are no longer slow outliers. |
+| `src/systems/tech-definitions.ts` | Retune only targeted starter prerequisite and first-real-unlock tech costs. Do not add metadata unless a tested outlier exception is deliberately chosen. |
+| `tests/systems/tech-definitions.test.ts` | Add structural tests for starter prerequisite and first-real-unlock membership plus cost windows. |
+| `tests/integration/pacing-simulation.test.ts` | Add deterministic Bronze Working baseline and science-invested turn-processing fixtures. |
+| `tests/ui/tech-panel.test.ts` | Add jsdom test proving visible Bronze Working ETA is based on live science per turn. |
+
+## Player Truth Table
+
+| Before | Action | Internal state | Immediate visible result | Must remain reachable |
+|---|---|---|---|---|
+| Tech panel is open, Stone Weapons is completed, Bronze Working is current research, one city produces 1 live science/turn | Player opens Research panel | `Tech.cost` for Bronze Working is retuned; no hidden science multiplier is applied | Current research summary shows `Turns remaining: 10` or another value in 9-11 | Full tech panel, queue controls, zoom controls |
+| Same state, city has idle production set to science and produces 2 live science/turn | Player opens Research panel | Live science calculation includes idle science through existing city yield path | Current research summary shows `Turns remaining: 5` or another value in 5-7 | Full tech panel, queue controls, zoom controls |
+| Pacing debug panel is available in local/dev surfaces | Developer opens the pacing audit surface | Tech audit row uses research profile helpers and actual `Tech.cost` | Audit row can distinguish recommended cost, audit ETA, and live one-city baseline ETA | Existing building and unit audit rows |
+
+## Misleading UI Risks
+
+- The tech panel must not display model-profile ETA as if it were live ETA. Player-facing ETA must use `calculateProjectedCityYields(...).science` and actual `Tech.cost`.
+- The pacing audit may show audit-profile estimates, but the row must carry a live one-city baseline value for opening techs so a future implementer cannot accidentally hide a 50-turn live Bronze Working behind a healthy model estimate.
+- The `first real unlock` helper must be structural. It must not inspect unlock prose, because prose is inconsistent and would make the audit brittle.
+- Specialized roots such as Espionage Scouting should not be flattened into the opening starter target unless their explicit or resolved pacing band is `starter`.
+
+## Interaction Replay Checklist
+
+This plan does not add new interactions. The UI regression path is:
+
+- open tech panel with Bronze Working current
+- inspect current research summary
+- inspect Bronze Working card text in the rendered tree
+- change only live science in fixture from 1 to 2
+- reopen tech panel
+- verify visible ETA changes from baseline range to science-invested range
+
+No add, reorder, remove, or repeat-click behavior changes in this plan.
+
+## Queue And ETA Checklist
+
+- Active item remains shown in the current research summary.
+- Queued follow-up display remains unchanged.
+- ETA text remains visible and live-science based.
+- Reorder and remove behavior are not changed in this plan.
+- If a queued item later becomes invalid, existing queue behavior remains responsible; this plan does not alter that path.
+
+---
+
+### Task 1: Research Pacing Model Helpers
+
+**Files:**
+- Modify: `src/systems/pacing-model.ts`
+- Modify: `tests/systems/pacing-model.test.ts`
+
+- [ ] **Step 1: Write failing research pacing model tests**
+
+Append these tests to `tests/systems/pacing-model.test.ts`:
+
+```ts
+import { TECH_TREE } from '@/systems/tech-definitions';
+import type { PacingMetadata } from '@/core/types';
+import {
+  estimateTurnsToComplete,
+  getMetadataComplexityMultiplier,
+  getProductionOutputProfileForEra,
+  getRecommendedTechCost,
+  getRecommendedTechTurnWindow,
+  getResearchOutputProfileForEra,
+  getResearchOutputProfileForTech,
+  getTargetTurnWindow,
+  isFirstRealUnlockTech,
+  isStarterPrerequisiteTech,
+} from '@/systems/pacing-model';
+
+function tech(id: string) {
+  const found = TECH_TREE.find(candidate => candidate.id === id);
+  if (!found) throw new Error(`missing tech ${id}`);
+  return found;
+}
+
+describe('research pacing model', () => {
+  it('returns stable established-era research profiles', () => {
+    expect(getResearchOutputProfileForEra(Number.NaN)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForEra(1)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForEra(2)).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+    expect(getResearchOutputProfileForEra(5)).toEqual({ name: 'era-5-established', outputPerTurn: 13 });
+    expect(getResearchOutputProfileForEra(99)).toEqual({ name: 'era-5-established', outputPerTurn: 13 });
+  });
+
+  it('classifies starter prerequisites structurally from era, prerequisites, and pacing band', () => {
+    expect(isStarterPrerequisiteTech(tech('stone-weapons'))).toBe(true);
+    expect(isStarterPrerequisiteTech(tech('fire'))).toBe(true);
+    expect(isStarterPrerequisiteTech(tech('espionage-scouting'))).toBe(false);
+    expect(isStarterPrerequisiteTech(tech('archery'))).toBe(false);
+  });
+
+  it('classifies first real unlocks structurally without reading unlock prose', () => {
+    expect(isFirstRealUnlockTech(tech('archery'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('bronze-working'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('writing'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('early-empire'))).toBe(false);
+    expect(isFirstRealUnlockTech(tech('lookouts'))).toBe(false);
+  });
+
+  it('uses the opening baseline profile for starter and first real unlock techs', () => {
+    expect(getResearchOutputProfileForTech(tech('stone-weapons'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('bronze-working'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('early-empire'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+  });
+
+  it('returns opening-specific turn windows before generic era windows', () => {
+    expect(getRecommendedTechTurnWindow(tech('stone-weapons'))).toEqual({ min: 2, max: 5 });
+    expect(getRecommendedTechTurnWindow(tech('archery'))).toEqual({ min: 8, max: 12 });
+    expect(getRecommendedTechTurnWindow(tech('bronze-working'))).toEqual({ min: 9, max: 11 });
+    expect(getRecommendedTechTurnWindow(tech('early-empire'))).toEqual({ min: 4, max: 7 });
+  });
+
+  it('applies metadata complexity with bounded cost pressure', () => {
+    const neutral: PacingMetadata = {
+      band: 'core',
+      role: 'neutral',
+      impact: 1,
+      scope: 'city',
+      snowball: 1,
+      urgency: 1,
+      situationality: 1,
+      unlockBreadth: 1,
+    };
+    const broadAccelerant: PacingMetadata = {
+      ...neutral,
+      impact: 1.25,
+      scope: 'empire',
+      snowball: 1.25,
+      unlockBreadth: 1.2,
+    };
+    const urgentNiche: PacingMetadata = {
+      ...neutral,
+      urgency: 1.25,
+      situationality: 1.25,
+    };
+
+    expect(getMetadataComplexityMultiplier(broadAccelerant)).toBeGreaterThan(getMetadataComplexityMultiplier(neutral));
+    expect(getMetadataComplexityMultiplier(urgentNiche)).toBeLessThan(getMetadataComplexityMultiplier(neutral));
+    expect(getMetadataComplexityMultiplier({
+      ...broadAccelerant,
+      impact: 9,
+      snowball: 9,
+      unlockBreadth: 9,
+    })).toBe(1.35);
+    expect(getMetadataComplexityMultiplier({
+      ...urgentNiche,
+      urgency: 9,
+      situationality: 9,
+    })).toBe(0.75);
+    expect(getMetadataComplexityMultiplier(broadAccelerant, { max: 1.1 })).toBe(1.1);
+  });
+
+  it('recommends readable opening tech costs inside accepted live turn windows', () => {
+    const stone = getRecommendedTechCost(tech('stone-weapons'));
+    const archery = getRecommendedTechCost(tech('archery'));
+    const bronze = getRecommendedTechCost(tech('bronze-working'));
+
+    expect(estimateTurnsToComplete({ cost: stone, outputPerTurn: 1 })).toBeGreaterThanOrEqual(2);
+    expect(estimateTurnsToComplete({ cost: stone, outputPerTurn: 1 })).toBeLessThanOrEqual(5);
+    expect(estimateTurnsToComplete({ cost: archery, outputPerTurn: 1 })).toBeGreaterThanOrEqual(8);
+    expect(estimateTurnsToComplete({ cost: archery, outputPerTurn: 1 })).toBeLessThanOrEqual(12);
+    expect(estimateTurnsToComplete({ cost: bronze, outputPerTurn: 1 })).toBeGreaterThanOrEqual(9);
+    expect(estimateTurnsToComplete({ cost: bronze, outputPerTurn: 1 })).toBeLessThanOrEqual(11);
+  });
+});
+```
+
+Remove the original import block at the top of the file before adding this expanded import block, so the file has one import list.
+
+- [ ] **Step 2: Run the pacing-model tests and verify they fail**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts
+```
+
+Expected: FAIL with missing exports such as `getResearchOutputProfileForEra`, `getRecommendedTechCost`, or `isFirstRealUnlockTech`.
+
+- [ ] **Step 3: Add research helpers to `src/systems/pacing-model.ts`**
+
+Replace the import block and add these helper definitions after `estimateTurnsToComplete`:
+
+```ts
+import type { Building, PacingBand, PacingContentType, PacingMetadata, Tech } from '@/core/types';
+import type { TRAINABLE_UNITS } from '@/systems/city-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
+
+export interface ResearchOutputProfile {
+  name:
+    | 'opening-baseline'
+    | 'opening-science-invested'
+    | 'era-2-established'
+    | 'era-3-established'
+    | 'era-4-established'
+    | 'era-5-established';
+  outputPerTurn: number;
+}
+
+const RESEARCH_OUTPUT_BY_ERA: Record<number, ResearchOutputProfile> = {
+  1: { name: 'opening-baseline', outputPerTurn: 1 },
+  2: { name: 'era-2-established', outputPerTurn: 4 },
+  3: { name: 'era-3-established', outputPerTurn: 7 },
+  4: { name: 'era-4-established', outputPerTurn: 10 },
+  5: { name: 'era-5-established', outputPerTurn: 13 },
+};
+
+export const OPENING_SCIENCE_INVESTED_PROFILE: ResearchOutputProfile = {
+  name: 'opening-science-invested',
+  outputPerTurn: 2,
+};
+
+export interface MetadataComplexityOptions {
+  min?: number;
+  max?: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeEra(era: number): number {
+  const numericEra = Number.isFinite(era) ? era : 1;
+  const normalized = Math.max(1, Math.floor(numericEra));
+  return Math.min(5, normalized);
+}
+
+function findTech(techId: string, techs: Tech[]): Tech | undefined {
+  return techs.find(candidate => candidate.id === techId);
+}
+
+export function getResearchOutputProfileForEra(era: number): ResearchOutputProfile {
+  return RESEARCH_OUTPUT_BY_ERA[normalizeEra(era)];
+}
+
+export function isStarterPrerequisiteTech(tech: Tech): boolean {
+  return tech.era === 1
+    && tech.prerequisites.length === 0
+    && resolveTechPacingBand(tech) === 'starter';
+}
+
+export function isFirstRealUnlockTech(tech: Tech, techs: Tech[] = TECH_TREE): boolean {
+  if (tech.era > 2 || tech.prerequisites.length !== 1) return false;
+  const prerequisite = findTech(tech.prerequisites[0], techs);
+  return Boolean(prerequisite && isStarterPrerequisiteTech(prerequisite));
+}
+
+export function getResearchOutputProfileForTech(tech: Tech, techs: Tech[] = TECH_TREE): ResearchOutputProfile {
+  if (isStarterPrerequisiteTech(tech) || isFirstRealUnlockTech(tech, techs)) {
+    return RESEARCH_OUTPUT_BY_ERA[1];
+  }
+
+  return getResearchOutputProfileForEra(tech.era);
+}
+
+export function getRecommendedTechTurnWindow(tech: Tech, techs: Tech[] = TECH_TREE): { min: number; max: number } {
+  if (tech.id === 'bronze-working') {
+    return { min: 9, max: 11 };
+  }
+  if (isStarterPrerequisiteTech(tech)) {
+    return { min: 2, max: 5 };
+  }
+  if (isFirstRealUnlockTech(tech, techs)) {
+    return { min: 8, max: 12 };
+  }
+
+  return getTargetTurnWindow({
+    era: tech.era,
+    band: resolveTechPacingBand(tech),
+    contentType: 'tech',
+  });
+}
+
+function inferTechScope(tech: Tech): PacingMetadata['scope'] {
+  const unlockText = tech.unlocks.join(' ').toLowerCase();
+  if (unlockText.includes('unit') || unlockText.includes('warrior') || unlockText.includes('swordsman')) {
+    return 'military';
+  }
+  if (unlockText.includes('building') || unlockText.includes('library') || unlockText.includes('monument')) {
+    return 'city';
+  }
+  return 'empire';
+}
+
+function metadataForTech(tech: Tech): PacingMetadata {
+  return tech.pacing ?? {
+    band: resolveTechPacingBand(tech),
+    role: 'inferred',
+    impact: 1,
+    scope: inferTechScope(tech),
+    snowball: 1,
+    urgency: 1,
+    situationality: 1,
+    unlockBreadth: 1,
+  };
+}
+
+export function getMetadataComplexityMultiplier(
+  metadata: PacingMetadata,
+  options: MetadataComplexityOptions = {},
+): number {
+  const min = options.min ?? 0.75;
+  const max = options.max ?? 1.35;
+  const scopeFactor = metadata.scope === 'empire'
+    ? 1.08
+    : metadata.scope === 'city'
+      ? 0.96
+      : 1;
+  const impactFactor = metadata.impact;
+  const snowballFactor = 1 + ((metadata.snowball - 1) * 0.5);
+  const unlockBreadthFactor = 1 + ((metadata.unlockBreadth - 1) * 0.4);
+  const urgencyFactor = clamp(1 - ((metadata.urgency - 1) * 0.25), 0.5, 1.25);
+  const situationalityFactor = clamp(1 - ((metadata.situationality - 1) * 0.2), 0.5, 1.25);
+
+  return Number(clamp(
+    scopeFactor
+      * impactFactor
+      * snowballFactor
+      * unlockBreadthFactor
+      * urgencyFactor
+      * situationalityFactor,
+    min,
+    max,
+  ).toFixed(2));
+}
+
+function roundRecommendedTechCost(cost: number): number {
+  if (cost < 20) return Math.max(1, Math.round(cost));
+  return Math.max(5, Math.round(cost / 5) * 5);
+}
+
+export function getRecommendedTechCost(tech: Tech, techs: Tech[] = TECH_TREE): number {
+  const profile = getResearchOutputProfileForTech(tech, techs);
+  const window = getRecommendedTechTurnWindow(tech, techs);
+  const targetTurns = Math.round((window.min + window.max) / 2);
+  const metadata = metadataForTech(tech);
+  return roundRecommendedTechCost(profile.outputPerTurn * targetTurns * getMetadataComplexityMultiplier(metadata));
+}
+```
+
+Keep the existing production helpers below these new helpers. Do not change `estimateTurnsToComplete`, `resolveBuildingPacingBand`, or `resolveUnitPacingBand` in this task.
+
+- [ ] **Step 4: Run pacing-model tests and verify they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts
+```
+
+Expected: PASS for all `pacing-model` tests.
+
+- [ ] **Step 5: Commit Task 1**
+
+Run:
+
+```bash
+git add src/systems/pacing-model.ts tests/systems/pacing-model.test.ts
+git commit -m "feat(pacing): add research cost model helpers"
+```
+
+---
+
+### Task 2: Tech Pacing Audit Rows
+
+**Files:**
+- Modify: `src/systems/pacing-audit.ts`
+- Modify: `tests/systems/pacing-audit.test.ts`
+
+- [ ] **Step 1: Write failing pacing-audit tests for tech profiles and slow outliers**
+
+Append these tests to `tests/systems/pacing-audit.test.ts`:
+
+```ts
+describe('tech pacing audit', () => {
+  it('reports research profile and live baseline fields for tech rows', () => {
+    const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
+
+    expect(bronze).toBeDefined();
+    expect(bronze?.contentType).toBe('tech');
+    expect(bronze?.researchProfile).toBe('opening-baseline');
+    expect(bronze?.liveBaselineTurns).toBe(bronze?.estimatedTurns);
+    expect(bronze?.liveBaselineTurns).toBeGreaterThan(11);
+    expect(bronze?.recommendedCost).toBeGreaterThan(0);
+  });
+
+  it('flags current Bronze Working as a slow opening outlier before the retune', () => {
+    const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
+
+    expect(bronze?.estimatedTurns).toBe(50);
+    expect(bronze?.target).toEqual({ min: 9, max: 11 });
+    expect(bronze?.outlier).toBe(true);
+    expect(bronze?.outlierReason).toBe('Slower than target window');
+  });
+});
+```
+
+- [ ] **Step 2: Run pacing-audit tests and verify they fail**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-audit.test.ts
+```
+
+Expected: FAIL because `researchProfile` and `liveBaselineTurns` do not exist on `PacingAuditRow`, and tech rows still use hardcoded `tech.era === 1 ? 3 : 8`.
+
+- [ ] **Step 3: Update `src/systems/pacing-audit.ts` tech row logic**
+
+Update the imports from `@/systems/pacing-model` to include:
+
+```ts
+  type ResearchOutputProfile,
+  getRecommendedTechCost,
+  getRecommendedTechTurnWindow,
+  getResearchOutputProfileForTech,
+```
+
+Extend `PacingAuditRow`:
+
+```ts
+  researchProfile?: ResearchOutputProfile['name'];
+  liveBaselineTurns?: number;
+```
+
+Replace the `...TECH_TREE.map(tech => { ... })` block with:
+
+```ts
+    ...TECH_TREE.map(tech => {
+      const band = resolveTechPacingBand(tech);
+      const profile = getResearchOutputProfileForTech(tech);
+      const target = getRecommendedTechTurnWindow(tech);
+      const currentCost = tech.cost;
+      return {
+        id: tech.id,
+        label: tech.name,
+        contentType: 'tech' as const,
+        era: tech.era,
+        band,
+        currentCost,
+        target,
+        researchProfile: profile.name,
+        liveBaselineTurns: profile.name === 'opening-baseline'
+          ? estimateTurnsToComplete({ cost: currentCost, outputPerTurn: 1 })
+          : undefined,
+        ...buildAuditSignals(currentCost, profile.outputPerTurn, target, getRecommendedTechCost(tech)),
+      };
+    }),
+```
+
+Then change `buildAuditSignals` to accept an optional recommended cost override:
+
+```ts
+function buildAuditSignals(
+  currentCost: number,
+  outputPerTurn: number,
+  target: { min: number; max: number },
+  recommendedCostOverride?: number,
+): Pick<PacingAuditRow, 'estimatedTurns' | 'recommendedCost' | 'outlier' | 'outlierReason'> {
+  const estimatedTurns = estimateTurnsToComplete({ cost: currentCost, outputPerTurn });
+  const recommendedTurns = Math.round((target.min + target.max) / 2);
+  const recommendedCost = recommendedCostOverride ?? recommendedTurns * outputPerTurn;
+  const outlier = estimatedTurns < target.min || estimatedTurns > target.max;
+  const outlierReason = estimatedTurns > target.max
+    ? 'Slower than target window'
+    : estimatedTurns < target.min
+      ? 'Faster than target window'
+      : 'Within target window';
+
+  return {
+    estimatedTurns,
+    recommendedCost,
+    outlier,
+    outlierReason,
+  };
+}
+```
+
+- [ ] **Step 4: Run pacing-audit tests and verify they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-audit.test.ts
+```
+
+Expected: PASS for all `pacing-audit` tests.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add src/systems/pacing-audit.ts tests/systems/pacing-audit.test.ts
+git commit -m "feat(pacing): audit tech research profiles"
+```
+
+---
+
+### Task 3: Deterministic Bronze Working And Visible ETA Regressions
+
+**Files:**
+- Modify: `tests/integration/pacing-simulation.test.ts`
+- Modify: `tests/ui/tech-panel.test.ts`
+
+- [ ] **Step 1: Add deterministic integration fixtures for Bronze Working**
+
+Add this import to `tests/integration/pacing-simulation.test.ts`:
+
+```ts
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+```
+
+Append this helper and tests to the same file:
+
+```ts
+
+function makeBronzeWorkingResearchState(scienceInvestment: 'baseline' | 'idle-science') {
+  const state = createNewGame(undefined, `bronze-working-${scienceInvestment}`, 'small');
+  const player = state.civilizations.player;
+  const settlerId = player.units.find(unitId => state.units[unitId]?.type === 'settler');
+  expect(settlerId).toBeDefined();
+
+  const city = foundCity('player', state.units[settlerId!].position, state.map);
+  state.cities[city.id] = {
+    ...city,
+    productionQueue: [],
+    idleProduction: scienceInvestment === 'idle-science' ? 'science' : null,
+  };
+  player.cities.push(city.id);
+  for (const coord of city.ownedTiles) {
+    const key = hexKey(coord);
+    state.map.tiles[key] = {
+      ...state.map.tiles[key],
+      terrain: 'grassland',
+      resource: null,
+      improvement: 'none',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      owner: 'player',
+    };
+  }
+
+  player.techState.completed = ['stone-weapons'];
+  player.techState.currentResearch = 'bronze-working';
+  player.techState.researchProgress = 0;
+  player.techState.researchQueue = [];
+
+  expect(calculateProjectedCityYields(state, city.id).science).toBe(
+    scienceInvestment === 'idle-science' ? 2 : 1,
+  );
+
+  return state;
+}
+
+function turnsToCompleteBronzeWorking(scienceInvestment: 'baseline' | 'idle-science'): number {
+  let next = makeBronzeWorkingResearchState(scienceInvestment);
+  for (let turn = 1; turn <= 20; turn++) {
+    next = processTurn(next, new EventBus());
+    if (next.civilizations.player.techState.completed.includes('bronze-working')) {
+      return turn;
+    }
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
+it('completes Bronze Working in 9-11 turns for a baseline one-city opening', () => {
+  const turns = turnsToCompleteBronzeWorking('baseline');
+  expect(turns).toBeGreaterThanOrEqual(9);
+  expect(turns).toBeLessThanOrEqual(11);
+});
+
+it('completes Bronze Working in 5-7 turns when opening production is invested into science', () => {
+  const turns = turnsToCompleteBronzeWorking('idle-science');
+  expect(turns).toBeGreaterThanOrEqual(5);
+  expect(turns).toBeLessThanOrEqual(7);
+});
+```
+
+- [ ] **Step 2: Run integration pacing tests and verify Bronze tests fail before retune**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/integration/pacing-simulation.test.ts
+```
+
+Expected: FAIL because current Bronze Working cost is 50, so baseline completion is outside 9-11 turns.
+
+- [ ] **Step 3: Add visible ETA regression test to tech panel**
+
+In `tests/ui/tech-panel.test.ts`, add imports:
+
+```ts
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
+```
+
+Append this helper and test:
+
+```ts
+function makeBronzeWorkingPanelState(scienceInvestment: 'baseline' | 'idle-science' = 'baseline') {
+  const state = createNewGame(undefined, 'tech-panel-bronze-working-eta', 'small');
+  const player = state.civilizations.player;
+  const settlerId = player.units.find(unitId => state.units[unitId]?.type === 'settler');
+  expect(settlerId).toBeDefined();
+
+  const city = foundCity('player', state.units[settlerId!].position, state.map);
+  state.cities[city.id] = {
+    ...city,
+    productionQueue: [],
+    idleProduction: scienceInvestment === 'idle-science' ? 'science' : null,
+  };
+  player.cities.push(city.id);
+  for (const coord of city.ownedTiles) {
+    const key = hexKey(coord);
+    state.map.tiles[key] = {
+      ...state.map.tiles[key],
+      terrain: 'grassland',
+      resource: null,
+      improvement: 'none',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      owner: 'player',
+    };
+  }
+
+  player.techState.completed = ['stone-weapons'];
+  player.techState.currentResearch = 'bronze-working';
+  player.techState.researchProgress = 0;
+  player.techState.researchQueue = [];
+
+  expect(calculateProjectedCityYields(state, city.id).science).toBe(
+    scienceInvestment === 'idle-science' ? 2 : 1,
+  );
+
+  return state;
+}
+
+it('shows live Bronze Working ETA from current science instead of audit-profile math', () => {
+  const state = makeBronzeWorkingPanelState();
+
+  const panel = createTechPanel(document.body, state, {
+    onQueueResearch: () => {},
+    onMoveQueuedResearch: () => {},
+    onRemoveQueuedResearch: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.textContent).toContain('Researching: Bronze Working');
+  expect(panel.textContent).toMatch(/Turns remaining: (9|10|11)/);
+  expect(panel.textContent).not.toContain('50');
+  expect(panel.querySelector('[data-tech-id="bronze-working"]')?.textContent).toMatch(/(9|10|11) turns/);
+});
+```
+
+Append this companion test to prove the same rendered surface reacts to live science changes:
+
+```ts
+it('updates visible Bronze Working ETA when opening production is invested into science', () => {
+  const state = makeBronzeWorkingPanelState('idle-science');
+
+  const panel = createTechPanel(document.body, state, {
+    onQueueResearch: () => {},
+    onMoveQueuedResearch: () => {},
+    onRemoveQueuedResearch: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.textContent).toContain('Researching: Bronze Working');
+  expect(panel.textContent).toMatch(/Turns remaining: (5|6|7)/);
+  expect(panel.textContent).not.toMatch(/Turns remaining: (9|10|11)/);
+  expect(panel.querySelector('[data-tech-id="bronze-working"]')?.textContent).toMatch(/(5|6|7) turns/);
+});
+```
+
+- [ ] **Step 4: Run tech-panel test and verify it fails before retune**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/tech-panel.test.ts
+```
+
+Expected: FAIL because current Bronze Working ETA is outside 9-11 turns.
+
+- [ ] **Step 5: Keep failing tests uncommitted until Task 4**
+
+Do not commit Task 3 yet. These tests describe the desired behavior and should turn green after the data retune in Task 4.
+
+---
+
+### Task 4: Retune Opening Tech Costs And Add Structural Data Tests
+
+**Files:**
+- Modify: `src/systems/tech-definitions.ts`
+- Modify: `tests/systems/tech-definitions.test.ts`
+- Test: `tests/integration/pacing-simulation.test.ts`
+- Test: `tests/ui/tech-panel.test.ts`
+- Test: `tests/systems/pacing-audit.test.ts`
+
+- [ ] **Step 1: Add structural cost tests to tech definitions**
+
+Add imports to `tests/systems/tech-definitions.test.ts`:
+
+```ts
+import {
+  estimateTurnsToComplete,
+  getResearchOutputProfileForTech,
+  isFirstRealUnlockTech,
+  isStarterPrerequisiteTech,
+} from '@/systems/pacing-model';
+```
+
+Append these tests:
+
+```ts
+describe('opening research pacing data', () => {
+  it('keeps starter prerequisites inside the 2-5 turn baseline window', () => {
+    const starters = TECH_TREE.filter(tech => isStarterPrerequisiteTech(tech));
+    expect(starters.map(tech => tech.id)).toEqual(expect.arrayContaining([
+      'stone-weapons',
+      'gathering',
+      'fire',
+      'tribal-council',
+      'pathfinding',
+      'foraging',
+      'herbalism',
+      'oral-tradition',
+      'cave-painting',
+      'rafts',
+      'copper-working',
+      'mud-brick',
+      'drums',
+      'animism',
+    ]));
+    expect(starters.map(tech => tech.id)).not.toContain('espionage-scouting');
+
+    const outliers = starters
+      .map(tech => `${tech.id}:${estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: 1 })}`)
+      .filter(entry => {
+        const turns = Number(entry.split(':')[1]);
+        return turns < 2 || turns > 5;
+      });
+
+    expect(outliers).toEqual([]);
+  });
+
+  it('keeps structural first real unlocks inside the 8-12 turn baseline window', () => {
+    const firstUnlocks = TECH_TREE.filter(tech => isFirstRealUnlockTech(tech));
+    expect(firstUnlocks.map(tech => tech.id)).toEqual(expect.arrayContaining([
+      'archery',
+      'bronze-working',
+      'writing',
+      'wheel',
+      'pottery',
+      'animal-husbandry',
+      'code-of-laws',
+      'cartography',
+      'sailing',
+      'domestication',
+      'granary-design',
+      'bone-setting',
+      'midwifery',
+      'mythology',
+      'rhetoric',
+      'storytelling',
+      'fishing',
+      'smelting',
+      'thatching',
+      'foundations',
+      'smoke-signals',
+      'burial-rites',
+    ]));
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('early-empire');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('lookouts');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('music');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('tool-making');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('messengers');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('sacred-sites');
+
+    const outliers = firstUnlocks
+      .filter(tech => tech.id !== 'bronze-working')
+      .map(tech => `${tech.id}:${estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: 1 })}`)
+      .filter(entry => {
+        const turns = Number(entry.split(':')[1]);
+        return turns < 8 || turns > 12;
+      });
+
+    expect(outliers).toEqual([]);
+  });
+
+  it('keeps Bronze Working in its explicit 9-11 turn baseline window', () => {
+    const bronze = TECH_TREE.find(tech => tech.id === 'bronze-working');
+    expect(bronze).toBeDefined();
+    expect(getResearchOutputProfileForTech(bronze!)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 1 })).toBeGreaterThanOrEqual(9);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 1 })).toBeLessThanOrEqual(11);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeGreaterThanOrEqual(5);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeLessThanOrEqual(7);
+  });
+});
+```
+
+- [ ] **Step 2: Run tech-definitions tests and verify they fail before retune**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/tech-definitions.test.ts
+```
+
+Expected: FAIL because current opening costs are too high.
+
+- [ ] **Step 3: Retune targeted tech costs in `src/systems/tech-definitions.ts`**
+
+Change only `cost` fields for starter prerequisite and first-real-unlock techs. Use this target table:
+
+```ts
+// Starter prerequisites: target 2-5 turns at 1 science/turn
+stone-weapons: 4
+gathering: 4
+fire: 4
+tribal-council: 4
+pathfinding: 4
+foraging: 5
+herbalism: 5
+oral-tradition: 5
+cave-painting: 5
+rafts: 5
+copper-working: 5
+mud-brick: 5
+drums: 5
+animism: 5
+
+// First real unlocks: target 8-12 turns at 1 science/turn
+archery: 10
+bronze-working: 10
+pottery: 10
+animal-husbandry: 12
+writing: 10
+wheel: 10
+code-of-laws: 10
+cartography: 10
+sailing: 10
+domestication: 10
+granary-design: 10
+bone-setting: 10
+midwifery: 10
+mythology: 10
+rhetoric: 10
+storytelling: 10
+fishing: 10
+smelting: 10
+thatching: 10
+foundations: 10
+smoke-signals: 10
+burial-rites: 10
+```
+
+Do not change `espionage-scouting`, `lookouts`, `early-empire`, prerequisites, IDs, unlock text, era values, or track values in this task.
+
+- [ ] **Step 4: Run data and player-visible ETA tests and verify retune passes**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts
+```
+
+Expected: PASS. Bronze Working baseline completes in 10 turns and science-invested completes in 5 turns.
+
+- [ ] **Step 5: Update the pre-retune audit test expectations**
+
+The Task 2 tests must now become green post-retune regressions.
+
+In `reports research profile and live baseline fields for tech rows`, replace the live-baseline assertions with:
+
+```ts
+    expect(bronze?.liveBaselineTurns).toBe(bronze?.estimatedTurns);
+    expect(bronze?.liveBaselineTurns).toBeGreaterThanOrEqual(9);
+    expect(bronze?.liveBaselineTurns).toBeLessThanOrEqual(11);
+```
+
+Replace `flags current Bronze Working as a slow opening outlier before the retune` with:
+
+```ts
+  it('keeps retuned Bronze Working inside its opening target window', () => {
+    const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
+
+    expect(bronze?.estimatedTurns).toBeGreaterThanOrEqual(9);
+    expect(bronze?.estimatedTurns).toBeLessThanOrEqual(11);
+    expect(bronze?.target).toEqual({ min: 9, max: 11 });
+    expect(bronze?.outlier).toBe(false);
+    expect(bronze?.outlierReason).toBe('Within target window');
+  });
+```
+
+Also append this audit regression:
+
+```ts
+  it('has no slow tech outliers among opening-baseline tech rows after retune', () => {
+    const slowOutliers = buildPacingAudit()
+      .filter(row => row.contentType === 'tech')
+      .filter(row => row.researchProfile === 'opening-baseline')
+      .filter(row => row.estimatedTurns > row.target.max)
+      .map(row => `${row.id}:${row.estimatedTurns}/${row.target.max}`);
+
+    expect(slowOutliers).toEqual([]);
+  });
+```
+
+- [ ] **Step 6: Run all Task 4 targeted tests again**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts tests/systems/pacing-audit.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Tasks 3 and 4 together**
+
+Run:
+
+```bash
+git add src/systems/tech-definitions.ts tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts tests/systems/pacing-audit.test.ts
+git commit -m "fix(pacing): retune opening research costs"
+```
+
+---
+
+### Task 5: Final Verification And Regression Audit
+
+**Files:**
+- Verify: `src/systems/pacing-model.ts`
+- Verify: `src/systems/pacing-audit.ts`
+- Verify: `src/systems/tech-definitions.ts`
+- Verify: `tests/systems/pacing-model.test.ts`
+- Verify: `tests/systems/pacing-audit.test.ts`
+- Verify: `tests/systems/tech-definitions.test.ts`
+- Verify: `tests/integration/pacing-simulation.test.ts`
+- Verify: `tests/ui/tech-panel.test.ts`
+- Verify: `docs/superpowers/plans/2026-05-14-tech-research-pacing.md`
+
+- [ ] **Step 1: Run source rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/pacing-model.ts src/systems/pacing-audit.ts src/systems/tech-definitions.ts
+```
+
+Expected: PASS with no rule violation output.
+
+- [ ] **Step 2: Run mirrored and targeted tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts tests/systems/tech-progression.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build for TypeScript validation**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS. This command runs `tsc` and Vite production build.
+
+- [ ] **Step 4: Inspect committed and uncommitted diffs**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- docs/superpowers/plans/2026-05-14-tech-research-pacing.md src/systems/pacing-model.ts src/systems/pacing-audit.ts src/systems/tech-definitions.ts tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts
+```
+
+Expected:
+
+- Branch diff includes this plan file plus only planned source and test files.
+- Uncommitted diff is empty.
+- Full diff shows no changes to tech IDs, prerequisites, unlock behavior, turn processing, save format, or research queue semantics.
+
+- [ ] **Step 5: Commit any verification-only cleanup**
+
+If Step 4 shows a small fix was needed, run targeted tests again and commit it:
+
+```bash
+git add docs/superpowers/plans/2026-05-14-tech-research-pacing.md src/systems/pacing-model.ts src/systems/pacing-audit.ts src/systems/tech-definitions.ts tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts
+git commit -m "test(pacing): lock research pacing regressions"
+```
+
+If Step 4 shows no changes, do not create an empty commit.
+
+## Self-Review Checklist
+
+### Spec Coverage
+
+- Intent and root cause: Task 1 and Task 2 model/audit fix raw cost divided by live science.
+- Player baseline targets: Task 3 and Task 4 verify Bronze Working 9-11 turns and starter prerequisites 2-5 turns.
+- Science-investment target: Task 3 verifies Bronze Working 5-7 turns with idle production converted to science.
+- Structural first-real-unlock definition: Task 1 tests helper membership; Task 4 tests inclusion and exclusion spot checks.
+- Specialized root protection: Task 1 and Task 4 test Espionage Scouting and Lookouts stay out of starter/first-unlock flattening.
+- Audit contract: Task 2 adds profile/live-baseline audit fields; Task 4 proves no slow opening tech outliers after retune.
+- UI contract: Task 3 verifies visible tech panel ETA from live science and actual `Tech.cost`.
+- Boundaries: Task 5 diff inspection checks no turn-processing, save, prerequisite, queue, or hidden multiplier changes.
+
+### Placeholder Scan
+
+A placeholder scan was run. No incomplete-marker text, vague test instructions, or references to functions outside the Task 1 definitions remain.
+
+### Type Consistency
+
+Planned exported names are consistent across tasks:
+
+- `ResearchOutputProfile`
+- `MetadataComplexityOptions`
+- `OPENING_SCIENCE_INVESTED_PROFILE`
+- `getResearchOutputProfileForEra`
+- `getResearchOutputProfileForTech`
+- `isStarterPrerequisiteTech`
+- `isFirstRealUnlockTech`
+- `getRecommendedTechTurnWindow`
+- `getMetadataComplexityMultiplier`
+- `getRecommendedTechCost`
+
+Planned audit fields are consistent across tasks:
+
+- `researchProfile?: ResearchOutputProfile['name']`
+- `liveBaselineTurns?: number`

--- a/docs/superpowers/plans/2026-05-14-tech-research-pacing.md
+++ b/docs/superpowers/plans/2026-05-14-tech-research-pacing.md
@@ -126,6 +126,8 @@ describe('research pacing model', () => {
   it('uses the opening baseline profile for starter and first real unlock techs', () => {
     expect(getResearchOutputProfileForTech(tech('stone-weapons'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
     expect(getResearchOutputProfileForTech(tech('bronze-working'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('espionage-scouting'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+    expect(getResearchOutputProfileForTech(tech('lookouts'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
     expect(getResearchOutputProfileForTech(tech('early-empire'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
   });
 
@@ -274,6 +276,10 @@ export function isFirstRealUnlockTech(tech: Tech, techs: Tech[] = TECH_TREE): bo
 export function getResearchOutputProfileForTech(tech: Tech, techs: Tech[] = TECH_TREE): ResearchOutputProfile {
   if (isStarterPrerequisiteTech(tech) || isFirstRealUnlockTech(tech, techs)) {
     return RESEARCH_OUTPUT_BY_ERA[1];
+  }
+
+  if (tech.era <= 1) {
+    return RESEARCH_OUTPUT_BY_ERA[2];
   }
 
   return getResearchOutputProfileForEra(tech.era);
@@ -1039,6 +1045,7 @@ If Step 4 shows no changes, do not create an empty commit.
 - Science-investment target: Task 3 verifies Bronze Working 5-7 turns with idle production converted to science.
 - Structural first-real-unlock definition: Task 1 tests helper membership; Task 4 tests inclusion and exclusion spot checks.
 - Specialized root protection: Task 1 and Task 4 test Espionage Scouting and Lookouts stay out of starter/first-unlock flattening.
+- Specialized profile protection: Task 1 verifies non-starter Era 1 espionage techs use the established profile instead of the opening baseline profile.
 - Audit contract: Task 2 adds profile/live-baseline audit fields; Task 4 proves no slow opening tech outliers after retune.
 - UI contract: Task 3 verifies visible tech panel ETA from live science and actual `Tech.cost`.
 - Boundaries: Task 5 diff inspection checks no turn-processing, save, prerequisite, queue, or hidden multiplier changes.

--- a/docs/superpowers/specs/2026-05-13-tech-research-pacing-design.md
+++ b/docs/superpowers/specs/2026-05-13-tech-research-pacing-design.md
@@ -1,0 +1,307 @@
+# Tech Research Pacing Design
+
+**Date:** 2026-05-13
+**Status:** Proposed
+**Issue:** #133 - Pacing Issue - Tech still takes too long
+**Depends on:** Current `main` as of 2026-05-13
+**Goal:** Make early research feel active and fun by applying the existing production-style pacing model to tech costs, so first real unlocks complete in 8-12 baseline turns and 5-7 turns with early science investment.
+
+---
+
+## 1. Intent
+
+Issue #133 is still reproducible because early research costs are not aligned with early science output. A one-city baseline game produces 1 science per turn, while Bronze Working costs 50 research. That creates a 50-turn wait for an early, player-visible unlock.
+
+The root fix is not a one-off Bronze Working discount. The game already has the shape of a better balancing system for production: pacing bands, expected output profiles, actual costs, and metadata that describes complexity, payoff, and scope. Research should use the same approach.
+
+This design makes tech cost recommendations explicit, auditable, and tied to fun turn windows. The actual `Tech.cost` values remain plain data, but they must be justified against a deterministic research pacing model.
+
+## 2. Player Experience
+
+The opening should give the player meaningful research payoffs at a steady clip.
+
+Baseline target:
+
+- A plain early one-city empire should complete the first real unlock tier in 8-12 turns.
+- Bronze Working should complete in 9-11 turns in that baseline.
+- Starter prerequisite techs should complete in 2-5 turns in the same baseline.
+
+Science-investment target:
+
+- If the player deliberately invests in early science, the same first real unlock tier should fall to 5-7 turns.
+- Science investment can come from science buildings, science focus, idle production converted to science, civilization bonuses, or other existing systems.
+- The target is not to make science mandatory for fun pacing. It should make an already acceptable baseline feel sharper.
+
+Texture target:
+
+- Broad first unlocks should be fast enough to be fun.
+- Stronger, broader, or more snowballing techs may cost more than simpler peers.
+- Niche or situational techs may cost less so they are not dead picks.
+- No early first-unlock tech should take dozens of turns in baseline play.
+
+Definition:
+
+- A `starter prerequisite tech` is an Era 1 tech with no prerequisites whose explicit or resolved pacing band is `starter`.
+- A `first real unlock` is an Era 1 or Era 2 tech with exactly one prerequisite, where that prerequisite is a starter prerequisite tech. Bronze Working qualifies because it requires Stone Weapons.
+- The first-real-unlock audit set must be structural. Do not inspect unlock prose to decide whether a tech counts.
+
+## 3. Architecture
+
+### 3.1 Pacing Model
+
+Extend `src/systems/pacing-model.ts` with research-specific helpers:
+
+- `getResearchOutputProfileForEra(era)`
+- `getResearchOutputProfileForTech(tech)`
+- `getMetadataComplexityMultiplier(metadata, options?)`
+- `getRecommendedTechCost(tech)`
+- `getRecommendedTechTurnWindow(tech)`
+
+The production helpers remain intact. Research gets its own output profile because empire science does not scale like one city's production. `getResearchOutputProfileForEra` is the general era fallback. `getResearchOutputProfileForTech` is the helper the tech audit and tech cost recommendations must call, because opening first-unlock techs need an availability-aware profile instead of a raw era profile.
+
+### 3.2 Existing Metadata Becomes Real
+
+`PacingMetadata` already includes:
+
+- `band`
+- `role`
+- `impact`
+- `scope`
+- `snowball`
+- `urgency`
+- `situationality`
+- `unlockBreadth`
+
+These fields must affect recommended tech cost. They should no longer be treated as labels used only for grouping.
+
+### 3.3 Tech Definitions Stay Data-Driven
+
+`src/systems/tech-definitions.ts` remains the source of actual tech costs. The implementation should retune costs in that file after adding the recommendation helper.
+
+The pacing model recommends costs; it does not dynamically override `Tech.cost` during gameplay.
+
+### 3.4 Pacing Audit
+
+Update `src/systems/pacing-audit.ts` so tech rows use the research pacing model:
+
+- expected research output comes from `getResearchOutputProfileForTech`
+- recommended tech cost comes from `getRecommendedTechCost`
+- slow-outlier detection compares actual `Tech.cost` against the recommended turn window using the same profile
+- tech rows expose enough information to distinguish `recommendedCost`, audit-profile ETA, and live one-city baseline ETA for opening techs
+
+The audit must flag early techs like the current Bronze Working state as slow outliers.
+
+## 4. Research Cost Model
+
+The recommended cost formula is:
+
+```text
+recommendedCost =
+  expectedResearchPerTurnForTech
+  * targetTurns
+  * metadataComplexityMultiplier
+```
+
+Where:
+
+- `expectedResearchPerTurnForTech` comes from the availability-aware research output profile for the tech.
+- `targetTurns` comes from `getRecommendedTechTurnWindow(tech)`, which uses availability tier before era for opening techs.
+- `metadataComplexityMultiplier` adjusts the band target for payoff and complexity.
+
+### 4.1 Research Output Profile
+
+The opening profile must match real opening output, not an aspirational science economy. This matters because the actual tech panel and turn loop use live science per turn. If the model recommends Bronze Working from a 5 science/turn assumption while the baseline city produces 1 science/turn, the player still sees a long wait.
+
+The implementation must use two related profiles:
+
+| Profile | Research per turn | Used for | Intent |
+|---|---:|---|
+| `opening-baseline` | 1 | Starter prerequisites and first real unlocks | Plain one-city game with no special science investment |
+| `opening-science-invested` | 2 | Verification only | Same opening with explicit early science investment |
+| `era-2-established` | 4 | Era 2 techs outside the first-real-unlock tier | Early expansion and first science choices begin to matter |
+| `era-3-established` | 7 | Era 3 general audit fallback | Mature early empire research |
+| `era-4-established` | 10 | Era 4 general audit fallback | Mid-late empire research |
+| `era-5-established` | 13 | Era 5 general audit fallback | Late-era research without runaway costs |
+
+These are balancing assumptions for recommended costs and audit, not forced yields.
+
+Rules:
+
+- `getResearchOutputProfileForTech` must return `opening-baseline` for starter prerequisite techs and first real unlocks.
+- `getResearchOutputProfileForEra` may return established-era profiles, but it must not be used directly for first real unlock tech recommendations.
+- The science-invested profile is not used to set costs. It is used to verify that explicit science investment makes the same costs complete in 5-7 turns.
+- Era 1 no-prerequisite techs whose pacing band is not `starter` do not automatically get the opening-baseline target. This preserves deliberate pacing for specialized root systems such as espionage if their metadata or resolved band marks them as more complex.
+
+### 4.2 Band Windows
+
+The current pacing bands remain valid, but research should interpret them with tech-specific expectations.
+
+For this issue:
+
+- `starter`: very quick prerequisites and onboarding techs
+- `core`: ordinary first unlocks
+- `specialist`: narrower or synergy-driven techs
+- `infrastructure`: economic, city, or empire setup techs
+- `power-spike`: strong capability jumps or broad unlock hubs
+- `marquee`: capstones and late foundations
+
+Era 1 first real unlocks should usually resolve to `core`, `specialist`, or low `power-spike` recommendations that still land inside the 8-12 baseline target unless metadata strongly justifies a longer wait.
+
+Opening first real unlocks that are technically `era: 2`, such as Bronze Working, still use the opening first-unlock target for this issue. Their era value may still matter for tree structure and era progression, but it must not force them into an established Era 2 cost profile.
+
+Opening turn windows:
+
+| Availability tier | Target window |
+|---|---:|
+| Starter prerequisite tech | 2-5 turns |
+| First real unlock | 8-12 turns |
+| Bronze Working | 9-11 turns |
+
+These opening windows override the generic era/band window when `getRecommendedTechTurnWindow(tech)` evaluates starter prerequisite techs or first real unlocks.
+
+### 4.3 Complexity Multiplier
+
+The multiplier should be bounded and legible. It should reward fun pacing more than simulated difficulty.
+
+Required influences:
+
+- `impact` above 1 raises cost; below 1 lowers it.
+- `snowball` above 1 raises cost for accelerants.
+- `unlockBreadth` above 1 raises cost for broad unlock hubs.
+- `scope: empire` raises cost slightly compared with city or military scope.
+- `urgency` above 1 lowers cost slightly because urgent basics should arrive sooner.
+- `situationality` above 1 lowers cost slightly because niche techs should remain tempting.
+
+The implementation must clamp the final multiplier to `0.75` through `1.35` so metadata combinations cannot create extreme costs.
+
+If a tech has no explicit `pacing` metadata, the helper must use:
+
+- `resolveTechPacingBand(tech)` for the band
+- neutral metadata values of `1` for numeric factors
+- `scope: empire` only when the tech unlocks empire-wide effects; otherwise default to `scope: military` for unit unlocks and `scope: city` for building unlocks when that can be inferred
+
+If the implementation cannot infer scope confidently, it must use `scope: empire` as the conservative default. Missing metadata must never bypass the cost audit.
+
+### 4.4 Human-Friendly Costs
+
+Recommended costs should be rounded to readable values.
+
+Rules:
+
+- Costs below 20 should round to whole numbers.
+- Costs from 20 through 49 should round to the nearest 5.
+- Costs 50 and above should round to the nearest 5.
+- Rounding must not push first-unlock techs outside the target turn window unless metadata justifies the exception.
+- Actual `Tech.cost` values for opening baseline techs must be checked against live ETA, not only against rounded recommended cost.
+
+## 5. Retuning Scope
+
+The first implementation should retune tech costs enough to fix #133 broadly, without trying to solve the entire campaign in one pass.
+
+Must retune:
+
+- Era 1 starter prerequisite techs
+- Era 1 first real unlocks after starter prerequisites
+- Era 2 first unlocks that are reachable from one starter prerequisite, including Bronze Working
+
+Must audit, but not necessarily retune in the first slice:
+
+- deeper Era 2 cross-track techs
+- Era 3-5 techs
+- late-era scaffolding nodes
+- espionage late-stage techs
+
+Do not change:
+
+- tech IDs
+- prerequisites
+- unlock behavior
+- tech tree shape
+- save format
+- research queue semantics
+- actual per-turn science generation rules unless the user explicitly approves a separate design that changes science yields
+
+The first implementation must also preserve the existing player-visible ETA path. `src/ui/tech-panel.ts` and `src/systems/tech-progression.ts` should continue to calculate ETA from actual current science per turn and actual `Tech.cost`. The model and audit may recommend costs, but the UI must not display model-profile ETAs as if they were live game ETAs.
+
+## 6. Acceptance Criteria
+
+The design is satisfied when:
+
+- A baseline one-city Bronze Working simulation completes in 9-11 turns.
+- The same scenario with early science investment completes in 5-7 turns.
+- Starter prerequisite techs complete in 2-5 turns in the baseline opening fixture.
+- First real unlocks broadly avoid slow early outliers in the pacing audit.
+- Every tech in the structural first-real-unlock audit set either completes in 8-12 baseline turns or has explicit pacing metadata and a test explaining why it is allowed outside that window.
+- Stronger or broader unlocks remain slightly more expensive through metadata, not one-off exceptions.
+- `pacing-audit` uses `getRecommendedTechCost` for tech recommended costs.
+- Tech panel ETA remains based on live science per turn and shows the retuned Bronze Working ETA in the accepted baseline range.
+- Tests prove the issue cannot regress by silently returning Bronze Working to a 50-turn baseline.
+
+## 7. Testing Contract
+
+Add or update tests in:
+
+- `tests/systems/pacing-model.test.ts`
+- `tests/systems/pacing-audit.test.ts`
+- `tests/integration/pacing-simulation.test.ts`
+- `tests/systems/tech-definitions.test.ts` if cost invariants are added there
+
+Required coverage:
+
+- `getResearchOutputProfileForEra` returns stable, clamped era profiles.
+- `getResearchOutputProfileForTech` returns the opening baseline profile for starter prerequisite techs and first real unlocks, including Bronze Working.
+- `getRecommendedTechTurnWindow` returns 2-5 for starter prerequisite techs, 8-12 for first real unlocks, and 9-11 for Bronze Working.
+- `getMetadataComplexityMultiplier` raises cost for high impact, high snowball, and broad unlocks.
+- `getMetadataComplexityMultiplier` lowers cost for urgent or situational techs.
+- `getRecommendedTechCost` returns a readable cost inside the expected turn target.
+- Bronze Working baseline one-city simulation completes in the accepted 9-11 turn range.
+- A science-investment variant completes Bronze Working in the accepted 5-7 turn range.
+- Early first-unlock tech audit rows have no slow outliers.
+- The structural first-real-unlock helper includes spot checks such as Archery, Bronze Working, Writing, Wheel, Pottery, Animal Husbandry, Code of Laws, Cartography, Sailing, Domestication, Bone Setting, Mythology, Storytelling, Fishing, Smelting, Thatching, Smoke Signals, and Burial Rites.
+- The structural first-real-unlock helper excludes deeper follow-ups such as Early Empire, because their prerequisite is not a starter prerequisite tech.
+- The structural first-real-unlock helper excludes specialized roots and their children when the root is not `starter`, such as Lookouts if Espionage Scouting remains a non-starter root.
+- A deliberately high-complexity tech can remain above the basic first-unlock target without failing the broad audit, as long as metadata explains it.
+- Tech panel visible ETA for Bronze Working in the baseline fixture shows 9-11 turns.
+
+The Bronze Working integration tests must use a fixed fixture rather than relying on map seed luck:
+
+- one city owned by the player
+- current research set to Bronze Working
+- Stone Weapons already completed
+- baseline fixture produces exactly 1 live science per turn
+- science-invested fixture produces exactly 2 live science per turn through an existing mechanic such as idle production converted to science
+
+If future yield changes alter those live science values, the tests must update the fixture to preserve the meaning of baseline and science-invested, not loosen the accepted turn ranges.
+
+## 8. Implementation Boundaries
+
+This is a balance-model and data-retune change. It should not redesign UI layout, change turn processing, or add hidden research multipliers.
+
+Allowed:
+
+- add pacing-model helpers
+- update pacing-audit tech calculations
+- retune selected tech costs
+- add tech pacing metadata where missing
+- add focused regression tests
+
+Not allowed:
+
+- multiply science during `processTurn`
+- special-case Bronze Working in research processing
+- hide real cost or ETA math from the UI
+- display audit-profile ETAs in player-facing UI
+- change tech prerequisites to make costs appear faster
+- delete techs or collapse tracks
+
+## 9. Implementation Notes
+
+The implementation plan will pick exact numeric values for the first retune by running the new audit after the helper exists. Those values must still satisfy the acceptance criteria above.
+
+The design-approved targets are:
+
+- baseline first real unlocks: 8-12 turns
+- Bronze Working baseline: 9-11 turns
+- science-invested first real unlocks: 5-7 turns
+
+If exact audit output suggests a small exception, the exception must be encoded through metadata and covered by a test.

--- a/src/systems/pacing-audit.ts
+++ b/src/systems/pacing-audit.ts
@@ -1,6 +1,10 @@
 import { BUILDINGS, TRAINABLE_UNITS, getCatalogProductionCost } from '@/systems/city-system';
 import {
+  type ResearchOutputProfile,
   getProductionOutputProfileForEra,
+  getRecommendedTechCost,
+  getRecommendedTechTurnWindow,
+  getResearchOutputProfileForTech,
   getTargetTurnWindow,
   estimateTurnsToComplete,
   resolveBuildingPacingBand,
@@ -21,6 +25,8 @@ export interface PacingAuditRow {
   target: { min: number; max: number };
   outlier: boolean;
   outlierReason: string;
+  researchProfile?: ResearchOutputProfile['name'];
+  liveBaselineTurns?: number;
 }
 
 function getUnlockEra(techId?: string | null): number {
@@ -35,10 +41,11 @@ function buildAuditSignals(
   currentCost: number,
   outputPerTurn: number,
   target: { min: number; max: number },
+  recommendedCostOverride?: number,
 ): Pick<PacingAuditRow, 'estimatedTurns' | 'recommendedCost' | 'outlier' | 'outlierReason'> {
   const estimatedTurns = estimateTurnsToComplete({ cost: currentCost, outputPerTurn });
   const recommendedTurns = Math.round((target.min + target.max) / 2);
-  const recommendedCost = recommendedTurns * outputPerTurn;
+  const recommendedCost = recommendedCostOverride ?? recommendedTurns * outputPerTurn;
   const outlier = estimatedTurns < target.min || estimatedTurns > target.max;
   const outlierReason = estimatedTurns > target.max
     ? 'Slower than target window'
@@ -101,21 +108,22 @@ export function buildPacingAudit(options: { era?: number } = {}): PacingAuditRow
     }),
     ...TECH_TREE.map(tech => {
       const band = resolveTechPacingBand(tech);
-      const outputPerTurn = tech.era === 1 ? 3 : 8;
-      const target = getTargetTurnWindow({
-        era: tech.era,
-        band,
-        contentType: 'tech',
-      });
+      const profile = getResearchOutputProfileForTech(tech);
+      const target = getRecommendedTechTurnWindow(tech);
+      const currentCost = tech.cost;
       return {
         id: tech.id,
         label: tech.name,
         contentType: 'tech' as const,
         era: tech.era,
         band,
-        currentCost: tech.cost,
+        currentCost,
         target,
-        ...buildAuditSignals(tech.cost, outputPerTurn, target),
+        researchProfile: profile.name,
+        liveBaselineTurns: profile.name === 'opening-baseline'
+          ? estimateTurnsToComplete({ cost: currentCost, outputPerTurn: 1 })
+          : undefined,
+        ...buildAuditSignals(currentCost, profile.outputPerTurn, target, getRecommendedTechCost(tech)),
       };
     }),
   ];

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -1,5 +1,6 @@
-import type { Building, PacingBand, PacingContentType, Tech } from '@/core/types';
+import type { Building, PacingBand, PacingContentType, PacingMetadata, Tech } from '@/core/types';
 import type { TRAINABLE_UNITS } from '@/systems/city-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
 
 const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number, number] }> = {
   starter: { early: [2, 4], late: [2, 5] },
@@ -35,6 +36,157 @@ export function estimateTurnsToComplete(input: { cost: number; outputPerTurn: nu
   }
 
   return Math.ceil(input.cost / input.outputPerTurn);
+}
+
+export interface ResearchOutputProfile {
+  name:
+    | 'opening-baseline'
+    | 'opening-science-invested'
+    | 'era-2-established'
+    | 'era-3-established'
+    | 'era-4-established'
+    | 'era-5-established';
+  outputPerTurn: number;
+}
+
+const RESEARCH_OUTPUT_BY_ERA: Record<number, ResearchOutputProfile> = {
+  1: { name: 'opening-baseline', outputPerTurn: 1 },
+  2: { name: 'era-2-established', outputPerTurn: 4 },
+  3: { name: 'era-3-established', outputPerTurn: 7 },
+  4: { name: 'era-4-established', outputPerTurn: 10 },
+  5: { name: 'era-5-established', outputPerTurn: 13 },
+};
+
+export const OPENING_SCIENCE_INVESTED_PROFILE: ResearchOutputProfile = {
+  name: 'opening-science-invested',
+  outputPerTurn: 2,
+};
+
+export interface MetadataComplexityOptions {
+  min?: number;
+  max?: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizeEra(era: number): number {
+  const numericEra = Number.isFinite(era) ? era : 1;
+  const normalized = Math.max(1, Math.floor(numericEra));
+  return Math.min(5, normalized);
+}
+
+function findTech(techId: string, techs: Tech[]): Tech | undefined {
+  return techs.find(candidate => candidate.id === techId);
+}
+
+export function getResearchOutputProfileForEra(era: number): ResearchOutputProfile {
+  return RESEARCH_OUTPUT_BY_ERA[normalizeEra(era)];
+}
+
+export function isStarterPrerequisiteTech(tech: Tech): boolean {
+  return tech.era === 1
+    && tech.prerequisites.length === 0
+    && resolveTechPacingBand(tech) === 'starter';
+}
+
+export function isFirstRealUnlockTech(tech: Tech, techs: Tech[] = TECH_TREE): boolean {
+  if (tech.era > 2 || tech.prerequisites.length !== 1) return false;
+  const prerequisite = findTech(tech.prerequisites[0], techs);
+  return Boolean(prerequisite && isStarterPrerequisiteTech(prerequisite));
+}
+
+export function getResearchOutputProfileForTech(tech: Tech, techs: Tech[] = TECH_TREE): ResearchOutputProfile {
+  if (isStarterPrerequisiteTech(tech) || isFirstRealUnlockTech(tech, techs)) {
+    return RESEARCH_OUTPUT_BY_ERA[1];
+  }
+
+  return getResearchOutputProfileForEra(tech.era);
+}
+
+export function getRecommendedTechTurnWindow(tech: Tech, techs: Tech[] = TECH_TREE): { min: number; max: number } {
+  if (tech.id === 'bronze-working') {
+    return { min: 9, max: 11 };
+  }
+  if (isStarterPrerequisiteTech(tech)) {
+    return { min: 2, max: 5 };
+  }
+  if (isFirstRealUnlockTech(tech, techs)) {
+    return { min: 8, max: 12 };
+  }
+
+  return getTargetTurnWindow({
+    era: tech.era,
+    band: resolveTechPacingBand(tech),
+    contentType: 'tech',
+  });
+}
+
+function inferTechScope(tech: Tech): PacingMetadata['scope'] {
+  const unlockText = tech.unlocks.join(' ').toLowerCase();
+  if (unlockText.includes('unit') || unlockText.includes('warrior') || unlockText.includes('swordsman')) {
+    return 'military';
+  }
+  if (unlockText.includes('building') || unlockText.includes('library') || unlockText.includes('monument')) {
+    return 'city';
+  }
+  return 'empire';
+}
+
+function metadataForTech(tech: Tech): PacingMetadata {
+  return tech.pacing ?? {
+    band: resolveTechPacingBand(tech),
+    role: 'inferred',
+    impact: 1,
+    scope: inferTechScope(tech),
+    snowball: 1,
+    urgency: 1,
+    situationality: 1,
+    unlockBreadth: 1,
+  };
+}
+
+export function getMetadataComplexityMultiplier(
+  metadata: PacingMetadata,
+  options: MetadataComplexityOptions = {},
+): number {
+  const min = options.min ?? 0.75;
+  const max = options.max ?? 1.35;
+  const scopeFactor = metadata.scope === 'empire'
+    ? 1.08
+    : metadata.scope === 'city'
+      ? 0.96
+      : 1;
+  const impactFactor = metadata.impact;
+  const snowballFactor = 1 + ((metadata.snowball - 1) * 0.5);
+  const unlockBreadthFactor = 1 + ((metadata.unlockBreadth - 1) * 0.4);
+  const urgencyFactor = clamp(1 - ((metadata.urgency - 1) * 0.25), 0.5, 1.25);
+  const situationalityFactor = clamp(1 - ((metadata.situationality - 1) * 0.2), 0.5, 1.25);
+
+  return Number(clamp(
+    scopeFactor
+      * impactFactor
+      * snowballFactor
+      * unlockBreadthFactor
+      * urgencyFactor
+      * situationalityFactor,
+    min,
+    max,
+  ).toFixed(2));
+}
+
+function roundRecommendedTechCost(cost: number): number {
+  if (cost < 20) return Math.max(1, Math.round(cost));
+  return Math.max(5, Math.round(cost / 5) * 5);
+}
+
+export function getRecommendedTechCost(tech: Tech, techs: Tech[] = TECH_TREE): number {
+  const profile = getResearchOutputProfileForTech(tech, techs);
+  const window = getRecommendedTechTurnWindow(tech, techs);
+  const targetTurns = Math.round((window.min + window.max) / 2);
+  const metadata = metadataForTech(tech);
+  return roundRecommendedTechCost(profile.outputPerTurn * targetTurns * getMetadataComplexityMultiplier(metadata));
 }
 
 type TrainableUnit = (typeof TRAINABLE_UNITS)[number];

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -102,6 +102,10 @@ export function getResearchOutputProfileForTech(tech: Tech, techs: Tech[] = TECH
     return RESEARCH_OUTPUT_BY_ERA[1];
   }
 
+  if (tech.era <= 1) {
+    return RESEARCH_OUTPUT_BY_ERA[2];
+  }
+
   return getResearchOutputProfileForEra(tech.era);
 }
 

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -2,9 +2,9 @@ import type { Tech } from '@/core/types';
 
 export const TECH_TREE: Tech[] = [
   // === MILITARY TRACK (8 techs, existing) ===
-  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 10, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
-  { id: 'archery', name: 'Archery', track: 'military', cost: 35, prerequisites: ['stone-weapons'], unlocks: ['Unlock Archer unit'], era: 1 },
-  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 50, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit'], era: 2 },
+  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 4, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
+  { id: 'archery', name: 'Archery', track: 'military', cost: 10, prerequisites: ['stone-weapons'], unlocks: ['Unlock Archer unit'], era: 1 },
+  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 10, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit'], era: 2 },
   { id: 'horseback-riding', name: 'Horseback Riding', track: 'military', cost: 55, prerequisites: ['animal-husbandry'], unlocks: ['Unlock Stable, mounted units'], era: 2 },
   { id: 'fortification', name: 'Fortification', track: 'military', cost: 60, prerequisites: ['bronze-working'], unlocks: ['Unlock Walls building', 'pikeman'], era: 3 },
   { id: 'iron-forging', name: 'Iron Forging', track: 'military', cost: 80, prerequisites: ['bronze-working', 'mining-tech'], unlocks: ['Stronger melee units'], era: 3 },
@@ -12,9 +12,9 @@ export const TECH_TREE: Tech[] = [
   { id: 'tactics', name: 'Tactics', track: 'military', cost: 100, prerequisites: ['iron-forging'], unlocks: ['Units get +10% combat bonus', 'musketeer'], era: 4 },
 
   // === ECONOMY TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 8, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
-  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 25, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge'], era: 1 },
-  { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 35, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
+  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 4, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
+  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 10, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge'], era: 1 },
+  { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 12, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
   { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 45, prerequisites: ['pottery'], unlocks: ['Farms yield +1 food'], era: 2 },
   { id: 'currency', name: 'Currency', track: 'economy', cost: 60, prerequisites: ['pottery'], unlocks: ['Unlock Marketplace building'], era: 3 },
   { id: 'mining-tech', name: 'Advanced Mining', track: 'economy', cost: 65, prerequisites: ['animal-husbandry'], unlocks: ['Mines yield +1 production'], era: 3 },
@@ -23,9 +23,9 @@ export const TECH_TREE: Tech[] = [
   { id: 'global-logistics', name: 'Global Logistics', track: 'economy', cost: 155, prerequisites: ['trade-routes', 'banking'], unlocks: ['Late-era supply chains and wonder distribution requirements'], era: 5, countsForEraAdvancement: false, countsForCityMaturity: true },
 
   // === SCIENCE TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'fire', name: 'Fire', track: 'science', cost: 8, prerequisites: [], unlocks: ['Unlock basic research'], era: 1, pacing: { band: 'starter', role: 'foundational-science', impact: 1, scope: 'empire', snowball: 1.15, urgency: 1.1, situationality: 1, unlockBreadth: 1.1 } },
-  { id: 'writing', name: 'Writing', track: 'science', cost: 30, prerequisites: ['fire'], unlocks: ['Unlock Library building'], era: 1 },
-  { id: 'wheel', name: 'The Wheel', track: 'science', cost: 40, prerequisites: ['fire'], unlocks: ['Foundational mechanics knowledge'], era: 2 },
+  { id: 'fire', name: 'Fire', track: 'science', cost: 4, prerequisites: [], unlocks: ['Unlock basic research'], era: 1, pacing: { band: 'starter', role: 'foundational-science', impact: 1, scope: 'empire', snowball: 1.15, urgency: 1.1, situationality: 1, unlockBreadth: 1.1 } },
+  { id: 'writing', name: 'Writing', track: 'science', cost: 10, prerequisites: ['fire'], unlocks: ['Unlock Library building'], era: 1 },
+  { id: 'wheel', name: 'The Wheel', track: 'science', cost: 10, prerequisites: ['fire'], unlocks: ['Foundational mechanics knowledge'], era: 2 },
   { id: 'mathematics', name: 'Mathematics', track: 'science', cost: 60, prerequisites: ['writing'], unlocks: ['Unlock Archive building'], era: 2 },
   { id: 'engineering', name: 'Engineering', track: 'science', cost: 80, prerequisites: ['mathematics', 'wheel'], unlocks: ['Unlock Aqueduct, Forge'], era: 3 },
   { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: ['Unlock Temple building'], era: 3 },
@@ -34,8 +34,8 @@ export const TECH_TREE: Tech[] = [
   { id: 'nuclear-theory', name: 'Nuclear Theory', track: 'science', cost: 165, prerequisites: ['astronomy', 'medicine'], unlocks: ['Late-era atomic research and wonder prerequisites'], era: 5, countsForEraAdvancement: false },
 
   // === CIVICS TRACK (8 techs, existing) ===
-  { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 8, prerequisites: [], unlocks: ['Basic governance'], era: 1, pacing: { band: 'starter', role: 'foundational-civics', impact: 1, scope: 'empire', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1.05 } },
-  { id: 'code-of-laws', name: 'Code of Laws', track: 'civics', cost: 30, prerequisites: ['tribal-council'], unlocks: ['Unlock Monument building'], era: 1 },
+  { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 4, prerequisites: [], unlocks: ['Basic governance'], era: 1, pacing: { band: 'starter', role: 'foundational-civics', impact: 1, scope: 'empire', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1.05 } },
+  { id: 'code-of-laws', name: 'Code of Laws', track: 'civics', cost: 10, prerequisites: ['tribal-council'], unlocks: ['Unlock Monument building'], era: 1 },
   { id: 'early-empire', name: 'Early Empire', track: 'civics', cost: 45, prerequisites: ['code-of-laws'], unlocks: ['Cities claim +1 tile radius'], era: 2 },
   { id: 'state-workforce', name: 'State Workforce', track: 'civics', cost: 55, prerequisites: ['early-empire'], unlocks: ['Unlock Lumbermill, Quarry'], era: 2 },
   { id: 'diplomacy-tech', name: 'Diplomacy', track: 'civics', cost: 65, prerequisites: ['early-empire', 'writing'], unlocks: ['Unlock Non-Aggression Pacts'], era: 3 },
@@ -44,9 +44,9 @@ export const TECH_TREE: Tech[] = [
   { id: 'political-philosophy', name: 'Political Philosophy', track: 'civics', cost: 100, prerequisites: ['civil-service', 'philosophy'], unlocks: ['Unlock alliances'], era: 4 },
 
   // === EXPLORATION TRACK (8 techs, existing) ===
-  { id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 8, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1, pacing: { band: 'starter', role: 'foundational-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
-  { id: 'cartography', name: 'Cartography', track: 'exploration', cost: 30, prerequisites: ['pathfinding'], unlocks: ['Reveal map edges'], era: 1 },
-  { id: 'sailing', name: 'Sailing', track: 'exploration', cost: 45, prerequisites: ['pathfinding'], unlocks: ['Units can embark on coast'], era: 2 },
+  { id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 4, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1, pacing: { band: 'starter', role: 'foundational-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
+  { id: 'cartography', name: 'Cartography', track: 'exploration', cost: 10, prerequisites: ['pathfinding'], unlocks: ['Reveal map edges'], era: 1 },
+  { id: 'sailing', name: 'Sailing', track: 'exploration', cost: 10, prerequisites: ['pathfinding'], unlocks: ['Units can embark on coast'], era: 2 },
   { id: 'celestial-navigation', name: 'Celestial Navigation', track: 'exploration', cost: 55, prerequisites: ['sailing', 'fire'], unlocks: ['Units can cross ocean'], era: 2 },
   { id: 'road-building', name: 'Road Building', track: 'exploration', cost: 50, prerequisites: ['wheel', 'pathfinding'], unlocks: ['Workers can build roads'], era: 3 },
   { id: 'harbor-tech', name: 'Harbors', track: 'exploration', cost: 70, prerequisites: ['sailing', 'currency'], unlocks: ['Unlock Harbor building'], era: 3 },
@@ -54,38 +54,38 @@ export const TECH_TREE: Tech[] = [
   { id: 'military-logistics', name: 'Military Logistics', track: 'exploration', cost: 100, prerequisites: ['road-building', 'tactics'], unlocks: ['Units move +1 on roads'], era: 4 },
 
   // === AGRICULTURE TRACK (8 techs, new) ===
-  { id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 20, prerequisites: [], unlocks: ['Food storage'], era: 1 },
-  { id: 'domestication', name: 'Domestication', track: 'agriculture', cost: 25, prerequisites: ['foraging'], unlocks: ['Animal pens'], era: 1 },
+  { id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 5, prerequisites: [], unlocks: ['Food storage'], era: 1 },
+  { id: 'domestication', name: 'Domestication', track: 'agriculture', cost: 10, prerequisites: ['foraging'], unlocks: ['Animal pens'], era: 1 },
   { id: 'crop-rotation', name: 'Crop Rotation', track: 'agriculture', cost: 45, prerequisites: ['domestication', 'irrigation'], unlocks: ['Improved farms'], era: 2 },
-  { id: 'granary-design', name: 'Granary Design', track: 'agriculture', cost: 40, prerequisites: ['foraging'], unlocks: ['Granary upgrade'], era: 2 },
+  { id: 'granary-design', name: 'Granary Design', track: 'agriculture', cost: 10, prerequisites: ['foraging'], unlocks: ['Granary upgrade'], era: 2 },
   { id: 'fertilization', name: 'Fertilization', track: 'agriculture', cost: 80, prerequisites: ['crop-rotation'], unlocks: ['Fertile fields'], era: 3 },
   { id: 'livestock-breeding', name: 'Livestock Breeding', track: 'agriculture', cost: 85, prerequisites: ['crop-rotation', 'granary-design'], unlocks: ['Ranch'], era: 3 },
   { id: 'selective-breeding', name: 'Selective Breeding', track: 'agriculture', cost: 120, prerequisites: ['livestock-breeding'], unlocks: ['Hybrid crops'], era: 4 },
   { id: 'agricultural-science', name: 'Agricultural Science', track: 'agriculture', cost: 125, prerequisites: ['fertilization', 'livestock-breeding'], unlocks: ['Agricultural lab'], era: 4 },
 
   // === MEDICINE TRACK (8 techs, new) ===
-  { id: 'herbalism', name: 'Herbalism', track: 'medicine', cost: 20, prerequisites: [], unlocks: ['Healer'], era: 1 },
-  { id: 'bone-setting', name: 'Bone Setting', track: 'medicine', cost: 25, prerequisites: ['herbalism'], unlocks: ['Field medic'], era: 1 },
+  { id: 'herbalism', name: 'Herbalism', track: 'medicine', cost: 5, prerequisites: [], unlocks: ['Healer'], era: 1 },
+  { id: 'bone-setting', name: 'Bone Setting', track: 'medicine', cost: 10, prerequisites: ['herbalism'], unlocks: ['Field medic'], era: 1 },
   { id: 'sanitation', name: 'Sanitation', track: 'medicine', cost: 45, prerequisites: ['bone-setting'], unlocks: ['Sewers'], era: 2 },
-  { id: 'midwifery', name: 'Midwifery', track: 'medicine', cost: 40, prerequisites: ['herbalism'], unlocks: ['Birth rate bonus'], era: 2 },
+  { id: 'midwifery', name: 'Midwifery', track: 'medicine', cost: 10, prerequisites: ['herbalism'], unlocks: ['Birth rate bonus'], era: 2 },
   { id: 'surgery', name: 'Surgery', track: 'medicine', cost: 85, prerequisites: ['sanitation', 'philosophy'], unlocks: ['Hospital'], era: 3 },
   { id: 'quarantine', name: 'Quarantine', track: 'medicine', cost: 80, prerequisites: ['sanitation'], unlocks: ['Plague defense'], era: 3 },
   { id: 'apothecary', name: 'Apothecary', track: 'medicine', cost: 120, prerequisites: ['surgery'], unlocks: ['Pharmacy'], era: 4 },
   { id: 'anatomy', name: 'Anatomy', track: 'medicine', cost: 130, prerequisites: ['surgery', 'quarantine'], unlocks: ['Medical school'], era: 4 },
 
   // === PHILOSOPHY TRACK (8 techs, new) ===
-  { id: 'oral-tradition', name: 'Oral Tradition', track: 'philosophy', cost: 20, prerequisites: [], unlocks: ['Storyteller'], era: 1 },
-  { id: 'mythology', name: 'Mythology', track: 'philosophy', cost: 25, prerequisites: ['oral-tradition'], unlocks: ['Shrine'], era: 1 },
+  { id: 'oral-tradition', name: 'Oral Tradition', track: 'philosophy', cost: 5, prerequisites: [], unlocks: ['Storyteller'], era: 1 },
+  { id: 'mythology', name: 'Mythology', track: 'philosophy', cost: 10, prerequisites: ['oral-tradition'], unlocks: ['Shrine'], era: 1 },
   { id: 'ethics', name: 'Ethics', track: 'philosophy', cost: 45, prerequisites: ['mythology', 'writing'], unlocks: ['Ethical code'], era: 2 },
-  { id: 'rhetoric', name: 'Rhetoric', track: 'philosophy', cost: 50, prerequisites: ['oral-tradition'], unlocks: ['Forum'], era: 2 },
+  { id: 'rhetoric', name: 'Rhetoric', track: 'philosophy', cost: 10, prerequisites: ['oral-tradition'], unlocks: ['Forum'], era: 2 },
   { id: 'logic', name: 'Logic', track: 'philosophy', cost: 85, prerequisites: ['ethics', 'rhetoric'], unlocks: ['School of thought'], era: 3 },
   { id: 'metaphysics', name: 'Metaphysics', track: 'philosophy', cost: 80, prerequisites: ['ethics'], unlocks: ['Great thinker'], era: 3 },
   { id: 'humanism', name: 'Humanism', track: 'philosophy', cost: 125, prerequisites: ['logic', 'metaphysics'], unlocks: ['Enlightenment'], era: 4 },
   { id: 'natural-philosophy', name: 'Natural Philosophy', track: 'philosophy', cost: 120, prerequisites: ['logic'], unlocks: ['Empiricism'], era: 4 },
 
   // === ARTS TRACK (8 techs, new) ===
-  { id: 'cave-painting', name: 'Cave Painting', track: 'arts', cost: 20, prerequisites: [], unlocks: ['Art gallery'], era: 1 },
-  { id: 'storytelling', name: 'Storytelling', track: 'arts', cost: 25, prerequisites: ['cave-painting'], unlocks: ['Bard'], era: 1 },
+  { id: 'cave-painting', name: 'Cave Painting', track: 'arts', cost: 5, prerequisites: [], unlocks: ['Art gallery'], era: 1 },
+  { id: 'storytelling', name: 'Storytelling', track: 'arts', cost: 10, prerequisites: ['cave-painting'], unlocks: ['Bard'], era: 1 },
   { id: 'pottery-arts', name: 'Pottery Arts', track: 'arts', cost: 40, prerequisites: ['storytelling', 'pottery'], unlocks: ['Kiln'], era: 2 },
   { id: 'music', name: 'Music', track: 'arts', cost: 45, prerequisites: ['storytelling'], unlocks: ['Concert hall'], era: 2 },
   { id: 'sculpture', name: 'Sculpture', track: 'arts', cost: 80, prerequisites: ['pottery-arts'], unlocks: ['Statue'], era: 3 },
@@ -94,8 +94,8 @@ export const TECH_TREE: Tech[] = [
   { id: 'architecture-arts', name: 'Architecture Arts', track: 'arts', cost: 130, prerequisites: ['sculpture', 'drama'], unlocks: ['Grand monument'], era: 4 },
 
   // === MARITIME TRACK (8 techs, new) ===
-  { id: 'rafts', name: 'Rafts', track: 'maritime', cost: 20, prerequisites: [], unlocks: ['Raft'], era: 1 },
-  { id: 'fishing', name: 'Fishing', track: 'maritime', cost: 25, prerequisites: ['rafts'], unlocks: ['Fishing boat'], era: 1 },
+  { id: 'rafts', name: 'Rafts', track: 'maritime', cost: 5, prerequisites: [], unlocks: ['Raft'], era: 1 },
+  { id: 'fishing', name: 'Fishing', track: 'maritime', cost: 10, prerequisites: ['rafts'], unlocks: ['Fishing boat'], era: 1 },
   { id: 'galleys', name: 'Galleys', track: 'maritime', cost: 45, prerequisites: ['fishing', 'sailing'], unlocks: ['Galley'], era: 2 },
   { id: 'navigation', name: 'Navigation', track: 'maritime', cost: 50, prerequisites: ['galleys'], unlocks: ['Navigator'], era: 2 },
   { id: 'triremes', name: 'Triremes', track: 'maritime', cost: 85, prerequisites: ['navigation'], unlocks: ['Trireme'], era: 3 },
@@ -104,8 +104,8 @@ export const TECH_TREE: Tech[] = [
   { id: 'naval-warfare', name: 'Naval Warfare', track: 'maritime', cost: 130, prerequisites: ['triremes'], unlocks: ['Warship'], era: 4 },
 
   // === METALLURGY TRACK (8 techs, new) ===
-  { id: 'copper-working', name: 'Copper Working', track: 'metallurgy', cost: 20, prerequisites: [], unlocks: ['Copper tools'], era: 1 },
-  { id: 'smelting', name: 'Smelting', track: 'metallurgy', cost: 25, prerequisites: ['copper-working'], unlocks: ['Furnace'], era: 1 },
+  { id: 'copper-working', name: 'Copper Working', track: 'metallurgy', cost: 5, prerequisites: [], unlocks: ['Copper tools'], era: 1 },
+  { id: 'smelting', name: 'Smelting', track: 'metallurgy', cost: 10, prerequisites: ['copper-working'], unlocks: ['Furnace'], era: 1 },
   { id: 'bronze-casting', name: 'Bronze Casting', track: 'metallurgy', cost: 45, prerequisites: ['smelting', 'bronze-working'], unlocks: ['Bronze armor'], era: 2 },
   { id: 'tool-making', name: 'Tool Making', track: 'metallurgy', cost: 40, prerequisites: ['smelting'], unlocks: ['Improved tools'], era: 2 },
   { id: 'iron-smelting', name: 'Iron Smelting', track: 'metallurgy', cost: 85, prerequisites: ['bronze-casting'], unlocks: ['Iron ore'], era: 3 },
@@ -114,18 +114,18 @@ export const TECH_TREE: Tech[] = [
   { id: 'armor-craft', name: 'Armor Craft', track: 'metallurgy', cost: 120, prerequisites: ['iron-smelting'], unlocks: ['Plate armor'], era: 4 },
 
   // === CONSTRUCTION TRACK (8 techs, new) ===
-  { id: 'mud-brick', name: 'Mud Brick', track: 'construction', cost: 20, prerequisites: [], unlocks: ['Basic walls'], era: 1 },
-  { id: 'thatching', name: 'Thatching', track: 'construction', cost: 25, prerequisites: ['mud-brick'], unlocks: ['Shelter'], era: 1 },
+  { id: 'mud-brick', name: 'Mud Brick', track: 'construction', cost: 5, prerequisites: [], unlocks: ['Basic walls'], era: 1 },
+  { id: 'thatching', name: 'Thatching', track: 'construction', cost: 10, prerequisites: ['mud-brick'], unlocks: ['Shelter'], era: 1 },
   { id: 'masonry', name: 'Masonry', track: 'construction', cost: 45, prerequisites: ['thatching'], unlocks: ['Stone walls'], era: 2 },
-  { id: 'foundations', name: 'Foundations', track: 'construction', cost: 40, prerequisites: ['mud-brick'], unlocks: ['Sturdy buildings'], era: 2 },
+  { id: 'foundations', name: 'Foundations', track: 'construction', cost: 10, prerequisites: ['mud-brick'], unlocks: ['Sturdy buildings'], era: 2 },
   { id: 'aqueducts', name: 'Aqueducts', track: 'construction', cost: 85, prerequisites: ['masonry', 'engineering'], unlocks: ['Water system'], era: 3 },
   { id: 'arches', name: 'Arches', track: 'construction', cost: 80, prerequisites: ['masonry', 'foundations'], unlocks: ['Grand buildings'], era: 3 },
   { id: 'fortresses', name: 'Fortresses', track: 'construction', cost: 125, prerequisites: ['arches'], unlocks: ['Fortress'], era: 4 },
   { id: 'city-planning', name: 'City Planning', track: 'construction', cost: 130, prerequisites: ['aqueducts', 'arches'], unlocks: ['Planned city'], era: 4 },
 
   // === COMMUNICATION TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'drums', name: 'Drums', track: 'communication', cost: 20, prerequisites: [], unlocks: ['Signal drums'], era: 1 },
-  { id: 'smoke-signals', name: 'Smoke Signals', track: 'communication', cost: 25, prerequisites: ['drums'], unlocks: ['Watchtower'], era: 1 },
+  { id: 'drums', name: 'Drums', track: 'communication', cost: 5, prerequisites: [], unlocks: ['Signal drums'], era: 1 },
+  { id: 'smoke-signals', name: 'Smoke Signals', track: 'communication', cost: 10, prerequisites: ['drums'], unlocks: ['Watchtower'], era: 1 },
   { id: 'pictographs', name: 'Pictographs', track: 'communication', cost: 45, prerequisites: ['smoke-signals', 'writing'], unlocks: ['Record keeping'], era: 2 },
   { id: 'messengers', name: 'Messengers', track: 'communication', cost: 40, prerequisites: ['smoke-signals'], unlocks: ['Messenger post'], era: 2 },
   { id: 'courier-networks', name: 'Courier Networks', track: 'communication', cost: 80, prerequisites: ['messengers', 'pictographs'], unlocks: ['Postal service'], era: 3 },
@@ -147,8 +147,8 @@ export const TECH_TREE: Tech[] = [
   { id: 'cyber-warfare', name: 'Cyber Warfare', track: 'espionage', cost: 185, prerequisites: ['digital-surveillance'], unlocks: ['Cyber Attack', 'Election Interference'], era: 5 },
 
   // === SPIRITUALITY TRACK (8 techs, new) ===
-  { id: 'animism', name: 'Animism', track: 'spirituality', cost: 20, prerequisites: [], unlocks: ['Spirit shrine'], era: 1 },
-  { id: 'burial-rites', name: 'Burial Rites', track: 'spirituality', cost: 25, prerequisites: ['animism'], unlocks: ['Burial ground'], era: 1 },
+  { id: 'animism', name: 'Animism', track: 'spirituality', cost: 5, prerequisites: [], unlocks: ['Spirit shrine'], era: 1 },
+  { id: 'burial-rites', name: 'Burial Rites', track: 'spirituality', cost: 10, prerequisites: ['animism'], unlocks: ['Burial ground'], era: 1 },
   { id: 'shamanism', name: 'Shamanism', track: 'spirituality', cost: 45, prerequisites: ['burial-rites', 'tribal-council'], unlocks: ['Shaman'], era: 2 },
   { id: 'sacred-sites', name: 'Sacred Sites', track: 'spirituality', cost: 40, prerequisites: ['burial-rites'], unlocks: ['Holy site'], era: 2 },
   { id: 'temples', name: 'Temples', track: 'spirituality', cost: 85, prerequisites: ['shamanism', 'sacred-sites'], unlocks: ['Grand temple'], era: 3 },

--- a/tests/integration/pacing-simulation.test.ts
+++ b/tests/integration/pacing-simulation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import { processTurn } from '@/core/turn-manager';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
 
@@ -33,5 +34,67 @@ describe('pacing simulation', () => {
     }
 
     expect(warriorDone || fireDone).toBe(true);
+  });
+
+  function makeBronzeWorkingResearchState(scienceInvestment: 'baseline' | 'idle-science') {
+    const state = createNewGame(undefined, `bronze-working-${scienceInvestment}`, 'small');
+    const player = state.civilizations.player;
+    const settlerId = player.units.find(unitId => state.units[unitId]?.type === 'settler');
+    expect(settlerId).toBeDefined();
+
+    const city = foundCity('player', state.units[settlerId!].position, state.map);
+    state.cities[city.id] = {
+      ...city,
+      productionQueue: [],
+      idleProduction: scienceInvestment === 'idle-science' ? 'science' : null,
+    };
+    player.cities.push(city.id);
+    for (const coord of city.ownedTiles) {
+      const key = hexKey(coord);
+      state.map.tiles[key] = {
+        ...state.map.tiles[key],
+        terrain: 'grassland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+        owner: 'player',
+      };
+    }
+
+    player.techState.completed = ['stone-weapons'];
+    player.techState.currentResearch = 'bronze-working';
+    player.techState.researchProgress = 0;
+    player.techState.researchQueue = [];
+
+    expect(calculateProjectedCityYields(state, city.id).science).toBe(
+      scienceInvestment === 'idle-science' ? 2 : 1,
+    );
+
+    return state;
+  }
+
+  function turnsToCompleteBronzeWorking(scienceInvestment: 'baseline' | 'idle-science'): number {
+    let next = makeBronzeWorkingResearchState(scienceInvestment);
+    for (let turn = 1; turn <= 20; turn++) {
+      next = processTurn(next, new EventBus());
+      if (next.civilizations.player.techState.completed.includes('bronze-working')) {
+        return turn;
+      }
+    }
+    return Number.POSITIVE_INFINITY;
+  }
+
+  it('completes Bronze Working in 9-11 turns for a baseline one-city opening', () => {
+    const turns = turnsToCompleteBronzeWorking('baseline');
+    expect(turns).toBeGreaterThanOrEqual(9);
+    expect(turns).toBeLessThanOrEqual(11);
+  });
+
+  it('completes Bronze Working in 5-7 turns when opening production is invested into science', () => {
+    const turns = turnsToCompleteBronzeWorking('idle-science');
+    expect(turns).toBeGreaterThanOrEqual(5);
+    expect(turns).toBeLessThanOrEqual(7);
   });
 });

--- a/tests/systems/pacing-audit.test.ts
+++ b/tests/systems/pacing-audit.test.ts
@@ -74,16 +74,28 @@ describe('tech pacing audit', () => {
     expect(bronze?.contentType).toBe('tech');
     expect(bronze?.researchProfile).toBe('opening-baseline');
     expect(bronze?.liveBaselineTurns).toBe(bronze?.estimatedTurns);
-    expect(bronze?.liveBaselineTurns).toBeGreaterThan(11);
+    expect(bronze?.liveBaselineTurns).toBeGreaterThanOrEqual(9);
+    expect(bronze?.liveBaselineTurns).toBeLessThanOrEqual(11);
     expect(bronze?.recommendedCost).toBeGreaterThan(0);
   });
 
-  it('flags current Bronze Working as a slow opening outlier before the retune', () => {
+  it('keeps retuned Bronze Working inside its opening target window', () => {
     const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
 
-    expect(bronze?.estimatedTurns).toBe(50);
+    expect(bronze?.estimatedTurns).toBeGreaterThanOrEqual(9);
+    expect(bronze?.estimatedTurns).toBeLessThanOrEqual(11);
     expect(bronze?.target).toEqual({ min: 9, max: 11 });
-    expect(bronze?.outlier).toBe(true);
-    expect(bronze?.outlierReason).toBe('Slower than target window');
+    expect(bronze?.outlier).toBe(false);
+    expect(bronze?.outlierReason).toBe('Within target window');
+  });
+
+  it('has no slow tech outliers among opening-baseline tech rows after retune', () => {
+    const slowOutliers = buildPacingAudit()
+      .filter(row => row.contentType === 'tech')
+      .filter(row => row.researchProfile === 'opening-baseline')
+      .filter(row => row.estimatedTurns > row.target.max)
+      .map(row => `${row.id}:${row.estimatedTurns}/${row.target.max}`);
+
+    expect(slowOutliers).toEqual([]);
   });
 });

--- a/tests/systems/pacing-audit.test.ts
+++ b/tests/systems/pacing-audit.test.ts
@@ -65,3 +65,25 @@ describe('pacing-audit', () => {
     expect(slowOutliers).toEqual([]);
   });
 });
+
+describe('tech pacing audit', () => {
+  it('reports research profile and live baseline fields for tech rows', () => {
+    const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
+
+    expect(bronze).toBeDefined();
+    expect(bronze?.contentType).toBe('tech');
+    expect(bronze?.researchProfile).toBe('opening-baseline');
+    expect(bronze?.liveBaselineTurns).toBe(bronze?.estimatedTurns);
+    expect(bronze?.liveBaselineTurns).toBeGreaterThan(11);
+    expect(bronze?.recommendedCost).toBeGreaterThan(0);
+  });
+
+  it('flags current Bronze Working as a slow opening outlier before the retune', () => {
+    const bronze = buildPacingAudit().find(row => row.id === 'bronze-working');
+
+    expect(bronze?.estimatedTurns).toBe(50);
+    expect(bronze?.target).toEqual({ min: 9, max: 11 });
+    expect(bronze?.outlier).toBe(true);
+    expect(bronze?.outlierReason).toBe('Slower than target window');
+  });
+});

--- a/tests/systems/pacing-model.test.ts
+++ b/tests/systems/pacing-model.test.ts
@@ -62,6 +62,8 @@ describe('research pacing model', () => {
   it('uses the opening baseline profile for starter and first real unlock techs', () => {
     expect(getResearchOutputProfileForTech(tech('stone-weapons'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
     expect(getResearchOutputProfileForTech(tech('bronze-working'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('espionage-scouting'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+    expect(getResearchOutputProfileForTech(tech('lookouts'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
     expect(getResearchOutputProfileForTech(tech('early-empire'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
   });
 

--- a/tests/systems/pacing-model.test.ts
+++ b/tests/systems/pacing-model.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { estimateTurnsToComplete, getProductionOutputProfileForEra, getTargetTurnWindow } from '@/systems/pacing-model';
+import type { PacingMetadata } from '@/core/types';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import {
+  estimateTurnsToComplete,
+  getMetadataComplexityMultiplier,
+  getProductionOutputProfileForEra,
+  getRecommendedTechCost,
+  getRecommendedTechTurnWindow,
+  getResearchOutputProfileForEra,
+  getResearchOutputProfileForTech,
+  getTargetTurnWindow,
+  isFirstRealUnlockTech,
+  isStarterPrerequisiteTech,
+} from '@/systems/pacing-model';
+
+function tech(id: string) {
+  const found = TECH_TREE.find(candidate => candidate.id === id);
+  if (!found) throw new Error(`missing tech ${id}`);
+  return found;
+}
 
 describe('pacing-model', () => {
   it('gives Era 1 starter items a 2-4 turn target window', () => {
@@ -13,5 +32,96 @@ describe('pacing-model', () => {
 
   it('uses Era 1 production assumptions when the era is invalid', () => {
     expect(getProductionOutputProfileForEra(Number.NaN)).toBe(4);
+  });
+});
+
+describe('research pacing model', () => {
+  it('returns stable established-era research profiles', () => {
+    expect(getResearchOutputProfileForEra(Number.NaN)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForEra(1)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForEra(2)).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+    expect(getResearchOutputProfileForEra(5)).toEqual({ name: 'era-5-established', outputPerTurn: 13 });
+    expect(getResearchOutputProfileForEra(99)).toEqual({ name: 'era-5-established', outputPerTurn: 13 });
+  });
+
+  it('classifies starter prerequisites structurally from era, prerequisites, and pacing band', () => {
+    expect(isStarterPrerequisiteTech(tech('stone-weapons'))).toBe(true);
+    expect(isStarterPrerequisiteTech(tech('fire'))).toBe(true);
+    expect(isStarterPrerequisiteTech(tech('espionage-scouting'))).toBe(false);
+    expect(isStarterPrerequisiteTech(tech('archery'))).toBe(false);
+  });
+
+  it('classifies first real unlocks structurally without reading unlock prose', () => {
+    expect(isFirstRealUnlockTech(tech('archery'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('bronze-working'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('writing'))).toBe(true);
+    expect(isFirstRealUnlockTech(tech('early-empire'))).toBe(false);
+    expect(isFirstRealUnlockTech(tech('lookouts'))).toBe(false);
+  });
+
+  it('uses the opening baseline profile for starter and first real unlock techs', () => {
+    expect(getResearchOutputProfileForTech(tech('stone-weapons'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('bronze-working'))).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(getResearchOutputProfileForTech(tech('early-empire'))).toEqual({ name: 'era-2-established', outputPerTurn: 4 });
+  });
+
+  it('returns opening-specific turn windows before generic era windows', () => {
+    expect(getRecommendedTechTurnWindow(tech('stone-weapons'))).toEqual({ min: 2, max: 5 });
+    expect(getRecommendedTechTurnWindow(tech('archery'))).toEqual({ min: 8, max: 12 });
+    expect(getRecommendedTechTurnWindow(tech('bronze-working'))).toEqual({ min: 9, max: 11 });
+    expect(getRecommendedTechTurnWindow(tech('early-empire'))).toEqual({ min: 4, max: 7 });
+  });
+
+  it('applies metadata complexity with bounded cost pressure', () => {
+    const neutral: PacingMetadata = {
+      band: 'core',
+      role: 'neutral',
+      impact: 1,
+      scope: 'city',
+      snowball: 1,
+      urgency: 1,
+      situationality: 1,
+      unlockBreadth: 1,
+    };
+    const broadAccelerant: PacingMetadata = {
+      ...neutral,
+      impact: 1.25,
+      scope: 'empire',
+      snowball: 1.25,
+      unlockBreadth: 1.2,
+    };
+    const urgentNiche: PacingMetadata = {
+      ...neutral,
+      urgency: 1.25,
+      situationality: 1.25,
+    };
+
+    expect(getMetadataComplexityMultiplier(broadAccelerant)).toBeGreaterThan(getMetadataComplexityMultiplier(neutral));
+    expect(getMetadataComplexityMultiplier(urgentNiche)).toBeLessThan(getMetadataComplexityMultiplier(neutral));
+    expect(getMetadataComplexityMultiplier({
+      ...broadAccelerant,
+      impact: 9,
+      snowball: 9,
+      unlockBreadth: 9,
+    })).toBe(1.35);
+    expect(getMetadataComplexityMultiplier({
+      ...urgentNiche,
+      urgency: 9,
+      situationality: 9,
+    })).toBe(0.75);
+    expect(getMetadataComplexityMultiplier(broadAccelerant, { max: 1.1 })).toBe(1.1);
+  });
+
+  it('recommends readable opening tech costs inside accepted live turn windows', () => {
+    const stone = getRecommendedTechCost(tech('stone-weapons'));
+    const archery = getRecommendedTechCost(tech('archery'));
+    const bronze = getRecommendedTechCost(tech('bronze-working'));
+
+    expect(estimateTurnsToComplete({ cost: stone, outputPerTurn: 1 })).toBeGreaterThanOrEqual(2);
+    expect(estimateTurnsToComplete({ cost: stone, outputPerTurn: 1 })).toBeLessThanOrEqual(5);
+    expect(estimateTurnsToComplete({ cost: archery, outputPerTurn: 1 })).toBeGreaterThanOrEqual(8);
+    expect(estimateTurnsToComplete({ cost: archery, outputPerTurn: 1 })).toBeLessThanOrEqual(12);
+    expect(estimateTurnsToComplete({ cost: bronze, outputPerTurn: 1 })).toBeGreaterThanOrEqual(9);
+    expect(estimateTurnsToComplete({ cost: bronze, outputPerTurn: 1 })).toBeLessThanOrEqual(11);
   });
 });

--- a/tests/systems/tech-definitions.test.ts
+++ b/tests/systems/tech-definitions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { TECH_TREE, getEraAdvancementTechs } from '@/systems/tech-definitions';
+import {
+  estimateTurnsToComplete,
+  getResearchOutputProfileForTech,
+  isFirstRealUnlockTech,
+  isStarterPrerequisiteTech,
+} from '@/systems/pacing-model';
 
 describe('tech definitions', () => {
   it('has exactly 125 techs after adding late-era Slice 3 scaffolding', () => {
@@ -118,5 +124,91 @@ describe('tech definitions', () => {
   it('has no orphan late-era nodes', () => {
     const lateEra = TECH_TREE.filter(t => t.era >= 5);
     expect(lateEra.every(t => t.prerequisites.length > 0)).toBe(true);
+  });
+});
+
+describe('opening research pacing data', () => {
+  it('keeps starter prerequisites inside the 2-5 turn baseline window', () => {
+    const starters = TECH_TREE.filter(tech => isStarterPrerequisiteTech(tech));
+    expect(starters.map(tech => tech.id)).toEqual(expect.arrayContaining([
+      'stone-weapons',
+      'gathering',
+      'fire',
+      'tribal-council',
+      'pathfinding',
+      'foraging',
+      'herbalism',
+      'oral-tradition',
+      'cave-painting',
+      'rafts',
+      'copper-working',
+      'mud-brick',
+      'drums',
+      'animism',
+    ]));
+    expect(starters.map(tech => tech.id)).not.toContain('espionage-scouting');
+
+    const outliers = starters
+      .map(tech => `${tech.id}:${estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: 1 })}`)
+      .filter(entry => {
+        const turns = Number(entry.split(':')[1]);
+        return turns < 2 || turns > 5;
+      });
+
+    expect(outliers).toEqual([]);
+  });
+
+  it('keeps structural first real unlocks inside the 8-12 turn baseline window', () => {
+    const firstUnlocks = TECH_TREE.filter(tech => isFirstRealUnlockTech(tech));
+    expect(firstUnlocks.map(tech => tech.id)).toEqual(expect.arrayContaining([
+      'archery',
+      'bronze-working',
+      'writing',
+      'wheel',
+      'pottery',
+      'animal-husbandry',
+      'code-of-laws',
+      'cartography',
+      'sailing',
+      'domestication',
+      'granary-design',
+      'bone-setting',
+      'midwifery',
+      'mythology',
+      'rhetoric',
+      'storytelling',
+      'fishing',
+      'smelting',
+      'thatching',
+      'foundations',
+      'smoke-signals',
+      'burial-rites',
+    ]));
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('early-empire');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('lookouts');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('music');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('tool-making');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('messengers');
+    expect(firstUnlocks.map(tech => tech.id)).not.toContain('sacred-sites');
+
+    const outliers = firstUnlocks
+      .filter(tech => tech.id !== 'bronze-working')
+      .map(tech => `${tech.id}:${estimateTurnsToComplete({ cost: tech.cost, outputPerTurn: 1 })}`)
+      .filter(entry => {
+        const turns = Number(entry.split(':')[1]);
+        return turns < 8 || turns > 12;
+      });
+
+    expect(outliers).toEqual([]);
+  });
+
+  it('keeps Bronze Working in its explicit 9-11 turn baseline window', () => {
+    const bronze = TECH_TREE.find(tech => tech.id === 'bronze-working');
+    expect(bronze).toBeDefined();
+    expect(getResearchOutputProfileForTech(bronze!)).toEqual({ name: 'opening-baseline', outputPerTurn: 1 });
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 1 })).toBeGreaterThanOrEqual(9);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 1 })).toBeLessThanOrEqual(11);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeGreaterThanOrEqual(5);
+    expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeLessThanOrEqual(7);
   });
 });

--- a/tests/systems/tech-progression.test.ts
+++ b/tests/systems/tech-progression.test.ts
@@ -103,8 +103,8 @@ describe('tech progression view model', () => {
       researchQueue: ['fire'],
     }, { sciencePerTurn: 3, zoom: 'all' });
 
-    expect(view.nodesById.get('stone-weapons')?.turnsToResearch).toBe(2);
-    expect(view.nodesById.get('fire')?.turnsToResearch).toBe(3);
+    expect(view.nodesById.get('stone-weapons')?.turnsToResearch).toBe(0);
+    expect(view.nodesById.get('fire')?.turnsToResearch).toBe(2);
     expect(view.nodesById.get('banking')?.turnsToResearch).toBeNull();
   });
 

--- a/tests/systems/tech-progression.test.ts
+++ b/tests/systems/tech-progression.test.ts
@@ -99,11 +99,11 @@ describe('tech progression view model', () => {
     const view = buildTechProgressionView({
       ...createTechState(),
       currentResearch: 'stone-weapons',
-      researchProgress: 4,
+      researchProgress: 1,
       researchQueue: ['fire'],
     }, { sciencePerTurn: 3, zoom: 'all' });
 
-    expect(view.nodesById.get('stone-weapons')?.turnsToResearch).toBe(0);
+    expect(view.nodesById.get('stone-weapons')?.turnsToResearch).toBe(1);
     expect(view.nodesById.get('fire')?.turnsToResearch).toBe(2);
     expect(view.nodesById.get('banking')?.turnsToResearch).toBeNull();
   });

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -2,6 +2,9 @@
 
 import { describe, expect, it, vi } from 'vitest';
 import { createNewGame } from '@/core/game-state';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
 import { enqueueResearch } from '@/systems/planning-system';
 import { startResearch, TECH_TREE } from '@/systems/tech-system';
 import { createTechPanel } from '@/ui/tech-panel';
@@ -583,5 +586,76 @@ describe('tech-panel', () => {
     const downBtn = document.body.querySelector<HTMLButtonElement>('[data-queue-action="down"][data-queue-index="1"]');
     expect(downBtn).toBeTruthy();
     expect(downBtn!.disabled).toBe(true);
+  });
+
+  function makeBronzeWorkingPanelState(scienceInvestment: 'baseline' | 'idle-science' = 'baseline') {
+    const state = createNewGame(undefined, 'tech-panel-bronze-working-eta', 'small');
+    const player = state.civilizations.player;
+    const settlerId = player.units.find(unitId => state.units[unitId]?.type === 'settler');
+    expect(settlerId).toBeDefined();
+
+    const city = foundCity('player', state.units[settlerId!].position, state.map);
+    state.cities[city.id] = {
+      ...city,
+      productionQueue: [],
+      idleProduction: scienceInvestment === 'idle-science' ? 'science' : null,
+    };
+    player.cities.push(city.id);
+    for (const coord of city.ownedTiles) {
+      const key = hexKey(coord);
+      state.map.tiles[key] = {
+        ...state.map.tiles[key],
+        terrain: 'grassland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+        owner: 'player',
+      };
+    }
+
+    player.techState.completed = ['stone-weapons'];
+    player.techState.currentResearch = 'bronze-working';
+    player.techState.researchProgress = 0;
+    player.techState.researchQueue = [];
+
+    expect(calculateProjectedCityYields(state, city.id).science).toBe(
+      scienceInvestment === 'idle-science' ? 2 : 1,
+    );
+
+    return state;
+  }
+
+  it('shows live Bronze Working ETA from current science instead of audit-profile math', () => {
+    const state = makeBronzeWorkingPanelState();
+
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Researching: Bronze Working');
+    expect(panel.textContent).toMatch(/Turns remaining: (9|10|11)/);
+    expect(panel.textContent).not.toContain('50');
+    expect(panel.querySelector('[data-tech-id="bronze-working"]')?.textContent).toMatch(/(9|10|11) turns/);
+  });
+
+  it('updates visible Bronze Working ETA when opening production is invested into science', () => {
+    const state = makeBronzeWorkingPanelState('idle-science');
+
+    const panel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Researching: Bronze Working');
+    expect(panel.textContent).toMatch(/Turns remaining: (5|6|7)/);
+    expect(panel.textContent).not.toMatch(/Turns remaining: (9|10|11)/);
+    expect(panel.querySelector('[data-tech-id="bronze-working"]')?.textContent).toMatch(/(5|6|7) turns/);
   });
 });


### PR DESCRIPTION
## Summary
- Adds research-specific pacing profiles, structural opening-tier helpers, and metadata-based recommended tech costs.
- Wires tech pacing audit rows to the research model while preserving live ETA math in the tech panel.
- Retunes starter prerequisite and first real unlock costs so Bronze Working lands in the 9-11 baseline turn window and 5-7 turns with early science investment.

## Gameplay impact
- Early research now produces meaningful first unlocks in roughly 10 turns instead of dozens.
- Specialized espionage roots are not flattened into the opening baseline profile.
- No tech IDs, prerequisites, unlock behavior, queue semantics, save format, or per-turn science generation rules changed.

## Test Plan
- scripts/check-src-rule-violations.sh src/systems/pacing-model.ts src/systems/pacing-audit.ts src/systems/tech-definitions.ts
- ./scripts/run-with-mise.sh yarn test --run tests/systems/pacing-model.test.ts tests/systems/pacing-audit.test.ts tests/systems/tech-definitions.test.ts tests/integration/pacing-simulation.test.ts tests/ui/tech-panel.test.ts tests/systems/tech-progression.test.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test

Closes #133