### PR TITLE
Fix combat targeting, fog memory, and unit motion

### DIFF
--- a/docs/superpowers/plans/2026-05-15-combat-visibility-unit-motion-bug-bundle.md
+++ b/docs/superpowers/plans/2026-05-15-combat-visibility-unit-motion-bug-bundle.md
@@ -1,0 +1,2361 @@
+# Combat, Visibility, And Unit Motion Bug Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task inline. Steps use checkbox (`- [ ]`) syntax for tracking. Do not use subagents for this plan.
+
+**Goal:** Fix issues #198-#201 by separating movement from attack eligibility, preserving viewer-scoped fog/last-seen truth at every zoom/wrap copy, giving barbarian and minor-civ units clear visual identity, and adding full per-sprite unit motion frames.
+
+**Architecture:** Implement this in two reviewable slices. Slice 1 adds shared attack targeting plus viewer-scoped last-seen tile presentation, then wires player and non-player paths through those helpers. Slice 2 adds a shared unit visual resolver, role markers, sprite motion frames, and movement animation command lockout.
+
+**Tech Stack:** TypeScript, Canvas 2D renderer, Vite, Vitest, custom JSX sprite runtime, existing `./scripts/run-with-mise.sh yarn ...` command wrapper.
+
+---
+
+## Source Spec
+
+- Design spec: `docs/superpowers/specs/2026-05-15-combat-visibility-unit-motion-bug-bundle-design.md`
+- Issues: #198, #199, #200, #201
+
+## File Structure
+
+### Slice 1: Attack Rules And Visibility Truth
+
+- Create: `src/systems/attack-targeting.ts`
+  - Owns typed attack profiles, attack distance checks, target classification, and attack target collection.
+- Create: `tests/systems/attack-targeting.test.ts`
+  - Proves melee adjacency, explicit ranged attacks, fog gating, wrapped distance, and no ranged city attack without siege/bombard.
+- Create: `src/input/selected-unit-highlights.ts`
+  - Converts movement range and attack target data into renderer-facing `HexHighlight[]` records.
+- Create: `tests/input/selected-unit-highlights.test.ts`
+  - Proves movement and attack highlights do not lie to the player.
+- Modify: `src/input/selected-unit-tap-intent.ts`
+  - Stops using movement range as the gate for city assault when attack profile disallows it.
+- Modify: `tests/input/selected-unit-tap-intent.test.ts`
+  - Adds non-adjacent melee and ranged-city negative coverage.
+- Modify: `src/main.ts`
+  - Stores separate movement and attack target ranges, opens combat preview only for legal attack targets, and revalidates on attack confirmation.
+- Create: `src/systems/last-seen-presentation.ts`
+  - Owns viewer-scoped serializable last-seen tile presentation snapshots.
+- Create: `tests/systems/last-seen-presentation.test.ts`
+  - Proves snapshots update only from visible tiles, are viewer-scoped, and do not read live fogged city state.
+- Modify: `src/core/types.ts`
+  - Adds serializable `LastSeenTilePresentation` and `VisibilityMap.lastSeen`.
+- Modify: `src/systems/fog-of-war.ts`
+  - Exposes canonical visibility coordinate helpers and refreshes last-seen presentation after visibility updates.
+- Modify: `src/systems/unit-movement-system.ts`
+  - Refreshes last-seen presentation after player, AI, and automation movement changes visibility.
+- Modify: `src/core/game-state.ts`
+  - Seeds last-seen presentation after initial visibility is computed for new games and hot-seat starts.
+- Modify: `src/core/turn-manager.ts`
+  - Refreshes last-seen presentation after per-turn visibility updates and minor-civ shared vision.
+- Create: `src/renderer/tile-presentation.ts`
+  - Resolves live, last-seen, or unknown tile presentation for rendering.
+- Create: `tests/renderer/tile-presentation.test.ts`
+  - Proves fogged tiles render from last-seen data and missing last-seen renders as unknown fog.
+- Modify: `src/renderer/hex-renderer.ts`
+  - Draws visible tiles from live state, fogged tiles from last-seen presentation, and unexplored tiles from hidden presentation.
+- Modify: `src/renderer/city-renderer.ts`
+  - Draws visible cities from live state, fogged cities from last-seen presentation, and no city at all on unexplored tiles.
+- Modify: `tests/renderer/city-renderer.test.ts`
+  - Proves fogged city rendering uses stale name/owner/population and does not leak live production, unrest, occupation, or destruction.
+- Modify: `src/renderer/fog-renderer.ts`
+  - Uses canonical visibility for wrap ghost copies and keeps overlay opacity stable at low zoom.
+- Modify: `tests/renderer/fog-renderer.test.ts`
+  - Adds low-zoom/wrap canonical overlay coverage.
+- Modify: `src/renderer/render-visibility.ts`
+  - Allows last-seen ownership presentation for fogged tiles without using live foreign ownership.
+
+### Slice 2: Unit Visual Identity And Motion
+
+- Create: `src/renderer/unit-visual-resolver.ts`
+  - Owns owner role, palette/color, fallback icon, role marker, sprite key, and motion state.
+- Create: `tests/renderer/unit-visual-resolver.test.ts`
+  - Proves major, barbarian, and minor-civ role marker decisions and privacy-safe minor-civ color fallback.
+- Modify: `src/renderer/unit-renderer.ts`
+  - Draws units through the visual resolver, exposes a single-unit drawing helper for movement animation, draws role markers, and skips units currently rendered as movement animations.
+- Modify: `tests/renderer/unit-renderer.test.ts`
+  - Proves barbarian chevron, minor-civ diamond, stack count, and hidden moving unit behavior.
+- Modify: `src/main.ts`
+  - Includes barbarian and active minor-civ palettes when calling `initSprites`.
+- Modify: `src/renderer/sprites/units.tsx`
+  - Adds full per-sprite moving frame support for every current unit sprite.
+- Modify: `src/renderer/sprites/sprite-catalog.ts`
+  - Keeps catalog type compatible with motion-capable unit sprite props.
+- Modify: `src/renderer/sprites/sprite-loader.ts`
+  - Loads/caches idle and motion frame images by civ palette without breaking uncached `null` behavior.
+- Modify: `tests/renderer/sprites/sprite-catalog.test.ts`
+  - Proves every unit type has idle and moving output.
+- Modify: `tests/renderer/sprites/sprite-loader.test.ts`
+  - Proves sprite cache returns motion frames for loaded civs and `null` for uncached civs.
+- Create: `src/renderer/unit-movement-animation.ts`
+  - Owns interpolation, wrapped route projection, animation duration, moving-unit IDs, and frame choice.
+- Create: `tests/renderer/unit-movement-animation.test.ts`
+  - Proves short wrapped route, duration clamp, frame selection, and moved-unit hiding.
+- Modify: `src/renderer/animation-system.ts`
+  - Gives movement animation a typed hook while preserving existing hex reveal and combat flash behavior.
+- Modify: `src/renderer/render-loop.ts`
+  - Draws moving units after stationary units and before fog overlay, so animation still respects visibility.
+- Modify: `src/main.ts`
+  - Starts movement animation from `executeUnitMove` results, blocks duplicate commands while a unit is moving, and resumes selection after completion.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Warrior selected, visible enemy two hexes away, tile inside movement range | Player taps enemy | No combat preview opens; enemy tile is not red-highlighted |
+| Archer selected, visible enemy unit two hexes away | Player taps enemy | Combat preview opens; Archer stays on original tile when attack is confirmed |
+| Archer selected, hostile city two hexes away | Player taps city | No ranged city/capture preview opens |
+| Enemy unit position is fogged or unexplored | Player selects ranged unit | Hidden enemy does not get an attack highlight |
+| Previously visible tile becomes fogged | Player zooms out or pans across wrap copies | Last-seen tile presentation remains under fog overlay; live unit/city changes stay hidden |
+| Barbarian or minor-civ unit is visible | Player looks at map | Unit uses same base sprite as major civ, owner color, and role marker |
+| Unit moves | Player watches movement | Unit travels along route and uses per-sprite motion frames while role marker remains visible |
+| Unit is mid-animation | Player taps moving unit or destination | No duplicate command is accepted; normal commands resume after animation completes |
+| Unit crosses horizontal wrap edge | Player watches movement | Unit takes the short wrapped route instead of sliding across the full map |
+
+## Misleading UI Risks
+
+- **Attackable:** A tile is attackable only if `canUnitAttackTarget()` returns `ok: true`. Movement reach alone must not create an attack highlight.
+- **Visible target:** Player-ranged attacks require current visibility. A fogged historical target must not appear attackable.
+- **City attack:** Ordinary ranged units attack units only. A city target requires adjacent melee/city assault unless a later siege/bombard profile exists.
+- **Fog/stale:** Fogged tiles show viewer-scoped last-seen presentation. They must not read live units, live city ownership, live destruction, live garrisons, or live improvements.
+- **Role marker:** Barbarian and minor-civ role markers are identity cues, not diplomacy state. They must not reveal undiscovered minor-civ names or hidden details.
+- **Moving unit:** A moving unit is visually busy. Accepting a second command during animation creates stale-state UX and must be blocked.
+
+## Interaction Replay Checklist
+
+- Select Warrior, verify only adjacent hostile targets are red-highlighted.
+- Select Archer, verify visible hostile unit at range is red-highlighted and hostile city at range is not.
+- Open combat preview, mutate target legality in the test fixture, click `Attack`, and verify execution revalidates before applying combat.
+- Move a unit one hex, verify moving visual appears, repeat-click is ignored, animation completes, and normal selection resumes.
+- Move one unit out of a stack, verify stack count updates after animation and no duplicate idle copy is drawn.
+- Pan/zoom wrapped map at low zoom, verify fog overlays and last-seen presentation are identical for canonical and ghost copies.
+- Load a save missing `visibility.lastSeen`, render fogged tile, and verify unknown fog appears without live terrain leak.
+
+---
+
+## Task 1: Shared Attack Targeting Helper
+
+**Files:**
+- Create: `src/systems/attack-targeting.ts`
+- Create: `tests/systems/attack-targeting.test.ts`
+- Modify: `src/systems/unit-system.ts`
+
+- [ ] **Step 1: Write failing attack targeting tests**
+
+Create `tests/systems/attack-targeting.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { GameMap, GameState, HexCoord, Unit } from '@/core/types';
+import { canUnitAttackTarget, getAttackTargets, getUnitAttackProfile } from '@/systems/attack-targeting';
+import { createUnit } from '@/systems/unit-system';
+import { hexKey } from '@/systems/hex-utils';
+
+function grassMap(width = 6, height = 4, wrapsHorizontally = false): GameMap {
+  const tiles: GameMap['tiles'] = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < height; r++) {
+      tiles[hexKey({ q, r })] = {
+        coord: { q, r },
+        terrain: 'grassland',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: null,
+        improvementTurnsLeft: 0,
+        hasRiver: false,
+        wonder: null,
+      };
+    }
+  }
+  return { width, height, wrapsHorizontally, tiles, rivers: [] };
+}
+
+function unit(id: string, type: Unit['type'], owner: string, position: HexCoord): Unit {
+  return { ...createUnit(type, owner, position), id, owner, position };
+}
+
+function stateWithUnits(units: Record<string, Unit>, visibility: Record<string, 'visible' | 'fog' | 'unexplored'> = {}): GameState {
+  return {
+    turn: 1,
+    era: 1,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: grassMap(),
+    units,
+    cities: {},
+    civilizations: {
+      player: { id: 'player', name: 'Player', color: '#4a90d9', isHuman: true, civType: 'generic', cities: [], units: Object.keys(units).filter(id => units[id].owner === 'player'), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, visibility: { tiles: visibility }, score: 0, diplomacy: { relationships: { 'ai-1': -50 }, treaties: [], events: [], atWarWith: ['ai-1'], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } } },
+      'ai-1': { id: 'ai-1', name: 'AI', color: '#d94a4a', isHuman: false, civType: 'generic', cities: [], units: Object.keys(units).filter(id => units[id].owner === 'ai-1'), techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any }, gold: 0, visibility: { tiles: {} }, score: 0, diplomacy: { relationships: { player: -50 }, treaties: [], events: [], atWarWith: ['player'], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } } },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tribalVillages: {},
+    resources: {},
+    improvements: {},
+    settings: { soundEnabled: false, musicEnabled: false, musicVolume: 0.5, sfxVolume: 0.5, tutorialEnabled: false, advisorsEnabled: false, councilTalkLevel: 'normal' },
+  } as unknown as GameState;
+}
+
+describe('attack-targeting', () => {
+  it('gives warriors the default melee profile and archers an explicit ranged profile', () => {
+    expect(getUnitAttackProfile('warrior')).toEqual({ kind: 'melee', range: 1, targets: ['unit', 'city'] });
+    expect(getUnitAttackProfile('archer')).toEqual({ kind: 'ranged', range: 2, targets: ['unit'] });
+  });
+
+  it('rejects non-adjacent melee attacks even when the enemy is inside movement range', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'out-of-range',
+    });
+  });
+
+  it('allows archers to attack visible hostile units at range without moving into the defender hex', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toMatchObject({
+      ok: true,
+      targetType: 'unit',
+      targetUnitId: 'defender',
+      range: 2,
+    });
+  });
+
+  it('rejects ranged attacks against fogged targets through the player path', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'fog' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'not-visible',
+    });
+  });
+
+  it('rejects unit attacks against major civs that are not at war', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'not-hostile',
+    });
+  });
+
+  it('rejects ordinary archer attacks against cities from range', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const state = stateWithUnits({ attacker }, { '2,0': 'visible' });
+    state.cities.enemyCity = { id: 'enemyCity', name: 'Enemy City', owner: 'ai-1', position: { q: 2, r: 0 }, population: 4, buildings: [], productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 10, workedTiles: [], ownedTiles: [{ q: 2, r: 0 }], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any;
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'unsupported-target',
+    });
+  });
+
+  it('uses wrapped distance for melee adjacency at the horizontal edge', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 1 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 5, r: 1 });
+    const state = stateWithUnits({ attacker, defender }, { '5,1': 'visible' });
+    state.map = grassMap(6, 4, true);
+
+    expect(canUnitAttackTarget(state, attacker, { q: 5, r: 1 }, { viewerId: 'player' })).toMatchObject({
+      ok: true,
+      targetUnitId: 'defender',
+      range: 1,
+    });
+  });
+
+  it('collects only legal attack target coordinates', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const visibleDefender = unit('visible-defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const foggedDefender = unit('fogged-defender', 'warrior', 'ai-1', { q: 1, r: 1 });
+    const state = stateWithUnits(
+      { attacker, 'visible-defender': visibleDefender, 'fogged-defender': foggedDefender },
+      { '2,0': 'visible', '1,1': 'fog' },
+    );
+
+    expect(getAttackTargets(state, attacker, { viewerId: 'player' }).map(target => hexKey(target.coord))).toEqual(['2,0']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing attack targeting tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/attack-targeting.test.ts
+```
+
+Expected: FAIL because `src/systems/attack-targeting.ts` does not exist.
+
+- [ ] **Step 3: Add attack profile types to unit definitions**
+
+Modify `src/core/types.ts`:
+
+```ts
+export interface UnitAttackProfile {
+  kind: 'melee' | 'ranged' | 'siege' | 'bombard';
+  range: number;
+  targets: Array<'unit' | 'city'>;
+}
+
+export interface UnitDefinition {
+  type: UnitType;
+  name: string;
+  movementPoints: number;
+  visionRange: number;
+  strength: number;
+  canFoundCity: boolean;
+  canBuildImprovements: boolean;
+  productionCost: number;
+  spyDetectionChance?: number;
+  attackProfile?: UnitAttackProfile;
+}
+```
+
+Modify only the Archer entry in `src/systems/unit-system.ts`:
+
+```ts
+  archer: {
+    type: 'archer', name: 'Archer', movementPoints: 2,
+    visionRange: 2, strength: 15, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 35,
+    attackProfile: { kind: 'ranged', range: 2, targets: ['unit'] },
+  },
+```
+
+- [ ] **Step 4: Implement `src/systems/attack-targeting.ts`**
+
+Create `src/systems/attack-targeting.ts`:
+
+```ts
+import type { GameState, HexCoord, Unit, UnitAttackProfile, UnitType } from '@/core/types';
+import { hexDistance, hexKey, hexesInRange, getWrappedHexesInRange, wrappedHexDistance } from '@/systems/hex-utils';
+import { getVisibility } from '@/systems/fog-of-war';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type AttackTargetFailure =
+  | 'missing-attacker'
+  | 'no-combat-strength'
+  | 'out-of-range'
+  | 'not-visible'
+  | 'no-target'
+  | 'friendly-target'
+  | 'not-hostile'
+  | 'unsupported-target';
+
+export type AttackTargetResult =
+  | { ok: true; targetType: 'unit'; targetUnitId: string; coord: HexCoord; range: number }
+  | { ok: true; targetType: 'city'; cityId: string; coord: HexCoord; range: number }
+  | { ok: false; reason: AttackTargetFailure };
+
+export interface AttackTargetOptions {
+  viewerId?: string;
+  requireVisibility?: boolean;
+}
+
+export interface AttackTarget {
+  coord: HexCoord;
+  result: Extract<AttackTargetResult, { ok: true }>;
+}
+
+const DEFAULT_ATTACK_PROFILE: UnitAttackProfile = { kind: 'melee', range: 1, targets: ['unit', 'city'] };
+
+export function getUnitAttackProfile(type: UnitType): UnitAttackProfile {
+  return UNIT_DEFINITIONS[type].attackProfile ?? DEFAULT_ATTACK_PROFILE;
+}
+
+function distanceForMap(state: GameState, from: HexCoord, to: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(from, to, state.map.width)
+    : hexDistance(from, to);
+}
+
+function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord: HexCoord): boolean {
+  if (!viewerId) return true;
+  const visibility = state.civilizations[viewerId]?.visibility;
+  if (!visibility) return false;
+  return getVisibility(visibility, coord) === 'visible';
+}
+
+function unitAt(state: GameState, attacker: Unit, coord: HexCoord): [string, Unit] | null {
+  const targetKey = hexKey(coord);
+  const entry = Object.entries(state.units).find(([, unit]) =>
+    unit.id !== attacker.id
+    && hexKey(unit.position) === targetKey,
+  );
+  return entry ?? null;
+}
+
+function hostileCityAt(state: GameState, attacker: Unit, coord: HexCoord): [string, { owner: string; position: HexCoord }] | null {
+  const targetKey = hexKey(coord);
+  const entry = Object.entries(state.cities).find(([, city]) =>
+    city.owner !== attacker.owner
+    && hexKey(city.position) === targetKey,
+  );
+  return entry ? [entry[0], entry[1]] : null;
+}
+
+function canAttackUnitOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
+  if (targetOwner === attackerOwner) return false;
+  if (targetOwner === 'barbarian' || targetOwner === 'rebels') return true;
+  return state.civilizations[attackerOwner]?.diplomacy?.atWarWith.includes(targetOwner) ?? false;
+}
+
+export function canUnitAttackTarget(
+  state: GameState,
+  attacker: Unit | undefined,
+  coord: HexCoord,
+  options: AttackTargetOptions = {},
+): AttackTargetResult {
+  if (!attacker) return { ok: false, reason: 'missing-attacker' };
+  if (UNIT_DEFINITIONS[attacker.type].strength <= 0) return { ok: false, reason: 'no-combat-strength' };
+
+  const profile = getUnitAttackProfile(attacker.type);
+  const range = distanceForMap(state, attacker.position, coord);
+  if (range > profile.range || range === 0) return { ok: false, reason: 'out-of-range' };
+
+  const requireVisibility = options.requireVisibility ?? Boolean(options.viewerId);
+  if (requireVisibility && !isVisibleToViewer(state, options.viewerId, coord)) {
+    return { ok: false, reason: 'not-visible' };
+  }
+
+  const targetUnit = unitAt(state, attacker, coord);
+  if (targetUnit) {
+    if (targetUnit[1].owner === attacker.owner) return { ok: false, reason: 'friendly-target' };
+    if (!canAttackUnitOwner(state, attacker.owner, targetUnit[1].owner)) return { ok: false, reason: 'not-hostile' };
+    if (!profile.targets.includes('unit')) return { ok: false, reason: 'unsupported-target' };
+    return { ok: true, targetType: 'unit', targetUnitId: targetUnit[0], coord, range };
+  }
+
+  const targetCity = hostileCityAt(state, attacker, coord);
+  if (targetCity) {
+    if (!profile.targets.includes('city')) return { ok: false, reason: 'unsupported-target' };
+    return { ok: true, targetType: 'city', cityId: targetCity[0], coord, range };
+  }
+
+  return { ok: false, reason: 'no-target' };
+}
+
+export function getAttackTargets(
+  state: GameState,
+  attacker: Unit,
+  options: AttackTargetOptions = {},
+): AttackTarget[] {
+  const profile = getUnitAttackProfile(attacker.type);
+  const candidates = state.map.wrapsHorizontally
+    ? getWrappedHexesInRange(attacker.position, profile.range, state.map.width)
+    : hexesInRange(attacker.position, profile.range);
+
+  return candidates
+    .filter(coord => hexKey(coord) !== hexKey(attacker.position))
+    .map(coord => ({ coord, result: canUnitAttackTarget(state, attacker, coord, options) }))
+    .filter((target): target is AttackTarget => target.result.ok);
+}
+```
+
+- [ ] **Step 5: Run attack targeting tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/attack-targeting.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add src/core/types.ts src/systems/unit-system.ts src/systems/attack-targeting.ts tests/systems/attack-targeting.test.ts
+git commit -m "feat(combat): add shared attack targeting"
+```
+
+## Task 2: Player Highlights, Tap Intent, And Combat Revalidation
+
+**Files:**
+- Create: `src/input/selected-unit-highlights.ts`
+- Create: `tests/input/selected-unit-highlights.test.ts`
+- Modify: `src/input/selected-unit-tap-intent.ts`
+- Modify: `tests/input/selected-unit-tap-intent.test.ts`
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Write failing selected-unit highlight tests**
+
+Create `tests/input/selected-unit-highlights.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createUnit } from '@/systems/unit-system';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import { hexKey } from '@/systems/hex-utils';
+
+describe('selected-unit-highlights', () => {
+  it('does not mark non-adjacent melee targets as attack highlights', () => {
+    const state = createNewGame(undefined, 'melee-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.visibility.tiles['2,0'] = 'visible';
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('2,0');
+    expect(result.highlights.filter(h => h.type === 'attack').map(h => hexKey(h.coord))).not.toContain('2,0');
+  });
+
+  it('marks visible archer targets as attack and not movement', () => {
+    const state = createNewGame(undefined, 'archer-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      archer: { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'archer', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['archer'];
+    state.civilizations.player.visibility.tiles['2,0'] = 'visible';
+
+    const result = buildSelectedUnitHighlights(state, 'archer');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).toContain('2,0');
+    expect(result.highlights).toContainEqual({ coord: { q: 2, r: 0 }, type: 'attack' });
+  });
+
+  it('does not highlight fogged archer targets', () => {
+    const state = createNewGame(undefined, 'archer-fog-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      archer: { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'archer', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['archer'];
+    state.civilizations.player.visibility.tiles['2,0'] = 'fog';
+
+    const result = buildSelectedUnitHighlights(state, 'archer');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('2,0');
+    expect(result.highlights.filter(h => h.type === 'attack')).toHaveLength(0);
+  });
+
+  it('leaves adjacent hostile cities on the movement/city-assault path instead of combat-preview attack targets', () => {
+    const state = createNewGame(undefined, 'city-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior', movementPointsLeft: 2 },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.visibility.tiles['1,0'] = 'visible';
+    state.cities.enemyCity = { id: 'enemyCity', name: 'Enemy City', owner: 'ai-1', position: { q: 1, r: 0 }, population: 4, buildings: [], productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 10, workedTiles: [], ownedTiles: [{ q: 1, r: 0 }], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any;
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('1,0');
+    expect(result.highlights.filter(h => h.type === 'attack').map(h => hexKey(h.coord))).not.toContain('1,0');
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing highlight tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-highlights.test.ts
+```
+
+Expected: FAIL because `src/input/selected-unit-highlights.ts` does not exist.
+
+- [ ] **Step 3: Implement selected-unit highlight projection**
+
+Create `src/input/selected-unit-highlights.ts`:
+
+```ts
+import type { GameState, HexCoord } from '@/core/types';
+import type { HexHighlight } from '@/renderer/render-loop';
+import { getAttackTargets, type AttackTarget } from '@/systems/attack-targeting';
+import { hexKey } from '@/systems/hex-utils';
+import { buildUnitOccupancy } from '@/systems/unit-occupancy';
+import { getMovementRange } from '@/systems/unit-system';
+
+export interface SelectedUnitHighlightResult {
+  movementRange: HexCoord[];
+  attackTargets: AttackTarget[];
+  highlights: HexHighlight[];
+}
+
+export function buildSelectedUnitHighlights(state: GameState, unitId: string): SelectedUnitHighlightResult {
+  const unit = state.units[unitId];
+  if (!unit || unit.owner !== state.currentPlayer) {
+    return { movementRange: [], attackTargets: [], highlights: [] };
+  }
+
+  const occupancy = buildUnitOccupancy(state.units);
+  const movementRange = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
+  const attackTargets = getAttackTargets(state, unit, { viewerId: state.currentPlayer })
+    .filter(target => target.result.targetType === 'unit');
+  const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));
+
+  const moveHighlights = movementRange
+    .filter(coord => !attackKeys.has(hexKey(coord)))
+    .map(coord => ({ coord, type: 'move' as const }));
+
+  const attackHighlights = attackTargets.map(target => ({ coord: target.coord, type: 'attack' as const }));
+
+  return {
+    movementRange,
+    attackTargets,
+    highlights: [...moveHighlights, ...attackHighlights],
+  };
+}
+```
+
+- [ ] **Step 4: Add tap intent tests for non-adjacent melee and ranged city negatives**
+
+Append to `tests/input/selected-unit-tap-intent.test.ts`:
+
+```ts
+  it('returns move when a melee unit taps a non-adjacent hostile city inside movement range', () => {
+    const state = makeTapAssaultFixture();
+    state.cities.enemyCity.position = { q: 2, r: 0 };
+    state.cities.enemyCity.ownedTiles = [{ q: 2, r: 0 }];
+    state.units['unit-1'] = { ...state.units['unit-1'], movementPointsLeft: 2 };
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 2, r: 0 }, [{ q: 1, r: 0 }, { q: 2, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
+
+  it('returns move when an ordinary archer taps a non-adjacent hostile city', () => {
+    const state = makeTapAssaultFixture();
+    state.units['unit-1'] = { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'unit-1', movementPointsLeft: 2 };
+    state.cities.enemyCity.position = { q: 2, r: 0 };
+    state.cities.enemyCity.ownedTiles = [{ q: 2, r: 0 }];
+    state.civilizations.player.visibility.tiles['2,0'] = 'visible';
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 2, r: 0 }, [{ q: 1, r: 0 }, { q: 2, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
+```
+
+- [ ] **Step 5: Update tap intent to require legal city attack**
+
+Modify `src/input/selected-unit-tap-intent.ts` imports:
+
+```ts
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+```
+
+In `resolveSelectedUnitTapIntent`, immediately before returning `assault-minor-civ`, `confirm-war-city`, or `assault-city`, add:
+
+```ts
+  const attackResult = canUnitAttackTarget(state, unit, targetCoord, { viewerId: state.currentPlayer });
+  if (!attackResult.ok || attackResult.targetType !== 'city') {
+    return { kind: 'move' };
+  }
+```
+
+Keep the existing friendly/alliance branch before this check so allied city entry still returns `move`.
+
+- [ ] **Step 6: Wire `main.ts` selection and combat preview to separate attack targets**
+
+In `src/main.ts`, add import:
+
+```ts
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+```
+
+Near existing `movementRange`, add:
+
+```ts
+let attackRange: HexCoord[] = [];
+```
+
+In `selectUnit`, replace the manual movement/highlight block with:
+
+```ts
+  const highlightResult = buildSelectedUnitHighlights(gameState, unitId);
+  movementRange = highlightResult.movementRange;
+  attackRange = highlightResult.attackTargets.map(target => target.coord);
+  renderLoop.setHighlights(highlightResult.highlights);
+```
+
+In `deselectUnit`, clear both arrays:
+
+```ts
+  movementRange = [];
+  attackRange = [];
+```
+
+In the tap handler, split attack from movement:
+
+```ts
+  const tappedAttackTarget = selectedUnitId && attackRange.some(h => hexKey(h) === key);
+  const tappedMovementTarget = selectedUnitId && movementRange.some(h => hexKey(h) === key);
+```
+
+Change the combat preview branch to use `tappedAttackTarget`. In the `attackBtn` listener, revalidate:
+
+```ts
+        attackBtn.addEventListener('click', () => {
+          const attacker = selectedUnitId ? gameState.units[selectedUnitId] : undefined;
+          const legality = canUnitAttackTarget(gameState, attacker, coord, { viewerId: gameState.currentPlayer });
+          if (!legality.ok || legality.targetType !== 'unit') {
+            showNotification('That target is no longer attackable.', 'warning');
+            if (selectedUnitId) selectUnit(selectedUnitId);
+            return;
+          }
+          executeAttack(selectedUnitId!, key);
+        });
+```
+
+Also revalidate inside `executeAttack` itself so keyboard shortcuts, future automation hooks, or stale closures cannot bypass the shared rule. Add `parseHexKey` to the `hex-utils` import and change the start of `executeAttack` to:
+
+```ts
+function executeAttack(attackerId: string, targetKey: string): void {
+  const attacker = gameState.units[attackerId];
+  const targetCoord = parseHexKey(targetKey);
+  const legality = canUnitAttackTarget(gameState, attacker, targetCoord, { viewerId: gameState.currentPlayer });
+  if (!attacker || !legality.ok || legality.targetType !== 'unit') {
+    showNotification('That target is no longer attackable.', 'warning');
+    if (selectedUnitId) selectUnit(selectedUnitId);
+    return;
+  }
+
+  const defenderId = legality.targetUnitId;
+  const defender = gameState.units[defenderId];
+  if (!defender) return;
+
+  // Keep the existing combat resolution body from this point onward, using
+  // `defenderId` and `defender` from the validated legality result.
+}
+```
+
+- [ ] **Step 7: Run targeted input tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/attack-targeting.test.ts tests/input/selected-unit-highlights.test.ts tests/input/selected-unit-tap-intent.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+Run:
+
+```bash
+git add src/input/selected-unit-highlights.ts src/input/selected-unit-tap-intent.ts src/main.ts tests/input/selected-unit-highlights.test.ts tests/input/selected-unit-tap-intent.test.ts
+git commit -m "fix(combat): separate attack and movement targeting"
+```
+
+## Task 3: Non-Player Attack Parity
+
+**Files:**
+- Modify: `src/ai/basic-ai.ts`
+- Modify: `src/core/turn-manager.ts`
+- Modify: `src/systems/minor-civ-system.ts`
+- Modify: `tests/ai/basic-ai.test.ts`
+- Modify: `tests/systems/barbarian-system.test.ts`
+- Modify: `tests/systems/minor-civ-system.test.ts`
+
+- [ ] **Step 1: Add parity regression tests**
+
+Add a test to `tests/ai/basic-ai.test.ts` that creates an AI Warrior two hexes from a player unit, runs one AI turn, and asserts no combat event was emitted and both units survive.
+
+```ts
+it('does not let AI melee units attack non-adjacent targets', () => {
+  const state = createNewGame(undefined, 'ai-melee-range', 'small');
+  const attacker = createUnit('warrior', 'ai-1', { q: 0, r: 0 });
+  attacker.id = 'ai-warrior';
+  const defender = createUnit('warrior', 'player', { q: 2, r: 0 });
+  defender.id = 'player-warrior';
+  state.units = { [attacker.id]: attacker, [defender.id]: defender };
+  state.civilizations['ai-1'].units = [attacker.id];
+  state.civilizations.player.units = [defender.id];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  const combatEvents: unknown[] = [];
+  const bus = { emit: (type: string, payload: unknown) => { if (type === 'combat:resolved') combatEvents.push(payload); } } as any;
+
+  runBasicAI(state, 'ai-1', bus);
+
+  expect(combatEvents).toHaveLength(0);
+  expect(state.units[attacker.id]).toBeDefined();
+  expect(state.units[defender.id]).toBeDefined();
+});
+```
+
+Add equivalent nearest-domain tests:
+
+- `tests/systems/barbarian-system.test.ts`: barbarian Warrior two hexes away must not produce an attack order.
+- `tests/systems/minor-civ-system.test.ts`: minor-civ Warrior two hexes away must not resolve a scuffle/combat.
+
+- [ ] **Step 2: Run parity tests to expose current behavior**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ai/basic-ai.test.ts tests/systems/barbarian-system.test.ts tests/systems/minor-civ-system.test.ts
+```
+
+Expected: At least one new test fails if a non-player path still derives attacks from movement range or loose proximity.
+
+- [ ] **Step 3: Wire non-player paths through `canUnitAttackTarget`**
+
+In each non-player attack selection path, import:
+
+```ts
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+```
+
+Use this predicate before resolving combat:
+
+```ts
+const legality = canUnitAttackTarget(newState, attacker, defender.position, { requireVisibility: false });
+if (!legality.ok || legality.targetType !== 'unit') {
+  continue;
+}
+```
+
+For barbarian system functions that return attack orders without full `GameState`, use the helper only after constructing enough state context. If the existing function cannot receive `GameState` without broad churn, add a narrow helper to `src/systems/attack-targeting.ts`:
+
+```ts
+export function canAttackByProfileOnMap(attacker: Unit, target: Unit, map: GameMap): boolean {
+  const profile = getUnitAttackProfile(attacker.type);
+  const range = map.wrapsHorizontally
+    ? wrappedHexDistance(attacker.position, target.position, map.width)
+    : hexDistance(attacker.position, target.position);
+  return UNIT_DEFINITIONS[attacker.type].strength > 0
+    && profile.targets.includes('unit')
+    && range > 0
+    && range <= profile.range;
+}
+```
+
+- [ ] **Step 4: Run parity tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ai/basic-ai.test.ts tests/systems/barbarian-system.test.ts tests/systems/minor-civ-system.test.ts tests/systems/attack-targeting.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+Run:
+
+```bash
+git add src/ai/basic-ai.ts src/core/turn-manager.ts src/systems/minor-civ-system.ts src/systems/attack-targeting.ts tests/ai/basic-ai.test.ts tests/systems/barbarian-system.test.ts tests/systems/minor-civ-system.test.ts tests/systems/attack-targeting.test.ts
+git commit -m "fix(combat): enforce melee range for non-player attacks"
+```
+
+## Task 4: Viewer-Scoped Last-Seen Presentation Model
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Create: `src/systems/last-seen-presentation.ts`
+- Create: `tests/systems/last-seen-presentation.test.ts`
+- Modify: `src/systems/fog-of-war.ts`
+- Modify: `src/systems/unit-movement-system.ts`
+- Modify: `src/core/game-state.ts`
+- Modify: `src/core/turn-manager.ts`
+
+- [ ] **Step 1: Write failing last-seen tests**
+
+Create `tests/systems/last-seen-presentation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+
+describe('last-seen-presentation', () => {
+  it('captures serializable tile presentation for visible tiles', () => {
+    const state = createNewGame(undefined, 'last-seen-visible', 'small');
+    const tile = state.map.tiles['0,0'];
+    tile.terrain = 'forest';
+    tile.resource = 'deer';
+    tile.owner = 'player';
+    tile.improvement = 'camp' as any;
+    tile.improvementTurnsLeft = 0;
+
+    const snapshot = createLastSeenTilePresentation(state, 'player', tile);
+
+    expect(snapshot).toMatchObject({
+      coord: tile.coord,
+      terrain: 'forest',
+      elevation: tile.elevation,
+      resource: 'deer',
+      owner: 'player',
+      improvement: 'camp',
+      improvementTurnsLeft: 0,
+      hasRiver: tile.hasRiver,
+      wonder: tile.wonder,
+    });
+    expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot);
+  });
+
+  it('updates only currently visible tiles for the viewer', () => {
+    const state = createNewGame(undefined, 'last-seen-refresh', 'small');
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'fog' };
+    state.map.tiles['0,0'].terrain = 'forest';
+    state.map.tiles['1,0'].terrain = 'desert';
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('forest');
+    expect(state.civilizations.player.visibility.lastSeen?.['1,0']).toBeUndefined();
+  });
+
+  it('keeps hot-seat viewers separate', () => {
+    const state = createNewGame(undefined, 'last-seen-hotseat', 'small');
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible' };
+    state.civilizations['ai-1'].visibility.tiles = { '0,0': 'fog' };
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']).toBeDefined();
+    expect(state.civilizations['ai-1'].visibility.lastSeen?.['0,0']).toBeUndefined();
+  });
+
+  it('does not update fogged city presentation from live city changes', () => {
+    const state = createNewGame(undefined, 'last-seen-city', 'small');
+    state.cities.enemyCity = { id: 'enemyCity', name: 'Old City', owner: 'ai-1', position: { q: 0, r: 0 }, population: 2, buildings: [], productionQueue: ['warrior'], productionProgress: 0, food: 0, foodNeeded: 10, workedTiles: [], ownedTiles: [{ q: 0, r: 0 }], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any;
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible' };
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    state.civilizations.player.visibility.tiles = { '0,0': 'fog' };
+    state.cities.enemyCity = { ...state.cities.enemyCity, name: 'Live City', owner: 'player', population: 9 };
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.city).toEqual({
+      id: 'enemyCity',
+      name: 'Old City',
+      owner: 'ai-1',
+      population: 2,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run last-seen tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/last-seen-presentation.test.ts
+```
+
+Expected: FAIL because `src/systems/last-seen-presentation.ts` does not exist.
+
+- [ ] **Step 3: Add serializable visibility snapshot types**
+
+Modify `src/core/types.ts`:
+
+```ts
+export interface LastSeenCityPresentation {
+  id: string;
+  name: string;
+  owner: string;
+  population: number;
+}
+
+export interface LastSeenTilePresentation {
+  coord: HexCoord;
+  terrain: TerrainType;
+  elevation: Elevation;
+  resource: string | null;
+  improvement: ImprovementType;
+  improvementTurnsLeft: number;
+  owner: string | null;
+  hasRiver: boolean;
+  wonder: string | null;
+  city?: LastSeenCityPresentation;
+}
+
+export interface VisibilityMap {
+  tiles: Record<string, VisibilityState>;
+  lastSeen?: Record<string, LastSeenTilePresentation>;
+}
+```
+
+- [ ] **Step 4: Implement last-seen system helper**
+
+Create `src/systems/last-seen-presentation.ts`:
+
+```ts
+import type { GameState, HexTile, LastSeenTilePresentation } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { getVisibility } from '@/systems/fog-of-war';
+
+export function createLastSeenTilePresentation(
+  state: GameState,
+  viewerId: string,
+  tile: HexTile,
+): LastSeenTilePresentation {
+  const tileKey = hexKey(tile.coord);
+  const city = Object.values(state.cities).find(candidate => hexKey(candidate.position) === tileKey);
+  return {
+    coord: { ...tile.coord },
+    terrain: tile.terrain,
+    elevation: tile.elevation,
+    resource: tile.resource,
+    improvement: tile.improvement,
+    improvementTurnsLeft: tile.improvementTurnsLeft,
+    owner: tile.owner,
+    hasRiver: tile.hasRiver,
+    wonder: tile.wonder,
+    city: city
+      ? { id: city.id, name: city.name, owner: city.owner, population: city.population }
+      : undefined,
+  };
+}
+
+export function refreshLastSeenPresentationsForCiv(state: GameState, viewerId: string): void {
+  const civ = state.civilizations[viewerId];
+  if (!civ?.visibility) return;
+
+  civ.visibility.lastSeen ??= {};
+  for (const [key, tile] of Object.entries(state.map.tiles)) {
+    if (getVisibility(civ.visibility, tile.coord) !== 'visible') continue;
+    civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, viewerId, tile);
+  }
+}
+```
+
+- [ ] **Step 5: Refresh snapshots after movement visibility updates**
+
+Modify `src/systems/unit-movement-system.ts`:
+
+```ts
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+```
+
+After the `updateVisibility(...)` call:
+
+```ts
+  refreshLastSeenPresentationsForCiv(state, options.civId);
+```
+
+Also call `refreshLastSeenPresentationsForCiv` after any other direct visibility-update call discovered by:
+
+```bash
+rg -n "updateVisibility\\(" src
+```
+
+For each found call, add a matching targeted test in that file's mirrored test when the call affects player-visible map rendering.
+
+At minimum, wire these existing call sites:
+
+- `src/core/game-state.ts`: after initial `updateVisibility(...)` calls in `createNewGame` and hot-seat setup so turn 1 visible tiles have last-seen snapshots before the first movement.
+- `src/core/turn-manager.ts`: after each civilization visibility refresh and after shared minor-civ vision updates so end-turn visibility changes do not leave stale snapshots missing.
+- `src/main.ts`: after manual visibility refreshes around turn/startup UI flows, if those calls still exist after the system-level wiring.
+
+- [ ] **Step 6: Run last-seen tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/last-seen-presentation.test.ts tests/systems/unit-movement-system.test.ts tests/systems/fog-of-war.test.ts tests/core/game-state.test.ts tests/core/turn-manager.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 4**
+
+Run:
+
+```bash
+git add src/core/types.ts src/core/game-state.ts src/core/turn-manager.ts src/systems/last-seen-presentation.ts src/systems/unit-movement-system.ts src/systems/fog-of-war.ts tests/systems/last-seen-presentation.test.ts tests/systems/unit-movement-system.test.ts tests/systems/fog-of-war.test.ts tests/core/game-state.test.ts tests/core/turn-manager.test.ts
+git commit -m "feat(visibility): track viewer last-seen tiles"
+```
+
+## Task 5: Render Fogged Tiles From Last-Seen Presentation
+
+**Files:**
+- Create: `src/renderer/tile-presentation.ts`
+- Create: `tests/renderer/tile-presentation.test.ts`
+- Modify: `src/renderer/hex-renderer.ts`
+- Modify: `src/renderer/city-renderer.ts`
+- Modify: `tests/renderer/city-renderer.test.ts`
+- Modify: `src/renderer/fog-renderer.ts`
+- Modify: `tests/renderer/fog-renderer.test.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Modify: `src/renderer/render-visibility.ts`
+
+- [ ] **Step 1: Write failing tile presentation tests**
+
+Create `tests/renderer/tile-presentation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { GameMap, VisibilityMap } from '@/core/types';
+import { resolveTilePresentationForViewer } from '@/renderer/tile-presentation';
+
+const liveTile = {
+  coord: { q: 0, r: 0 },
+  terrain: 'forest',
+  elevation: 'lowland',
+  resource: 'deer',
+  improvement: 'none',
+  owner: 'ai-1',
+  improvementTurnsLeft: 0,
+  hasRiver: false,
+  wonder: null,
+} as const;
+
+const map = { width: 4, height: 3, wrapsHorizontally: true, tiles: { '0,0': liveTile }, rivers: [] } as unknown as GameMap;
+
+describe('tile-presentation', () => {
+  it('returns live tile presentation for visible tiles', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'live',
+      tile: liveTile,
+    });
+  });
+
+  it('returns last-seen presentation for fogged tiles', () => {
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'farm',
+          improvementTurnsLeft: 0,
+          owner: 'player',
+          hasRiver: true,
+          wonder: null,
+        },
+      },
+    };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'last-seen',
+      tile: expect.objectContaining({ terrain: 'plains', owner: 'player', improvement: 'farm' }),
+    });
+  });
+
+  it('returns unknown fog when an old save has no last-seen snapshot', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'fog' } };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'unknown-fog',
+      tile: expect.objectContaining({ terrain: 'grassland', owner: null, resource: null }),
+    });
+  });
+
+  it('canonicalizes wrapped render coordinates before visibility lookup', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'fog' }, lastSeen: { '0,0': { coord: { q: 0, r: 0 }, terrain: 'desert', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, owner: null, hasRiver: false, wonder: null } } };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 4, r: 0 })).toMatchObject({
+      kind: 'last-seen',
+      tile: expect.objectContaining({ terrain: 'desert' }),
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tile presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/tile-presentation.test.ts
+```
+
+Expected: FAIL because `src/renderer/tile-presentation.ts` does not exist.
+
+- [ ] **Step 3: Implement tile presentation resolver**
+
+Create `src/renderer/tile-presentation.ts`:
+
+```ts
+import type { GameMap, HexCoord, HexTile, LastSeenTilePresentation, VisibilityMap } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
+
+export type TilePresentationKind = 'live' | 'last-seen' | 'unknown-fog' | 'unexplored';
+
+export interface TilePresentation {
+  kind: TilePresentationKind;
+  tile: HexTile;
+}
+
+function unknownTile(coord: HexCoord): HexTile {
+  return {
+    coord,
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function lastSeenToTile(snapshot: LastSeenTilePresentation): HexTile {
+  return {
+    coord: { ...snapshot.coord },
+    terrain: snapshot.terrain,
+    elevation: snapshot.elevation,
+    resource: snapshot.resource,
+    improvement: snapshot.improvement,
+    owner: snapshot.owner,
+    improvementTurnsLeft: snapshot.improvementTurnsLeft,
+    hasRiver: snapshot.hasRiver,
+    wonder: snapshot.wonder,
+  };
+}
+
+export function resolveTilePresentationForViewer(
+  map: GameMap,
+  visibility: VisibilityMap | undefined,
+  renderCoord: HexCoord,
+): TilePresentation {
+  const coord = map.wrapsHorizontally ? wrapHexCoord(renderCoord, map.width) : renderCoord;
+  const key = hexKey(coord);
+  const liveTile = map.tiles[key] ?? unknownTile(coord);
+  const state = visibility ? getVisibility(visibility, coord) : 'visible';
+
+  if (state === 'visible') return { kind: 'live', tile: liveTile };
+  if (state === 'unexplored') return { kind: 'unexplored', tile: unknownTile(coord) };
+
+  const snapshot = visibility?.lastSeen?.[key];
+  if (snapshot) return { kind: 'last-seen', tile: lastSeenToTile(snapshot) };
+  return { kind: 'unknown-fog', tile: unknownTile(coord) };
+}
+```
+
+- [ ] **Step 4: Wire `hex-renderer` through tile presentation**
+
+Modify `src/renderer/hex-renderer.ts` imports:
+
+```ts
+import { resolveTilePresentationForViewer } from './tile-presentation';
+```
+
+In `drawHexMap`, before drawing:
+
+```ts
+      const presentation = resolveTilePresentationForViewer(map, viewerVisibility, renderCoord);
+      drawTileAtScreen(ctx, screen, scaledSize, presentation.tile, isVillage && presentation.kind === 'live', currentPlayer, viewerVisibility, camera.zoom);
+```
+
+Remove the old direct `drawTileAtScreen(..., tile, ...)` call. Do not draw village markers for `last-seen`, `unknown-fog`, or `unexplored` unless a later spec adds village memory.
+
+- [ ] **Step 5: Hide live rivers and territory where tile presentation is hidden**
+
+Modify `src/renderer/hex-renderer.ts` so river and minor-civ territory rendering cannot bypass the same visibility decision as base tiles.
+
+Change `drawRivers` signature:
+
+```ts
+export function drawRivers(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  viewerVisibility?: VisibilityMap,
+): void {
+```
+
+Before drawing each river segment, require at least one endpoint to have a visible or last-seen presentation:
+
+```ts
+function canRenderRiverEndpoint(map: GameMap, visibility: VisibilityMap | undefined, coord: HexCoord): boolean {
+  const presentation = resolveTilePresentationForViewer(map, visibility, coord);
+  return presentation.kind === 'live' || presentation.kind === 'last-seen';
+}
+```
+
+Use this guard for live river segments and wrap ghost river segments:
+
+```ts
+if (
+  !canRenderRiverEndpoint(map, viewerVisibility, river.from)
+  && !canRenderRiverEndpoint(map, viewerVisibility, river.to)
+) {
+  continue;
+}
+```
+
+Update the `drawRivers(...)` call in `src/renderer/render-loop.ts`:
+
+```ts
+drawRivers(this.ctx, this.state.map, this.camera, viewerVisibility);
+```
+
+Modify `src/renderer/render-visibility.ts` so last-seen owner borders can render without live foreign ownership leaks:
+
+```ts
+export function shouldRenderOwnedTileBorderForPresentation(
+  presentationKind: 'live' | 'last-seen' | 'unknown-fog' | 'unexplored',
+  viewerCivId: string | undefined,
+  ownerId: string | null | undefined,
+): boolean {
+  if (!viewerCivId || !ownerId) return false;
+  if (presentationKind === 'unexplored' || presentationKind === 'unknown-fog') return false;
+  if (ownerId === viewerCivId) return true;
+  return presentationKind === 'live' || presentationKind === 'last-seen';
+}
+```
+
+Use this helper from `drawHexMap` when drawing the tile presentation. Do not call `shouldRenderOwnedTileBorder` with live visibility state for a last-seen tile, because that hides stale foreign borders and tempts later code to read live ownership.
+
+- [ ] **Step 6: Render fogged cities from last-seen city presentation**
+
+Append to `tests/renderer/city-renderer.test.ts`:
+
+```ts
+it('renders fogged cities from last-seen presentation without live production or unrest badges', () => {
+  const state = createNewGame(undefined, 'city-last-seen-render', 'small');
+  state.cities.enemyCity = { id: 'enemyCity', name: 'Live City', owner: 'player', position: { q: 0, r: 0 }, population: 9, buildings: [], productionQueue: ['warrior'], productionProgress: 0, food: 0, foodNeeded: 10, workedTiles: [], ownedTiles: [{ q: 0, r: 0 }], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 2, unrestTurns: 3, spyUnrestBonus: 0 } as any;
+  state.civilizations.player.visibility = {
+    tiles: { '0,0': 'fog' },
+    lastSeen: {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'plains',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: 'ai-1',
+        hasRiver: false,
+        wonder: null,
+        city: { id: 'enemyCity', name: 'Old City', owner: 'ai-1', population: 2 },
+      },
+    },
+  };
+  const ctx = createContext();
+  const camera = createCamera();
+
+  drawCities(ctx, state, camera, 'player');
+
+  expect(ctx.fillText).toHaveBeenCalledWith('Old City (2)', expect.any(Number), expect.any(Number));
+  expect(ctx.fillText).not.toHaveBeenCalledWith('Live City (9)', expect.any(Number), expect.any(Number));
+});
+```
+
+Modify `src/renderer/city-renderer.ts` by importing `getVisibility` and adding a viewer-facing city projection:
+
+```ts
+import { getVisibility, isVisible } from '@/systems/fog-of-war';
+```
+
+```ts
+interface CityRenderProjection {
+  name: string;
+  position: HexCoord;
+  population: number;
+  owner: string;
+  isLive: boolean;
+}
+
+function getCityRenderProjection(state: GameState, playerCivId: string): CityRenderProjection[] {
+  const vis = state.civilizations[playerCivId]?.visibility;
+  if (!vis) return [];
+
+  const liveCities = Object.values(state.cities)
+    .filter(city => getVisibility(vis, city.position) === 'visible')
+    .map(city => ({ name: city.name, position: city.position, population: city.population, owner: city.owner, isLive: true }));
+
+  const staleCities = Object.values(vis.lastSeen ?? {})
+    .filter(snapshot => getVisibility(vis, snapshot.coord) === 'fog' && snapshot.city)
+    .map(snapshot => ({
+      name: snapshot.city!.name,
+      position: snapshot.coord,
+      population: snapshot.city!.population,
+      owner: snapshot.city!.owner,
+      isLive: false,
+    }));
+
+  return [...liveCities, ...staleCities];
+}
+```
+
+Change `drawCities` to iterate over `getCityRenderProjection(...)`. Only live projections may draw production badges, unrest, occupation, breakaway, idle production, or minor-civ archetype details. Stale projections draw the generic city icon, stale owner color when available, and stale `Name (population)` only.
+
+- [ ] **Step 7: Add fog-renderer canonical visibility regression**
+
+Append to `tests/renderer/fog-renderer.test.ts`:
+
+```ts
+  it('uses canonical visibility for wrapped ghost overlays', () => {
+    const map = createWrappedMap(5, 3);
+    const visibility = createVisibility(map);
+    visibility.tiles['0,1'] = 'visible';
+    const ctx = createContext();
+    const camera = new Camera();
+    camera.setViewport(320, 240);
+    camera.centerOn({ q: 5, r: 1 });
+
+    drawFogOfWar(ctx, visibility, map.width, map.height, camera, map.wrapsHorizontally);
+
+    const fillCount = (ctx.fill as ReturnType<typeof vi.fn>).mock.calls.length;
+    expect(fillCount).toBeLessThan(map.width * map.height + 5);
+  });
+```
+
+- [ ] **Step 8: Run renderer visibility tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/tile-presentation.test.ts tests/renderer/fog-renderer.test.ts tests/renderer/hex-renderer.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 5**
+
+Run:
+
+```bash
+git add src/renderer/tile-presentation.ts src/renderer/hex-renderer.ts src/renderer/city-renderer.ts src/renderer/fog-renderer.ts src/renderer/render-loop.ts src/renderer/render-visibility.ts tests/renderer/tile-presentation.test.ts tests/renderer/fog-renderer.test.ts tests/renderer/hex-renderer.test.ts tests/renderer/city-renderer.test.ts
+git commit -m "fix(renderer): render fog from last-seen state"
+```
+
+## Task 6: Unit Visual Resolver And Role Markers
+
+**Files:**
+- Create: `src/renderer/unit-visual-resolver.ts`
+- Create: `tests/renderer/unit-visual-resolver.test.ts`
+- Modify: `src/renderer/unit-renderer.ts`
+- Modify: `tests/renderer/unit-renderer.test.ts`
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Write failing unit visual resolver tests**
+
+Create `tests/renderer/unit-visual-resolver.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createUnit } from '@/systems/unit-system';
+import { resolveUnitVisual } from '@/renderer/unit-visual-resolver';
+
+describe('unit-visual-resolver', () => {
+  it('omits role marker for major civ units', () => {
+    const state = createNewGame(undefined, 'major-visual', 'small');
+    const unit = { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior' };
+
+    expect(resolveUnitVisual(state, unit, { player: '#4a90d9' })).toMatchObject({
+      role: 'major',
+      roleMarker: null,
+      color: '#4a90d9',
+    });
+  });
+
+  it('uses hostile chevron marker for barbarian units', () => {
+    const state = createNewGame(undefined, 'barbarian-visual', 'small');
+    const unit = { ...createUnit('warrior', 'barbarian', { q: 0, r: 0 }), id: 'barb' };
+
+    expect(resolveUnitVisual(state, unit, { barbarian: '#8b4513' })).toMatchObject({
+      role: 'barbarian',
+      roleMarker: 'chevron',
+      color: '#8b4513',
+    });
+  });
+
+  it('uses city-state diamond marker for minor-civ units', () => {
+    const state = createNewGame(undefined, 'minor-visual', 'small');
+    state.minorCivs['mc-warriors'] = { id: 'mc-warriors', definitionId: 'warriors', cityId: 'city-1', units: [], diplomacy: {} as any, activeQuests: {}, isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1 };
+    const unit = { ...createUnit('warrior', 'mc-warriors', { q: 0, r: 0 }), id: 'mc-unit' };
+
+    expect(resolveUnitVisual(state, unit, { 'mc-warriors': '#8a6f2a' })).toMatchObject({
+      role: 'minor',
+      roleMarker: 'diamond',
+      color: '#8a6f2a',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing resolver tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/unit-visual-resolver.test.ts
+```
+
+Expected: FAIL because `src/renderer/unit-visual-resolver.ts` does not exist.
+
+- [ ] **Step 3: Implement unit visual resolver**
+
+Create `src/renderer/unit-visual-resolver.ts`:
+
+```ts
+import type { GameState, Unit } from '@/core/types';
+
+export type UnitOwnerRole = 'major' | 'minor' | 'barbarian';
+export type UnitRoleMarker = 'chevron' | 'diamond' | null;
+export type UnitMotionState = 'idle' | 'move-a' | 'move-b';
+
+const FALLBACK_ICONS: Record<string, string> = {
+  settler: '🏕️',
+  worker: '👷',
+  scout: '🔭',
+  warrior: '⚔️',
+  archer: '🏹',
+  swordsman: '🗡️',
+  pikeman: '🔱',
+  musketeer: '🔫',
+  galley: '⛵',
+  trireme: '🚢',
+  spy_scout: '🕵️',
+  spy_informant: '🕵️',
+  spy_agent: '🕵️',
+  spy_operative: '🕵️',
+  spy_hacker: '💻',
+  scout_hound: '🐕',
+  shadow_warden: '🦅',
+  war_hound: '🐺',
+};
+
+export interface UnitVisual {
+  role: UnitOwnerRole;
+  roleMarker: UnitRoleMarker;
+  color: string;
+  fallbackIcon: string;
+  spriteOwnerId: string;
+  motion: UnitMotionState;
+}
+
+function getRole(unit: Unit): UnitOwnerRole {
+  if (unit.owner === 'barbarian') return 'barbarian';
+  if (unit.owner.startsWith('mc-')) return 'minor';
+  return 'major';
+}
+
+export function resolveUnitVisual(
+  state: GameState,
+  unit: Unit,
+  colorLookup: Record<string, string> = {},
+  motion: UnitMotionState = 'idle',
+): UnitVisual {
+  const role = getRole(unit);
+  const color = colorLookup[unit.owner]
+    ?? state.civilizations[unit.owner]?.color
+    ?? (role === 'barbarian' ? '#8b4513' : '#888');
+  return {
+    role,
+    roleMarker: role === 'barbarian' ? 'chevron' : role === 'minor' ? 'diamond' : null,
+    color,
+    fallbackIcon: FALLBACK_ICONS[unit.type] ?? '?',
+    spriteOwnerId: unit.owner,
+    motion,
+  };
+}
+```
+
+- [ ] **Step 4: Draw role markers in `unit-renderer`**
+
+In `src/renderer/unit-renderer.ts`, import resolver:
+
+```ts
+import { resolveUnitVisual, type UnitRoleMarker } from './unit-visual-resolver';
+```
+
+Add helper:
+
+```ts
+function drawRoleMarker(
+  ctx: CanvasRenderingContext2D,
+  marker: UnitRoleMarker,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  if (!marker) return;
+  const markerX = x + size * 0.28;
+  const markerY = y - size * 0.3;
+  ctx.beginPath();
+  if (marker === 'chevron') {
+    ctx.moveTo(markerX - size * 0.1, markerY - size * 0.06);
+    ctx.lineTo(markerX, markerY + size * 0.08);
+    ctx.lineTo(markerX + size * 0.1, markerY - size * 0.06);
+  } else {
+    ctx.moveTo(markerX, markerY - size * 0.11);
+    ctx.lineTo(markerX + size * 0.11, markerY);
+    ctx.lineTo(markerX, markerY + size * 0.11);
+    ctx.lineTo(markerX - size * 0.11, markerY);
+  }
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(0,0,0,0.72)';
+  ctx.lineWidth = Math.max(1, size * 0.025);
+  ctx.stroke();
+}
+```
+
+Inside the unit loop, replace `ownerColor` and `UNIT_ICONS` reads with:
+
+```ts
+        const visual = resolveUnitVisual(state, unit, colorLookup);
+        const ownerColor = visual.color;
+```
+
+After drawing sprite or fallback icon, call:
+
+```ts
+        drawRoleMarker(ctx, visual.roleMarker, unitX, unitY, size);
+```
+
+Extract the body that draws one unit glyph into an exported helper so stationary units and movement animation share the same owner color, fallback icon, health bar, stack badge, and role marker rules:
+
+```ts
+export interface UnitGlyphDrawOptions {
+  stackSize: number;
+  stackIndex: number;
+  motion?: UnitMotionState;
+  spriteOverride?: HTMLImageElement | null;
+}
+
+export function drawUnitGlyph(
+  ctx: CanvasRenderingContext2D,
+  state: GameState,
+  unit: Unit,
+  x: number,
+  y: number,
+  size: number,
+  colorLookup: Record<string, string> | undefined,
+  options: UnitGlyphDrawOptions,
+): void {
+  const visual = resolveUnitVisual(state, unit, colorLookup, options.motion ?? 'idle');
+  const ownerColor = visual.color;
+  const sprite = options.spriteOverride ?? spriteCache.getUnit(unit.type, visual.spriteOwnerId);
+  // The existing sprite, fallback icon, health bar, and fortify badge branches move into this helper.
+  // Replace direct `UNIT_ICONS` reads with `visual.fallbackIcon`.
+  drawRoleMarker(ctx, visual.roleMarker, x, y, size);
+}
+```
+
+Update the stack loop to call `drawUnitGlyph(...)` instead of duplicating drawing logic inline.
+
+- [ ] **Step 5: Add marker renderer tests**
+
+Append to `tests/renderer/unit-renderer.test.ts`:
+
+```ts
+describe('unit role markers', () => {
+  it('draws a chevron marker for barbarian units', () => {
+    const ctx = createContext();
+    const units = {
+      barb: { id: 'barb', owner: 'barbarian', type: 'warrior', position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+    } as any;
+    const state = { map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] } } as GameState;
+    const camera = { zoom: 0.2, hexSize: 48, isHexVisible: () => true, worldToScreen: (x: number, y: number) => ({ x, y }) } as Camera;
+
+    drawUnits(ctx, units, camera, { tiles: { '0,0': 'visible' } }, state, 'player', { barbarian: '#8b4513' });
+
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
+  });
+
+  it('draws a diamond marker for minor-civ units', () => {
+    const ctx = createContext();
+    const units = {
+      minor: { id: 'minor', owner: 'mc-warriors', type: 'warrior', position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+    } as any;
+    const state = { map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] } } as GameState;
+    const camera = { zoom: 0.2, hexSize: 48, isHexVisible: () => true, worldToScreen: (x: number, y: number) => ({ x, y }) } as Camera;
+
+    drawUnits(ctx, units, camera, { tiles: { '0,0': 'visible' } }, state, 'player', { 'mc-warriors': '#8a6f2a' });
+
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
+  });
+});
+```
+
+Update `createContext()` in that test to include `moveTo`, `lineTo`, and `closePath` spies.
+
+- [ ] **Step 6: Preload barbarian and active minor-civ sprite palettes**
+
+In `src/main.ts`, find the `initSprites(civColors)` call in `startGame`. Build a palette map that includes major civs, the barbarian owner, and every active minor civ before passing it to `initSprites`:
+
+```ts
+  const spriteColors: Record<string, string> = {
+    ...civColors,
+    barbarian: '#8b4513',
+  };
+  for (const mc of Object.values(gameState.minorCivs ?? {})) {
+    const def = MINOR_CIV_DEFINITIONS.find(candidate => candidate.id === mc.definitionId);
+    if (def) spriteColors[mc.id] = def.color;
+  }
+  await initSprites(spriteColors);
+```
+
+Remove the older direct `await initSprites(civColors)` call. This does not reveal hidden minor-civ identities by itself; it only prepares sprite images for owners already present in state, and map rendering still gates visibility through `VisibilityMap`.
+
+- [ ] **Step 7: Run visual resolver and renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/unit-visual-resolver.test.ts tests/renderer/unit-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 6**
+
+Run:
+
+```bash
+git add src/renderer/unit-visual-resolver.ts src/renderer/unit-renderer.ts src/main.ts tests/renderer/unit-visual-resolver.test.ts tests/renderer/unit-renderer.test.ts
+git commit -m "feat(renderer): add unit role markers"
+```
+
+## Task 7: Full Per-Sprite Moving Frames
+
+**Files:**
+- Modify: `src/renderer/sprites/units.tsx`
+- Modify: `src/renderer/sprites/sprite-catalog.ts`
+- Modify: `src/renderer/sprites/sprite-loader.ts`
+- Modify: `tests/renderer/sprites/sprite-catalog.test.ts`
+- Modify: `tests/renderer/sprites/sprite-loader.test.ts`
+
+- [ ] **Step 1: Add failing moving output catalog tests**
+
+Append to `tests/renderer/sprites/sprite-catalog.test.ts`:
+
+```ts
+import { derivePalette } from '@/renderer/sprites/sprite-system';
+
+it('every unit sprite returns distinct moving output', () => {
+  const palette = derivePalette('#4a90d9');
+  for (const [type, render] of Object.entries(UNIT_SPRITE_CATALOG)) {
+    const idle = render({ palette, svgOnly: true, motion: 'idle' });
+    const movingA = render({ palette, svgOnly: true, motion: 'move-a' });
+    const movingB = render({ palette, svgOnly: true, motion: 'move-b' });
+    expect(idle, `${type} idle sprite`).toContain('data-motion="idle"');
+    expect(movingA, `${type} move-a sprite`).toContain('data-motion="move-a"');
+    expect(movingB, `${type} move-b sprite`).toContain('data-motion="move-b"');
+    expect(movingA, `${type} move-a differs from idle`).not.toBe(idle);
+    expect(movingB, `${type} move-b differs from move-a`).not.toBe(movingA);
+  }
+});
+```
+
+- [ ] **Step 2: Run failing sprite catalog test**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/sprites/sprite-catalog.test.ts
+```
+
+Expected: FAIL because `UnitSpriteProps` has no `motion` field and sprites do not emit `data-motion`.
+
+- [ ] **Step 3: Add motion prop and helper transforms**
+
+Modify `src/renderer/sprites/units.tsx`:
+
+```ts
+export type UnitSpriteMotion = 'idle' | 'move-a' | 'move-b';
+export type UnitSpriteProps = { palette: FactionPalette; svgOnly?: boolean; motion?: UnitSpriteMotion };
+
+function motionData(motion: UnitSpriteMotion = 'idle'): { attr: UnitSpriteMotion; humanoid: string; animal: string; naval: string } {
+  if (motion === 'move-a') {
+    return {
+      attr: motion,
+      humanoid: 'translate(0 -2) rotate(-2 64 70)',
+      animal: 'translate(-3 -2) rotate(-2 64 70)',
+      naval: 'translate(-2 1) rotate(-1 64 82)',
+    };
+  }
+  if (motion === 'move-b') {
+    return {
+      attr: motion,
+      humanoid: 'translate(0 1) rotate(2 64 70)',
+      animal: 'translate(3 1) rotate(2 64 70)',
+      naval: 'translate(2 -1) rotate(1 64 82)',
+    };
+  }
+  return { attr: 'idle', humanoid: '', animal: '', naval: '' };
+}
+```
+
+For each sprite, accept `motion = 'idle'`, compute `const m = motionData(motion);`, and put all visible moving parts inside a `<g data-motion={m.attr} transform={m.humanoid}>`, `<g data-motion={m.attr} transform={m.animal}>`, or `<g data-motion={m.attr} transform={m.naval}>`.
+
+Example for Warrior:
+
+```tsx
+export function WarriorSprite({ palette, svgOnly = false, motion = 'idle' }: UnitSpriteProps): string {
+  const m = motionData(motion);
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g data-motion={m.attr} transform={m.humanoid}>
+        <Shadow />
+        <Humanoid cx={64} cy={70} scale={1} cloth={palette.mid} pants={P.cloth.wool} accent={palette.dark} hair="#3a2a1a" />
+        <g transform="translate(42 64)">
+          <circle r="14" fill={P.wood.mid} stroke={P.ink.line} strokeWidth="1" />
+          <circle r="14" fill={palette.mid} opacity="0.85" />
+          <circle r="3" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.6" />
+          <path d="M-12,0 L12,0 M0,-12 L0,12" stroke={palette.dark} strokeWidth="1.2" />
+        </g>
+        <g transform="translate(86 38) rotate(15)">
+          <rect x="-1.2" y="0" width="2.4" height="42" fill={P.wood.dark} />
+          <path d="M-7,-6 L7,-6 L9,6 L-9,6 Z" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="0.8" />
+          <path d="M-7,-6 L7,-6 L7,-2 L-7,-2 Z" fill={P.metal.shine} opacity="0.5" />
+        </g>
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+Apply this pattern to every current unit sprite. Use `humanoid` for Settler, Worker, Scout, Shadow Warden, Warrior, Swordsman, Pikeman, Archer, Musketeer, and all spy sprites. Use `animal` for Scout Hound and War Hound. Use `naval` for Galley and Trireme.
+
+- [ ] **Step 4: Load motion frames in sprite cache**
+
+Modify `src/renderer/sprites/sprite-loader.ts`:
+
+```ts
+import type { UnitSpriteMotion } from './units';
+
+const UNIT_MOTIONS: UnitSpriteMotion[] = ['idle', 'move-a', 'move-b'];
+```
+
+Inside `loadCiv`, replace unit loading with:
+
+```ts
+    const unitWork = Object.entries(UNIT_SPRITE_CATALOG).flatMap(([type, fn]) =>
+      UNIT_MOTIONS.map(async (motion) => {
+        const svg = fn({ palette, svgOnly: true, motion });
+        if (!svg) return;
+        const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE);
+        this.units.set(`${type}:${civId}:${motion}`, img);
+        if (motion === 'idle') {
+          this.units.set(`${type}:${civId}`, img);
+        }
+      }),
+    );
+```
+
+Add:
+
+```ts
+  getUnitMotion(type: UnitType, civId: string, motion: UnitSpriteMotion): HTMLImageElement | null {
+    return this.units.get(`${type}:${civId}:${motion}`) ?? null;
+  }
+```
+
+- [ ] **Step 5: Add sprite loader motion tests**
+
+Append to `tests/renderer/sprites/sprite-loader.test.ts`:
+
+```ts
+  it('getUnitMotion returns moving frames for a loaded civ', () => {
+    expect(spriteCache.getUnitMotion('warrior', 'player', 'move-a')).toBeInstanceOf(HTMLImageElement);
+    expect(spriteCache.getUnitMotion('warrior', 'player', 'move-b')).toBeInstanceOf(HTMLImageElement);
+  });
+
+  it('getUnitMotion returns null for an uncached civ', () => {
+    expect(spriteCache.getUnitMotion('warrior', 'uncached-civ', 'move-a')).toBeNull();
+  });
+```
+
+- [ ] **Step 6: Run sprite tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/sprites/sprite-catalog.test.ts tests/renderer/sprites/sprite-loader.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 7**
+
+Run:
+
+```bash
+git add src/renderer/sprites/units.tsx src/renderer/sprites/sprite-catalog.ts src/renderer/sprites/sprite-loader.ts tests/renderer/sprites/sprite-catalog.test.ts tests/renderer/sprites/sprite-loader.test.ts
+git commit -m "feat(sprites): add moving unit frames"
+```
+
+## Task 8: Movement Animation, Wrapped Route, Stack Coherency, And Command Lockout
+
+**Files:**
+- Create: `src/renderer/unit-movement-animation.ts`
+- Create: `tests/renderer/unit-movement-animation.test.ts`
+- Modify: `src/renderer/animation-system.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Modify: `src/renderer/unit-renderer.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/renderer/render-loop-wrap.test.ts`
+- Modify: `tests/renderer/unit-renderer.test.ts`
+
+- [ ] **Step 1: Write failing movement animation tests**
+
+Create `tests/renderer/unit-movement-animation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { GameMap, Unit } from '@/core/types';
+import { createMovementAnimation, getMovementAnimationPosition, getMovementDurationMs, getMovingUnitIds } from '@/renderer/unit-movement-animation';
+import { createUnit } from '@/systems/unit-system';
+
+const map = { width: 6, height: 4, wrapsHorizontally: true, tiles: {}, rivers: [] } as GameMap;
+
+function unit(id: string): Unit {
+  return { ...createUnit('warrior', 'player', { q: 0, r: 1 }), id };
+}
+
+describe('unit-movement-animation', () => {
+  it('uses a short wrapped route across the horizontal edge', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 5, r: 1 }, map);
+
+    expect(animation.renderFrom.q).toBe(0);
+    expect(animation.renderTo.q).toBe(-1);
+  });
+
+  it('clamps normal movement duration to a responsive range', () => {
+    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }])).toBe(250);
+    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 }, { q: 3, r: 0 }])).toBeLessThanOrEqual(600);
+  });
+
+  it('interpolates position and alternates moving frames', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
+    const halfway = getMovementAnimationPosition(animation, 0.5);
+
+    expect(halfway.coord.q).toBeCloseTo(0.5);
+    expect(halfway.motion).toBe('move-b');
+  });
+
+  it('tracks moving unit ids for stationary renderer hiding', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
+
+    expect(getMovingUnitIds([animation])).toEqual(new Set(['u1']));
+  });
+});
+```
+
+- [ ] **Step 2: Run failing movement animation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/unit-movement-animation.test.ts
+```
+
+Expected: FAIL because `src/renderer/unit-movement-animation.ts` does not exist.
+
+- [ ] **Step 3: Implement movement animation helper**
+
+Create `src/renderer/unit-movement-animation.ts`:
+
+```ts
+import type { GameMap, HexCoord, Unit } from '@/core/types';
+import type { UnitMotionState } from '@/renderer/unit-visual-resolver';
+
+export interface UnitMovementAnimation {
+  unit: Unit;
+  from: HexCoord;
+  to: HexCoord;
+  renderFrom: HexCoord;
+  renderTo: HexCoord;
+  duration: number;
+}
+
+export interface UnitMovementFrame {
+  coord: HexCoord;
+  motion: UnitMotionState;
+}
+
+export function getMovementDurationMs(path: HexCoord[]): number {
+  const steps = Math.max(1, path.length - 1);
+  return Math.min(600, 250 + Math.max(0, steps - 1) * 120);
+}
+
+function wrappedRenderDestination(from: HexCoord, to: HexCoord, map: GameMap): HexCoord {
+  if (!map.wrapsHorizontally) return to;
+  const directDelta = to.q - from.q;
+  const westDelta = to.q - map.width - from.q;
+  const eastDelta = to.q + map.width - from.q;
+  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0];
+  return { q: from.q + bestDelta, r: to.r };
+}
+
+export function createMovementAnimation(unit: Unit, from: HexCoord, to: HexCoord, map: GameMap): UnitMovementAnimation {
+  const renderTo = wrappedRenderDestination(from, to, map);
+  return {
+    unit,
+    from,
+    to,
+    renderFrom: from,
+    renderTo,
+    duration: getMovementDurationMs([from, to]),
+  };
+}
+
+export function getMovementAnimationPosition(animation: UnitMovementAnimation, progress: number): UnitMovementFrame {
+  const clamped = Math.max(0, Math.min(1, progress));
+  const motion: UnitMotionState = Math.floor(clamped * 6) % 2 === 0 ? 'move-a' : 'move-b';
+  return {
+    coord: {
+      q: animation.renderFrom.q + (animation.renderTo.q - animation.renderFrom.q) * clamped,
+      r: animation.renderFrom.r + (animation.renderTo.r - animation.renderFrom.r) * clamped,
+    },
+    motion,
+  };
+}
+
+export function getMovingUnitIds(animations: UnitMovementAnimation[]): Set<string> {
+  return new Set(animations.map(animation => animation.unit.id));
+}
+```
+
+- [ ] **Step 4: Hide moving units from stationary `drawUnits`**
+
+Modify `drawUnits` signature in `src/renderer/unit-renderer.ts`:
+
+```ts
+  colorLookup?: Record<string, string>,
+  options: { hiddenUnitIds?: Set<string> } = {},
+): void {
+```
+
+Update visible unit filter:
+
+```ts
+  const visibleUnits = Object.values(units).filter(unit =>
+    !options.hiddenUnitIds?.has(unit.id)
+    && isVisible(playerVisibility, unit.position)
+    && !isForestConcealedUnit(state, currentPlayer, unit),
+  );
+```
+
+- [ ] **Step 5: Add movement animation support to render loop**
+
+Modify `src/renderer/render-loop.ts` to import helpers:
+
+```ts
+import type { VisibilityMap } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { createMovementAnimation, getMovementAnimationPosition, getMovingUnitIds, type UnitMovementAnimation } from './unit-movement-animation';
+import { resolveUnitVisual } from './unit-visual-resolver';
+import { drawUnitGlyph } from './unit-renderer';
+import { spriteCache } from './sprites/sprite-loader';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
+```
+
+Add class field and methods:
+
+```ts
+  private unitMovementAnimations: Array<UnitMovementAnimation & { startTime: number; onComplete?: () => void }> = [];
+
+  animateUnitMove(unit: Unit, from: HexCoord, to: HexCoord, onComplete?: () => void): void {
+    if (!this.state) return;
+    this.unitMovementAnimations.push({
+      ...createMovementAnimation(unit, from, to, this.state.map),
+      startTime: performance.now(),
+      onComplete,
+    });
+  }
+
+  hasMovingUnit(unitId: string): boolean {
+    return this.unitMovementAnimations.some(animation => animation.unit.id === unitId);
+  }
+```
+
+When calling `drawUnits`, pass hidden IDs:
+
+```ts
+      drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup, {
+        hiddenUnitIds: getMovingUnitIds(this.unitMovementAnimations),
+      });
+```
+
+Add a private `drawUnitMovementAnimations(now: number)` method that:
+
+- computes progress from `now - startTime`
+- uses `getMovementAnimationPosition`
+- draws sprite cache motion frame with `spriteCache.getUnitMotion(unit.type, visual.spriteOwnerId, frame.motion)`
+- calls `drawUnitGlyph(...)` with `motion: frame.motion` and `spriteOverride` so fallback icon, health, owner color, and role marker stay identical to stationary rendering
+- removes completed animations and calls `onComplete`
+
+Use this implementation shape:
+
+```ts
+  private drawUnitMovementAnimations(now: number, colorLookup: Record<string, string>, viewerVisibility: VisibilityMap): void {
+    if (!this.state) return;
+    const remaining: typeof this.unitMovementAnimations = [];
+    for (const animation of this.unitMovementAnimations) {
+      const elapsed = now - animation.startTime;
+      const progress = Math.min(1, elapsed / animation.duration);
+      const frame = getMovementAnimationPosition(animation, progress);
+      if (getVisibility(viewerVisibility, animation.to) === 'unexplored') {
+        if (progress < 1) remaining.push(animation);
+        continue;
+      }
+      const renderCoords = this.state.map.wrapsHorizontally
+        ? getHorizontalWrapRenderCoords(frame.coord, this.state.map.width, this.camera)
+        : [frame.coord];
+      const visual = resolveUnitVisual(this.state, animation.unit, colorLookup, frame.motion);
+      const sprite = this.camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
+        ? spriteCache.getUnitMotion(animation.unit.type, visual.spriteOwnerId, frame.motion)
+        : null;
+      for (const renderCoord of renderCoords) {
+        if (!this.camera.isHexVisible(renderCoord)) continue;
+        const pixel = hexToPixel(renderCoord, this.camera.hexSize);
+        const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+        drawUnitGlyph(this.ctx, this.state, animation.unit, screen.x, screen.y, this.camera.hexSize * this.camera.zoom, colorLookup, {
+          stackSize: 1,
+          stackIndex: 0,
+          motion: frame.motion,
+          spriteOverride: sprite,
+        });
+      }
+      if (progress < 1) {
+        remaining.push(animation);
+      } else {
+        animation.onComplete?.();
+      }
+    }
+    this.unitMovementAnimations = remaining;
+  }
+```
+
+Call it after stationary units and before fog overlay:
+
+```ts
+    this.drawUnitMovementAnimations(performance.now());
+```
+
+- [ ] **Step 6: Wire movement animation and command lockout in `main.ts`**
+
+Add helper near movement functions:
+
+```ts
+function isUnitAnimationLocked(unitId: string | null): boolean {
+  return Boolean(unitId && renderLoop.hasMovingUnit(unitId));
+}
+```
+
+At the start of `selectUnit`:
+
+```ts
+  if (renderLoop.hasMovingUnit(unitId)) {
+    showNotification('Unit is moving.', 'info');
+    return;
+  }
+```
+
+In the tap handler, before acting on selected unit:
+
+```ts
+  if (isUnitAnimationLocked(selectedUnitId)) {
+    showNotification('Unit is moving.', 'info');
+    return;
+  }
+```
+
+After `executeUnitMove(...)`, capture result:
+
+```ts
+      const moveResult = executeUnitMove(gameState, selectedUnitId, coord, {
+        actor: 'player',
+        civId: gameState.currentPlayer,
+        bus,
+      });
+      const movedUnit = gameState.units[selectedUnitId];
+      if (movedUnit) {
+        renderLoop.animateUnitMove({ ...movedUnit, position: moveResult.from }, moveResult.from, moveResult.to, () => {
+          renderLoop.setGameState(gameState);
+          updateHUD();
+        });
+      }
+```
+
+Do the same in busy-worker confirmed moves and minor-civ city assault moves. Do not animate combat attacks in this task.
+
+- [ ] **Step 7: Add renderer tests for hidden moving units**
+
+Append to `tests/renderer/unit-renderer.test.ts`:
+
+```ts
+it('does not draw stationary copy for hidden moving unit ids', () => {
+  const ctx = createContext();
+  const units = {
+    mover: { id: 'mover', owner: 'player', type: 'warrior', position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false },
+  } as any;
+  const state = { map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] } } as GameState;
+  const camera = { zoom: 0.2, hexSize: 48, isHexVisible: () => true, worldToScreen: (x: number, y: number) => ({ x, y }) } as Camera;
+
+  drawUnits(ctx, units, camera, { tiles: { '0,0': 'visible' } }, state, 'player', { player: '#4a90d9' }, { hiddenUnitIds: new Set(['mover']) });
+
+  expect(ctx.fillText).not.toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
+});
+```
+
+- [ ] **Step 8: Run movement renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/unit-movement-animation.test.ts tests/renderer/unit-renderer.test.ts tests/renderer/render-loop-wrap.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 8**
+
+Run:
+
+```bash
+git add src/renderer/unit-movement-animation.ts src/renderer/animation-system.ts src/renderer/render-loop.ts src/renderer/unit-renderer.ts src/main.ts tests/renderer/unit-movement-animation.test.ts tests/renderer/unit-renderer.test.ts tests/renderer/render-loop-wrap.test.ts
+git commit -m "feat(renderer): animate unit movement"
+```
+
+## Task 9: Final Verification And Rule Checks
+
+**Files:**
+- Verify changed files from Tasks 1-8.
+
+- [ ] **Step 1: Run source rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh \
+  src/core/types.ts \
+  src/core/game-state.ts \
+  src/core/turn-manager.ts \
+  src/systems/unit-system.ts \
+  src/systems/attack-targeting.ts \
+  src/systems/last-seen-presentation.ts \
+  src/systems/fog-of-war.ts \
+  src/systems/unit-movement-system.ts \
+  src/input/selected-unit-highlights.ts \
+  src/input/selected-unit-tap-intent.ts \
+  src/renderer/tile-presentation.ts \
+  src/renderer/hex-renderer.ts \
+  src/renderer/city-renderer.ts \
+  src/renderer/fog-renderer.ts \
+  src/renderer/render-visibility.ts \
+  src/renderer/unit-visual-resolver.ts \
+  src/renderer/unit-renderer.ts \
+  src/renderer/sprites/units.tsx \
+  src/renderer/sprites/sprite-catalog.ts \
+  src/renderer/sprites/sprite-loader.ts \
+  src/renderer/unit-movement-animation.ts \
+  src/renderer/animation-system.ts \
+  src/renderer/render-loop.ts \
+  src/main.ts
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run all targeted tests from this plan**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run \
+  tests/systems/attack-targeting.test.ts \
+  tests/input/selected-unit-highlights.test.ts \
+  tests/input/selected-unit-tap-intent.test.ts \
+  tests/ai/basic-ai.test.ts \
+  tests/systems/barbarian-system.test.ts \
+  tests/systems/minor-civ-system.test.ts \
+  tests/systems/last-seen-presentation.test.ts \
+  tests/systems/unit-movement-system.test.ts \
+  tests/systems/fog-of-war.test.ts \
+  tests/core/game-state.test.ts \
+  tests/core/turn-manager.test.ts \
+  tests/renderer/tile-presentation.test.ts \
+  tests/renderer/fog-renderer.test.ts \
+  tests/renderer/hex-renderer.test.ts \
+  tests/renderer/city-renderer.test.ts \
+  tests/renderer/unit-visual-resolver.test.ts \
+  tests/renderer/unit-renderer.test.ts \
+  tests/renderer/sprites/sprite-catalog.test.ts \
+  tests/renderer/sprites/sprite-loader.test.ts \
+  tests/renderer/unit-movement-animation.test.ts \
+  tests/renderer/render-loop-wrap.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run full test suite before push or PR**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect diffs before completion**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff
+```
+
+Expected: diff contains only planned source, test, and plan/spec changes. No `.superpowers/` scratch files are staged.
+
+## Self-Review Checklist
+
+- [ ] Every spec acceptance criterion maps to one or more tasks above.
+- [ ] Attack profile model separates movement and attack reach.
+- [ ] Ranged unit attacks are visible-unit attacks only, and ordinary ranged city attacks are blocked.
+- [ ] Player highlights, tap intent, preview, confirmation, and non-player attack selection use shared targeting.
+- [ ] Last-seen presentation is viewer-scoped, serializable, and safe for old saves.
+- [ ] Fogged rendering never reads live units or live city state.
+- [ ] Wrap rendering uses canonical visibility and short movement routes.
+- [ ] Barbarian and minor-civ unit visuals use same base sprites with owner color and role marker.
+- [ ] Every current unit sprite has intentional moving output.
+- [ ] Movement animation hides duplicate stationary copies, handles stacks, and blocks repeat commands.
+- [ ] Tests assert rendered/player-visible behavior, not only internal state.
+- [ ] Required rule checks, targeted tests, build, and full test suite are listed.
+
+## Inline Execution Notes
+
+The user requested inline execution with no subagents. When executing this plan, use `superpowers:executing-plans` and work task-by-task in this session. Pause after each task commit for a short checkpoint summary that includes commands run and any changed assumptions.

--- a/docs/superpowers/specs/2026-05-15-combat-visibility-unit-motion-bug-bundle-design.md
+++ b/docs/superpowers/specs/2026-05-15-combat-visibility-unit-motion-bug-bundle-design.md
@@ -1,0 +1,205 @@
+# Combat, Visibility, And Unit Motion Bug Bundle Design
+
+## Issue Set
+
+- [#198: Barbarian and Minor Civ Graphics](https://github.com/a1flecke/conquestoria/issues/198)
+- [#199: Missing unit animations](https://github.com/a1flecke/conquestoria/issues/199)
+- [#200: Melee should be next to each other when attacking](https://github.com/a1flecke/conquestoria/issues/200)
+- [#201: Shadow/overlay problem when zoomed out](https://github.com/a1flecke/conquestoria/issues/201)
+
+## Goals
+
+Fix the next bug bundle as one coherent design with two reviewable implementation slices:
+
+1. **Rules and visibility truth:** melee/ranged attack eligibility plus fog and wrap rendering correctness.
+2. **Unit visual identity and motion:** barbarian/minor-civ sprite identity plus full per-sprite movement animation.
+
+The bundle must make player-visible behavior consistent across the live UI, renderer, player input, and non-player combat paths. Combat and visibility must feel legible rather than surprising: players must understand why a target can be attacked, why a tile is hidden, and which faction a moving unit belongs to without opening a panel.
+
+## Non-Goals
+
+- Do not create unique barbarian-only or minor-civ-only base unit art in this bundle. Barbarians and minor civs reuse the same base unit sprites as major civilizations.
+- Do not replace the entire visibility model with a full historical replay system. This bundle adds a lightweight viewer-scoped last-seen presentation snapshot for fogged tiles, but it must not record turn-by-turn history or expose hidden live state.
+- Do not ship generic slide-only movement as the final #199 fix. Movement must include per-sprite moving-state art or motion frames.
+- Do not fork gameplay or renderer behavior for web versus Tauri.
+
+## Slice 1: Attack Rules And Visibility Truth
+
+### Attack Eligibility
+
+Introduce an explicit attack-profile model for units. The default profile is melee range 1. Ranged units such as Archers get an explicit ranged profile. Any future ranged unit must opt into range through typed metadata instead of inheriting attack range from movement range.
+
+The attack profile must distinguish attack reach from movement reach. A melee unit can move multiple hexes in one turn, but it can only attack a hostile target on an adjacent hex. A ranged unit can attack hostile units within its explicit attack range without moving into the defender's hex. Ranged attacks consume the attacker's action and movement for the turn unless a unit definition explicitly grants a later exception.
+
+City attacks and city capture remain adjacent actions by default. A ranged unit can attack a city from range only if it has an explicit future `siege` or `bombard` attack profile; ordinary Archer-style ranged attacks do not capture, raze, or damage cities from range in this bundle.
+
+The shared attack-target helper must answer whether a unit can attack a target hex using:
+
+- the unit attack profile
+- hex distance, including horizontal wrapping
+- current visibility for player-visible attacks
+- occupant or city target state
+- hostility and diplomacy rules
+- target terrain where combat preview or resolution already needs defense information
+
+Player selection highlights, tap intent, combat preview, and player attack execution must use this helper or a thin renderer-facing projection of it. AI, barbarian, minor-civ, and turn-manager attack selection must also use the shared rule unless a later spec creates an explicitly named special attack profile. Melee units must not attack non-adjacent hostile units or cities through player, AI, barbarian, minor-civ, or turn-processing paths.
+
+Attack highlights must be separate from movement highlights. A non-adjacent ranged unit target must be marked as an attack target, not as a movement destination. A non-adjacent melee target must not be highlighted as attackable even if the tile is inside the unit's movement range.
+
+### Visibility And Fog Rendering
+
+`VisibilityMap` remains the source of truth for whether a tile is `visible`, `fog`, or `unexplored`. Renderer code must normalize every rendered coordinate, including horizontal wrap ghost copies, back to the canonical map tile before checking visibility.
+
+Fogged tiles need viewer-scoped last-seen presentation data. The snapshot is not a full history log; it is the latest player-earned presentation for terrain, visible improvements/resources, known city presence, ownership/territory presentation, and any other map content the renderer would otherwise be tempted to read live. It must be updated when the tile is currently visible. It must not update while the tile is fogged or unexplored.
+
+The snapshot must stay serializable with the rest of game state. Existing saves that have only `VisibilityMap` must migrate safely by treating missing last-seen presentation as unknown until the tile is visible again; they must not crash and must not reveal live state as a fallback.
+
+The visual contract is:
+
+- `visible`: show live terrain, cities, and currently visible units.
+- `fog`: show the viewer's last-seen presentation under the existing dim overlay, but do not show live units or undiscovered current changes.
+- `unexplored`: keep the tile fully hidden.
+
+This contract must be invariant across zoom levels. Low zoom and wide viewports must not skip overlays, thin them until terrain leaks through, or render wrap copies with a different visibility state from the canonical tile. The renderer must not choose a low-detail path that bypasses canonical visibility or last-seen presentation.
+
+## Slice 2: Unit Visual Identity And Full Motion
+
+### Barbarian And Minor-Civ Graphics
+
+Barbarian and minor-civ units reuse the same base unit sprite catalog as major civilizations. Their visual identity comes from:
+
+- owner-specific palette or color
+- a small role marker that distinguishes `barbarian`, `minor`, and `major`
+- the same fallback icon behavior used by major-civ units if an image is unavailable
+
+The role marker must render for both stationary and moving units. It must remain readable at normal unit-rendering zoom. It can simplify or disappear only at an existing low-detail threshold where sprites already fall back to simpler marks. Use these role semantics: barbarian units get a small hostile chevron marker, minor-civ units get a small city-state diamond marker, and major-civ units omit the marker.
+
+Sprite loading must either preload barbarian and active minor-civ palettes or generate/cache those palette variants on demand. `getUnit()` and `getBuilding()` must continue returning `null` for uncached keys so existing fallback behavior remains safe. Palette generation must not leak undiscovered minor-civ identity details beyond what the player has earned through normal visibility and presentation rules.
+
+### Movement Animation
+
+Movement animation must show both:
+
+- travel from the source hex to the destination hex
+- per-sprite locomotion while traveling
+
+Each current unit sprite must support a moving state or motion-frame sequence appropriate to that unit. Infantry must visibly step; animal units must run or lope; ships must sail with wake or hull motion; future wheeled/mechanical units must animate wheels or comparable motion. This is full per-sprite motion, not a generic slide with one shared effect. The moving state can reuse shared sprite subparts, but each unit's exported sprite must intentionally define what its moving frames look like.
+
+The moving unit must use the same resolved visual identity as the stationary unit: base sprite, owner palette, fallback behavior, and barbarian/minor role marker. During movement, the renderer must avoid drawing both the stale idle unit at the destination and the animated moving unit in a way that looks duplicated. Player commands must not be accepted against a stale moving unit state. Movement animation must be fast enough to keep the game responsive: target 200-350ms for a normal one-hex move, scaling modestly for longer paths without exceeding 600ms for ordinary player movement.
+
+## Data Flow
+
+### Attack Flow
+
+1. Unit selection builds player-visible move and attack targets from shared movement and attack helpers.
+2. The renderer receives distinct highlight records for movement and legal attack targets.
+3. Tapping a legal attack target opens combat preview.
+4. Confirming the preview revalidates legality and executes combat through the same boundary.
+5. Non-player attack selection uses the same melee/ranged distance rule where it can attack units or cities.
+
+### Visibility Flow
+
+1. Systems update each civilization's canonical `VisibilityMap`.
+2. When a tile becomes or remains visible, systems refresh that viewer's last-seen presentation for the tile.
+3. Render loop asks renderer helpers for canonical visibility when drawing base tiles, wrap copies, cities, units, and fog overlays.
+4. Visible tiles render from live state. Fogged tiles render from viewer-scoped last-seen presentation. Unexplored tiles render only the hidden treatment.
+5. Fog overlays are drawn after map content, but their canonical visibility decision must match the underlying tile and every wrap copy.
+6. Unit/city rendering must show only data allowed by the viewer's canonical visibility state and last-seen presentation.
+
+### Unit Visual Flow
+
+1. A shared unit-visual resolver accepts unit, owner, game state, current zoom/detail tier, and animation state.
+2. The resolver returns sprite key, palette/color, fallback icon, role marker, and motion-state information without changing game state.
+3. Stationary drawing and movement animation both consume the resolver.
+4. Sprite catalog coverage proves every current unit has idle and moving visual output.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| A Warrior is selected and an enemy is two hexes away inside movement range | Player taps the enemy | No combat preview opens; the enemy tile is not attack-highlighted; movement/selection state remains understandable |
+| An Archer is selected and a visible enemy is inside its attack range | Player taps the enemy | Combat preview opens; confirming attacks without moving the Archer into the defender's hex |
+| An Archer is selected and a hostile city is two hexes away | Player taps the city | No ranged city attack or capture preview opens unless that unit has an explicit siege/bombard profile |
+| A ranged unit has a fogged or unexplored enemy location inside theoretical attack range | Player selects the unit | No attack highlight appears for that hidden target |
+| A tile leaves vision | Player zooms out or pans across wrap copies | The tile remains fogged with last-seen presentation and does not reveal live units, live city changes, or uncovered terrain |
+| A barbarian or minor-civ unit moves | Movement begins | The moving unit shows its owner color, role marker, and per-sprite motion frames throughout travel |
+| A unit is moving | Player taps the moving unit or its destination before animation completion | No second command is accepted against stale visual state; once animation completes, normal selection resumes |
+| A wrapped move crosses the horizontal edge | Movement begins | The unit takes the short wrapped route, not a long slide across the whole map |
+
+## Edge Cases
+
+- Wrapped maps must compare attack range and visibility with wrapped distance, not raw `q` deltas.
+- Ranged units cannot attack targets hidden by fog or unexplored visibility through the player UI.
+- Fogged tiles must not display live enemy units, barbarian units, minor-civ units, or newly changed city/unit state. If a city was last seen on a tile, the renderer shows the last-seen city presentation, but not live ownership, population, garrison, production, or destruction changes until the tile becomes visible again.
+- Missing last-seen presentation must render as unknown fog, not as live terrain.
+- Last-seen presentation must be viewer-scoped. Hot-seat players must not share each other's stale map knowledge.
+- Barbarian and minor-civ role markers must not depend on hardcoded owner IDs beyond the existing `barbarian` owner and `mc-` minor-civ ID convention.
+- If sprite loading for a minor civ has not completed, rendering falls back to the same base icon plus owner color and marker rather than throwing or showing a major-civ sprite.
+- Movement animation must preserve health bars, stack indicators, and role markers where those are visible for stationary units.
+- Movement animation must handle wrapped movement without jumping across the long side of the map when a short wrapped path exists.
+- Movement animation must handle stacked units by animating only the unit that moved and preserving a coherent stack count before and after the move.
+- If a moving unit enters or leaves visibility during the animation, the final rendered state must obey the viewer's current visibility after movement resolution.
+
+## Test Requirements
+
+Slice 1 tests:
+
+- system tests proving melee units cannot attack non-adjacent hostile units or cities
+- system tests proving ranged units can attack at their explicit range
+- negative tests proving ordinary ranged units cannot attack or capture cities from range without an explicit siege/bombard profile
+- negative tests proving ranged attacks cannot target fogged or unexplored units through the player path
+- player input or UI tests proving attack highlights and combat preview respect melee/ranged eligibility
+- a replay test proving attack confirmation revalidates legality after selection state changes
+- AI or turn-manager parity tests if implementation changes non-player attack selection
+- fog renderer tests for low zoom, wide viewport, and horizontal wrap ghost copies
+- visibility tests proving canonical wrapped coordinates share one visibility state
+- hot-seat visibility tests proving last-seen presentation is viewer-scoped
+- migration tests proving saves without last-seen presentation do not crash or reveal live fogged terrain
+- stale-city tests proving fogged city presentation does not read live ownership, garrison, population, destruction, or production state
+
+Slice 2 tests:
+
+- sprite catalog or sprite-system tests proving every current unit sprite has idle and moving visual output
+- renderer tests proving barbarian units use the shared base unit sprite with barbarian color and marker
+- renderer tests proving minor-civ units use the shared base unit sprite with minor-civ color and marker
+- animation tests proving moving units use the same visual resolver as stationary units
+- animation tests proving movement interpolation does not draw duplicate idle and moving copies
+- wrap movement animation tests proving the animation follows the short wrapped route
+- animation tests proving command lockout during movement and normal command availability after completion
+- stack animation tests proving moving one unit out of a stack updates the visible stack count coherently
+
+Required verification for implementation:
+
+- `scripts/check-src-rule-violations.sh` for changed `src/` files
+- mirrored or smallest relevant targeted tests for changed source areas
+- `./scripts/run-with-mise.sh yarn build` before push or PR
+- `./scripts/run-with-mise.sh yarn test` before push or PR
+
+## Implementation Slices
+
+### Slice 1: Rules And Visibility Truth
+
+Implement attack profiles and shared attack eligibility first, then wire player highlights, tap intent, combat preview, and player attack execution through that rule. Audit non-player attack paths and add parity coverage where they can currently violate melee adjacency. Ranged attacks must be modeled as attacks, not as movement into an occupied hex.
+
+Then fix fog/wrap rendering by canonicalizing visibility lookups for every render copy, adding lightweight viewer-scoped last-seen presentation, and strengthening low-zoom overlay tests.
+
+### Slice 2: Unit Visual Identity And Motion
+
+Create the shared unit-visual resolver. Use it for stationary unit rendering first, adding barbarian and minor-civ palette plus role marker support.
+
+Then extend the sprite catalog with moving-state or motion-frame output for every current unit sprite. Wire movement animation to use those frames while interpolating along the unit path, preserving owner color and role markers throughout the animation. The slice must not ship a moving animation entry point until all current unit sprites have an intentional moving state or frame sequence.
+
+## Acceptance Criteria
+
+- Warriors, Swordsmen, Pikemen, hounds, spies, ships without ranged profiles, and other melee/default units cannot attack non-adjacent targets.
+- Archers and any future explicitly ranged units can attack visible hostile units at their stated range.
+- Ordinary ranged units cannot attack or capture cities from range without an explicit siege/bombard profile.
+- Zooming out never reveals terrain or live state that should be hidden by `fog` or `unexplored`.
+- Fogged tiles render viewer-scoped last-seen presentation, not live state.
+- Horizontal wrap copies render with the same visibility state as their canonical tile.
+- Barbarian and minor-civ units use the same base sprites as major civs, but unique colors and role markers make their owner type clear.
+- Unit movement shows per-sprite moving animation while traveling between hexes.
+- Moving units keep the same sprite, owner color, marker, and fallback identity as stationary units.
+- Moving units cannot receive duplicate commands during animation, and normal commands resume after animation completion.
+- Ranged attacks, fog behavior, role markers, and motion frames make combat more readable and lively without adding hidden information or slowing down ordinary turn flow.
+- The implementation can ship as two reviewable slices without leaving dead player-visible controls or half-wired visual states.

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,13 +1,14 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
-import { hexKey, hexNeighbors } from '@/systems/hex-utils';
+import { hexKey } from '@/systems/hex-utils';
 import { foundCity, getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { buildUnitOccupancy } from '@/systems/unit-occupancy';
-import { resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
+import { resolveCombat } from '@/systems/combat-system';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { getAttackTargets } from '@/systems/attack-targeting';
+import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
 import { updateVisibility } from '@/systems/fog-of-war';
 import { resolveCivDefinition } from '@/systems/civ-registry';
@@ -348,25 +349,11 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
   for (const unit of militaryUnits) {
     if (unit.movementPointsLeft <= 0) continue;
 
-    const occupancy = buildUnitOccupancy(newState.units);
-
-    // Check for nearby enemies to attack
-    const neighbors = hexNeighbors(unit.position);
     let attacked = false;
-    for (const neighbor of neighbors) {
-      const neighborKey = hexKey(neighbor);
-      const occupantIds = occupancy.unitIdsByHex[neighborKey] ?? [];
-      if (occupantIds.length > 0) {
-        const attackableDefenders = occupantIds
-          .map(id => newState.units[id])
-          .filter((candidate): candidate is Unit => {
-            if (!candidate || candidate.owner === civId) return false;
-            const isBarbarian = candidate.owner === 'barbarian';
-            const isRebel = candidate.owner === 'rebels';
-            const atWar = civ.diplomacy?.atWarWith.includes(candidate.owner) ?? false;
-            return isBarbarian || isRebel || atWar;
-          });
-        const occupant = selectDefenderForAttack(attackableDefenders, newState.map);
+    const attackTargets = getAttackTargets(newState, unit, { requireVisibility: false });
+    for (const target of attackTargets) {
+      if (target.result.targetType === 'unit') {
+        const occupant = newState.units[target.result.targetUnitId];
         if (occupant) {
           const seed = newState.turn * 16807 + unit.id.charCodeAt(0);
           const attackerBonus = resolveCivDefinition(newState, civ.civType ?? '')?.bonusEffect;
@@ -430,6 +417,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     }
 
     // Explore: move toward unexplored territory
+    const occupancy = buildUnitOccupancy(newState.units);
     const range = getMovementRange(unit, newState.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
     if (range.length > 0) {
       const unexplored = range.filter(

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -20,6 +20,7 @@ import { placeWonders } from '@/systems/wonder-system';
 import { placeVillages } from '@/systems/village-system';
 import { placeMinorCivs } from '@/systems/minor-civ-system';
 import { initializeEspionage } from '@/systems/espionage-system';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
 
 function hashSeed(s: string): number {
   let h = 0;
@@ -291,6 +292,7 @@ export function createNewGame(
   Object.assign(state.units, mcResult.units);
 
   for (const civId of Object.keys(state.civilizations)) {
+    refreshLastSeenPresentationsForCiv(state, civId);
     syncCivilizationContactsFromVisibility(state, civId);
   }
 
@@ -407,6 +409,7 @@ export function createHotSeatGame(config: HotSeatConfig, seed?: string, gameTitl
   Object.assign(state.units, mcResult.units);
 
   for (const civId of Object.keys(state.civilizations)) {
+    refreshLastSeenPresentationsForCiv(state, civId);
     syncCivilizationContactsFromVisibility(state, civId);
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -15,6 +15,7 @@ import { calculateCityYields } from '@/systems/resource-system';
 import type { HexCoord } from './types';
 import { updateVisibility, revealMinorCivCities, applySharedVision, applySatelliteSurveillance } from '@/systems/fog-of-war';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
 import {
   processRelationshipDrift,
   decayEvents,
@@ -321,6 +322,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
         applySharedVision(newState.civilizations[civId].visibility, mcPositions, newState.map);
       }
     }
+    refreshLastSeenPresentationsForCiv(newState, civId);
 
     // Clear expired advisor disable timers after all start-of-turn effects are processed.
     if (currentCivState.advisorDisabledUntil) {

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -8,6 +8,7 @@ import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-wor
 import { processResearch, getTechById } from '@/systems/tech-system';
 import { processBarbarians } from '@/systems/barbarian-system';
 import { resolveCombat } from '@/systems/combat-system';
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { calculateCityYields } from '@/systems/resource-system';
@@ -455,6 +456,8 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     const attacker = newState.units[attack.attackerUnitId];
     const defender = newState.units[attack.defenderUnitId];
     if (!attacker || !defender) continue;
+    const legality = canUnitAttackTarget(newState, attacker, defender.position, { requireVisibility: false });
+    if (!legality.ok || legality.targetType !== 'unit' || legality.targetUnitId !== defender.id) continue;
     const combatSeed = barbSeed ^ attack.attackerUnitId.charCodeAt(0);
     const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
     const applied = applyCombatOutcomeToState(newState, result, combatSeed);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -190,6 +190,27 @@ export interface GameMap {
 
 export interface VisibilityMap {
   tiles: Record<string, VisibilityState>; // key is "q,r"
+  lastSeen?: Record<string, LastSeenTilePresentation>;
+}
+
+export interface LastSeenCityPresentation {
+  id: string;
+  name: string;
+  owner: string;
+  population: number;
+}
+
+export interface LastSeenTilePresentation {
+  coord: HexCoord;
+  terrain: TerrainType;
+  elevation: Elevation;
+  resource: string | null;
+  improvement: ImprovementType;
+  improvementTurnsLeft: number;
+  owner: string | null;
+  hasRiver: boolean;
+  wonder: string | null;
+  city?: LastSeenCityPresentation;
 }
 
 // --- Units ---

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -200,6 +200,12 @@ export type UnitType =
   | 'spy_scout' | 'spy_informant' | 'spy_agent' | 'spy_operative' | 'spy_hacker'
   | 'scout_hound' | 'shadow_warden' | 'war_hound';
 
+export interface UnitAttackProfile {
+  kind: 'melee' | 'ranged' | 'siege' | 'bombard';
+  range: number;
+  targets: Array<'unit' | 'city'>;
+}
+
 export interface UnitDefinition {
   type: UnitType;
   name: string;
@@ -210,6 +216,7 @@ export interface UnitDefinition {
   canBuildImprovements: boolean;
   productionCost: number;
   spyDetectionChance?: number; // 0–1, probability per adjacent spy unit per turn
+  attackProfile?: UnitAttackProfile;
 }
 
 export interface WorkerTask {

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -1,0 +1,37 @@
+import type { GameState, HexCoord } from '@/core/types';
+import type { HexHighlight } from '@/renderer/render-loop';
+import { getAttackTargets, type AttackTarget } from '@/systems/attack-targeting';
+import { hexKey } from '@/systems/hex-utils';
+import { buildUnitOccupancy } from '@/systems/unit-occupancy';
+import { getMovementRange } from '@/systems/unit-system';
+
+export interface SelectedUnitHighlightResult {
+  movementRange: HexCoord[];
+  attackTargets: AttackTarget[];
+  highlights: HexHighlight[];
+}
+
+export function buildSelectedUnitHighlights(state: GameState, unitId: string): SelectedUnitHighlightResult {
+  const unit = state.units[unitId];
+  if (!unit || unit.owner !== state.currentPlayer) {
+    return { movementRange: [], attackTargets: [], highlights: [] };
+  }
+
+  const occupancy = buildUnitOccupancy(state.units);
+  const movementRange = getMovementRange(unit, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
+  const attackTargets = getAttackTargets(state, unit, { viewerId: state.currentPlayer })
+    .filter(target => target.result.targetType === 'unit');
+  const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));
+
+  const moveHighlights = movementRange
+    .filter(coord => !attackKeys.has(hexKey(coord)))
+    .map(coord => ({ coord, type: 'move' as const }));
+
+  const attackHighlights = attackTargets.map(target => ({ coord: target.coord, type: 'attack' as const }));
+
+  return {
+    movementRange,
+    attackTargets,
+    highlights: [...moveHighlights, ...attackHighlights],
+  };
+}

--- a/src/input/selected-unit-tap-intent.ts
+++ b/src/input/selected-unit-tap-intent.ts
@@ -1,5 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
-import { hexKey } from '@/systems/hex-utils';
+import { getUnitAttackProfile } from '@/systems/attack-targeting';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { buildUnitOccupancy, getStackRelationship } from '@/systems/unit-occupancy';
 import { getMovementRange } from '@/systems/unit-system';
 
@@ -19,6 +20,17 @@ function hasTreaty(state: GameState, civA: string, civB: string, type: string): 
 
 function canEnterForeignCityPeacefully(state: GameState, owner: string, targetOwner: string): boolean {
   return hasTreaty(state, owner, targetOwner, 'alliance');
+}
+
+function canReachCityAssault(state: GameState, unitId: string, targetCoord: HexCoord): boolean {
+  const unit = state.units[unitId];
+  if (!unit) return false;
+  const profile = getUnitAttackProfile(unit.type);
+  if (!profile.targets.includes('city')) return false;
+  const distance = state.map.wrapsHorizontally
+    ? wrappedHexDistance(unit.position, targetCoord, state.map.width)
+    : hexDistance(unit.position, targetCoord);
+  return distance > 0 && distance <= profile.range;
 }
 
 export function resolveSelectedUnitTapIntent(
@@ -51,6 +63,10 @@ export function resolveSelectedUnitTapIntent(
     && city.owner !== state.currentPlayer,
   );
   if (!cityAtTarget) {
+    return { kind: 'move' };
+  }
+
+  if (!canReachCityAssault(state, unitId, targetCoord)) {
     return { kind: 'move' };
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,13 @@ import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
 import { processTurn } from '@/core/turn-manager';
 import { processAITurn } from '@/ai/basic-ai';
-import { RenderLoop, type HexHighlight } from '@/renderer/render-loop';
+import { RenderLoop } from '@/renderer/render-loop';
 import { initSprites } from '@/renderer/sprites/sprite-loader';
 import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
 import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
-import { hexKey, hexesInRange, wrapHexCoord } from '@/systems/hex-utils';
-import { getMovementRange, moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
+import { hexKey, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
+import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
 import { foundCity } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
@@ -22,6 +22,8 @@ import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
 import { createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { resolveCombat, getTerrainDefenseBonus, selectDefenderForAttack } from '@/systems/combat-system';
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
 import { updateVisibility, isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
@@ -141,6 +143,7 @@ import { showPauseMenu } from '@/ui/pause-menu-panel';
 let gameState: GameState;
 let selectedUnitId: string | null = null;
 let movementRange: HexCoord[] = [];
+let attackRange: HexCoord[] = [];
 let currentCityIndex = 0;
 let inputInitialized = false;
 let councilPanelOpen = false;
@@ -1070,18 +1073,10 @@ function selectUnit(unitId: string): void {
   const unit = gameState.units[unitId];
   if (!unit || unit.owner !== gameState.currentPlayer) return;
 
-  const occupancy = buildUnitOccupancy(gameState.units);
-  movementRange = getMovementRange(unit, gameState.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId);
-
-  // Classify hexes as move or attack and send to renderer
-  const highlights: HexHighlight[] = movementRange.map(coord => {
-    const k = hexKey(coord);
-    if (visibleHostileUnitEntriesAtKey(k).length > 0) {
-      return { coord, type: 'attack' as const };
-    }
-    return { coord, type: 'move' as const };
-  });
-  renderLoop.setHighlights(highlights);
+  const highlightResult = buildSelectedUnitHighlights(gameState, unitId);
+  movementRange = highlightResult.movementRange;
+  attackRange = highlightResult.attackTargets.map(target => target.coord);
+  renderLoop.setHighlights(highlightResult.highlights);
 
   // Show unit info panel
   const panel = document.getElementById('info-panel');
@@ -1254,6 +1249,7 @@ function selectUnit(unitId: string): void {
 function deselectUnit(): void {
   selectedUnitId = null;
   movementRange = [];
+  attackRange = [];
   renderLoop.clearHighlights();
   const panel = document.getElementById('info-panel');
   if (panel) {
@@ -1514,10 +1510,17 @@ function beginPlayerCityAssault(
 
 function executeAttack(attackerId: string, targetKey: string): void {
   const attacker = gameState.units[attackerId];
-  const defenderEntry = selectDefenderEntryAtKey(targetKey);
-  if (!attacker || !defenderEntry) return;
+  const targetCoord = parseHexKey(targetKey);
+  const legality = canUnitAttackTarget(gameState, attacker, targetCoord, { viewerId: gameState.currentPlayer });
+  if (!attacker || !legality.ok || legality.targetType !== 'unit') {
+    showNotification('That target is no longer attackable.', 'warning');
+    if (selectedUnitId) selectUnit(selectedUnitId);
+    return;
+  }
 
-  const [defenderId, defender] = defenderEntry;
+  const defenderId = legality.targetUnitId;
+  const defender = gameState.units[defenderId];
+  if (!defender) return;
 
   const defOwnerCiv = defender.owner;
   const isBarbarian = defOwnerCiv === 'barbarian' || defOwnerCiv.startsWith('mc-');
@@ -1634,7 +1637,8 @@ function handleHexTap(rawCoord: HexCoord): void {
   const key = hexKey(coord);
 
   const selectedUnitCanMoveToTappedHex = selectedUnitId && movementRange.some(h => hexKey(h) === key);
-  if (!selectedUnitCanMoveToTappedHex) {
+  const selectedUnitCanAttackTappedHex = selectedUnitId && attackRange.some(h => hexKey(h) === key);
+  if (!selectedUnitCanMoveToTappedHex && !selectedUnitCanAttackTappedHex) {
     if (handleFriendlyUnitStackTap(gameState, coord, selectedUnitId, {
       onSelectUnit: selectUnit,
       onOpenStackPicker: openUnitStackPicker,
@@ -1643,7 +1647,7 @@ function handleHexTap(rawCoord: HexCoord): void {
     }
   }
 
-  if (selectedUnitId && !selectedUnitCanMoveToTappedHex) {
+  if (selectedUnitId && !selectedUnitCanMoveToTappedHex && !selectedUnitCanAttackTappedHex) {
     const selectedUnit = gameState.units[selectedUnitId];
     if (selectedUnit) {
       const civ = currentCiv();
@@ -1746,14 +1750,14 @@ function handleHexTap(rawCoord: HexCoord): void {
     }
   }
 
-  // If unit is selected and tapping a movement target
-  if (selectedUnitId && movementRange.some(h => hexKey(h) === key)) {
+  // If unit is selected and tapping a movement or attack target
+  if (selectedUnitId && (selectedUnitCanMoveToTappedHex || selectedUnitCanAttackTappedHex)) {
     const unit = gameState.units[selectedUnitId];
     if (!unit) return;
 
     // Check for enemy unit at target — show combat preview
     const defenderEntry = selectDefenderEntryAtKey(key);
-    if (defenderEntry) {
+    if (selectedUnitCanAttackTappedHex && defenderEntry) {
       const defender = defenderEntry[1];
       const atkDef = UNIT_DEFINITIONS[unit.type];
       const defDef = UNIT_DEFINITIONS[defender.type];
@@ -1834,6 +1838,13 @@ function handleHexTap(rawCoord: HexCoord): void {
 
         cancelBtn.addEventListener('click', deselectUnit);
         attackBtn.addEventListener('click', () => {
+          const attacker = selectedUnitId ? gameState.units[selectedUnitId] : undefined;
+          const legality = canUnitAttackTarget(gameState, attacker, coord, { viewerId: gameState.currentPlayer });
+          if (!legality.ok || legality.targetType !== 'unit') {
+            showNotification('That target is no longer attackable.', 'warning');
+            if (selectedUnitId) selectUnit(selectedUnitId);
+            return;
+          }
           executeAttack(selectedUnitId!, key);
         });
         return; // Wait for button press

--- a/src/main.ts
+++ b/src/main.ts
@@ -1270,9 +1270,15 @@ function isUnitAnimationLocked(unitId: string | null): boolean {
 function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
   const movedUnit = gameState.units[unitId];
   if (!movedUnit) return;
+  movementRange = [];
+  attackRange = [];
+  renderLoop.clearHighlights();
   renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
     renderLoop.setGameState(gameState);
     updateHUD();
+    if (selectedUnitId === unitId && gameState.units[unitId]?.owner === gameState.currentPlayer) {
+      selectUnit(unitId);
+    }
   });
 }
 
@@ -1960,9 +1966,7 @@ function handleHexTap(rawCoord: HexCoord): void {
             SFX.tap();
             renderLoop.setGameState(gameState);
             updateHUD();
-            if (gameState.units[selectedId]?.movementPointsLeft > 0) {
-              selectUnit(selectedId);
-            } else {
+            if ((gameState.units[selectedId]?.movementPointsLeft ?? 0) <= 0) {
               selectNextUnit();
             }
           },
@@ -1979,9 +1983,7 @@ function handleHexTap(rawCoord: HexCoord): void {
       SFX.tap();
 
       // Re-select to update movement range, or advance to next unit
-      if (gameState.units[selectedUnitId]?.movementPointsLeft > 0) {
-        selectUnit(selectedUnitId);
-      } else {
+      if ((gameState.units[selectedUnitId]?.movementPointsLeft ?? 0) <= 0) {
         selectNextUnit();
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1070,6 +1070,10 @@ function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
 }
 
 function selectUnit(unitId: string): void {
+  if (renderLoop.hasMovingUnit(unitId)) {
+    showNotification('Unit is moving.', 'info');
+    return;
+  }
   selectedUnitId = unitId;
   const unit = gameState.units[unitId];
   if (!unit || unit.owner !== gameState.currentPlayer) return;
@@ -1257,6 +1261,19 @@ function deselectUnit(): void {
     panel.style.display = 'none';
     panel.replaceChildren();
   }
+}
+
+function isUnitAnimationLocked(unitId: string | null): boolean {
+  return Boolean(unitId && renderLoop.hasMovingUnit(unitId));
+}
+
+function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
+  const movedUnit = gameState.units[unitId];
+  if (!movedUnit) return;
+  renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
+    renderLoop.setGameState(gameState);
+    updateHUD();
+  });
 }
 
 function startAutoExplore(unitId: string): void {
@@ -1639,6 +1656,11 @@ function handleHexTap(rawCoord: HexCoord): void {
     : rawCoord;
   const key = hexKey(coord);
 
+  if (isUnitAnimationLocked(selectedUnitId)) {
+    showNotification('Unit is moving.', 'info');
+    return;
+  }
+
   const selectedUnitCanMoveToTappedHex = selectedUnitId && movementRange.some(h => hexKey(h) === key);
   const selectedUnitCanAttackTappedHex = selectedUnitId && attackRange.some(h => hexKey(h) === key);
   if (!selectedUnitCanMoveToTappedHex && !selectedUnitCanAttackTappedHex) {
@@ -1900,11 +1922,12 @@ function handleHexTap(rawCoord: HexCoord): void {
         if (mc && !mc.isDestroyed) {
           const cityName = gameState.cities[tapIntent.cityId]?.name ?? 'City-State';
           // Move the unit onto the city hex (updates fog, position, movement cost).
-          executeUnitMove(gameState, selectedUnitId, coord, {
+          const moveResult = executeUnitMove(gameState, selectedUnitId, coord, {
             actor: 'player',
             civId: gameState.currentPlayer,
             bus,
           });
+          animateMovedUnit(selectedUnitId, moveResult.from, moveResult.to);
           // Conquering a city ends the unit's turn regardless of remaining movement.
           const movedUnit = gameState.units[selectedUnitId];
           if (movedUnit) {
@@ -1928,11 +1951,12 @@ function handleHexTap(rawCoord: HexCoord): void {
           improvementName: task ? getImprovementDisplayName(task.action) : 'Improvement',
           onCancel: () => selectUnit(selectedId),
           onConfirm: () => {
-            confirmBusyWorkerMove(gameState, selectedId, coord, {
+            const moveResult = confirmBusyWorkerMove(gameState, selectedId, coord, {
               actor: 'player',
               civId: gameState.currentPlayer,
               bus,
             });
+            animateMovedUnit(selectedId, moveResult.from, moveResult.to);
             SFX.tap();
             renderLoop.setGameState(gameState);
             updateHUD();
@@ -1946,11 +1970,12 @@ function handleHexTap(rawCoord: HexCoord): void {
         return;
       }
 
-      executeUnitMove(gameState, selectedUnitId, coord, {
+      const moveResult = executeUnitMove(gameState, selectedUnitId, coord, {
         actor: 'player',
         civId: gameState.currentPlayer,
         bus,
       });
+      animateMovedUnit(selectedUnitId, moveResult.from, moveResult.to);
       SFX.tap();
 
       // Re-select to update movement range, or advance to next unit

--- a/src/main.ts
+++ b/src/main.ts
@@ -138,6 +138,7 @@ import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow'
 import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
 
 // --- App State ---
 let gameState: GameState;
@@ -1327,6 +1328,7 @@ function refreshCurrentPlayerVisibility(): void {
     .filter((position): position is HexCoord => position !== undefined);
 
   updateVisibility(civ.visibility, playerUnits, gameState.map, cityPositions);
+  refreshLastSeenPresentationsForCiv(gameState, gameState.currentPlayer);
   for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
     bus.emit('civilization:first-contact', contact);
   }
@@ -1399,6 +1401,7 @@ function foundCityAction(): void {
     .map(id => gameState.cities[id]?.position)
     .filter((p): p is HexCoord => p !== undefined);
   updateVisibility(currentCiv().visibility, playerUnits, gameState.map, cityPositions);
+  refreshLastSeenPresentationsForCiv(gameState, gameState.currentPlayer);
   for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
     bus.emit('civilization:first-contact', contact);
   }

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -1,6 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { hexToPixel } from '@/systems/hex-utils';
-import { isVisible } from '@/systems/fog-of-war';
+import { getVisibility } from '@/systems/fog-of-war';
 import { getOccupiedCityMood } from '@/systems/city-occupation-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
@@ -35,6 +35,15 @@ interface CityRenderInfo {
   breakawayTurnsLeft?: number;
 }
 
+interface CityRenderProjection {
+  name: string;
+  position: HexCoord;
+  population: number;
+  owner: string;
+  isLive: boolean;
+  liveCityId?: string;
+}
+
 const OWNER_COLORS: Record<string, string> = {
   player: '#4a90d9',
   'ai-1': '#d94a4a',
@@ -67,16 +76,16 @@ export function drawCities(
   const vis = state.civilizations[playerCivId]?.visibility;
   if (!vis) return;
 
-  for (const city of Object.values(state.cities)) {
-    if (!isVisible(vis, city.position)) continue;
-    const mcState = city.owner.startsWith('mc-') ? state.minorCivs?.[city.owner] : null;
+  for (const projection of getCityRenderProjection(state, playerCivId)) {
+    const city = projection.liveCityId ? state.cities[projection.liveCityId] : undefined;
+    const mcState = projection.isLive && projection.owner.startsWith('mc-') ? state.minorCivs?.[projection.owner] : null;
     const mcDef = mcState ? MINOR_CIV_DEFINITIONS.find(d => d.id === mcState.definitionId) : null;
-    const color = mcDef?.color ?? state.civilizations[city.owner]?.color ?? OWNER_COLORS[city.owner] ?? '#888';
-    const breakaway = state.civilizations[city.owner]?.breakaway;
+    const color = mcDef?.color ?? state.civilizations[projection.owner]?.color ?? OWNER_COLORS[projection.owner] ?? '#888';
+    const breakaway = projection.isLive ? state.civilizations[projection.owner]?.breakaway : undefined;
 
     const renderCoords = state.map.wrapsHorizontally
-      ? getHorizontalWrapRenderCoords(city.position, state.map.width, camera)
-      : [city.position];
+      ? getHorizontalWrapRenderCoords(projection.position, state.map.width, camera)
+      : [projection.position];
 
     for (const renderCoord of renderCoords) {
       if (!camera.isHexVisible(renderCoord)) continue;
@@ -98,9 +107,9 @@ export function drawCities(
       ctx.font = `${size * 0.45}px system-ui`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
-      const isMinorCiv = city.owner.startsWith('mc-');
+      const isMinorCiv = projection.isLive && projection.owner.startsWith('mc-');
       if (isMinorCiv) {
-        const mcState = state.minorCivs?.[city.owner];
+        const mcState = state.minorCivs?.[projection.owner];
         const def = mcState ? MINOR_CIV_DEFINITIONS.find(d => d.id === mcState.definitionId) : null;
         const icon = def?.archetype === 'militaristic' ? '⚔️'
           : def?.archetype === 'mercantile' ? '🪙'
@@ -115,19 +124,19 @@ export function drawCities(
       ctx.fillStyle = '#fff';
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
-      ctx.fillText(`${city.name} (${city.population})`, screen.x, screen.y + size * 0.5);
+      ctx.fillText(`${projection.name} (${projection.population})`, screen.x, screen.y + size * 0.5);
 
-      if (breakaway) {
+      if (projection.isLive && city && breakaway) {
         ctx.font = `${size * 0.28}px system-ui`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(breakaway.status === 'secession' ? '⛓' : '👑', screen.x + size * 0.45, screen.y - size * 0.45);
-      } else if (city.occupation) {
+      } else if (projection.isLive && city?.occupation) {
         ctx.font = `${size * 0.28}px system-ui`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.fillText(getOccupiedCityMood(city) === 2 ? '☹' : '⚡', screen.x + size * 0.45, screen.y - size * 0.45);
-      } else if (city.unrestLevel > 0) {
+      } else if (projection.isLive && city && city.unrestLevel > 0) {
         ctx.font = `${size * 0.28}px system-ui`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
@@ -135,7 +144,7 @@ export function drawCities(
       }
 
       // Bottom-right badge: currently-building icon (player-owned, non-empty queue only)
-      if (city.owner === playerCivId) {
+      if (projection.isLive && city && city.owner === playerCivId) {
         const badgeSprite = camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
           ? getProductionBadgeSprite(city, playerCivId)
           : null;
@@ -162,6 +171,8 @@ export function drawCities(
 
       // Top-left badge: idle production mode (player-owned, queue empty, idleProduction set)
       if (
+        projection.isLive &&
+        city &&
         city.owner === playerCivId &&
         city.productionQueue.length === 0 &&
         (city.idleProduction === 'gold' || city.idleProduction === 'science')
@@ -175,4 +186,32 @@ export function drawCities(
       }
     }
   }
+}
+
+function getCityRenderProjection(state: GameState, playerCivId: string): CityRenderProjection[] {
+  const vis = state.civilizations[playerCivId]?.visibility;
+  if (!vis) return [];
+
+  const liveCities = Object.values(state.cities)
+    .filter(city => getVisibility(vis, city.position) === 'visible')
+    .map(city => ({
+      name: city.name,
+      position: city.position,
+      population: city.population,
+      owner: city.owner,
+      isLive: true,
+      liveCityId: city.id,
+    }));
+
+  const staleCities = Object.values(vis.lastSeen ?? {})
+    .filter(snapshot => getVisibility(vis, snapshot.coord) === 'fog' && snapshot.city)
+    .map(snapshot => ({
+      name: snapshot.city!.name,
+      position: snapshot.coord,
+      population: snapshot.city!.population,
+      owner: snapshot.city!.owner,
+      isLive: false,
+    }));
+
+  return [...liveCities, ...staleCities];
 }

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -288,7 +288,7 @@ function drawHex(
   // Draw ownership indicator
   const renderOwnership = viewerVisibility
     ? shouldRenderOwnedTileBorderForPresentation(presentationKind, currentPlayer, tile.owner)
-    : shouldRenderOwnedTileBorder(viewerVisibility, currentPlayer, tile.owner, tile.coord);
+    : shouldRenderOwnedTileBorder(viewerVisibility, currentPlayer, tile.owner ?? undefined, tile.coord);
   if (tile.owner && currentPlayer && renderOwnership) {
     ctx.strokeStyle = tile.owner === currentPlayer ? 'rgba(74,144,217,0.5)' : 'rgba(217,74,74,0.5)';
     ctx.lineWidth = 2;

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -2,7 +2,8 @@ import type { GameMap, HexCoord, HexTile, TerrainType, VisibilityMap } from '@/c
 import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY } from '@/systems/hex-utils';
 import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
-import { shouldRenderOwnedTileBorder } from './render-visibility';
+import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
+import { resolveTilePresentationForViewer, type TilePresentationKind } from './tile-presentation';
 
 // --- Terrain labels ---
 
@@ -57,8 +58,9 @@ function drawTileAtScreen(
   currentPlayer: string | undefined,
   viewerVisibility: VisibilityMap | undefined,
   zoom: number,
+  presentationKind: TilePresentationKind,
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind);
   if (shouldShowTerrainLabel(zoom)) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -91,7 +93,18 @@ export function drawHexMap(
       const pixel = hexToPixel(renderCoord, size);
       const screen = camera.worldToScreen(pixel.x, pixel.y);
       const scaledSize = size * camera.zoom;
-      drawTileAtScreen(ctx, screen, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, camera.zoom);
+      const presentation = resolveTilePresentationForViewer(map, viewerVisibility, renderCoord);
+      drawTileAtScreen(
+        ctx,
+        screen,
+        scaledSize,
+        presentation.tile,
+        isVillage && presentation.kind === 'live',
+        currentPlayer,
+        viewerVisibility,
+        camera.zoom,
+        presentation.kind,
+      );
     }
   }
 }
@@ -116,8 +129,15 @@ export function drawWrapGhostRivers(
   ctx: CanvasRenderingContext2D,
   map: GameMap,
   camera: Camera,
+  viewerVisibility?: VisibilityMap,
 ): void {
   for (const river of map.rivers) {
+    if (
+      !canRenderRiverEndpoint(map, viewerVisibility, river.from)
+      && !canRenderRiverEndpoint(map, viewerVisibility, river.to)
+    ) {
+      continue;
+    }
     for (const offset of getHorizontalWrapOffsetsForRiver(river.from, river.to, map.width)) {
       const ghostFrom: HexCoord = { q: river.from.q + offset, r: river.from.r };
       const ghostTo: HexCoord = { q: river.to.q + offset, r: river.to.r };
@@ -131,19 +151,31 @@ export function drawRivers(
   ctx: CanvasRenderingContext2D,
   map: GameMap,
   camera: Camera,
+  viewerVisibility?: VisibilityMap,
 ): void {
   ctx.strokeStyle = '#4a8faf';
   ctx.lineWidth = 3 * camera.zoom;
   ctx.lineCap = 'round';
 
   for (const river of map.rivers) {
+    if (
+      !canRenderRiverEndpoint(map, viewerVisibility, river.from)
+      && !canRenderRiverEndpoint(map, viewerVisibility, river.to)
+    ) {
+      continue;
+    }
     if (!camera.isHexVisible(river.from) && !camera.isHexVisible(river.to)) continue;
     drawRiverSegment(ctx, camera, river.from, river.to);
   }
 
   if (map.wrapsHorizontally) {
-    drawWrapGhostRivers(ctx, map, camera);
+    drawWrapGhostRivers(ctx, map, camera, viewerVisibility);
   }
+}
+
+function canRenderRiverEndpoint(map: GameMap, visibility: VisibilityMap | undefined, coord: HexCoord): boolean {
+  const presentation = resolveTilePresentationForViewer(map, visibility, coord);
+  return presentation.kind === 'live' || presentation.kind === 'last-seen';
 }
 
 function drawRiverSegment(
@@ -183,6 +215,7 @@ function drawHex(
   isVillage: boolean = false,
   currentPlayer?: string,
   viewerVisibility?: VisibilityMap,
+  presentationKind: TilePresentationKind = 'live',
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -253,7 +286,10 @@ function drawHex(
   }
 
   // Draw ownership indicator
-  if (tile.owner && currentPlayer && shouldRenderOwnedTileBorder(viewerVisibility, currentPlayer, tile.owner, tile.coord)) {
+  const renderOwnership = viewerVisibility
+    ? shouldRenderOwnedTileBorderForPresentation(presentationKind, currentPlayer, tile.owner)
+    : shouldRenderOwnedTileBorder(viewerVisibility, currentPlayer, tile.owner, tile.coord);
+  if (tile.owner && currentPlayer && renderOwnership) {
     ctx.strokeStyle = tile.owner === currentPlayer ? 'rgba(74,144,217,0.5)' : 'rgba(217,74,74,0.5)';
     ctx.lineWidth = 2;
     ctx.stroke();

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -1,4 +1,4 @@
-import type { GameState, HexCoord } from '@/core/types';
+import type { GameState, HexCoord, Unit, VisibilityMap } from '@/core/types';
 import { Camera } from './camera';
 import { drawHexMap, drawRivers, drawMinorCivTerritory, drawHexHighlight } from './hex-renderer';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
@@ -9,6 +9,12 @@ import { AnimationSystem } from './animation-system';
 import { hexToPixel } from '@/systems/hex-utils';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
+import { getVisibility } from '@/systems/fog-of-war';
+import { createMovementAnimation, getMovementAnimationPosition, getMovingUnitIds, type UnitMovementAnimation } from './unit-movement-animation';
+import { resolveUnitVisual } from './unit-visual-resolver';
+import { drawUnitGlyph } from './unit-renderer';
+import { spriteCache } from './sprites/sprite-loader';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
 
 export interface HexHighlight {
   coord: HexCoord;
@@ -24,6 +30,7 @@ export class RenderLoop {
   private running = false;
   private animFrameId = 0;
   private highlights: HexHighlight[] = [];
+  private unitMovementAnimations: Array<UnitMovementAnimation & { startTime: number; onComplete?: () => void }> = [];
 
   setHighlights(highlights: HexHighlight[]): void {
     this.highlights = highlights;
@@ -31,6 +38,19 @@ export class RenderLoop {
 
   clearHighlights(): void {
     this.highlights = [];
+  }
+
+  animateUnitMove(unit: Unit, from: HexCoord, to: HexCoord, onComplete?: () => void): void {
+    if (!this.state) return;
+    this.unitMovementAnimations.push({
+      ...createMovementAnimation(unit, from, to, this.state.map),
+      startTime: performance.now(),
+      onComplete,
+    });
+  }
+
+  hasMovingUnit(unitId: string): boolean {
+    return this.unitMovementAnimations.some(animation => animation.unit.id === unitId);
   }
 
   constructor(canvas: HTMLCanvasElement) {
@@ -152,7 +172,10 @@ export class RenderLoop {
         if (def) colorLookup[mc.id] = def.color;
       }
       const visibleUnits = getVisibleUnitsForPlayer(this.state.units, this.state, viewerId);
-      drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup);
+      drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup, {
+        hiddenUnitIds: getMovingUnitIds(this.unitMovementAnimations),
+      });
+      this.drawUnitMovementAnimations(performance.now(), colorLookup, viewerVisibility);
     }
 
     // Draw fog of war
@@ -169,6 +192,48 @@ export class RenderLoop {
 
     // Draw animations
     this.animations.update(this.ctx, performance.now());
+  }
+
+  private drawUnitMovementAnimations(
+    now: number,
+    colorLookup: Record<string, string>,
+    viewerVisibility: VisibilityMap,
+  ): void {
+    if (!this.state) return;
+    const remaining: typeof this.unitMovementAnimations = [];
+    for (const animation of this.unitMovementAnimations) {
+      const elapsed = now - animation.startTime;
+      const progress = Math.min(1, elapsed / animation.duration);
+      const frame = getMovementAnimationPosition(animation, progress);
+      if (getVisibility(viewerVisibility, animation.to) === 'unexplored') {
+        if (progress < 1) remaining.push(animation);
+        continue;
+      }
+      const renderCoords = this.state.map.wrapsHorizontally
+        ? getHorizontalWrapRenderCoords(frame.coord, this.state.map.width, this.camera)
+        : [frame.coord];
+      const visual = resolveUnitVisual(this.state, animation.unit, colorLookup, frame.motion);
+      const sprite = this.camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
+        ? spriteCache.getUnitMotion(animation.unit.type, visual.spriteOwnerId, frame.motion)
+        : null;
+      for (const renderCoord of renderCoords) {
+        if (!this.camera.isHexVisible(renderCoord)) continue;
+        const pixel = hexToPixel(renderCoord, this.camera.hexSize);
+        const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+        drawUnitGlyph(this.ctx, this.state, animation.unit, screen.x, screen.y, this.camera.hexSize * this.camera.zoom, colorLookup, {
+          stackSize: 1,
+          stackIndex: 0,
+          motion: frame.motion,
+          spriteOverride: sprite,
+        });
+      }
+      if (progress < 1) {
+        remaining.push(animation);
+      } else {
+        animation.onComplete?.();
+      }
+    }
+    this.unitMovementAnimations = remaining;
   }
 
   private drawEmbeddedSpyIndicators(): void {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -201,6 +201,7 @@ export class RenderLoop {
   ): void {
     if (!this.state) return;
     const remaining: typeof this.unitMovementAnimations = [];
+    const completedCallbacks: Array<() => void> = [];
     for (const animation of this.unitMovementAnimations) {
       const elapsed = now - animation.startTime;
       const progress = Math.min(1, elapsed / animation.duration);
@@ -232,10 +233,13 @@ export class RenderLoop {
       if (progress < 1) {
         remaining.push(animation);
       } else {
-        animation.onComplete?.();
+        if (animation.onComplete) completedCallbacks.push(animation.onComplete);
       }
     }
     this.unitMovementAnimations = remaining;
+    for (const callback of completedCallbacks) {
+      callback();
+    }
   }
 
   private drawEmbeddedSpyIndicators(): void {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -213,7 +213,8 @@ export class RenderLoop {
         ? getHorizontalWrapRenderCoords(frame.coord, this.state.map.width, this.camera)
         : [frame.coord];
       const visual = resolveUnitVisual(this.state, animation.unit, colorLookup, frame.motion);
-      const sprite = this.camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
+      const useSprites = this.camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD;
+      const sprite = useSprites
         ? spriteCache.getUnitMotion(animation.unit.type, visual.spriteOwnerId, frame.motion)
         : null;
       for (const renderCoord of renderCoords) {
@@ -224,6 +225,7 @@ export class RenderLoop {
           stackSize: 1,
           stackIndex: 0,
           motion: frame.motion,
+          useSprites,
           spriteOverride: sprite,
         });
       }

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -95,7 +95,7 @@ export class RenderLoop {
     drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility);
 
     // Draw rivers
-    drawRivers(this.ctx, this.state.map, this.camera);
+    drawRivers(this.ctx, this.state.map, this.camera, viewerVisibility);
 
     // Draw minor civ territory
     if (this.state.minorCivs) {

--- a/src/renderer/render-visibility.ts
+++ b/src/renderer/render-visibility.ts
@@ -1,5 +1,6 @@
 import type { HexCoord, VisibilityMap } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
+import type { TilePresentationKind } from './tile-presentation';
 
 export function shouldRenderOwnedTileBorder(
   visibility: VisibilityMap | undefined,
@@ -15,4 +16,15 @@ export function shouldRenderOwnedTileBorder(
   }
 
   return visibilityState === 'visible';
+}
+
+export function shouldRenderOwnedTileBorderForPresentation(
+  presentationKind: TilePresentationKind,
+  viewerCivId: string | undefined,
+  ownerId: string | null | undefined,
+): boolean {
+  if (!viewerCivId || !ownerId) return false;
+  if (presentationKind === 'unexplored' || presentationKind === 'unknown-fog') return false;
+  if (ownerId === viewerCivId) return true;
+  return presentationKind === 'live' || presentationKind === 'last-seen';
 }

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -1,5 +1,5 @@
 import type { UnitType } from '@/core/types';
-import type { UnitSpriteProps } from './units';
+import type { UnitSpriteMotion, UnitSpriteProps } from './units';
 import type { BuildingSpriteProps } from './buildings';
 import {
   SettlerSprite, WorkerSprite, ScoutSprite, ScoutHoundSprite,
@@ -21,25 +21,78 @@ import {
 export type UnitSpriteComponent = (props: UnitSpriteProps) => string;
 export type BuildingSpriteComponent = (props: BuildingSpriteProps) => string;
 
+type UnitMotionStyle = 'humanoid' | 'animal' | 'naval';
+
+const UNIT_MOTION_STYLES: Record<UnitType, UnitMotionStyle> = {
+  settler: 'humanoid',
+  worker: 'humanoid',
+  scout: 'humanoid',
+  scout_hound: 'animal',
+  war_hound: 'animal',
+  shadow_warden: 'humanoid',
+  warrior: 'humanoid',
+  swordsman: 'humanoid',
+  pikeman: 'humanoid',
+  archer: 'humanoid',
+  musketeer: 'humanoid',
+  galley: 'naval',
+  trireme: 'naval',
+  spy_scout: 'humanoid',
+  spy_informant: 'humanoid',
+  spy_agent: 'humanoid',
+  spy_operative: 'humanoid',
+  spy_hacker: 'humanoid',
+};
+
+function motionTransform(style: UnitMotionStyle, motion: UnitSpriteMotion): string {
+  if (motion === 'idle') return '';
+  if (style === 'animal') {
+    return motion === 'move-a'
+      ? 'translate(-3 -2) rotate(-2 64 70)'
+      : 'translate(3 1) rotate(2 64 70)';
+  }
+  if (style === 'naval') {
+    return motion === 'move-a'
+      ? 'translate(-2 1) rotate(-1 64 82)'
+      : 'translate(2 -1) rotate(1 64 82)';
+  }
+  return motion === 'move-a'
+    ? 'translate(0 -2) rotate(-2 64 70)'
+    : 'translate(0 1) rotate(2 64 70)';
+}
+
+function applyUnitMotion(svg: string, style: UnitMotionStyle, motion: UnitSpriteMotion = 'idle'): string {
+  const transform = motionTransform(style, motion);
+  const attrs = `data-motion="${motion}"${transform ? ` transform="${transform}"` : ''}`;
+  return svg.replace('<g class="cq-sprite-figure">', `<g ${attrs} class="cq-sprite-figure">`);
+}
+
+function withMotion(type: UnitType, render: UnitSpriteComponent): UnitSpriteComponent {
+  return (props: UnitSpriteProps) => {
+    const motion = props.motion ?? 'idle';
+    return applyUnitMotion(render({ ...props, motion }), UNIT_MOTION_STYLES[type], motion);
+  };
+}
+
 export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
-  settler:        SettlerSprite,
-  worker:         WorkerSprite,
-  scout:          ScoutSprite,
-  scout_hound:    ScoutHoundSprite,
-  war_hound:      WarHoundSprite,
-  shadow_warden:  ShadowWardenSprite,
-  warrior:        WarriorSprite,
-  swordsman:      SwordsmanSprite,
-  pikeman:        PikemanSprite,
-  archer:         ArcherSprite,
-  musketeer:      MusketeerSprite,
-  galley:         GalleySprite,
-  trireme:        TriremeSprite,
-  spy_scout:      SpyScoutSprite,
-  spy_informant:  SpyInformantSprite,
-  spy_agent:      SpyAgentSprite,
-  spy_operative:  SpyOperativeSprite,
-  spy_hacker:     SpyHackerSprite,
+  settler:        withMotion('settler', SettlerSprite),
+  worker:         withMotion('worker', WorkerSprite),
+  scout:          withMotion('scout', ScoutSprite),
+  scout_hound:    withMotion('scout_hound', ScoutHoundSprite),
+  war_hound:      withMotion('war_hound', WarHoundSprite),
+  shadow_warden:  withMotion('shadow_warden', ShadowWardenSprite),
+  warrior:        withMotion('warrior', WarriorSprite),
+  swordsman:      withMotion('swordsman', SwordsmanSprite),
+  pikeman:        withMotion('pikeman', PikemanSprite),
+  archer:         withMotion('archer', ArcherSprite),
+  musketeer:      withMotion('musketeer', MusketeerSprite),
+  galley:         withMotion('galley', GalleySprite),
+  trireme:        withMotion('trireme', TriremeSprite),
+  spy_scout:      withMotion('spy_scout', SpyScoutSprite),
+  spy_informant:  withMotion('spy_informant', SpyInformantSprite),
+  spy_agent:      withMotion('spy_agent', SpyAgentSprite),
+  spy_operative:  withMotion('spy_operative', SpyOperativeSprite),
+  spy_hacker:     withMotion('spy_hacker', SpyHackerSprite),
 };
 
 export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = {

--- a/src/renderer/sprites/sprite-loader.ts
+++ b/src/renderer/sprites/sprite-loader.ts
@@ -5,6 +5,9 @@ import {
 } from './sprite-catalog';
 import type { UnitType } from '@/core/types';
 import type { FactionPalette } from './sprite-system';
+import type { UnitSpriteMotion } from './units';
+
+const UNIT_MOTIONS: UnitSpriteMotion[] = ['idle', 'move-a', 'move-b'];
 
 function svgStringToImage(svgString: string, size: number): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
@@ -24,12 +27,17 @@ class SpriteCache {
   async loadCiv(civId: string, civColor: string): Promise<void> {
     const palette: FactionPalette = derivePalette(civColor);
 
-    const unitWork = Object.entries(UNIT_SPRITE_CATALOG).map(async ([type, fn]) => {
-      const svg = fn({ palette, svgOnly: true });
-      if (!svg) return;
-      const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE);
-      this.units.set(`${type}:${civId}`, img);
-    });
+    const unitWork = Object.entries(UNIT_SPRITE_CATALOG).flatMap(([type, fn]) =>
+      UNIT_MOTIONS.map(async (motion) => {
+        const svg = fn({ palette, svgOnly: true, motion });
+        if (!svg) return;
+        const img = await svgStringToImage(svg, UNIT_SPRITE_SIZE);
+        this.units.set(`${type}:${civId}:${motion}`, img);
+        if (motion === 'idle') {
+          this.units.set(`${type}:${civId}`, img);
+        }
+      }),
+    );
 
     const buildingWork = Object.entries(BUILDING_SPRITE_CATALOG).map(async ([id, fn]) => {
       const svg = fn({ palette, svgOnly: true });
@@ -43,6 +51,10 @@ class SpriteCache {
 
   getUnit(type: UnitType, civId: string): HTMLImageElement | null {
     return this.units.get(`${type}:${civId}`) ?? null;
+  }
+
+  getUnitMotion(type: UnitType, civId: string, motion: UnitSpriteMotion): HTMLImageElement | null {
+    return this.units.get(`${type}:${civId}:${motion}`) ?? null;
   }
 
   getBuilding(buildingId: string, civId: string): HTMLImageElement | null {

--- a/src/renderer/sprites/sprite-loader.ts
+++ b/src/renderer/sprites/sprite-loader.ts
@@ -23,6 +23,7 @@ function svgStringToImage(svgString: string, size: number): Promise<HTMLImageEle
 class SpriteCache {
   private units = new Map<string, HTMLImageElement>();
   private buildings = new Map<string, HTMLImageElement>();
+  private civLoads = new Map<string, Promise<void>>();
 
   async loadCiv(civId: string, civColor: string): Promise<void> {
     const palette: FactionPalette = derivePalette(civColor);
@@ -55,6 +56,16 @@ class SpriteCache {
 
   getUnitMotion(type: UnitType, civId: string, motion: UnitSpriteMotion): HTMLImageElement | null {
     return this.units.get(`${type}:${civId}:${motion}`) ?? null;
+  }
+
+  ensureCiv(civId: string, civColor: string): void {
+    if (this.units.has(`warrior:${civId}`) || this.civLoads.has(civId)) return;
+    const load = this.loadCiv(civId, civColor)
+      .catch(() => undefined)
+      .finally(() => {
+        this.civLoads.delete(civId);
+      });
+    this.civLoads.set(civId, load);
   }
 
   getBuilding(buildingId: string, civId: string): HTMLImageElement | null {

--- a/src/renderer/sprites/units.tsx
+++ b/src/renderer/sprites/units.tsx
@@ -7,7 +7,8 @@ import {
   SpriteFrame,
 } from './sprite-system';
 
-export type UnitSpriteProps = { palette: FactionPalette; svgOnly?: boolean };
+export type UnitSpriteMotion = 'idle' | 'move-a' | 'move-b';
+export type UnitSpriteProps = { palette: FactionPalette; svgOnly?: boolean; motion?: UnitSpriteMotion };
 
 /* === CIVILIAN === */
 

--- a/src/renderer/tile-presentation.ts
+++ b/src/renderer/tile-presentation.ts
@@ -1,0 +1,56 @@
+import type { GameMap, HexCoord, HexTile, LastSeenTilePresentation, VisibilityMap } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
+
+export type TilePresentationKind = 'live' | 'last-seen' | 'unknown-fog' | 'unexplored';
+
+export interface TilePresentation {
+  kind: TilePresentationKind;
+  tile: HexTile;
+}
+
+function unknownTile(coord: HexCoord): HexTile {
+  return {
+    coord,
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function lastSeenToTile(snapshot: LastSeenTilePresentation): HexTile {
+  return {
+    coord: { ...snapshot.coord },
+    terrain: snapshot.terrain,
+    elevation: snapshot.elevation,
+    resource: snapshot.resource,
+    improvement: snapshot.improvement,
+    owner: snapshot.owner,
+    improvementTurnsLeft: snapshot.improvementTurnsLeft,
+    hasRiver: snapshot.hasRiver,
+    wonder: snapshot.wonder,
+  };
+}
+
+export function resolveTilePresentationForViewer(
+  map: GameMap,
+  visibility: VisibilityMap | undefined,
+  renderCoord: HexCoord,
+): TilePresentation {
+  const coord = map.wrapsHorizontally ? wrapHexCoord(renderCoord, map.width) : renderCoord;
+  const key = hexKey(coord);
+  const liveTile = map.tiles[key] ?? unknownTile(coord);
+  const state = visibility ? getVisibility(visibility, coord) : 'visible';
+
+  if (state === 'visible') return { kind: 'live', tile: liveTile };
+  if (state === 'unexplored') return { kind: 'unexplored', tile: unknownTile(coord) };
+
+  const snapshot = visibility?.lastSeen?.[key];
+  if (snapshot) return { kind: 'last-seen', tile: lastSeenToTile(snapshot) };
+  return { kind: 'unknown-fog', tile: unknownTile(coord) };
+}

--- a/src/renderer/unit-movement-animation.ts
+++ b/src/renderer/unit-movement-animation.ts
@@ -1,0 +1,56 @@
+import type { GameMap, HexCoord, Unit } from '@/core/types';
+import type { UnitMotionState } from '@/renderer/unit-visual-resolver';
+
+export interface UnitMovementAnimation {
+  unit: Unit;
+  from: HexCoord;
+  to: HexCoord;
+  renderFrom: HexCoord;
+  renderTo: HexCoord;
+  duration: number;
+}
+
+export interface UnitMovementFrame {
+  coord: HexCoord;
+  motion: UnitMotionState;
+}
+
+export function getMovementDurationMs(path: HexCoord[]): number {
+  const steps = Math.max(1, path.length - 1);
+  return Math.min(600, 250 + Math.max(0, steps - 1) * 120);
+}
+
+function wrappedRenderDestination(from: HexCoord, to: HexCoord, map: GameMap): HexCoord {
+  if (!map.wrapsHorizontally) return to;
+  const directDelta = to.q - from.q;
+  const westDelta = to.q - map.width - from.q;
+  const eastDelta = to.q + map.width - from.q;
+  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0];
+  return { q: from.q + bestDelta, r: to.r };
+}
+
+export function createMovementAnimation(unit: Unit, from: HexCoord, to: HexCoord, map: GameMap): UnitMovementAnimation {
+  return {
+    unit,
+    from,
+    to,
+    renderFrom: from,
+    renderTo: wrappedRenderDestination(from, to, map),
+    duration: getMovementDurationMs([from, to]),
+  };
+}
+
+export function getMovementAnimationPosition(animation: UnitMovementAnimation, progress: number): UnitMovementFrame {
+  const clamped = Math.max(0, Math.min(1, progress));
+  return {
+    coord: {
+      q: animation.renderFrom.q + (animation.renderTo.q - animation.renderFrom.q) * clamped,
+      r: animation.renderFrom.r + (animation.renderTo.r - animation.renderFrom.r) * clamped,
+    },
+    motion: Math.floor(clamped * 6) % 2 === 0 ? 'move-a' : 'move-b',
+  };
+}
+
+export function getMovingUnitIds(animations: UnitMovementAnimation[]): Set<string> {
+  return new Set(animations.map(animation => animation.unit.id));
+}

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -59,6 +59,7 @@ export interface UnitGlyphDrawOptions {
   stackSize: number;
   stackIndex: number;
   motion?: UnitMotionState;
+  useSprites?: boolean;
   spriteOverride?: HTMLImageElement | null;
 }
 
@@ -73,7 +74,14 @@ export function drawUnitGlyph(
   options: UnitGlyphDrawOptions,
 ): void {
   const visual = resolveUnitVisual(state, unit, colorLookup, options.motion ?? 'idle');
-  const sprite = options.spriteOverride ?? spriteCache.getUnit(unit.type, visual.spriteOwnerId);
+  const useSprites = options.useSprites ?? true;
+  const sprite = useSprites
+    ? ('spriteOverride' in options ? options.spriteOverride ?? null : spriteCache.getUnit(unit.type, visual.spriteOwnerId))
+    : null;
+
+  if (useSprites && !sprite) {
+    spriteCache.ensureCiv(visual.spriteOwnerId, visual.color);
+  }
 
   if (sprite) {
     const drawSize = size * (options.stackSize === 1 ? 0.9 : 0.65);
@@ -162,13 +170,10 @@ export function drawUnits(
         const offset = stack.length === 1 ? STACK_OFFSETS[0] : STACK_OFFSETS[index];
         const unitX = screen.x + offset.x * size;
         const unitY = screen.y + offset.y * size;
-        const sprite = camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
-          ? spriteCache.getUnit(unit.type, unit.owner)
-          : null;
         drawUnitGlyph(ctx, state, unit, unitX, unitY, size, colorLookup, {
           stackSize: stack.length,
           stackIndex: index,
-          spriteOverride: sprite,
+          useSprites: camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD,
         });
       }
 

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -135,9 +135,12 @@ export function drawUnits(
   state: GameState,
   currentPlayer: string,
   colorLookup?: Record<string, string>,
+  options: { hiddenUnitIds?: Set<string> } = {},
 ): void {
   const visibleUnits = Object.values(units).filter(unit =>
-    isVisible(playerVisibility, unit.position) && !isForestConcealedUnit(state, currentPlayer, unit),
+    !options.hiddenUnitIds?.has(unit.id)
+    && isVisible(playerVisibility, unit.position)
+    && !isForestConcealedUnit(state, currentPlayer, unit),
   );
 
   for (const stack of Object.values(groupUnitsByHex(visibleUnits))) {

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -5,33 +5,7 @@ import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { spriteCache } from './sprites/sprite-loader';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
-
-const UNIT_ICONS: Record<string, string> = {
-  settler:       '🏕️',
-  worker:        '👷',
-  scout:         '🔭',
-  warrior:       '⚔️',
-  archer:        '🏹',
-  swordsman:     '🗡️',
-  pikeman:       '🔱',
-  musketeer:     '🔫',
-  galley:        '⛵',
-  trireme:       '🚢',
-  spy_scout:     '🕵️',
-  spy_informant: '🕵️',
-  spy_agent:     '🕵️',
-  spy_operative: '🕵️',
-  spy_hacker:    '💻',
-  scout_hound:   '🐕',
-  shadow_warden: '🦅',
-  war_hound:     '🐺',
-};
-
-const OWNER_COLORS: Record<string, string> = {
-  player: '#4a90d9',
-  'ai-1': '#d94a4a',
-  barbarian: '#8b4513',
-};
+import { resolveUnitVisual, type UnitMotionState, type UnitRoleMarker } from './unit-visual-resolver';
 
 const STACK_OFFSETS = [
   { x: 0, y: 0 },
@@ -50,6 +24,107 @@ function groupUnitsByHex(units: Unit[]): Record<string, Unit[]> {
     group.sort((a, b) => a.id.localeCompare(b.id));
   }
   return groups;
+}
+
+function drawRoleMarker(
+  ctx: CanvasRenderingContext2D,
+  marker: UnitRoleMarker,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  if (!marker) return;
+  const markerX = x + size * 0.28;
+  const markerY = y - size * 0.3;
+  ctx.beginPath();
+  if (marker === 'chevron') {
+    ctx.moveTo(markerX - size * 0.1, markerY - size * 0.06);
+    ctx.lineTo(markerX, markerY + size * 0.08);
+    ctx.lineTo(markerX + size * 0.1, markerY - size * 0.06);
+  } else {
+    ctx.moveTo(markerX, markerY - size * 0.11);
+    ctx.lineTo(markerX + size * 0.11, markerY);
+    ctx.lineTo(markerX, markerY + size * 0.11);
+    ctx.lineTo(markerX - size * 0.11, markerY);
+  }
+  ctx.closePath();
+  ctx.fillStyle = 'rgba(255,255,255,0.92)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(0,0,0,0.72)';
+  ctx.lineWidth = Math.max(1, size * 0.025);
+  ctx.stroke();
+}
+
+export interface UnitGlyphDrawOptions {
+  stackSize: number;
+  stackIndex: number;
+  motion?: UnitMotionState;
+  spriteOverride?: HTMLImageElement | null;
+}
+
+export function drawUnitGlyph(
+  ctx: CanvasRenderingContext2D,
+  state: GameState,
+  unit: Unit,
+  x: number,
+  y: number,
+  size: number,
+  colorLookup: Record<string, string> | undefined,
+  options: UnitGlyphDrawOptions,
+): void {
+  const visual = resolveUnitVisual(state, unit, colorLookup, options.motion ?? 'idle');
+  const sprite = options.spriteOverride ?? spriteCache.getUnit(unit.type, visual.spriteOwnerId);
+
+  if (sprite) {
+    const drawSize = size * (options.stackSize === 1 ? 0.9 : 0.65);
+    ctx.drawImage(sprite, x - drawSize / 2, y - drawSize / 2, drawSize, drawSize);
+  } else {
+    ctx.beginPath();
+    ctx.arc(x, y, size * (options.stackSize === 1 ? 0.35 : 0.25), 0, Math.PI * 2);
+    ctx.fillStyle = visual.color;
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.6)';
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+    ctx.font = `${size * (options.stackSize === 1 ? 0.4 : 0.28)}px system-ui`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(visual.fallbackIcon, x, y);
+  }
+
+  drawRoleMarker(ctx, visual.roleMarker, x, y, size);
+
+  if (unit.health < 100) {
+    const barWidth = size * 0.42;
+    const barHeight = size * 0.06;
+    const barX = x - barWidth / 2;
+    const barY = y + size * 0.28;
+
+    ctx.fillStyle = 'rgba(0,0,0,0.5)';
+    ctx.fillRect(barX, barY, barWidth, barHeight);
+
+    const healthRatio = unit.health / 100;
+    ctx.fillStyle = healthRatio > 0.5 ? '#4caf50' : healthRatio > 0.25 ? '#ff9800' : '#f44336';
+    ctx.fillRect(barX, barY, barWidth * healthRatio, barHeight);
+  }
+
+  if (unit.isFortified) {
+    const badgeR = size * 0.16;
+    const badgeX = x - size * 0.34;
+    const badgeY = y - size * 0.34;
+    ctx.beginPath();
+    ctx.arc(badgeX, badgeY, badgeR, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(200,150,0,0.9)';
+    ctx.fill();
+    ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+    ctx.font = `${size * 0.18}px system-ui`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = 'white';
+    ctx.fillText('F', badgeX, badgeY);
+  }
 }
 
 export function drawUnits(
@@ -84,60 +159,14 @@ export function drawUnits(
         const offset = stack.length === 1 ? STACK_OFFSETS[0] : STACK_OFFSETS[index];
         const unitX = screen.x + offset.x * size;
         const unitY = screen.y + offset.y * size;
-        const ownerColor = colorLookup?.[unit.owner] ?? OWNER_COLORS[unit.owner] ?? '#888';
-
         const sprite = camera.zoom >= LOD_SPRITE_ZOOM_THRESHOLD
           ? spriteCache.getUnit(unit.type, unit.owner)
           : null;
-
-        if (sprite) {
-          const drawSize = size * (stack.length === 1 ? 0.9 : 0.65);
-          ctx.drawImage(sprite, unitX - drawSize / 2, unitY - drawSize / 2, drawSize, drawSize);
-        } else {
-          ctx.beginPath();
-          ctx.arc(unitX, unitY, size * (stack.length === 1 ? 0.35 : 0.25), 0, Math.PI * 2);
-          ctx.fillStyle = ownerColor;
-          ctx.fill();
-          ctx.strokeStyle = 'rgba(255,255,255,0.6)';
-          ctx.lineWidth = 1.5;
-          ctx.stroke();
-          ctx.font = `${size * (stack.length === 1 ? 0.4 : 0.28)}px system-ui`;
-          ctx.textAlign = 'center';
-          ctx.textBaseline = 'middle';
-          ctx.fillText(UNIT_ICONS[unit.type] ?? '?', unitX, unitY);
-        }
-
-        if (unit.health < 100) {
-          const barWidth = size * 0.42;
-          const barHeight = size * 0.06;
-          const barX = unitX - barWidth / 2;
-          const barY = unitY + size * 0.28;
-
-          ctx.fillStyle = 'rgba(0,0,0,0.5)';
-          ctx.fillRect(barX, barY, barWidth, barHeight);
-
-          const healthRatio = unit.health / 100;
-          ctx.fillStyle = healthRatio > 0.5 ? '#4caf50' : healthRatio > 0.25 ? '#ff9800' : '#f44336';
-          ctx.fillRect(barX, barY, barWidth * healthRatio, barHeight);
-        }
-
-        if (unit.isFortified) {
-          const badgeR = size * 0.16;
-          const badgeX = unitX - size * 0.34;
-          const badgeY = unitY - size * 0.34;
-          ctx.beginPath();
-          ctx.arc(badgeX, badgeY, badgeR, 0, Math.PI * 2);
-          ctx.fillStyle = 'rgba(200,150,0,0.9)';
-          ctx.fill();
-          ctx.strokeStyle = 'rgba(255,255,255,0.8)';
-          ctx.lineWidth = 1;
-          ctx.stroke();
-          ctx.font = `${size * 0.18}px system-ui`;
-          ctx.textAlign = 'center';
-          ctx.textBaseline = 'middle';
-          ctx.fillStyle = 'white';
-          ctx.fillText('F', badgeX, badgeY);
-        }
+        drawUnitGlyph(ctx, state, unit, unitX, unitY, size, colorLookup, {
+          stackSize: stack.length,
+          stackIndex: index,
+          spriteOverride: sprite,
+        });
       }
 
       if (stack.length > 1) {

--- a/src/renderer/unit-visual-resolver.ts
+++ b/src/renderer/unit-visual-resolver.ts
@@ -1,0 +1,61 @@
+import type { GameState, Unit } from '@/core/types';
+
+export type UnitOwnerRole = 'major' | 'minor' | 'barbarian';
+export type UnitRoleMarker = 'chevron' | 'diamond' | null;
+export type UnitMotionState = 'idle' | 'move-a' | 'move-b';
+
+const FALLBACK_ICONS: Record<string, string> = {
+  settler: '🏕️',
+  worker: '👷',
+  scout: '🔭',
+  warrior: '⚔️',
+  archer: '🏹',
+  swordsman: '🗡️',
+  pikeman: '🔱',
+  musketeer: '🔫',
+  galley: '⛵',
+  trireme: '🚢',
+  spy_scout: '🕵️',
+  spy_informant: '🕵️',
+  spy_agent: '🕵️',
+  spy_operative: '🕵️',
+  spy_hacker: '💻',
+  scout_hound: '🐕',
+  shadow_warden: '🦅',
+  war_hound: '🐺',
+};
+
+export interface UnitVisual {
+  role: UnitOwnerRole;
+  roleMarker: UnitRoleMarker;
+  color: string;
+  fallbackIcon: string;
+  spriteOwnerId: string;
+  motion: UnitMotionState;
+}
+
+function getRole(unit: Unit): UnitOwnerRole {
+  if (unit.owner === 'barbarian') return 'barbarian';
+  if (unit.owner.startsWith('mc-')) return 'minor';
+  return 'major';
+}
+
+export function resolveUnitVisual(
+  state: GameState,
+  unit: Unit,
+  colorLookup: Record<string, string> = {},
+  motion: UnitMotionState = 'idle',
+): UnitVisual {
+  const role = getRole(unit);
+  const color = colorLookup[unit.owner]
+    ?? state.civilizations?.[unit.owner]?.color
+    ?? (role === 'barbarian' ? '#8b4513' : '#888');
+  return {
+    role,
+    roleMarker: role === 'barbarian' ? 'chevron' : role === 'minor' ? 'diamond' : null,
+    color,
+    fallbackIcon: FALLBACK_ICONS[unit.type] ?? '?',
+    spriteOwnerId: unit.owner,
+    motion,
+  };
+}

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -1,0 +1,135 @@
+import type { GameMap, GameState, HexCoord, Unit, UnitAttackProfile, UnitType } from '@/core/types';
+import { isAtWar } from '@/systems/diplomacy-system';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexDistance, hexKey, hexesInRange, getWrappedHexesInRange, wrappedHexDistance } from '@/systems/hex-utils';
+import { selectDefenderForAttack } from '@/systems/combat-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type AttackTargetFailure =
+  | 'missing-attacker'
+  | 'no-combat-strength'
+  | 'out-of-range'
+  | 'not-visible'
+  | 'no-target'
+  | 'friendly-target'
+  | 'not-hostile'
+  | 'unsupported-target';
+
+export type AttackTargetResult =
+  | { ok: true; targetType: 'unit'; targetUnitId: string; coord: HexCoord; range: number }
+  | { ok: true; targetType: 'city'; cityId: string; coord: HexCoord; range: number }
+  | { ok: false; reason: AttackTargetFailure };
+
+export interface AttackTargetOptions {
+  viewerId?: string;
+  requireVisibility?: boolean;
+}
+
+export interface AttackTarget {
+  coord: HexCoord;
+  result: Extract<AttackTargetResult, { ok: true }>;
+}
+
+const DEFAULT_ATTACK_PROFILE: UnitAttackProfile = { kind: 'melee', range: 1, targets: ['unit', 'city'] };
+
+export function getUnitAttackProfile(type: UnitType): UnitAttackProfile {
+  return UNIT_DEFINITIONS[type].attackProfile ?? DEFAULT_ATTACK_PROFILE;
+}
+
+function distanceForMap(map: GameMap, from: HexCoord, to: HexCoord): number {
+  return map.wrapsHorizontally
+    ? wrappedHexDistance(from, to, map.width)
+    : hexDistance(from, to);
+}
+
+function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord: HexCoord): boolean {
+  if (!viewerId) return true;
+  const visibility = state.civilizations[viewerId]?.visibility;
+  if (!visibility) return false;
+  return getVisibility(visibility, coord) === 'visible';
+}
+
+function canAttackOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
+  if (targetOwner === attackerOwner) return false;
+  if (targetOwner === 'barbarian' || targetOwner === 'rebels' || targetOwner.startsWith('mc-')) return true;
+  const diplomacy = state.civilizations[attackerOwner]?.diplomacy;
+  return diplomacy ? isAtWar(diplomacy, targetOwner) : false;
+}
+
+function unitAt(state: GameState, attacker: Unit, coord: HexCoord): [string, Unit] | null {
+  const targetKey = hexKey(coord);
+  const defenders = Object.values(state.units).filter(unit =>
+    unit.id !== attacker.id && hexKey(unit.position) === targetKey,
+  );
+  const defender = selectDefenderForAttack(defenders, state.map);
+  return defender ? [defender.id, defender] : null;
+}
+
+function cityAt(state: GameState, attacker: Unit, coord: HexCoord): [string, { owner: string; position: HexCoord }] | null {
+  const targetKey = hexKey(coord);
+  const entry = Object.entries(state.cities).find(([, city]) =>
+    city.owner !== attacker.owner && hexKey(city.position) === targetKey,
+  );
+  return entry ? [entry[0], entry[1]] : null;
+}
+
+export function canAttackByProfileOnMap(attacker: Unit, target: Unit, map: GameMap): boolean {
+  const profile = getUnitAttackProfile(attacker.type);
+  const range = distanceForMap(map, attacker.position, target.position);
+  return UNIT_DEFINITIONS[attacker.type].strength > 0
+    && profile.targets.includes('unit')
+    && range > 0
+    && range <= profile.range;
+}
+
+export function canUnitAttackTarget(
+  state: GameState,
+  attacker: Unit | undefined,
+  coord: HexCoord,
+  options: AttackTargetOptions = {},
+): AttackTargetResult {
+  if (!attacker) return { ok: false, reason: 'missing-attacker' };
+  if (UNIT_DEFINITIONS[attacker.type].strength <= 0) return { ok: false, reason: 'no-combat-strength' };
+
+  const profile = getUnitAttackProfile(attacker.type);
+  const range = distanceForMap(state.map, attacker.position, coord);
+  if (range > profile.range || range === 0) return { ok: false, reason: 'out-of-range' };
+
+  const requireVisibility = options.requireVisibility ?? Boolean(options.viewerId);
+  if (requireVisibility && !isVisibleToViewer(state, options.viewerId, coord)) {
+    return { ok: false, reason: 'not-visible' };
+  }
+
+  const targetUnit = unitAt(state, attacker, coord);
+  if (targetUnit) {
+    if (targetUnit[1].owner === attacker.owner) return { ok: false, reason: 'friendly-target' };
+    if (!canAttackOwner(state, attacker.owner, targetUnit[1].owner)) return { ok: false, reason: 'not-hostile' };
+    if (!profile.targets.includes('unit')) return { ok: false, reason: 'unsupported-target' };
+    return { ok: true, targetType: 'unit', targetUnitId: targetUnit[0], coord, range };
+  }
+
+  const targetCity = cityAt(state, attacker, coord);
+  if (targetCity) {
+    if (!canAttackOwner(state, attacker.owner, targetCity[1].owner)) return { ok: false, reason: 'not-hostile' };
+    if (!profile.targets.includes('city')) return { ok: false, reason: 'unsupported-target' };
+    return { ok: true, targetType: 'city', cityId: targetCity[0], coord, range };
+  }
+
+  return { ok: false, reason: 'no-target' };
+}
+
+export function getAttackTargets(
+  state: GameState,
+  attacker: Unit,
+  options: AttackTargetOptions = {},
+): AttackTarget[] {
+  const profile = getUnitAttackProfile(attacker.type);
+  const candidates = state.map.wrapsHorizontally
+    ? getWrappedHexesInRange(attacker.position, profile.range, state.map.width)
+    : hexesInRange(attacker.position, profile.range);
+
+  return candidates
+    .filter(coord => hexKey(coord) !== hexKey(attacker.position))
+    .map(coord => ({ coord, result: canUnitAttackTarget(state, attacker, coord, options) }))
+    .filter((target): target is AttackTarget => target.result.ok);
+}

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -52,7 +52,8 @@ function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord
 function canAttackOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
   if (targetOwner === attackerOwner) return false;
   if (attackerOwner === 'barbarian' || attackerOwner === 'rebels') return true;
-  if (targetOwner === 'barbarian' || targetOwner === 'rebels' || targetOwner.startsWith('mc-')) return true;
+  if (targetOwner === 'barbarian' || targetOwner === 'rebels') return true;
+  if (targetOwner.startsWith('mc-')) return state.civilizations[attackerOwner]?.isHuman === true;
   const diplomacy = state.civilizations[attackerOwner]?.diplomacy;
   return diplomacy ? isAtWar(diplomacy, targetOwner) : false;
 }

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -51,6 +51,7 @@ function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord
 
 function canAttackOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
   if (targetOwner === attackerOwner) return false;
+  if (attackerOwner === 'barbarian' || attackerOwner === 'rebels') return true;
   if (targetOwner === 'barbarian' || targetOwner === 'rebels' || targetOwner.startsWith('mc-')) return true;
   const diplomacy = state.civilizations[attackerOwner]?.diplomacy;
   return diplomacy ? isAtWar(diplomacy, targetOwner) : false;

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -1,5 +1,6 @@
 import type { BarbarianCamp, GameMap, GameState, HexCoord, Unit } from '@/core/types';
-import { hexKey, hexDistance, hexNeighbors } from './hex-utils';
+import { canAttackByProfileOnMap } from './attack-targeting';
+import { hexKey, hexDistance, hexNeighbors, wrappedHexDistance } from './hex-utils';
 import { selectDefenderForAttack } from './combat-system';
 
 // Seeded LCG — avoids Math.random() per project rules
@@ -184,7 +185,9 @@ export function processBarbarians(
     let nearestTarget: Unit | null = null;
     let nearestDist = BARBARIAN_CHASE_RANGE + 1;
     for (const playerUnit of playerUnits) {
-      const dist = hexDistance(barbUnit.position, playerUnit.position);
+      const dist = map.wrapsHorizontally
+        ? wrappedHexDistance(barbUnit.position, playerUnit.position, map.width)
+        : hexDistance(barbUnit.position, playerUnit.position);
       if (dist < nearestDist) {
         nearestDist = dist;
         nearestTarget = playerUnit;
@@ -194,7 +197,7 @@ export function processBarbarians(
     if (!nearestTarget) continue;
 
     // If adjacent to target, issue an attack order
-    if (nearestDist === 1) {
+    if (canAttackByProfileOnMap(barbUnit, nearestTarget, map)) {
       const targetKey = hexKey(nearestTarget.position);
       const defender = selectPlayerDefenderAtTarget(playerUnits, targetKey, map) ?? nearestTarget;
       attackOrders.push({ attackerUnitId: barbUnit.id, defenderUnitId: defender.id });

--- a/src/systems/fog-of-war.ts
+++ b/src/systems/fog-of-war.ts
@@ -5,7 +5,7 @@ import { getWonderVisionBonus } from './wonder-system';
 import { resolveCivDefinition } from './civ-registry';
 
 export function createVisibilityMap(): VisibilityMap {
-  return { tiles: {} };
+  return { tiles: {}, lastSeen: {} };
 }
 
 export function getVisibility(vis: VisibilityMap, coord: HexCoord): VisibilityState {

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -1,0 +1,38 @@
+import type { GameState, HexTile, LastSeenTilePresentation } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey, parseHexKey } from '@/systems/hex-utils';
+
+export function createLastSeenTilePresentation(
+  state: GameState,
+  _viewerId: string,
+  tile: HexTile,
+): LastSeenTilePresentation {
+  const tileKey = hexKey(tile.coord);
+  const city = Object.values(state.cities).find(candidate => hexKey(candidate.position) === tileKey);
+  return {
+    coord: { ...tile.coord },
+    terrain: tile.terrain,
+    elevation: tile.elevation,
+    resource: tile.resource,
+    improvement: tile.improvement,
+    improvementTurnsLeft: tile.improvementTurnsLeft,
+    owner: tile.owner,
+    hasRiver: tile.hasRiver,
+    wonder: tile.wonder,
+    city: city
+      ? { id: city.id, name: city.name, owner: city.owner, population: city.population }
+      : undefined,
+  };
+}
+
+export function refreshLastSeenPresentationsForCiv(state: GameState, viewerId: string): void {
+  const civ = state.civilizations[viewerId];
+  if (!civ?.visibility) return;
+
+  civ.visibility.lastSeen ??= {};
+  for (const [key, tile] of Object.entries(state.map.tiles)) {
+    const coord = tile.coord ?? parseHexKey(key);
+    if (getVisibility(civ.visibility, coord) !== 'visible') continue;
+    civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, viewerId, { ...tile, coord });
+  }
+}

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -11,6 +11,7 @@ import { collectUsedCityNames } from './city-name-system';
 import { generateQuest, checkQuestCompletion, processQuestExpiry, awardQuestReward } from './quest-system';
 import { resolveCombat } from './combat-system';
 import { hasDiscoveredMinorCiv } from './discovery-system';
+import { canAttackByProfileOnMap } from './attack-targeting';
 
 const PLACEMENT_COUNTS: Record<string, [number, number]> = {
   small: [2, 4],
@@ -422,19 +423,18 @@ export function processScuffles(state: GameState, bus: EventBus): void {
       if (hexDistance(mcCity.position, otherCity.position) <= 8) {
         const attackerUnit = mc.units.map(uid => state.units[uid]).find(u => u);
         const defenderUnit = other.units.map(uid => state.units[uid]).find(u => u);
-        if (attackerUnit && defenderUnit) {
+        if (attackerUnit && defenderUnit && canAttackByProfileOnMap(attackerUnit, defenderUnit, state.map)) {
           const seed = state.turn * 16807 + attackerUnit.id.charCodeAt(0);
           const result = resolveCombat(attackerUnit, defenderUnit, state.map, seed, undefined, state.era);
           attackerUnit.health = Math.max(1, attackerUnit.health - result.attackerDamage);
           defenderUnit.health = Math.max(1, defenderUnit.health - result.defenderDamage);
+          bus.emit('minor-civ:scuffle', {
+            attackerId: mc.id,
+            defenderId: other.id,
+            position: otherCity.position,
+          });
+          break;
         }
-
-        bus.emit('minor-civ:scuffle', {
-          attackerId: mc.id,
-          defenderId: other.id,
-          position: otherCity.position,
-        });
-        break;
       }
     }
   }

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -6,6 +6,7 @@ import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, findPath } from '@/systems/unit-system';
 import { visitVillage } from '@/systems/village-system';
 import { processWonderDiscovery } from '@/systems/wonder-system';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
 
 export interface ExecuteUnitMoveOptions {
   actor: 'player' | 'automation' | 'ai';
@@ -133,6 +134,7 @@ export function executeUnitMove(
     state.map,
     getCivCityPositions(state, options.civId),
   );
+  refreshLastSeenPresentationsForCiv(state, options.civId);
   const contacts = syncCivilizationContactsFromVisibility(state, options.civId);
   for (const contact of contacts) {
     options.bus?.emit('civilization:first-contact', contact);

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -35,6 +35,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     type: 'archer', name: 'Archer', movementPoints: 2,
     visionRange: 2, strength: 15, canFoundCity: false,
     canBuildImprovements: false, productionCost: 35,
+    attackProfile: { kind: 'ranged', range: 2, targets: ['unit'] },
   },
   swordsman: {
     type: 'swordsman', name: 'Swordsman', movementPoints: 2,

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -172,6 +172,24 @@ describe('AI attack targeting', () => {
     expect(combatEvents).toHaveLength(1);
     expect(state.units[attacker.id]?.position).toEqual({ q: 0, r: 0 });
   });
+
+  it('does not make AI units opportunistically attack minor-civ units', () => {
+    const state = createNewGame(undefined, 'ai-minor-neutral-range', 'small');
+    const attacker = createUnit('warrior', 'ai-1', { q: 0, r: 0 });
+    attacker.id = 'ai-warrior';
+    const defender = createUnit('warrior', 'mc-sparta', { q: 1, r: 0 });
+    defender.id = 'minor-warrior';
+    state.units = { [attacker.id]: attacker, [defender.id]: defender };
+    state.civilizations['ai-1'].units = [attacker.id];
+    const combatEvents: unknown[] = [];
+    const bus = new EventBus();
+    bus.on('combat:resolved', payload => combatEvents.push(payload));
+
+    processAITurn(state, 'ai-1', bus);
+
+    expect(combatEvents).toHaveLength(0);
+    expect(state.units[defender.id]).toBeDefined();
+  });
 });
 
 function makeAiDefenseSpyState(): GameState {

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -6,6 +6,7 @@ import { foundCity } from '@/systems/city-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
 import { hexKey } from '@/systems/hex-utils';
 import { tickLegendaryWonderProjects } from '@/systems/legendary-wonder-system';
+import { createUnit } from '@/systems/unit-system';
 
 function makeAiRebelState(): GameState {
   return {
@@ -127,6 +128,51 @@ function makeAiRebelState(): GameState {
     defensiveLeagues: [],
   } as GameState;
 }
+
+describe('AI attack targeting', () => {
+  it('does not let AI melee units attack non-adjacent targets', () => {
+    const state = createNewGame(undefined, 'ai-melee-range', 'small');
+    const attacker = createUnit('warrior', 'ai-1', { q: 0, r: 0 });
+    attacker.id = 'ai-warrior';
+    const defender = createUnit('warrior', 'player', { q: 2, r: 0 });
+    defender.id = 'player-warrior';
+    state.units = { [attacker.id]: attacker, [defender.id]: defender };
+    state.civilizations['ai-1'].units = [attacker.id];
+    state.civilizations.player.units = [defender.id];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    const combatEvents: unknown[] = [];
+    const bus = new EventBus();
+    bus.on('combat:resolved', payload => combatEvents.push(payload));
+
+    processAITurn(state, 'ai-1', bus);
+
+    expect(combatEvents).toHaveLength(0);
+    expect(state.units[attacker.id]).toBeDefined();
+    expect(state.units[defender.id]).toBeDefined();
+  });
+
+  it('lets AI archers attack visible-by-rule hostile units at explicit range', () => {
+    const state = createNewGame(undefined, 'ai-archer-range', 'small');
+    const attacker = createUnit('archer', 'ai-1', { q: 0, r: 0 });
+    attacker.id = 'ai-archer';
+    const defender = createUnit('warrior', 'player', { q: 2, r: 0 });
+    defender.id = 'player-warrior';
+    state.units = { [attacker.id]: attacker, [defender.id]: defender };
+    state.civilizations['ai-1'].units = [attacker.id];
+    state.civilizations.player.units = [defender.id];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    const combatEvents: unknown[] = [];
+    const bus = new EventBus();
+    bus.on('combat:resolved', payload => combatEvents.push(payload));
+
+    processAITurn(state, 'ai-1', bus);
+
+    expect(combatEvents).toHaveLength(1);
+    expect(state.units[attacker.id]?.position).toEqual({ q: 0, r: 0 });
+  });
+});
 
 function makeAiDefenseSpyState(): GameState {
   return {

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
+
+describe('selected-unit-highlights', () => {
+  it('does not mark non-adjacent melee targets as attack highlights', () => {
+    const state = createNewGame(undefined, 'melee-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.visibility.tiles = { '2,0': 'visible' };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('2,0');
+    expect(result.highlights.filter(h => h.type === 'attack').map(h => hexKey(h.coord))).not.toContain('2,0');
+  });
+
+  it('marks visible archer targets as attack and not movement', () => {
+    const state = createNewGame(undefined, 'archer-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      archer: { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'archer', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['archer'];
+    state.civilizations.player.visibility.tiles = { '2,0': 'visible' };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    const result = buildSelectedUnitHighlights(state, 'archer');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).toContain('2,0');
+    expect(result.highlights).toContainEqual({ coord: { q: 2, r: 0 }, type: 'attack' });
+    expect(result.highlights.filter(h => h.type === 'move').map(h => hexKey(h.coord))).not.toContain('2,0');
+  });
+
+  it('does not highlight fogged archer targets', () => {
+    const state = createNewGame(undefined, 'archer-fog-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      archer: { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'archer', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 2, r: 0 }), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['archer'];
+    state.civilizations.player.visibility.tiles = { '2,0': 'fog' };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    const result = buildSelectedUnitHighlights(state, 'archer');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('2,0');
+    expect(result.highlights.filter(h => h.type === 'attack')).toHaveLength(0);
+  });
+
+  it('leaves adjacent hostile cities on the city-assault path instead of combat-preview attack targets', () => {
+    const state = createNewGame(undefined, 'city-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior', movementPointsLeft: 2 },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.visibility.tiles = { '1,0': 'visible' };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.cities.enemyCity = {
+      ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
+      id: 'enemyCity',
+      name: 'Enemy City',
+      owner: 'ai-1',
+      position: { q: 1, r: 0 },
+      population: 4,
+      ownedTiles: [{ q: 1, r: 0 }],
+    };
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('1,0');
+    expect(result.highlights.filter(h => h.type === 'attack').map(h => hexKey(h.coord))).not.toContain('1,0');
+  });
+});

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -183,4 +183,29 @@ describe('selected-unit-tap-intent', () => {
 
     expect(intent).toEqual({ kind: 'move' });
   });
+
+  it('returns move when a melee unit taps a non-adjacent hostile city inside movement range', () => {
+    const state = makeTapAssaultFixture();
+    state.cities.enemyCity.position = { q: 2, r: 0 };
+    state.cities.enemyCity.ownedTiles = [{ q: 2, r: 0 }];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 2, r: 0 }, [{ q: 1, r: 0 }, { q: 2, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
+
+  it('returns move when an ordinary archer taps a non-adjacent hostile city', () => {
+    const state = makeTapAssaultFixture();
+    state.units['unit-1'] = { ...createUnit('archer', 'player', { q: 0, r: 0 }), id: 'unit-1', movementPointsLeft: 2 };
+    state.cities.enemyCity.position = { q: 2, r: 0 };
+    state.cities.enemyCity.ownedTiles = [{ q: 2, r: 0 }];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+
+    const intent = resolveSelectedUnitTapIntent(state, 'unit-1', { q: 2, r: 0 }, [{ q: 1, r: 0 }, { q: 2, r: 0 }]);
+
+    expect(intent).toEqual({ kind: 'move' });
+  });
 });

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -167,6 +167,62 @@ describe('city renderer', () => {
     expect(overlayTexts).toContain('☹');
   });
 
+  it('renders fogged cities from last-seen presentation without live production or unrest badges', () => {
+    const state = createNewGame(undefined, 'city-last-seen-render', 'small');
+    state.cities.enemyCity = {
+      id: 'enemyCity',
+      name: 'Live City',
+      owner: 'player',
+      position: { q: 0, r: 0 },
+      population: 9,
+      buildings: [],
+      productionQueue: ['warrior'],
+      productionProgress: 0,
+      food: 0,
+      foodNeeded: 10,
+      workedTiles: [],
+      ownedTiles: [{ q: 0, r: 0 }],
+      focus: 'balanced',
+      maturity: 'outpost',
+      grid: [],
+      gridSize: 3,
+      unrestLevel: 2,
+      unrestTurns: 3,
+      spyUnrestBonus: 0,
+    };
+    state.civilizations.player.visibility = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: 'ai-1',
+          hasRiver: false,
+          wonder: null,
+          city: { id: 'enemyCity', name: 'Old City', owner: 'ai-1', population: 2 },
+        },
+      },
+    };
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const camera = {
+      zoom: 1,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+
+    drawCities(ctx, state, camera, 'player');
+
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
+    expect(texts).toContain('Old City (2)');
+    expect(texts).not.toContain('Live City (9)');
+    expect(texts).not.toContain('🔥');
+  });
+
   it('renders wrapped ghost cities at the horizontal seam when only the mirrored copy is on screen', () => {
     const state = createNewGame(undefined, 'wrapped-city-render');
     state.map.wrapsHorizontally = true;

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -85,7 +85,22 @@ describe('hex renderer privacy', () => {
 
   it('keeps player ownership borders on fogged tiles', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
-    const visibility: VisibilityMap = { tiles: { '0,0': 'fog', '1,0': 'unexplored' } };
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog', '1,0': 'unexplored' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'grassland',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: 'player',
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
 
     drawHexMap(ctx, makeMap(), makeCamera(), undefined, 'player', visibility);
 

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -26,10 +26,11 @@ vi.mock('@/renderer/city-renderer', () => ({
 
 vi.mock('@/renderer/unit-renderer', () => ({
   drawUnits: vi.fn(),
+  drawUnitGlyph: vi.fn(),
 }));
 
 import { RenderLoop } from '@/renderer/render-loop';
-import type { GameState } from '@/core/types';
+import type { GameState, Unit } from '@/core/types';
 
 function createCanvas(): HTMLCanvasElement {
   const ctx = {
@@ -121,5 +122,50 @@ describe('render-loop wrap parity', () => {
       'player',
       'mc-sparta',
     );
+  });
+
+  it('runs movement completion callbacks after the unit leaves the moving set', () => {
+    const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    const loop = new RenderLoop(createCanvas());
+    const unit = {
+      id: 'u1',
+      owner: 'player',
+      type: 'warrior',
+      position: { q: 0, r: 0 },
+      movementPointsLeft: 1,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    };
+    const state = {
+      turn: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      tribalVillages: {},
+      minorCivs: {},
+      cities: {},
+      units: { u1: unit },
+      civilizations: {
+        player: {
+          color: '#4a90d9',
+          visibility: { tiles: { '1,0': 'visible' } },
+        },
+      },
+    } as unknown as GameState;
+    let callbackSawMoving = true;
+
+    loop.setGameState(state);
+    loop.camera.isHexVisible = () => true;
+    loop.animateUnitMove(unit as Unit, { q: 0, r: 0 }, { q: 1, r: 0 }, () => {
+      callbackSawMoving = loop.hasMovingUnit('u1');
+    });
+    nowSpy.mockReturnValue(1000);
+
+    (loop as unknown as { render: () => void }).render();
+
+    expect(callbackSawMoving).toBe(false);
+    nowSpy.mockRestore();
   });
 });

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { UNIT_SPRITE_CATALOG, BUILDING_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import { derivePalette } from '@/renderer/sprites/sprite-system';
 import { BUILDINGS } from '@/systems/city-system';
 
 const ALL_UNIT_TYPES = [
@@ -17,6 +18,20 @@ describe('sprite-catalog coverage', () => {
         expect(typeof UNIT_SPRITE_CATALOG[unitType]).toBe('function');
       });
     }
+
+    it('every unit sprite returns distinct moving output', () => {
+      const palette = derivePalette('#4a90d9');
+      for (const [type, render] of Object.entries(UNIT_SPRITE_CATALOG)) {
+        const idle = render({ palette, svgOnly: true, motion: 'idle' });
+        const movingA = render({ palette, svgOnly: true, motion: 'move-a' });
+        const movingB = render({ palette, svgOnly: true, motion: 'move-b' });
+        expect(idle, `${type} idle sprite`).toContain('data-motion="idle"');
+        expect(movingA, `${type} move-a sprite`).toContain('data-motion="move-a"');
+        expect(movingB, `${type} move-b sprite`).toContain('data-motion="move-b"');
+        expect(movingA, `${type} move-a differs from idle`).not.toBe(idle);
+        expect(movingB, `${type} move-b differs from move-a`).not.toBe(movingA);
+      }
+    });
   });
 
   describe('BUILDING_SPRITE_CATALOG', () => {

--- a/tests/renderer/sprites/sprite-loader.test.ts
+++ b/tests/renderer/sprites/sprite-loader.test.ts
@@ -53,4 +53,13 @@ describe('SpriteCache after initSprites', () => {
   it('getUnitMotion returns null for an uncached civ', () => {
     expect(spriteCache.getUnitMotion('warrior', 'uncached-civ', 'move-a')).toBeNull();
   });
+
+  it('can load a neutral civ palette on demand', async () => {
+    spriteCache.ensureCiv('mc-on-demand-test', '#8a6f2a');
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(spriteCache.getUnit('warrior', 'mc-on-demand-test')).toBeInstanceOf(HTMLImageElement);
+    expect(spriteCache.getUnitMotion('warrior', 'mc-on-demand-test', 'move-a')).toBeInstanceOf(HTMLImageElement);
+  });
 });

--- a/tests/renderer/sprites/sprite-loader.test.ts
+++ b/tests/renderer/sprites/sprite-loader.test.ts
@@ -44,4 +44,13 @@ describe('SpriteCache after initSprites', () => {
   it('getUnit returns null for an uncached civ', () => {
     expect(spriteCache.getUnit('warrior', 'uncached-civ')).toBeNull();
   });
+
+  it('getUnitMotion returns moving frames for a loaded civ', () => {
+    expect(spriteCache.getUnitMotion('warrior', 'player', 'move-a')).toBeInstanceOf(HTMLImageElement);
+    expect(spriteCache.getUnitMotion('warrior', 'player', 'move-b')).toBeInstanceOf(HTMLImageElement);
+  });
+
+  it('getUnitMotion returns null for an uncached civ', () => {
+    expect(spriteCache.getUnitMotion('warrior', 'uncached-civ', 'move-a')).toBeNull();
+  });
 });

--- a/tests/renderer/tile-presentation.test.ts
+++ b/tests/renderer/tile-presentation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { GameMap, VisibilityMap } from '@/core/types';
+import { resolveTilePresentationForViewer } from '@/renderer/tile-presentation';
+
+const liveTile = {
+  coord: { q: 0, r: 0 },
+  terrain: 'forest',
+  elevation: 'lowland',
+  resource: 'deer',
+  improvement: 'none',
+  owner: 'ai-1',
+  improvementTurnsLeft: 0,
+  hasRiver: false,
+  wonder: null,
+} as const;
+
+const map = { width: 4, height: 3, wrapsHorizontally: true, tiles: { '0,0': liveTile }, rivers: [] } as unknown as GameMap;
+
+describe('tile-presentation', () => {
+  it('returns live tile presentation for visible tiles', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'live',
+      tile: liveTile,
+    });
+  });
+
+  it('returns last-seen presentation for fogged tiles', () => {
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'farm',
+          improvementTurnsLeft: 0,
+          owner: 'player',
+          hasRiver: true,
+          wonder: null,
+        },
+      },
+    };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'last-seen',
+      tile: expect.objectContaining({ terrain: 'plains', owner: 'player', improvement: 'farm' }),
+    });
+  });
+
+  it('returns unknown fog when an old save has no last-seen snapshot', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'fog' } };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 0, r: 0 })).toMatchObject({
+      kind: 'unknown-fog',
+      tile: expect.objectContaining({ terrain: 'grassland', owner: null, resource: null }),
+    });
+  });
+
+  it('canonicalizes wrapped render coordinates before visibility lookup', () => {
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'desert',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
+
+    expect(resolveTilePresentationForViewer(map, visibility, { q: 4, r: 0 })).toMatchObject({
+      kind: 'last-seen',
+      tile: expect.objectContaining({ terrain: 'desert' }),
+    });
+  });
+});

--- a/tests/renderer/unit-movement-animation.test.ts
+++ b/tests/renderer/unit-movement-animation.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { GameMap, Unit } from '@/core/types';
+import { createMovementAnimation, getMovementAnimationPosition, getMovementDurationMs, getMovingUnitIds } from '@/renderer/unit-movement-animation';
+import { createUnit } from '@/systems/unit-system';
+
+const map = { width: 6, height: 4, wrapsHorizontally: true, tiles: {}, rivers: [] } as GameMap;
+
+function unit(id: string): Unit {
+  return { ...createUnit('warrior', 'player', { q: 0, r: 1 }), id };
+}
+
+describe('unit-movement-animation', () => {
+  it('uses a short wrapped route across the horizontal edge', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 5, r: 1 }, map);
+
+    expect(animation.renderFrom.q).toBe(0);
+    expect(animation.renderTo.q).toBe(-1);
+  });
+
+  it('clamps normal movement duration to a responsive range', () => {
+    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }])).toBe(250);
+    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 }, { q: 3, r: 0 }])).toBeLessThanOrEqual(600);
+  });
+
+  it('interpolates position and alternates moving frames', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
+    const halfway = getMovementAnimationPosition(animation, 0.5);
+
+    expect(halfway.coord.q).toBeCloseTo(0.5);
+    expect(halfway.motion).toBe('move-b');
+  });
+
+  it('tracks moving unit ids for stationary renderer hiding', () => {
+    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
+
+    expect(getMovingUnitIds([animation])).toEqual(new Set(['u1']));
+  });
+});

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -207,3 +207,32 @@ describe('unit role markers', () => {
     expect(ctx.lineTo).toHaveBeenCalled();
   });
 });
+
+describe('moving unit rendering', () => {
+  it('does not draw stationary copy for hidden moving unit ids', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      mover: {
+        id: 'mover', owner: 'player', type: 'warrior',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+      },
+    };
+    const state = {
+      map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      civilizations: {},
+    } as unknown as GameState;
+    const camera = {
+      zoom: 0.2,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+
+    drawUnits(ctx, units, camera, { tiles: { '0,0': 'visible' } }, state, 'player', { player: '#4a90d9' }, {
+      hiddenUnitIds: new Set(['mover']),
+    });
+
+    expect(ctx.fillText).not.toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
+  });
+});

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { drawUnits } from '@/renderer/unit-renderer';
+import { drawUnitGlyph, drawUnits } from '@/renderer/unit-renderer';
 import type { GameState, Unit, VisibilityMap } from '@/core/types';
 import type { Camera } from '@/renderer/camera';
+import { spriteCache } from '@/renderer/sprites/sprite-loader';
 
 function createContext(): CanvasRenderingContext2D {
   return {
@@ -205,6 +206,47 @@ describe('unit role markers', () => {
 
     expect(ctx.moveTo).toHaveBeenCalled();
     expect(ctx.lineTo).toHaveBeenCalled();
+  });
+
+  it('requests an uncached neutral unit sprite palette when sprites are enabled', () => {
+    const ctx = createContext();
+    const ensureSpy = vi.spyOn(spriteCache, 'ensureCiv').mockImplementation(() => undefined);
+    const unit: Unit = {
+      id: 'minor', owner: 'mc-renderer-cache-test', type: 'warrior',
+      position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+      experience: 0, hasMoved: false, hasActed: false, isResting: false,
+    };
+
+    drawUnitGlyph(ctx, makeState(), unit, 24, 24, 48, { 'mc-renderer-cache-test': '#8a6f2a' }, {
+      stackSize: 1,
+      stackIndex: 0,
+      useSprites: true,
+    });
+
+    expect(ensureSpy).toHaveBeenCalledWith('mc-renderer-cache-test', '#8a6f2a');
+    ensureSpy.mockRestore();
+  });
+
+  it('keeps low zoom on fallback glyphs even when a sprite override is available', () => {
+    const ctx = createContext();
+    const ensureSpy = vi.spyOn(spriteCache, 'ensureCiv').mockImplementation(() => undefined);
+    const unit: Unit = {
+      id: 'warrior', owner: 'player', type: 'warrior',
+      position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+      experience: 0, hasMoved: false, hasActed: false, isResting: false,
+    };
+
+    drawUnitGlyph(ctx, makeState(), unit, 24, 24, 48, { player: '#4a90d9' }, {
+      stackSize: 1,
+      stackIndex: 0,
+      useSprites: false,
+      spriteOverride: {} as HTMLImageElement,
+    });
+
+    expect(ctx.drawImage).not.toHaveBeenCalled();
+    expect(ctx.fillText).toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
+    expect(ensureSpy).not.toHaveBeenCalled();
+    ensureSpy.mockRestore();
   });
 });
 

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -6,7 +6,11 @@ import type { Camera } from '@/renderer/camera';
 function createContext(): CanvasRenderingContext2D {
   return {
     beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    closePath: vi.fn(),
     arc: vi.fn(),
+    drawImage: vi.fn(),
     fill: vi.fn(),
     stroke: vi.fn(),
     fillText: vi.fn(),
@@ -115,6 +119,7 @@ describe('fortified unit badge', () => {
   function makeState(): GameState {
     return {
       map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      civilizations: {},
     } as unknown as GameState;
   }
 
@@ -150,5 +155,55 @@ describe('fortified unit badge', () => {
 
     const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
     expect(fillTextCalls.some(([text]) => text === 'F')).toBe(false);
+  });
+});
+
+describe('unit role markers', () => {
+  function makeCamera(): Camera {
+    return {
+      zoom: 0.2,
+      hexSize: 48,
+      isHexVisible: () => true,
+      worldToScreen: (x: number, y: number) => ({ x, y }),
+    } as unknown as Camera;
+  }
+
+  function makeState(): GameState {
+    return {
+      map: { width: 10, height: 10, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      civilizations: {},
+    } as unknown as GameState;
+  }
+
+  it('draws a chevron marker for barbarian units', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      barb: {
+        id: 'barb', owner: 'barbarian', type: 'warrior',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+      },
+    };
+
+    drawUnits(ctx, units, makeCamera(), { tiles: { '0,0': 'visible' } }, makeState(), 'player', { barbarian: '#8b4513' });
+
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
+  });
+
+  it('draws a diamond marker for minor-civ units', () => {
+    const ctx = createContext();
+    const units: Record<string, Unit> = {
+      minor: {
+        id: 'minor', owner: 'mc-sparta', type: 'warrior',
+        position: { q: 0, r: 0 }, movementPointsLeft: 2, health: 100,
+        experience: 0, hasMoved: false, hasActed: false, isResting: false,
+      },
+    };
+
+    drawUnits(ctx, units, makeCamera(), { tiles: { '0,0': 'visible' } }, makeState(), 'player', { 'mc-sparta': '#8a6f2a' });
+
+    expect(ctx.moveTo).toHaveBeenCalled();
+    expect(ctx.lineTo).toHaveBeenCalled();
   });
 });

--- a/tests/renderer/unit-visual-resolver.test.ts
+++ b/tests/renderer/unit-visual-resolver.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { resolveUnitVisual } from '@/renderer/unit-visual-resolver';
+import { createUnit } from '@/systems/unit-system';
+
+describe('unit-visual-resolver', () => {
+  it('omits role marker for major civ units', () => {
+    const state = createNewGame(undefined, 'major-visual', 'small');
+    const unit = { ...createUnit('warrior', 'player', { q: 0, r: 0 }), id: 'warrior' };
+
+    expect(resolveUnitVisual(state, unit, { player: '#4a90d9' })).toMatchObject({
+      role: 'major',
+      roleMarker: null,
+      color: '#4a90d9',
+    });
+  });
+
+  it('uses hostile chevron marker for barbarian units', () => {
+    const state = createNewGame(undefined, 'barbarian-visual', 'small');
+    const unit = { ...createUnit('warrior', 'barbarian', { q: 0, r: 0 }), id: 'barb' };
+
+    expect(resolveUnitVisual(state, unit, { barbarian: '#8b4513' })).toMatchObject({
+      role: 'barbarian',
+      roleMarker: 'chevron',
+      color: '#8b4513',
+    });
+  });
+
+  it('uses city-state diamond marker for minor-civ units', () => {
+    const state = createNewGame(undefined, 'minor-visual', 'small');
+    const unit = { ...createUnit('warrior', 'mc-sparta', { q: 0, r: 0 }), id: 'mc-unit' };
+
+    expect(resolveUnitVisual(state, unit, { 'mc-sparta': '#8a6f2a' })).toMatchObject({
+      role: 'minor',
+      roleMarker: 'diamond',
+      color: '#8a6f2a',
+    });
+  });
+});

--- a/tests/systems/attack-targeting.test.ts
+++ b/tests/systems/attack-targeting.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { HexCoord, Unit, UnitType } from '@/core/types';
+import { canUnitAttackTarget, getAttackTargets, getUnitAttackProfile } from '@/systems/attack-targeting';
+import { hexKey } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
+
+function unit(id: string, type: UnitType, owner: string, position: HexCoord): Unit {
+  return { ...createUnit(type, owner, position), id, owner, position };
+}
+
+function stateWithUnits(units: Record<string, Unit>, visibility: Record<string, 'visible' | 'fog' | 'unexplored'> = {}) {
+  const state = createNewGame(undefined, 'attack-targeting-test', 'small');
+  state.units = units;
+  state.civilizations.player.units = Object.keys(units).filter(id => units[id].owner === 'player');
+  state.civilizations['ai-1'].units = Object.keys(units).filter(id => units[id].owner === 'ai-1');
+  state.civilizations.player.visibility.tiles = visibility;
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+  return state;
+}
+
+describe('attack-targeting', () => {
+  it('gives warriors the default melee profile and archers an explicit ranged profile', () => {
+    expect(getUnitAttackProfile('warrior')).toEqual({ kind: 'melee', range: 1, targets: ['unit', 'city'] });
+    expect(getUnitAttackProfile('archer')).toEqual({ kind: 'ranged', range: 2, targets: ['unit'] });
+  });
+
+  it('rejects non-adjacent melee attacks even when the enemy is inside movement range', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'out-of-range',
+    });
+  });
+
+  it('allows archers to attack visible hostile units at range without moving into the defender hex', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toMatchObject({
+      ok: true,
+      targetType: 'unit',
+      targetUnitId: 'defender',
+      range: 2,
+    });
+  });
+
+  it('rejects ranged attacks against fogged targets through the player path', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'fog' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'not-visible',
+    });
+  });
+
+  it('rejects unit attacks against major civs that are not at war', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'not-hostile',
+    });
+  });
+
+  it('rejects ordinary archer attacks against cities from range', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const state = stateWithUnits({ attacker }, { '2,0': 'visible' });
+    state.cities.enemyCity = {
+      id: 'enemyCity',
+      name: 'Enemy City',
+      owner: 'ai-1',
+      position: { q: 2, r: 0 },
+      population: 4,
+      buildings: [],
+      productionQueue: [],
+      productionProgress: 0,
+      food: 0,
+      foodNeeded: 10,
+      ownedTiles: [{ q: 2, r: 0 }],
+      workedTiles: [],
+      focus: 'balanced',
+      maturity: 'outpost',
+      grid: [],
+      gridSize: 3,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    };
+
+    expect(canUnitAttackTarget(state, attacker, { q: 2, r: 0 }, { viewerId: 'player' })).toEqual({
+      ok: false,
+      reason: 'unsupported-target',
+    });
+  });
+
+  it('uses wrapped distance for melee adjacency at the horizontal edge', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 1 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 9, r: 1 });
+    const state = stateWithUnits({ attacker, defender }, { '9,1': 'visible' });
+    state.map.wrapsHorizontally = true;
+    state.map.width = 10;
+
+    expect(canUnitAttackTarget(state, attacker, { q: 9, r: 1 }, { viewerId: 'player' })).toMatchObject({
+      ok: true,
+      targetUnitId: 'defender',
+      range: 1,
+    });
+  });
+
+  it('collects only legal attack target coordinates', () => {
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const visibleDefender = unit('visible-defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const foggedDefender = unit('fogged-defender', 'warrior', 'ai-1', { q: 1, r: 1 });
+    const state = stateWithUnits(
+      { attacker, 'visible-defender': visibleDefender, 'fogged-defender': foggedDefender },
+      { '2,0': 'visible', '1,1': 'fog' },
+    );
+
+    expect(getAttackTargets(state, attacker, { viewerId: 'player' }).map(target => hexKey(target.coord))).toEqual(['2,0']);
+  });
+});

--- a/tests/systems/attack-targeting.test.ts
+++ b/tests/systems/attack-targeting.test.ts
@@ -74,6 +74,23 @@ describe('attack-targeting', () => {
     });
   });
 
+  it('allows human players to target minor-civ units without making AI treat them as hostile', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 0 });
+    const minor = unit('minor-warrior', 'warrior', 'mc-sparta', { q: 1, r: 0 });
+    const aiAttacker = unit('ai-attacker', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, 'minor-warrior': minor, 'ai-attacker': aiAttacker }, { '1,0': 'visible' });
+
+    expect(canUnitAttackTarget(state, attacker, { q: 1, r: 0 }, { viewerId: 'player' })).toMatchObject({
+      ok: true,
+      targetType: 'unit',
+      targetUnitId: 'minor-warrior',
+    });
+    expect(canUnitAttackTarget(state, aiAttacker, { q: 1, r: 0 }, { requireVisibility: false })).toEqual({
+      ok: false,
+      reason: 'not-hostile',
+    });
+  });
+
   it('rejects ordinary archer attacks against cities from range', () => {
     const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
     const state = stateWithUnits({ attacker }, { '2,0': 'visible' });

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -101,6 +101,34 @@ describe('processBarbarians', () => {
       defenderUnitId: 'warrior-second',
     });
   });
+
+  it('does not let barbarian melee units attack non-adjacent targets', () => {
+    const map = generateMap(30, 30, 'barb-melee-range');
+    const barbarian = createUnit('warrior', 'barbarian', { q: 10, r: 10 });
+    barbarian.id = 'barb';
+    const warrior = createUnit('warrior', 'player', { q: 12, r: 10 });
+    warrior.id = 'player-warrior';
+
+    const result = processBarbarians([], map, [warrior], 42, [barbarian]);
+
+    expect(result.attackOrders).toHaveLength(0);
+  });
+
+  it('uses wrapped distance when barbarian melee units attack across the horizontal edge', () => {
+    const map = generateMap(10, 6, 'barb-wrap-range');
+    map.wrapsHorizontally = true;
+    const barbarian = createUnit('warrior', 'barbarian', { q: 0, r: 2 });
+    barbarian.id = 'barb';
+    const warrior = createUnit('warrior', 'player', { q: 9, r: 2 });
+    warrior.id = 'player-warrior';
+
+    const result = processBarbarians([], map, [warrior], 42, [barbarian]);
+
+    expect(result.attackOrders).toContainEqual({
+      attackerUnitId: 'barb',
+      defenderUnitId: 'player-warrior',
+    });
+  });
 });
 
 describe('barbarian camp evolution', () => {

--- a/tests/systems/last-seen-presentation.test.ts
+++ b/tests/systems/last-seen-presentation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+
+describe('last-seen-presentation', () => {
+  it('captures serializable tile presentation for visible tiles', () => {
+    const state = createNewGame(undefined, 'last-seen-visible', 'small');
+    const tile = state.map.tiles['0,0'];
+    tile.terrain = 'forest';
+    tile.elevation = 'highland';
+    tile.resource = 'deer';
+    tile.owner = 'player';
+    tile.improvement = 'farm';
+    tile.improvementTurnsLeft = 0;
+
+    const snapshot = createLastSeenTilePresentation(state, 'player', tile);
+
+    expect(snapshot).toMatchObject({
+      coord: tile.coord,
+      terrain: 'forest',
+      elevation: 'highland',
+      resource: 'deer',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 0,
+      hasRiver: tile.hasRiver,
+      wonder: tile.wonder,
+    });
+    expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot);
+  });
+
+  it('updates only currently visible tiles for the viewer', () => {
+    const state = createNewGame(undefined, 'last-seen-refresh', 'small');
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'fog' };
+    state.map.tiles['0,0'].terrain = 'forest';
+    state.map.tiles['1,0'].terrain = 'desert';
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('forest');
+    expect(state.civilizations.player.visibility.lastSeen?.['1,0']).toBeUndefined();
+  });
+
+  it('keeps hot-seat viewers separate', () => {
+    const state = createNewGame(undefined, 'last-seen-hotseat', 'small');
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible' };
+    state.civilizations['ai-1'].visibility.tiles = { '0,0': 'fog' };
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']).toBeDefined();
+    expect(state.civilizations['ai-1'].visibility.lastSeen?.['0,0']).toBeUndefined();
+  });
+
+  it('does not update fogged city presentation from live city changes', () => {
+    const state = createNewGame(undefined, 'last-seen-city', 'small');
+    state.cities.enemyCity = {
+      id: 'enemyCity',
+      name: 'Old City',
+      owner: 'ai-1',
+      position: { q: 0, r: 0 },
+      population: 2,
+      buildings: [],
+      productionQueue: ['warrior'],
+      productionProgress: 0,
+      food: 0,
+      foodNeeded: 10,
+      workedTiles: [],
+      ownedTiles: [{ q: 0, r: 0 }],
+      focus: 'balanced',
+      maturity: 'outpost',
+      grid: [],
+      gridSize: 3,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    };
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible' };
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    state.civilizations.player.visibility.tiles = { '0,0': 'fog' };
+    state.cities.enemyCity = { ...state.cities.enemyCity, name: 'Live City', owner: 'player', population: 9 };
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.city).toEqual({
+      id: 'enemyCity',
+      name: 'Old City',
+      owner: 'ai-1',
+      population: 2,
+    });
+  });
+});

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -349,6 +349,53 @@ describe('scuffles between minor civs', () => {
     processScuffles(state, bus);
     expect(state).toBeDefined();
   });
+
+  it('does not resolve scuffle combat when minor-civ melee units are not adjacent', () => {
+    const state = createNewGame(undefined, 'mc-scuffle-range', 'small');
+    state.turn = 13;
+    state.minorCivs = {
+      'mc-sparta': {
+        id: 'mc-sparta',
+        definitionId: 'sparta',
+        cityId: 'city-sparta',
+        units: ['sparta-warrior'],
+        diplomacy: {} as any,
+        activeQuests: {},
+        isDestroyed: false,
+        garrisonCooldown: 0,
+        lastEraUpgrade: 1,
+      },
+      'mc-carthage': {
+        id: 'mc-carthage',
+        definitionId: 'carthage',
+        cityId: 'city-carthage',
+        units: ['carthage-warrior'],
+        diplomacy: {} as any,
+        activeQuests: {},
+        isDestroyed: false,
+        garrisonCooldown: 0,
+        lastEraUpgrade: 1,
+      },
+    };
+    state.cities = {
+      'city-sparta': { id: 'city-sparta', name: 'Sparta', owner: 'mc-sparta', position: { q: 0, r: 0 }, population: 3, buildings: [], productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 10, ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 },
+      'city-carthage': { id: 'city-carthage', name: 'Carthage', owner: 'mc-carthage', position: { q: 1, r: 0 }, population: 3, buildings: [], productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 10, ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'outpost', grid: [], gridSize: 3, unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 },
+    };
+    const attacker = createUnit('warrior', 'mc-sparta', { q: 0, r: 0 });
+    attacker.id = 'sparta-warrior';
+    const defender = createUnit('warrior', 'mc-carthage', { q: 2, r: 0 });
+    defender.id = 'carthage-warrior';
+    state.units = { [attacker.id]: attacker, [defender.id]: defender };
+    const scuffles: unknown[] = [];
+    const localBus = new EventBus();
+    localBus.on('minor-civ:scuffle', payload => scuffles.push(payload));
+
+    processScuffles(state, localBus);
+
+    expect(scuffles).toHaveLength(0);
+    expect(state.units['sparta-warrior'].health).toBe(100);
+    expect(state.units['carthage-warrior'].health).toBe(100);
+  });
 });
 
 describe('diplomatic agency', () => {


### PR DESCRIPTION
## Summary
- Adds shared attack targeting so melee/ranged attacks, player previews, AI, barbarians, and minor-civ scuffles use the same profile/range rules.
- Stores viewer-scoped last-seen tile/city presentations and renders fog/stale/hidden tiles consistently across zoom and wrap rendering.
- Gives barbarian/minor-civ units distinct role markers/colors, loads neutral sprite palettes on demand, and animates unit movement with matching motion frames.

## Review fixes included
- Preserves low-zoom fallback glyph rendering instead of accidentally drawing cached sprites.
- Reselects units only after movement animations finish, clearing stale highlights during movement.
- Keeps AI units from opportunistically treating minor-civ units as hostile.

## Test Plan
- scripts/check-src-rule-violations.sh src/ai/basic-ai.ts src/core/game-state.ts src/core/turn-manager.ts src/core/types.ts src/input/selected-unit-highlights.ts src/input/selected-unit-tap-intent.ts src/main.ts src/renderer/city-renderer.ts src/renderer/hex-renderer.ts src/renderer/render-loop.ts src/renderer/render-visibility.ts src/renderer/sprites/sprite-catalog.ts src/renderer/sprites/sprite-loader.ts src/renderer/sprites/units.tsx src/renderer/tile-presentation.ts src/renderer/unit-movement-animation.ts src/renderer/unit-renderer.ts src/renderer/unit-visual-resolver.ts src/systems/attack-targeting.ts src/systems/barbarian-system.ts src/systems/fog-of-war.ts src/systems/last-seen-presentation.ts src/systems/minor-civ-system.ts src/systems/unit-movement-system.ts src/systems/unit-system.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test

Fixes #198
Fixes #199
Fixes #200
Fixes #201