### PR TITLE
fix: sync unit ID counter on game load to prevent ID collisions

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
 import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
-import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
+import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason, syncUnitIdCounter } from '@/systems/unit-system';
 import { foundCity } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers, recalculateTerritory } from '@/systems/city-territory-system';
@@ -2824,6 +2824,8 @@ function showGameModeSelection(): void {
 }
 
 function startGame(): void {
+  syncUnitIdCounter(gameState.units);
+
   // Warm sprite cache non-blocking — renderers fall back to emoji while loading
   const civColors: Record<string, string> = {};
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -139,6 +139,18 @@ export function resetUnitId(): void {
   nextUnitId = 1;
 }
 
+export function syncUnitIdCounter(units: Record<string, { id: string }>): void {
+  let max = 0;
+  for (const id of Object.keys(units)) {
+    const match = /^unit-(\d+)$/.exec(id);
+    if (match) {
+      const n = parseInt(match[1], 10);
+      if (n > max) max = n;
+    }
+  }
+  if (max >= nextUnitId) nextUnitId = max + 1;
+}
+
 export function moveUnit(unit: Unit, to: HexCoord, cost: number): Unit {
   return {
     ...unit,

--- a/tests/systems/id-reset.test.ts
+++ b/tests/systems/id-reset.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { createUnit, resetUnitId } from '@/systems/unit-system';
+import { createUnit, resetUnitId, syncUnitIdCounter } from '@/systems/unit-system';
 import { foundCity, resetCityId } from '@/systems/city-system';
 import { spawnBarbarianCamp, resetCampId } from '@/systems/barbarian-system';
 import { _resetSpyIdCounter } from '@/systems/espionage-system';
@@ -95,5 +95,96 @@ describe('ID counter reset between games', () => {
     expect(freshUnit.id).toBe('unit-1');
     expect(freshCity.id).toBe('city-1');
     expect(freshCamp?.id).toBe('camp-1');
+  });
+});
+
+describe('syncUnitIdCounter — save/load ID collision prevention', () => {
+  beforeEach(() => {
+    resetUnitId();
+  });
+
+  it('createUnit collides with existing units when counter is not synced after load', () => {
+    // Simulate a game session: create units (advances counter to 4)
+    const existing1 = createUnit('warrior', 'player', { q: 0, r: 0 });
+    const existing2 = createUnit('settler', 'player', { q: 1, r: 0 });
+    const existing3 = createUnit('warrior', 'ai-1', { q: 5, r: 5 });
+    expect(existing1.id).toBe('unit-1');
+    expect(existing2.id).toBe('unit-2');
+    expect(existing3.id).toBe('unit-3');
+
+    // Simulate page reload: module re-imports reset counter to 1
+    resetUnitId();
+
+    // Without syncUnitIdCounter, the next createUnit reuses unit-1 — collision
+    const colliding = createUnit('warrior', 'player', { q: 2, r: 0 });
+    expect(colliding.id).toBe('unit-1'); // proves the counter restarted
+
+    // The collision means unit-1 would silently overwrite the existing warrior
+    const existingIds = new Set([existing1.id, existing2.id, existing3.id]);
+    expect(existingIds.has(colliding.id)).toBe(true); // THIS IS THE BUG
+  });
+
+  it('syncUnitIdCounter advances counter past all existing unit IDs so new units never collide', () => {
+    // Simulate existing save state: units created during prior session
+    const existingUnits: Record<string, ReturnType<typeof createUnit>> = {};
+    for (let i = 0; i < 5; i++) {
+      const u = createUnit('warrior', 'player', { q: i, r: 0 });
+      existingUnits[u.id] = u;
+    }
+    // existing IDs: unit-1 … unit-5, counter is now at 6
+
+    // Simulate page reload
+    resetUnitId();
+
+    // Call syncUnitIdCounter with the loaded state's units — should fast-forward counter
+    syncUnitIdCounter(existingUnits);
+
+    // All new units must have IDs not present in the existing save
+    const newUnit1 = createUnit('warrior', 'player', { q: 10, r: 0 });
+    const newUnit2 = createUnit('settler', 'player', { q: 11, r: 0 });
+
+    const existingIds = new Set(Object.keys(existingUnits));
+    expect(existingIds.has(newUnit1.id)).toBe(false);
+    expect(existingIds.has(newUnit2.id)).toBe(false);
+
+    // And they must be sequentially after the highest existing ID
+    expect(newUnit1.id).toBe('unit-6');
+    expect(newUnit2.id).toBe('unit-7');
+  });
+
+  it('syncUnitIdCounter handles non-sequential and large IDs from long play sessions', () => {
+    // Simulate a loaded game where the highest unit ID is unit-847
+    // (gaps are fine — the counter just needs to exceed the max)
+    const highIdUnit = { id: 'unit-847', type: 'warrior', owner: 'player', position: { q: 0, r: 0 } };
+    const lowIdUnit  = { id: 'unit-3',   type: 'warrior', owner: 'player', position: { q: 1, r: 0 } };
+    const loadedUnits = {
+      'unit-847': highIdUnit,
+      'unit-3':   lowIdUnit,
+    } as Record<string, ReturnType<typeof createUnit>>;
+
+    syncUnitIdCounter(loadedUnits);
+
+    const newUnit = createUnit('scout', 'player', { q: 5, r: 5 });
+    expect(newUnit.id).toBe('unit-848');
+    expect(Object.keys(loadedUnits).includes(newUnit.id)).toBe(false);
+  });
+
+  it('syncUnitIdCounter is a no-op on an empty units map', () => {
+    syncUnitIdCounter({});
+    const u = createUnit('warrior', 'player', { q: 0, r: 0 });
+    expect(u.id).toBe('unit-1');
+  });
+
+  it('syncUnitIdCounter ignores unit IDs that do not match the unit-N pattern', () => {
+    const alienUnits = {
+      'barbarian-warrior-1': { id: 'barbarian-warrior-1' },
+      'mc-unit-xyz':         { id: 'mc-unit-xyz' },
+    } as Record<string, ReturnType<typeof createUnit>>;
+
+    syncUnitIdCounter(alienUnits);
+
+    // Counter should remain at 1 — no numeric IDs found
+    const u = createUnit('warrior', 'player', { q: 0, r: 0 });
+    expect(u.id).toBe('unit-1');
   });
 });


### PR DESCRIPTION
After a page reload, the module-level nextUnitId counter resets to 1.
Loading a save that contains units with IDs unit-1…unit-N then causes
newly trained units to receive IDs that already exist in state.units,
silently overwriting the occupying unit and leaving duplicate entries
in civ.units. This appeared as units (including fortified ones)
disappearing around the time a city finished training a new unit.

Added syncUnitIdCounter() in unit-system.ts — scans all unit IDs from
the loaded state and advances nextUnitId past the highest found. Called
from startGame(), which is the common exit point for every load path
(auto-load, manual slot load, import).

https://github.com/a1flecke/conquestoria/issues/213