### PR TITLE
fix(fog): fix grassland overlay (#212) and cross-water city reveal (#216)

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -10,7 +10,7 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { getAttackTargets } from '@/systems/attack-targeting';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
-import { updateVisibility } from '@/systems/fog-of-war';
+import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { hasMetCivilization, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { hexDistance } from '@/systems/hex-utils';
@@ -970,13 +970,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
   }
 
   // Update AI visibility
-  const civUnits = civ.units
-    .map(id => newState.units[id])
-    .filter((u): u is Unit => u !== undefined);
-  const cityPositions = civ.cities
-    .map(id => newState.cities[id]?.position)
-    .filter((p): p is HexCoord => p !== undefined);
-  updateVisibility(newState.civilizations[civId].visibility, civUnits, newState.map, cityPositions);
+  updateAndRefreshVisibility(newState, civId);
   for (const contact of syncCivilizationContactsFromVisibility(newState, civId)) {
     bus.emit('civilization:first-contact', contact);
   }

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -633,6 +633,13 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     newState = { ...newState, espionage };
   }
 
+  // Re-snapshot all civs after espionage so spy-revealed tiles get lastSeen entries
+  // before they transition back to fog. This must run after all visibility.tiles mutations
+  // in the espionage block (processEspionageTurn, processDetection, spy city vision).
+  for (const civId of Object.keys(newState.civilizations)) {
+    refreshLastSeenPresentationsForCiv(newState, civId);
+  }
+
   // --- Vassalage protection & independence ---
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
     if (!civ.diplomacy?.vassalage.overlord) continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,7 +143,7 @@ import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
-import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
+import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 
 // --- App State ---
 let gameState: GameState;
@@ -2721,6 +2721,10 @@ function migrateLegacySave(): void {
   }
   for (const civId of Object.keys(gameState.civilizations)) {
     refreshKnownCivilizations(gameState, civId);
+  }
+  // Reconstruct missing lastSeen entries for fog tiles on old saves (M5 migration)
+  for (const civId of Object.keys(gameState.civilizations)) {
+    reconstructLastSeenFromMap(gameState, civId);
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
-import { updateVisibility, isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
+import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { autoSave, loadAutoSave, saveGame, loadGame, listSaves, loadSettings, saveSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
@@ -143,7 +143,7 @@ import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
-import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
 
 // --- App State ---
 let gameState: GameState;
@@ -1350,18 +1350,8 @@ function selectNextUnit(): void {
 }
 
 function refreshCurrentPlayerVisibility(): void {
-  const civ = currentCiv();
-  if (!civ?.visibility) return;
-
-  const playerUnits = civ.units
-    .map(id => gameState.units[id])
-    .filter((unit): unit is Unit => unit !== undefined);
-  const cityPositions = civ.cities
-    .map(id => gameState.cities[id]?.position)
-    .filter((position): position is HexCoord => position !== undefined);
-
-  updateVisibility(civ.visibility, playerUnits, gameState.map, cityPositions);
-  refreshLastSeenPresentationsForCiv(gameState, gameState.currentPlayer);
+  if (!currentCiv()?.visibility) return;
+  updateAndRefreshVisibility(gameState, gameState.currentPlayer);
   for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
     bus.emit('civilization:first-contact', contact);
   }
@@ -1424,14 +1414,7 @@ function foundCityAction(): void {
   SFX.foundCity();
 
   // Update visibility
-  const playerUnits = currentCiv().units
-    .map(id => gameState.units[id])
-    .filter((u): u is Unit => u !== undefined);
-  const cityPositions = currentCiv().cities
-    .map(id => gameState.cities[id]?.position)
-    .filter((p): p is HexCoord => p !== undefined);
-  updateVisibility(currentCiv().visibility, playerUnits, gameState.map, cityPositions);
-  refreshLastSeenPresentationsForCiv(gameState, gameState.currentPlayer);
+  updateAndRefreshVisibility(gameState, gameState.currentPlayer);
   for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
     bus.emit('civilization:first-contact', contact);
   }

--- a/src/systems/breakaway-system.ts
+++ b/src/systems/breakaway-system.ts
@@ -85,7 +85,7 @@ export function createBreakawayFromCity(
       trackPriorities: { ...previousOwner.techState.trackPriorities },
     },
     gold: 0,
-    visibility: { tiles: { ...previousOwner.visibility.tiles } },
+    visibility: { tiles: { ...previousOwner.visibility.tiles }, lastSeen: { ...(previousOwner.visibility.lastSeen ?? {}) } },
     score: 0,
     diplomacy: createDiplomacyState(newCivIds, breakawayId),
     breakaway: metadata,

--- a/src/systems/fog-of-war.ts
+++ b/src/systems/fog-of-war.ts
@@ -1,5 +1,5 @@
 import type { VisibilityMap, VisibilityState, HexCoord, Unit, GameMap, GameState } from '@/core/types';
-import { hexKey, hexesInRange, hexDistance, getWrappedHexesInRange, wrapHexCoord, wrappedHexDistance } from './hex-utils';
+import { hexKey, hexesInRange, hexDistance, getWrappedHexesInRange, wrapHexCoord, wrappedHexDistance, hexNeighbors, getWrappedHexNeighbors } from './hex-utils';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { getWonderVisionBonus } from './wonder-system';
 import { resolveCivDefinition } from './civ-registry';
@@ -104,21 +104,57 @@ export function getTerrainVisionBonus(terrain: string): number {
   return 0;
 }
 
+function landReachableFromCity(
+  cityCoord: HexCoord,
+  radius: number,
+  mapTiles: GameMap['tiles'],
+  map: GameMap,
+): Set<string> {
+  const startKey = hexKey(cityCoord);
+  const reachable = new Set<string>([startKey]);
+  const visited = new Set<string>([startKey]);
+  const queue: Array<{ coord: HexCoord; steps: number }> = [{ coord: cityCoord, steps: 0 }];
+  while (queue.length > 0) {
+    const { coord, steps } = queue.shift()!;
+    if (steps >= radius) continue;
+    const neighbors = map.wrapsHorizontally
+      ? getWrappedHexNeighbors(coord, map.width)
+      : hexNeighbors(coord);
+    for (const neighbor of neighbors) {
+      const k = hexKey(neighbor);
+      if (visited.has(k)) continue;
+      visited.add(k);
+      const tile = mapTiles[k];
+      if (!tile) continue;
+      if (tile.terrain === 'ocean' || tile.terrain === 'coast') continue;
+      reachable.add(k);
+      queue.push({ coord: neighbor, steps: steps + 1 });
+    }
+  }
+  return reachable;
+}
+
 export function revealMinorCivCities(
   vis: VisibilityMap,
   mcCityPositions: HexCoord[],
   map?: GameMap,
 ): void {
   for (const cityPos of mcCityPositions) {
-    const cityCoord = canonicalVisibilityCoord(cityPos, map);
+    const cityCoord = map ? canonicalVisibilityCoord(cityPos, map) : cityPos;
     const key = hexKey(cityCoord);
     if (vis.tiles[key] === 'visible') continue;
 
-    const nearby = getVisibilityRange(cityCoord, 2, map);
-    const anyExplored = nearby.some(h => {
-      const k = hexKey(h);
-      return vis.tiles[k] === 'fog' || vis.tiles[k] === 'visible';
-    });
+    let anyExplored: boolean;
+    if (map) {
+      const reachable = landReachableFromCity(cityCoord, 2, map.tiles, map);
+      anyExplored = [...reachable].some(k => vis.tiles[k] === 'fog' || vis.tiles[k] === 'visible');
+    } else {
+      const nearby = getVisibilityRange(cityCoord, 2, map);
+      anyExplored = nearby.some(h => {
+        const k = hexKey(h);
+        return vis.tiles[k] === 'fog' || vis.tiles[k] === 'visible';
+      });
+    }
 
     if (anyExplored) {
       vis.tiles[key] = 'visible';

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -1,5 +1,5 @@
-import type { GameState, HexTile, LastSeenTilePresentation } from '@/core/types';
-import { getVisibility } from '@/systems/fog-of-war';
+import type { GameState, HexCoord, HexTile, LastSeenTilePresentation, Unit } from '@/core/types';
+import { getVisibility, updateVisibility } from '@/systems/fog-of-war';
 import { hexKey, parseHexKey } from '@/systems/hex-utils';
 
 export function createLastSeenTilePresentation(
@@ -35,4 +35,35 @@ export function refreshLastSeenPresentationsForCiv(state: GameState, viewerId: s
     if (getVisibility(civ.visibility, coord) !== 'visible') continue;
     civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, viewerId, { ...tile, coord });
   }
+}
+
+/**
+ * One-time migration for old saves that have fog tiles but no lastSeen entries.
+ * Builds snapshots from the current live map state for any fogged tile that
+ * lacks a snapshot. Visible tiles are handled by the normal refresh cycle.
+ * Does not overwrite existing entries.
+ */
+export function reconstructLastSeenFromMap(state: GameState, civId: string): void {
+  const civ = state.civilizations[civId];
+  if (!civ?.visibility) return;
+  civ.visibility.lastSeen ??= {};
+  for (const [key, tile] of Object.entries(state.map.tiles)) {
+    if (civ.visibility.tiles[key] !== 'fog') continue;
+    if (civ.visibility.lastSeen[key]) continue;
+    const coord = tile.coord ?? parseHexKey(key);
+    civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, civId, { ...tile, coord });
+  }
+}
+
+export function updateAndRefreshVisibility(state: GameState, civId: string): void {
+  const civ = state.civilizations[civId];
+  if (!civ?.visibility) return;
+  const units = civ.units
+    .map(id => state.units[id])
+    .filter((u): u is Unit => u !== undefined);
+  const cityPositions = civ.cities
+    .map(id => state.cities[id]?.position)
+    .filter((p): p is HexCoord => p !== undefined);
+  updateVisibility(civ.visibility, units, state.map, cityPositions);
+  refreshLastSeenPresentationsForCiv(state, civId);
 }

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -775,3 +775,88 @@ describe('processTurn', () => {
     expect(afterCi).toBe(startCi + 2); // perTurnBonus = 2 + floor(0 * 0.1) = 2
   });
 });
+
+describe('espionage post-loop snapshot', () => {
+  it('spy city-vision tiles get lastSeen snapshots so they show correct terrain in fog', () => {
+    const state = createNewGame(undefined, 'spy-snapshot', 'small');
+    const bus = new EventBus();
+
+    // Create an enemy city at a far tile — outside normal player vision range
+    const enemyPos = { q: 5, r: 3 };
+    const tileKey = `${enemyPos.q},${enemyPos.r}`;
+    const enemyCityId = 'spy-test-enemy-city';
+
+    // Ensure the tile exists on the map and set a distinctive terrain
+    if (!state.map.tiles[tileKey]) {
+      state.map.tiles[tileKey] = {
+        coord: enemyPos,
+        terrain: 'desert',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: null,
+        hasRiver: false,
+        wonder: null,
+      };
+    } else {
+      state.map.tiles[tileKey].terrain = 'desert';
+    }
+
+    state.cities[enemyCityId] = {
+      id: enemyCityId,
+      name: 'Enemy Outpost',
+      owner: 'ai-1',
+      position: enemyPos,
+      population: 1,
+      buildings: [],
+      productionQueue: [],
+      productionProgress: 0,
+      food: 0,
+      foodNeeded: 10,
+      workedTiles: [],
+      ownedTiles: [enemyPos],
+      focus: 'balanced',
+      maturity: 'outpost',
+      grid: [],
+      gridSize: 3,
+      unrestLevel: 0,
+      unrestTurns: 0,
+      spyUnrestBonus: 0,
+    };
+
+    // Ensure the tile is outside normal visibility so only the spy makes it visible
+    state.civilizations.player.visibility.tiles[tileKey] = 'fog';
+    state.civilizations.player.visibility.lastSeen = {};
+
+    // Place a spy with active city-vision at that city
+    state.espionage!['player'] = {
+      ...state.espionage!['player']!,
+      spies: {
+        'test-spy-vision': {
+          id: 'test-spy-vision',
+          owner: 'player',
+          name: 'Shadow',
+          targetCivId: 'ai-1',
+          targetCityId: enemyCityId,
+          position: enemyPos,
+          status: 'infiltrating',
+          experience: 0,
+          currentMission: null,
+          cooldownTurns: 0,
+          promotionAvailable: false,
+          unitType: 'spy_scout' as UnitType,
+          stolenTechFrom: {},
+          infiltrationCityId: enemyCityId,
+          cityVisionTurnsLeft: 2,
+        },
+      },
+    };
+
+    const result = processTurn(state, bus);
+
+    // The spy city-vision section makes the tile 'visible'; the post-espionage snapshot
+    // must have captured its terrain before processTurn returns.
+    expect(result.civilizations.player.visibility.lastSeen?.[tileKey]?.terrain).toBe('desert');
+  });
+});

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -840,7 +840,7 @@ describe('espionage post-loop snapshot', () => {
           targetCivId: 'ai-1',
           targetCityId: enemyCityId,
           position: enemyPos,
-          status: 'infiltrating',
+          status: 'stationed',
           experience: 0,
           currentMission: null,
           cooldownTurns: 0,

--- a/tests/systems/breakaway-system.test.ts
+++ b/tests/systems/breakaway-system.test.ts
@@ -93,4 +93,30 @@ describe('breakaway-system', () => {
     expect(result.cities['city-border'].owner).toBe('player');
     expect(result.cities['city-border'].unrestLevel).toBeGreaterThan(0);
   });
+
+  it('spawned breakaway civ inherits lastSeen snapshots from the previous owner', () => {
+    const { state } = makeBreakawayFixture({ unrestLevel: 2, unrestTurns: 10, turn: 40 });
+    const bus = new EventBus();
+
+    // Plant a lastSeen snapshot on the player at tile '3,0' (plains in the fixture map)
+    state.civilizations.player.visibility.lastSeen = {
+      '3,0': {
+        coord: { q: 3, r: 0 },
+        terrain: 'plains',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: 'player',
+        hasRiver: false,
+        wonder: null,
+      },
+    };
+
+    const result = createBreakawayFromCity(state, 'city-border', bus);
+    const spawned = Object.values(result.civilizations).find(c => c.breakaway?.originCityId === 'city-border');
+
+    expect(spawned).toBeDefined();
+    expect(spawned!.visibility.lastSeen?.['3,0']?.terrain).toBe('plains');
+  });
 });

--- a/tests/systems/fog-of-war.test.ts
+++ b/tests/systems/fog-of-war.test.ts
@@ -214,6 +214,66 @@ describe('minor civ visibility', () => {
     expect(vis.tiles[hexKey(mcCityPos)]).toBeUndefined();
   });
 
+  // BFS water-block tests (issue #216)
+  function makeMapWithWaterColumn(
+    width: number,
+    height: number,
+    waterColumn: number,
+  ): GameMap {
+    const tiles: GameMap['tiles'] = {};
+    for (let q = 0; q < width; q++) {
+      for (let r = 0; r < height; r++) {
+        tiles[`${q},${r}`] = {
+          coord: { q, r },
+          terrain: q === waterColumn ? 'ocean' : 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        };
+      }
+    }
+    return { tiles, width, height, wrapsHorizontally: false } as GameMap;
+  }
+
+  it('does not reveal city across a water column (BFS water block)', () => {
+    // City at q=4, explored tile at q=6, ocean column at q=5
+    // BFS cannot cross q=5, so q=6 fog tile must not trigger reveal
+    const map = makeMapWithWaterColumn(10, 5, 5);
+    const vis = createVisibilityMap();
+    vis.tiles['6,2'] = 'fog'; // explored tile 2 steps east of city, separated by ocean
+
+    revealMinorCivCities(vis, [{ q: 4, r: 2 }], map);
+
+    expect(vis.tiles['4,2']).toBeUndefined(); // must NOT be revealed
+  });
+
+  it('reveals city when explored tile is reachable by land path within radius', () => {
+    // City at q=4, explored at q=3 (1 step, no water) — must reveal
+    const map = makeMapWithWaterColumn(10, 5, 8); // water far away
+    const vis = createVisibilityMap();
+    vis.tiles['3,2'] = 'fog';
+
+    revealMinorCivCities(vis, [{ q: 4, r: 2 }], map);
+
+    expect(vis.tiles['4,2']).toBe('visible');
+  });
+
+  it('does not reveal city when only explored tiles are across water on a wrapping map', () => {
+    // Wrapping map: ocean at q=5, city at q=4, explored tile at q=6
+    const map = makeMapWithWaterColumn(10, 5, 5);
+    (map as any).wrapsHorizontally = true;
+    const vis = createVisibilityMap();
+    vis.tiles['6,2'] = 'fog';
+
+    revealMinorCivCities(vis, [{ q: 4, r: 2 }], map);
+
+    expect(vis.tiles['4,2']).toBeUndefined();
+  });
+
   it('adds shared vision for friendly minor civ', () => {
     const vis = createVisibilityMap();
     const friendlyUnitPositions = [{ q: 15, r: 15 }];

--- a/tests/systems/last-seen-presentation.test.ts
+++ b/tests/systems/last-seen-presentation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv, updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 
 describe('last-seen-presentation', () => {
   it('captures serializable tile presentation for visible tiles', () => {
@@ -88,5 +88,89 @@ describe('last-seen-presentation', () => {
       owner: 'ai-1',
       population: 2,
     });
+  });
+});
+
+describe('updateAndRefreshVisibility', () => {
+  it('populates lastSeen for all visible tiles', () => {
+    const state = createNewGame(undefined, 'atomic-helper-visible', 'small');
+    // Clear any snapshots from game init so we prove the helper re-populates them
+    state.civilizations.player.visibility.lastSeen = {};
+
+    updateAndRefreshVisibility(state, 'player');
+
+    const visibleKeys = Object.entries(state.civilizations.player.visibility.tiles)
+      .filter(([, v]) => v === 'visible')
+      .map(([k]) => k);
+    expect(visibleKeys.length).toBeGreaterThan(0);
+    for (const key of visibleKeys) {
+      expect(state.civilizations.player.visibility.lastSeen?.[key]).toBeDefined();
+    }
+  });
+
+  it('preserves existing fog snapshots and does not clear them', () => {
+    const state = createNewGame(undefined, 'atomic-helper-fog', 'small');
+    // Plant a fog snapshot at a fake key — the helper must not wipe it
+    state.civilizations.player.visibility.lastSeen = {
+      '99,99': {
+        coord: { q: 99, r: 99 },
+        terrain: 'plains',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: null,
+        hasRiver: false,
+        wonder: null,
+      },
+    };
+
+    updateAndRefreshVisibility(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['99,99']?.terrain).toBe('plains');
+  });
+});
+
+describe('reconstructLastSeenFromMap', () => {
+  it('populates lastSeen for fogged tiles that have no snapshot (old-save migration)', () => {
+    const state = createNewGame(undefined, 'reconstruct-fog', 'small');
+
+    // Mark a known tile as fog with no snapshot
+    state.map.tiles['0,0'].terrain = 'desert';
+    state.civilizations.player.visibility.tiles['0,0'] = 'fog';
+    state.civilizations.player.visibility.lastSeen = {};
+
+    reconstructLastSeenFromMap(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('desert');
+  });
+
+  it('does not overwrite existing lastSeen entries or snapshot unexplored tiles', () => {
+    const state = createNewGame(undefined, 'reconstruct-preserve', 'small');
+
+    // Pre-existing snapshot at '0,0' (fog)
+    state.civilizations.player.visibility.tiles['0,0'] = 'fog';
+    state.civilizations.player.visibility.lastSeen = {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'forest',
+        elevation: 'highland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: null,
+        hasRiver: false,
+        wonder: null,
+      },
+    };
+    // Unexplored tile — must not get a snapshot
+    state.civilizations.player.visibility.tiles['1,0'] = 'unexplored';
+
+    reconstructLastSeenFromMap(state, 'player');
+
+    // Existing snapshot must be unchanged
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('forest');
+    // Unexplored tile must remain absent
+    expect(state.civilizations.player.visibility.lastSeen?.['1,0']).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- **#212 (grassland overlay in fog)**: Fixed by enforcing atomicity of `updateVisibility` + `refreshLastSeenPresentationsForCiv` across all call sites. Any caller that updated visibility without immediately snapshotting the visible tiles left fog tiles with no `lastSeen` entry, causing `resolveTilePresentationForViewer` to fall through to `unknownTile()` (hardcoded grassland). Adds a save migration (`reconstructLastSeenFromMap`) to back-fill fog snapshots in old saves from the current live map state.
- **#216 (city revealed across water)**: Fixed by replacing the raw hex-distance proximity check in `revealMinorCivCities` with a land-reachability BFS that skips `ocean`/`coast` tiles and respects horizontal map wrapping via `getWrappedHexNeighbors`.

## Changes

| File | Change |
|---|---|
| `src/systems/last-seen-presentation.ts` | Added `updateAndRefreshVisibility` (atomic helper) and `reconstructLastSeenFromMap` (save migration) |
| `src/ai/basic-ai.ts` | Migrated to atomic helper — AI fog tiles now get snapshots |
| `src/main.ts` | Migrated both visibility call sites; added M5 migration in `migrateLegacySave()` |
| `src/core/turn-manager.ts` | Added post-espionage refresh loop so spy-revealed tiles are snapshotted |
| `src/systems/fog-of-war.ts` | `revealMinorCivCities` now uses land-reachability BFS |
| `src/systems/breakaway-system.ts` | Breakaway civ inherits `lastSeen` from previous owner |
| `.claude/rules/game-systems.md` | Visibility Mutation rule documenting the atomic-pair requirement |

## Test plan

- [ ] 7 new commits all pass `yarn test` (2103 tests, 187 files)
- [ ] `yarn build` exits 0 (tsc clean)
- [ ] Fog overlay: load an old save, explore an area, end a turn — fogged tiles should show correct terrain (not grassland)
- [ ] Cross-water city: on a map with an ocean column, minor-civ city on the far side should not appear revealed when only near tiles have been explored
- [ ] Spy city vision: a spy with city vision should grant correct terrain snapshots when the tile goes back to fog
- [ ] Breakaway: a breakaway civ should see correct fog terrain in previously explored areas

Closes #212, closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)