### PR TITLE
feat(territory): add cultural territory worker improvements

### DIFF
--- a/docs/superpowers/plans/2026-05-15-cultural-territory-worker-improvements.md
+++ b/docs/superpowers/plans/2026-05-15-cultural-territory-worker-improvements.md
@@ -1,0 +1,1298 @@
+# Cultural Territory Worker Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build cultural territory ownership so workers can only improve their own civ's territory, while progressing from simple city-radius claims to inspectable culture-frontier border pressure.
+
+**Architecture:** `src/systems/city-territory-system.ts` becomes the canonical territory owner for claim generation, claim resolution, and state application. `City.ownedTiles` remains city attribution, `HexTile.owner` remains the fast civ lookup, and worker/UI code reads the canonical result instead of inventing separate territory rules.
+
+**Tech Stack:** TypeScript, Vite, Vitest, Canvas renderer highlights, DOM UI panels, existing `./scripts/run-with-mise.sh yarn` command wrapper.
+
+---
+
+## Source Spec
+
+- Design: `docs/superpowers/specs/2026-05-15-cultural-territory-worker-improvements-design.md`
+- Issue: https://github.com/a1flecke/conquestoria/issues/157
+
+## File Map
+
+- Modify `src/core/types.ts`: add serializable territory frontier types in MR5.
+- Modify `src/systems/city-territory-system.ts`: add territory claim/resolution APIs, growth thresholds, pressure formula, frontier cleanup helpers, and retain existing city work claim helpers.
+- Modify `src/systems/city-system.ts`: make `foundCity` create a city shell without independently deciding final territory, or delegate initial owned tiles to the territory helper.
+- Modify `src/main.ts`: wire founding first, then capture/raze/loss paths, to canonical territory recalculation.
+- Modify `src/systems/city-capture-system.ts`: route captured/razed city tile ownership through territory state application.
+- Modify `src/storage/save-manager.ts`: normalize legacy territory with holder preservation before city work claim cleanup.
+- Modify `src/systems/improvement-system.ts`: expose worker-action eligibility reasons for UI and mutation-layer failures.
+- Modify `src/systems/worker-action-system.ts`: return `outside-territory` for territory failures and cancel in-progress work on tile flip.
+- Modify `src/input/selected-unit-highlights.ts`: add worker guidance highlights in movement-preview range.
+- Modify `src/renderer/render-loop.ts`: add highlight types for worker buildable, worker owned-blocked, and worker foreign-blocked.
+- Modify `src/ui/selected-unit-info.ts`: render current-tile worker blockage text.
+- Modify `src/ui/notification-routing.ts`: route territory flip notifications to civs with visibility or direct ownership involvement.
+- Test `tests/systems/city-territory-system.test.ts`: territory claims, deterministic resolution, growth, pressure, frontier cleanup.
+- Test `tests/systems/worker-action-system.test.ts`: mutation-layer worker legality and task clearing.
+- Test `tests/systems/improvement-system.test.ts`: eligibility reason boundaries.
+- Test `tests/input/selected-unit-highlights.test.ts`: worker guidance highlight generation.
+- Test `tests/ui/selected-unit-info.test.ts`: current-tile blockage text.
+- Test `tests/storage/save-persistence.test.ts`: legacy territory normalization.
+
+## Plan-Wide Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Worker selected on own valid unimproved tile | Player opens selected-unit panel | Build button appears and current tile is green-highlighted |
+| Worker selected on own invalid tile | Player opens selected-unit panel | No build button; panel shows reason such as `Requires river`; movement-preview tile is amber |
+| Worker selected near foreign valid terrain | Player selects worker | Foreign valid terrain in movement-preview range is red, and no build action appears there after moving unless ownership changes |
+| Border tile flips with completed farm | Turn processing resolves territory | Notification log mentions tile/improvement transfer; old city no longer counts farm yield; new owner can work it |
+| Border tile flips with in-progress farm | Turn processing resolves territory | Construction disappears, original worker task is cleared, notification says construction was cancelled |
+| Frontier tile is contested in MR5 | Player inspects border/frontier surface | UI explains holder, challenger, trend, and reason without exposing unexplored map information |
+
+## Misleading UI Risks
+
+- A tile must not be green unless at least one worker action is valid now for the selected worker's owner.
+- A red foreign-blocked highlight must not reveal terrain in unexplored tiles; only visible or fog-known tiles may receive reason-colored worker guidance.
+- Amber means "your territory, blocked by local improvement rules"; it must not include foreign tiles.
+- Current-tile panel reasons must match mutation-layer failure reasons, especially `outside-territory`.
+- Frontier explanations must not appear before MR5 creates persistent frontier state.
+
+## Interaction Replay Checklist
+
+- Select worker, inspect current tile reason, move worker, reselect worker, inspect updated reason.
+- Select worker twice after a failed action; stale buttons must not mutate state.
+- Build on a valid tile, panel rerenders with worker charges/task state.
+- Reopen selected-unit panel after territory recalculation; blocked reason reflects current ownership.
+- End turn after border flip; notification log, city yields, worker task state, and map ownership agree.
+
+---
+
+### Task 1: MR1 Canonical Territory Foundation
+
+**Files:**
+- Modify: `src/systems/city-territory-system.ts`
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+- Test: `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Write failing territory helper tests**
+
+Add these tests to `tests/systems/city-territory-system.test.ts`:
+
+```ts
+import { recalculateTerritory, type TerritoryResolution } from '@/systems/city-territory-system';
+import { hexKey } from '@/systems/hex-utils';
+
+it('recalculates a founded city to radius 2 without claiming ocean or mountains', () => {
+  const state = createNewGame(undefined, 'territory-radius-2');
+  state.cities = {};
+  state.civilizations.player.cities = [];
+  const city = foundCity('player', { q: 10, r: 10 }, state.map);
+  city.id = 'city-player';
+  state.cities[city.id] = { ...city, ownedTiles: [] };
+  state.civilizations.player.cities = [city.id];
+  state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], terrain: 'mountain', owner: null };
+  state.map.tiles['12,10'] = { ...state.map.tiles['12,10'], terrain: 'ocean', owner: null };
+
+  const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+  const ownedKeys = result.state.cities[city.id].ownedTiles.map(hexKey);
+
+  expect(ownedKeys).toContain('10,10');
+  expect(ownedKeys).toContain('10,12');
+  expect(ownedKeys).not.toContain('11,10');
+  expect(ownedKeys).not.toContain('12,10');
+  for (const key of ownedKeys) {
+    expect(result.state.map.tiles[key]?.owner).toBe('player');
+  }
+});
+
+it('does not steal valid foreign-held tiles during MR1 founding recalculation', () => {
+  const state = createNewGame(undefined, 'territory-foreign-holder');
+  state.cities = {};
+  state.civilizations.player.cities = [];
+  const city = foundCity('player', { q: 10, r: 10 }, state.map);
+  city.id = 'city-player';
+  state.cities[city.id] = { ...city, ownedTiles: [] };
+  state.civilizations.player.cities = [city.id];
+  state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], terrain: 'grassland', owner: 'ai-1' };
+
+  const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+
+  expect(result.state.map.tiles['11,10'].owner).toBe('ai-1');
+  expect(result.state.cities[city.id].ownedTiles.map(hexKey)).not.toContain('11,10');
+});
+
+it('returns changed-tile metadata when ownership changes', () => {
+  const state = createNewGame(undefined, 'territory-resolution-metadata');
+  state.cities = {};
+  state.civilizations.player.cities = [];
+  const city = foundCity('player', { q: 10, r: 10 }, state.map);
+  city.id = 'city-player';
+  state.cities[city.id] = { ...city, ownedTiles: [] };
+  state.civilizations.player.cities = [city.id];
+
+  const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+  const centerResolution = result.resolutions.find((resolution: TerritoryResolution) => hexKey(resolution.coord) === '10,10');
+
+  expect(centerResolution).toMatchObject({
+    previousOwner: null,
+    winningCityId: city.id,
+    winningCivId: 'player',
+    reason: 'founding',
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused failing tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/systems/city-system.test.ts
+```
+
+Expected: FAIL because `recalculateTerritory`, `TerritoryResolution`, and radius-2 ownership behavior do not exist yet.
+
+- [ ] **Step 3: Add territory claim/resolution types and MR1 helper**
+
+In `src/systems/city-territory-system.ts`, add these exported types and functions above the work-claim section:
+
+```ts
+export type TerritoryRecalculationReason =
+  | 'founding'
+  | 'capture'
+  | 'raze'
+  | 'city-loss'
+  | 'turn'
+  | 'load';
+
+export interface TerritoryClaim {
+  cityId: string;
+  civId: string;
+  coord: HexCoord;
+  radiusBand: number;
+  pressure: number;
+  reason: TerritoryRecalculationReason;
+}
+
+export interface TerritoryResolution {
+  coord: HexCoord;
+  previousOwner: string | null;
+  winningCityId: string | null;
+  winningCivId: string | null;
+  competingClaims: TerritoryClaim[];
+  reason: TerritoryRecalculationReason;
+}
+
+export interface TerritoryRecalculationOptions {
+  reason: TerritoryRecalculationReason;
+  preserveForeignHolders?: boolean;
+}
+
+export interface TerritoryRecalculationResult {
+  state: GameState;
+  resolutions: TerritoryResolution[];
+  contestedResolutions: TerritoryResolution[];
+}
+
+function canClaimTile(tile: GameState['map']['tiles'][string] | undefined): boolean {
+  return Boolean(tile && tile.terrain !== 'ocean' && tile.terrain !== 'mountain');
+}
+
+export function getBaseTerritoryRadius(_city: City): number {
+  return 2;
+}
+
+export function generateTerritoryClaimsForCity(
+  state: GameState,
+  city: City,
+  reason: TerritoryRecalculationReason,
+): TerritoryClaim[] {
+  const claims: TerritoryClaim[] = [];
+  for (const rawCoord of hexesInRange(city.position, getBaseTerritoryRadius(city))) {
+    const coord = canonicalizeCityCoord(rawCoord, state.map);
+    const tile = state.map.tiles[hexKey(coord)];
+    if (!canClaimTile(tile)) continue;
+    claims.push({
+      cityId: city.id,
+      civId: city.owner,
+      coord,
+      radiusBand: cityDistance(city.position, coord, state.map),
+      pressure: 0,
+      reason,
+    });
+  }
+  return claims;
+}
+
+export function recalculateTerritory(
+  state: GameState,
+  options: TerritoryRecalculationOptions,
+): TerritoryRecalculationResult {
+  const claimsByTile = new Map<string, TerritoryClaim[]>();
+  for (const city of Object.values(state.cities)) {
+    for (const claim of generateTerritoryClaimsForCity(state, city, options.reason)) {
+      const key = hexKey(claim.coord);
+      claimsByTile.set(key, [...(claimsByTile.get(key) ?? []), claim]);
+    }
+  }
+
+  const nextTiles = { ...state.map.tiles };
+  const nextCities: GameState['cities'] = {};
+  const ownedByCity = new Map<string, HexCoord[]>();
+  const resolutions: TerritoryResolution[] = [];
+
+  for (const city of Object.values(state.cities)) {
+    nextCities[city.id] = { ...city, ownedTiles: [] };
+  }
+
+  for (const [key, claims] of claimsByTile.entries()) {
+    const tile = state.map.tiles[key];
+    if (!tile) continue;
+    const previousOwner = tile.owner ?? null;
+    const eligibleClaims = options.preserveForeignHolders && previousOwner && !claims.some(claim => claim.civId === previousOwner)
+      ? []
+      : claims;
+    const sorted = eligibleClaims.slice().sort((left, right) => {
+      if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
+      return left.cityId.localeCompare(right.cityId);
+    });
+    const winner = sorted[0] ?? null;
+    if (winner) {
+      nextTiles[key] = { ...tile, owner: winner.civId };
+      ownedByCity.set(winner.cityId, [...(ownedByCity.get(winner.cityId) ?? []), winner.coord]);
+    }
+    if ((winner?.civId ?? previousOwner) !== previousOwner) {
+      resolutions.push({
+        coord: tile.coord,
+        previousOwner,
+        winningCityId: winner?.cityId ?? null,
+        winningCivId: winner?.civId ?? null,
+        competingClaims: claims,
+        reason: options.reason,
+      });
+    }
+  }
+
+  for (const [cityId, city] of Object.entries(nextCities)) {
+    const seen = new Set<string>();
+    nextCities[cityId] = {
+      ...city,
+      ownedTiles: (ownedByCity.get(cityId) ?? []).filter(coord => {
+        const key = hexKey(coord);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      }),
+    };
+  }
+
+  const normalized = normalizeCityWorkClaims({
+    ...state,
+    map: { ...state.map, tiles: nextTiles },
+    cities: nextCities,
+  });
+  return { state: normalized.state, resolutions, contestedResolutions: [] };
+}
+```
+
+Also import `hexesInRange` from `./hex-utils`.
+
+- [ ] **Step 4: Wire founding through the helper**
+
+In `src/main.ts`, replace the manual tile owner loop in `foundCityAction()` with:
+
+```ts
+gameState.cities[city.id] = city;
+currentCiv().cities.push(city.id);
+gameState = initializeLegendaryWonderProjectsForCity(gameState, cp, city.id);
+gameState = recalculateTerritory(gameState, {
+  reason: 'founding',
+  preserveForeignHolders: true,
+}).state;
+```
+
+Import `recalculateTerritory` from `@/systems/city-territory-system`.
+
+- [ ] **Step 5: Update city-system tests for radius 2**
+
+In `tests/systems/city-system.test.ts`, update the existing "claims nearby tiles" expectation to require at least one distance-2 land tile:
+
+```ts
+it('creates radius 2 claim candidates for founded cities', () => {
+  const map = generateMap(30, 30, 'city-radius-2-test');
+  const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+  const city = foundCity('p1', landTile.coord, map);
+
+  expect(city.ownedTiles.length).toBeGreaterThanOrEqual(1);
+  expect(city.ownedTiles).toContainEqual(landTile.coord);
+});
+```
+
+Keep deeper final ownership assertions in `city-territory-system.test.ts` because the canonical helper owns the resolved territory.
+
+- [ ] **Step 6: Run tests and source rule check**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/city-territory-system.ts src/systems/city-system.ts src/main.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/systems/city-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit MR1 foundation**
+
+```bash
+git add src/systems/city-territory-system.ts src/systems/city-system.ts src/main.ts tests/systems/city-territory-system.test.ts tests/systems/city-system.test.ts
+git commit -m "feat(territory): add canonical founding ownership"
+```
+
+---
+
+### Task 2: MR1 Worker Legality Reasons And Guidance UI
+
+**Files:**
+- Modify: `src/systems/improvement-system.ts`
+- Modify: `src/systems/worker-action-system.ts`
+- Modify: `src/input/selected-unit-highlights.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Modify: `src/ui/selected-unit-info.ts`
+- Test: `tests/systems/improvement-system.test.ts`
+- Test: `tests/systems/worker-action-system.test.ts`
+- Test: `tests/input/selected-unit-highlights.test.ts`
+- Test: `tests/ui/selected-unit-info.test.ts`
+
+**Player Truth Table:**
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Worker on own valid tile | Select worker | Build button appears; tile gets worker-buildable highlight |
+| Worker on foreign valid tile | Select worker | No build button; panel says `Outside your territory`; nearby foreign valid tiles are red only if visible/fog-known |
+| Worker on own invalid terrain | Select worker | No build button; panel says specific local reason; tile or movement-preview tile is amber |
+
+**Misleading UI Risks:**
+
+- Do not call a tile buildable if `applyWorkerAction` would reject it.
+- Do not show red foreign-blocked highlights for unexplored terrain.
+- Do not show a generic "invalid action" in the panel when the specific reason is outside territory.
+
+- [ ] **Step 1: Write failing improvement reason tests**
+
+Add to `tests/systems/improvement-system.test.ts`:
+
+```ts
+import { getWorkerActionBlockerReason } from '@/systems/improvement-system';
+
+it('explains outside-territory worker blockers before terrain blockers', () => {
+  expect(getWorkerActionBlockerReason(tile({ terrain: 'forest', owner: 'enemy' }), 'farm', [], 'p1')).toBe('outside-territory');
+  expect(getWorkerActionBlockerReason(tile({ terrain: 'forest', owner: null }), 'farm', [], 'p1')).toBe('outside-territory');
+});
+
+it('explains local worker blockers inside owned territory', () => {
+  expect(getWorkerActionBlockerReason(tile({ terrain: 'plains', owner: 'p1', improvement: 'mine' }), 'farm', [], 'p1')).toBe('already-improved');
+  expect(getWorkerActionBlockerReason(tile({ terrain: 'plains', owner: 'p1', hasRiver: false }), 'watermill', [], 'p1')).toBe('requires-river');
+  expect(getWorkerActionBlockerReason(tile({ terrain: 'coast', owner: 'p1' }), 'farm', [], 'p1')).toBe('invalid-terrain');
+});
+```
+
+- [ ] **Step 2: Write failing worker mutation test**
+
+Add to `tests/systems/worker-action-system.test.ts`:
+
+```ts
+it('returns outside-territory for valid terrain outside worker territory', () => {
+  const start = state();
+  start.map.tiles['0,0'] = tile({ terrain: 'forest', owner: 'enemy' });
+
+  const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.reason).toBe('outside-territory');
+});
+```
+
+- [ ] **Step 3: Write failing selected-unit highlight test**
+
+Add to `tests/input/selected-unit-highlights.test.ts`:
+
+```ts
+it('adds worker guidance highlights for buildable, owned-blocked, and foreign-blocked movement-preview tiles', () => {
+  const state = createNewGame(undefined, 'worker-guidance-highlight', 'small');
+  state.currentPlayer = 'player';
+  state.units = {
+    worker: { ...createUnit('worker', 'player', { q: 0, r: 0 }), id: 'worker', movementPointsLeft: 2 },
+  };
+  state.civilizations.player.units = ['worker'];
+  state.civilizations.player.visibility.tiles = {
+    '0,0': 'visible',
+    '1,0': 'visible',
+    '0,1': 'visible',
+    '1,-1': 'visible',
+  };
+  state.map.tiles['1,0'] = { ...state.map.tiles['1,0'], terrain: 'plains', owner: 'player', improvement: 'none' };
+  state.map.tiles['0,1'] = { ...state.map.tiles['0,1'], terrain: 'coast', owner: 'player', improvement: 'none' };
+  state.map.tiles['1,-1'] = { ...state.map.tiles['1,-1'], terrain: 'plains', owner: 'ai-1', improvement: 'none' };
+
+  const result = buildSelectedUnitHighlights(state, 'worker');
+
+  expect(result.highlights).toContainEqual({ coord: { q: 1, r: 0 }, type: 'worker-buildable' });
+  expect(result.highlights).toContainEqual({ coord: { q: 0, r: 1 }, type: 'worker-owned-blocked' });
+  expect(result.highlights).toContainEqual({ coord: { q: 1, r: -1 }, type: 'worker-foreign-blocked' });
+});
+```
+
+- [ ] **Step 4: Implement blocker reasons**
+
+In `src/systems/improvement-system.ts`, add:
+
+```ts
+export type WorkerActionBlockerReason =
+  | 'outside-territory'
+  | 'city-center'
+  | 'already-improved'
+  | 'invalid-terrain'
+  | 'requires-river'
+  | 'requires-tech'
+  | 'none';
+
+export function getWorkerActionBlockerReason(
+  tile: HexTile | undefined,
+  action: WorkerActionType,
+  completedTechs: string[] = [],
+  ownerId?: string,
+  options: WorkerActionEligibilityOptions = {},
+): WorkerActionBlockerReason {
+  if (!tile) return 'invalid-terrain';
+  if (ownerId && tile.owner !== ownerId) return 'outside-territory';
+  if (options.isCityTile) return 'city-center';
+  if (tile.improvement !== 'none') return 'already-improved';
+  if (action === 'drain_swamp') return tile.terrain === 'swamp' ? 'none' : 'invalid-terrain';
+  const definition = IMPROVEMENT_DEFINITIONS[action];
+  if (!definition.validTerrains.includes(tile.terrain)) return 'invalid-terrain';
+  if (definition.requiresRiver && !tile.hasRiver) return 'requires-river';
+  if (definition.requiredTech && !completedTechs.includes(definition.requiredTech)) return 'requires-tech';
+  return 'none';
+}
+
+export function formatWorkerActionBlockerReason(reason: WorkerActionBlockerReason): string {
+  switch (reason) {
+    case 'outside-territory': return 'Outside your territory';
+    case 'city-center': return 'City centers cannot be improved';
+    case 'already-improved': return 'Already improved';
+    case 'invalid-terrain': return 'No worker improvement fits this terrain';
+    case 'requires-river': return 'Requires river';
+    case 'requires-tech': return 'Requires technology';
+    case 'none': return '';
+  }
+}
+```
+
+- [ ] **Step 5: Implement worker mutation failure reason**
+
+In `src/systems/worker-action-system.ts`, extend `WorkerActionFailureReason` with `'outside-territory'`. In `applyWorkerAction`, before returning `invalid-action`, use:
+
+```ts
+const blockerReason = getWorkerActionBlockerReason(tile, action, completedTechs, unit.owner, eligibilityOptions);
+if (blockerReason !== 'none') {
+  return {
+    ok: false,
+    state,
+    reason: blockerReason === 'outside-territory' ? 'outside-territory' : 'invalid-action',
+    events: [],
+  };
+}
+```
+
+Import `getWorkerActionBlockerReason`.
+
+- [ ] **Step 6: Extend highlight types and renderer colors**
+
+In `src/renderer/render-loop.ts`, change `HexHighlight`:
+
+```ts
+export interface HexHighlight {
+  coord: HexCoord;
+  type: 'move' | 'attack' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
+}
+```
+
+Replace color selection with:
+
+```ts
+const colorByType: Record<HexHighlight['type'], string> = {
+  move: 'rgba(74, 144, 217, 0.35)',
+  attack: 'rgba(217, 74, 74, 0.45)',
+  'worker-buildable': 'rgba(80, 200, 120, 0.45)',
+  'worker-owned-blocked': 'rgba(232, 193, 112, 0.40)',
+  'worker-foreign-blocked': 'rgba(217, 74, 74, 0.35)',
+};
+const color = colorByType[highlight.type];
+```
+
+- [ ] **Step 7: Generate worker guidance highlights**
+
+In `src/input/selected-unit-highlights.ts`, after `moveHighlights`, append worker guidance for worker units:
+
+```ts
+const workerGuidanceHighlights: HexHighlight[] = [];
+if (unit.type === 'worker') {
+  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  for (const coord of movementRange) {
+    const key = hexKey(coord);
+    const tile = state.map.tiles[key];
+    if (!tile) continue;
+    const visibility = state.civilizations[state.currentPlayer]?.visibility.tiles[key] ?? 'unexplored';
+    if (visibility === 'unexplored') continue;
+    const isCityTile = Object.values(state.cities).some(city => hexKey(city.position) === key);
+    const actions = getAvailableWorkerActions(tile, completedTechs, unit.owner, { isCityTile });
+    if (actions.length > 0) {
+      workerGuidanceHighlights.push({ coord, type: 'worker-buildable' });
+      continue;
+    }
+    const plausibleAction = getBestPlausibleWorkerAction(tile, completedTechs);
+    if (!plausibleAction) continue;
+    const blocker = getWorkerActionBlockerReason(tile, plausibleAction, completedTechs, unit.owner, { isCityTile });
+    if (blocker === 'outside-territory') workerGuidanceHighlights.push({ coord, type: 'worker-foreign-blocked' });
+    else if (blocker !== 'none') workerGuidanceHighlights.push({ coord, type: 'worker-owned-blocked' });
+  }
+}
+```
+
+Add a local helper in the same file:
+
+```ts
+function getBestPlausibleWorkerAction(tile: GameState['map']['tiles'][string], completedTechs: string[]): WorkerActionType | null {
+  for (const action of ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp'] as WorkerActionType[]) {
+    const reason = getWorkerActionBlockerReason(tile, action, completedTechs);
+    if (reason !== 'invalid-terrain' && reason !== 'requires-tech') return action;
+  }
+  return null;
+}
+```
+
+Return highlights as:
+
+```ts
+highlights: [...moveHighlights, ...workerGuidanceHighlights, ...attackHighlights],
+```
+
+- [ ] **Step 8: Add selected-unit current tile explanation**
+
+In `src/ui/selected-unit-info.ts`, after worker charges render, compute the current tile blocker:
+
+```ts
+const workerActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, { isCityTile });
+if (workerActions.length === 0) {
+  const firstAction = getBestWorkerActionExplanation(tile, completedTechs, unit.owner, { isCityTile });
+  if (firstAction) {
+    const reason = getWorkerActionBlockerReason(tile, firstAction, completedTechs, unit.owner, { isCityTile });
+    if (reason !== 'none') {
+      const reasonDiv = document.createElement('div');
+      reasonDiv.dataset.workerActionReason = reason;
+      reasonDiv.style.cssText = 'font-size:10px;color:#e8c170;margin-top:4px;';
+      reasonDiv.textContent = formatWorkerActionBlockerReason(reason);
+      wrapper.appendChild(reasonDiv);
+    }
+  }
+}
+```
+
+Add a local helper that checks `farm`, `mine`, `lumber_camp`, `watermill`, `drain_swamp` and returns the first action whose reason is not `invalid-terrain`, falling back to `farm`.
+
+- [ ] **Step 9: Run tests and source rule check**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/improvement-system.ts src/systems/worker-action-system.ts src/input/selected-unit-highlights.ts src/renderer/render-loop.ts src/ui/selected-unit-info.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/improvement-system.test.ts tests/systems/worker-action-system.test.ts tests/input/selected-unit-highlights.test.ts tests/ui/selected-unit-info.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit worker guidance**
+
+```bash
+git add src/systems/improvement-system.ts src/systems/worker-action-system.ts src/input/selected-unit-highlights.ts src/renderer/render-loop.ts src/ui/selected-unit-info.ts tests/systems/improvement-system.test.ts tests/systems/worker-action-system.test.ts tests/input/selected-unit-highlights.test.ts tests/ui/selected-unit-info.test.ts
+git commit -m "feat(worker): explain territory improvement blockers"
+```
+
+---
+
+### Task 3: MR2 Ownership Path Integration
+
+**Files:**
+- Modify: `src/systems/city-territory-system.ts`
+- Modify: `src/systems/city-capture-system.ts`
+- Modify: `src/main.ts`
+- Modify: `src/storage/save-manager.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+- Test: `tests/systems/city-capture-system.test.ts`
+- Test: `tests/storage/save-persistence.test.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add to `tests/systems/city-territory-system.test.ts`:
+
+```ts
+it('normalizes city work claims after territory loss', () => {
+  const state = createNewGame(undefined, 'territory-work-normalize');
+  const city = addCity(state, 'player', 10, 10);
+  const lost = { q: 11, r: 10 };
+  state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], owner: 'ai-1', terrain: 'grassland' };
+  state.cities[city.id] = { ...city, ownedTiles: [city.position, lost], workedTiles: [lost] };
+
+  const result = recalculateTerritory(state, { reason: 'load', preserveForeignHolders: true });
+
+  expect(result.state.cities[city.id].workedTiles).toEqual([]);
+  expect(result.state.map.tiles['11,10'].owner).toBe('ai-1');
+});
+```
+
+Add to `tests/storage/save-persistence.test.ts`:
+
+```ts
+it('preserves legacy tile owner as holder when normalizing ambiguous territory', async () => {
+  const state = createNewGame(undefined, 'legacy-territory-holder');
+  const city = Object.values(state.cities).find(c => c.owner === 'player')!;
+  const coord = { q: city.position.q + 1, r: city.position.r };
+  const key = hexKey(coord);
+  state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'grassland', owner: 'ai-1' };
+  state.cities[city.id] = { ...city, ownedTiles: [...city.ownedTiles, coord], workedTiles: [coord] };
+
+  const normalized = normalizeLoadedStateForTest(state);
+
+  expect(normalized.map.tiles[key].owner).toBe('ai-1');
+  expect(normalized.cities[city.id].workedTiles).not.toContainEqual(coord);
+});
+```
+
+If `normalizeLoadedState` is not exported for tests, export it as `normalizeLoadedStateForTest` from `save-manager.ts`.
+
+- [ ] **Step 2: Run failing integration tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/systems/city-capture-system.test.ts tests/storage/save-persistence.test.ts
+```
+
+Expected: FAIL until capture/save paths use canonical territory.
+
+- [ ] **Step 3: Add territory application options for existing holders**
+
+Extend `TerritoryRecalculationOptions` in `src/systems/city-territory-system.ts`:
+
+```ts
+export interface TerritoryRecalculationOptions {
+  reason: TerritoryRecalculationReason;
+  preserveForeignHolders?: boolean;
+  preserveCurrentHolderOnTie?: boolean;
+  cityIds?: string[];
+}
+```
+
+Update resolution sorting so when `preserveCurrentHolderOnTie` is true, claims from `previousOwner` sort before claims with equal band/pressure:
+
+```ts
+if (options.preserveCurrentHolderOnTie && previousOwner) {
+  const leftHeld = left.civId === previousOwner ? 0 : 1;
+  const rightHeld = right.civId === previousOwner ? 0 : 1;
+  if (leftHeld !== rightHeld) return leftHeld - rightHeld;
+}
+```
+
+- [ ] **Step 4: Wire capture/raze through canonical territory**
+
+In `src/systems/city-capture-system.ts`, after changing city owner/civilization arrays for occupy, call:
+
+```ts
+const territoryResult = recalculateTerritory(nextState, {
+  reason: 'capture',
+  preserveCurrentHolderOnTie: true,
+});
+return {
+  state: territoryResult.state,
+  outcome: 'occupied',
+  goldAwarded: 0,
+};
+```
+
+For raze, delete the city first, then call:
+
+```ts
+const territoryResult = recalculateTerritory(nextStateWithoutCity, {
+  reason: 'raze',
+  preserveCurrentHolderOnTie: true,
+});
+```
+
+Remove the direct loops that assign every previous `city.ownedTiles` tile owner by hand.
+
+- [ ] **Step 5: Wire save normalization**
+
+In `src/storage/save-manager.ts`, after legacy city shape normalization and before returning:
+
+```ts
+const territoryNormalized = recalculateTerritory(normalizedCityState, {
+  reason: 'load',
+  preserveForeignHolders: true,
+  preserveCurrentHolderOnTie: true,
+}).state;
+return normalizeCityWorkClaims(territoryNormalized).state;
+```
+
+Export a test-only alias:
+
+```ts
+export const normalizeLoadedStateForTest = normalizeLoadedState;
+```
+
+- [ ] **Step 6: Run checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/city-territory-system.ts src/systems/city-capture-system.ts src/main.ts src/storage/save-manager.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/systems/city-capture-system.test.ts tests/storage/save-persistence.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit ownership path integration**
+
+```bash
+git add src/systems/city-territory-system.ts src/systems/city-capture-system.ts src/main.ts src/storage/save-manager.ts tests/systems/city-territory-system.test.ts tests/systems/city-capture-system.test.ts tests/storage/save-persistence.test.ts
+git commit -m "feat(territory): integrate ownership recalculation paths"
+```
+
+---
+
+### Task 4: MR3 Simple Cultural Growth
+
+**Files:**
+- Modify: `src/systems/city-territory-system.ts`
+- Modify: `src/core/turn-manager.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+- Test: `tests/core/turn-manager.test.ts`
+
+- [ ] **Step 1: Write failing growth threshold tests**
+
+Add to `tests/systems/city-territory-system.test.ts`:
+
+```ts
+it('keeps outpost population 3 without culture buildings at radius 2', () => {
+  const state = createNewGame(undefined, 'territory-growth-no');
+  const city = addCity(state, 'player', 10, 10);
+  state.cities[city.id] = { ...city, population: 3, maturity: 'outpost', buildings: [] };
+
+  expect(getCulturalTerritoryRadius(state.cities[city.id])).toBe(2);
+});
+
+it('grows to radius 3 from population, maturity, or culture buildings', () => {
+  const state = createNewGame(undefined, 'territory-growth-yes');
+  const city = addCity(state, 'player', 10, 10);
+
+  expect(getCulturalTerritoryRadius({ ...city, population: 4 })).toBe(3);
+  expect(getCulturalTerritoryRadius({ ...city, maturity: 'town' })).toBe(3);
+  expect(getCulturalTerritoryRadius({ ...city, population: 3, buildings: ['shrine'] })).toBe(3);
+  expect(getCulturalTerritoryRadius({ ...city, buildings: ['shrine', 'monument'] })).toBe(3);
+});
+```
+
+- [ ] **Step 2: Implement growth radius helper**
+
+In `src/systems/city-territory-system.ts`, add:
+
+```ts
+const CULTURE_BUILDING_IDS = new Set(
+  Object.values(BUILDINGS)
+    .filter(building => building.category === 'culture')
+    .map(building => building.id),
+);
+
+export function countCultureBuildings(city: City): number {
+  return city.buildings.filter(id => CULTURE_BUILDING_IDS.has(id)).length;
+}
+
+export function getCulturalTerritoryRadius(city: City): number {
+  const cultureBuildings = countCultureBuildings(city);
+  if (city.population >= 4) return 3;
+  if (city.maturity === 'town' || city.maturity === 'city' || city.maturity === 'metropolis') return 3;
+  if (city.population >= 3 && cultureBuildings >= 1) return 3;
+  if (cultureBuildings >= 2) return 3;
+  return 2;
+}
+```
+
+Import `BUILDINGS` from `./city-system`, and update claim generation to use `getCulturalTerritoryRadius(city)`.
+
+- [ ] **Step 3: Wire turn-flow recalculation**
+
+In `src/core/turn-manager.ts`, after city processing and before marketplace supply is calculated, add:
+
+```ts
+newState = recalculateTerritory(newState, {
+  reason: 'turn',
+  preserveCurrentHolderOnTie: true,
+}).state;
+```
+
+Import `recalculateTerritory`.
+
+- [ ] **Step 4: Write turn-manager regression**
+
+Add to `tests/core/turn-manager.test.ts`:
+
+```ts
+it('recalculates cultural territory before marketplace supply counts city territory', () => {
+  const state = createNewGame(undefined, 'turn-territory-growth');
+  const city = Object.values(state.cities).find(c => c.owner === 'player')!;
+  state.cities[city.id] = { ...city, population: 4, ownedTiles: [city.position] };
+  const radius3 = { q: city.position.q + 3, r: city.position.r };
+  const key = hexKey(radius3);
+  state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'grassland', owner: null, resource: 'horses' };
+
+  const next = processTurn(state, new EventBus());
+
+  expect(next.cities[city.id].ownedTiles.map(hexKey)).toContain(key);
+  expect(next.map.tiles[key].owner).toBe('player');
+});
+```
+
+- [ ] **Step 5: Run checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/city-territory-system.ts src/core/turn-manager.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/core/turn-manager.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit simple growth**
+
+```bash
+git add src/systems/city-territory-system.ts src/core/turn-manager.ts tests/systems/city-territory-system.test.ts tests/core/turn-manager.test.ts
+git commit -m "feat(territory): grow cultural borders from city milestones"
+```
+
+---
+
+### Task 5: MR4 Soft Trim Competition And Improvement Transfer
+
+**Files:**
+- Modify: `src/systems/city-territory-system.ts`
+- Modify: `src/systems/worker-action-system.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+- Test: `tests/systems/resource-system.test.ts`
+- Test: `tests/systems/worker-action-system.test.ts`
+
+- [ ] **Step 1: Write pressure and margin tests**
+
+Add to `tests/systems/city-territory-system.test.ts`:
+
+```ts
+it('does not flip an overlap when pressure margin is only one', () => {
+  const state = createNewGame(undefined, 'territory-soft-trim-margin-one');
+  state.cities = {};
+  const holder = addCity(state, 'player', 10, 10);
+  const challenger = addCity(state, 'ai-1', 13, 10);
+  const overlap = { q: 12, r: 10 };
+  state.map.tiles[hexKey(overlap)] = { ...state.map.tiles[hexKey(overlap)], terrain: 'grassland', owner: 'player' };
+  state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+  state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+
+  const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+  expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('player');
+});
+
+it('flips an overlap when rival pressure margin is at least two', () => {
+  const state = createNewGame(undefined, 'territory-soft-trim-margin-two');
+  state.cities = {};
+  const holder = addCity(state, 'player', 10, 10);
+  const challenger = addCity(state, 'ai-1', 13, 10);
+  const overlap = { q: 12, r: 10 };
+  state.map.tiles[hexKey(overlap)] = { ...state.map.tiles[hexKey(overlap)], terrain: 'grassland', owner: 'player' };
+  state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+  state.cities[challenger.id] = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [] };
+
+  const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+  expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
+});
+```
+
+- [ ] **Step 2: Write transfer/cancel tests**
+
+Add to `tests/systems/worker-action-system.test.ts`:
+
+```ts
+it('cancels in-progress improvement and clears worker task when territory flips', () => {
+  const start = state();
+  start.map.tiles['0,0'] = tile({ terrain: 'plains', owner: 'player', improvement: 'farm', improvementTurnsLeft: 3 });
+  start.units['worker-1'] = worker({ workerTask: { action: 'farm', coord: { q: 0, r: 0 } } });
+  start.cities['enemy-city'] = city({ id: 'enemy-city', owner: 'ai-1', position: { q: 1, r: 0 }, population: 8, maturity: 'town', ownedTiles: [] });
+  start.civilizations['ai-1'].cities.push('enemy-city');
+
+  const result = recalculateTerritory(start, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+  expect(result.state.map.tiles['0,0']).toMatchObject({ owner: 'ai-1', improvement: 'none', improvementTurnsLeft: 0 });
+  expect(result.state.units['worker-1'].workerTask).toBeUndefined();
+});
+```
+
+Add to `tests/systems/resource-system.test.ts` a completed improvement transfer yield test that creates one city per civ, flips the farm tile to the second civ, and asserts `calculateCityYields` includes farm yield only for the new owner city after `workedTiles` assignment.
+
+- [ ] **Step 3: Implement v1 pressure formula**
+
+In `src/systems/city-territory-system.ts`, add:
+
+```ts
+const MATURITY_PRESSURE_BONUS: Record<City['maturity'], number> = {
+  outpost: 0,
+  village: 1,
+  town: 2,
+  city: 3,
+  metropolis: 4,
+};
+
+export function calculateCityPressureForTile(state: GameState, city: City, coord: HexCoord): number {
+  return 6
+    + MATURITY_PRESSURE_BONUS[city.maturity]
+    + Math.floor(city.population / 2)
+    + Math.min(3, countCultureBuildings(city))
+    - cityDistance(city.position, coord, state.map);
+}
+```
+
+Populate `TerritoryClaim.pressure` from this helper.
+
+- [ ] **Step 4: Implement Soft Trim resolution**
+
+In claim sorting, preserve holder unless challenger pressure is at least 2 higher:
+
+```ts
+function resolveWinningClaim(
+  claims: TerritoryClaim[],
+  previousOwner: string | null,
+): TerritoryClaim | null {
+  const holderClaim = previousOwner ? claims.find(claim => claim.civId === previousOwner) : null;
+  const strongest = claims.slice().sort((left, right) => {
+    if (right.pressure !== left.pressure) return right.pressure - left.pressure;
+    if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
+    return left.cityId.localeCompare(right.cityId);
+  })[0] ?? null;
+  if (!strongest) return null;
+  if (holderClaim && strongest.civId !== holderClaim.civId && strongest.pressure - holderClaim.pressure < 2) {
+    return holderClaim;
+  }
+  return strongest;
+}
+```
+
+- [ ] **Step 5: Implement completed transfer and in-progress cancellation**
+
+In territory state application, when `previousOwner !== winner.civId`, transform the tile:
+
+```ts
+let nextTile = { ...tile, owner: winner.civId };
+if (tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
+  nextTile = { ...nextTile, improvement: 'none', improvementTurnsLeft: 0 };
+  nextUnits = clearWorkerTasksForCoord(nextUnits, tile.coord);
+}
+nextTiles[key] = nextTile;
+```
+
+Add `clearWorkerTasksForCoord` in `city-territory-system.ts` or export a helper from `worker-action-system.ts`; prefer keeping the territory flip cleanup inside `city-territory-system.ts` to avoid circular imports.
+
+- [ ] **Step 6: Run checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/city-territory-system.ts src/systems/worker-action-system.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/systems/resource-system.test.ts tests/systems/worker-action-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Soft Trim**
+
+```bash
+git add src/systems/city-territory-system.ts src/systems/worker-action-system.ts tests/systems/city-territory-system.test.ts tests/systems/resource-system.test.ts tests/systems/worker-action-system.test.ts
+git commit -m "feat(territory): resolve cultural pressure overlaps"
+```
+
+---
+
+### Task 6: MR5 Culture Frontier State And Explanations
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/city-territory-system.ts`
+- Create: `src/ui/territory-frontier-info.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+- Test: `tests/ui/territory-frontier-info.test.ts`
+
+- [ ] **Step 1: Add frontier types test**
+
+Add to `tests/systems/city-territory-system.test.ts`:
+
+```ts
+it('records frontier progress for contested held tiles before flipping', () => {
+  const state = createNewGame(undefined, 'territory-frontier-progress');
+  state.territoryFrontiers = {};
+  const holder = addCity(state, 'player', 10, 10);
+  const challenger = addCity(state, 'ai-1', 13, 10);
+  const coord = { q: 12, r: 10 };
+  state.map.tiles[hexKey(coord)] = { ...state.map.tiles[hexKey(coord)], terrain: 'grassland', owner: 'player' };
+  state.cities[holder.id] = { ...holder, ownedTiles: [coord] };
+  state.cities[challenger.id] = { ...challenger, population: 5, buildings: ['shrine'], ownedTiles: [] };
+
+  const result = processTerritoryFrontiers(state);
+  const frontier = result.territoryFrontiers?.[hexKey(coord)];
+
+  expect(frontier).toMatchObject({
+    holderCivId: 'player',
+    challengerCivId: 'ai-1',
+    holderCityId: holder.id,
+    challengerCityId: challenger.id,
+  });
+  expect(frontier?.reason).toContain('cultural pressure');
+});
+
+it('cleans frontier records when a source city is gone', () => {
+  const state = createNewGame(undefined, 'territory-frontier-cleanup');
+  state.territoryFrontiers = {
+    '5,5': {
+      coord: { q: 5, r: 5 },
+      holderCivId: 'player',
+      challengerCivId: 'ai-1',
+      holderCityId: 'missing-city',
+      challengerCityId: 'also-missing',
+      progress: 3,
+      trend: 'contested',
+      reason: 'Stale frontier',
+    },
+  };
+
+  const result = cleanupTerritoryFrontiers(state);
+
+  expect(result.territoryFrontiers).toEqual({});
+});
+```
+
+- [ ] **Step 2: Add serializable types**
+
+In `src/core/types.ts`, add near city/map types:
+
+```ts
+export interface TerritoryFrontierState {
+  coord: HexCoord;
+  holderCivId: string;
+  challengerCivId: string;
+  holderCityId: string;
+  challengerCityId: string;
+  progress: number;
+  trend: 'held' | 'contested' | 'likely-to-flip';
+  reason: string;
+}
+```
+
+In `GameState`, add:
+
+```ts
+territoryFrontiers?: Record<string, TerritoryFrontierState>;
+```
+
+- [ ] **Step 3: Implement frontier processing**
+
+In `src/systems/city-territory-system.ts`, add:
+
+```ts
+export function cleanupTerritoryFrontiers(state: GameState): GameState {
+  const next: Record<string, TerritoryFrontierState> = {};
+  for (const [key, frontier] of Object.entries(state.territoryFrontiers ?? {})) {
+    if (!state.cities[frontier.holderCityId] || !state.cities[frontier.challengerCityId]) continue;
+    const tile = state.map.tiles[key];
+    if (!tile || tile.owner !== frontier.holderCivId) continue;
+    next[key] = frontier;
+  }
+  return { ...state, territoryFrontiers: next };
+}
+
+export function processTerritoryFrontiers(state: GameState): GameState {
+  const territory = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+  const frontiers: Record<string, TerritoryFrontierState> = { ...(territory.state.territoryFrontiers ?? {}) };
+  for (const resolution of territory.resolutions) {
+    const holder = resolution.previousOwner;
+    const challenger = resolution.winningCivId;
+    if (!holder || !challenger || holder === challenger) continue;
+    const holderClaim = resolution.competingClaims.find(claim => claim.civId === holder);
+    const challengerClaim = resolution.competingClaims.find(claim => claim.civId === challenger);
+    if (!holderClaim || !challengerClaim) continue;
+    const key = hexKey(resolution.coord);
+    const previous = frontiers[key]?.progress ?? 0;
+    const delta = Math.max(1, challengerClaim.pressure - holderClaim.pressure);
+    const progress = Math.min(10, previous + delta);
+    frontiers[key] = {
+      coord: resolution.coord,
+      holderCivId: holder,
+      challengerCivId: challenger,
+      holderCityId: holderClaim.cityId,
+      challengerCityId: challengerClaim.cityId,
+      progress,
+      trend: progress >= 8 ? 'likely-to-flip' : 'contested',
+      reason: `${challenger} cultural pressure is challenging ${holder}.`,
+    };
+  }
+  return cleanupTerritoryFrontiers({ ...territory.state, territoryFrontiers: frontiers });
+}
+```
+
+Populate `contestedResolutions` inside `recalculateTerritory` whenever two or more claims compete for a tile, the previous holder keeps ownership, and the strongest challenger has positive pressure against the holder. `processTerritoryFrontiers` must read `contestedResolutions`, not ownership-change `resolutions`, so frontier progress records before a flip.
+
+- [ ] **Step 4: Add inspectable explanation UI**
+
+Create `src/ui/territory-frontier-info.ts`:
+
+```ts
+import type { TerritoryFrontierState } from '@/core/types';
+
+export function renderTerritoryFrontierInfo(frontier: TerritoryFrontierState): HTMLElement {
+  const panel = document.createElement('section');
+  panel.dataset.territoryFrontier = frontier.trend;
+  const title = document.createElement('div');
+  title.textContent = frontier.trend === 'likely-to-flip' ? 'Border likely to shift' : 'Contested border';
+  const reason = document.createElement('p');
+  reason.textContent = frontier.reason;
+  panel.append(title, reason);
+  return panel;
+}
+```
+
+Add a UI test that renders a `likely-to-flip` frontier and asserts visible title and reason text.
+
+- [ ] **Step 5: Run checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/city-territory-system.ts src/ui/territory-frontier-info.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/ui/territory-frontier-info.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit frontier state**
+
+```bash
+git add src/core/types.ts src/systems/city-territory-system.ts src/ui/territory-frontier-info.ts tests/systems/city-territory-system.test.ts tests/ui/territory-frontier-info.test.ts
+git commit -m "feat(territory): track cultural frontier pressure"
+```
+
+---
+
+### Task 7: MR6 Notifications, Balance Review, And Full Verification
+
+**Files:**
+- Modify: `src/systems/city-territory-system.ts`
+- Modify: `src/ui/notification-routing.ts`
+- Modify: `src/core/turn-manager.ts`
+- Modify: `src/main.ts`
+- Test: `tests/ui/notification-routing.test.ts`
+- Test: `tests/systems/city-territory-system.test.ts`
+
+- [ ] **Step 1: Write notification routing tests**
+
+Add to `tests/ui/notification-routing.test.ts`:
+
+```ts
+it('routes territory improvement transfer notifications to the previous and new owner when both have intel', () => {
+  const state = createNewGame(undefined, 'territory-transfer-notification');
+  state.civilizations.player.visibility.tiles['5,5'] = 'visible';
+  state.civilizations['ai-1'].visibility.tiles['5,5'] = 'visible';
+
+  const targets = getNotificationTargetsForEvent(state, {
+    type: 'territory:tile-flipped',
+    coord: { q: 5, r: 5 },
+    previousOwner: 'player',
+    newOwner: 'ai-1',
+    improvement: 'farm',
+    constructionCancelled: false,
+  });
+
+  expect(targets.sort()).toEqual(['ai-1', 'player']);
+});
+```
+
+- [ ] **Step 2: Add territory event payload**
+
+In `src/core/types.ts`, extend `GameEvents`:
+
+```ts
+'territory:tile-flipped': {
+  coord: HexCoord;
+  previousOwner: string | null;
+  newOwner: string | null;
+  improvement: ImprovementType;
+  constructionCancelled: boolean;
+};
+```
+
+- [ ] **Step 3: Emit events from territory changes**
+
+Where `recalculateTerritory` results are applied in turn/founding/capture paths, emit one `territory:tile-flipped` event per ownership change with:
+
+```ts
+{
+  coord: resolution.coord,
+  previousOwner: resolution.previousOwner,
+  newOwner: resolution.winningCivId,
+  improvement: tileAfter.improvement,
+  constructionCancelled: tileBefore.improvement !== 'none' && tileBefore.improvementTurnsLeft > 0,
+}
+```
+
+Do not emit events from steady-state scans where ownership did not change.
+
+- [ ] **Step 4: Add notification text**
+
+In the notification routing/display layer, use:
+
+```ts
+const message = event.constructionCancelled
+  ? 'Border shifted; in-progress construction was cancelled.'
+  : event.improvement !== 'none'
+    ? `Border shifted; ${getImprovementDisplayName(event.improvement)} transferred.`
+    : 'Border shifted.';
+```
+
+- [ ] **Step 5: Run targeted checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/city-territory-system.ts src/ui/notification-routing.ts src/main.ts
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/ui/notification-routing.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full required verification**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+./scripts/run-with-mise.sh yarn test
+git diff --stat origin/main...HEAD
+git diff --stat
+```
+
+Expected: build exits 0, full test exits 0, and diffs contain only intended territory/worker/docs changes.
+
+- [ ] **Step 7: Commit final polish**
+
+```bash
+git add src/core/types.ts src/systems/city-territory-system.ts src/ui/notification-routing.ts src/main.ts tests/systems/city-territory-system.test.ts tests/ui/notification-routing.test.ts
+git commit -m "feat(territory): notify cultural border changes"
+```
+
+## Self-Review
+
+- Spec coverage: MR1-MR6 map to ownership foundation, canonical path integration, growth, Soft Trim, culture frontier, UI feedback, save behavior, and verification.
+- UI guardrails: plan includes a truth table, misleading UI risks, replay checklist, and rendered UI tests for panel/highlight/frontier behavior.
+- Type consistency: plan uses `TerritoryClaim`, `TerritoryResolution`, `TerritoryFrontierState`, `recalculateTerritory`, and worker blocker reason names consistently.
+- Verification coverage: each task includes targeted tests and source rule checks; final task includes build, full test suite, and diff review.

--- a/docs/superpowers/specs/2026-05-15-cultural-territory-worker-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-15-cultural-territory-worker-improvements-design.md
@@ -1,0 +1,136 @@
+# Cultural Territory And Worker Improvements Design
+
+## Context
+
+GitHub issue: https://github.com/a1flecke/conquestoria/issues/157
+
+Workers must not build farms or other improvements outside their own civilization's territory. The current code already has `City.ownedTiles` and `HexTile.owner`, and recent `origin/main` rejects worker actions on unowned or enemy-owned tiles. The missing product model is a satisfying cultural territory system: cities should begin useful, stronger neighboring civilizations should be able to constrain borders, and the UI should explain why worker actions are available or blocked.
+
+This work intentionally includes the heavier cultural frontier destination, but it must be delivered in small MRs that each ship coherent behavior. Early MRs use simple radius and milestone rules; later MRs replace the resolution internals with richer culture pressure without changing the player-facing contract.
+
+## Goals
+
+- Workers can only improve tiles owned by their own civilization.
+- City territory is cultural territory, not merely a static city-radius bookkeeping field.
+- Territory remains city-attributed so existing city yields, resource supply, capture, and city panels stay coherent.
+- New cities begin with useful radius 2 territory unless clearly stronger nearby rival culture trims overlapping tiles.
+- Cultural territory can grow, compete, transfer improvements, and eventually advance through a visible frontier/progress model.
+- Selected-worker UI and map highlights show why a tile is buildable or blocked.
+- All ownership changes flow through canonical systems/helpers instead of scattered direct tile-owner mutation.
+
+## Non-Goals
+
+- Open borders does not allow workers to improve foreign tiles.
+- Workers do not build improvements for allies, vassals, or treaty partners in this work.
+- MR1 does not need the full frontier history model, but it must not introduce APIs or state shapes that block it.
+- Culture frontier UI should not ship before the underlying frontier state exists.
+
+## MR Ladder
+
+### MR1: Ownership Foundation
+
+- Founding creates radius 2 cultural territory for the new city.
+- `City.ownedTiles` remains the city-facing attribution list.
+- `HexTile.owner` remains the fast civ lookup for renderer, worker actions, and resource systems.
+- Workers can improve only own-civ tiles.
+- The selected-worker map guidance distinguishes buildable tiles from blocked tiles.
+
+### MR2: Deterministic Territory Recalculation
+
+- Add a canonical helper that recalculates city-attributed territory from city claims.
+- Founding, capture, raze, city loss, and save normalization use that helper instead of manual tile-owner edits.
+- The first implementation may still use simple radius bands, but it must centralize claim generation, claim resolution, and state application.
+
+### MR3: Simple Cultural Growth
+
+- Cities can grow from radius 2 to radius 3 during turn processing.
+- Growth eligibility comes from simple population/maturity milestones plus culture-building modifiers.
+- Growth happens once per round/turn flow, while major political events still recalculate immediately.
+
+### MR4: Soft Trim Competition
+
+- Overlapping city claims compare a simple pressure score.
+- A rival claim wins or keeps an overlapping tile only when its pressure beats the competing claim by at least `2`.
+- Ties and smaller margins preserve the current holder when possible, then use deterministic city-id tie-breakers.
+- Improvements transfer with the tile owner when a tile flips.
+
+### MR5: Culture Frontier
+
+- Add persistent frontier state for contested tiles.
+- Frontier state tracks current holder, challenger, pressure source city, accumulated progress, trend, and player-facing reason text.
+- Border changes can occur through gradual culture pressure, not only milestone recalculation.
+- The player can inspect why a tile is held, contested, or likely to flip.
+
+### MR6: UX Polish And Balance
+
+- Tune thresholds and pressure weights.
+- Add notification-log entries for meaningful border changes, especially improvement transfers.
+- Make selected-worker and border guidance clear enough for normal play.
+
+## Architecture
+
+`src/systems/city-territory-system.ts` should become the canonical territory module. It owns three responsibilities:
+
+1. Claim generation: create candidate tile claims for each city.
+2. Claim resolution: choose a winning city for each tile.
+3. State application: update `City.ownedTiles`, `HexTile.owner`, and invalid worked-tile claims.
+
+Other systems should call this module rather than editing territorial ownership directly. The relevant paths include city founding, city capture, raze/city loss, turn processing, save normalization, and any future culture-frontier tick.
+
+The model stays city-attributed. `HexTile.owner` stores the owning civ id for fast lookup. `City.ownedTiles` stores which city controls the tile. If a tile belongs to a civ, exactly one living city of that civ should attribute it unless the tile is intentionally neutral/unowned.
+
+Existing city work normalization should remain part of the application path. If a city loses a tile, its `workedTiles` must drop that coordinate before yields are calculated again.
+
+## Gameplay Rules
+
+Workers may only improve tiles where `tile.owner === worker.owner`. This remains true even with open borders.
+
+Newly founded cities claim radius 2 territory, excluding invalid claim terrain such as ocean and mountains. Early MRs can use radius bands. Later MRs add pressure and frontier progress without changing the rule that worker improvements require own-civ ownership.
+
+Gradual growth happens during turn flow. Founding, capture, raze, and city loss recalculate immediately so major political events feel responsive.
+
+When a tile changes owner through cultural pressure, existing improvements stay on the tile and become usable by the new owner. The old owner must stop receiving yields from that tile as soon as territory is recalculated.
+
+Soft Trim defines "clearly stronger rival pressure" as pressure at least `2` higher than the competing claim. The exact pressure formula can evolve across MRs, but the margin requirement is part of the player-facing contract unless later design explicitly changes it.
+
+## UI And Feedback
+
+When a worker is selected, the map should show improvement guidance:
+
+- Green: owned by the worker's civ and at least one worker action is valid.
+- Amber: owned by the worker's civ but blocked by terrain, city center, existing improvement, missing river, missing tech, or another local rule.
+- Red: otherwise plausible improvement terrain blocked because the tile is foreign or unowned.
+
+The selected-unit panel should explain why the worker has no action on the current tile. Examples include "Outside your territory", "City centers cannot be improved", "Requires river", "Already improved", and "Requires technology".
+
+MR4 and later should add notification-log entries when a tile flips between civs. If a tile has a completed or in-progress improvement, the notification should mention that the improvement transferred. MR5 should add inspectable frontier explanations only after frontier state exists.
+
+## Error Handling And Save Behavior
+
+`applyWorkerAction` must reject outside-territory actions at the mutation layer even if the UI is stale. It should return a specific failure reason for outside territory instead of only a generic invalid action.
+
+Legacy saves should normalize ownership when loaded. If `City.ownedTiles` and `HexTile.owner` disagree, territory recalculation should rebuild ownership first, then city work normalization should remove invalid worked tiles.
+
+Territory recalculation must be deterministic. Identical state must produce identical ownership, including tie-breaks, so tests and saves remain stable.
+
+## Testing Requirements
+
+Each MR needs focused regressions:
+
+- Founding radius 2 claims land, avoids invalid terrain, and updates `HexTile.owner`.
+- Workers cannot improve unowned or foreign tiles; the mutation result reports the outside-territory reason.
+- Selected-worker UI/map guidance shows buildable, owned-blocked, and foreign-blocked tiles distinctly.
+- Territory recalculation is deterministic across founding, capture, raze, city loss, and load normalization.
+- Radius 3 growth happens only when milestone thresholds are met.
+- Soft Trim flips overlapping claims only when pressure margin is at least `2`; margin `0` or `1` is insufficient.
+- Improvement transfer causes the new owner to receive yields and the old owner to stop receiving yields.
+- Culture frontier progress produces deterministic flips and visible explanations for held, contested, and likely-to-flip tiles.
+
+## Implementation Guardrails
+
+- Keep state serializable plain objects.
+- Use axial hex coordinates and existing wrapped-coordinate helpers.
+- Do not branch shared gameplay logic on platform or distribution.
+- Do not ship player-visible actions whose backing behavior is deferred to a later MR.
+- If an MR exposes a button, highlight, notification, or inspection label, tests must prove the live UI path renders or updates it.
+- Before implementation begins, create a separate implementation plan that maps each MR to files, tests, and verification commands.

--- a/docs/superpowers/specs/2026-05-15-cultural-territory-worker-improvements-design.md
+++ b/docs/superpowers/specs/2026-05-15-cultural-territory-worker-improvements-design.md
@@ -6,7 +6,7 @@ GitHub issue: https://github.com/a1flecke/conquestoria/issues/157
 
 Workers must not build farms or other improvements outside their own civilization's territory. The current code already has `City.ownedTiles` and `HexTile.owner`, and recent `origin/main` rejects worker actions on unowned or enemy-owned tiles. The missing product model is a satisfying cultural territory system: cities should begin useful, stronger neighboring civilizations should be able to constrain borders, and the UI should explain why worker actions are available or blocked.
 
-This work intentionally includes the heavier cultural frontier destination, but it must be delivered in small MRs that each ship coherent behavior. Early MRs use simple radius and milestone rules; later MRs replace the resolution internals with richer culture pressure without changing the player-facing contract.
+This work intentionally includes the heavier cultural frontier destination, but it must be delivered in small MRs that each ship coherent behavior. Early MRs use simple radius and milestone rules while introducing the same canonical ownership path that later MRs will enrich with pressure and frontier state. No MR should add a temporary ownership path that must be thrown away later.
 
 ## Goals
 
@@ -27,24 +27,31 @@ This work intentionally includes the heavier cultural frontier destination, but 
 
 ## MR Ladder
 
-### MR1: Ownership Foundation
+### MR1: Canonical Ownership Foundation
 
+- Add the first canonical territory recalculation helper in `city-territory-system`.
 - Founding creates radius 2 cultural territory for the new city.
+- Radius 2 claims include valid land tiles and exclude ocean and mountains.
+- New founding claims may take neutral tiles and same-civ tiles, but they do not steal valid foreign-held tiles in MR1. This is the early "strong neighbor protection" rule until pressure-based Soft Trim arrives.
 - `City.ownedTiles` remains the city-facing attribution list.
 - `HexTile.owner` remains the fast civ lookup for renderer, worker actions, and resource systems.
 - Workers can improve only own-civ tiles.
-- The selected-worker map guidance distinguishes buildable tiles from blocked tiles.
+- The selected-worker panel explains the current tile, and selected-worker map guidance distinguishes buildable tiles from blocked tiles in movement-preview range.
 
-### MR2: Deterministic Territory Recalculation
+### MR2: Ownership Path Integration
 
-- Add a canonical helper that recalculates city-attributed territory from city claims.
-- Founding, capture, raze, city loss, and save normalization use that helper instead of manual tile-owner edits.
-- The first implementation may still use simple radius bands, but it must centralize claim generation, claim resolution, and state application.
+- Keep founding on the MR1 helper, and move capture, raze, city loss, save normalization, and territory-normalization turn hooks onto the canonical territory helper.
+- Remove or bypass scattered manual tile-owner edits in those paths.
+- Preserve deterministic holder tie-break behavior when migrating old or partially inconsistent state.
 
 ### MR3: Simple Cultural Growth
 
 - Cities can grow from radius 2 to radius 3 during turn processing.
-- Growth eligibility comes from simple population/maturity milestones plus culture-building modifiers.
+- A city qualifies for radius 3 when any of these are true:
+  - population is at least 4
+  - maturity is `town`, `city`, or `metropolis`
+  - population is at least 3 and the city has at least one culture-category building
+  - the city has at least two culture-category buildings
 - Growth happens once per round/turn flow, while major political events still recalculate immediately.
 
 ### MR4: Soft Trim Competition
@@ -52,14 +59,17 @@ This work intentionally includes the heavier cultural frontier destination, but 
 - Overlapping city claims compare a simple pressure score.
 - A rival claim wins or keeps an overlapping tile only when its pressure beats the competing claim by at least `2`.
 - Ties and smaller margins preserve the current holder when possible, then use deterministic city-id tie-breakers.
-- Improvements transfer with the tile owner when a tile flips.
+- Completed improvements transfer with the tile owner when a tile flips.
+- In-progress improvements do not transfer. If a tile with `improvementTurnsLeft > 0` flips, the construction is cancelled, the tile resets to `improvement: 'none'`, and any worker task assigned to that tile is cleared.
 
 ### MR5: Culture Frontier
 
 - Add persistent frontier state for contested tiles.
-- Frontier state tracks current holder, challenger, pressure source city, accumulated progress, trend, and player-facing reason text.
+- Frontier state lives in serializable game state, keyed by tile coordinate.
+- Frontier state tracks current holder, challenger, holder city, challenger city, accumulated progress, trend, and player-facing reason text.
 - Border changes can occur through gradual culture pressure, not only milestone recalculation.
 - The player can inspect why a tile is held, contested, or likely to flip.
+- Frontier records are deleted when their tile no longer has competing claims, when either source city is gone, or when a city capture/raze/loss invalidates the holder or challenger.
 
 ### MR6: UX Polish And Balance
 
@@ -69,47 +79,63 @@ This work intentionally includes the heavier cultural frontier destination, but 
 
 ## Architecture
 
-`src/systems/city-territory-system.ts` should become the canonical territory module. It owns three responsibilities:
+`src/systems/city-territory-system.ts` should become the canonical territory module. It owns three responsibilities from MR1 onward:
 
 1. Claim generation: create candidate tile claims for each city.
 2. Claim resolution: choose a winning city for each tile.
 3. State application: update `City.ownedTiles`, `HexTile.owner`, and invalid worked-tile claims.
 
-Other systems should call this module rather than editing territorial ownership directly. The relevant paths include city founding, city capture, raze/city loss, turn processing, save normalization, and any future culture-frontier tick.
+Other systems should call this module rather than editing territorial ownership directly. MR1 wires founding. MR2 wires city capture, raze/city loss, save normalization, and territory-normalization turn hooks. MR3 adds growth to the turn hook. MR5 adds the culture-frontier tick.
 
 The model stays city-attributed. `HexTile.owner` stores the owning civ id for fast lookup. `City.ownedTiles` stores which city controls the tile. If a tile belongs to a civ, exactly one living city of that civ should attribute it unless the tile is intentionally neutral/unowned.
 
 Existing city work normalization should remain part of the application path. If a city loses a tile, its `workedTiles` must drop that coordinate before yields are calculated again.
 
+The helper APIs should expose structured claim and resolution metadata so later MRs can add pressure/frontier behavior without changing every caller. The intended shape is:
+
+- `TerritoryClaim`: city id, civ id, coord, radius band, pressure score, and reason.
+- `TerritoryResolution`: coord, previous owner, winning city/civ or neutral, competing claims, and ownership-change reason.
+- `recalculateTerritory(state, options)`: returns a new state plus changed-tile metadata for UI/events.
+
 ## Gameplay Rules
 
 Workers may only improve tiles where `tile.owner === worker.owner`. This remains true even with open borders.
 
-Newly founded cities claim radius 2 territory, excluding invalid claim terrain such as ocean and mountains. Early MRs can use radius bands. Later MRs add pressure and frontier progress without changing the rule that worker improvements require own-civ ownership.
+Newly founded cities claim radius 2 territory, excluding invalid claim terrain such as ocean and mountains. MR1 does not steal valid foreign-held tiles. Later MRs add pressure and frontier progress without changing the rule that worker improvements require own-civ ownership.
 
 Gradual growth happens during turn flow. Founding, capture, raze, and city loss recalculate immediately so major political events feel responsive.
 
-When a tile changes owner through cultural pressure, existing improvements stay on the tile and become usable by the new owner. The old owner must stop receiving yields from that tile as soon as territory is recalculated.
+When a tile changes owner through cultural pressure, completed improvements stay on the tile and become usable by the new owner. The old owner must stop receiving yields from that tile as soon as territory is recalculated. In-progress improvements are cancelled on flip, because the original worker can no longer legally complete the work and the new owner did not spend the worker action.
 
-Soft Trim defines "clearly stronger rival pressure" as pressure at least `2` higher than the competing claim. The exact pressure formula can evolve across MRs, but the margin requirement is part of the player-facing contract unless later design explicitly changes it.
+Soft Trim defines "clearly stronger rival pressure" as pressure at least `2` higher than the competing claim. MR4 uses this v1 pressure formula:
+
+```text
+pressure = 6 + maturityBonus + floor(population / 2) + cultureBonus - distance
+```
+
+- `maturityBonus`: outpost 0, village 1, town 2, city 3, metropolis 4.
+- `cultureBonus`: +1 per culture-category building, capped at +3.
+- `distance`: wrapped city distance from city center to the tile.
+
+The formula can be tuned in MR6, but the `+2` margin requirement is part of the player-facing contract unless later design explicitly changes it.
 
 ## UI And Feedback
 
-When a worker is selected, the map should show improvement guidance:
+When a worker is selected, the map should show improvement guidance in movement-preview range. The selected-unit panel explains the worker's current tile. The map preview explains where the worker could move and then build.
 
 - Green: owned by the worker's civ and at least one worker action is valid.
 - Amber: owned by the worker's civ but blocked by terrain, city center, existing improvement, missing river, missing tech, or another local rule.
-- Red: otherwise plausible improvement terrain blocked because the tile is foreign or unowned.
+- Red: otherwise plausible improvement terrain blocked because the tile is foreign or unowned. Red should be limited to visible or fog-known tiles where showing the terrain does not leak unexplored information.
 
 The selected-unit panel should explain why the worker has no action on the current tile. Examples include "Outside your territory", "City centers cannot be improved", "Requires river", "Already improved", and "Requires technology".
 
-MR4 and later should add notification-log entries when a tile flips between civs. If a tile has a completed or in-progress improvement, the notification should mention that the improvement transferred. MR5 should add inspectable frontier explanations only after frontier state exists.
+MR4 and later should add notification-log entries when a tile flips between civs. If a tile has a completed improvement, the notification should mention that the improvement transferred. If in-progress construction is cancelled, the notification should mention cancellation instead of transfer. MR5 should add inspectable frontier explanations only after frontier state exists.
 
 ## Error Handling And Save Behavior
 
 `applyWorkerAction` must reject outside-territory actions at the mutation layer even if the UI is stale. It should return a specific failure reason for outside territory instead of only a generic invalid action.
 
-Legacy saves should normalize ownership when loaded. If `City.ownedTiles` and `HexTile.owner` disagree, territory recalculation should rebuild ownership first, then city work normalization should remove invalid worked tiles.
+Legacy saves should normalize ownership when loaded. If `City.ownedTiles` and `HexTile.owner` disagree, territory recalculation should use the existing `HexTile.owner` as the current holder for tie preservation, rebuild ownership through the canonical helper, then city work normalization should remove invalid worked tiles. This avoids surprising players by flipping every ambiguous legacy tile at once.
 
 Territory recalculation must be deterministic. Identical state must produce identical ownership, including tie-breaks, so tests and saves remain stable.
 
@@ -118,13 +144,16 @@ Territory recalculation must be deterministic. Identical state must produce iden
 Each MR needs focused regressions:
 
 - Founding radius 2 claims land, avoids invalid terrain, and updates `HexTile.owner`.
+- Founding beside valid foreign-held territory does not steal that foreign territory in MR1.
 - Workers cannot improve unowned or foreign tiles; the mutation result reports the outside-territory reason.
 - Selected-worker UI/map guidance shows buildable, owned-blocked, and foreign-blocked tiles distinctly.
 - Territory recalculation is deterministic across founding, capture, raze, city loss, and load normalization.
 - Radius 3 growth happens only when milestone thresholds are met.
 - Soft Trim flips overlapping claims only when pressure margin is at least `2`; margin `0` or `1` is insufficient.
-- Improvement transfer causes the new owner to receive yields and the old owner to stop receiving yields.
+- Completed improvement transfer causes the new owner to receive yields and the old owner to stop receiving yields.
+- In-progress improvement flips cancel construction and clear the original worker task.
 - Culture frontier progress produces deterministic flips and visible explanations for held, contested, and likely-to-flip tiles.
+- Frontier records are cleaned up when source cities are captured, razed, lost, or no longer competing for the tile.
 
 ## Implementation Guardrails
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -46,7 +46,11 @@ import { processDetection } from '@/systems/detection-system';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
-import { recalculateTerritory } from '@/systems/city-territory-system';
+import {
+  applyTerritoryFrontierProgressWithEvents,
+  buildTerritoryTileFlippedEvents,
+  recalculateTerritory,
+} from '@/systems/city-territory-system';
 import {
   getLegendaryWonderCityYieldBonus,
   getLegendaryWonderCivYieldBonus,
@@ -361,10 +365,23 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     }
   }
 
-  newState = recalculateTerritory(newState, {
+  const territoryBefore = newState;
+  const territoryResult = recalculateTerritory(territoryBefore, {
     reason: 'turn',
     preserveCurrentHolderOnTie: true,
-  }).state;
+  });
+  for (const event of buildTerritoryTileFlippedEvents(territoryBefore, territoryResult.state, territoryResult.resolutions)) {
+    bus.emit('territory:tile-flipped', event);
+  }
+  const frontierResult = applyTerritoryFrontierProgressWithEvents(territoryResult);
+  for (const event of buildTerritoryTileFlippedEvents(
+    territoryResult.state,
+    frontierResult.state,
+    frontierResult.flippedResolutions,
+  )) {
+    bus.emit('territory:tile-flipped', event);
+  }
+  newState = frontierResult.state;
 
   newState = tickLegendaryWonderProjects(newState, bus);
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -46,6 +46,7 @@ import { processDetection } from '@/systems/detection-system';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
+import { recalculateTerritory } from '@/systems/city-territory-system';
 import {
   getLegendaryWonderCityYieldBonus,
   getLegendaryWonderCivYieldBonus,
@@ -359,6 +360,11 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       city.productionDisabledTurns = Math.max(0, (city.productionDisabledTurns ?? 0) - 1);
     }
   }
+
+  newState = recalculateTerritory(newState, {
+    reason: 'turn',
+    preserveCurrentHolderOnTie: true,
+  }).state;
 
   newState = tickLegendaryWonderProjects(newState, bus);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -186,6 +186,17 @@ export interface GameMap {
   rivers: Array<{ from: HexCoord; to: HexCoord }>;
 }
 
+export interface TerritoryFrontierState {
+  coord: HexCoord;
+  holderCivId: string;
+  challengerCivId: string;
+  holderCityId: string;
+  challengerCityId: string;
+  progress: number;
+  trend: 'held' | 'contested' | 'likely-to-flip';
+  reason: string;
+}
+
 // --- Visibility (per player) ---
 
 export interface VisibilityMap {
@@ -999,6 +1010,7 @@ export interface GameState {
   embargoes: Embargo[];
   defensiveLeagues: DefensiveLeague[];
   pendingDiplomacyRequests?: PendingDiplomaticRequest[];
+  territoryFrontiers?: Record<string, TerritoryFrontierState>;
   mapScript?: MapScript;  // undefined on old saves → treat as 'procedural'
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1061,6 +1061,13 @@ export interface GameEvents {
   'fog:revealed': { tiles: HexCoord[] };
   'improvement:started': { unitId: string; coord: HexCoord; type: ImprovementType };
   'improvement:completed': { coord: HexCoord; type: ImprovementType };
+  'territory:tile-flipped': {
+    coord: HexCoord;
+    previousOwner: string;
+    newOwner: string;
+    improvement: ImprovementType;
+    constructionCancelled: boolean;
+  };
   'civilization:first-contact': { civA: string; civB: string };
   'barbarian:spawned': { campId: string; unitId: string };
   'barbarian:camp-destroyed': { campId: string; reward: number };

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -1,7 +1,9 @@
-import type { GameState, HexCoord } from '@/core/types';
+import type { GameState, HexCoord, WorkerActionType } from '@/core/types';
 import type { HexHighlight } from '@/renderer/render-loop';
 import { getAttackTargets, type AttackTarget } from '@/systems/attack-targeting';
+import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
+import { getAvailableWorkerActions } from '@/systems/improvement-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getMovementRange } from '@/systems/unit-system';
 
@@ -9,6 +11,60 @@ export interface SelectedUnitHighlightResult {
   movementRange: HexCoord[];
   attackTargets: AttackTarget[];
   highlights: HexHighlight[];
+}
+
+const WORKER_ACTIONS: WorkerActionType[] = ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp'];
+
+function isCityTile(state: GameState, coord: HexCoord): boolean {
+  const key = hexKey(coord);
+  return Object.values(state.cities).some(city => hexKey(city.position) === key);
+}
+
+function isPlausibleWorkerActionTile(
+  state: GameState,
+  coord: HexCoord,
+  completedTechs: string[],
+): boolean {
+  const tile = state.map.tiles[hexKey(coord)];
+  if (!tile) return false;
+  return getAvailableWorkerActions(tile, completedTechs, undefined, { isCityTile: isCityTile(state, coord) })
+    .some(action => WORKER_ACTIONS.includes(action));
+}
+
+function buildWorkerGuidanceHighlights(
+  state: GameState,
+  unitId: string,
+  movementRange: HexCoord[],
+): HexHighlight[] {
+  const unit = state.units[unitId];
+  if (!unit || unit.type !== 'worker') return [];
+
+  const visibility = state.civilizations[state.currentPlayer]?.visibility;
+  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  const coords = [unit.position, ...movementRange];
+  const seenKeys = new Set<string>();
+  const highlights: HexHighlight[] = [];
+
+  for (const coord of coords) {
+    const key = hexKey(coord);
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+    const tile = state.map.tiles[key];
+    if (!tile) continue;
+    if (visibility && getVisibility(visibility, coord) === 'unexplored') continue;
+
+    const options = { isCityTile: isCityTile(state, coord) };
+    const availableActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, options);
+    if (availableActions.length > 0) {
+      highlights.push({ coord, type: 'worker-buildable' });
+    } else if (tile.owner === unit.owner) {
+      highlights.push({ coord, type: 'worker-owned-blocked' });
+    } else if (isPlausibleWorkerActionTile(state, coord, completedTechs)) {
+      highlights.push({ coord, type: 'worker-foreign-blocked' });
+    }
+  }
+
+  return highlights;
 }
 
 export function buildSelectedUnitHighlights(state: GameState, unitId: string): SelectedUnitHighlightResult {
@@ -28,10 +84,11 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
     .map(coord => ({ coord, type: 'move' as const }));
 
   const attackHighlights = attackTargets.map(target => ({ coord: target.coord, type: 'attack' as const }));
+  const workerHighlights = buildWorkerGuidanceHighlights(state, unitId, movementRange);
 
   return {
     movementRange,
     attackTargets,
-    highlights: [...moveHighlights, ...attackHighlights],
+    highlights: [...moveHighlights, ...attackHighlights, ...workerHighlights],
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,6 +129,8 @@ import {
   routeLegendaryWonder,
   routePeaceMade,
   routePeaceRequested,
+  routeTerritoryTileFlipped,
+  getTerritoryTileFlippedMessage,
   routeWarDeclared,
   type NotificationSink,
 } from '@/ui/notification-routing';
@@ -136,6 +138,7 @@ import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
 import { initializeDesktopMenu } from '@/platform/desktop-menu';
 import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
 import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
+import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
@@ -2045,7 +2048,9 @@ function handleHexLongPress(rawCoord: HexCoord): void {
   }
 
   const wonderInfo = tile.wonder ? ` · ⭐ ${getWonderDefinition(tile.wonder)?.name ?? tile.wonder}` : '';
-  showNotification(`${tile.terrain} · ${tile.elevation}${tile.improvement !== 'none' ? ' · ' + getImprovementDisplayName(tile.improvement) : ''}${tile.resource ? ' · ' + tile.resource : ''}${wonderInfo}`);
+  const frontier = gameState.territoryFrontiers?.[hexKey(coord)];
+  const frontierInfo = frontier ? ` · ${renderTerritoryFrontierInfo(frontier).textContent ?? ''}` : '';
+  showNotification(`${tile.terrain} · ${tile.elevation}${tile.improvement !== 'none' ? ' · ' + getImprovementDisplayName(tile.improvement) : ''}${tile.resource ? ' · ' + tile.resource : ''}${wonderInfo}${frontierInfo}`);
 }
 
 function handleVictoryIfNeeded(): boolean {
@@ -2481,6 +2486,13 @@ bus.on('combat:resolved', ({ result }) => {
 
 bus.on('combat:reward-earned', ({ reward }) => {
   routeCombatRewardEarned(gameState, reward, appendToCivLog);
+});
+
+bus.on('territory:tile-flipped', event => {
+  routeTerritoryTileFlipped(gameState, { type: 'territory:tile-flipped', ...event }, appendToCivLog);
+  if (event.previousOwner === gameState.currentPlayer || event.newOwner === gameState.currentPlayer) {
+    showNotification(getTerritoryTileFlippedMessage(event), event.constructionCancelled ? 'warning' : 'info');
+  }
 });
 
 bus.on('barbarian:spawned', ({ campId, unitId }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { hexKey, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-u
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
 import { foundCity } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
-import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
+import { formatCityFoundingBlockerMessage, getCityFoundingBlockers, recalculateTerritory } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
@@ -1398,22 +1398,19 @@ function foundCityAction(): void {
   gameState.cities[city.id] = city;
   currentCiv().cities.push(city.id);
   gameState = initializeLegendaryWonderProjectsForCity(gameState, cp, city.id);
-
-  // Mark tiles as owned
-  for (const coord of city.ownedTiles) {
-    const key = hexKey(coord);
-    if (gameState.map.tiles[key]) {
-      gameState.map.tiles[key].owner = cp;
-    }
-  }
+  gameState = recalculateTerritory(gameState, {
+    reason: 'founding',
+    preserveForeignHolders: true,
+  }).state;
 
   // Remove settler
   delete gameState.units[selectedUnitId];
   currentCiv().units = currentCiv().units.filter(id => id !== selectedUnitId);
 
   deselectUnit();
-  bus.emit('city:founded', { city });
-  showNotification(`${city.name} has been founded!`, 'success');
+  const foundedCity = gameState.cities[city.id] ?? city;
+  bus.emit('city:founded', { city: foundedCity });
+  showNotification(`${foundedCity.name} has been founded!`, 'success');
   SFX.foundCity();
 
   // Update visibility

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -18,8 +18,16 @@ import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
 
 export interface HexHighlight {
   coord: HexCoord;
-  type: 'move' | 'attack';
+  type: 'move' | 'attack' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
 }
+
+const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
+  move: 'rgba(74, 144, 217, 0.35)',
+  attack: 'rgba(217, 74, 74, 0.45)',
+  'worker-buildable': 'rgba(80, 200, 120, 0.45)',
+  'worker-owned-blocked': 'rgba(232, 193, 112, 0.40)',
+  'worker-foreign-blocked': 'rgba(217, 74, 74, 0.35)',
+};
 
 export class RenderLoop {
   private ctx: CanvasRenderingContext2D;
@@ -150,7 +158,7 @@ export class RenderLoop {
         const pixel = hexToPixel(renderCoord, this.camera.hexSize);
         const screen = this.camera.worldToScreen(pixel.x, pixel.y);
         const scaledSize = this.camera.hexSize * this.camera.zoom;
-        const color = highlight.type === 'move' ? 'rgba(74, 144, 217, 0.35)' : 'rgba(217, 74, 74, 0.45)';
+        const color = HEX_HIGHLIGHT_COLORS[highlight.type];
         drawHexHighlight(this.ctx, screen.x, screen.y, scaledSize, color);
       }
     }

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -2,7 +2,7 @@ import type { City, CityFocus, CityMaturity, GameState, SaveSlotMeta } from '@/c
 import { drawNextCityName } from '@/systems/city-name-system';
 import { createEmptyCityGrid } from '@/systems/city-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from '@/systems/city-maturity-system';
-import { canonicalizeCityCoord, normalizeCityWorkClaims } from '@/systems/city-territory-system';
+import { canonicalizeCityCoord, normalizeCityWorkClaims, recalculateTerritory } from '@/systems/city-territory-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { dbGet, dbPut, dbDelete, dbGetAllKeys } from './db';
@@ -69,24 +69,39 @@ function normalizeLegacyCitySimState(state: GameState): GameState {
   for (const [cityId, city] of Object.entries(state.cities ?? {})) {
     const rawGridSize = Number(city.gridSize);
     const gridSize: 3 | 5 | 7 = rawGridSize >= 7 ? 7 : rawGridSize >= 5 ? 5 : 3;
+    const canonicalizeLoadedCoord = (coord: { q: number; r: number }) => (
+      state.map ? canonicalizeCityCoord(coord, state.map) : { ...coord }
+    );
     cities[cityId] = {
       ...city,
-      ownedTiles: (city.ownedTiles ?? []).map(coord => canonicalizeCityCoord(coord, state.map)),
-      workedTiles: (city.workedTiles ?? []).map(coord => canonicalizeCityCoord(coord, state.map)),
+      ownedTiles: (city.ownedTiles ?? []).map(canonicalizeLoadedCoord),
+      workedTiles: (city.workedTiles ?? []).map(canonicalizeLoadedCoord),
       focus: (city.focus ?? INITIAL_CITY_FOCUS) as CityFocus,
       maturity: (city.maturity ?? INITIAL_CITY_MATURITY) as CityMaturity,
       grid: normalizeCityGrid(city.grid),
       gridSize,
     };
   }
-  return normalizeCityWorkClaims({ ...state, cities }).state;
+  return { ...state, cities };
 }
 
 function normalizeLoadedState(state: GameState): GameState {
-  const normalized = normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state))));
+  const normalizedCityState = normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state))));
+  if (!normalizedCityState.map?.tiles) {
+    normalizedCityState.pendingDiplomacyRequests ??= [];
+    return normalizedCityState;
+  }
+  const territoryNormalized = recalculateTerritory(normalizedCityState, {
+    reason: 'load',
+    preserveForeignHolders: true,
+    preserveCurrentHolderOnTie: true,
+  }).state;
+  const normalized = normalizeCityWorkClaims(territoryNormalized).state;
   normalized.pendingDiplomacyRequests ??= [];
   return normalized;
 }
+
+export const normalizeLoadedStateForTest = normalizeLoadedState;
 
 function getCityNamingInfo(state: GameState, ownerId: string): { civType: string; civName: string; namingPool?: string[] } {
   const majorCiv = state.civilizations[ownerId];

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -1,8 +1,8 @@
 import type { City, GameState, LegendaryWonderProject } from '@/core/types';
 import { reconquerBreakawayCity } from '@/systems/breakaway-system';
 import { BUILDINGS } from '@/systems/city-system';
+import { recalculateTerritory } from '@/systems/city-territory-system';
 import { modifyRelationship } from '@/systems/diplomacy-system';
-import { hexKey } from '@/systems/hex-utils';
 
 export type MajorCityCaptureDisposition = 'occupy' | 'raze';
 
@@ -79,15 +79,20 @@ export function resolveMajorCityCapture(
 
   if (forcedDisposition === 'occupy' && previousOwner?.breakaway?.originOwnerId === newOwnerId) {
     const reconquered = reconquerBreakawayCity(state, newOwnerId, previousOwnerId, cityId);
+    const nextState = {
+      ...reconquered,
+      legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
+        reconquered.legendaryWonderProjects,
+        cityId,
+        newOwnerId,
+      ),
+    };
+    const territoryResult = recalculateTerritory(nextState, {
+      reason: 'capture',
+      preserveCurrentHolderOnTie: true,
+    });
     return {
-      state: {
-        ...reconquered,
-        legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
-          reconquered.legendaryWonderProjects,
-          cityId,
-          newOwnerId,
-        ),
-      },
+      state: territoryResult.state,
       outcome: 'occupied',
       goldAwarded: 0,
     };
@@ -108,58 +113,44 @@ export function resolveMajorCityCapture(
       },
     };
 
-    const nextTiles = { ...state.map.tiles };
-    for (const coord of occupiedCity.ownedTiles) {
-      const key = hexKey(coord);
-      if (nextTiles[key]) {
-        nextTiles[key] = { ...nextTiles[key], owner: newOwnerId };
-      }
-    }
+    const nextState: GameState = {
+      ...state,
+      cities: {
+        ...state.cities,
+        [cityId]: occupiedCity,
+      },
+      civilizations: {
+        ...state.civilizations,
+        ...(previousOwner ? {
+          [previousOwnerId]: {
+            ...previousOwner,
+            cities: previousOwner.cities.filter(id => id !== cityId),
+          },
+        } : {}),
+        [newOwnerId]: {
+          ...capturingCiv,
+          cities: capturingCiv.cities.includes(cityId) ? capturingCiv.cities : [...capturingCiv.cities, cityId],
+        },
+      },
+      legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
+        state.legendaryWonderProjects,
+        cityId,
+        newOwnerId,
+      ),
+    };
+    const territoryResult = recalculateTerritory(nextState, {
+      reason: 'capture',
+      preserveCurrentHolderOnTie: true,
+    });
 
     return {
-      state: {
-        ...state,
-        map: {
-          ...state.map,
-          tiles: nextTiles,
-        },
-        cities: {
-          ...state.cities,
-          [cityId]: occupiedCity,
-        },
-        civilizations: {
-          ...state.civilizations,
-          ...(previousOwner ? {
-            [previousOwnerId]: {
-              ...previousOwner,
-              cities: previousOwner.cities.filter(id => id !== cityId),
-            },
-          } : {}),
-          [newOwnerId]: {
-            ...capturingCiv,
-            cities: capturingCiv.cities.includes(cityId) ? capturingCiv.cities : [...capturingCiv.cities, cityId],
-          },
-        },
-        legendaryWonderProjects: transferLegendaryWonderProjectsForCity(
-          state.legendaryWonderProjects,
-          cityId,
-          newOwnerId,
-        ),
-      },
+      state: territoryResult.state,
       outcome: 'occupied',
       goldAwarded: 0,
     };
   }
 
   const goldAwarded = computeRazeGold(city);
-  const nextTiles = { ...state.map.tiles };
-  for (const coord of city.ownedTiles) {
-    const key = hexKey(coord);
-    if (nextTiles[key]) {
-      nextTiles[key] = { ...nextTiles[key], owner: null };
-    }
-  }
-
   const nextCivilizations = {
     ...state.civilizations,
     ...(previousOwner ? {
@@ -178,17 +169,19 @@ export function resolveMajorCityCapture(
   const nextCities = { ...state.cities };
   delete nextCities[cityId];
 
+  const nextState: GameState = {
+    ...state,
+    cities: nextCities,
+    civilizations: nextCivilizations,
+    legendaryWonderProjects: removeLegendaryWonderProjectsForCity(state.legendaryWonderProjects, cityId),
+  };
+  const territoryResult = recalculateTerritory(nextState, {
+    reason: 'raze',
+    preserveCurrentHolderOnTie: true,
+  });
+
   return {
-    state: {
-      ...state,
-      map: {
-        ...state.map,
-        tiles: nextTiles,
-      },
-      cities: nextCities,
-      civilizations: nextCivilizations,
-      legendaryWonderProjects: removeLegendaryWonderProjectsForCity(state.legendaryWonderProjects, cityId),
-    },
+    state: territoryResult.state,
     outcome: 'razed',
     goldAwarded,
   };
@@ -213,10 +206,13 @@ export function transferCapturedCityOwnership(
   }
 
   if (previousOwner?.breakaway?.originOwnerId === newOwnerId) {
-    return reconquerBreakawayCity(state, newOwnerId, previousOwnerId, cityId);
+    return recalculateTerritory(
+      reconquerBreakawayCity(state, newOwnerId, previousOwnerId, cityId),
+      { reason: 'capture', preserveCurrentHolderOnTie: true },
+    ).state;
   }
 
-  return {
+  const nextState: GameState = {
     ...state,
     cities: {
       ...state.cities,
@@ -243,4 +239,8 @@ export function transferCapturedCityOwnership(
       },
     },
   };
+  return recalculateTerritory(nextState, {
+    reason: 'capture',
+    preserveCurrentHolderOnTie: true,
+  }).state;
 }

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -98,6 +98,22 @@ export function getBaseTerritoryRadius(city: City): number {
   return getCulturalTerritoryRadius(city);
 }
 
+const MATURITY_PRESSURE_BONUS: Record<City['maturity'], number> = {
+  outpost: 0,
+  village: 1,
+  town: 2,
+  city: 3,
+  metropolis: 4,
+};
+
+export function calculateCityPressureForTile(state: GameState, city: City, coord: HexCoord): number {
+  return 6
+    + MATURITY_PRESSURE_BONUS[city.maturity]
+    + Math.floor(city.population / 2)
+    + Math.min(3, countCultureBuildings(city))
+    - cityDistance(city.position, coord, state.map);
+}
+
 export function generateTerritoryClaimsForCity(
   state: GameState,
   city: City,
@@ -113,7 +129,7 @@ export function generateTerritoryClaimsForCity(
       civId: city.owner,
       coord,
       radiusBand: cityDistance(city.position, coord, state.map),
-      pressure: 0,
+      pressure: calculateCityPressureForTile(state, city, coord),
       reason,
     });
   }
@@ -131,16 +147,37 @@ function chooseTerritoryWinner(
     return null;
   }
 
-  return claims.slice().sort((left, right) => {
+  const holderClaim = previousOwner ? claims.find(claim => claim.civId === previousOwner) ?? null : null;
+  const strongest = claims.slice().sort((left, right) => {
+    if (right.pressure !== left.pressure) return right.pressure - left.pressure;
     if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
-    if (left.pressure !== right.pressure) return right.pressure - left.pressure;
-    if (options.preserveCurrentHolderOnTie && previousOwner) {
-      const leftHeld = left.civId === previousOwner ? 0 : 1;
-      const rightHeld = right.civId === previousOwner ? 0 : 1;
-      if (leftHeld !== rightHeld) return leftHeld - rightHeld;
-    }
     return left.cityId.localeCompare(right.cityId);
   })[0] ?? null;
+  if (
+    options.preserveCurrentHolderOnTie
+    && holderClaim
+    && strongest
+    && strongest.civId !== holderClaim.civId
+    && strongest.pressure - holderClaim.pressure < 2
+  ) {
+    return holderClaim;
+  }
+  return strongest;
+}
+
+function clearWorkerTasksForCoord(units: GameState['units'], coord: HexCoord): GameState['units'] {
+  const key = hexKey(coord);
+  let changed = false;
+  const nextUnits: GameState['units'] = {};
+  for (const [unitId, unit] of Object.entries(units)) {
+    if (unit.workerTask && hexKey(unit.workerTask.coord) === key) {
+      nextUnits[unitId] = { ...unit, workerTask: undefined };
+      changed = true;
+    } else {
+      nextUnits[unitId] = unit;
+    }
+  }
+  return changed ? nextUnits : units;
 }
 
 export function recalculateTerritory(
@@ -157,6 +194,7 @@ export function recalculateTerritory(
 
   const nextTiles = { ...state.map.tiles };
   const nextCities: GameState['cities'] = {};
+  let nextUnits = state.units;
   const ownedByCity = new Map<string, HexCoord[]>();
   const resolutions: TerritoryResolution[] = [];
 
@@ -178,10 +216,20 @@ export function recalculateTerritory(
     const winner = chooseTerritoryWinner(claims, previousOwner, options);
     const winningCivId = winner?.civId ?? (options.preserveForeignHolders && previousOwner ? previousOwner : null);
     if (winner) {
-      nextTiles[key] = { ...tile, owner: winner.civId };
+      let nextTile = { ...tile, owner: winner.civId };
+      if (previousOwner !== winner.civId && tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
+        nextTile = { ...nextTile, improvement: 'none', improvementTurnsLeft: 0 };
+        nextUnits = clearWorkerTasksForCoord(nextUnits, tile.coord);
+      }
+      nextTiles[key] = nextTile;
       ownedByCity.set(winner.cityId, [...(ownedByCity.get(winner.cityId) ?? []), winner.coord]);
     } else if (!options.preserveForeignHolders || !previousOwner) {
-      nextTiles[key] = { ...tile, owner: null };
+      let nextTile = { ...tile, owner: null };
+      if (previousOwner !== null && tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
+        nextTile = { ...nextTile, improvement: 'none', improvementTurnsLeft: 0 };
+        nextUnits = clearWorkerTasksForCoord(nextUnits, tile.coord);
+      }
+      nextTiles[key] = nextTile;
     }
 
     if (winningCivId !== previousOwner) {
@@ -216,6 +264,7 @@ export function recalculateTerritory(
       tiles: nextTiles,
     },
     cities: nextCities,
+    units: nextUnits,
   });
 
   return { state: normalized.state, resolutions, contestedResolutions: [] };

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -1,4 +1,4 @@
-import type { City, GameMap, GameState, HexCoord, TerritoryFrontierState } from '@/core/types';
+import type { City, GameEvents, GameMap, GameState, HexCoord, TerritoryFrontierState } from '@/core/types';
 import { BUILDINGS } from './city-system';
 import { hexDistance, hexesInRange, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-utils';
 
@@ -54,13 +54,17 @@ export interface TerritoryRecalculationOptions {
   reason: TerritoryRecalculationReason;
   preserveForeignHolders?: boolean;
   preserveCurrentHolderOnTie?: boolean;
-  cityIds?: string[];
 }
 
 export interface TerritoryRecalculationResult {
   state: GameState;
   resolutions: TerritoryResolution[];
   contestedResolutions: TerritoryResolution[];
+}
+
+export interface TerritoryFrontierProgressResult {
+  state: GameState;
+  flippedResolutions: TerritoryResolution[];
 }
 
 export function canonicalizeCityCoord(coord: HexCoord, map: GameMap): HexCoord {
@@ -193,6 +197,17 @@ function clearWorkerTasksForCoord(units: GameState['units'], coord: HexCoord): G
   return changed ? nextUnits : units;
 }
 
+function addOwnedTile(city: City, coord: HexCoord): City {
+  const key = hexKey(coord);
+  if (city.ownedTiles.some(owned => hexKey(owned) === key)) return city;
+  return { ...city, ownedTiles: [...city.ownedTiles, coord] };
+}
+
+function removeOwnedTile(city: City, coord: HexCoord): City {
+  const key = hexKey(coord);
+  return { ...city, ownedTiles: city.ownedTiles.filter(owned => hexKey(owned) !== key) };
+}
+
 export function recalculateTerritory(
   state: GameState,
   options: TerritoryRecalculationOptions,
@@ -297,20 +312,67 @@ export function recalculateTerritory(
   return { state: normalized.state, resolutions, contestedResolutions };
 }
 
+export function buildTerritoryTileFlippedEvents(
+  before: GameState,
+  after: GameState,
+  resolutions: TerritoryResolution[],
+): GameEvents['territory:tile-flipped'][] {
+  const events: GameEvents['territory:tile-flipped'][] = [];
+  for (const resolution of resolutions) {
+    if (!resolution.previousOwner || !resolution.winningCivId || resolution.previousOwner === resolution.winningCivId) {
+      continue;
+    }
+    const key = hexKey(resolution.coord);
+    const beforeTile = before.map.tiles[key];
+    const afterTile = after.map.tiles[key];
+    if (!beforeTile || !afterTile) continue;
+    events.push({
+      coord: resolution.coord,
+      previousOwner: resolution.previousOwner,
+      newOwner: resolution.winningCivId,
+      improvement: afterTile.improvement,
+      constructionCancelled: beforeTile.improvement !== 'none'
+        && beforeTile.improvementTurnsLeft > 0
+        && afterTile.improvement === 'none'
+        && afterTile.improvementTurnsLeft === 0,
+    });
+  }
+  return events;
+}
+
+function hasStrongerCompetingFrontierClaim(state: GameState, frontier: TerritoryFrontierState): boolean {
+  const holderCity = state.cities[frontier.holderCityId];
+  const challengerCity = state.cities[frontier.challengerCityId];
+  if (!holderCity || !challengerCity) return false;
+  const key = hexKey(frontier.coord);
+  const holderClaim = generateTerritoryClaimsForCity(state, holderCity, 'turn')
+    .find(claim => hexKey(claim.coord) === key && claim.civId === frontier.holderCivId);
+  const challengerClaim = generateTerritoryClaimsForCity(state, challengerCity, 'turn')
+    .find(claim => hexKey(claim.coord) === key && claim.civId === frontier.challengerCivId);
+  return Boolean(holderClaim && challengerClaim && challengerClaim.pressure > holderClaim.pressure);
+}
+
 export function cleanupTerritoryFrontiers(state: GameState): GameState {
   const next: Record<string, TerritoryFrontierState> = {};
   for (const [key, frontier] of Object.entries(state.territoryFrontiers ?? {})) {
     if (!state.cities[frontier.holderCityId] || !state.cities[frontier.challengerCityId]) continue;
     const tile = state.map.tiles[key];
     if (!tile || tile.owner !== frontier.holderCivId) continue;
+    if (!hasStrongerCompetingFrontierClaim(state, frontier)) continue;
     next[key] = frontier;
   }
   return { ...state, territoryFrontiers: next };
 }
 
-export function processTerritoryFrontiers(state: GameState): GameState {
-  const territory = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+export function applyTerritoryFrontierProgress(territory: TerritoryRecalculationResult): GameState {
+  return applyTerritoryFrontierProgressWithEvents(territory).state;
+}
+
+export function applyTerritoryFrontierProgressWithEvents(
+  territory: TerritoryRecalculationResult,
+): TerritoryFrontierProgressResult {
   const frontiers: Record<string, TerritoryFrontierState> = { ...(territory.state.territoryFrontiers ?? {}) };
+  const flippedResolutions: TerritoryResolution[] = [];
 
   for (const resolution of territory.contestedResolutions) {
     const holder = resolution.previousOwner;
@@ -323,6 +385,15 @@ export function processTerritoryFrontiers(state: GameState): GameState {
     const previous = frontiers[key]?.progress ?? 0;
     const delta = Math.max(1, challengerClaim.pressure - holderClaim.pressure);
     const progress = Math.min(10, previous + delta);
+    if (progress >= 10) {
+      flippedResolutions.push({
+        ...resolution,
+        winningCityId: challengerClaim.cityId,
+        winningCivId: challengerClaim.civId,
+      });
+      delete frontiers[key];
+      continue;
+    }
     frontiers[key] = {
       coord: resolution.coord,
       holderCivId: holder,
@@ -335,7 +406,48 @@ export function processTerritoryFrontiers(state: GameState): GameState {
     };
   }
 
-  return cleanupTerritoryFrontiers({ ...territory.state, territoryFrontiers: frontiers });
+  let nextState = cleanupTerritoryFrontiers({ ...territory.state, territoryFrontiers: frontiers });
+  if (flippedResolutions.length === 0) {
+    return { state: nextState, flippedResolutions };
+  }
+
+  let nextUnits = nextState.units;
+  const nextTiles = { ...nextState.map.tiles };
+  const nextCities = { ...nextState.cities };
+  const appliedResolutions: TerritoryResolution[] = [];
+  for (const resolution of flippedResolutions) {
+    if (!resolution.previousOwner || !resolution.winningCivId || !resolution.winningCityId) continue;
+    const key = hexKey(resolution.coord);
+    const tile = nextTiles[key];
+    if (!tile || tile.owner !== resolution.previousOwner) continue;
+    let nextTile = { ...tile, owner: resolution.winningCivId };
+    if (tile.improvement !== 'none' && tile.improvementTurnsLeft > 0) {
+      nextTile = { ...nextTile, improvement: 'none', improvementTurnsLeft: 0 };
+      nextUnits = clearWorkerTasksForCoord(nextUnits, tile.coord);
+    }
+    nextTiles[key] = nextTile;
+    const holderCity = nextCities[resolution.competingClaims.find(claim => claim.civId === resolution.previousOwner)?.cityId ?? ''];
+    const challengerCity = nextCities[resolution.winningCityId];
+    if (holderCity) nextCities[holderCity.id] = removeOwnedTile(holderCity, resolution.coord);
+    if (challengerCity) nextCities[challengerCity.id] = addOwnedTile(challengerCity, resolution.coord);
+    delete nextState.territoryFrontiers?.[key];
+    appliedResolutions.push(resolution);
+  }
+
+  nextState = normalizeCityWorkClaims({
+    ...nextState,
+    map: { ...nextState.map, tiles: nextTiles },
+    cities: nextCities,
+    units: nextUnits,
+  }).state;
+
+  return { state: nextState, flippedResolutions: appliedResolutions };
+}
+
+export function processTerritoryFrontiers(state: GameState): GameState {
+  return applyTerritoryFrontierProgress(
+    recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true }),
+  );
 }
 
 function isValidCityCenterTerrain(state: GameState, position: HexCoord): boolean {

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -1,4 +1,5 @@
 import type { City, GameMap, GameState, HexCoord } from '@/core/types';
+import { BUILDINGS } from './city-system';
 import { hexDistance, hexesInRange, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-utils';
 
 export const MIN_CITY_CENTER_DISTANCE = 4;
@@ -74,8 +75,27 @@ function canClaimTile(tile: GameState['map']['tiles'][string] | undefined): bool
   return Boolean(tile && tile.terrain !== 'ocean' && tile.terrain !== 'mountain');
 }
 
-export function getBaseTerritoryRadius(_city: City): number {
+const CULTURE_BUILDING_IDS = new Set(
+  Object.values(BUILDINGS)
+    .filter(building => building.category === 'culture')
+    .map(building => building.id),
+);
+
+export function countCultureBuildings(city: City): number {
+  return city.buildings.filter(id => CULTURE_BUILDING_IDS.has(id)).length;
+}
+
+export function getCulturalTerritoryRadius(city: City): number {
+  const cultureBuildings = countCultureBuildings(city);
+  if (city.population >= 4) return 3;
+  if (city.maturity === 'town' || city.maturity === 'city' || city.maturity === 'metropolis') return 3;
+  if (city.population >= 3 && cultureBuildings >= 1) return 3;
+  if (cultureBuildings >= 2) return 3;
   return 2;
+}
+
+export function getBaseTerritoryRadius(city: City): number {
+  return getCulturalTerritoryRadius(city);
 }
 
 export function generateTerritoryClaimsForCity(

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -1,4 +1,4 @@
-import type { City, GameMap, GameState, HexCoord } from '@/core/types';
+import type { City, GameMap, GameState, HexCoord, TerritoryFrontierState } from '@/core/types';
 import { BUILDINGS } from './city-system';
 import { hexDistance, hexesInRange, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-utils';
 
@@ -114,6 +114,19 @@ export function calculateCityPressureForTile(state: GameState, city: City, coord
     - cityDistance(city.position, coord, state.map);
 }
 
+function getStrongestChallengerClaim(
+  claims: TerritoryClaim[],
+  holderCivId: string,
+): TerritoryClaim | null {
+  return claims
+    .filter(claim => claim.civId !== holderCivId)
+    .sort((left, right) => {
+      if (right.pressure !== left.pressure) return right.pressure - left.pressure;
+      if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
+      return left.cityId.localeCompare(right.cityId);
+    })[0] ?? null;
+}
+
 export function generateTerritoryClaimsForCity(
   state: GameState,
   city: City,
@@ -197,6 +210,7 @@ export function recalculateTerritory(
   let nextUnits = state.units;
   const ownedByCity = new Map<string, HexCoord[]>();
   const resolutions: TerritoryResolution[] = [];
+  const contestedResolutions: TerritoryResolution[] = [];
 
   for (const city of Object.values(state.cities)) {
     nextCities[city.id] = { ...city, ownedTiles: [] };
@@ -241,6 +255,19 @@ export function recalculateTerritory(
         competingClaims: claims,
         reason: options.reason,
       });
+    } else if (previousOwner && winner?.civId === previousOwner && claims.length > 1) {
+      const holderClaim = claims.find(claim => claim.civId === previousOwner) ?? null;
+      const challengerClaim = getStrongestChallengerClaim(claims, previousOwner);
+      if (holderClaim && challengerClaim && challengerClaim.pressure > holderClaim.pressure) {
+        contestedResolutions.push({
+          coord: tile.coord,
+          previousOwner,
+          winningCityId: challengerClaim.cityId,
+          winningCivId: challengerClaim.civId,
+          competingClaims: claims,
+          reason: options.reason,
+        });
+      }
     }
   }
 
@@ -267,7 +294,48 @@ export function recalculateTerritory(
     units: nextUnits,
   });
 
-  return { state: normalized.state, resolutions, contestedResolutions: [] };
+  return { state: normalized.state, resolutions, contestedResolutions };
+}
+
+export function cleanupTerritoryFrontiers(state: GameState): GameState {
+  const next: Record<string, TerritoryFrontierState> = {};
+  for (const [key, frontier] of Object.entries(state.territoryFrontiers ?? {})) {
+    if (!state.cities[frontier.holderCityId] || !state.cities[frontier.challengerCityId]) continue;
+    const tile = state.map.tiles[key];
+    if (!tile || tile.owner !== frontier.holderCivId) continue;
+    next[key] = frontier;
+  }
+  return { ...state, territoryFrontiers: next };
+}
+
+export function processTerritoryFrontiers(state: GameState): GameState {
+  const territory = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+  const frontiers: Record<string, TerritoryFrontierState> = { ...(territory.state.territoryFrontiers ?? {}) };
+
+  for (const resolution of territory.contestedResolutions) {
+    const holder = resolution.previousOwner;
+    const challenger = resolution.winningCivId;
+    if (!holder || !challenger || holder === challenger) continue;
+    const holderClaim = resolution.competingClaims.find(claim => claim.civId === holder);
+    const challengerClaim = resolution.competingClaims.find(claim => claim.civId === challenger);
+    if (!holderClaim || !challengerClaim) continue;
+    const key = hexKey(resolution.coord);
+    const previous = frontiers[key]?.progress ?? 0;
+    const delta = Math.max(1, challengerClaim.pressure - holderClaim.pressure);
+    const progress = Math.min(10, previous + delta);
+    frontiers[key] = {
+      coord: resolution.coord,
+      holderCivId: holder,
+      challengerCivId: challenger,
+      holderCityId: holderClaim.cityId,
+      challengerCityId: challengerClaim.cityId,
+      progress,
+      trend: progress >= 8 ? 'likely-to-flip' : 'contested',
+      reason: `${challenger} cultural pressure is challenging ${holder}.`,
+    };
+  }
+
+  return cleanupTerritoryFrontiers({ ...territory.state, territoryFrontiers: frontiers });
 }
 
 function isValidCityCenterTerrain(state: GameState, position: HexCoord): boolean {

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -1,5 +1,5 @@
 import type { City, GameMap, GameState, HexCoord } from '@/core/types';
-import { hexDistance, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-utils';
+import { hexDistance, hexesInRange, hexKey, wrapHexCoord, wrappedHexDistance } from './hex-utils';
 
 export const MIN_CITY_CENTER_DISTANCE = 4;
 
@@ -23,12 +23,165 @@ export interface CityWorkClaimNormalizationResult {
   changedCityIds: string[];
 }
 
+export type TerritoryRecalculationReason =
+  | 'founding'
+  | 'capture'
+  | 'raze'
+  | 'city-loss'
+  | 'turn'
+  | 'load';
+
+export interface TerritoryClaim {
+  cityId: string;
+  civId: string;
+  coord: HexCoord;
+  radiusBand: number;
+  pressure: number;
+  reason: TerritoryRecalculationReason;
+}
+
+export interface TerritoryResolution {
+  coord: HexCoord;
+  previousOwner: string | null;
+  winningCityId: string | null;
+  winningCivId: string | null;
+  competingClaims: TerritoryClaim[];
+  reason: TerritoryRecalculationReason;
+}
+
+export interface TerritoryRecalculationOptions {
+  reason: TerritoryRecalculationReason;
+  preserveForeignHolders?: boolean;
+}
+
+export interface TerritoryRecalculationResult {
+  state: GameState;
+  resolutions: TerritoryResolution[];
+  contestedResolutions: TerritoryResolution[];
+}
+
 export function canonicalizeCityCoord(coord: HexCoord, map: GameMap): HexCoord {
   return map.wrapsHorizontally ? wrapHexCoord(coord, map.width) : { ...coord };
 }
 
 export function cityDistance(a: HexCoord, b: HexCoord, map: GameMap): number {
   return map.wrapsHorizontally ? wrappedHexDistance(a, b, map.width) : hexDistance(a, b);
+}
+
+function canClaimTile(tile: GameState['map']['tiles'][string] | undefined): boolean {
+  return Boolean(tile && tile.terrain !== 'ocean' && tile.terrain !== 'mountain');
+}
+
+export function getBaseTerritoryRadius(_city: City): number {
+  return 2;
+}
+
+export function generateTerritoryClaimsForCity(
+  state: GameState,
+  city: City,
+  reason: TerritoryRecalculationReason,
+): TerritoryClaim[] {
+  const claims: TerritoryClaim[] = [];
+  for (const rawCoord of hexesInRange(city.position, getBaseTerritoryRadius(city))) {
+    const coord = canonicalizeCityCoord(rawCoord, state.map);
+    const tile = state.map.tiles[hexKey(coord)];
+    if (!canClaimTile(tile)) continue;
+    claims.push({
+      cityId: city.id,
+      civId: city.owner,
+      coord,
+      radiusBand: cityDistance(city.position, coord, state.map),
+      pressure: 0,
+      reason,
+    });
+  }
+  return claims;
+}
+
+function chooseTerritoryWinner(
+  claims: TerritoryClaim[],
+  previousOwner: string | null,
+  options: TerritoryRecalculationOptions,
+): TerritoryClaim | null {
+  if (options.preserveForeignHolders && previousOwner) {
+    const holderClaim = claims.find(claim => claim.civId === previousOwner);
+    if (holderClaim) return holderClaim;
+    return null;
+  }
+
+  return claims.slice().sort((left, right) => {
+    if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
+    return left.cityId.localeCompare(right.cityId);
+  })[0] ?? null;
+}
+
+export function recalculateTerritory(
+  state: GameState,
+  options: TerritoryRecalculationOptions,
+): TerritoryRecalculationResult {
+  const claimsByTile = new Map<string, TerritoryClaim[]>();
+  for (const city of Object.values(state.cities)) {
+    for (const claim of generateTerritoryClaimsForCity(state, city, options.reason)) {
+      const key = hexKey(claim.coord);
+      claimsByTile.set(key, [...(claimsByTile.get(key) ?? []), claim]);
+    }
+  }
+
+  const nextTiles = { ...state.map.tiles };
+  const nextCities: GameState['cities'] = {};
+  const ownedByCity = new Map<string, HexCoord[]>();
+  const resolutions: TerritoryResolution[] = [];
+
+  for (const city of Object.values(state.cities)) {
+    nextCities[city.id] = { ...city, ownedTiles: [] };
+  }
+
+  for (const [key, claims] of claimsByTile.entries()) {
+    const tile = state.map.tiles[key];
+    if (!tile) continue;
+
+    const previousOwner = tile.owner ?? null;
+    const winner = chooseTerritoryWinner(claims, previousOwner, options);
+    if (winner) {
+      nextTiles[key] = { ...tile, owner: winner.civId };
+      ownedByCity.set(winner.cityId, [...(ownedByCity.get(winner.cityId) ?? []), winner.coord]);
+    }
+
+    if ((winner?.civId ?? previousOwner) !== previousOwner) {
+      resolutions.push({
+        coord: tile.coord,
+        previousOwner,
+        winningCityId: winner?.cityId ?? null,
+        winningCivId: winner?.civId ?? null,
+        competingClaims: claims,
+        reason: options.reason,
+      });
+    }
+  }
+
+  for (const [cityId, city] of Object.entries(nextCities)) {
+    const seen = new Set<string>();
+    nextCities[cityId] = {
+      ...city,
+      ownedTiles: (ownedByCity.get(cityId) ?? []).filter(coord => {
+        const key = hexKey(coord);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      }),
+    };
+  }
+
+  const normalized = normalizeCityWorkClaims({
+    ...state,
+    map: {
+      ...state.map,
+      tiles: nextTiles,
+    },
+    cities: nextCities,
+  });
+
+  return { state: normalized.state, resolutions, contestedResolutions: [] };
 }
 
 function isValidCityCenterTerrain(state: GameState, position: HexCoord): boolean {

--- a/src/systems/city-territory-system.ts
+++ b/src/systems/city-territory-system.ts
@@ -52,6 +52,8 @@ export interface TerritoryResolution {
 export interface TerritoryRecalculationOptions {
   reason: TerritoryRecalculationReason;
   preserveForeignHolders?: boolean;
+  preserveCurrentHolderOnTie?: boolean;
+  cityIds?: string[];
 }
 
 export interface TerritoryRecalculationResult {
@@ -111,6 +113,12 @@ function chooseTerritoryWinner(
 
   return claims.slice().sort((left, right) => {
     if (left.radiusBand !== right.radiusBand) return left.radiusBand - right.radiusBand;
+    if (left.pressure !== right.pressure) return right.pressure - left.pressure;
+    if (options.preserveCurrentHolderOnTie && previousOwner) {
+      const leftHeld = left.civId === previousOwner ? 0 : 1;
+      const rightHeld = right.civId === previousOwner ? 0 : 1;
+      if (leftHeld !== rightHeld) return leftHeld - rightHeld;
+    }
     return left.cityId.localeCompare(right.cityId);
   })[0] ?? null;
 }
@@ -136,23 +144,32 @@ export function recalculateTerritory(
     nextCities[city.id] = { ...city, ownedTiles: [] };
   }
 
-  for (const [key, claims] of claimsByTile.entries()) {
+  const keysToResolve = new Set<string>(claimsByTile.keys());
+  for (const [key, tile] of Object.entries(state.map.tiles)) {
+    if (tile.owner) keysToResolve.add(key);
+  }
+
+  for (const key of keysToResolve) {
+    const claims = claimsByTile.get(key) ?? [];
     const tile = state.map.tiles[key];
     if (!tile) continue;
 
     const previousOwner = tile.owner ?? null;
     const winner = chooseTerritoryWinner(claims, previousOwner, options);
+    const winningCivId = winner?.civId ?? (options.preserveForeignHolders && previousOwner ? previousOwner : null);
     if (winner) {
       nextTiles[key] = { ...tile, owner: winner.civId };
       ownedByCity.set(winner.cityId, [...(ownedByCity.get(winner.cityId) ?? []), winner.coord]);
+    } else if (!options.preserveForeignHolders || !previousOwner) {
+      nextTiles[key] = { ...tile, owner: null };
     }
 
-    if ((winner?.civId ?? previousOwner) !== previousOwner) {
+    if (winningCivId !== previousOwner) {
       resolutions.push({
         coord: tile.coord,
         previousOwner,
         winningCityId: winner?.cityId ?? null,
-        winningCivId: winner?.civId ?? null,
+        winningCivId,
         competingClaims: claims,
         reason: options.reason,
       });

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -22,6 +22,15 @@ export interface WorkerActionEligibilityOptions {
   isCityTile?: boolean;
 }
 
+export type WorkerActionBlockerReason =
+  | 'outside-territory'
+  | 'city-center'
+  | 'already-improved'
+  | 'invalid-terrain'
+  | 'requires-river'
+  | 'requires-tech'
+  | 'none';
+
 export const IMPROVEMENT_DEFINITIONS: Record<BuildableImprovementType, ImprovementDefinition> = {
   farm: {
     type: 'farm',
@@ -116,6 +125,41 @@ export function getAvailableWorkerActions(
   }
   if (canDrainSwamp(tile, ownerId, options)) actions.push('drain_swamp');
   return actions;
+}
+
+export function getWorkerActionBlockerReason(
+  tile: HexTile | undefined,
+  action: WorkerActionType,
+  completedTechs: string[] = [],
+  ownerId?: string,
+  options: WorkerActionEligibilityOptions = {},
+): WorkerActionBlockerReason {
+  if (!tile) return 'invalid-terrain';
+  if (ownerId && tile.owner !== ownerId) return 'outside-territory';
+  if (options.isCityTile) return 'city-center';
+  if (tile.improvement !== 'none') return 'already-improved';
+
+  if (action === 'drain_swamp') {
+    return tile.terrain === 'swamp' ? 'none' : 'invalid-terrain';
+  }
+
+  const definition = IMPROVEMENT_DEFINITIONS[action];
+  if (!definition.validTerrains.includes(tile.terrain)) return 'invalid-terrain';
+  if (definition.requiresRiver && !tile.hasRiver) return 'requires-river';
+  if (definition.requiredTech && !completedTechs.includes(definition.requiredTech)) return 'requires-tech';
+  return 'none';
+}
+
+export function formatWorkerActionBlockerReason(reason: WorkerActionBlockerReason): string {
+  switch (reason) {
+    case 'outside-territory': return 'Outside your territory';
+    case 'city-center': return 'City centers cannot be improved';
+    case 'already-improved': return 'Already improved';
+    case 'invalid-terrain': return 'No worker improvement fits this terrain';
+    case 'requires-river': return 'Requires river';
+    case 'requires-tech': return 'Requires technology';
+    case 'none': return '';
+  }
 }
 
 export function getImprovementYieldBonus(type: ImprovementType): ResourceYield {

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -12,8 +12,7 @@ import { createRng } from './map-generator';
 import { hexDistance, hexKey } from './hex-utils';
 import {
   IMPROVEMENT_BUILD_TURNS,
-  canBuildImprovement,
-  canDrainSwamp,
+  getWorkerActionBlockerReason,
   getWorkerActionLabel,
 } from './improvement-system';
 
@@ -31,6 +30,7 @@ export type WorkerActionFailureReason =
   | 'not-worker'
   | 'missing-tile'
   | 'invalid-action'
+  | 'outside-territory'
   | 'no-charges'
   | 'already-acted';
 
@@ -124,12 +124,14 @@ export function applyWorkerAction(
 
   const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
   const eligibilityOptions = { isCityTile: isCityCenterTile(state, unit.position) };
-  if (isBuildableImprovement(action)) {
-    if (!canBuildImprovement(tile, action, completedTechs, unit.owner, eligibilityOptions)) {
-      return { ok: false, state, reason: 'invalid-action', events: [] };
-    }
-  } else if (!canDrainSwamp(tile, unit.owner, eligibilityOptions)) {
-    return { ok: false, state, reason: 'invalid-action', events: [] };
+  const blockerReason = getWorkerActionBlockerReason(tile, action, completedTechs, unit.owner, eligibilityOptions);
+  if (blockerReason !== 'none') {
+    return {
+      ok: false,
+      state,
+      reason: blockerReason === 'outside-territory' ? 'outside-territory' : 'invalid-action',
+      events: [],
+    };
   }
 
   const chargesAfter = Math.max(0, chargesBefore - 1);

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -1,5 +1,7 @@
-import type { CombatResult, CombatRewardNotification, GameState } from '@/core/types';
+import type { CombatResult, CombatRewardNotification, GameEvents, GameState } from '@/core/types';
 import { collectEvent } from '@/core/hotseat-events';
+import { hexKey } from '@/systems/hex-utils';
+import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import type { NotificationEntry } from '@/ui/notification-log';
@@ -18,6 +20,55 @@ type FactionTransitionEvent =
   | { type: 'faction:breakaway-started'; cityId: string; oldOwner: string; breakawayId: string }
   | { type: 'faction:breakaway-established'; civId: string; originOwnerId: string }
   | { type: 'faction:critical-status'; cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string };
+
+type TerritoryTileFlippedRoutingEvent =
+  GameEvents['territory:tile-flipped'] & { type: 'territory:tile-flipped' };
+
+type NotificationRoutingEvent = TerritoryTileFlippedRoutingEvent;
+
+export function getNotificationTargetsForEvent(
+  state: GameState,
+  event: NotificationRoutingEvent,
+): string[] {
+  if (event.type !== 'territory:tile-flipped') return [];
+
+  const key = hexKey(event.coord);
+  const targets = new Set<string>();
+  if (state.civilizations[event.previousOwner]) targets.add(event.previousOwner);
+  if (state.civilizations[event.newOwner]) targets.add(event.newOwner);
+  for (const [civId, civ] of Object.entries(state.civilizations)) {
+    const visibility = civ.visibility?.tiles?.[key];
+    if (visibility === 'visible' || visibility === 'fog') {
+      targets.add(civId);
+    }
+  }
+  return [...targets];
+}
+
+export function getTerritoryTileFlippedMessage(event: GameEvents['territory:tile-flipped']): string {
+  if (event.constructionCancelled) {
+    return 'Border shifted; in-progress construction was cancelled.';
+  }
+  if (event.improvement !== 'none') {
+    return `Border shifted; ${getImprovementDisplayName(event.improvement)} transferred.`;
+  }
+  return 'Border shifted.';
+}
+
+export function routeTerritoryTileFlipped(
+  state: GameState,
+  event: TerritoryTileFlippedRoutingEvent,
+  sink: NotificationSink,
+): void {
+  const message = getTerritoryTileFlippedMessage(event);
+  for (const civId of getNotificationTargetsForEvent(state, event)) {
+    sink(civId, message, event.constructionCancelled ? 'warning' : 'info', {
+      kind: 'map',
+      coord: { ...event.coord },
+      label: 'Border shifted',
+    });
+  }
+}
 
 export function routeFactionTransition(
   state: GameState,

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -3,7 +3,14 @@ import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-sys
 import { getExperienceToNextTier, getVeterancyCombatModifier, getVeterancyTier } from '@/systems/combat-reward-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
 import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
-import { getAvailableWorkerActions, getWorkerActionLabel } from '@/systems/improvement-system';
+import {
+  formatWorkerActionBlockerReason,
+  getAvailableWorkerActions,
+  getWorkerActionBlockerReason,
+  getWorkerActionLabel,
+  type WorkerActionBlockerReason,
+  type WorkerActionEligibilityOptions,
+} from '@/systems/improvement-system';
 import { DEFAULT_WORKER_CHARGES, getWorkerChargesRemaining } from '@/systems/worker-action-system';
 import { hexKey } from '@/systems/hex-utils';
 import { canFoundCityAt, formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
@@ -40,6 +47,24 @@ function nextTierLabel(currentLabel: string): string | null {
   if (currentLabel === 'Seasoned') return 'Veteran';
   if (currentLabel === 'Veteran') return 'Elite';
   return null;
+}
+
+const WORKER_ACTIONS: WorkerActionType[] = ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp'];
+
+function chooseWorkerBlockerReason(
+  tile: GameState['map']['tiles'][string] | undefined,
+  completedTechs: string[],
+  ownerId: string,
+  options: WorkerActionEligibilityOptions,
+): WorkerActionBlockerReason {
+  let fallback: WorkerActionBlockerReason = 'invalid-terrain';
+  for (const action of WORKER_ACTIONS) {
+    const reason = getWorkerActionBlockerReason(tile, action, completedTechs, ownerId, options);
+    if (reason === 'none') return 'none';
+    if (reason !== 'invalid-terrain' && reason !== 'requires-tech') return reason;
+    fallback = reason;
+  }
+  return fallback;
 }
 
 export function renderSelectedUnitInfo(
@@ -155,7 +180,8 @@ export function renderSelectedUnitInfo(
       const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
       const unitTileKey = hexKey(unit.position);
       const isCityTile = Object.values(state.cities).some(city => hexKey(city.position) === unitTileKey);
-      for (const action of getAvailableWorkerActions(tile, completedTechs, unit.owner, { isCityTile })) {
+      const workerActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, { isCityTile });
+      for (const action of workerActions) {
         const color = action === 'farm'
           ? '#6b9b4b'
           : action === 'mine'
@@ -166,6 +192,16 @@ export function renderSelectedUnitInfo(
                 ? '#3f7f8f'
                 : '#64748b';
         actionsDiv.appendChild(makeButton(getWorkerActionLabel(action), color, () => callbacks.onWorkerAction!(action)));
+      }
+      if (workerActions.length === 0) {
+        const blockerReason = chooseWorkerBlockerReason(tile, completedTechs, unit.owner, { isCityTile });
+        const blockerText = formatWorkerActionBlockerReason(blockerReason);
+        if (blockerText) {
+          const blockerDiv = document.createElement('div');
+          blockerDiv.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
+          blockerDiv.textContent = blockerText;
+          wrapper.appendChild(blockerDiv);
+        }
       }
     }
   }

--- a/src/ui/territory-frontier-info.ts
+++ b/src/ui/territory-frontier-info.ts
@@ -1,0 +1,16 @@
+import type { TerritoryFrontierState } from '@/core/types';
+
+export function renderTerritoryFrontierInfo(frontier: TerritoryFrontierState): HTMLElement {
+  const panel = document.createElement('section');
+  panel.dataset.territoryFrontier = frontier.trend;
+
+  const title = document.createElement('div');
+  title.textContent = frontier.trend === 'likely-to-flip' ? 'Border likely to shift' : 'Contested border';
+
+  const reason = document.createElement('p');
+  reason.textContent = frontier.reason;
+
+  panel.appendChild(title);
+  panel.appendChild(reason);
+  return panel;
+}

--- a/src/ui/territory-frontier-info.ts
+++ b/src/ui/territory-frontier-info.ts
@@ -5,7 +5,7 @@ export function renderTerritoryFrontierInfo(frontier: TerritoryFrontierState): H
   panel.dataset.territoryFrontier = frontier.trend;
 
   const title = document.createElement('div');
-  title.textContent = frontier.trend === 'likely-to-flip' ? 'Border likely to shift' : 'Contested border';
+  title.textContent = frontier.trend === 'likely-to-flip' ? 'Border likely to shift: ' : 'Contested border: ';
 
   const reason = document.createElement('p');
   reason.textContent = frontier.reason;

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -130,6 +130,132 @@ describe('processTurn', () => {
     expect(Object.keys(result.minorCivs).length).toBeGreaterThan(0);
   });
 
+  it('emits territory tile-flipped events during turn territory recalculation', () => {
+    const state = createNewGame(undefined, 'turn-territory-flip-event', 'small');
+    state.cities = {};
+    state.units = {};
+    state.barbarianCamps = {};
+    state.minorCivs = {};
+    state.civilizations.player.cities = [];
+    state.civilizations.player.units = [];
+    state.civilizations['ai-1'].cities = [];
+    state.civilizations['ai-1'].units = [];
+    const holder = foundCity('player', { q: 6, r: 6 }, state.map);
+    const challenger = foundCity('ai-1', { q: 9, r: 6 }, state.map);
+    holder.id = 'holder-city';
+    challenger.id = 'challenger-city';
+    const overlap = { q: 8, r: 6 };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [] };
+    state.civilizations.player.cities = [holder.id];
+    state.civilizations['ai-1'].cities = [challenger.id];
+    state.map.tiles[hexKey(overlap)] = {
+      ...state.map.tiles[hexKey(overlap)],
+      terrain: 'grassland',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 0,
+    };
+    const bus = new EventBus();
+    const tileFlipped = vi.fn();
+    bus.on('territory:tile-flipped', tileFlipped);
+
+    processTurn(state, bus);
+
+    expect(tileFlipped).toHaveBeenCalledWith(expect.objectContaining({
+      coord: overlap,
+      previousOwner: 'player',
+      newOwner: 'ai-1',
+      improvement: 'farm',
+      constructionCancelled: false,
+    }));
+  });
+
+  it('advances cultural frontier pressure during turn processing before a tile flips', () => {
+    const state = createNewGame(undefined, 'turn-territory-frontier-progress', 'small');
+    state.cities = {};
+    state.units = {};
+    state.barbarianCamps = {};
+    state.minorCivs = {};
+    state.civilizations.player.cities = [];
+    state.civilizations.player.units = [];
+    state.civilizations['ai-1'].cities = [];
+    state.civilizations['ai-1'].units = [];
+    const holder = foundCity('player', { q: 6, r: 6 }, state.map);
+    const challenger = foundCity('ai-1', { q: 9, r: 6 }, state.map);
+    holder.id = 'frontier-holder';
+    challenger.id = 'frontier-challenger';
+    const overlap = { q: 8, r: 6 };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+    state.civilizations.player.cities = [holder.id];
+    state.civilizations['ai-1'].cities = [challenger.id];
+    state.map.tiles[hexKey(overlap)] = { ...state.map.tiles[hexKey(overlap)], terrain: 'grassland', owner: 'player' };
+
+    const result = processTurn(state, new EventBus());
+
+    expect(result.territoryFrontiers?.[hexKey(overlap)]).toEqual(expect.objectContaining({
+      holderCivId: 'player',
+      challengerCivId: 'ai-1',
+      holderCityId: holder.id,
+      challengerCityId: challenger.id,
+    }));
+  });
+
+  it('emits a territory event when frontier progress reaches a tile flip', () => {
+    const state = createNewGame(undefined, 'turn-territory-frontier-flip-event', 'small');
+    state.cities = {};
+    state.units = {};
+    state.barbarianCamps = {};
+    state.minorCivs = {};
+    state.civilizations.player.cities = [];
+    state.civilizations.player.units = [];
+    state.civilizations['ai-1'].cities = [];
+    state.civilizations['ai-1'].units = [];
+    const holder = foundCity('player', { q: 6, r: 6 }, state.map);
+    const challenger = foundCity('ai-1', { q: 9, r: 6 }, state.map);
+    holder.id = 'frontier-event-holder';
+    challenger.id = 'frontier-event-challenger';
+    const overlap = { q: 8, r: 6 };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+    state.civilizations.player.cities = [holder.id];
+    state.civilizations['ai-1'].cities = [challenger.id];
+    state.map.tiles[hexKey(overlap)] = {
+      ...state.map.tiles[hexKey(overlap)],
+      terrain: 'grassland',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 0,
+    };
+    state.territoryFrontiers = {
+      [hexKey(overlap)]: {
+        coord: overlap,
+        holderCivId: 'player',
+        challengerCivId: 'ai-1',
+        holderCityId: holder.id,
+        challengerCityId: challenger.id,
+        progress: 9,
+        trend: 'likely-to-flip',
+        reason: 'ai-1 cultural pressure is challenging player.',
+      },
+    };
+    const bus = new EventBus();
+    const tileFlipped = vi.fn();
+    bus.on('territory:tile-flipped', tileFlipped);
+
+    const result = processTurn(state, bus);
+
+    expect(result.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
+    expect(tileFlipped).toHaveBeenCalledWith(expect.objectContaining({
+      coord: overlap,
+      previousOwner: 'player',
+      newOwner: 'ai-1',
+      improvement: 'farm',
+      constructionCancelled: false,
+    }));
+  });
+
   it('awards barbarian units experience when they defeat a player unit during turn processing', () => {
     const state = createNewGame(undefined, 'barbarian-reward', 'small');
     state.turn = 5;

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -291,6 +291,36 @@ describe('processTurn', () => {
     expect(updated.productionProgress).toBe(3);
   });
 
+  it('recalculates cultural territory before marketplace supply counts city territory', () => {
+    const state = createNewGame(undefined, 'turn-territory-growth', 'small');
+    const playerCiv = state.civilizations.player;
+    const startPos = state.units[playerCiv.units[0]].position;
+    const city = foundCity('player', startPos, state.map);
+    const radius3 = state.map.wrapsHorizontally
+      ? { q: (city.position.q + 3) % state.map.width, r: city.position.r }
+      : { q: city.position.q + 3, r: city.position.r };
+    const key = hexKey(radius3);
+    state.map.tiles[key] = {
+      ...state.map.tiles[key],
+      coord: radius3,
+      terrain: 'grassland',
+      elevation: 'lowland',
+      owner: null,
+      improvement: 'none',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      resource: 'horses',
+    };
+    state.cities[city.id] = { ...city, population: 4, ownedTiles: [city.position] };
+    playerCiv.cities = [city.id];
+
+    const next = processTurn(state, new EventBus());
+
+    expect(next.cities[city.id].ownedTiles.map(hexKey)).toContain(key);
+    expect(next.map.tiles[key].owner).toBe('player');
+  });
+
   it('reassigns focused city worked tiles after growth without working the city center', () => {
     const state = createNewGame(undefined, 'focused-growth-worked-tiles', 'small');
     const bus = new EventBus();

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -82,4 +82,28 @@ describe('selected-unit-highlights', () => {
     expect(result.attackTargets.map(target => hexKey(target.coord))).not.toContain('1,0');
     expect(result.highlights.filter(h => h.type === 'attack').map(h => hexKey(h.coord))).not.toContain('1,0');
   });
+
+  it('adds worker guidance highlights for buildable, owned-blocked, and foreign-blocked movement-preview tiles', () => {
+    const state = createNewGame(undefined, 'worker-guidance-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      worker: { ...createUnit('worker', 'player', { q: 0, r: 0 }), id: 'worker', movementPointsLeft: 2 },
+    };
+    state.civilizations.player.units = ['worker'];
+    state.civilizations.player.visibility.tiles = {
+      '0,0': 'visible',
+      '1,0': 'visible',
+      '29,0': 'visible',
+      '1,-1': 'visible',
+    };
+    state.map.tiles['1,0'] = { coord: { q: 1, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null, owner: 'player', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+    state.map.tiles['29,0'] = { coord: { q: 29, r: 0 }, terrain: 'tundra', elevation: 'lowland', resource: null, owner: 'player', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+    state.map.tiles['1,-1'] = { coord: { q: 1, r: -1 }, terrain: 'plains', elevation: 'lowland', resource: null, owner: 'ai-1', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+
+    const result = buildSelectedUnitHighlights(state, 'worker');
+
+    expect(result.highlights).toContainEqual({ coord: { q: 1, r: 0 }, type: 'worker-buildable' });
+    expect(result.highlights).toContainEqual({ coord: { q: 29, r: 0 }, type: 'worker-owned-blocked' });
+    expect(result.highlights).toContainEqual({ coord: { q: 1, r: -1 }, type: 'worker-foreign-blocked' });
+  });
 });

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -12,9 +12,10 @@ vi.mock('@/storage/db', () => ({
   dbGetAllKeys: vi.fn(async () => Array.from(dbState.keys())),
 }));
 
-import { loadGame, migrateLegacyNamingState, saveGame } from '@/storage/save-manager';
+import { loadGame, migrateLegacyNamingState, normalizeLoadedStateForTest, saveGame } from '@/storage/save-manager';
 import type { CustomCivDefinition, GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
 
 // --- Minimal in-memory localStorage mock ---
 function makeLocalStorageMock() {
@@ -176,6 +177,26 @@ describe('save persistence (#38)', () => {
     const loaded = await loadGame('slot-pending-peace');
 
     expect(loaded?.pendingDiplomacyRequests).toEqual(state.pendingDiplomacyRequests);
+  });
+
+  it('preserves legacy tile owner as holder when normalizing ambiguous territory', async () => {
+    const state = createNewGame(undefined, 'legacy-territory-holder');
+    const city = {
+      ...foundCity('player', { q: 10, r: 10 }, state.map),
+      id: 'legacy-city',
+      position: { q: 10, r: 10 },
+    };
+    state.cities = { [city.id]: city };
+    state.civilizations.player.cities = [city.id];
+    const coord = { q: city.position.q + 1, r: city.position.r };
+    const key = hexKey(coord);
+    state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'grassland', owner: 'ai-1' };
+    state.cities[city.id] = { ...city, ownedTiles: [...city.ownedTiles, coord], workedTiles: [coord] };
+
+    const normalized = normalizeLoadedStateForTest(state);
+
+    expect(normalized.map.tiles[key].owner).toBe('ai-1');
+    expect(normalized.cities[city.id].workedTiles).not.toContainEqual(coord);
   });
 
   it('normalizes older saves without pending diplomacy requests', async () => {

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -19,6 +19,7 @@ describe('city-capture-system', () => {
     state.civilizations['ai-1'].cities = [];
     state.civilizations.player.diplomacy.relationships['ai-1'] = 0;
     state.civilizations['ai-1'].diplomacy.relationships.player = 0;
+    state.cities = {};
 
     state.cities.athens = {
       ...foundCity('ai-1', { q: 1, r: 0 }, state.map),
@@ -89,6 +90,18 @@ describe('city-capture-system', () => {
     }
   });
 
+  it('recalculates captured city territory when legacy owned tiles are missing', () => {
+    const state = makeExposedCityCaptureState({ population: 6, buildings: [] });
+    state.cities.athens = { ...state.cities.athens, ownedTiles: [] };
+    state.map.tiles[hexKey({ q: 1, r: 0 })].owner = 'ai-1';
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(result.outcome).toBe('occupied');
+    expect(result.state.cities.athens.ownedTiles.map(hexKey)).toContain('1,0');
+    expect(result.state.map.tiles[hexKey({ q: 1, r: 0 })].owner).toBe('player');
+  });
+
   it('reassigns legendary wonder projects to the new owner when a city is occupied', () => {
     const state = makeExposedCityCaptureState({ population: 6, buildings: ['granary'] });
     addLegendaryProject(state, 'ai-1', 'athens');
@@ -146,5 +159,35 @@ describe('city-capture-system', () => {
 
     expect(result.state.cities.athens).toBeUndefined();
     expect(result.state.legendaryWonderProjects).toEqual({});
+  });
+
+  it('preserves another current holder when razing a city with stale owned tiles', () => {
+    const state = makeExposedCityCaptureState({ population: 4, buildings: [] });
+    const shared = { q: 1, r: 1 };
+    state.cities.rome = {
+      ...foundCity('player', { q: 3, r: 1 }, state.map),
+      id: 'rome',
+      name: 'Rome',
+      owner: 'player',
+      position: { q: 3, r: 1 },
+      ownedTiles: [shared],
+      workedTiles: [shared],
+    };
+    state.civilizations.player.cities = ['rome'];
+    state.map.tiles[hexKey(shared)] = {
+      ...state.map.tiles[hexKey(shared)],
+      terrain: 'grassland',
+      owner: 'player',
+    };
+    state.cities.athens = {
+      ...state.cities.athens,
+      ownedTiles: [state.cities.athens.position, shared],
+    };
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
+
+    expect(result.outcome).toBe('razed');
+    expect(result.state.map.tiles[hexKey(shared)].owner).toBe('player');
+    expect(result.state.cities.rome.workedTiles).toEqual([shared]);
   });
 });

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -196,6 +196,36 @@ describe('city founding territory rules', () => {
     expect(getCulturalTerritoryRadius({ ...city, population: 3, buildings: ['shrine'] })).toBe(3);
     expect(getCulturalTerritoryRadius({ ...city, buildings: ['shrine', 'monument'] })).toBe(3);
   });
+
+  it('does not flip an overlap when pressure margin is only one', () => {
+    const state = createNewGame(undefined, 'territory-soft-trim-margin-one');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const overlap = { q: 12, r: 10 };
+    state.map.tiles[hexKey(overlap)] = { ...state.map.tiles[hexKey(overlap)], terrain: 'grassland', owner: 'player' };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+
+    const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+    expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('player');
+  });
+
+  it('flips an overlap when rival pressure margin is at least two', () => {
+    const state = createNewGame(undefined, 'territory-soft-trim-margin-two');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const overlap = { q: 12, r: 10 };
+    state.map.tiles[hexKey(overlap)] = { ...state.map.tiles[hexKey(overlap)], terrain: 'grassland', owner: 'player' };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [] };
+
+    const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+    expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
+  });
 });
 
 describe('work claim indexing', () => {

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -5,6 +5,7 @@ import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
 import {
   buildCityWorkClaimIndex,
+  buildTerritoryTileFlippedEvents,
   canonicalizeCityCoord,
   cityDistance,
   cleanupTerritoryFrontiers,
@@ -229,6 +230,66 @@ describe('city founding territory rules', () => {
     expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
   });
 
+  it('builds tile-flipped events for completed improvements that transfer owners', () => {
+    const state = createNewGame(undefined, 'territory-transfer-event');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const overlap = { q: 12, r: 10 };
+    state.map.tiles[hexKey(overlap)] = {
+      ...state.map.tiles[hexKey(overlap)],
+      terrain: 'grassland',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 0,
+    };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [] };
+
+    const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+    const events = buildTerritoryTileFlippedEvents(state, result.state, result.resolutions);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        coord: overlap,
+        previousOwner: 'player',
+        newOwner: 'ai-1',
+        improvement: 'farm',
+        constructionCancelled: false,
+      }),
+    ]);
+  });
+
+  it('marks tile-flipped events when in-progress construction is cancelled by a border shift', () => {
+    const state = createNewGame(undefined, 'territory-transfer-cancel-event');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const overlap = { q: 12, r: 10 };
+    state.map.tiles[hexKey(overlap)] = {
+      ...state.map.tiles[hexKey(overlap)],
+      terrain: 'grassland',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 2,
+    };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap] };
+    state.cities[challenger.id] = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [] };
+
+    const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+    const events = buildTerritoryTileFlippedEvents(state, result.state, result.resolutions);
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        coord: overlap,
+        previousOwner: 'player',
+        newOwner: 'ai-1',
+        improvement: 'none',
+        constructionCancelled: true,
+      }),
+    ]);
+  });
+
   it('records frontier progress for contested held tiles before flipping', () => {
     const state = createNewGame(undefined, 'territory-frontier-progress');
     state.territoryFrontiers = {};
@@ -252,6 +313,37 @@ describe('city founding territory rules', () => {
     expect(frontier?.reason).toContain('cultural pressure');
   });
 
+  it('flips a contested frontier tile when accumulated progress reaches the threshold', () => {
+    const state = createNewGame(undefined, 'territory-frontier-threshold-flip');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const coord = { q: 12, r: 10 };
+    state.map.tiles[hexKey(coord)] = { ...state.map.tiles[hexKey(coord)], terrain: 'grassland', owner: 'player' };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [coord], workedTiles: [coord] };
+    state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+    state.territoryFrontiers = {
+      [hexKey(coord)]: {
+        coord,
+        holderCivId: 'player',
+        challengerCivId: 'ai-1',
+        holderCityId: holder.id,
+        challengerCityId: challenger.id,
+        progress: 9,
+        trend: 'likely-to-flip',
+        reason: 'ai-1 cultural pressure is challenging player.',
+      },
+    };
+
+    const result = processTerritoryFrontiers(state);
+
+    expect(result.map.tiles[hexKey(coord)].owner).toBe('ai-1');
+    expect(result.cities[holder.id].ownedTiles.map(hexKey)).not.toContain(hexKey(coord));
+    expect(result.cities[holder.id].workedTiles).toEqual([]);
+    expect(result.cities[challenger.id].ownedTiles.map(hexKey)).toContain(hexKey(coord));
+    expect(result.territoryFrontiers?.[hexKey(coord)]).toBeUndefined();
+  });
+
   it('cleans frontier records when a source city is gone', () => {
     const state = createNewGame(undefined, 'territory-frontier-cleanup');
     state.territoryFrontiers = {
@@ -262,6 +354,31 @@ describe('city founding territory rules', () => {
         holderCityId: 'missing-city',
         challengerCityId: 'also-missing',
         progress: 3,
+        trend: 'contested',
+        reason: 'Stale frontier',
+      },
+    };
+
+    const result = cleanupTerritoryFrontiers(state);
+
+    expect(result.territoryFrontiers).toEqual({});
+  });
+
+  it('cleans frontier records when the challenger no longer has a stronger competing claim', () => {
+    const state = createNewGame(undefined, 'territory-frontier-cleanup-no-competition');
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 20, 20);
+    const coord = { q: 12, r: 10 };
+    state.map.tiles[hexKey(coord)] = { ...state.map.tiles[hexKey(coord)], terrain: 'grassland', owner: 'player' };
+    state.territoryFrontiers = {
+      [hexKey(coord)]: {
+        coord,
+        holderCivId: 'player',
+        challengerCivId: 'ai-1',
+        holderCityId: holder.id,
+        challengerCityId: challenger.id,
+        progress: 4,
         trend: 'contested',
         reason: 'Stale frontier',
       },

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { City, GameState } from '@/core/types';
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
 import {
   buildCityWorkClaimIndex,
   canonicalizeCityCoord,
@@ -10,6 +11,8 @@ import {
   getCityFoundingBlockers,
   MIN_CITY_CENTER_DISTANCE,
   normalizeCityWorkClaims,
+  recalculateTerritory,
+  type TerritoryResolution,
 } from '@/systems/city-territory-system';
 
 function addCity(state: GameState, owner: string, q: number, r: number): City {
@@ -99,6 +102,67 @@ describe('city founding territory rules', () => {
       { reason: 'too-close', cityName: 'Ephyra', distance: 2 },
     ])).toBe('Too close to Ephyra.');
     expect(formatCityFoundingBlockerMessage([{ reason: 'invalid-terrain' }])).toBe('Cities must be founded on land.');
+  });
+
+  it('recalculates a founded city to radius 2 without claiming ocean or mountains', () => {
+    const state = createNewGame(undefined, 'territory-radius-2');
+    state.cities = {};
+    state.civilizations.player.cities = [];
+    const city = foundCity('player', { q: 10, r: 10 }, state.map);
+    city.id = 'city-player';
+    state.cities[city.id] = { ...city, ownedTiles: [] };
+    state.civilizations.player.cities = [city.id];
+    state.map.tiles['10,10'] = { ...state.map.tiles['10,10'], terrain: 'grassland', owner: null };
+    state.map.tiles['10,12'] = { ...state.map.tiles['10,12'], terrain: 'grassland', owner: null };
+    state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], terrain: 'mountain', owner: null };
+    state.map.tiles['12,10'] = { ...state.map.tiles['12,10'], terrain: 'ocean', owner: null };
+
+    const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+    const ownedKeys = result.state.cities[city.id].ownedTiles.map(hexKey);
+
+    expect(ownedKeys).toContain('10,10');
+    expect(ownedKeys).toContain('10,12');
+    expect(ownedKeys).not.toContain('11,10');
+    expect(ownedKeys).not.toContain('12,10');
+    for (const key of ownedKeys) {
+      expect(result.state.map.tiles[key]?.owner).toBe('player');
+    }
+  });
+
+  it('does not steal valid foreign-held tiles during MR1 founding recalculation', () => {
+    const state = createNewGame(undefined, 'territory-foreign-holder');
+    state.cities = {};
+    state.civilizations.player.cities = [];
+    const city = foundCity('player', { q: 10, r: 10 }, state.map);
+    city.id = 'city-player';
+    state.cities[city.id] = { ...city, ownedTiles: [] };
+    state.civilizations.player.cities = [city.id];
+    state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], terrain: 'grassland', owner: 'ai-1' };
+
+    const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+
+    expect(result.state.map.tiles['11,10'].owner).toBe('ai-1');
+    expect(result.state.cities[city.id].ownedTiles.map(hexKey)).not.toContain('11,10');
+  });
+
+  it('returns changed-tile metadata when ownership changes', () => {
+    const state = createNewGame(undefined, 'territory-resolution-metadata');
+    state.cities = {};
+    state.civilizations.player.cities = [];
+    const city = foundCity('player', { q: 10, r: 10 }, state.map);
+    city.id = 'city-player';
+    state.cities[city.id] = { ...city, ownedTiles: [] };
+    state.civilizations.player.cities = [city.id];
+
+    const result = recalculateTerritory(state, { reason: 'founding', preserveForeignHolders: true });
+    const centerResolution = result.resolutions.find((resolution: TerritoryResolution) => hexKey(resolution.coord) === '10,10');
+
+    expect(centerResolution).toMatchObject({
+      previousOwner: null,
+      winningCityId: city.id,
+      winningCivId: 'player',
+      reason: 'founding',
+    });
   });
 });
 

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -9,6 +9,7 @@ import {
   cityDistance,
   formatCityFoundingBlockerMessage,
   getCityFoundingBlockers,
+  getCulturalTerritoryRadius,
   MIN_CITY_CENTER_DISTANCE,
   normalizeCityWorkClaims,
   recalculateTerritory,
@@ -176,6 +177,24 @@ describe('city founding territory rules', () => {
 
     expect(result.state.cities[city.id].workedTiles).toEqual([]);
     expect(result.state.map.tiles['11,10'].owner).toBe('ai-1');
+  });
+
+  it('keeps outpost population 3 without culture buildings at radius 2', () => {
+    const state = createNewGame(undefined, 'territory-growth-no');
+    const city = addCity(state, 'player', 10, 10);
+    state.cities[city.id] = { ...city, population: 3, maturity: 'outpost', buildings: [] };
+
+    expect(getCulturalTerritoryRadius(state.cities[city.id])).toBe(2);
+  });
+
+  it('grows to radius 3 from population, maturity, or culture buildings', () => {
+    const state = createNewGame(undefined, 'territory-growth-yes');
+    const city = addCity(state, 'player', 10, 10);
+
+    expect(getCulturalTerritoryRadius({ ...city, population: 4 })).toBe(3);
+    expect(getCulturalTerritoryRadius({ ...city, maturity: 'town' })).toBe(3);
+    expect(getCulturalTerritoryRadius({ ...city, population: 3, buildings: ['shrine'] })).toBe(3);
+    expect(getCulturalTerritoryRadius({ ...city, buildings: ['shrine', 'monument'] })).toBe(3);
   });
 });
 

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -7,11 +7,13 @@ import {
   buildCityWorkClaimIndex,
   canonicalizeCityCoord,
   cityDistance,
+  cleanupTerritoryFrontiers,
   formatCityFoundingBlockerMessage,
   getCityFoundingBlockers,
   getCulturalTerritoryRadius,
   MIN_CITY_CENTER_DISTANCE,
   normalizeCityWorkClaims,
+  processTerritoryFrontiers,
   recalculateTerritory,
   type TerritoryResolution,
 } from '@/systems/city-territory-system';
@@ -225,6 +227,49 @@ describe('city founding territory rules', () => {
     const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
 
     expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
+  });
+
+  it('records frontier progress for contested held tiles before flipping', () => {
+    const state = createNewGame(undefined, 'territory-frontier-progress');
+    state.territoryFrontiers = {};
+    state.cities = {};
+    const holder = addCity(state, 'player', 10, 10);
+    const challenger = addCity(state, 'ai-1', 13, 10);
+    const coord = { q: 12, r: 10 };
+    state.map.tiles[hexKey(coord)] = { ...state.map.tiles[hexKey(coord)], terrain: 'grassland', owner: 'player' };
+    state.cities[holder.id] = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [coord] };
+    state.cities[challenger.id] = { ...challenger, population: 3, maturity: 'outpost', ownedTiles: [] };
+
+    const result = processTerritoryFrontiers(state);
+    const frontier = result.territoryFrontiers?.[hexKey(coord)];
+
+    expect(frontier).toMatchObject({
+      holderCivId: 'player',
+      challengerCivId: 'ai-1',
+      holderCityId: holder.id,
+      challengerCityId: challenger.id,
+    });
+    expect(frontier?.reason).toContain('cultural pressure');
+  });
+
+  it('cleans frontier records when a source city is gone', () => {
+    const state = createNewGame(undefined, 'territory-frontier-cleanup');
+    state.territoryFrontiers = {
+      '5,5': {
+        coord: { q: 5, r: 5 },
+        holderCivId: 'player',
+        challengerCivId: 'ai-1',
+        holderCityId: 'missing-city',
+        challengerCityId: 'also-missing',
+        progress: 3,
+        trend: 'contested',
+        reason: 'Stale frontier',
+      },
+    };
+
+    const result = cleanupTerritoryFrontiers(state);
+
+    expect(result.territoryFrontiers).toEqual({});
   });
 });
 

--- a/tests/systems/city-territory-system.test.ts
+++ b/tests/systems/city-territory-system.test.ts
@@ -164,6 +164,19 @@ describe('city founding territory rules', () => {
       reason: 'founding',
     });
   });
+
+  it('normalizes city work claims after territory loss', () => {
+    const state = createNewGame(undefined, 'territory-work-normalize');
+    const city = addCity(state, 'player', 10, 10);
+    const lost = { q: 11, r: 10 };
+    state.map.tiles['11,10'] = { ...state.map.tiles['11,10'], owner: 'ai-1', terrain: 'grassland' };
+    state.cities[city.id] = { ...city, ownedTiles: [city.position, lost], workedTiles: [lost] };
+
+    const result = recalculateTerritory(state, { reason: 'load', preserveForeignHolders: true });
+
+    expect(result.state.cities[city.id].workedTiles).toEqual([]);
+    expect(result.state.map.tiles['11,10'].owner).toBe('ai-1');
+  });
 });
 
 describe('work claim indexing', () => {

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -4,6 +4,7 @@ import {
   getAvailableWorkerActions,
   getImprovementDisplayName,
   getImprovementYieldBonus,
+  getWorkerActionBlockerReason,
 } from '@/systems/improvement-system';
 import type { HexTile } from '@/core/types';
 
@@ -144,5 +145,16 @@ describe('lumber camp and watermill eligibility', () => {
   it('returns expected yields for lumber camp and watermill', () => {
     expect(getImprovementYieldBonus('lumber_camp')).toEqual({ food: 0, production: 2, gold: 0, science: 0 });
     expect(getImprovementYieldBonus('watermill')).toEqual({ food: 1, production: 1, gold: 0, science: 0 });
+  });
+
+  it('explains outside-territory worker blockers before terrain blockers', () => {
+    expect(getWorkerActionBlockerReason(tile({ terrain: 'forest', owner: 'enemy' }), 'farm', [], 'p1')).toBe('outside-territory');
+    expect(getWorkerActionBlockerReason(tile({ terrain: 'forest', owner: null }), 'farm', [], 'p1')).toBe('outside-territory');
+  });
+
+  it('explains local worker blockers inside owned territory', () => {
+    expect(getWorkerActionBlockerReason(tile({ terrain: 'plains', owner: 'p1', improvement: 'mine' }), 'farm', [], 'p1')).toBe('already-improved');
+    expect(getWorkerActionBlockerReason(tile({ terrain: 'plains', owner: 'p1', hasRiver: false }), 'watermill', [], 'p1')).toBe('requires-river');
+    expect(getWorkerActionBlockerReason(tile({ terrain: 'coast', owner: 'p1' }), 'farm', [], 'p1')).toBe('invalid-terrain');
   });
 });

--- a/tests/systems/resource-system.test.ts
+++ b/tests/systems/resource-system.test.ts
@@ -1,7 +1,9 @@
 import { calculateCityYields, TERRAIN_YIELDS } from '@/systems/resource-system';
 import type { GameMap, HexCoord, TerrainType } from '@/core/types';
+import { createNewGame } from '@/core/game-state';
 import { generateMap } from '@/systems/map-generator';
 import { foundCity } from '@/systems/city-system';
+import { recalculateTerritory } from '@/systems/city-territory-system';
 import { hexKey } from '@/systems/hex-utils';
 
 describe('calculateCityYields', () => {
@@ -132,6 +134,42 @@ describe('calculateCityYields', () => {
 
     expect(yields.food).toBeGreaterThanOrEqual(3);
     expect(yields.production).toBeGreaterThanOrEqual(2);
+  });
+
+  it('counts a transferred completed farm only for the new owner after reassignment', () => {
+    const state = createNewGame(undefined, 'farm-transfer-yield', 'small');
+    state.cities = {};
+    state.civilizations.player.cities = [];
+    state.civilizations['ai-1'].cities = [];
+    const holder = { ...foundCity('player', { q: 10, r: 10 }, state.map), id: 'holder' };
+    const challenger = { ...foundCity('ai-1', { q: 13, r: 10 }, state.map), id: 'challenger' };
+    const overlap = { q: 12, r: 10 };
+    state.map.tiles[hexKey(overlap)] = {
+      ...state.map.tiles[hexKey(overlap)],
+      coord: overlap,
+      terrain: 'plains',
+      owner: 'player',
+      improvement: 'farm',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      resource: null,
+    };
+    state.cities.holder = { ...holder, population: 2, maturity: 'outpost', ownedTiles: [overlap], workedTiles: [overlap] };
+    state.cities.challenger = { ...challenger, population: 6, maturity: 'town', buildings: ['shrine'], ownedTiles: [], workedTiles: [] };
+    state.civilizations.player.cities = ['holder'];
+    state.civilizations['ai-1'].cities = ['challenger'];
+
+    const result = recalculateTerritory(state, { reason: 'turn', preserveCurrentHolderOnTie: true });
+    const oldOwnerYields = calculateCityYields(result.state.cities.holder, result.state.map);
+    const newOwnerYields = calculateCityYields(
+      { ...result.state.cities.challenger, population: 1, workedTiles: [overlap] },
+      result.state.map,
+    );
+
+    expect(result.state.map.tiles[hexKey(overlap)].owner).toBe('ai-1');
+    expect(result.state.cities.holder.workedTiles).not.toContainEqual(overlap);
+    expect(newOwnerYields.food).toBeGreaterThan(oldOwnerYields.food);
   });
 });
 

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -248,7 +248,7 @@ describe('worker action system', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.reason).toBe('invalid-action');
+    expect(result.reason).toBe('outside-territory');
     expect(result.state.map.tiles['0,0']).toMatchObject({ terrain: 'forest', improvement: 'none' });
   });
 
@@ -260,8 +260,19 @@ describe('worker action system', () => {
 
     expect(result.ok).toBe(false);
     if (result.ok) return;
-    expect(result.reason).toBe('invalid-action');
+    expect(result.reason).toBe('outside-territory');
     expect(result.state.cities['city-1'].productionProgress).toBe(0);
+  });
+
+  it('returns outside-territory for valid terrain outside worker territory', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'forest', owner: 'enemy' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'farm');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('outside-territory');
   });
 
   it('rejects worker improvements on a city-center tile even when the terrain is otherwise valid', () => {

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { City, GameState, HexTile, Unit } from '@/core/types';
+import { recalculateTerritory } from '@/systems/city-territory-system';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement, getWorkerChargesRemaining } from '@/systems/worker-action-system';
 
@@ -201,6 +202,28 @@ describe('worker action system', () => {
     const result = clearCompletedWorkerTasksForImprovement(start, { q: 0, r: 0 });
 
     expect(result.units['worker-1'].workerTask).toEqual({ action: 'farm', coord: { q: 0, r: 0 } });
+  });
+
+  it('cancels in-progress improvement and clears worker task when territory flips', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'plains', owner: 'player', improvement: 'farm', improvementTurnsLeft: 3 });
+    start.units['worker-1'] = worker({ workerTask: { action: 'farm', coord: { q: 0, r: 0 } } });
+    start.civilizations['ai-1'] = {
+      ...start.civilizations.player,
+      id: 'ai-1',
+      name: 'AI',
+      isHuman: false,
+      cities: [],
+      units: [],
+      diplomacy: createDiplomacyState(['player', 'ai-1'], 'ai-1'),
+    };
+    start.cities['enemy-city'] = city({ id: 'enemy-city', owner: 'ai-1', position: { q: 1, r: 0 }, population: 8, maturity: 'town', ownedTiles: [] });
+    start.civilizations['ai-1'].cities.push('enemy-city');
+
+    const result = recalculateTerritory(start, { reason: 'turn', preserveCurrentHolderOnTie: true });
+
+    expect(result.state.map.tiles['0,0']).toMatchObject({ owner: 'ai-1', improvement: 'none', improvementTurnsLeft: 0 });
+    expect(result.state.units['worker-1'].workerTask).toBeUndefined();
   });
 
   it('converts forest farm to plains and grants production to nearest owned city', () => {

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { CombatResult, GameState } from '@/core/types';
 import {
+  getNotificationTargetsForEvent,
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeCombatResolved,
@@ -297,5 +298,23 @@ describe('notification routing', () => {
 
     routeBarbarianSpawned(state, { q: 0, r: 0 }, 'camp-2', dedup, sink, isVisible);
     expect(calls.map(c => c.civId)).toEqual(['p1', 'p1']);
+  });
+
+  it('routes territory improvement transfer notifications to involved civs and visible observers', () => {
+    const state = makeState();
+    (state.civilizations.p1 as any).visibility = { tiles: { '5,5': 'visible' } };
+    (state.civilizations.p2 as any).visibility = { tiles: { '5,5': 'visible' } };
+    (state.civilizations.p3 as any).visibility = { tiles: { '5,5': 'visible' } };
+
+    const targets = getNotificationTargetsForEvent(state, {
+      type: 'territory:tile-flipped',
+      coord: { q: 5, r: 5 },
+      previousOwner: 'p1',
+      newOwner: 'p2',
+      improvement: 'farm',
+      constructionCancelled: false,
+    });
+
+    expect(targets.sort()).toEqual(['p1', 'p2', 'p3']);
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -413,6 +413,32 @@ describe('renderSelectedUnitInfo - worker actions', () => {
     }
   });
 
+  it('explains outside-territory worker blockers on the current tile', () => {
+    const state = makeWorkerState({ terrain: 'forest', owner: 'enemy' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    const buttons = findButtons(container).map(button => button.textContent);
+    expect(text).toContain('Outside your territory');
+    expect(buttons).not.toContain('Build Farm');
+  });
+
+  it('explains local worker blockers on owned current tiles', () => {
+    const state = makeWorkerState({ terrain: 'plains', owner: 'player', improvement: 'mine' });
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'worker-1', {
+      onWorkerAction: () => {},
+    });
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('Already improved');
+  });
+
   it('hides worker actions after the worker has already acted', () => {
     const state = makeWorkerState({ terrain: 'forest' }, { hasActed: true });
     const container = new MockElement('div');

--- a/tests/ui/territory-frontier-info.test.ts
+++ b/tests/ui/territory-frontier-info.test.ts
@@ -28,12 +28,20 @@ class MockDocument {
 }
 
 describe('renderTerritoryFrontierInfo', () => {
+  const originalDocument = globalThis.document;
+
   beforeEach(() => {
-    (globalThis as typeof globalThis & { document?: unknown }).document = new MockDocument();
+    Object.defineProperty(globalThis, 'document', {
+      value: new MockDocument() as unknown as Document,
+      configurable: true,
+    });
   });
 
   afterEach(() => {
-    (globalThis as typeof globalThis & { document?: unknown }).document = undefined;
+    Object.defineProperty(globalThis, 'document', {
+      value: originalDocument,
+      configurable: true,
+    });
   });
 
   it('renders a likely-to-flip frontier title and reason', () => {

--- a/tests/ui/territory-frontier-info.test.ts
+++ b/tests/ui/territory-frontier-info.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
+import type { TerritoryFrontierState } from '@/core/types';
+
+class MockElement {
+  children: MockElement[] = [];
+  dataset: Record<string, string> = {};
+  private ownText = '';
+
+  get textContent(): string {
+    return `${this.ownText}${this.children.map(child => child.textContent).join('')}`;
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+  }
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class MockDocument {
+  createElement(): MockElement {
+    return new MockElement();
+  }
+}
+
+describe('renderTerritoryFrontierInfo', () => {
+  beforeEach(() => {
+    (globalThis as typeof globalThis & { document?: unknown }).document = new MockDocument();
+  });
+
+  afterEach(() => {
+    (globalThis as typeof globalThis & { document?: unknown }).document = undefined;
+  });
+
+  it('renders a likely-to-flip frontier title and reason', () => {
+    const frontier: TerritoryFrontierState = {
+      coord: { q: 5, r: 5 },
+      holderCivId: 'player',
+      challengerCivId: 'ai-1',
+      holderCityId: 'rome',
+      challengerCityId: 'athens',
+      progress: 8,
+      trend: 'likely-to-flip',
+      reason: 'ai-1 cultural pressure is challenging player.',
+    };
+
+    const panel = renderTerritoryFrontierInfo(frontier);
+
+    expect((panel as unknown as MockElement).dataset.territoryFrontier).toBe('likely-to-flip');
+    expect(panel.textContent).toContain('Border likely to shift');
+    expect(panel.textContent).toContain(frontier.reason);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds canonical cultural territory recalculation for founding, capture/loss/load/turn hooks, growth milestones, pressure overlap resolution, and frontier progress flips.
- Keeps worker improvements legal to owned territory only, with player-facing blocker explanations, transfer/cancel behavior on border shifts, and normalized city work claims.
- Wires border/frontier feedback into live UI and notification logs, including improvement transfer/cancel messages for visible or involved civs.

## Test Plan
- scripts/check-src-rule-violations.sh src/core/types.ts src/core/turn-manager.ts src/systems/city-territory-system.ts src/ui/notification-routing.ts src/ui/territory-frontier-info.ts src/main.ts
- ./scripts/run-with-mise.sh yarn test --run tests/systems/city-territory-system.test.ts tests/ui/notification-routing.test.ts tests/ui/territory-frontier-info.test.ts tests/core/turn-manager.test.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test
- git diff --check origin/main...HEAD

Closes #157