### PR TITLE
[codex] Add treasury maintenance and rush-buy strain

### DIFF
--- a/docs/superpowers/plans/2026-05-16-cost-dynamics-implementation.md
+++ b/docs/superpowers/plans/2026-05-16-cost-dynamics-implementation.md
@@ -1,0 +1,1901 @@
+# Cost Dynamics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Do not use subagents for this work.
+
+**Goal:** Add generous, kid-friendly unit/building maintenance and active-item rush-buying without making normal early play feel punished.
+
+**Architecture:** Add a single economy resolver that owns maintenance, projected economy, resolved economy status, strain, and rush-buy quotes. Refactor production completion into a shared helper so normal turn production and rush-buy use the same building/unit side effects. UI reads economy projections and quotes; it does not reimplement maintenance math.
+
+**Tech Stack:** TypeScript, Vite, Vitest, DOM tests with JSDOM, Canvas game shell.
+
+---
+
+## Spec And Rule Inputs
+
+- Spec: `docs/superpowers/specs/2026-05-16-cost-dynamics-design.md`
+- Repo rules to read before editing:
+  - `.claude/rules/game-systems.md` for `src/core/**` and `src/systems/**`
+  - `.claude/rules/strategy-game-mechanics.md` for `src/core/**` and `src/systems/**`
+  - `.claude/rules/end-to-end-wiring.md` for `src/**`
+  - `.claude/rules/ui-panels.md` for `src/ui/**` and `src/main.ts`
+  - `docs/superpowers/plans/README.md` for city panel and queue/rush-buy UI guardrails
+
+## File Structure
+
+- Create `src/systems/economy-system.ts`
+  - Owns maintenance policy, city building upkeep, civ unit upkeep, economy projection, resolved economy application, rush-buy quotes, and rush-buy execution.
+- Modify `src/core/types.ts`
+  - Adds serializable economy status types, `GameState.economyStatusByCiv`, and economy notification events.
+- Modify `src/systems/city-system.ts`
+  - Extracts production completion into `completeCityProductionItem`.
+  - Keeps `processCity` behavior unchanged by calling the helper.
+- Modify `src/core/turn-manager.ts`
+  - Uses economy resolver to apply net gold with a zero floor.
+  - Stores last resolved economy status.
+  - Emits treasury strain notifications.
+  - Uses shared production completion for city production where needed.
+- Modify `src/systems/faction-system.ts`
+  - Adds Era 3+ unrest pressure from last resolved critical treasury strain.
+- Modify `src/ui/city-panel.ts`
+  - Shows maintenance summary and future upkeep.
+  - Shows active-item rush-buy quote and disabled reasons.
+  - Calls `onRushBuyActiveProduction`.
+- Modify `src/main.ts`
+  - HUD shows projected net gold.
+  - City panel callback executes rush-buy and updates state/HUD/render loop.
+- Modify `src/ui/notification-routing.ts`
+  - Routes economy strain events to one civilization-level warning per turn.
+- Test files:
+  - Create `tests/systems/economy-system.test.ts`
+  - Modify `tests/systems/faction-system.test.ts`
+  - Create `tests/systems/rush-buy-system.test.ts`
+  - Modify `tests/ui/city-panel.test.ts`
+  - Create `tests/ui/hud-economy.test.ts`
+
+## Player Truth Table
+
+| Before | Action | Internal change | Immediate visible result | Still reachable |
+|---|---|---|---|---|
+| HUD shows `Gold 40 (+6)` from gross income | Add enough optional buildings to create upkeep | Projected economy recomputes net | HUD shows `Gold 40 (+2 net)` and compact strain only if unpaid maintenance exists | City panel breakdown |
+| City panel has no active production | View production block | Rush-buy quote returns `no-active-production` | No buy button or disabled text `No active production to buy` | Build list remains reachable |
+| City panel active `Workshop`, enough gold, no high strain | Click `Buy now: 10 gold` | Gold decreases, workshop completes, queue shifts | Panel rerenders: workshop appears in Buildings, new active item appears or no active production | Build list, queue controls |
+| City panel active `Warrior`, enough gold, no high strain | Click `Buy now: X gold` | Gold decreases, unit is created through shared completion path | Panel rerenders, gold/HUD updates, queue shifts | Unit remains selectable through normal game surfaces |
+| Active production is `legendary:pyramids` | View production block | Rush-buy quote returns `wonder-blocked` | Disabled reason says wonders cannot be bought | Legendary Wonders tab remains reachable |
+| Projected strain is `high` | View active production | Rush-buy quote returns `treasury-strain` | Disabled reason says treasury strain is too high | Remove queue, delete units, end turn, normal production |
+| Player deletes units or gains gold after high strain projection | Reopen or rerender city panel | Projection recalculates | Buy button becomes available if strain drops and gold is enough | All build options |
+
+## Misleading UI Risks
+
+- `Free support` is misleading if exempt buildings consume support. Exempt rows must say `0 upkeep` and not count against support used.
+- `Two defenders per city free` is misleading if units must stand in cities. Defender slots are empire support capacity; tests must prove position does not matter.
+- `Net gold` is misleading if it omits maintenance. HUD projection must include building upkeep and unit upkeep.
+- `Treasury strain` is misleading if reserves can still pay the bill. Strain starts only when `unpaidMaintenance > 0`.
+- `Buy now` is misleading if it can buy wonders, follow-up queue items, or stale DOM rows. Rush-buy applies only to the active item and rerenders after every click.
+
+## Interaction Replay Checklist
+
+- Add first production item, see active item and buy quote.
+- Add second production item, see active item plus queue row and ETA.
+- Rush-buy active item, see queue shift and quote recalculate for the next item.
+- Remove queued follow-up after a rush-buy, see ETA/order update.
+- Repeat-click old buy button must not buy twice from stale DOM because panel rerenders.
+- Reopen city panel after rush-buy and see completed building/unit outcome reflected.
+
+## Queue And ETA Checklist
+
+- Active item remains in the current production block.
+- Follow-up queue remains in the existing `Production Queue` block.
+- Rush-buy only targets the active item.
+- ETA text must recalculate after buy, reorder, and remove.
+- If an active item becomes invalid through existing tech/legendary rules, normal queue filtering still owns invalidation; rush-buy should quote `invalid-active-item` for unknown ids.
+
+---
+
+### Task 1: Economy Types And Resolver
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Create: `src/systems/economy-system.ts`
+- Create: `tests/systems/economy-system.test.ts`
+
+- [ ] **Step 1: Read rules before editing**
+
+Run:
+
+```bash
+sed -n '1,220p' .claude/rules/game-systems.md
+sed -n '1,220p' .claude/rules/strategy-game-mechanics.md
+sed -n '1,220p' .claude/rules/end-to-end-wiring.md
+```
+
+Expected: rules are visible in terminal; keep mutations in system helpers and keep UI wired to computed data.
+
+- [ ] **Step 2: Write failing tests for maintenance and strain**
+
+Create `tests/systems/economy-system.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { City, GameState, HexCoord, Unit, UnitType } from '@/core/types';
+import {
+  calculateCityBuildingMaintenance,
+  calculateCivEconomy,
+  calculateCivUnitMaintenance,
+  getRushBuyQuote,
+  projectCivEconomy,
+} from '@/systems/economy-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+
+function city(id: string, overrides: Partial<City> = {}): City {
+  return {
+    id,
+    name: id,
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    population: 2,
+    food: 0,
+    foodNeeded: 20,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    grid: [[null]],
+    gridSize: 3,
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    idleProduction: null,
+    ...overrides,
+  };
+}
+
+function unit(id: string, type: UnitType, position: HexCoord = { q: 0, r: 0 }): Unit {
+  return {
+    id,
+    type,
+    owner: 'player',
+    position,
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+}
+
+function state(overrides: Partial<GameState> = {}): GameState {
+  const c = city('city-1');
+  return {
+    turn: 12,
+    era: 2,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { [c.id]: c },
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'egypt',
+        cities: [c.id],
+        units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0,
+        visibility: { tiles: {} },
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: false,
+      musicEnabled: false,
+      musicVolume: 0,
+      sfxVolume: 0,
+      tutorialEnabled: false,
+      advisorsEnabled: {} as any,
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    ...overrides,
+  } as GameState;
+}
+
+describe('economy-system', () => {
+  it('keeps likely-needed buildings free and charges optional excess deterministically', () => {
+    const s = state();
+    s.cities['city-1'].population = 1;
+    s.cities['city-1'].buildings = [
+      'herbalist',
+      'workshop',
+      'shrine',
+      'barracks',
+      'library',
+      'granary',
+      'marketplace',
+      'harbor',
+      'forge',
+      'observatory',
+      'security-bureau',
+    ];
+
+    const result = calculateCityBuildingMaintenance(s, 'city-1');
+
+    expect(result.freeSupport).toBe(4);
+    expect(result.exemptBuildings.map(row => row.id)).toEqual([
+      'herbalist',
+      'workshop',
+      'shrine',
+      'barracks',
+      'library',
+      'granary',
+    ]);
+    expect(result.supportedBuildings.map(row => row.id)).toEqual([
+      'marketplace',
+      'forge',
+      'harbor',
+      'observatory',
+    ]);
+    expect(result.paidBuildings.map(row => row.id)).toEqual(['security-bureau']);
+    expect(result.upkeep).toBe(2);
+  });
+
+  it('grants two free combat defenders per city without requiring city position', () => {
+    const s = state();
+    s.cities['city-1'].population = 1;
+    s.units = {
+      settler: unit('settler', 'settler', { q: 5, r: 5 }),
+      worker: unit('worker', 'worker', { q: 5, r: 6 }),
+      scout: unit('scout', 'scout', { q: 6, r: 6 }),
+      warrior1: unit('warrior1', 'warrior', { q: 9, r: 9 }),
+      warrior2: unit('warrior2', 'warrior', { q: 8, r: 8 }),
+      archer: unit('archer', 'archer', { q: 7, r: 7 }),
+      swordsman: unit('swordsman', 'swordsman', { q: 6, r: 7 }),
+    };
+    s.civilizations.player.units = Object.keys(s.units);
+
+    const result = calculateCivUnitMaintenance(s, 'player');
+
+    expect(result.exemptUnits.map(row => row.id)).toEqual(['scout', 'settler', 'worker']);
+    expect(result.freeDefenderUnits.map(row => row.id)).toEqual(['warrior1', 'warrior2']);
+    expect(result.freeSupport).toBe(4);
+    expect(result.upkeep).toBe(0);
+  });
+
+  it('charges excess armies after exemptions and generous support are exhausted', () => {
+    const s = state();
+    const units = Array.from({ length: 10 }, (_, index) => unit(`warrior-${index}`, 'warrior', { q: index, r: 0 }));
+    s.units = Object.fromEntries(units.map(u => [u.id, u]));
+    s.civilizations.player.units = units.map(u => u.id);
+
+    const result = calculateCivUnitMaintenance(s, 'player');
+
+    expect(result.freeDefenderUnits).toHaveLength(2);
+    expect(result.supportedUnits).toHaveLength(4);
+    expect(result.paidUnits).toHaveLength(4);
+    expect(result.upkeep).toBe(4);
+  });
+
+  it('uses reserves before creating treasury strain', () => {
+    const s = state();
+    s.civilizations.player.gold = 20;
+
+    const result = calculateCivEconomy(s, 'player', 0, { buildingMaintenance: 12, unitMaintenance: 3 });
+
+    expect(result.totalMaintenance).toBe(15);
+    expect(result.netGoldPerTurn).toBe(-15);
+    expect(result.endingGold).toBe(5);
+    expect(result.unpaidMaintenance).toBe(0);
+    expect(result.strainLevel).toBe('none');
+  });
+
+  it('classifies unpaid maintenance into low high and critical strain', () => {
+    const s = state();
+
+    expect(calculateCivEconomy(s, 'player', 0, { buildingMaintenance: 2, unitMaintenance: 0 }).strainLevel).toBe('low');
+    expect(calculateCivEconomy(s, 'player', 0, { buildingMaintenance: 5, unitMaintenance: 0 }).strainLevel).toBe('high');
+    expect(calculateCivEconomy(s, 'player', 0, { buildingMaintenance: 10, unitMaintenance: 0 }).strainLevel).toBe('critical');
+  });
+
+  it('projects current economy for HUD and rush-buy without mutating state', () => {
+    const s = state();
+    s.cities['city-1'].buildings = ['marketplace'];
+    s.civilizations.player.gold = 30;
+
+    const projected = projectCivEconomy(s, 'player');
+
+    expect(projected.grossGoldIncome).toBeGreaterThanOrEqual(0);
+    expect(s.civilizations.player.gold).toBe(30);
+  });
+
+  it('quotes only active normal production and blocks legendary wonders', () => {
+    const s = state();
+    s.civilizations.player.gold = 100;
+    s.cities['city-1'].productionQueue = ['workshop'];
+    s.cities['city-1'].productionProgress = 2;
+
+    expect(getRushBuyQuote(s, 'player', 'city-1')).toMatchObject({
+      available: true,
+      itemId: 'workshop',
+      cost: 25,
+    });
+
+    s.cities['city-1'].productionQueue = ['legendary:pyramids'];
+    expect(getRushBuyQuote(s, 'player', 'city-1')).toMatchObject({
+      available: false,
+      reason: 'wonders-cannot-be-bought',
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Run the failing economy tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/economy-system.test.ts
+```
+
+Expected: FAIL because `@/systems/economy-system` does not exist.
+
+- [ ] **Step 4: Add economy types**
+
+In `src/core/types.ts`, add near the civilization section:
+
+```ts
+export type TreasuryStrainLevel = 'none' | 'low' | 'high' | 'critical';
+
+export interface EconomyStatus {
+  turn: number;
+  grossGoldIncome: number;
+  buildingMaintenance: number;
+  unitMaintenance: number;
+  netGoldPerTurn: number;
+  unpaidMaintenance: number;
+  strainLevel: TreasuryStrainLevel;
+}
+```
+
+In `GameState`, add:
+
+```ts
+  economyStatusByCiv?: Record<string, EconomyStatus>;
+```
+
+In `GameEvents`, add:
+
+```ts
+  'economy:treasury-strain': { civId: string; level: Exclude<TreasuryStrainLevel, 'none'>; netGoldPerTurn: number; unpaidMaintenance: number };
+```
+
+- [ ] **Step 5: Create the economy resolver**
+
+Create `src/systems/economy-system.ts`:
+
+```ts
+import type { City, EconomyStatus, GameState, TreasuryStrainLevel, Unit, UnitType } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { BUILDINGS, getProductionCostForItem, TRAINABLE_UNITS } from '@/systems/city-system';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getLegendaryWonderCityYieldBonus, getLegendaryWonderCivYieldBonus } from '@/systems/legendary-wonder-system';
+import { processTradeRouteIncome } from '@/systems/trade-system';
+
+export type RushBuyDisabledReason =
+  | 'no-active-production'
+  | 'invalid-active-item'
+  | 'not-owner'
+  | 'not-enough-gold'
+  | 'treasury-strain-too-high'
+  | 'wonders-cannot-be-bought';
+
+export interface MaintenanceRow {
+  id: string;
+  label: string;
+  upkeep: number;
+  reason: 'exempt' | 'free-support' | 'paid';
+}
+
+export interface CityBuildingMaintenance {
+  cityId: string;
+  freeSupport: number;
+  supportUsed: number;
+  upkeep: number;
+  exemptBuildings: MaintenanceRow[];
+  supportedBuildings: MaintenanceRow[];
+  paidBuildings: MaintenanceRow[];
+  rows: MaintenanceRow[];
+}
+
+export interface CivUnitMaintenance {
+  civId: string;
+  freeSupport: number;
+  supportUsed: number;
+  defenderSlots: number;
+  defenderSlotsUsed: number;
+  upkeep: number;
+  exemptUnits: MaintenanceRow[];
+  freeDefenderUnits: MaintenanceRow[];
+  supportedUnits: MaintenanceRow[];
+  paidUnits: MaintenanceRow[];
+  rows: MaintenanceRow[];
+}
+
+export interface CivEconomyResult extends EconomyStatus {
+  civId: string;
+  startingGold: number;
+  endingGold: number;
+  totalMaintenance: number;
+  buildingBreakdown: CityBuildingMaintenance[];
+  unitBreakdown: CivUnitMaintenance;
+  rushBuyBlockedByStrain: boolean;
+}
+
+export interface RushBuyQuote {
+  available: boolean;
+  reason?: RushBuyDisabledReason;
+  itemId?: string;
+  label?: string;
+  cost?: number;
+  remainingProduction?: number;
+}
+
+const CORE_FREE_BUILDINGS = new Set(['city-center', 'herbalist', 'workshop', 'shrine', 'barracks', 'library', 'granary']);
+const FREE_UNIT_TYPES = new Set<UnitType>(['settler', 'worker', 'scout']);
+const ADVANCED_UNIT_TYPES = new Set<UnitType>([
+  'swordsman', 'pikeman', 'musketeer', 'galley', 'trireme',
+  'spy_scout', 'spy_informant', 'spy_agent', 'spy_operative', 'spy_hacker',
+  'scout_hound', 'shadow_warden', 'war_hound',
+]);
+const ADVANCED_BUILDINGS = new Set(['forge', 'observatory', 'harbor', 'amphitheater', 'security-bureau']);
+const MATURITY_SUPPORT: Record<City['maturity'], number> = {
+  outpost: 0,
+  village: 1,
+  town: 2,
+  city: 3,
+  metropolis: 4,
+};
+export const ECONOMY_UNREST_PRESSURE = 12;
+
+function buildingLabel(id: string): string {
+  return BUILDINGS[id]?.name ?? id;
+}
+
+function unitLabel(unit: Unit): string {
+  return UNIT_DEFINITIONS[unit.type]?.name ?? unit.type;
+}
+
+function buildingUpkeep(id: string): number {
+  if (CORE_FREE_BUILDINGS.has(id)) return 0;
+  if (ADVANCED_BUILDINGS.has(id)) return 2;
+  return BUILDINGS[id] ? 1 : 0;
+}
+
+function unitUpkeep(type: UnitType): number {
+  if (FREE_UNIT_TYPES.has(type)) return 0;
+  if (ADVANCED_UNIT_TYPES.has(type)) return 2;
+  return 1;
+}
+
+function buildingPriority(id: string): number {
+  if (CORE_FREE_BUILDINGS.has(id)) return 0;
+  const building = BUILDINGS[id];
+  if (building?.pacing?.band === 'starter') return 1;
+  if (building?.category === 'economy' || building?.category === 'food' || building?.category === 'production') return 2;
+  return 3;
+}
+
+function unitPriority(type: UnitType): number {
+  if (type === 'warrior' || type === 'archer') return 0;
+  if (type === 'swordsman' || type === 'pikeman' || type === 'musketeer') return 1;
+  if (type === 'war_hound') return 2;
+  return 3;
+}
+
+function strainLevel(unpaidMaintenance: number, totalMaintenance: number): TreasuryStrainLevel {
+  if (unpaidMaintenance <= 0) return 'none';
+  const ratio = unpaidMaintenance / Math.max(1, totalMaintenance);
+  if (unpaidMaintenance >= 10 || ratio >= 0.5) return 'critical';
+  if (unpaidMaintenance >= 5 || ratio >= 0.25) return 'high';
+  return 'low';
+}
+
+export function calculateCityBuildingMaintenance(state: GameState, cityId: string): CityBuildingMaintenance {
+  const city = state.cities[cityId];
+  if (!city) {
+    return { cityId, freeSupport: 0, supportUsed: 0, upkeep: 0, exemptBuildings: [], supportedBuildings: [], paidBuildings: [], rows: [] };
+  }
+
+  const freeSupport = 4 + Math.floor(city.population / 2) + (MATURITY_SUPPORT[city.maturity] ?? 0);
+  const exemptBuildings: MaintenanceRow[] = [];
+  const candidates = city.buildings
+    .filter(id => BUILDINGS[id])
+    .map(id => ({ id, label: buildingLabel(id), upkeep: buildingUpkeep(id), reason: 'paid' as const }));
+
+  const paidCandidates: MaintenanceRow[] = [];
+  for (const row of candidates) {
+    if (CORE_FREE_BUILDINGS.has(row.id) || row.upkeep === 0) {
+      exemptBuildings.push({ ...row, upkeep: 0, reason: 'exempt' });
+    } else {
+      paidCandidates.push(row);
+    }
+  }
+
+  paidCandidates.sort((left, right) =>
+    buildingPriority(left.id) - buildingPriority(right.id)
+    || left.upkeep - right.upkeep
+    || left.id.localeCompare(right.id),
+  );
+
+  const supportedBuildings = paidCandidates.slice(0, freeSupport).map(row => ({ ...row, upkeep: 0, reason: 'free-support' as const }));
+  const paidBuildings = paidCandidates.slice(freeSupport).map(row => ({ ...row, reason: 'paid' as const }));
+  const upkeep = paidBuildings.reduce((sum, row) => sum + row.upkeep, 0);
+  const rows = [...exemptBuildings, ...supportedBuildings, ...paidBuildings];
+
+  return {
+    cityId,
+    freeSupport,
+    supportUsed: supportedBuildings.length,
+    upkeep,
+    exemptBuildings,
+    supportedBuildings,
+    paidBuildings,
+    rows,
+  };
+}
+
+function isCombatCapable(unit: Unit): boolean {
+  return (UNIT_DEFINITIONS[unit.type]?.strength ?? 0) > 0;
+}
+
+export function calculateCivUnitMaintenance(state: GameState, civId: string): CivUnitMaintenance {
+  const civ = state.civilizations[civId];
+  if (!civ) {
+    return { civId, freeSupport: 0, supportUsed: 0, defenderSlots: 0, defenderSlotsUsed: 0, upkeep: 0, exemptUnits: [], freeDefenderUnits: [], supportedUnits: [], paidUnits: [], rows: [] };
+  }
+
+  const units = civ.units.map(id => state.units[id]).filter((u): u is Unit => Boolean(u));
+  const exemptUnits: MaintenanceRow[] = [];
+  const candidates: Unit[] = [];
+  for (const u of units) {
+    if (FREE_UNIT_TYPES.has(u.type)) {
+      exemptUnits.push({ id: u.id, label: unitLabel(u), upkeep: 0, reason: 'exempt' });
+    } else {
+      candidates.push(u);
+    }
+  }
+
+  const defenderSlots = civ.cities.length * 2;
+  const combat = candidates
+    .filter(isCombatCapable)
+    .sort((left, right) =>
+      unitPriority(left.type) - unitPriority(right.type)
+      || unitUpkeep(left.type) - unitUpkeep(right.type)
+      || left.id.localeCompare(right.id),
+    );
+  const defenderIds = new Set(combat.slice(0, defenderSlots).map(u => u.id));
+  const freeDefenderUnits = combat
+    .filter(u => defenderIds.has(u.id))
+    .map(u => ({ id: u.id, label: unitLabel(u), upkeep: 0, reason: 'free-support' as const }));
+
+  const totalPopulation = civ.cities.reduce((sum, id) => sum + (state.cities[id]?.population ?? 0), 0);
+  const freeSupport = 2 + civ.cities.length * 2 + Math.floor(totalPopulation / 3);
+  const remaining = candidates
+    .filter(u => !defenderIds.has(u.id))
+    .map(u => ({ id: u.id, label: unitLabel(u), upkeep: unitUpkeep(u.type), reason: 'paid' as const, type: u.type }))
+    .sort((left, right) =>
+      unitPriority(left.type) - unitPriority(right.type)
+      || left.upkeep - right.upkeep
+      || left.id.localeCompare(right.id),
+    );
+
+  const supportedUnits = remaining.slice(0, freeSupport).map(({ type: _type, ...row }) => ({ ...row, upkeep: 0, reason: 'free-support' as const }));
+  const paidUnits = remaining.slice(freeSupport).map(({ type: _type, ...row }) => ({ ...row, reason: 'paid' as const }));
+  const upkeep = paidUnits.reduce((sum, row) => sum + row.upkeep, 0);
+  const rows = [...exemptUnits, ...freeDefenderUnits, ...supportedUnits, ...paidUnits];
+
+  return {
+    civId,
+    freeSupport,
+    supportUsed: supportedUnits.length,
+    defenderSlots,
+    defenderSlotsUsed: freeDefenderUnits.length,
+    upkeep,
+    exemptUnits,
+    freeDefenderUnits,
+    supportedUnits,
+    paidUnits,
+    rows,
+  };
+}
+
+export function calculateCivEconomy(
+  state: GameState,
+  civId: string,
+  grossGoldIncome: number,
+  overrideMaintenance?: { buildingMaintenance: number; unitMaintenance: number },
+): CivEconomyResult {
+  const civ = state.civilizations[civId];
+  const buildingBreakdown = civ
+    ? civ.cities.map(cityId => calculateCityBuildingMaintenance(state, cityId))
+    : [];
+  const unitBreakdown = calculateCivUnitMaintenance(state, civId);
+  const buildingMaintenance = overrideMaintenance?.buildingMaintenance ?? buildingBreakdown.reduce((sum, row) => sum + row.upkeep, 0);
+  const unitMaintenance = overrideMaintenance?.unitMaintenance ?? unitBreakdown.upkeep;
+  const totalMaintenance = buildingMaintenance + unitMaintenance;
+  const startingGold = civ?.gold ?? 0;
+  const netGoldPerTurn = grossGoldIncome - totalMaintenance;
+  const endingGold = Math.max(0, startingGold + netGoldPerTurn);
+  const unpaidMaintenance = Math.max(0, totalMaintenance - (startingGold + grossGoldIncome));
+  const level = strainLevel(unpaidMaintenance, totalMaintenance);
+
+  return {
+    civId,
+    turn: state.turn,
+    startingGold,
+    endingGold,
+    grossGoldIncome,
+    buildingMaintenance,
+    unitMaintenance,
+    totalMaintenance,
+    netGoldPerTurn,
+    unpaidMaintenance,
+    strainLevel: level,
+    rushBuyBlockedByStrain: level === 'high' || level === 'critical',
+    buildingBreakdown,
+    unitBreakdown,
+  };
+}
+
+export function projectCivEconomy(state: GameState, civId: string): CivEconomyResult {
+  const civ = state.civilizations[civId];
+  if (!civ) return calculateCivEconomy(state, civId, 0);
+  const civDef = resolveCivDefinition(state, civ.civType);
+  let grossGoldIncome = 0;
+  for (const cityId of civ.cities) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+    const yields = calculateProjectedCityYields(state, cityId, civDef?.bonusEffect);
+    const wonderCityBonus = getLegendaryWonderCityYieldBonus(state, civId, cityId);
+    grossGoldIncome += yields.gold + (wonderCityBonus.gold ?? 0);
+    if (city.productionQueue.length === 0 && city.idleProduction === 'gold') {
+      grossGoldIncome += yields.production;
+    }
+  }
+  const wonderCivBonus = getLegendaryWonderCivYieldBonus(state, civId);
+  grossGoldIncome += wonderCivBonus.gold ?? 0;
+  if (civDef?.bonusEffect.type === 'allied_kingdoms') {
+    const allianceCount = civ.diplomacy.treaties.filter(t => t.type === 'alliance').length;
+    grossGoldIncome += allianceCount * civDef.bonusEffect.allianceYieldBonus;
+  }
+  for (const treaty of civ.diplomacy.treaties) {
+    if (treaty.type === 'trade_agreement' && treaty.goldPerTurn) {
+      grossGoldIncome += treaty.goldPerTurn;
+    }
+  }
+  if (state.marketplace) {
+    grossGoldIncome += processTradeRouteIncome(
+      state.marketplace.tradeRoutes.filter(route => state.cities[route.fromCityId]?.owner === civId),
+    );
+  }
+  return calculateCivEconomy(state, civId, grossGoldIncome);
+}
+
+export function applyEconomyTurn(state: GameState, civId: string, result: CivEconomyResult): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civId]: { ...civ, gold: result.endingGold },
+    },
+    economyStatusByCiv: {
+      ...(state.economyStatusByCiv ?? {}),
+      [civId]: {
+        turn: state.turn,
+        grossGoldIncome: result.grossGoldIncome,
+        buildingMaintenance: result.buildingMaintenance,
+        unitMaintenance: result.unitMaintenance,
+        netGoldPerTurn: result.netGoldPerTurn,
+        unpaidMaintenance: result.unpaidMaintenance,
+        strainLevel: result.strainLevel,
+      },
+    },
+  };
+}
+
+function activeItemLabel(itemId: string): string {
+  return BUILDINGS[itemId]?.name ?? TRAINABLE_UNITS.find(u => u.type === itemId)?.name ?? itemId;
+}
+
+export function getRushBuyQuote(state: GameState, civId: string, cityId: string): RushBuyQuote {
+  const city = state.cities[cityId];
+  const civ = state.civilizations[civId];
+  if (!city || !civ || city.owner !== civId) return { available: false, reason: 'not-owner' };
+  const itemId = city.productionQueue[0];
+  if (!itemId) return { available: false, reason: 'no-active-production' };
+  if (itemId.startsWith('legendary:')) return { available: false, reason: 'wonders-cannot-be-bought', itemId, label: activeItemLabel(itemId) };
+  const building = BUILDINGS[itemId];
+  const unit = TRAINABLE_UNITS.find(u => u.type === itemId);
+  if (!building && !unit) return { available: false, reason: 'invalid-active-item', itemId, label: activeItemLabel(itemId) };
+
+  const projected = projectCivEconomy(state, civId);
+  if (projected.rushBuyBlockedByStrain) {
+    return { available: false, reason: 'treasury-strain-too-high', itemId, label: activeItemLabel(itemId) };
+  }
+
+  const civDef = resolveCivDefinition(state, civ.civType);
+  const totalCost = getProductionCostForItem(itemId, { city, bonusEffect: civDef?.bonusEffect, era: state.era });
+  const remainingProduction = Math.max(0, totalCost - city.productionProgress);
+  const cost = Math.max(10, Math.ceil(remainingProduction * 2.5));
+  if (civ.gold < cost) {
+    return { available: false, reason: 'not-enough-gold', itemId, label: activeItemLabel(itemId), cost, remainingProduction };
+  }
+
+  return { available: true, itemId, label: activeItemLabel(itemId), cost, remainingProduction };
+}
+
+export function emitEconomyStrainIfNeeded(bus: EventBus, result: CivEconomyResult): void {
+  if (result.strainLevel === 'none') return;
+  bus.emit('economy:treasury-strain', {
+    civId: result.civId,
+    level: result.strainLevel,
+    netGoldPerTurn: result.netGoldPerTurn,
+    unpaidMaintenance: result.unpaidMaintenance,
+  });
+}
+```
+
+Do not add rush-buy execution yet; that comes after shared production completion in Task 2.
+
+- [ ] **Step 6: Run economy tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/economy-system.test.ts
+```
+
+Expected: PASS for maintenance, strain, projection, and quote tests.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add src/core/types.ts src/systems/economy-system.ts tests/systems/economy-system.test.ts
+git commit -m "feat(economy): add maintenance resolver"
+```
+
+---
+
+### Task 2: Shared Production Completion And Rush-Buy Execution
+
+**Files:**
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/systems/economy-system.ts`
+- Create: `tests/systems/rush-buy-system.test.ts`
+
+- [ ] **Step 1: Write failing rush-buy execution tests**
+
+Create `tests/systems/rush-buy-system.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import type { City, GameState } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { rushBuyActiveProduction } from '@/systems/economy-system';
+
+function city(overrides: Partial<City> = {}): City {
+  return {
+    id: 'city-1',
+    name: 'Capital',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    population: 2,
+    food: 0,
+    foodNeeded: 20,
+    buildings: [],
+    productionQueue: ['workshop'],
+    productionProgress: 2,
+    ownedTiles: [],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    grid: Array.from({ length: 7 }, (_, row) => Array.from({ length: 7 }, (_, col) => row === 3 && col === 3 ? 'city-center' : null)),
+    gridSize: 3,
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    idleProduction: null,
+    ...overrides,
+  };
+}
+
+function state(c: City = city()): GameState {
+  return {
+    turn: 12,
+    era: 1,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { [c.id]: c },
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'egypt',
+        cities: [c.id],
+        units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 100,
+        visibility: { tiles: {} },
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: false,
+      musicEnabled: false,
+      musicVolume: 0,
+      sfxVolume: 0,
+      tutorialEnabled: false,
+      advisorsEnabled: {} as any,
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+  } as GameState;
+}
+
+describe('rush-buy-system', () => {
+  it('buys active normal building through shared completion semantics', () => {
+    const bus = new EventBus();
+    const complete = vi.fn();
+    bus.on('city:building-complete', complete);
+
+    const result = rushBuyActiveProduction(state(), 'player', 'city-1', bus);
+
+    expect(result.success).toBe(true);
+    expect(result.state.civilizations.player.gold).toBe(75);
+    expect(result.state.cities['city-1'].buildings).toContain('workshop');
+    expect(result.state.cities['city-1'].grid.flat()).toContain('workshop');
+    expect(result.state.cities['city-1'].productionQueue).toEqual([]);
+    expect(result.state.cities['city-1'].productionProgress).toBe(0);
+    expect(complete).toHaveBeenCalledWith({ cityId: 'city-1', buildingId: 'workshop' });
+  });
+
+  it('buys active normal unit through shared completion semantics', () => {
+    const bus = new EventBus();
+    const trained = vi.fn();
+    bus.on('city:unit-trained', trained);
+    const c = city({ productionQueue: ['warrior'], productionProgress: 0 });
+
+    const result = rushBuyActiveProduction(state(c), 'player', 'city-1', bus);
+
+    expect(result.success).toBe(true);
+    expect(result.state.civilizations.player.gold).toBe(80);
+    expect(result.state.civilizations.player.units).toHaveLength(1);
+    const newUnitId = result.state.civilizations.player.units[0];
+    expect(result.state.units[newUnitId].type).toBe('warrior');
+    expect(result.state.units[newUnitId].position).toEqual({ q: 0, r: 0 });
+    expect(trained).toHaveBeenCalledWith({ cityId: 'city-1', unitType: 'warrior' });
+  });
+
+  it('rejects high treasury strain with an explicit reason', () => {
+    const bus = new EventBus();
+    const s = state(city({ productionQueue: ['warrior'] }));
+    s.civilizations.player.gold = 20;
+    s.units = Object.fromEntries(Array.from({ length: 100 }, (_, index) => [`u-${index}`, {
+      id: `u-${index}`,
+      type: 'warrior',
+      owner: 'player',
+      position: { q: index, r: 0 },
+      movementPointsLeft: 2,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    }]));
+    s.civilizations.player.units = Object.keys(s.units);
+
+    const result = rushBuyActiveProduction(s, 'player', 'city-1', bus);
+
+    expect(result).toMatchObject({ success: false, reason: 'treasury-strain-too-high' });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing rush-buy tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/rush-buy-system.test.ts
+```
+
+Expected: FAIL because `rushBuyActiveProduction` and `completeCityProductionItem` are missing.
+
+- [ ] **Step 3: Extract production completion helper**
+
+In `src/systems/city-system.ts`, add:
+
+```ts
+export interface ProductionCompletionResult {
+  city: City;
+  completedBuilding: string | null;
+  completedUnit: UnitType | null;
+}
+
+export function completeCityProductionItem(city: City, itemId: string): ProductionCompletionResult {
+  const building = BUILDINGS[itemId];
+  if (building) {
+    const buildings = city.buildings.includes(building.id)
+      ? city.buildings
+      : [...city.buildings, building.id];
+    const completedCity = placeBuildingInGrid({ ...city, buildings }, building.id);
+    return { city: completedCity, completedBuilding: building.id, completedUnit: null };
+  }
+
+  const unitDef = TRAINABLE_UNITS.find(u => u.type === itemId);
+  if (unitDef) {
+    return { city, completedBuilding: null, completedUnit: unitDef.type };
+  }
+
+  return { city, completedBuilding: null, completedUnit: null };
+}
+```
+
+Then replace the duplicate completion logic inside `processCity` with:
+
+```ts
+    const completion = completeCityProductionItem({ ...city, buildings: newBuildings }, currentItem);
+    if (completion.completedBuilding && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
+      completedBuilding = completion.completedBuilding;
+      newBuildings.length = 0;
+      newBuildings.push(...completion.city.buildings);
+      newQueue.shift();
+      newProgress = 0;
+    }
+
+    if (completion.completedUnit && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
+      completedUnit = completion.completedUnit;
+      newQueue.shift();
+      newProgress = 0;
+    }
+```
+
+Keep the final `if (completedBuilding) nextCity = placeBuildingInGrid(...)` block or remove it only if tests prove placement still happens exactly once. Prefer keeping it because `placeBuildingInGrid` is idempotent.
+
+- [ ] **Step 4: Add rush-buy execution**
+
+Append to `src/systems/economy-system.ts`:
+
+```ts
+import {
+  completeCityProductionItem,
+  getProductionCostForItem,
+} from '@/systems/city-system';
+import { createSpyFromUnit, isSpyUnitType } from '@/systems/espionage-system';
+```
+
+Merge imports instead of duplicating existing imports.
+
+Add:
+
+```ts
+export type RushBuyResult =
+  | { success: true; state: GameState; itemId: string; label: string; cost: number }
+  | { success: false; state: GameState; reason: RushBuyDisabledReason };
+
+export function rushBuyActiveProduction(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  bus: EventBus,
+): RushBuyResult {
+  const quote = getRushBuyQuote(state, civId, cityId);
+  if (!quote.available || !quote.itemId || quote.cost === undefined) {
+    return { success: false, state, reason: quote.reason ?? 'invalid-active-item' };
+  }
+
+  const city = state.cities[cityId];
+  const civ = state.civilizations[civId];
+  if (!city || !civ) return { success: false, state, reason: 'not-owner' };
+
+  const completion = completeCityProductionItem(city, quote.itemId);
+  if (!completion.completedBuilding && !completion.completedUnit) {
+    return { success: false, state, reason: 'invalid-active-item' };
+  }
+
+  const nextCity: City = {
+    ...completion.city,
+    productionQueue: city.productionQueue.slice(1),
+    productionProgress: 0,
+  };
+  let nextState: GameState = {
+    ...state,
+    cities: { ...state.cities, [cityId]: nextCity },
+    civilizations: {
+      ...state.civilizations,
+      [civId]: { ...civ, gold: civ.gold - quote.cost },
+    },
+  };
+
+  if (completion.completedBuilding) {
+    bus.emit('city:building-complete', { cityId, buildingId: completion.completedBuilding });
+  }
+
+  if (completion.completedUnit) {
+    const civDef = resolveCivDefinition(state, civ.civType);
+    const newUnit = createUnit(completion.completedUnit, civId, city.position, civDef?.bonusEffect);
+    nextState = {
+      ...nextState,
+      units: { ...nextState.units, [newUnit.id]: newUnit },
+      civilizations: {
+        ...nextState.civilizations,
+        [civId]: {
+          ...nextState.civilizations[civId],
+          units: [...nextState.civilizations[civId].units, newUnit.id],
+        },
+      },
+    };
+    bus.emit('city:unit-trained', { cityId, unitType: completion.completedUnit });
+
+    if (isSpyUnitType(completion.completedUnit) && nextState.espionage?.[civId]) {
+      const { state: updatedEsp, spy } = createSpyFromUnit(
+        nextState.espionage[civId],
+        newUnit.id,
+        civId,
+        completion.completedUnit,
+        `spy-unit-${newUnit.id}-${nextState.turn}`,
+      );
+      nextState = {
+        ...nextState,
+        espionage: { ...nextState.espionage, [civId]: updatedEsp },
+      };
+      bus.emit('espionage:spy-recruited', { civId, spy });
+    }
+  }
+
+  return { success: true, state: nextState, itemId: quote.itemId, label: quote.label ?? quote.itemId, cost: quote.cost };
+}
+```
+
+- [ ] **Step 5: Run rush-buy and city tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/rush-buy-system.test.ts tests/systems/city-system.test.ts
+```
+
+If `tests/systems/city-system.test.ts` does not exist, run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/economy-system.test.ts tests/systems/rush-buy-system.test.ts
+```
+
+Expected: PASS. If TypeScript import conflicts appear in `economy-system.ts`, consolidate city-system imports into one import block.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/systems/city-system.ts src/systems/economy-system.ts tests/systems/rush-buy-system.test.ts
+git commit -m "feat(economy): add rush buy execution"
+```
+
+---
+
+### Task 3: Turn Manager Economy Application And Notifications
+
+**Files:**
+- Modify: `src/core/turn-manager.ts`
+- Modify: `src/ui/notification-routing.ts`
+- Modify: `tests/systems/economy-system.test.ts`
+- Create or modify: `tests/systems/turn-manager-economy.test.ts`
+
+- [ ] **Step 1: Write failing turn-manager tests**
+
+Create `tests/systems/turn-manager-economy.test.ts` with a focused fixture based on existing turn-manager tests:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import type { City, GameState } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+
+function city(overrides: Partial<City> = {}): City {
+  return {
+    id: 'city-1',
+    name: 'Capital',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    population: 1,
+    food: 0,
+    foodNeeded: 20,
+    buildings: ['security-bureau', 'observatory', 'forge', 'harbor', 'marketplace', 'temple', 'walls', 'stable', 'safehouse'],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    grid: [[null]],
+    gridSize: 3,
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    idleProduction: null,
+    ...overrides,
+  };
+}
+
+function state(gold: number): GameState {
+  const c = city();
+  return {
+    turn: 20,
+    era: 3,
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { [c.id]: c },
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'egypt',
+        cities: [c.id],
+        units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold,
+        visibility: { tiles: {} },
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: false,
+      musicEnabled: false,
+      musicVolume: 0,
+      sfxVolume: 0,
+      tutorialEnabled: false,
+      advisorsEnabled: {} as any,
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+  } as GameState;
+}
+
+describe('turn-manager economy', () => {
+  it('applies maintenance with a zero gold floor and stores resolved status', () => {
+    const bus = new EventBus();
+    const next = processTurn(state(0), bus);
+
+    expect(next.civilizations.player.gold).toBe(0);
+    expect(next.economyStatusByCiv?.player).toMatchObject({
+      turn: 20,
+      strainLevel: 'high',
+    });
+    expect(next.economyStatusByCiv!.player.buildingMaintenance).toBeGreaterThan(0);
+  });
+
+  it('emits one treasury strain event for an affected civ turn', () => {
+    const bus = new EventBus();
+    const strain = vi.fn();
+    bus.on('economy:treasury-strain', strain);
+
+    processTurn(state(0), bus);
+
+    expect(strain).toHaveBeenCalledTimes(1);
+    expect(strain.mock.calls[0][0]).toMatchObject({ civId: 'player', level: 'high' });
+  });
+});
+```
+
+- [ ] **Step 2: Run failing turn-manager tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/turn-manager-economy.test.ts
+```
+
+Expected: FAIL because `processTurn` still directly adds gross gold and does not store economy status.
+
+- [ ] **Step 3: Integrate economy in turn-manager**
+
+In `src/core/turn-manager.ts`, import:
+
+```ts
+import { applyEconomyTurn, calculateCivEconomy, emitEconomyStrainIfNeeded } from '@/systems/economy-system';
+```
+
+Remove the direct gold update block:
+
+```ts
+    // Update gold
+    newState.civilizations[civId].gold += totalGold;
+```
+
+Do not apply economy at that exact location yet. Keep accumulating `totalGold` until after diplomacy treaty income is known.
+
+Keep vassalage, treaty, and trade route income behavior coherent:
+
+- Vassalage tribute should still be based on positive gross income before maintenance, as it is today.
+- If tribute currently subtracts after gold is added, move it before `calculateCivEconomy` by reducing `totalGold` for the vassal and directly adding tribute to the overlord.
+- Treaty `goldPerTurn` should add to `totalGold`, not directly to `civ.gold`.
+- Marketplace trade route income should add to `totalGold` inside this civ loop before `calculateCivEconomy`; remove the later block that directly adds route income to `newState.civilizations[civId].gold`.
+
+Use this replacement for vassalage block:
+
+```ts
+    if (civ.diplomacy?.vassalage.overlord) {
+      const tribute = processVassalageTribute(totalGold);
+      totalGold -= tribute.tributeAmount;
+      const overlordId = civ.diplomacy.vassalage.overlord;
+      if (newState.civilizations[overlordId]) {
+        newState.civilizations[overlordId].gold += tribute.tributeAmount;
+      }
+    }
+```
+
+Place it before `calculateCivEconomy`.
+
+In the diplomacy treaty loop, replace direct gold mutation:
+
+```ts
+          newState.civilizations[civId].gold += treaty.goldPerTurn;
+```
+
+with:
+
+```ts
+          totalGold += treaty.goldPerTurn;
+```
+
+Before applying economy, add marketplace route income:
+
+```ts
+    if (newState.marketplace) {
+      totalGold += processTradeRouteIncome(
+        newState.marketplace.tradeRoutes.filter(route => {
+          const city = newState.cities[route.fromCityId];
+          return city?.owner === civId;
+        }),
+      );
+    }
+```
+
+Then apply economy after diplomacy treaty processing and marketplace route income, before visibility updates:
+
+```ts
+    const economyResult = calculateCivEconomy(newState, civId, totalGold);
+    newState = applyEconomyTurn(newState, civId, economyResult);
+    emitEconomyStrainIfNeeded(bus, economyResult);
+```
+
+In the later marketplace section, delete only the direct route-income addition loop:
+
+```ts
+    // Trade route income for each civ
+    for (const [civId, civ] of Object.entries(newState.civilizations)) {
+      const civRouteIncome = processTradeRouteIncome(
+        newState.marketplace.tradeRoutes.filter(r => {
+          const city = newState.cities[r.fromCityId];
+          return city?.owner === civId;
+        }),
+      );
+      newState.civilizations[civId].gold += civRouteIncome;
+    }
+```
+
+Keep fashion cycle and price updates in the marketplace section unchanged.
+
+- [ ] **Step 4: Route economy strain notifications**
+
+In `src/ui/notification-routing.ts`, extend the local routing type:
+
+```ts
+type EconomyTreasuryStrainRoutingEvent =
+  GameEvents['economy:treasury-strain'] & { type: 'economy:treasury-strain' };
+```
+
+Add a route helper:
+
+```ts
+export function routeEconomyTreasuryStrain(
+  _state: GameState,
+  event: EconomyTreasuryStrainRoutingEvent,
+  sink: NotificationSink,
+): void {
+  if (event.level === 'low') {
+    sink(event.civId, 'Treasury strain: maintenance is outpacing available gold.', 'warning');
+    return;
+  }
+  if (event.level === 'high') {
+    sink(event.civId, 'Treasury strain is high. Rush-buy is unavailable until the budget recovers.', 'warning');
+    return;
+  }
+  sink(event.civId, 'Treasury strain is critical. From Era 3 onward, this increases unrest pressure.', 'warning');
+}
+```
+
+In `src/main.ts`, add `routeEconomyTreasuryStrain` to the existing import from `@/ui/notification-routing` near `routeFactionTransition` and `routeTerritoryTileFlipped`. Then add this listener after the existing `territory:tile-flipped` listener or before the faction listeners:
+
+```ts
+bus.on('economy:treasury-strain', event => {
+  routeEconomyTreasuryStrain(gameState, { type: 'economy:treasury-strain', ...event }, appendToCivLog);
+});
+```
+
+- [ ] **Step 5: Run turn-manager tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/turn-manager-economy.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git add src/core/turn-manager.ts src/ui/notification-routing.ts src/main.ts tests/systems/turn-manager-economy.test.ts
+git commit -m "feat(economy): apply maintenance during turns"
+```
+
+---
+
+### Task 4: Era 3+ Unrest Integration
+
+**Files:**
+- Modify: `src/systems/faction-system.ts`
+- Modify: `tests/systems/faction-system.test.ts`
+
+- [ ] **Step 1: Add failing faction tests**
+
+Append to `tests/systems/faction-system.test.ts`:
+
+```ts
+it('does not add treasury strain pressure before Era 3', () => {
+  const base = makeState({ era: 2 });
+  base.economyStatusByCiv = {
+    player: {
+      turn: base.turn - 1,
+      grossGoldIncome: 0,
+      buildingMaintenance: 20,
+      unitMaintenance: 0,
+      netGoldPerTurn: -20,
+      unpaidMaintenance: 20,
+      strainLevel: 'critical',
+    },
+  };
+
+  expect(computeUnrestPressure('city-1', base)).toBe(0);
+});
+
+it('adds treasury strain pressure in Era 3 only for critical strain', () => {
+  const critical = makeState({ era: 3 });
+  critical.economyStatusByCiv = {
+    player: {
+      turn: critical.turn - 1,
+      grossGoldIncome: 0,
+      buildingMaintenance: 20,
+      unitMaintenance: 0,
+      netGoldPerTurn: -20,
+      unpaidMaintenance: 20,
+      strainLevel: 'critical',
+    },
+  };
+
+  const high = makeState({ era: 3 });
+  high.economyStatusByCiv = {
+    player: {
+      turn: high.turn - 1,
+      grossGoldIncome: 0,
+      buildingMaintenance: 8,
+      unitMaintenance: 0,
+      netGoldPerTurn: -8,
+      unpaidMaintenance: 8,
+      strainLevel: 'high',
+    },
+  };
+
+  expect(computeUnrestPressure('city-1', critical)).toBeGreaterThan(computeUnrestPressure('city-1', high));
+  expect(computeUnrestPressure('city-1', high)).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run failing faction tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/faction-system.test.ts
+```
+
+Expected: FAIL because critical economy status does not affect pressure.
+
+- [ ] **Step 3: Add economy pressure helper**
+
+In `src/systems/faction-system.ts`, import:
+
+```ts
+import { ECONOMY_UNREST_PRESSURE } from './economy-system';
+```
+
+Inside `computeUnrestPressure`, after spy unrest bonus:
+
+```ts
+  const economyStatus = state.economyStatusByCiv?.[owner];
+  if (state.era >= 3 && economyStatus?.strainLevel === 'critical') {
+    pressure += ECONOMY_UNREST_PRESSURE;
+  }
+```
+
+- [ ] **Step 4: Run faction tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/faction-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/systems/faction-system.ts tests/systems/faction-system.test.ts
+git commit -m "feat(economy): add treasury strain unrest pressure"
+```
+
+---
+
+### Task 5: HUD Projection
+
+**Files:**
+- Create: `src/ui/hud-economy.ts`
+- Modify: `src/main.ts`
+- Create: `tests/ui/hud-economy.test.ts`
+
+- [ ] **Step 1: Write failing HUD helper tests**
+
+Create `tests/ui/hud-economy.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import type { GameState } from '@/core/types';
+import { formatGoldHudText } from '@/ui/hud-economy';
+
+describe('hud-economy', () => {
+  it('labels positive and negative projected net gold clearly', () => {
+    expect(formatGoldHudText(42, 5, 'none')).toBe('💰 42 (+5 net)');
+    expect(formatGoldHudText(42, -3, 'low')).toBe('💰 42 (-3 net) · Treasury strain');
+    expect(formatGoldHudText(42, -8, 'high')).toBe('💰 42 (-8 net) · Rush-buy blocked');
+    expect(formatGoldHudText(42, -12, 'critical')).toBe('💰 42 (-12 net) · Critical strain');
+  });
+});
+```
+
+- [ ] **Step 2: Run failing HUD test**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/hud-economy.test.ts
+```
+
+Expected: FAIL because `src/ui/hud-economy.ts` does not exist.
+
+- [ ] **Step 3: Add HUD formatter**
+
+Create `src/ui/hud-economy.ts`:
+
+```ts
+import type { TreasuryStrainLevel } from '@/core/types';
+
+export function formatGoldHudText(gold: number, netGoldPerTurn: number, strainLevel: TreasuryStrainLevel): string {
+  const sign = netGoldPerTurn >= 0 ? '+' : '';
+  const base = `💰 ${gold} (${sign}${netGoldPerTurn} net)`;
+  if (strainLevel === 'critical') return `${base} · Critical strain`;
+  if (strainLevel === 'high') return `${base} · Rush-buy blocked`;
+  if (strainLevel === 'low') return `${base} · Treasury strain`;
+  return base;
+}
+```
+
+- [ ] **Step 4: Wire HUD to projection**
+
+In `src/main.ts`, import:
+
+```ts
+import { projectCivEconomy } from '@/systems/economy-system';
+import { formatGoldHudText } from '@/ui/hud-economy';
+```
+
+In `updateHUD`, replace the gold span text:
+
+```ts
+  const economy = projectCivEconomy(gameState, gameState.currentPlayer);
+  goldSpan.textContent = formatGoldHudText(civ.gold, economy.netGoldPerTurn, economy.strainLevel);
+```
+
+Keep `totalGold` calculation for other local display only if still used; remove it if it becomes unused.
+
+- [ ] **Step 5: Run HUD test**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/hud-economy.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add src/ui/hud-economy.ts src/main.ts tests/ui/hud-economy.test.ts
+git commit -m "feat(ui): show projected net gold"
+```
+
+---
+
+### Task 6: City Panel Maintenance And Rush-Buy UX
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Read UI rule**
+
+```bash
+sed -n '1,260p' .claude/rules/ui-panels.md
+sed -n '1,260p' docs/superpowers/plans/README.md
+```
+
+Expected: confirm `textContent` for dynamic values, immediate panel rerender, no hidden full catalog.
+
+- [ ] **Step 2: Add failing city panel tests**
+
+Append focused tests to `tests/ui/city-panel.test.ts` using existing `createCityPanel` fixtures:
+
+```ts
+it('shows city maintenance support and future upkeep without hiding build choices', () => {
+  city.buildings = ['herbalist', 'workshop', 'marketplace', 'harbor', 'forge', 'observatory', 'security-bureau'];
+  const panel = createCityPanel(container, city, state, {
+    onBuild: vi.fn(),
+    onOpenWonderPanel: vi.fn(),
+    onClose: vi.fn(),
+  });
+
+  expect(panel.textContent).toContain('Free support');
+  expect(panel.textContent).toContain('Paid upkeep');
+  expect(panel.textContent).toContain('Build');
+  expect(panel.textContent).toContain('Units');
+  expect(panel.querySelectorAll('.build-item').length).toBeGreaterThan(0);
+});
+
+it('shows buy now for active normal production and rerenders after click', () => {
+  city.productionQueue = ['workshop', 'warrior'];
+  city.productionProgress = 2;
+  state.civilizations[state.currentPlayer].gold = 100;
+  const onRushBuyActiveProduction = vi.fn((cityId: string) => {
+    state.civilizations[state.currentPlayer].gold = 75;
+    state.cities[cityId] = {
+      ...state.cities[cityId],
+      buildings: [...state.cities[cityId].buildings, 'workshop'],
+      productionQueue: ['warrior'],
+      productionProgress: 0,
+    };
+    return state;
+  });
+
+  const panel = createCityPanel(container, city, state, {
+    onBuild: vi.fn(),
+    onOpenWonderPanel: vi.fn(),
+    onClose: vi.fn(),
+    onRushBuyActiveProduction,
+  });
+
+  const button = panel.querySelector<HTMLButtonElement>('[data-rush-buy-active]');
+  expect(button?.textContent).toContain('Buy now');
+  button!.click();
+
+  const refreshed = container.querySelector('#city-panel')!;
+  expect(onRushBuyActiveProduction).toHaveBeenCalledWith(city.id);
+  expect(refreshed.textContent).toContain('Workshop');
+  expect(refreshed.textContent).toContain('Warrior');
+});
+
+it('shows explicit disabled reasons for treasury strain and legendary wonders', () => {
+  city.productionQueue = ['legendary:pyramids'];
+  const panel = createCityPanel(container, city, state, {
+    onBuild: vi.fn(),
+    onOpenWonderPanel: vi.fn(),
+    onClose: vi.fn(),
+  });
+
+  expect(panel.textContent).toContain('Wonders cannot be bought');
+});
+```
+
+If the existing test file uses different `beforeEach` names, add this as a separate `describe('maintenance and rush-buy UI', ...)` block with local `container`, `city`, and `state` fixtures. The assertions must inspect visible panel text after clicks, not only callback calls.
+
+- [ ] **Step 3: Run failing city panel tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts
+```
+
+Expected: FAIL because city panel has no maintenance summary or rush-buy controls.
+
+- [ ] **Step 4: Add callback and economy imports**
+
+In `src/ui/city-panel.ts`, import:
+
+```ts
+import {
+  calculateCityBuildingMaintenance,
+  getRushBuyQuote,
+  type RushBuyDisabledReason,
+} from '@/systems/economy-system';
+```
+
+Extend `CityPanelCallbacks`:
+
+```ts
+  onRushBuyActiveProduction?: (cityId: string) => GameState | void;
+```
+
+Add helper:
+
+```ts
+function rushBuyReasonText(reason: RushBuyDisabledReason | undefined): string {
+  switch (reason) {
+    case 'no-active-production': return 'No active production to buy';
+    case 'not-enough-gold': return 'Not enough gold';
+    case 'treasury-strain-too-high': return 'Treasury strain is too high';
+    case 'wonders-cannot-be-bought': return 'Wonders cannot be bought';
+    case 'not-owner': return 'Only the owner can buy production';
+    case 'invalid-active-item': return 'This production item cannot be bought';
+    default: return 'Cannot buy this item';
+  }
+}
+```
+
+- [ ] **Step 5: Render maintenance and rush-buy**
+
+Near the top of `createCityPanel`, after `currentCiv`, compute:
+
+```ts
+  const cityMaintenance = calculateCityBuildingMaintenance(state, city.id);
+  const rushBuyQuote = getRushBuyQuote(state, state.currentPlayer, city.id);
+```
+
+In each built building row, include nonzero upkeep:
+
+```ts
+const upkeepRow = cityMaintenance.rows.find(row => row.id === bid);
+const upkeepText = upkeepRow?.upkeep ? ` · ${upkeepRow.upkeep} gold/turn` : ' · 0 upkeep';
+```
+
+Add a maintenance summary after the yield row:
+
+```html
+<div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;margin-bottom:12px;font-size:12px;">
+  <strong>Free support</strong>: <span data-text="maintenance-support"></span><br>
+  <strong>Paid upkeep</strong>: <span data-text="maintenance-paid"></span>
+</div>
+```
+
+Set:
+
+```ts
+  setText('maintenance-support', `${cityMaintenance.supportUsed}/${cityMaintenance.freeSupport} buildings`);
+  setText('maintenance-paid', `${cityMaintenance.upkeep} gold/turn`);
+```
+
+For build options, append future upkeep text:
+
+```ts
+const futureCity = {
+  ...city,
+  buildings: city.buildings.includes(b.id) ? city.buildings : [...city.buildings, b.id],
+};
+const futureState = {
+  ...state,
+  cities: { ...state.cities, [city.id]: futureCity },
+};
+const futureRow = calculateCityBuildingMaintenance(futureState, city.id).rows.find(row => row.id === b.id);
+const futureUpkeep = futureRow?.upkeep ?? 0;
+```
+
+For active production, add inside `currentProductionHtml`:
+
+```html
+<div data-rush-buy-row style="margin-top:10px;"></div>
+```
+
+After `panel.innerHTML = html`, populate the row with DOM APIs:
+
+```ts
+  const rushRow = panel.querySelector<HTMLElement>('[data-rush-buy-row]');
+  if (rushRow && city.productionQueue.length > 0) {
+    if (rushBuyQuote.available && rushBuyQuote.cost !== undefined) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.dataset.rushBuyActive = 'true';
+      button.textContent = `Buy now: ${rushBuyQuote.cost} gold`;
+      button.style.cssText = 'padding:6px 10px;border-radius:6px;background:#d4aa2c;border:none;color:#111;cursor:pointer;font-size:12px;font-weight:bold;';
+      button.addEventListener('click', () => {
+        const nextState = callbacks.onRushBuyActiveProduction?.(city.id);
+        rerenderPanel(nextState);
+      });
+      rushRow.appendChild(button);
+    } else {
+      const reason = document.createElement('div');
+      reason.dataset.rushBuyDisabledReason = rushBuyQuote.reason ?? 'unknown';
+      reason.style.cssText = 'font-size:12px;color:#d9a25c;';
+      reason.textContent = rushBuyReasonText(rushBuyQuote.reason);
+      rushRow.appendChild(reason);
+    }
+  }
+```
+
+This code references `rerenderPanel`, so place the DOM population after `rerenderPanel` is declared or split into a local `renderRushBuyRow` function called after `rerenderPanel` exists.
+
+- [ ] **Step 6: Wire main callback**
+
+In `src/main.ts`, import:
+
+```ts
+import { rushBuyActiveProduction } from '@/systems/economy-system';
+```
+
+Add to `createCityPanel` callbacks:
+
+```ts
+    onRushBuyActiveProduction: (cityId) => {
+      const result = rushBuyActiveProduction(gameState, gameState.currentPlayer, cityId, bus);
+      if (!result.success) {
+        showNotification(`Cannot buy production: ${result.reason}`, 'warning');
+        return gameState;
+      }
+      gameState = result.state;
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      showNotification(`${gameState.cities[cityId].name}: bought ${result.label} for ${result.cost} gold`, 'success');
+      return gameState;
+    },
+```
+
+- [ ] **Step 7: Run city panel tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts
+```
+
+Expected: PASS and visible DOM tests prove maintenance text, disabled reasons, and immediate rerender.
+
+- [ ] **Step 8: Commit Task 6**
+
+```bash
+git add src/ui/city-panel.ts src/main.ts tests/ui/city-panel.test.ts
+git commit -m "feat(ui): add maintenance and rush buy controls"
+```
+
+---
+
+### Task 7: Save Compatibility, Rule Checks, And Regression Sweep
+
+**Files:**
+- Modify only if failures require it:
+  - `src/storage/**`
+  - `src/core/game-state.ts`
+  - `tests/**`
+
+- [ ] **Step 1: Run source rule checks for changed source files**
+
+Run with the actual changed source paths:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/economy-system.ts src/systems/city-system.ts src/core/turn-manager.ts src/systems/faction-system.ts src/ui/city-panel.ts src/ui/hud-economy.ts src/ui/notification-routing.ts src/main.ts
+```
+
+Expected: PASS. If it reports `innerHTML` risk in newly added dynamic UI, replace dynamic sections with `textContent`/DOM creation.
+
+- [ ] **Step 2: Run targeted tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/economy-system.test.ts tests/systems/rush-buy-system.test.ts tests/systems/turn-manager-economy.test.ts tests/systems/faction-system.test.ts tests/ui/hud-economy.test.ts tests/ui/city-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS. This catches type errors that `yarn test` does not.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect committed and uncommitted diffs**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- src tests docs/superpowers
+```
+
+Expected:
+
+- Source changes are limited to economy, production completion, turn manager, faction pressure, HUD, city panel, notification routing, and tests.
+- `git diff --stat` is empty before final status.
+
+- [ ] **Step 6: Commit verification fixes if any**
+
+If verification required changes:
+
+```bash
+git add <changed-files>
+git commit -m "fix(economy): address maintenance regressions"
+```
+
+If no changes were required, do not create an empty commit.
+
+## Final Self-Review Checklist For Implementer
+
+- Gameplay remains fun: likely-needed buildings are free, two defenders per city are free, reserves absorb bad turns before strain starts.
+- No hidden punishment: gold floors at `0`; no disbanding, no building shutdown, no negative gold.
+- No data drift: `economyStatusByCiv` is serializable and optional for old saves.
+- No logic ambiguity: support assignment order is deterministic for buildings and units.
+- No UI confusion: HUD says `net`, city panel says `Free support` and `Paid upkeep`, disabled rush-buy gives one clear reason.
+- No stale interaction bug: buy button rerenders the panel immediately after success.
+- No wonder exploit: `legendary:*` and future wonder-classified items cannot be bought.
+- No unrest surprise: treasury strain unrest pressure starts only in Era 3+ and uses last resolved critical status.
+- No notification spam: one strain warning per civ turn, not one per city.
+- Regression coverage exists for resolver math, rush-buy, turn application, unrest gating, HUD projection, and city panel visible DOM.

--- a/docs/superpowers/specs/2026-05-16-cost-dynamics-design.md
+++ b/docs/superpowers/specs/2026-05-16-cost-dynamics-design.md
@@ -1,0 +1,302 @@
+# Cost Dynamics Design
+
+Issue: https://github.com/a1flecke/conquestoria/issues/158
+
+## Purpose
+
+Add recurring maintenance and coin-based rush-buying so gold becomes a meaningful strategic resource. The system should slow players who spam units and optional buildings, while keeping early play generous and fun for younger players. Normal expansion, core city development, exploration, and basic defense should feel supported rather than punished.
+
+## Goals
+
+- Model that units and buildings cost money to maintain.
+- Make maintenance mostly invisible during normal early play, then increasingly relevant when a player overbuilds or fields an oversized army.
+- Let players spend gold to immediately complete normal units and buildings as a "rush order" action.
+- Never allow rush-buying wonders or `legendary:*` production.
+- Keep treasury policy flexible so the game can later switch from soft pressure to debt or forced cuts without rewriting turn processing.
+- Surface maintenance, net gold, strain, and rush-buy reasons clearly in the live UI.
+
+## Non-Goals
+
+- Do not add a separate happiness system.
+- Do not disband units, disable buildings, or allow negative gold in the initial implementation.
+- Do not make queue skipping a rush-buy feature; buying applies only to the active production item.
+- Do not tune final balance from this spec. The numbers below are starting values and must live in one configurable policy module.
+
+## Design Guardrails
+
+- Favor kid-friendly generosity over tight economic punishment. Maintenance should be a late warning system for overbuilding, not a tax on obvious play.
+- Keep all maintenance math deterministic. If the game decides which buildings or units are free, tests and UI must be able to explain the exact assignment.
+- Keep the visible UI compact by default. Show net gold, support usage, and rush-buy reasons first; put detailed breakdown rows behind existing panel structure or a small details area.
+- Use one economy resolver for turn processing, HUD projections, city panel text, AI checks, and rush-buy validation. UI must not reimplement maintenance rules.
+- Separate projected economy from last resolved economy. The UI can recompute a projection from the current state; turn effects and notifications use the last resolved turn result stored in state.
+
+## Maintenance Model
+
+Building maintenance is city-local. Each city receives generous free building support, and likely-needed early buildings are free or protected by that support. Paid building upkeep should mainly appear when a city stacks optional, specialized, or advanced buildings beyond normal development.
+
+Initial free building support:
+
+- `4 + floor(population / 2) + maturityBonus`
+- Suggested maturity bonuses: `outpost: 0`, `village: 1`, `town: 2`, `city: 3`, `metropolis: 4`
+
+Initial free or exempt building IDs:
+
+- `city-center`
+- `herbalist`
+- `workshop`
+- `shrine`
+- `barracks`
+- `library`
+- `granary`
+
+The exempt list is intentionally data-driven. It represents "you likely need these buildings" and can be changed independently from the recommendation UI. If future recommendation logic introduces a stronger source of truth for core city needs, the economy policy can consume that metadata instead.
+
+Suggested building upkeep:
+
+- Exempt/core buildings: `0 gold/turn`
+- Most normal buildings: `1 gold/turn`
+- Advanced or high-impact buildings: `2 gold/turn`
+
+Building support assignment order:
+
+1. Exempt buildings are always `0 upkeep` and do not consume free support.
+2. Remaining buildings are sorted by policy priority, then upkeep cost, then building id for stable ties.
+3. Free support covers the first supported buildings in that ordered list.
+4. Buildings outside support pay their configured upkeep.
+
+This avoids a confusing outcome where an optional advanced building silently consumes support ahead of a basic building. The policy can later add metadata such as `maintenancePriority: 'core' | 'standard' | 'advanced'`, but the first implementation can derive priority from the explicit exempt list, pacing band, category, and configured upkeep.
+
+Unit maintenance is empire-wide. Each civilization receives generous free unit support, plus explicit protection for basic defense.
+
+Initial free unit support:
+
+- Starter/exploration/expansion exemptions are applied first.
+- Two combat-capable defender slots per owned city are free.
+- Additional free support: `2 + cityCount * 2 + floor(totalPopulation / 3)`
+
+Initial free or discounted unit behavior:
+
+- Settlers, workers, and scouts are free.
+- Defender slots are empire support capacity, not a garrison-position requirement. A child should not lose free support because a warrior is one tile away from a city.
+- Defender slots apply to combat-capable owned units after starter exemptions.
+- Basic early defenders are assigned to free defender slots before advanced, spy, naval, or specialized units.
+
+Suggested unit upkeep:
+
+- Exempt starter units: `0 gold/turn`
+- Most regular military units: `1 gold/turn`
+- Advanced, spy, naval, or specialized units: `2 gold/turn`
+
+Unit support assignment order:
+
+1. Exempt units such as settlers, workers, and scouts are `0 upkeep` and do not consume support.
+2. Combat-capable units are sorted by defender priority, then upkeep cost, then unit id for stable ties.
+3. `cityCount * 2` defender slots cover the first combat-capable units in that ordered list.
+4. Remaining units are sorted by policy priority, upkeep cost, then unit id.
+5. General free support covers the next units.
+6. Units outside support pay their configured upkeep.
+
+The resolver must return breakdown rows for city building upkeep and civilization unit upkeep so UI and tests do not have to re-derive the rules.
+
+## Treasury Strain
+
+The initial policy is soft pressure:
+
+- Gold cannot go below `0`.
+- Unpaid maintenance creates a computed treasury strain result for the turn.
+- No unit disbanding, building shutdown, or negative gold is applied.
+
+Economy math for a civilization:
+
+- `startingGold` is the civilization's gold before this turn's economy application.
+- `grossGoldIncome` is all positive and negative per-turn gold income before maintenance.
+- `totalMaintenance` is building upkeep plus unit upkeep.
+- `netGoldPerTurn = grossGoldIncome - totalMaintenance`
+- `endingGold = max(0, startingGold + netGoldPerTurn)`
+- `unpaidMaintenance = max(0, totalMaintenance - (startingGold + grossGoldIncome))`
+
+If reserves cover a bad turn, `unpaidMaintenance` is `0`. The player sees a shrinking treasury through `netGoldPerTurn`, but strain only starts once the civilization cannot actually pay its bills.
+
+Strain bands:
+
+- `none`: all upkeep is paid.
+- `low`: unpaid maintenance exists, but pressure is mild. The UI warns, and rush-buy can still work if the specific purchase is affordable and no stronger rule blocks it.
+- `high`: unpaid maintenance crosses the high threshold. Rush-buy is fully disabled for the civilization. Disabled UI must give a reason such as "Rush-buy unavailable: treasury strain is too high."
+- `critical`: unpaid maintenance crosses the critical threshold. Rush-buy remains disabled. Starting in Era 3, critical strain adds unrest pressure to owned cities.
+
+Initial generous thresholds:
+
+- `none`: `unpaidMaintenance === 0`
+- `low`: unpaid maintenance is below both high thresholds.
+- `high`: `unpaidMaintenance >= 5` or `unpaidMaintenance / max(1, totalMaintenance) >= 0.25`
+- `critical`: `unpaidMaintenance >= 10` or `unpaidMaintenance / max(1, totalMaintenance) >= 0.5`
+
+Treasury strain can affect spending immediately, including in Era 1 and Era 2. Treasury strain must not contribute to unrest or unhappiness until Era 3 or later.
+
+The strain policy must be swappable. The initial implementation should use a policy shape such as `soft-pressure`, with thresholds and effects in one config object. Later policies may allow debt, scaling penalties, or forced cuts without changing UI callers or turn-manager flow.
+
+## Unrest Integration
+
+Treasury strain contributes to the existing faction/unrest pressure model, not a new happiness system. `computeUnrestPressure` should include an economy pressure component only when:
+
+- the game era is `3` or later
+- the owning civilization has `critical` treasury strain
+
+Because `processFactionTurn` currently runs before city yield and economy resolution, unrest should read the last resolved economy status from the prior turn. A newly critical treasury creates notifications immediately and affects rush-buy immediately, then contributes unrest pressure on the next faction tick if it is still the last resolved status. This one-turn delay is easier to understand than a same-turn revolt from a bill the player just saw.
+
+Era 1 and Era 2 tests must prove that even critical treasury strain does not add unrest pressure. Era 3+ tests must prove that critical strain adds pressure while `none`, `low`, and `high` do not.
+
+## Rush-Buy
+
+Rush-buy is a city action for the active production item.
+
+Allowed:
+
+- Active normal unit
+- Active normal building
+
+Blocked:
+
+- No active production
+- Insufficient gold
+- `high` or `critical` treasury strain
+- Any `legendary:*` queue item
+- Any current or future production item classified as a wonder
+
+Initial cost formula:
+
+- `ceil(remainingProduction * 2.5)`
+- minimum cost: `10 gold`
+- remaining production is `max(0, totalProductionCost - productionProgress)`
+
+Buying should spend gold and complete the item through shared completion semantics. Add or extract a helper such as `completeCityProductionItem` so normal turn production and rush-buy use the same completion path. A bought building must be added to the city and placed in the city grid the same way turn production does. A bought unit must be created and registered the same way turn production does, including spy-unit side effects where applicable. Buying must emit or route the same player-visible completion behavior that normal production uses.
+
+Rush-buy applies only to the active queue item. It must not buy follow-up queue entries or skip ahead in the queue.
+
+Rush-buy validation uses the current projected economy result, not only the last resolved turn status. This lets the button recover immediately if the player deletes units, changes queues, gains gold, or otherwise fixes the economy before ending the turn.
+
+## UI Contract
+
+HUD:
+
+- Show net gold rather than only gross city gold.
+- Example: `42 (+5 net)`.
+- Net gold must include city income, building maintenance, unit maintenance, and known per-turn gold from wonders, diplomacy, trade routes, and idle production where the current turn model can calculate them.
+- If the current projection has treasury strain, the HUD should show a compact warning state.
+- Avoid presenting a large accounting table in the HUD. Detailed breakdown belongs in the city panel and any future economy detail surface.
+
+City panel:
+
+- Show a city maintenance summary near yields or production.
+- Example: `Maintenance: 1/6 support used, 0 gold/turn paid`.
+- Built buildings should show upkeep when nonzero.
+- Build options should show future upkeep, including `0 upkeep` for protected core items.
+- Use child-friendly wording where possible: `Free support`, `Paid upkeep`, and `Treasury strain` are clearer than abstract terms like `capacity deficit`.
+
+Rush-buy UI:
+
+- The active production block should show `Buy now: X gold` when buying is available.
+- Disabled buy controls must show the exact reason: no active production, insufficient gold, treasury strain too high, or wonders cannot be bought.
+- After a successful buy, the panel must rerender immediately with the completed item, updated gold, queue state, and any new active production.
+
+Notifications:
+
+- When strain reaches `high`, notify the affected human player once per turn that rush-buy is unavailable due to treasury strain.
+- When strain reaches `critical` in Era 3+, notify that treasury strain is increasing unrest pressure.
+- Do not notify every city separately for the same treasury strain. Use one civilization-level warning per turn so the feature feels like guidance, not nagging.
+
+## Architecture
+
+Add a dedicated economy system, likely `src/systems/economy-system.ts`.
+
+Core helpers:
+
+- `calculateCityBuildingMaintenance(state, cityId)` returns city-local upkeep, free support, exempt buildings, paid buildings, and breakdown rows.
+- `calculateCivUnitMaintenance(state, civId)` returns empire unit upkeep, free support, exempt units, paid units, free defender assignments, and breakdown rows.
+- `calculateCivEconomy(state, civId, grossGoldIncome)` combines income, upkeep, net gold, unpaid maintenance, strain level, and rush-buy availability.
+- `applyEconomyTurn(state, civId, economyResult)` applies gold with a `0` floor and stores the minimal resolved strain status needed by notifications and next-turn unrest.
+- `projectCivEconomy(state, civId)` recomputes a best-effort projection for HUD, city panel, and rush-buy validation without mutating state.
+- `getRushBuyQuote(state, civId, cityId)` returns availability, cost, and a disabled reason for the active item.
+- `rushBuyActiveProduction(state, civId, cityId, bus)` validates the quote, spends gold, completes the item through shared production completion, and returns the next state plus a result object.
+
+Policy configuration should live in one place:
+
+- free building support formula
+- maturity bonuses
+- free unit support formula
+- free/exempt buildings
+- free/exempt unit types
+- defender slot count per city
+- per-building upkeep values
+- per-unit upkeep values
+- rush-buy cost formula
+- strain thresholds
+- active treasury policy mode
+- economy unrest pressure amount for Era 3+ critical strain
+
+State shape:
+
+- Add a serializable optional field such as `economyStatusByCiv?: Record<string, EconomyStatus>`.
+- `EconomyStatus` should include `turn`, `grossGoldIncome`, `buildingMaintenance`, `unitMaintenance`, `netGoldPerTurn`, `unpaidMaintenance`, and `strainLevel`.
+- This field records the last resolved economy turn. It is not the only source for UI, because UI should use projections from the current state.
+- Save migration should tolerate missing `economyStatusByCiv` by treating strain as `none`.
+
+Turn manager integration:
+
+1. Compute city yields as today.
+2. Track gross gold income as today, including city yields and existing bonuses.
+3. Add city building maintenance for each city owned by the civilization.
+4. Add unit maintenance after city processing.
+5. Apply net gold through the economy system instead of directly adding gross gold.
+6. Store the resulting status in `economyStatusByCiv`.
+7. On the next `processFactionTurn`, let Era 3+ cities read their owner's last resolved critical strain as one pressure source.
+
+Rush-buy should live in the same economy/planning boundary rather than as a city-panel-only mutation. The UI calls a shared helper that validates the action, spends gold, completes the active item, updates state, and returns a result with a success message or disabled reason.
+
+## Testing
+
+System tests:
+
+- City building maintenance honors core building exemptions.
+- City building maintenance uses generous free support before charging paid upkeep.
+- City building maintenance assigns support deterministically, with optional advanced buildings paying before protected core buildings.
+- Unit maintenance exempts settlers, workers, and scouts.
+- Unit maintenance grants two free combat defenders per city.
+- Unit maintenance assigns defender support deterministically without requiring a unit to stand inside a city.
+- Unit maintenance charges excess armies after exemptions and support.
+- Turn processing applies net gold with a `0` floor.
+- Reserves can pay a negative net turn without creating strain until maintenance cannot be paid.
+- Unpaid maintenance produces `low`, `high`, and `critical` strain at configured thresholds.
+- `high` and `critical` strain disable rush-buy.
+- Critical strain from the prior resolved economy turn adds unrest pressure only in Era 3+.
+- Critical strain does not add unrest pressure in Era 1 or Era 2.
+- `none`, `low`, and `high` strain do not add unrest pressure even in Era 3+.
+
+Rush-buy tests:
+
+- Buying an active normal building spends gold, completes the building, places it in the grid, removes it from the queue, and rerenders the panel.
+- Buying an active normal unit spends gold, creates the unit through the shared completion path, removes it from the queue, and rerenders the panel.
+- Buying is rejected for `legendary:*`.
+- Buying is rejected for future wonder-classified production items.
+- Buying is rejected with explicit reasons for insufficient gold and high treasury strain.
+- Rush-buy availability recalculates from current projected economy after gold or maintenance changes.
+
+UI tests:
+
+- HUD shows net gold after maintenance.
+- HUD uses projected economy and does not require the player to end turn before seeing maintenance changes.
+- City panel shows maintenance support and paid upkeep.
+- Build options show future upkeep.
+- Active production shows a buy button and cost when available.
+- Disabled buy controls show the correct reason.
+- Panel state updates immediately after a successful buy.
+- Treasury strain notifications are civilization-level and do not spam once per city.
+
+Acceptance criteria:
+
+- A normal early game can build likely-needed buildings, explore, settle, and defend cities without punitive maintenance.
+- Two defenders per city remain free.
+- Players who overbuild optional buildings or maintain a large excess army see net gold shrink.
+- High treasury strain disables rush-buy with a visible reason.
+- Critical treasury strain contributes unrest pressure only from Era 3 onward.
+- Wonders and `legendary:*` production can never be rush-bought.

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -57,6 +57,7 @@ import {
   initializeLegendaryWonderProjectsForAllCities,
   tickLegendaryWonderProjects,
 } from '@/systems/legendary-wonder-system';
+import { applyEconomyTurn, emitEconomyStrainIfNeeded } from '@/systems/economy-system';
 
 export function processTurn(state: GameState, bus: EventBus): GameState {
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
@@ -67,6 +68,8 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   newState = processFactionTurn(newState, bus);
   newState = processBreakawayTurn(newState, bus);
   newState = tickOccupiedCities(newState);
+  const grossGoldByCiv: Record<string, number> = {};
+  const previousEconomyStatusByCiv = newState.economyStatusByCiv ?? {};
 
   // --- Process each civilization ---
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
@@ -197,18 +200,16 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       }
     }
 
-    // Update gold
-    newState.civilizations[civId].gold += totalGold;
-
     // Vassalage tribute (25% of gold income flows to overlord)
     if (civ.diplomacy?.vassalage.overlord) {
       const tribute = processVassalageTribute(totalGold);
-      newState.civilizations[civId].gold -= tribute.tributeAmount;
+      totalGold -= tribute.tributeAmount;
       const overlordId = civ.diplomacy.vassalage.overlord;
       if (newState.civilizations[overlordId]) {
-        newState.civilizations[overlordId].gold += tribute.tributeAmount;
+        grossGoldByCiv[overlordId] = (grossGoldByCiv[overlordId] ?? 0) + tribute.tributeAmount;
       }
     }
+    grossGoldByCiv[civId] = (grossGoldByCiv[civId] ?? 0) + totalGold;
 
     // Update peak counts (read from newState to pick up earlier mutations in this loop)
     if (currentCivState.diplomacy) {
@@ -289,7 +290,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       // Trade agreement gold income
       for (const treaty of dipState.treaties) {
         if (treaty.type === 'trade_agreement' && treaty.goldPerTurn) {
-          newState.civilizations[civId].gold += treaty.goldPerTurn;
+          grossGoldByCiv[civId] = (grossGoldByCiv[civId] ?? 0) + treaty.goldPerTurn;
         }
       }
 
@@ -387,17 +388,6 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
 
   // --- Process marketplace ---
   if (newState.marketplace) {
-    // Trade route income for each civ
-    for (const [civId, civ] of Object.entries(newState.civilizations)) {
-      const civRouteIncome = processTradeRouteIncome(
-        newState.marketplace.tradeRoutes.filter(r => {
-          const city = newState.cities[r.fromCityId];
-          return city?.owner === civId;
-        }),
-      );
-      newState.civilizations[civId].gold += civRouteIncome;
-    }
-
     // Simple fashion cycle with seeded rng
     let rngState = newState.turn * 16807;
     const simpleRng = () => {
@@ -713,6 +703,18 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     newState.embargoes = cleanupEmbargoes(newState.embargoes);
   }
 
+  if (newState.marketplace) {
+    for (const civId of Object.keys(newState.civilizations)) {
+      const civRouteIncome = processTradeRouteIncome(
+        newState.marketplace.tradeRoutes.filter(route => {
+          const city = newState.cities[route.fromCityId];
+          return city?.owner === civId;
+        }),
+      );
+      grossGoldByCiv[civId] = (grossGoldByCiv[civId] ?? 0) + civRouteIncome;
+    }
+  }
+
   // --- League dissolution check ---
   if (newState.defensiveLeagues) {
     const warPairs: Array<{ civA: string; civB: string }> = [];
@@ -741,6 +743,11 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     for (const mc of Object.values(newState.minorCivs)) {
       processMinorCivEraUpgrade(newState, mc);
     }
+  }
+
+  for (const civId of Object.keys(newState.civilizations)) {
+    newState = applyEconomyTurn(newState, civId, grossGoldByCiv[civId] ?? 0);
+    emitEconomyStrainIfNeeded(previousEconomyStatusByCiv[civId], newState.economyStatusByCiv![civId], bus);
   }
 
   // --- Advance turn ---

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -336,6 +336,31 @@ export interface City {
   idleProduction?: 'gold' | 'science' | null; // conversion mode when queue is empty
 }
 
+// --- Economy ---
+
+export type EconomyStrainLevel = 'stable' | 'strained' | 'critical';
+
+export interface EconomyMaintenanceBreakdown {
+  buildingUpkeep: number;
+  unitUpkeep: number;
+  freeBuildings: number;
+  freeUnits: number;
+  paidBuildings: number;
+  paidUnits: number;
+}
+
+export interface EconomyStatus {
+  civId: string;
+  grossGoldPerTurn: number;
+  maintenanceGoldPerTurn: number;
+  netGoldPerTurn: number;
+  projectedGold: number;
+  unpaidMaintenance: number;
+  strainLevel: EconomyStrainLevel;
+  rushBuyDisabled: boolean;
+  breakdown: EconomyMaintenanceBreakdown;
+}
+
 // --- Tech ---
 
 export type TechTrack =
@@ -1009,6 +1034,7 @@ export interface GameState {
   winner: string | null;
   settings: GameSettings;
   marketplace?: MarketplaceState;
+  economyStatusByCiv?: Record<string, EconomyStatus>;
   hotSeat?: HotSeatConfig;
   pendingEvents?: Record<string, GameEvent[]>;
   councilMemory?: CouncilMemoryState;
@@ -1068,6 +1094,7 @@ export interface GameEvents {
   'city:unit-trained': { cityId: string; unitType: UnitType };
   'city:grew': { cityId: string; newPopulation: number };
   'city:maturity-upgraded': { cityId: string; previous: CityMaturity; current: CityMaturity };
+  'economy:treasury-strain': { civId: string; level: Exclude<EconomyStrainLevel, 'stable'>; netGoldPerTurn: number; unpaidMaintenance: number };
   'combat:resolved': { result: CombatResult };
   'combat:reward-earned': { reward: CombatRewardNotification };
   'tech:completed': { civId: string; techId: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -673,7 +673,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
 
       if (completion.completedUnit) {
         const civDef = resolveCivDefinition(gameState, civ.civType ?? '');
-        const newUnit = createUnit(completion.completedUnit, civId, targetCity.position, civDef?.bonusEffect);
+        const newUnit = createUnit(completion.completedUnit, civId, targetCity.position, gameState.idCounters, civDef?.bonusEffect);
         gameState.units[newUnit.id] = newUnit;
         gameState.civilizations[civId].units.push(newUnit.id);
         bus.emit('city:unit-trained', { cityId, unitType: completion.completedUnit });

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
 import { scanIdCounters } from '@/core/id-counters';
-import { foundCity, BUILDINGS, getUnplacedBuildings, placeBuilding } from '@/systems/city-system';
+import { completeCityProductionItem, foundCity, BUILDINGS, TRAINABLE_UNITS, getUnplacedBuildings, placeBuilding } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers, recalculateTerritory } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
@@ -104,6 +104,7 @@ import {
   executeSpy,
   startInterrogation,
   isSpyUnitType,
+  createSpyFromUnit,
   missionRequiresPlacedSpy,
   recallSpy,
   resolveMissionResult,
@@ -126,6 +127,7 @@ import {
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeCombatResolved,
+  routeEconomyTreasuryStrain,
   routeFactionTransition,
   queueFirstContactPendingEvents,
   routeFirstContact,
@@ -144,6 +146,7 @@ import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel'
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
+import { calculateCivEconomy, formatGoldHudText, formatMaintenanceTooltip, getRushBuyQuote } from '@/systems/economy-system';
 
 // --- App State ---
 let gameState: GameState;
@@ -242,16 +245,16 @@ function updateHUD(): void {
   const civ = currentCiv();
 
   // Sum yields across all cities
-  let totalFood = 0, totalProd = 0, totalGold = 0, totalScience = 0;
+  let totalFood = 0, totalProd = 0, totalScience = 0;
   for (const cityId of civ.cities) {
     const city = gameState.cities[cityId];
     if (!city) continue;
     const y = calculateProjectedCityYields(gameState, cityId);
     totalFood += y.food;
     totalProd += y.production;
-    totalGold += y.gold;
     totalScience += y.science;
   }
+  const economyStatus = calculateCivEconomy(gameState, civ.id);
 
   const techName = civ.techState.currentResearch ?? 'None';
   hud.textContent = '';
@@ -268,7 +271,8 @@ function updateHUD(): void {
   yieldsRow.appendChild(prodSpan);
 
   const goldSpan = document.createElement('span');
-  goldSpan.textContent = `💰 ${civ.gold} (+${totalGold})`;
+  goldSpan.textContent = `💰 ${formatGoldHudText(economyStatus, civ.gold)}`;
+  goldSpan.title = formatMaintenanceTooltip(economyStatus);
   yieldsRow.appendChild(goldSpan);
 
   const sciSpan = document.createElement('span');
@@ -645,6 +649,59 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       gameState = { ...gameState, cities: { ...gameState.cities, [cityId]: updated } };
       renderLoop.setGameState(gameState);
       openCityPanelForCity(updated);
+    },
+    onRushBuyActiveProduction: (cityId) => {
+      const targetCity = gameState.cities[cityId];
+      if (!targetCity) return gameState;
+      const quote = getRushBuyQuote(gameState, cityId);
+      if (!quote.available || !quote.itemId) {
+        showNotification(quote.reason ?? 'Rush buy is not available.', 'warning');
+        return gameState;
+      }
+
+      const civId = targetCity.owner;
+      const civ = gameState.civilizations[civId];
+      if (!civ) return gameState;
+      const completion = completeCityProductionItem(targetCity, quote.itemId);
+      const nextCiv = { ...civ, gold: civ.gold - quote.cost, units: [...civ.units] };
+      gameState.cities[cityId] = completion.city;
+      gameState.civilizations[civId] = nextCiv;
+
+      if (completion.completedBuilding) {
+        bus.emit('city:building-complete', { cityId, buildingId: completion.completedBuilding });
+      }
+
+      if (completion.completedUnit) {
+        const civDef = resolveCivDefinition(gameState, civ.civType ?? '');
+        const newUnit = createUnit(completion.completedUnit, civId, targetCity.position, civDef?.bonusEffect);
+        gameState.units[newUnit.id] = newUnit;
+        gameState.civilizations[civId].units.push(newUnit.id);
+        bus.emit('city:unit-trained', { cityId, unitType: completion.completedUnit });
+
+        if (isSpyUnitType(completion.completedUnit) && gameState.espionage?.[civId]) {
+          const { state: updatedEsp, spy } = createSpyFromUnit(
+            gameState.espionage[civId],
+            newUnit.id,
+            civId,
+            completion.completedUnit,
+            `spy-unit-${newUnit.id}-${gameState.turn}`,
+          );
+          gameState.espionage[civId] = updatedEsp;
+          bus.emit('espionage:spy-recruited', { civId, spy });
+        }
+      }
+
+      gameState.economyStatusByCiv = {
+        ...(gameState.economyStatusByCiv ?? {}),
+        [civId]: calculateCivEconomy(gameState, civId),
+      };
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      const itemName = BUILDINGS[quote.itemId]?.name
+        ?? TRAINABLE_UNITS.find(unit => unit.type === quote.itemId)?.name
+        ?? quote.itemId;
+      showNotification(`${targetCity.name}: rush bought ${itemName} for ${quote.cost} gold.`, 'success');
+      return gameState;
     },
   });
 }
@@ -2548,6 +2605,18 @@ bus.on('faction:breakaway-established', event => {
 
 bus.on('faction:critical-status', event => {
   routeFactionTransition(gameState, { type: 'faction:critical-status', ...event }, appendFactionNotice);
+});
+
+bus.on('economy:treasury-strain', event => {
+  routeEconomyTreasuryStrain(gameState, event, appendToCivLog);
+  if (event.civId === gameState.currentPlayer) {
+    showNotification(
+      event.level === 'critical'
+        ? 'Treasury strain is critical. Rush buy is disabled.'
+        : 'Treasury is strained by maintenance.',
+      'warning',
+    );
+  }
 });
 
 bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -352,6 +352,53 @@ export interface CityProcessResult {
   idleScienceBonus: number;
 }
 
+export interface CityProductionCompletionResult {
+  city: City;
+  completedBuilding: string | null;
+  completedUnit: UnitType | null;
+}
+
+export function completeCityProductionItem(city: City, itemId: string): CityProductionCompletionResult {
+  const newQueue = [...city.productionQueue];
+  const newBuildings = [...city.buildings];
+  let completedBuilding: string | null = null;
+  let completedUnit: UnitType | null = null;
+
+  if (newQueue[0] === itemId) {
+    newQueue.shift();
+  }
+
+  const building = BUILDINGS[itemId];
+  if (building) {
+    if (!newBuildings.includes(building.id)) {
+      newBuildings.push(building.id);
+      completedBuilding = building.id;
+    }
+  } else {
+    const unitDef = TRAINABLE_UNITS.find(u => u.type === itemId);
+    if (unitDef) {
+      completedUnit = unitDef.type;
+    }
+  }
+
+  let nextCity: City = {
+    ...city,
+    productionQueue: newQueue,
+    productionProgress: 0,
+    buildings: newBuildings,
+  };
+
+  if (completedBuilding) {
+    nextCity = placeBuildingInGrid(nextCity, completedBuilding);
+  }
+
+  return {
+    city: nextCity,
+    completedBuilding,
+    completedUnit,
+  };
+}
+
 export function processCity(
   city: City,
   map: GameMap,
@@ -383,6 +430,7 @@ export function processCity(
   let newProgress = city.productionProgress;
   const newQueue = [...city.productionQueue];
   const newBuildings = [...city.buildings];
+  let newGrid = city.grid;
 
   // Drop queued unit types that aren't trainable for this civ's tech state
   if (completedTechs.length > 0 && newQueue.length > 0) {
@@ -405,23 +453,20 @@ export function processCity(
     newProgress += productionYield;
     const currentItem = newQueue[0];
 
-    // Check if it's a building
-    const building = BUILDINGS[currentItem];
-    if (building && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
-      if (!newBuildings.includes(building.id)) {
-        newBuildings.push(building.id);
-        completedBuilding = building.id;
-      }
-      newQueue.shift();
-      newProgress = 0;
-    }
-
-    // Check if it's a unit
     const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    if (unitDef && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
-      newQueue.shift();
-      newProgress = 0;
-      completedUnit = unitDef.type;
+    if ((BUILDINGS[currentItem] || unitDef) && newProgress >= getProductionCostForItem(currentItem, { city, bonusEffect, era })) {
+      const completion = completeCityProductionItem(
+        { ...city, productionQueue: newQueue, productionProgress: newProgress, buildings: newBuildings },
+        currentItem,
+      );
+      newQueue.length = 0;
+      newQueue.push(...completion.city.productionQueue);
+      newBuildings.length = 0;
+      newBuildings.push(...completion.city.buildings);
+      newProgress = completion.city.productionProgress;
+      newGrid = completion.city.grid;
+      completedBuilding = completion.completedBuilding;
+      completedUnit = completion.completedUnit;
     }
   }
 
@@ -443,11 +488,8 @@ export function processCity(
     productionProgress: newProgress,
     productionQueue: newQueue,
     buildings: newBuildings,
+    grid: newGrid,
   };
-
-  if (completedBuilding) {
-    nextCity = placeBuildingInGrid(nextCity, completedBuilding);
-  }
 
   return {
     city: nextCity,

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -364,9 +364,10 @@ export function completeCityProductionItem(city: City, itemId: string): CityProd
   let completedBuilding: string | null = null;
   let completedUnit: UnitType | null = null;
 
-  if (newQueue[0] === itemId) {
-    newQueue.shift();
+  if (newQueue[0] !== itemId) {
+    return { city, completedBuilding, completedUnit };
   }
+  newQueue.shift();
 
   const building = BUILDINGS[itemId];
   if (building) {

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -319,7 +319,7 @@ export function getEconomyStatusForCiv(state: GameState, civId: string): Economy
 export function getRushBuyQuote(state: GameState, cityId: string): RushBuyQuote {
   const city = state.cities[cityId];
   const civ = city ? state.civilizations[city.owner] : undefined;
-  const status = city ? getEconomyStatusForCiv(state, city.owner) : calculateCivEconomy(state, '');
+  const status = city ? calculateCivEconomy(state, city.owner) : calculateCivEconomy(state, '');
 
   if (!city || !civ) {
     return { available: false, itemId: null, cost: 0, reason: 'City not found.', status };
@@ -344,7 +344,8 @@ export function getRushBuyQuote(state: GameState, cityId: string): RushBuyQuote 
     };
   }
 
-  const cost = getProductionCostForItem(itemId, { city, era: state.era });
+  const civDef = resolveCivDefinition(state, civ.civType ?? '');
+  const cost = getProductionCostForItem(itemId, { city, bonusEffect: civDef?.bonusEffect, era: state.era });
   if (cost <= 0) {
     return { available: false, itemId, cost: 0, reason: 'This item cannot be rush bought.', status };
   }

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -1,0 +1,387 @@
+import type {
+  City,
+  EconomyMaintenanceBreakdown,
+  EconomyStatus,
+  EconomyStrainLevel,
+  GameState,
+  Unit,
+  UnitType,
+} from '@/core/types';
+import { getProductionCostForItem } from './city-system';
+import { calculateProjectedCityYields } from './city-work-system';
+import { EventBus } from '@/core/event-bus';
+import { getLegendaryWonderCityYieldBonus, getLegendaryWonderCivYieldBonus } from './legendary-wonder-system';
+import { processTradeRouteIncome } from './trade-system';
+import { UNIT_DEFINITIONS } from './unit-system';
+import { resolveCivDefinition } from './civ-registry';
+
+export const ECONOMY_RULES = {
+  rushBuyMultiplier: 2.5,
+  coreFreeBuildings: new Set([
+    'city-center',
+    'herbalist',
+    'workshop',
+    'shrine',
+    'barracks',
+    'library',
+    'granary',
+  ]),
+  advancedBuildingUpkeep: new Set([
+    'forge',
+    'observatory',
+    'harbor',
+    'amphitheater',
+    'security-bureau',
+    'intelligence-agency',
+  ]),
+  freeUnitTypes: new Set<UnitType>(['settler', 'worker', 'scout']),
+  advancedUnitTypes: new Set<UnitType>([
+    'swordsman',
+    'pikeman',
+    'musketeer',
+    'galley',
+    'trireme',
+    'spy_scout',
+    'spy_informant',
+    'spy_agent',
+    'spy_operative',
+    'spy_hacker',
+    'scout_hound',
+    'shadow_warden',
+    'war_hound',
+  ]),
+  criticalDeficitThreshold: -10,
+  criticalTreasuryThreshold: 15,
+} as const;
+
+export interface CalculateCivEconomyOptions {
+  grossGoldPerTurn?: number;
+  maintenanceOverride?: {
+    buildingUpkeep?: number;
+    unitUpkeep?: number;
+  };
+}
+
+export interface RushBuyQuote {
+  available: boolean;
+  itemId: string | null;
+  cost: number;
+  reason: string | null;
+  status: EconomyStatus;
+}
+
+function getBuildingUpkeep(buildingId: string): number {
+  if (ECONOMY_RULES.coreFreeBuildings.has(buildingId)) return 0;
+  return ECONOMY_RULES.advancedBuildingUpkeep.has(buildingId) ? 2 : 1;
+}
+
+function getUnitUpkeep(unitType: UnitType): number {
+  if (ECONOMY_RULES.freeUnitTypes.has(unitType)) return 0;
+  return ECONOMY_RULES.advancedUnitTypes.has(unitType) ? 2 : 1;
+}
+
+function getFreeBuildingSlots(city: City): number {
+  const maturityBonusByLevel: Record<City['maturity'], number> = {
+    outpost: 0,
+    village: 1,
+    town: 2,
+    city: 3,
+    metropolis: 4,
+  };
+  return 4 + Math.floor(city.population / 2) + maturityBonusByLevel[city.maturity];
+}
+
+function getFreeGeneralUnitSlots(cities: City[]): number {
+  const totalPopulation = cities.reduce((sum, city) => sum + city.population, 0);
+  return 2 + cities.length * 2 + Math.floor(totalPopulation / 3);
+}
+
+function sortByHighestAvoidedUpkeep(a: { upkeep: number; id: string }, b: { upkeep: number; id: string }): number {
+  if (b.upkeep !== a.upkeep) return b.upkeep - a.upkeep;
+  return a.id.localeCompare(b.id);
+}
+
+function sortCombatUnitsForFreeDefenders(a: Unit, b: Unit): number {
+  const aUpkeep = getUnitUpkeep(a.type);
+  const bUpkeep = getUnitUpkeep(b.type);
+  if (bUpkeep !== aUpkeep) return bUpkeep - aUpkeep;
+  const aStrength = UNIT_DEFINITIONS[a.type]?.strength ?? 0;
+  const bStrength = UNIT_DEFINITIONS[b.type]?.strength ?? 0;
+  if (bStrength !== aStrength) return bStrength - aStrength;
+  return a.id.localeCompare(b.id);
+}
+
+export function calculateMaintenance(state: GameState, civId: string): EconomyMaintenanceBreakdown {
+  const civ = state.civilizations[civId];
+  if (!civ) {
+    return {
+      buildingUpkeep: 0,
+      unitUpkeep: 0,
+      freeBuildings: 0,
+      freeUnits: 0,
+      paidBuildings: 0,
+      paidUnits: 0,
+    };
+  }
+
+  let buildingUpkeep = 0;
+  let freeBuildings = 0;
+  let paidBuildings = 0;
+  const cities = civ.cities.map(cityId => state.cities[cityId]).filter((city): city is City => Boolean(city));
+
+  for (const city of cities) {
+    const coreBuildings = city.buildings.filter(buildingId => ECONOMY_RULES.coreFreeBuildings.has(buildingId));
+    freeBuildings += coreBuildings.length;
+
+    const paidCandidates = city.buildings
+      .filter(buildingId => !ECONOMY_RULES.coreFreeBuildings.has(buildingId))
+      .map(buildingId => ({ id: buildingId, upkeep: getBuildingUpkeep(buildingId) }))
+      .sort(sortByHighestAvoidedUpkeep);
+
+    const freeSlots = getFreeBuildingSlots(city);
+    for (const [index, candidate] of paidCandidates.entries()) {
+      if (index < freeSlots) {
+        freeBuildings++;
+      } else {
+        paidBuildings++;
+        buildingUpkeep += candidate.upkeep;
+      }
+    }
+  }
+
+  const units = civ.units.map(unitId => state.units[unitId]).filter((unit): unit is Unit => Boolean(unit));
+  let unitUpkeep = 0;
+  let freeUnits = 0;
+  let paidUnits = 0;
+  const freeUnitIds = new Set<string>();
+
+  for (const unit of units) {
+    if (ECONOMY_RULES.freeUnitTypes.has(unit.type)) {
+      freeUnitIds.add(unit.id);
+      freeUnits++;
+    }
+  }
+
+  const combatUnits = units
+    .filter(unit => !freeUnitIds.has(unit.id) && (UNIT_DEFINITIONS[unit.type]?.strength ?? 0) > 0)
+    .sort(sortCombatUnitsForFreeDefenders);
+  for (const unit of combatUnits.slice(0, cities.length * 2)) {
+    freeUnitIds.add(unit.id);
+    freeUnits++;
+  }
+
+  const supportCandidates = units
+    .filter(unit => !freeUnitIds.has(unit.id))
+    .map(unit => ({ id: unit.id, upkeep: getUnitUpkeep(unit.type) }))
+    .sort(sortByHighestAvoidedUpkeep);
+  const supportSlots = getFreeGeneralUnitSlots(cities);
+  for (const candidate of supportCandidates.slice(0, supportSlots)) {
+    freeUnitIds.add(candidate.id);
+    freeUnits++;
+  }
+
+  for (const unit of units) {
+    if (freeUnitIds.has(unit.id)) continue;
+    paidUnits++;
+    unitUpkeep += getUnitUpkeep(unit.type);
+  }
+
+  return {
+    buildingUpkeep,
+    unitUpkeep,
+    freeBuildings,
+    freeUnits,
+    paidBuildings,
+    paidUnits,
+  };
+}
+
+export function projectCivGrossGold(state: GameState, civId: string): number {
+  const civ = state.civilizations[civId];
+  if (!civ) return 0;
+
+  const civDef = resolveCivDefinition(state, civ.civType ?? '');
+  let grossGold = 0;
+
+  for (const cityId of civ.cities) {
+    const projected = calculateProjectedCityYields(state, cityId, civDef?.bonusEffect);
+    const wonderCityBonuses = getLegendaryWonderCityYieldBonus(state, civId, cityId);
+    grossGold += projected.gold + (wonderCityBonuses.gold ?? 0);
+  }
+
+  const wonderCivBonuses = getLegendaryWonderCivYieldBonus(state, civId);
+  grossGold += wonderCivBonuses.gold ?? 0;
+
+  if (civDef?.bonusEffect.type === 'allied_kingdoms') {
+    const allianceCount = civ.diplomacy.treaties.filter(treaty => treaty.type === 'alliance').length;
+    grossGold += allianceCount * civDef.bonusEffect.allianceYieldBonus;
+  }
+
+  for (const treaty of civ.diplomacy.treaties) {
+    if (treaty.type === 'trade_agreement' && treaty.goldPerTurn) {
+      grossGold += treaty.goldPerTurn;
+    }
+  }
+
+  if (state.marketplace) {
+    grossGold += processTradeRouteIncome(
+      state.marketplace.tradeRoutes.filter(route => state.cities[route.fromCityId]?.owner === civId),
+    );
+  }
+
+  return grossGold;
+}
+
+function getStrainLevel(netGoldPerTurn: number, projectedGold: number, unpaidMaintenance: number): EconomyStrainLevel {
+  if (
+    unpaidMaintenance > 0 ||
+    (netGoldPerTurn <= ECONOMY_RULES.criticalDeficitThreshold && projectedGold <= ECONOMY_RULES.criticalTreasuryThreshold)
+  ) {
+    return 'critical';
+  }
+  if (netGoldPerTurn < 0) return 'strained';
+  return 'stable';
+}
+
+export function calculateCivEconomy(
+  state: GameState,
+  civId: string,
+  options: CalculateCivEconomyOptions = {},
+): EconomyStatus {
+  const civ = state.civilizations[civId];
+  const grossGoldPerTurn = options.grossGoldPerTurn ?? projectCivGrossGold(state, civId);
+  const baseBreakdown = calculateMaintenance(state, civId);
+  const breakdown = {
+    ...baseBreakdown,
+    buildingUpkeep: options.maintenanceOverride?.buildingUpkeep ?? baseBreakdown.buildingUpkeep,
+    unitUpkeep: options.maintenanceOverride?.unitUpkeep ?? baseBreakdown.unitUpkeep,
+  };
+  const maintenanceGoldPerTurn = breakdown.buildingUpkeep + breakdown.unitUpkeep;
+  const netGoldPerTurn = grossGoldPerTurn - maintenanceGoldPerTurn;
+  const currentGold = civ?.gold ?? 0;
+  const projectedGold = Math.max(0, currentGold + netGoldPerTurn);
+  const unpaidMaintenance = Math.max(0, maintenanceGoldPerTurn - currentGold - grossGoldPerTurn);
+  const strainLevel = getStrainLevel(netGoldPerTurn, projectedGold, unpaidMaintenance);
+
+  return {
+    civId,
+    grossGoldPerTurn,
+    maintenanceGoldPerTurn,
+    netGoldPerTurn,
+    projectedGold,
+    unpaidMaintenance,
+    strainLevel,
+    rushBuyDisabled: strainLevel === 'critical',
+    breakdown,
+  };
+}
+
+export function applyEconomyTurn(state: GameState, civId: string, grossGoldPerTurn: number): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  const status = calculateCivEconomy(state, civId, { grossGoldPerTurn });
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civId]: {
+        ...civ,
+        gold: status.projectedGold,
+      },
+    },
+    economyStatusByCiv: {
+      ...(state.economyStatusByCiv ?? {}),
+      [civId]: status,
+    },
+  };
+}
+
+export function emitEconomyStrainIfNeeded(
+  previous: EconomyStatus | undefined,
+  current: EconomyStatus,
+  bus: EventBus,
+): void {
+  if (current.strainLevel === 'stable') return;
+  if (previous?.strainLevel === current.strainLevel && previous.unpaidMaintenance === current.unpaidMaintenance) return;
+  bus.emit('economy:treasury-strain', {
+    civId: current.civId,
+    level: current.strainLevel,
+    netGoldPerTurn: current.netGoldPerTurn,
+    unpaidMaintenance: current.unpaidMaintenance,
+  });
+}
+
+export function getEconomyStatusForCiv(state: GameState, civId: string): EconomyStatus {
+  return state.economyStatusByCiv?.[civId] ?? calculateCivEconomy(state, civId);
+}
+
+export function getRushBuyQuote(state: GameState, cityId: string): RushBuyQuote {
+  const city = state.cities[cityId];
+  const civ = city ? state.civilizations[city.owner] : undefined;
+  const status = city ? getEconomyStatusForCiv(state, city.owner) : calculateCivEconomy(state, '');
+
+  if (!city || !civ) {
+    return { available: false, itemId: null, cost: 0, reason: 'City not found.', status };
+  }
+
+  const itemId = city.productionQueue[0] ?? null;
+  if (!itemId) {
+    return { available: false, itemId: null, cost: 0, reason: 'Choose a production item before rush buying.', status };
+  }
+
+  if (itemId.startsWith('legendary:')) {
+    return { available: false, itemId, cost: 0, reason: 'Legendary wonders cannot be rush bought.', status };
+  }
+
+  if (status.rushBuyDisabled) {
+    return {
+      available: false,
+      itemId,
+      cost: 0,
+      reason: 'Rush buy disabled: treasury strain is critical.',
+      status,
+    };
+  }
+
+  const cost = getProductionCostForItem(itemId, { city, era: state.era });
+  if (cost <= 0) {
+    return { available: false, itemId, cost: 0, reason: 'This item cannot be rush bought.', status };
+  }
+
+  const remainingProduction = Math.max(1, cost - city.productionProgress);
+  const rushCost = Math.ceil(remainingProduction * ECONOMY_RULES.rushBuyMultiplier);
+  if (civ.gold < rushCost) {
+    return {
+      available: false,
+      itemId,
+      cost: rushCost,
+      reason: `Need ${rushCost} gold to rush buy.`,
+      status,
+    };
+  }
+
+  return { available: true, itemId, cost: rushCost, reason: null, status };
+}
+
+export function formatGoldHudText(status: EconomyStatus, currentGold: number): string {
+  const sign = status.netGoldPerTurn >= 0 ? '+' : '';
+  return `${currentGold} (${sign}${status.netGoldPerTurn}/turn)`;
+}
+
+export function formatMaintenanceTooltip(status: EconomyStatus): string {
+  const parts = [
+    `Income: ${status.grossGoldPerTurn}`,
+    `Maintenance: -${status.maintenanceGoldPerTurn}`,
+  ];
+  if (status.breakdown.paidBuildings > 0) {
+    parts.push(`${status.breakdown.paidBuildings} paid buildings`);
+  }
+  if (status.breakdown.paidUnits > 0) {
+    parts.push(`${status.breakdown.paidUnits} paid units`);
+  }
+  if (status.unpaidMaintenance > 0) {
+    parts.push(`${status.unpaidMaintenance} unpaid`);
+  }
+  return parts.join(' | ');
+}

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -5,6 +5,7 @@ import { createRng } from './map-generator';
 import { createUnit } from './unit-system';
 import { hexDistance } from './hex-utils';
 import { createBreakawayFromCity } from './breakaway-system';
+import { getEconomyStatusForCiv } from './economy-system';
 
 // --- Thresholds ---
 const UNREST_TRIGGER_PRESSURE = 40;
@@ -16,6 +17,7 @@ const GOLD_APPEASE_COST_PER_POP = 15;
 const MAX_PRESSURE_EMPIRE = 30;
 const MAX_PRESSURE_DISTANCE = 20;
 const MAX_PRESSURE_WAR = 24;
+const MAX_PRESSURE_ECONOMY = 20;
 
 // --- Pressure computation ---
 
@@ -54,6 +56,15 @@ export function computeUnrestPressure(cityId: string, state: GameState): number 
 
   // Spy unrest bonus
   pressure += city.spyUnrestBonus;
+
+  if (state.era >= 3) {
+    const economy = getEconomyStatusForCiv(state, owner);
+    if (economy.strainLevel === 'critical') {
+      pressure += Math.min(MAX_PRESSURE_ECONOMY, 12 + economy.unpaidMaintenance * 2);
+    } else if (economy.strainLevel === 'strained') {
+      pressure += 8;
+    }
+  }
 
   return Math.min(100, pressure);
 }

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -7,6 +7,7 @@ import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/c
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createCityGrid } from './city-grid';
+import { formatMaintenanceTooltip, getEconomyStatusForCiv, getRushBuyQuote } from '@/systems/economy-system';
 
 export interface CityPanelCallbacks {
   onBuild: (cityId: string, itemId: string) => void;
@@ -21,6 +22,7 @@ export interface CityPanelCallbacks {
   onNextCity?: () => void;
   onUpgradeUnit?: (unitId: string) => void;
   onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => void;
+  onRushBuyActiveProduction?: (cityId: string) => GameState | void;
 }
 
 type CityPanelTab = 'list' | 'grid';
@@ -56,6 +58,9 @@ export function createCityPanel(
   });
   const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map.tiles);
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
+  const economyStatus = getEconomyStatusForCiv(state, city.owner);
+  const maintenanceTooltip = formatMaintenanceTooltip(economyStatus);
+  const rushBuyQuote = getRushBuyQuote(state, city.id);
 
   // Build placeholders for dynamic data; style attributes with pure numbers (progress%) are safe
   let buildingPlaceholders = '';
@@ -124,6 +129,12 @@ export function createCityPanel(
     const currentItem = city.productionQueue[0];
     const totalCost = getDisplayedCost(currentItem);
     const progress = totalCost > 0 ? Math.round((city.productionProgress / totalCost) * 100) : 0;
+    const rushBuyLabel = rushBuyQuote.cost > 0 ? `Rush buy (${rushBuyQuote.cost} gold)` : 'Rush buy';
+    const rushDisabled = !rushBuyQuote.available || !callbacks.onRushBuyActiveProduction;
+    const rushDisabledAttr = rushDisabled ? 'disabled' : '';
+    const rushButtonStyle = rushDisabled
+      ? 'background:rgba(255,255,255,0.08);border:1px solid rgba(255,255,255,0.12);color:rgba(255,255,255,0.45);cursor:not-allowed;'
+      : 'background:#d4aa2c;border:1px solid rgba(255,255,255,0.2);color:#1f1700;cursor:pointer;';
 
     currentProductionHtml = `
       <div style="background:rgba(255,255,255,0.1);border-radius:10px;padding:12px;margin-bottom:16px;">
@@ -131,6 +142,10 @@ export function createCityPanel(
         <div style="font-size:12px;opacity:0.7;"><span data-text="prod-turns"></span> turns remaining</div>
         <div style="background:rgba(0,0,0,0.3);border-radius:4px;height:8px;margin-top:8px;">
           <div style="background:#6b9b4b;border-radius:4px;height:8px;width:${progress}%;"></div>
+        </div>
+        <div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap;">
+          <button type="button" data-rush-buy="active" ${rushDisabledAttr} title="" style="min-height:34px;padding:7px 10px;border-radius:6px;font-size:12px;font-weight:bold;${rushButtonStyle}">${rushBuyLabel}</button>
+          ${rushBuyQuote.reason ? '<span style="font-size:11px;color:#d9a25c;" data-text="rush-reason"></span>' : ''}
         </div>
       </div>
     `;
@@ -208,6 +223,11 @@ export function createCityPanel(
       <span>💰 +<span data-text="yield-gold"></span></span>
       <span>🔬 +<span data-text="yield-science"></span></span>
     </div>
+    <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:16px;font-size:12px;color:#d9d3c0;">
+      <span title="" data-maintenance-summary>Maintenance: -${economyStatus.maintenanceGoldPerTurn}/turn</span>
+      <span>Net treasury: ${economyStatus.netGoldPerTurn >= 0 ? '+' : ''}${economyStatus.netGoldPerTurn}/turn</span>
+      ${economyStatus.strainLevel !== 'stable' ? '<span style="color:#d9a25c;" data-text="economy-strain"></span>' : ''}
+    </div>
 
     <div style="display:flex;gap:8px;margin-bottom:12px;">
       <div id="tab-list" style="padding:6px 16px;background:rgba(255,255,255,0.15);border-radius:6px;cursor:pointer;font-size:12px;font-weight:bold;">List</div>
@@ -258,6 +278,16 @@ export function createCityPanel(
     const turnsLeft = yields.production > 0 ? Math.ceil((totalCost - city.productionProgress) / yields.production) : '∞';
     setText('prod-name', building?.name ?? unit?.name ?? currentItem);
     setText('prod-turns', String(turnsLeft));
+    if (rushBuyQuote.reason) {
+      setText('rush-reason', rushBuyQuote.reason);
+    }
+    const rushButton = panel.querySelector<HTMLElement>('[data-rush-buy]');
+    if (rushButton && rushBuyQuote.reason) rushButton.title = rushBuyQuote.reason;
+  }
+  const maintenanceSummary = panel.querySelector<HTMLElement>('[data-maintenance-summary]');
+  if (maintenanceSummary) maintenanceSummary.title = maintenanceTooltip;
+  if (economyStatus.strainLevel !== 'stable') {
+    setText('economy-strain', economyStatus.strainLevel === 'critical' ? 'Critical strain' : 'Treasury strained');
   }
 
   let bldgIdx = 0;
@@ -350,6 +380,13 @@ export function createCityPanel(
         callbacks.onMoveQueueItem?.(city.id, index, index + 1);
         rerenderPanel();
       }
+    });
+  });
+
+  panel.querySelectorAll<HTMLElement>('[data-rush-buy]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const nextState = callbacks.onRushBuyActiveProduction?.(city.id);
+      rerenderPanel(nextState);
     });
   });
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -7,7 +7,7 @@ import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/c
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createCityGrid } from './city-grid';
-import { formatMaintenanceTooltip, getEconomyStatusForCiv, getRushBuyQuote } from '@/systems/economy-system';
+import { calculateCivEconomy, formatMaintenanceTooltip, getRushBuyQuote } from '@/systems/economy-system';
 
 export interface CityPanelCallbacks {
   onBuild: (cityId: string, itemId: string) => void;
@@ -58,7 +58,7 @@ export function createCityPanel(
   });
   const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map.tiles);
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
-  const economyStatus = getEconomyStatusForCiv(state, city.owner);
+  const economyStatus = calculateCivEconomy(state, city.owner);
   const maintenanceTooltip = formatMaintenanceTooltip(economyStatus);
   const rushBuyQuote = getRushBuyQuote(state, city.id);
 
@@ -138,7 +138,7 @@ export function createCityPanel(
 
     currentProductionHtml = `
       <div style="background:rgba(255,255,255,0.1);border-radius:10px;padding:12px;margin-bottom:16px;">
-        <div style="font-weight:bold;color:#e8c170;">Building: ${PRODUCTION_ICONS[currentItem] ?? PRODUCTION_ICON_FALLBACK} <span data-text="prod-name"></span></div>
+        <div style="font-weight:bold;color:#e8c170;">Producing: ${PRODUCTION_ICONS[currentItem] ?? PRODUCTION_ICON_FALLBACK} <span data-text="prod-name"></span></div>
         <div style="font-size:12px;opacity:0.7;"><span data-text="prod-turns"></span> turns remaining</div>
         <div style="background:rgba(0,0,0,0.3);border-radius:4px;height:8px;margin-top:8px;">
           <div style="background:#6b9b4b;border-radius:4px;height:8px;width:${progress}%;"></div>

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -134,6 +134,26 @@ export function routeFactionTransition(
   sink(event.originOwnerId, `${city?.name ?? civ?.name ?? 'A breakaway state'} is now an established civilization.`, 'warning');
 }
 
+export function routeEconomyTreasuryStrain(
+  state: GameState,
+  event: GameEvents['economy:treasury-strain'],
+  sink: NotificationSink,
+): void {
+  const civ = state.civilizations[event.civId];
+  if (!civ) return;
+  const maintenanceNote = event.unpaidMaintenance > 0
+    ? ` ${event.unpaidMaintenance} maintenance went unpaid.`
+    : '';
+  const action = event.level === 'critical'
+    ? ' Rush buy is disabled until the treasury recovers.'
+    : ' Consider more gold income before expanding further.';
+  sink(
+    event.civId,
+    `Treasury ${event.level === 'critical' ? 'is in critical strain' : 'is strained'} (${event.netGoldPerTurn}/turn).${maintenanceNote}${action}`,
+    'warning',
+  );
+}
+
 // Writes to both parties' logs from their own perspective.
 export function routeWarDeclared(
   state: GameState,

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -14,6 +14,7 @@ import { calculateCityYields } from '@/systems/resource-system';
 import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
+import { createUnit } from '@/systems/unit-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -101,6 +102,59 @@ describe('processTurn', () => {
 
     const newState = processTurn(state, bus);
     expect(newState).toBeDefined();
+  });
+
+  it('stores net economy status and applies maintenance during turn processing', () => {
+    const state = createNewGame(undefined, 'turn-economy', 'small');
+    const bus = new EventBus();
+    const city = foundCity('player', { q: 2, r: 2 }, state.map);
+    city.id = 'capital';
+    city.population = 2;
+    city.buildings = ['marketplace'];
+    city.workedTiles = [];
+    city.productionQueue = [];
+    state.cities = { capital: city };
+    state.civilizations.player.cities = ['capital'];
+    state.civilizations.player.units = [];
+    state.units = {};
+    state.civilizations.player.gold = 20;
+
+    const result = processTurn(state, bus);
+    const status = result.economyStatusByCiv?.player;
+
+    expect(status).toBeDefined();
+    expect(status!.netGoldPerTurn).toBe(status!.grossGoldPerTurn - status!.maintenanceGoldPerTurn);
+    expect(result.civilizations.player.gold).toBe(status!.projectedGold);
+    expect(state.civilizations.player.gold).toBe(20);
+  });
+
+  it('caps gold at zero and emits critical treasury strain when upkeep cannot be paid', () => {
+    const state = createNewGame(undefined, 'turn-economy-critical', 'small');
+    const bus = new EventBus();
+    const listener = vi.fn();
+    bus.on('economy:treasury-strain', listener);
+    const city = foundCity('player', { q: 2, r: 2 }, state.map);
+    city.id = 'capital';
+    city.population = 1;
+    city.workedTiles = [];
+    city.productionQueue = [];
+    state.cities = { capital: city };
+    state.civilizations.player.cities = ['capital'];
+    state.civilizations.player.units = [];
+    state.units = {};
+    state.civilizations.player.gold = 0;
+    for (let index = 0; index < 40; index++) {
+      const unit = createUnit('warrior', 'player', city.position);
+      state.units[unit.id] = unit;
+      state.civilizations.player.units.push(unit.id);
+    }
+
+    const result = processTurn(state, bus);
+
+    expect(result.civilizations.player.gold).toBe(0);
+    expect(result.economyStatusByCiv?.player.strainLevel).toBe('critical');
+    expect(result.economyStatusByCiv?.player.rushBuyDisabled).toBe(true);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ civId: 'player', level: 'critical' }));
   });
 
   it('applies occupied-city penalties and decrements the occupation timer during turn processing', () => {

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -107,7 +107,7 @@ describe('processTurn', () => {
   it('stores net economy status and applies maintenance during turn processing', () => {
     const state = createNewGame(undefined, 'turn-economy', 'small');
     const bus = new EventBus();
-    const city = foundCity('player', { q: 2, r: 2 }, state.map);
+    const city = foundCity('player', { q: 2, r: 2 }, state.map, state.idCounters);
     city.id = 'capital';
     city.population = 2;
     city.buildings = ['marketplace'];
@@ -133,7 +133,7 @@ describe('processTurn', () => {
     const bus = new EventBus();
     const listener = vi.fn();
     bus.on('economy:treasury-strain', listener);
-    const city = foundCity('player', { q: 2, r: 2 }, state.map);
+    const city = foundCity('player', { q: 2, r: 2 }, state.map, state.idCounters);
     city.id = 'capital';
     city.population = 1;
     city.workedTiles = [];
@@ -144,7 +144,7 @@ describe('processTurn', () => {
     state.units = {};
     state.civilizations.player.gold = 0;
     for (let index = 0; index < 40; index++) {
-      const unit = createUnit('warrior', 'player', city.position);
+      const unit = createUnit('warrior', 'player', city.position, state.idCounters);
       state.units[unit.id] = unit;
       state.civilizations.player.units.push(unit.id);
     }

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -358,6 +358,22 @@ describe('completeCityProductionItem', () => {
     expect(result.city.productionProgress).toBe(0);
     expect(result.city.buildings).toEqual([]);
   });
+
+  it('does not complete an item that is not the active production item', () => {
+    const map = generateMap(30, 30, 'direct-completion-active-only');
+    const city = {
+      ...foundCity('p1', { q: 10, r: 10 }, map),
+      productionQueue: ['warrior', 'workshop'],
+      productionProgress: 4,
+    };
+
+    const result = completeCityProductionItem(city, 'workshop');
+
+    expect(result.completedBuilding).toBeNull();
+    expect(result.completedUnit).toBeNull();
+    expect(result.city.productionQueue).toEqual(['warrior', 'workshop']);
+    expect(result.city.buildings).toEqual([]);
+  });
 });
 
 describe('expanded buildings', () => {

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -327,7 +327,7 @@ describe('completeCityProductionItem', () => {
   it('uses the same completion path for direct building completion as turn production', () => {
     const map = generateMap(30, 30, 'direct-building-completion');
     const city = {
-      ...foundCity('p1', { q: 10, r: 10 }, map),
+      ...foundCity('p1', { q: 10, r: 10 }, map, mkC()),
       productionQueue: ['workshop', 'warrior'],
       productionProgress: 4,
     };
@@ -345,7 +345,7 @@ describe('completeCityProductionItem', () => {
   it('uses the same completion path for direct unit completion as turn production', () => {
     const map = generateMap(30, 30, 'direct-unit-completion');
     const city = {
-      ...foundCity('p1', { q: 10, r: 10 }, map),
+      ...foundCity('p1', { q: 10, r: 10 }, map, mkC()),
       productionQueue: ['warrior', 'workshop'],
       productionProgress: 4,
     };
@@ -362,7 +362,7 @@ describe('completeCityProductionItem', () => {
   it('does not complete an item that is not the active production item', () => {
     const map = generateMap(30, 30, 'direct-completion-active-only');
     const city = {
-      ...foundCity('p1', { q: 10, r: 10 }, map),
+      ...foundCity('p1', { q: 10, r: 10 }, map, mkC()),
       productionQueue: ['warrior', 'workshop'],
       productionProgress: 4,
     };

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -2,6 +2,7 @@ import {
   foundCity,
   getAvailableBuildings,
   processCity,
+  completeCityProductionItem,
   checkGridExpansion,
   purchaseGridExpansion,
   getUnplacedBuildings,
@@ -319,6 +320,43 @@ describe('processCity', () => {
     expect(era4Result.completedUnit).toBeNull();
     expect(era4Result.city.productionQueue).toEqual(['settler']);
     expect(era4Result.city.productionProgress).toBe(40);
+  });
+});
+
+describe('completeCityProductionItem', () => {
+  it('uses the same completion path for direct building completion as turn production', () => {
+    const map = generateMap(30, 30, 'direct-building-completion');
+    const city = {
+      ...foundCity('p1', { q: 10, r: 10 }, map),
+      productionQueue: ['workshop', 'warrior'],
+      productionProgress: 4,
+    };
+
+    const result = completeCityProductionItem(city, 'workshop');
+
+    expect(result.completedBuilding).toBe('workshop');
+    expect(result.completedUnit).toBeNull();
+    expect(result.city.productionQueue).toEqual(['warrior']);
+    expect(result.city.productionProgress).toBe(0);
+    expect(result.city.buildings).toContain('workshop');
+    expect(result.city.grid.flat()).toContain('workshop');
+  });
+
+  it('uses the same completion path for direct unit completion as turn production', () => {
+    const map = generateMap(30, 30, 'direct-unit-completion');
+    const city = {
+      ...foundCity('p1', { q: 10, r: 10 }, map),
+      productionQueue: ['warrior', 'workshop'],
+      productionProgress: 4,
+    };
+
+    const result = completeCityProductionItem(city, 'warrior');
+
+    expect(result.completedBuilding).toBeNull();
+    expect(result.completedUnit).toBe('warrior');
+    expect(result.city.productionQueue).toEqual(['workshop']);
+    expect(result.city.productionProgress).toBe(0);
+    expect(result.city.buildings).toEqual([]);
   });
 });
 

--- a/tests/systems/economy-system.test.ts
+++ b/tests/systems/economy-system.test.ts
@@ -9,12 +9,11 @@ import {
   getRushBuyQuote,
 } from '@/systems/economy-system';
 import { foundCity } from '@/systems/city-system';
-import { createUnit, resetUnitId } from '@/systems/unit-system';
+import { createUnit } from '@/systems/unit-system';
 
 function makeState(): GameState {
-  resetUnitId();
   const state = createNewGame(undefined, 'economy-test', 'small');
-  const city = foundCity('player', { q: 2, r: 2 }, state.map);
+  const city = foundCity('player', { q: 2, r: 2 }, state.map, state.idCounters);
   city.id = 'capital';
   city.name = 'Capital';
   city.population = 2;
@@ -37,7 +36,7 @@ function city(state: GameState): City {
 
 function addUnits(state: GameState, count: number): void {
   for (let index = 0; index < count; index++) {
-    const unit = createUnit('warrior', 'player', city(state).position);
+    const unit = createUnit('warrior', 'player', city(state).position, state.idCounters);
     state.units[unit.id] = unit;
     state.civilizations.player.units.push(unit.id);
   }

--- a/tests/systems/economy-system.test.ts
+++ b/tests/systems/economy-system.test.ts
@@ -1,0 +1,158 @@
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import type { City, GameState } from '@/core/types';
+import {
+  applyEconomyTurn,
+  calculateCivEconomy,
+  calculateMaintenance,
+  emitEconomyStrainIfNeeded,
+  getRushBuyQuote,
+} from '@/systems/economy-system';
+import { foundCity } from '@/systems/city-system';
+import { createUnit, resetUnitId } from '@/systems/unit-system';
+
+function makeState(): GameState {
+  resetUnitId();
+  const state = createNewGame(undefined, 'economy-test', 'small');
+  const city = foundCity('player', { q: 2, r: 2 }, state.map);
+  city.id = 'capital';
+  city.name = 'Capital';
+  city.population = 2;
+  city.maturity = 'outpost';
+  city.buildings = [];
+  city.productionQueue = [];
+  city.productionProgress = 0;
+
+  state.cities = { capital: city };
+  state.civilizations.player.cities = ['capital'];
+  state.civilizations.player.units = [];
+  state.civilizations.player.gold = 20;
+  state.units = {};
+  return state;
+}
+
+function city(state: GameState): City {
+  return state.cities.capital;
+}
+
+function addUnits(state: GameState, count: number): void {
+  for (let index = 0; index < count; index++) {
+    const unit = createUnit('warrior', 'player', city(state).position);
+    state.units[unit.id] = unit;
+    state.civilizations.player.units.push(unit.id);
+  }
+}
+
+describe('economy maintenance', () => {
+  it('keeps starter infrastructure and two defenders per city free', () => {
+    const state = makeState();
+    city(state).buildings = [
+      'herbalist',
+      'workshop',
+      'shrine',
+      'barracks',
+      'library',
+      'granary',
+      'marketplace',
+      'forum',
+      'temple',
+      'monument',
+    ];
+    addUnits(state, 6);
+
+    const maintenance = calculateMaintenance(state, 'player');
+
+    expect(maintenance.buildingUpkeep).toBe(0);
+    expect(maintenance.paidBuildings).toBe(0);
+    expect(maintenance.freeBuildings).toBe(10);
+    expect(maintenance.unitUpkeep).toBe(0);
+    expect(maintenance.freeUnits).toBe(6);
+  });
+
+  it('charges upkeep only after generous free support is exhausted', () => {
+    const state = makeState();
+    city(state).buildings = [
+      'herbalist',
+      'workshop',
+      'shrine',
+      'barracks',
+      'library',
+      'granary',
+      'marketplace',
+      'forum',
+      'temple',
+      'monument',
+      'forge',
+      'observatory',
+      'harbor',
+    ];
+    addUnits(state, 10);
+
+    const maintenance = calculateMaintenance(state, 'player');
+
+    expect(maintenance.paidBuildings).toBe(2);
+    expect(maintenance.buildingUpkeep).toBe(2);
+    expect(maintenance.paidUnits).toBe(4);
+    expect(maintenance.unitUpkeep).toBe(4);
+  });
+
+  it('projects and applies net gold without mutating the input state', () => {
+    const state = makeState();
+    city(state).buildings = ['marketplace'];
+    addUnits(state, 10);
+
+    const status = calculateCivEconomy(state, 'player');
+    const result = applyEconomyTurn(state, 'player', status.grossGoldPerTurn);
+
+    expect(state.civilizations.player.gold).toBe(20);
+    expect(result.civilizations.player.gold).toBe(status.projectedGold);
+    expect(result.economyStatusByCiv?.player.netGoldPerTurn).toBe(status.netGoldPerTurn);
+  });
+
+  it('marks critical strain when upkeep cannot be paid and emits one strain event', () => {
+    const state = makeState();
+    state.civilizations.player.gold = 0;
+    addUnits(state, 40);
+    const status = calculateCivEconomy(state, 'player', { grossGoldPerTurn: 0 });
+    const bus = new EventBus();
+    const listener = vi.fn();
+    bus.on('economy:treasury-strain', listener);
+
+    emitEconomyStrainIfNeeded(undefined, status, bus);
+    emitEconomyStrainIfNeeded(status, status, bus);
+
+    expect(status.strainLevel).toBe('critical');
+    expect(status.rushBuyDisabled).toBe(true);
+    expect(status.unpaidMaintenance).toBeGreaterThan(0);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('rush buy quote', () => {
+  it('blocks rush buy during critical treasury strain with a clear reason', () => {
+    const state = makeState();
+    state.civilizations.player.gold = 0;
+    city(state).productionQueue = ['workshop'];
+    city(state).productionProgress = 2;
+    addUnits(state, 40);
+
+    const quote = getRushBuyQuote(state, 'capital');
+
+    expect(quote.available).toBe(false);
+    expect(quote.reason).toContain('treasury strain is critical');
+    expect(quote.status.rushBuyDisabled).toBe(true);
+  });
+
+  it('quotes the remaining production cost when the treasury can support it', () => {
+    const state = makeState();
+    state.civilizations.player.gold = 100;
+    city(state).productionQueue = ['workshop'];
+    city(state).productionProgress = 2;
+
+    const quote = getRushBuyQuote(state, 'capital');
+
+    expect(quote.available).toBe(true);
+    expect(quote.itemId).toBe('workshop');
+    expect(quote.cost).toBe(25);
+  });
+});

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -262,6 +262,58 @@ describe('faction-system', () => {
     expect(events).toEqual([]);
   });
 
+  it('ignores treasury strain before Era 3 so the early game stays forgiving', () => {
+    const state = makeState({ era: 2 });
+    state.economyStatusByCiv = {
+      player: {
+        civId: 'player',
+        grossGoldPerTurn: 0,
+        maintenanceGoldPerTurn: 30,
+        netGoldPerTurn: -30,
+        projectedGold: 0,
+        unpaidMaintenance: 30,
+        strainLevel: 'critical',
+        rushBuyDisabled: true,
+        breakdown: {
+          buildingUpkeep: 0,
+          unitUpkeep: 30,
+          freeBuildings: 0,
+          freeUnits: 0,
+          paidBuildings: 0,
+          paidUnits: 30,
+        },
+      },
+    };
+
+    expect(computeUnrestPressure('city-1', state)).toBe(0);
+  });
+
+  it('adds treasury strain pressure from Era 3 onward', () => {
+    const state = makeState({ era: 3 });
+    state.economyStatusByCiv = {
+      player: {
+        civId: 'player',
+        grossGoldPerTurn: 0,
+        maintenanceGoldPerTurn: 30,
+        netGoldPerTurn: -30,
+        projectedGold: 0,
+        unpaidMaintenance: 30,
+        strainLevel: 'critical',
+        rushBuyDisabled: true,
+        breakdown: {
+          buildingUpkeep: 0,
+          unitUpkeep: 30,
+          freeBuildings: 0,
+          freeUnits: 0,
+          paidBuildings: 0,
+          paidUnits: 30,
+        },
+      },
+    };
+
+    expect(computeUnrestPressure('city-1', state)).toBe(20);
+  });
+
   it('clears existing unrest state in Era 1 instead of preserving penalties from saves', () => {
     const state = makeState({
       era: 1,

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -256,6 +256,66 @@ describe('city-panel navigation', () => {
     expect(rendered).toContain('Done in 10 turns');
   });
 
+  it('shows maintenance, net treasury, and rush buy for active production', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.productionQueue = ['workshop'];
+    city.productionProgress = 2;
+    state.civilizations[state.currentPlayer].gold = 100;
+    const onRushBuyActiveProduction = vi.fn(() => state);
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onRushBuyActiveProduction,
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Maintenance: -0/turn');
+    expect(rendered).toContain('Net treasury:');
+    expect(rendered).toContain('Rush buy (25 gold)');
+    clickElement(panel.querySelector('[data-rush-buy]'));
+    expect(onRushBuyActiveProduction).toHaveBeenCalledWith(city.id);
+  });
+
+  it('disables rush buy with a visible reason during critical treasury strain', () => {
+    const { container, city, state } = makeMultiCityFixture();
+    city.productionQueue = ['workshop'];
+    city.productionProgress = 2;
+    state.economyStatusByCiv = {
+      [state.currentPlayer]: {
+        civId: state.currentPlayer,
+        grossGoldPerTurn: 0,
+        maintenanceGoldPerTurn: 50,
+        netGoldPerTurn: -50,
+        projectedGold: 0,
+        unpaidMaintenance: 50,
+        strainLevel: 'critical',
+        rushBuyDisabled: true,
+        breakdown: {
+          buildingUpkeep: 0,
+          unitUpkeep: 50,
+          freeBuildings: 0,
+          freeUnits: 0,
+          paidBuildings: 0,
+          paidUnits: 50,
+        },
+      },
+    };
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onRushBuyActiveProduction: () => state,
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const rushButton = panel.querySelector<HTMLButtonElement>('[data-rush-buy]');
+
+    expect(collectText(panel)).toContain('Rush buy disabled: treasury strain is critical.');
+    expect(collectText(panel)).toContain('Critical strain');
+    expect(rushButton?.disabled).toBe(true);
+  });
+
   it('renders Overview, Buildings/Core, and Worked Land And Water sections in the Grid tab', () => {
     const { container, city, state } = makeWonderPanelFixture();
     city.focus = 'balanced';

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -287,7 +287,7 @@ describe('city-panel navigation', () => {
     state.civilizations[state.currentPlayer].units = [];
     state.units = {};
     for (let index = 0; index < 40; index++) {
-      const unit = createUnit('warrior', state.currentPlayer, city.position);
+      const unit = createUnit('warrior', state.currentPlayer, city.position, state.idCounters);
       state.units[unit.id] = unit;
       state.civilizations[state.currentPlayer].units.push(unit.id);
     }

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createCityPanel } from '@/ui/city-panel';
 import { createEmptyCityGrid } from '@/systems/city-system';
+import { createUnit } from '@/systems/unit-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { hexKey } from '@/systems/hex-utils';
 import { collectText, makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
@@ -282,26 +283,14 @@ describe('city-panel navigation', () => {
     const { container, city, state } = makeMultiCityFixture();
     city.productionQueue = ['workshop'];
     city.productionProgress = 2;
-    state.economyStatusByCiv = {
-      [state.currentPlayer]: {
-        civId: state.currentPlayer,
-        grossGoldPerTurn: 0,
-        maintenanceGoldPerTurn: 50,
-        netGoldPerTurn: -50,
-        projectedGold: 0,
-        unpaidMaintenance: 50,
-        strainLevel: 'critical',
-        rushBuyDisabled: true,
-        breakdown: {
-          buildingUpkeep: 0,
-          unitUpkeep: 50,
-          freeBuildings: 0,
-          freeUnits: 0,
-          paidBuildings: 0,
-          paidUnits: 50,
-        },
-      },
-    };
+    state.civilizations[state.currentPlayer].gold = 0;
+    state.civilizations[state.currentPlayer].units = [];
+    state.units = {};
+    for (let index = 0; index < 40; index++) {
+      const unit = createUnit('warrior', state.currentPlayer, city.position);
+      state.units[unit.id] = unit;
+      state.civilizations[state.currentPlayer].units.push(unit.id);
+    }
 
     const panel = createCityPanel(container, city, state, {
       onBuild: () => {},
@@ -782,7 +771,7 @@ describe('city-panel navigation', () => {
     });
 
     const rendered = (panel as unknown as { innerHTML?: string }).innerHTML ?? '';
-    expect(rendered).toContain('Building:');      // current build block is present
+    expect(rendered).toContain('Producing:');     // current build block is present
     expect(rendered).not.toContain('Production Queue'); // no follow-up queue section
   });
 

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -5,6 +5,7 @@ import {
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeCombatResolved,
+  routeEconomyTreasuryStrain,
   queueFirstContactPendingEvents,
   routeLegendaryWonder,
   routeFactionTransition,
@@ -76,6 +77,25 @@ describe('notification routing', () => {
         civId: 'p2',
         message: expect.stringMatching(/Alice requests peace/i),
         type: 'info',
+      }),
+    ]);
+  });
+
+  it('routes treasury strain to the affected civilization with the rush-buy consequence', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+
+    routeEconomyTreasuryStrain(
+      state,
+      { civId: 'p1', level: 'critical', netGoldPerTurn: -12, unpaidMaintenance: 4 },
+      sink,
+    );
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        civId: 'p1',
+        message: expect.stringMatching(/Rush buy is disabled/i),
+        type: 'warning',
       }),
     ]);
   });


### PR DESCRIPTION
## Summary
- Adds a flexible economy resolver for building/unit upkeep, free support allowances, strain levels, and rush-buy eligibility.
- Applies upkeep through the turn economy path, including diplomacy and marketplace income, with treasury-strain notifications.
- Surfaces maintenance/net gold in the HUD and city panel, adds rush-buy completion, and gates late-game unrest pressure to Era 3+.

Closes #158

## Test Plan
- ./scripts/run-with-mise.sh yarn test
- ./scripts/run-with-mise.sh yarn build
- scripts/check-src-rule-violations.sh src/core/types.ts src/core/turn-manager.ts src/main.ts src/systems/city-system.ts src/systems/economy-system.ts src/systems/faction-system.ts src/ui/city-panel.ts src/ui/notification-routing.ts

## Notes
- Browser smoke reached the local app title/URL once, then the in-app browser backend became unavailable; automated build and tests are green.