### PR TITLE
Fix treasury strain toast copy

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -123,6 +123,7 @@ import {
   type NotificationEntry,
 } from '@/ui/notification-log';
 import {
+  formatEconomyTreasuryStrainMessage,
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeCombatResolved,
@@ -2570,12 +2571,7 @@ bus.on('faction:critical-status', event => {
 bus.on('economy:treasury-strain', event => {
   routeEconomyTreasuryStrain(gameState, event, appendToCivLog);
   if (event.civId === gameState.currentPlayer) {
-    showNotification(
-      event.level === 'critical'
-        ? 'Treasury strain is critical. Rush buy is disabled.'
-        : 'Treasury is strained by maintenance.',
-      'warning',
-    );
+    showNotification(formatEconomyTreasuryStrainMessage(gameState, event), 'warning');
   }
 });
 

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -141,27 +141,25 @@ export function routeEconomyTreasuryStrain(
 ): void {
   const civ = state.civilizations[event.civId];
   if (!civ) return;
+  sink(event.civId, formatEconomyTreasuryStrainMessage(state, event), 'warning');
+}
+
+export function formatEconomyTreasuryStrainMessage(
+  state: GameState,
+  event: GameEvents['economy:treasury-strain'],
+): string {
   const maintenanceNote = event.unpaidMaintenance > 0
     ? ` ${event.unpaidMaintenance} maintenance went unpaid.`
     : '';
   if (event.level === 'low') {
-    sink(
-      event.civId,
-      `Treasury strain (${event.netGoldPerTurn}/turn).${maintenanceNote} Rush buy is still available if you can afford it.`,
-      'warning',
-    );
-    return;
+    return `Treasury strain (${event.netGoldPerTurn}/turn).${maintenanceNote} Rush buy is still available if you can afford it.`;
   }
 
   const unrestNote = state.era >= 3
     ? ' Unhappiness pressure is rising.'
     : '';
   const label = event.level === 'critical' ? 'Critical treasury strain' : 'Treasury strain is high';
-  sink(
-    event.civId,
-    `${label} (${event.netGoldPerTurn}/turn).${maintenanceNote} Rush buy is unavailable until the budget recovers.${unrestNote}`,
-    'warning',
-  );
+  return `${label} (${event.netGoldPerTurn}/turn).${maintenanceNote} Rush buy is unavailable until the budget recovers.${unrestNote}`;
 }
 
 // Writes to both parties' logs from their own perspective.

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { CombatResult, GameState } from '@/core/types';
 import {
+  formatEconomyTreasuryStrainMessage,
   getNotificationTargetsForEvent,
   routeBarbarianSpawned,
   routeCombatRewardEarned,
@@ -139,6 +140,19 @@ describe('notification routing', () => {
       }),
     ]);
     expect(calls[0]!.message).not.toMatch(/Unhappiness/i);
+  });
+
+  it('formats treasury strain copy once for logs and immediate toasts', () => {
+    const state = makeState({ era: 3 } as Partial<GameState>);
+    const event = { civId: 'p1', level: 'high' as const, netGoldPerTurn: -8, unpaidMaintenance: 5 };
+    const { sink, calls } = makeSink();
+
+    routeEconomyTreasuryStrain(state, event, sink);
+
+    expect(formatEconomyTreasuryStrainMessage(state, event)).toBe(calls[0]!.message);
+    expect(calls[0]!.message).toContain('Treasury strain is high');
+    expect(calls[0]!.message).toContain('Rush buy is unavailable until the budget recovers.');
+    expect(calls[0]!.message).toContain('Unhappiness pressure is rising.');
   });
 
   it('first-contact writes encounter messages to both civ logs', () => {


### PR DESCRIPTION
## Summary
- Extracts shared treasury-strain notification copy for both log entries and immediate toasts.
- Replaces the generic current-player toast with low/high/critical-specific wording, including Era 3 unhappiness context.
- Adds regression coverage that the route and formatter stay aligned.

## Test Plan
- [x] scripts/check-src-rule-violations.sh src/ui/notification-routing.ts src/main.ts
- [x] ./scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts
- [x] ./scripts/run-with-mise.sh yarn build
- [x] ./scripts/run-with-mise.sh yarn test