### PR TITLE
feat(wonders): surface legendary wonder construction

### DIFF
--- a/docs/superpowers/plans/2026-05-20-legendary-wonder-ui.md
+++ b/docs/superpowers/plans/2026-05-20-legendary-wonder-ui.md
@@ -1,0 +1,1405 @@
+# Legendary Wonder UI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Target worker model:** GPT-5.4, reasoning effort medium.
+
+**Goal:** Fix issue #217 by making legendary wonders discoverable from the normal city Build list, then opening a clearer Crafted Journal-style detail panel for requirements, quest progress, race state, and Start Construction.
+
+**Architecture:** Add one system-adjacent presentation helper that turns existing legendary wonder project state into city-scoped, viewer-safe UI entries. City and wonder panels render that shared view model, while `legendary-wonder-system.ts` remains authoritative for eligibility, starting construction, race resolution, and intel masking.
+
+**Tech Stack:** TypeScript, DOM UI panels, Canvas-adjacent production metadata, Vitest with jsdom UI tests, existing EventBus and legendary wonder systems.
+
+---
+
+## Scope Check
+
+This plan implements **Stage 1 only** from `docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md`.
+
+It does not implement Stage 2 wonder SVGs, map animations, completion ceremony, or Empire Legacy gallery. Those are intentionally separate follow-up work after the build-flow contract is accepted.
+
+---
+
+## Files And Responsibilities
+
+- Create `src/systems/legendary-wonder-presentation.ts`
+  - Single source for city-scoped wonder presentation entries, missing requirement labels, near-eligible filtering, state buckets, action labels, and legendary production metadata.
+- Create `tests/systems/legendary-wonder-presentation.test.ts`
+  - Unit coverage for entry classification, human-readable labels, compact-list filtering, metadata, stale-ready guards, and negative near-eligible boundaries.
+- Modify `src/systems/legendary-wonder-system.ts`
+  - Re-check current eligibility inside `startLegendaryWonderBuild` so stale UI/direct calls cannot start invalid wonders.
+- Modify `src/systems/city-system.ts`
+  - Expose display helpers for production item name/icon/cost, including `legendary:<wonderId>`.
+- Modify `tests/systems/city-system.test.ts`
+  - Assert legendary queue display metadata and production costs.
+- Modify `src/ui/city-panel.ts`
+  - Render the compact Legendary Wonders subsection in the normal Build list, use shared production display helpers for current build and queue rows, and route wonder cards to the detail panel.
+- Modify `tests/ui/city-panel.test.ts`
+  - Click-through coverage for the build-list doorway, human-readable legendary queue rows, ETA, no far-future crowding, and queue preservation after Start Construction.
+- Modify `src/ui/wonder-panel.ts`
+  - Render Crafted Journal sections from shared presentation entries, expose Start Construction with explicit queue-preservation copy, close at the top, and refresh after action.
+- Modify `tests/ui/wonder-panel.test.ts`
+  - Section grouping, close behavior, Start Construction callback, current-player scoping, full catalog reachability, and earned rival intel masking.
+- Modify `src/ui/legendary-wonder-notifications.ts`
+  - Tighten notification copy so ready/lost/completed/revealed messages point to city action and remain understandable.
+- Modify `tests/ui/legendary-wonder-notifications.test.ts`
+  - Assert player-facing notification copy and intel masking.
+- Review `src/ui/advisor-system.ts`
+  - Confirm current Artisan text points toward city action; if it does not, adjust only the relevant wonder advice strings.
+- Review `tests/ui/advisor-system.test.ts`
+  - Add text coverage when `advisor-system.ts` changes.
+
+---
+
+## Player Truth Table
+
+| Before | Action | Internal state change | Immediate visible result | Must remain reachable |
+|---|---|---|---|---|
+| City Build list shows buildings, Legendary Wonders subsection, and units | Click `Oracle of Delphi` wonder card | No production mutation | City panel closes and Wonder panel opens for the same city | Buildings, units, and all selected-city wonder ambitions |
+| Wonder panel shows `Ready` Oracle with `Start Construction - current queue continues after this wonder` | Click Start Construction | `startLegendaryWonderBuild` inserts `legendary:oracle-of-delphi` at queue front and keeps old queue behind it | Open panel refreshes: Oracle moves to Building, active production text shows Oracle, queue shows previous work as follow-ups | Reopen city panel still shows previous queue entries |
+| City has current queue `library, warrior, worker` | Start Oracle construction | Queue becomes `legendary:oracle-of-delphi, library, warrior, worker` | Current build row shows `Oracle of Delphi`; queue rows show `Library`, `Warrior`, `Worker` with ETA/order text | Reorder/remove controls still work on follow-ups |
+| City has early-era far-future wonder with only two formal requirements missing | Open city Build list | No mutation | Far-future wonder is absent from compact subsection | Full Wonder panel still has a complete ambitions surface |
+| Rival wonder intel exists only for another hot-seat player | Open current player's Wonder panel | No mutation | Rival section is hidden | Current player's own wonders remain visible |
+
+## Misleading UI Risks
+
+- `Ready` means quest steps are complete **and** current tech/resource/city/global/same-owner eligibility is valid. A stale `ready_to_build` project with missing stone or wrong terrain must not show Start Construction.
+- `Near-eligible` means era is current or next era **and** at most two requirements are missing. A late wonder outside the era window must stay out of the compact Build list.
+- `Recommended` or `Best fits` cannot be the only action surface. `Show all ambitions` or complete section coverage must prove every selected-city project remains reachable.
+- `Start Construction` must not read as a harmless append. Copy must tell the player that the wonder becomes active and the current queue continues after it.
+- `Rival Intel` must render from stored viewer-safe intel, never from live rival projects.
+
+## Interaction Replay Checklist
+
+- Open city panel, click wonder card, open wonder panel.
+- Start construction, then inspect refreshed visible state.
+- Start construction with a non-empty queue and verify preserved follow-ups.
+- Reopen city panel and verify active item and ETA/order text.
+- Reorder and remove follow-up queue entries after a legendary item becomes active.
+- Repeat-click stale Start Construction and verify only one active legendary item exists.
+- Switch current hot-seat player and verify city-scoped/rival intel visibility updates.
+
+## Queue And ETA Checklist
+
+- Active item is shown in the current production header.
+- Follow-up queue entries are shown in the Production Queue section.
+- Legendary active/follow-up labels use wonder names, not raw `legendary:` ids.
+- ETA uses the legendary wonder production cost when `legendary:<wonderId>` is active or queued.
+- Reorder/remove rows continue to target queue indexes after a legendary item becomes active.
+- Invalid unknown legendary queue ids show a safe fallback name and do not crash rendering.
+
+---
+
+### Task 0: Prepare Workspace And Read Rules
+
+**Files:**
+- Read: `CLAUDE.md`
+- Read: `.claude/rules/game-systems.md`
+- Read: `.claude/rules/ui-panels.md`
+- Read: `.claude/rules/strategy-game-mechanics.md`
+- Read: `.claude/rules/end-to-end-wiring.md`
+- Read: `.claude/rules/spec-fidelity.md`
+- Read: `docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md`
+
+- [ ] **Step 1: Create a fresh worktree from latest origin/main**
+
+Run:
+
+```bash
+git fetch origin main
+git worktree add .worktrees/issue-217-legendary-wonder-ui origin/main -b codex/issue-217-legendary-wonder-ui
+```
+
+Expected: worktree created on `codex/issue-217-legendary-wonder-ui`.
+
+- [ ] **Step 2: Enter the worktree and trust/install only if needed**
+
+Run:
+
+```bash
+cd .worktrees/issue-217-legendary-wonder-ui
+mise trust
+./scripts/run-with-mise.sh yarn install
+```
+
+Expected: `mise trust` succeeds or reports already trusted; `yarn install` succeeds or reports install is already current.
+
+- [ ] **Step 3: Read required rules and spec**
+
+Run:
+
+```bash
+sed -n '1,220p' CLAUDE.md
+sed -n '1,220p' .claude/rules/game-systems.md
+sed -n '1,240p' .claude/rules/ui-panels.md
+sed -n '1,220p' .claude/rules/strategy-game-mechanics.md
+sed -n '1,220p' .claude/rules/end-to-end-wiring.md
+sed -n '1,180p' .claude/rules/spec-fidelity.md
+sed -n '1,380p' docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md
+```
+
+Expected: rules are read before editing `src/` files.
+
+---
+
+### Task 1: Add Legendary Wonder Presentation Helper
+
+**Files:**
+- Create: `src/systems/legendary-wonder-presentation.ts`
+- Create: `tests/systems/legendary-wonder-presentation.test.ts`
+- Modify: `src/systems/legendary-wonder-system.ts`
+- Test: `tests/systems/legendary-wonder-presentation.test.ts`
+- Test: `tests/systems/legendary-wonder-system.test.ts`
+
+- [ ] **Step 1: Write failing presentation tests**
+
+Add `tests/systems/legendary-wonder-presentation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import {
+  getCompactLegendaryWonderEntriesForCity,
+  getLegendaryWonderPresentationForCity,
+  getLegendaryWonderQueueItemMetadata,
+} from '@/systems/legendary-wonder-presentation';
+import { startLegendaryWonderBuild } from '@/systems/legendary-wonder-system';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-presentation', () => {
+  it('classifies ready, questing, building, recovered, near, and blocked entries for one city', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages', 'city-planning', 'printing'],
+      resources: ['stone'],
+      oracleStepsCompleted: 2,
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+    state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+    state.legendaryWonderProjects!['sun-spire:player:city-river'] = {
+      wonderId: 'sun-spire',
+      ownerId: 'player',
+      cityId: 'city-river',
+      phase: 'building',
+      investedProduction: 70,
+      transferableProduction: 0,
+      questSteps: [
+        { id: 'complete-sacred-route', description: 'Establish a sacred trade route.', completed: true },
+        { id: 'defeat-nearby-stronghold', description: 'Clear a nearby barbarian stronghold.', completed: true },
+      ],
+    };
+    state.cities['city-river'].productionQueue = ['legendary:sun-spire'];
+    state.cities['city-river'].productionProgress = 70;
+
+    const entries = getLegendaryWonderPresentationForCity(state, 'player', 'city-river', 10);
+    expect(entries.find(entry => entry.wonderId === 'oracle-of-delphi')).toMatchObject({
+      name: 'Oracle of Delphi',
+      visibleState: 'ready',
+      eligibilityState: 'buildable',
+      canStartBuild: true,
+      startActionLabel: 'Start Construction',
+      queueItemId: 'legendary:oracle-of-delphi',
+    });
+    expect(entries.find(entry => entry.wonderId === 'grand-canal')).toMatchObject({
+      visibleState: 'recovered',
+      transferableProduction: 24,
+    });
+    expect(entries.find(entry => entry.wonderId === 'sun-spire')).toMatchObject({
+      visibleState: 'building',
+      investedProduction: 70,
+    });
+  });
+
+  it('keeps far-future blocked wonders out of the compact build-list surface', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.era = 1;
+    state.legendaryWonderProjects = undefined;
+
+    const compact = getCompactLegendaryWonderEntriesForCity(state, 'player', 'city-river', 4);
+
+    expect(compact.map(entry => entry.wonderId)).not.toContain('internet');
+    expect(compact.map(entry => entry.wonderId)).not.toContain('manhattan-project');
+  });
+
+  it('surfaces near-eligible current-era wonders only when the era and missing-condition boundary both hold', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: ['philosophy'], resources: ['stone'] });
+    state.era = 3;
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'questing';
+
+    const compact = getCompactLegendaryWonderEntriesForCity(state, 'player', 'city-river', 4);
+    const oracle = compact.find(entry => entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({
+      eligibilityState: 'near-eligible',
+      missingRequirements: ['Pilgrimages'],
+    });
+  });
+
+  it('uses human-readable legendary production metadata', () => {
+    expect(getLegendaryWonderQueueItemMetadata('legendary:oracle-of-delphi')).toEqual({
+      kind: 'legendary-wonder',
+      wonderId: 'oracle-of-delphi',
+      name: 'Oracle of Delphi',
+      icon: '✦',
+      productionCost: 120,
+    });
+    expect(getLegendaryWonderQueueItemMetadata('legendary:missing-wonder')).toEqual({
+      kind: 'legendary-wonder',
+      wonderId: 'missing-wonder',
+      name: 'Missing Wonder',
+      icon: '✦',
+      productionCost: 0,
+    });
+  });
+
+  it('does not treat seeded shells as actionable before eligibility and quest completion are true', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.legendaryWonderProjects = undefined;
+
+    const entries = getLegendaryWonderPresentationForCity(state, 'player', 'city-river', 4);
+    const oracle = entries.find(entry => entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle?.canStartBuild).toBe(false);
+    expect(oracle?.visibleState).not.toBe('ready');
+  });
+
+  it('refuses a stale ready project when current requirements are no longer satisfied', () => {
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, completedTechs: ['philosophy'], resources: [] });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+
+    const result = startLegendaryWonderBuild(state, 'player', 'city-river', 'oracle-of-delphi', new EventBus());
+
+    expect(result.legendaryWonderProjects!['oracle-of-delphi'].phase).toBe('ready_to_build');
+    expect(result.cities['city-river'].productionQueue).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-system.test.ts
+```
+
+Expected: FAIL because `legendary-wonder-presentation.ts` does not exist and `startLegendaryWonderBuild` still trusts stale ready state.
+
+- [ ] **Step 3: Create presentation helper**
+
+Create `src/systems/legendary-wonder-presentation.ts`:
+
+```ts
+import type { GameState, LegendaryWonderProject } from '@/core/types';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import {
+  getEligibleLegendaryWonders,
+  initializeLegendaryWonderProjectsForCity,
+} from '@/systems/legendary-wonder-system';
+import { getTechById } from '@/systems/tech-system';
+
+export const LEGENDARY_WONDER_PRODUCTION_ICON = '✦';
+
+export type LegendaryWonderVisibleState =
+  | 'ready'
+  | 'questing'
+  | 'building'
+  | 'blocked'
+  | 'recovered'
+  | 'completed'
+  | 'lost';
+
+export type LegendaryWonderEligibilityState =
+  | 'buildable'
+  | 'questing'
+  | 'near-eligible'
+  | 'blocked'
+  | 'in-progress'
+  | 'resolved';
+
+export interface LegendaryWonderPresentationEntry {
+  wonderId: string;
+  queueItemId: `legendary:${string}`;
+  projectKey: string;
+  name: string;
+  cityId: string;
+  ownerId: string;
+  visibleState: LegendaryWonderVisibleState;
+  eligibilityState: LegendaryWonderEligibilityState;
+  missingRequirements: string[];
+  questCompleted: number;
+  questTotal: number;
+  nextQuestStep: string | null;
+  rewardSummary: string;
+  productionCost: number;
+  turnsRemaining: number | null;
+  investedProduction: number;
+  transferableProduction: number;
+  canStartBuild: boolean;
+  startActionLabel: string | null;
+  sortBucket: 'ready' | 'active' | 'questing' | 'near' | 'blocked' | 'resolved';
+}
+
+export interface LegendaryWonderQueueItemMetadata {
+  kind: 'legendary-wonder';
+  wonderId: string;
+  name: string;
+  icon: string;
+  productionCost: number;
+}
+
+function titleCaseKebab(value: string): string {
+  return value
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function ownedResources(state: GameState, cityId: string): Set<string> {
+  const city = state.cities[cityId];
+  if (!city) return new Set();
+  return new Set(
+    city.ownedTiles
+      .map(coord => state.map.tiles[`${coord.q},${coord.r}`]?.resource)
+      .filter((resource): resource is string => resource !== null),
+  );
+}
+
+export function getLegendaryWonderQueueItemMetadata(itemId: string): LegendaryWonderQueueItemMetadata | null {
+  if (!itemId.startsWith('legendary:')) return null;
+  const wonderId = itemId.slice('legendary:'.length);
+  const definition = getLegendaryWonderDefinition(wonderId);
+  return {
+    kind: 'legendary-wonder',
+    wonderId,
+    name: definition?.name ?? titleCaseKebab(wonderId),
+    icon: LEGENDARY_WONDER_PRODUCTION_ICON,
+    productionCost: definition?.productionCost ?? 0,
+  };
+}
+
+export function getLegendaryWonderDisplayName(itemId: string): string | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.name ?? null;
+}
+
+export function getLegendaryWonderProductionCost(itemId: string): number | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.productionCost ?? null;
+}
+
+function hasCityRequirement(state: GameState, cityId: string, requirement: 'river' | 'coastal' | 'any'): boolean {
+  const city = state.cities[cityId];
+  if (!city) return false;
+  if (requirement === 'river') {
+    return city.ownedTiles.some(coord => state.map.tiles[`${coord.q},${coord.r}`]?.hasRiver);
+  }
+  if (requirement === 'coastal') {
+    return city.ownedTiles.some(coord => {
+      const terrain = state.map.tiles[`${coord.q},${coord.r}`]?.terrain;
+      return terrain === 'coast' || terrain === 'ocean';
+    });
+  }
+  return true;
+}
+
+export function getLegendaryWonderMissingRequirements(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  wonderId: string,
+): string[] {
+  const definition = getLegendaryWonderDefinition(wonderId);
+  const civ = state.civilizations[civId];
+  if (!definition || !civ || !state.cities[cityId]) return ['Requirements unavailable'];
+  const resources = ownedResources(state, cityId);
+  const missing = [
+    ...definition.requiredTechs
+      .filter(techId => !civ.techState.completed.includes(techId))
+      .map(techId => getTechById(techId)?.name ?? titleCaseKebab(techId)),
+    ...definition.requiredResources
+      .filter(resource => !resources.has(resource))
+      .map(titleCaseKebab),
+  ];
+  if (!hasCityRequirement(state, cityId, definition.cityRequirement)) {
+    missing.push(definition.cityRequirement === 'river' ? 'River city' : 'Coastal city');
+  }
+  return missing;
+}
+
+function visibleStateFor(project: LegendaryWonderProject): LegendaryWonderVisibleState {
+  if (project.phase === 'ready_to_build') return 'ready';
+  if (project.phase === 'lost_race') return 'recovered';
+  if (project.phase === 'locked') return 'blocked';
+  return project.phase;
+}
+
+function sortBucketFor(entry: Pick<LegendaryWonderPresentationEntry, 'visibleState' | 'eligibilityState'>): LegendaryWonderPresentationEntry['sortBucket'] {
+  if (entry.visibleState === 'ready') return 'ready';
+  if (entry.visibleState === 'building') return 'active';
+  if (entry.visibleState === 'questing') return 'questing';
+  if (entry.eligibilityState === 'near-eligible') return 'near';
+  if (entry.visibleState === 'completed' || entry.visibleState === 'lost' || entry.visibleState === 'recovered') return 'resolved';
+  return 'blocked';
+}
+
+function isNearEligible(state: GameState, wonderId: string, missingCount: number): boolean {
+  const definition = getLegendaryWonderDefinition(wonderId);
+  if (!definition) return false;
+  return definition.era <= state.era + 1 && missingCount <= 2;
+}
+
+function turnsRemaining(cost: number, invested: number, productionPerTurn: number): number | null {
+  if (productionPerTurn <= 0) return null;
+  return Math.max(0, Math.ceil(Math.max(0, cost - invested) / productionPerTurn));
+}
+
+export function getLegendaryWonderPresentationForCity(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  productionPerTurn: number = 0,
+): LegendaryWonderPresentationEntry[] {
+  const seededState = initializeLegendaryWonderProjectsForCity(state, civId, cityId);
+  const eligible = new Set(getEligibleLegendaryWonders(seededState, civId, cityId));
+  return Object.entries(seededState.legendaryWonderProjects ?? {})
+    .filter(([, project]) => project.ownerId === civId && project.cityId === cityId)
+    .map(([projectKey, project]) => {
+      const definition = getLegendaryWonderDefinition(project.wonderId);
+      const missingRequirements = getLegendaryWonderMissingRequirements(seededState, civId, cityId, project.wonderId);
+      const questCompleted = project.questSteps.filter(step => step.completed).length;
+      const questTotal = project.questSteps.length;
+      const metadata = getLegendaryWonderQueueItemMetadata(`legendary:${project.wonderId}`);
+      const visibleState = visibleStateFor(project);
+      const canStartBuild = project.phase === 'ready_to_build' && eligible.has(project.wonderId);
+      const eligibleForQuest = eligible.has(project.wonderId);
+      const eligibilityState: LegendaryWonderEligibilityState = project.phase === 'building'
+        ? 'in-progress'
+        : project.phase === 'completed' || project.phase === 'lost_race'
+          ? 'resolved'
+          : canStartBuild
+            ? 'buildable'
+            : eligibleForQuest
+              ? 'questing'
+              : isNearEligible(seededState, project.wonderId, missingRequirements.length)
+                ? 'near-eligible'
+                : 'blocked';
+      const baseEntry = {
+        wonderId: project.wonderId,
+        queueItemId: `legendary:${project.wonderId}` as const,
+        projectKey,
+        name: metadata?.name ?? project.wonderId,
+        cityId,
+        ownerId: civId,
+        visibleState,
+        eligibilityState,
+        missingRequirements,
+        questCompleted,
+        questTotal,
+        nextQuestStep: project.questSteps.find(step => !step.completed)?.description ?? null,
+        rewardSummary: definition?.reward.summary ?? 'Reward unavailable.',
+        productionCost: definition?.productionCost ?? 0,
+        turnsRemaining: turnsRemaining(definition?.productionCost ?? 0, project.investedProduction, productionPerTurn),
+        investedProduction: project.investedProduction,
+        transferableProduction: project.transferableProduction,
+        canStartBuild,
+        startActionLabel: canStartBuild ? 'Start Construction' : null,
+      };
+      return {
+        ...baseEntry,
+        sortBucket: sortBucketFor(baseEntry),
+      };
+    })
+    .sort((left, right) => {
+      const bucketRank = { ready: 0, active: 1, questing: 2, near: 3, blocked: 4, resolved: 5 };
+      return bucketRank[left.sortBucket] - bucketRank[right.sortBucket]
+        || left.name.localeCompare(right.name);
+    });
+}
+
+export function getCompactLegendaryWonderEntriesForCity(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  productionPerTurn: number = 0,
+): LegendaryWonderPresentationEntry[] {
+  return getLegendaryWonderPresentationForCity(state, civId, cityId, productionPerTurn)
+    .filter(entry =>
+      entry.visibleState === 'ready'
+      || entry.visibleState === 'questing'
+      || entry.visibleState === 'building'
+      || entry.visibleState === 'recovered'
+      || entry.eligibilityState === 'near-eligible',
+    );
+}
+```
+
+- [ ] **Step 4: Harden `startLegendaryWonderBuild` eligibility**
+
+Modify `src/systems/legendary-wonder-system.ts` so `startLegendaryWonderBuild` imports no presentation helper and reuses local truth:
+
+```ts
+  const eligibleWonderIds = new Set(getEligibleLegendaryWonders(seededState, civId, cityId));
+  if (
+    !projectKey
+    || !project
+    || project.phase !== 'ready_to_build'
+    || !eligibleWonderIds.has(wonderId)
+    || !isLegendaryWonderStillAvailable(seededState, wonderId)
+    || hasActiveLegendaryWonderBuildForCiv(seededState, civId, wonderId, cityId)
+  ) {
+    return seededState;
+  }
+```
+
+Keep this inside `startLegendaryWonderBuild` after `seededState`, `projectKey`, and `project` are defined.
+
+- [ ] **Step 5: Run presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+Run:
+
+```bash
+git add src/systems/legendary-wonder-presentation.ts src/systems/legendary-wonder-system.ts tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-system.test.ts
+git commit -m "feat(wonders): add city wonder presentation helper"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Wire Legendary Production Display Metadata
+
+**Files:**
+- Modify: `src/systems/city-system.ts`
+- Modify: `tests/systems/city-system.test.ts`
+- Test: `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Write failing city-system metadata tests**
+
+Add to `tests/systems/city-system.test.ts`:
+
+```ts
+import {
+  getCatalogProductionCost,
+  getProductionDisplayName,
+  getProductionIconForItem,
+  getProductionCostForItem,
+} from '@/systems/city-system';
+
+describe('legendary wonder production display metadata', () => {
+  it('returns human-readable names, costs, and icon for legendary queue ids', () => {
+    expect(getProductionDisplayName('legendary:oracle-of-delphi')).toBe('Oracle of Delphi');
+    expect(getProductionIconForItem('legendary:oracle-of-delphi')).toBe('✦');
+    expect(getCatalogProductionCost('legendary:oracle-of-delphi')).toBe(120);
+    expect(getProductionCostForItem('legendary:oracle-of-delphi')).toBe(120);
+  });
+
+  it('returns safe fallback metadata for unknown legendary queue ids', () => {
+    expect(getProductionDisplayName('legendary:lost-masterpiece')).toBe('Lost Masterpiece');
+    expect(getProductionIconForItem('legendary:lost-masterpiece')).toBe('✦');
+    expect(getCatalogProductionCost('legendary:lost-masterpiece')).toBe(0);
+  });
+});
+```
+
+If the file already imports some of these functions, extend the existing import rather than duplicating it.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-system.test.ts
+```
+
+Expected: FAIL because the display helper functions do not exist and legendary costs are still `0`.
+
+- [ ] **Step 3: Add production display helpers**
+
+Modify `src/systems/city-system.ts`:
+
+```ts
+import {
+  getLegendaryWonderDisplayName,
+  getLegendaryWonderProductionCost,
+  getLegendaryWonderQueueItemMetadata,
+  LEGENDARY_WONDER_PRODUCTION_ICON,
+} from './legendary-wonder-presentation';
+```
+
+Then update/add helpers:
+
+```ts
+export function getCatalogProductionCost(itemId: string, era: number = 1): number {
+  const legendaryCost = getLegendaryWonderProductionCost(itemId);
+  if (legendaryCost !== null) return legendaryCost;
+
+  const building = BUILDINGS[itemId];
+  if (building) return building.productionCost;
+
+  const unit = TRAINABLE_UNITS.find(candidate => candidate.type === itemId);
+  if (!unit) return 0;
+  if (unit.type === 'settler') return getSettlerProductionCost(era);
+  return unit.cost;
+}
+
+export function getProductionDisplayName(itemId: string): string {
+  const legendaryName = getLegendaryWonderDisplayName(itemId);
+  if (legendaryName) return legendaryName;
+  return BUILDINGS[itemId]?.name
+    ?? TRAINABLE_UNITS.find(unit => unit.type === itemId)?.name
+    ?? itemId;
+}
+
+export function getProductionIconForItem(itemId: string): string {
+  if (getLegendaryWonderQueueItemMetadata(itemId)) {
+    return LEGENDARY_WONDER_PRODUCTION_ICON;
+  }
+  return PRODUCTION_ICONS[itemId] ?? PRODUCTION_ICON_FALLBACK;
+}
+```
+
+- [ ] **Step 4: Run city-system tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+Run:
+
+```bash
+git add src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(wonders): display legendary production names"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Add City Build List Wonder Doorway
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Modify: `tests/ui/city-panel.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Write failing city-panel doorway tests**
+
+Add tests to the existing `describe('city-panel legendary wonders', ...)` block in `tests/ui/city-panel.test.ts`:
+
+```ts
+  it('shows relevant legendary wonders in the normal Build list with readable state and reward text', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.era = 3;
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    state.legendaryWonderProjects!['oracle-of-delphi'].questSteps = state.legendaryWonderProjects!['oracle-of-delphi'].questSteps
+      .map(step => ({ ...step, completed: true }));
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const wonderSection = panel.querySelector<HTMLElement>('[data-section="city-build-legendary-wonders"]');
+    expect(wonderSection).toBeTruthy();
+    expect(wonderSection!.textContent).toContain('Legendary Wonders');
+    expect(wonderSection!.textContent).toContain('Oracle of Delphi');
+    expect(wonderSection!.textContent).toContain('Ready');
+    expect(wonderSection!.textContent).toContain('Quest 2/2');
+    expect(wonderSection!.textContent).toContain('+60 research');
+  });
+
+  it('opens the wonder panel callback instead of starting production when a build-list wonder card is clicked', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    const onBuild = vi.fn();
+    const onOpenWonderPanel = vi.fn();
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild,
+      onOpenWonderPanel,
+      onClose: () => {},
+    });
+
+    clickElement(panel.querySelector('[data-wonder-card="oracle-of-delphi"]'));
+
+    expect(onOpenWonderPanel).toHaveBeenCalledWith('city-river');
+    expect(onBuild).not.toHaveBeenCalled();
+  });
+
+  it('does not crowd the compact Build list with far-future blocked wonders', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.era = 1;
+    state.civilizations.player.techState.completed = [];
+    state.legendaryWonderProjects = undefined;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const wonderSection = panel.querySelector<HTMLElement>('[data-section="city-build-legendary-wonders"]');
+    expect(wonderSection?.textContent ?? '').not.toContain('Internet');
+    expect(wonderSection?.textContent ?? '').not.toContain('Manhattan Project');
+  });
+
+  it('renders legendary current production and follow-up queue rows with names and ETA text', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = ['legendary:oracle-of-delphi', 'library'];
+    city.productionProgress = 20;
+    state.cities[city.id] = city;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onMoveQueueItem: () => {},
+      onRemoveQueueItem: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('Building: ✦ Oracle of Delphi');
+    expect(rendered).toContain('Library');
+    expect(rendered).toContain('Starts in');
+    expect(rendered).not.toContain('legendary:oracle-of-delphi');
+  });
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts
+```
+
+Expected: FAIL because the new subsection and legendary display helpers are not wired into the panel.
+
+- [ ] **Step 3: Render the compact Legendary Wonders subsection**
+
+Modify the top import in `src/ui/city-panel.ts`:
+
+```ts
+import {
+  getAvailableBuildings,
+  BUILDINGS,
+  TRAINABLE_UNITS,
+  getTrainableUnitsForCiv,
+  getProductionCostForItem,
+  getProductionDisplayName,
+  getProductionIconForItem,
+} from '@/systems/city-system';
+import { getCompactLegendaryWonderEntriesForCity } from '@/systems/legendary-wonder-presentation';
+```
+
+After `availableBuildings`, compute entries:
+
+```ts
+  const compactWonderEntries = getCompactLegendaryWonderEntriesForCity(
+    state,
+    state.currentPlayer,
+    city.id,
+    yields.production,
+  );
+```
+
+Build wonder HTML before units using static markup and `data-text` placeholders for dynamic text:
+
+```ts
+  const formatWonderStateLabel = (value: string): string =>
+    value.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+
+  const wonderItemPlaceholders = compactWonderEntries.map((entry, idx) => {
+    return `<div class="wonder-build-card" data-wonder-card="${entry.wonderId}" style="background:rgba(232,193,112,0.12);border:1px solid rgba(232,193,112,0.36);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;">
+        <div style="font-weight:bold;font-size:13px;" data-text="wonder-name-${idx}"></div>
+        <div style="font-size:11px;color:#e8c170;" data-text="wonder-state-${idx}"></div>
+      </div>
+      <div style="font-size:11px;opacity:0.76;" data-text="wonder-progress-${idx}"></div>
+      <div style="font-size:10px;opacity:0.68;" data-text="wonder-reward-${idx}"></div>
+      <div style="font-size:10px;opacity:0.62;" data-text="wonder-missing-${idx}"></div>
+      <div style="font-size:10px;opacity:0.62;" data-text="wonder-next-${idx}"></div>
+    </div>`;
+  }).join('');
+```
+
+Insert the subsection in the Build list before Units:
+
+```ts
+        ${wonderItemPlaceholders ? `<div data-section="city-build-legendary-wonders" style="margin-top:12px;margin-bottom:12px;"><h3 style="font-size:14px;margin:0 0 8px;color:#e8c170;">Legendary Wonders</h3>${wonderItemPlaceholders}</div>` : ''}
+        <div style="margin-top:12px;font-size:12px;opacity:0.5;margin-bottom:8px;">Units</div>
+```
+
+Register click handlers after the existing `.build-item` handlers:
+
+```ts
+  panel.querySelectorAll<HTMLElement>('[data-wonder-card]').forEach(el => {
+    el.addEventListener('click', () => {
+      callbacks.onOpenWonderPanel(city.id);
+      panel.remove();
+    });
+  });
+```
+
+After the existing `setText` calls for buildings and units, fill the wonder card placeholders with `textContent`:
+
+```ts
+  compactWonderEntries.forEach((entry, idx) => {
+    const eta = entry.turnsRemaining !== null ? ` · ${entry.turnsRemaining} turns` : '';
+    setText(`wonder-name-${idx}`, `✦ ${entry.name}`);
+    setText(`wonder-state-${idx}`, formatWonderStateLabel(entry.visibleState));
+    setText(`wonder-progress-${idx}`, `Quest ${entry.questCompleted}/${entry.questTotal} · Cost ${entry.productionCost}${eta}`);
+    setText(`wonder-reward-${idx}`, entry.rewardSummary);
+    setText(`wonder-missing-${idx}`, entry.missingRequirements.length > 0 ? `Missing: ${entry.missingRequirements.join(', ')}` : '');
+    setText(`wonder-next-${idx}`, entry.nextQuestStep ? `Next: ${entry.nextQuestStep}` : '');
+  });
+```
+
+- [ ] **Step 4: Use production display helpers everywhere in `city-panel.ts`**
+
+Replace production icon/name expressions:
+
+```ts
+${getProductionIconForItem(b.id)}
+${getProductionIconForItem(u.type)}
+${getProductionIconForItem(currentItem)}
+${getProductionIconForItem(city.productionQueue[idx])}
+```
+
+Replace current and queue name setters:
+
+```ts
+setText('prod-name', getProductionDisplayName(currentItem));
+```
+
+```ts
+city.productionQueue.forEach((itemId, index) => {
+  setText(`queue-name-${index}`, getProductionDisplayName(itemId));
+});
+```
+
+- [ ] **Step 5: Run city-panel tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "feat(wonders): surface wonders in city build list"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Redesign Wonder Panel And Start Construction Refresh
+
+**Files:**
+- Modify: `src/ui/wonder-panel.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/ui/wonder-panel.test.ts`
+- Test: `tests/ui/wonder-panel.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Write failing wonder-panel tests**
+
+Add to `tests/ui/wonder-panel.test.ts`:
+
+```ts
+  it('renders a Crafted Journal city title, top close control, sections, and Show all ambitions', () => {
+    const { container, state } = makeWonderPanelFixture();
+    state.cities['city-river'].name = 'Athens';
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+
+    const panel = createWonderPanel(container, state, 'city-river', {
+      onStartBuild: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.querySelector('[data-action="close-wonder-panel"]')).toBeTruthy();
+    expect(panel.textContent).toContain('Athens Wonders');
+    expect(panel.textContent).toContain('Show all ambitions');
+    expect(panel.querySelector('[data-section="ready-wonders"]')).toBeTruthy();
+    expect(panel.querySelector('[data-section="blocked-wonders"]')).toBeTruthy();
+  });
+
+  it('shows explicit Start Construction copy and calls the start callback only for buildable ready wonders', () => {
+    const { container, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    state.legendaryWonderProjects!['oracle-of-delphi'].questSteps = state.legendaryWonderProjects!['oracle-of-delphi'].questSteps
+      .map(step => ({ ...step, completed: true }));
+    const started: Array<[string, string]> = [];
+
+    const panel = createWonderPanel(container, state, 'city-river', {
+      onStartBuild: (cityId, wonderId) => started.push([cityId, wonderId]),
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Start Construction - current queue continues after this wonder.');
+    clickElement(panel.querySelector('[data-action="start-legendary-wonder"][data-wonder-id="oracle-of-delphi"]'));
+
+    expect(started).toEqual([['city-river', 'oracle-of-delphi']]);
+  });
+
+  it('keeps every selected-city wonder reachable in the full ambitions section', () => {
+    const { container, state } = makeWonderPanelFixture();
+    const seededState = initializeLegendaryWonderProjectsForCity(state, 'player', 'city-river');
+
+    const panel = createWonderPanel(container, seededState, 'city-river', {
+      onStartBuild: () => {},
+      onClose: () => {},
+    });
+
+    const selectedCityProjects = Object.values(seededState.legendaryWonderProjects ?? {}).filter(project =>
+      project.ownerId === seededState.currentPlayer && project.cityId === 'city-river',
+    );
+    expect(panel.querySelectorAll('[data-project-card]')).toHaveLength(selectedCityProjects.length);
+  });
+```
+
+Ensure `clickElement` exists in this file. If it does not, add:
+
+```ts
+function clickElement(element: Element | null | undefined): void {
+  expect(element).toBeTruthy();
+  element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-panel.test.ts
+```
+
+Expected: FAIL because the panel still renders the old structure and button copy.
+
+- [ ] **Step 3: Render panel from presentation entries**
+
+Modify `src/ui/wonder-panel.ts` imports:
+
+```ts
+import {
+  getLegendaryWonderPresentationForCity,
+  type LegendaryWonderPresentationEntry,
+} from '@/systems/legendary-wonder-presentation';
+```
+
+Replace local missing-condition and priority logic with presentation entries:
+
+```ts
+function formatWonderStateLabel(value: string): string {
+  return value.replace(/[-_]/g, ' ').replace(/\b\w/g, char => char.toUpperCase());
+}
+
+function appendProjectCard(
+  entry: LegendaryWonderPresentationEntry,
+  section: HTMLElement,
+  callbacks: WonderPanelCallbacks,
+): void {
+  const article = document.createElement('article');
+  article.dataset.projectCard = entry.wonderId;
+  article.style.cssText = 'border:1px solid rgba(232,193,112,0.28);border-radius:8px;padding:12px;margin-bottom:10px;background:rgba(255,255,255,0.06);';
+
+  const header = document.createElement('h3');
+  header.textContent = `✦ ${entry.name}`;
+  article.appendChild(header);
+
+  const stateLine = document.createElement('p');
+  stateLine.textContent = `${formatWonderStateLabel(entry.visibleState)} · Quest ${entry.questCompleted}/${entry.questTotal}`;
+  article.appendChild(stateLine);
+
+  if (entry.missingRequirements.length > 0) {
+    const missing = document.createElement('p');
+    missing.textContent = `Missing: ${entry.missingRequirements.join(', ')}.`;
+    article.appendChild(missing);
+  }
+
+  if (entry.nextQuestStep) {
+    const next = document.createElement('p');
+    next.textContent = `Next: ${entry.nextQuestStep}`;
+    article.appendChild(next);
+  }
+
+  const reward = document.createElement('p');
+  reward.textContent = `Reward: ${entry.rewardSummary}`;
+  article.appendChild(reward);
+
+  const progress = document.createElement('p');
+  progress.textContent = entry.visibleState === 'building'
+    ? `Construction: ${entry.investedProduction}/${entry.productionCost} production${entry.turnsRemaining !== null ? ` · ${entry.turnsRemaining} turns` : ''}.`
+    : entry.visibleState === 'recovered'
+      ? `Recovered effort: ${entry.transferableProduction} carryover remains in this city.`
+      : `Cost: ${entry.productionCost} production.`;
+  article.appendChild(progress);
+
+  if (entry.canStartBuild) {
+    const help = document.createElement('p');
+    help.textContent = 'Start Construction - current queue continues after this wonder.';
+    article.appendChild(help);
+
+    const startBuild = createGameButton('Start Construction', 'primary');
+    startBuild.dataset.action = 'start-legendary-wonder';
+    startBuild.dataset.wonderId = entry.wonderId;
+    startBuild.addEventListener('click', () => callbacks.onStartBuild(entry.cityId, entry.wonderId));
+    article.appendChild(startBuild);
+  }
+
+  section.appendChild(article);
+}
+```
+
+Build sections with a helper:
+
+```ts
+function appendEntrySection(
+  panel: HTMLElement,
+  heading: string,
+  dataSection: string,
+  entries: LegendaryWonderPresentationEntry[],
+  callbacks: WonderPanelCallbacks,
+): void {
+  const section = document.createElement('section');
+  section.dataset.section = dataSection;
+  const header = document.createElement('h3');
+  header.textContent = heading;
+  section.appendChild(header);
+  if (entries.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'None right now.';
+    section.appendChild(empty);
+  } else {
+    for (const entry of entries) appendProjectCard(entry, section, callbacks);
+  }
+  panel.appendChild(section);
+}
+```
+
+Inside `createWonderPanel`, replace the old body with:
+
+```ts
+  const city = state.cities[cityId];
+  const entries = getLegendaryWonderPresentationForCity(state, state.currentPlayer, cityId);
+  const titleRow = document.createElement('div');
+  titleRow.style.cssText = 'display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px;';
+
+  const titleWrap = document.createElement('div');
+  const eyebrow = document.createElement('div');
+  eyebrow.textContent = 'Legendary Ambitions';
+  eyebrow.style.cssText = 'font-size:12px;text-transform:uppercase;letter-spacing:0.08em;color:#d9a25c;';
+  const title = document.createElement('h2');
+  title.textContent = `${city?.name ?? 'City'} Wonders`;
+  title.style.cssText = 'margin:4px 0 4px;color:#e8c170;';
+  const intro = document.createElement('p');
+  intro.textContent = 'Track quests, requirements, rival races, and the construction that will define this city.';
+  intro.style.cssText = 'margin:0;color:rgba(244,241,232,0.72);font-size:13px;';
+  titleWrap.append(eyebrow, title, intro);
+
+  const close = createGameButton('Close', 'ghost');
+  close.dataset.action = 'close-wonder-panel';
+  close.addEventListener('click', () => callbacks.onClose());
+  titleRow.append(titleWrap, close);
+  panel.appendChild(titleRow);
+
+  const allLabel = document.createElement('p');
+  allLabel.textContent = 'Show all ambitions';
+  allLabel.style.cssText = 'font-size:12px;color:#e8c170;';
+  panel.appendChild(allLabel);
+
+  appendEntrySection(panel, 'Ready', 'ready-wonders', entries.filter(entry => entry.visibleState === 'ready'), callbacks);
+  appendEntrySection(panel, 'Questing', 'questing-wonders', entries.filter(entry => entry.visibleState === 'questing'), callbacks);
+  appendEntrySection(panel, 'Building', 'building-wonders', entries.filter(entry => entry.visibleState === 'building'), callbacks);
+  appendEntrySection(panel, 'Blocked', 'blocked-wonders', entries.filter(entry => entry.visibleState === 'blocked'), callbacks);
+  appendEntrySection(panel, 'Recovered', 'recovered-wonders', entries.filter(entry => entry.visibleState === 'recovered'), callbacks);
+```
+
+Keep rival intel rendering through `getLegendaryWonderIntelForViewer(state, state.currentPlayer)`, but rename the section to `Rival Intel` and preserve the existing no-leak behavior.
+
+Update existing `tests/ui/wonder-panel.test.ts` assertions that refer to the old `Best fits right now`, `All ambitions in this city`, or `In progress elsewhere` headings so they assert the new section names and `Show all ambitions` complete-catalog affordance instead.
+
+- [ ] **Step 4: Refresh the open wonder panel after Start Construction in `src/main.ts`**
+
+Extend the city-system import near the top of `src/main.ts`:
+
+```ts
+import { foundCity, getProductionDisplayName } from '@/systems/city-system';
+```
+
+Inside `openCityPanelForCity`, replace the current inline `onOpenWonderPanel` callback body with a local helper and callback:
+
+```ts
+  const openWonderPanelForCity = (selectedCityId: string): void => {
+    gameState = initializeLegendaryWonderProjectsForCity(gameState, gameState.currentPlayer, selectedCityId);
+    document.getElementById('wonder-panel')?.remove();
+    createWonderPanel(uiLayer, gameState, selectedCityId, {
+      onStartBuild: (buildCityId, wonderId) => {
+        gameState = startLegendaryWonderBuild(gameState, gameState.currentPlayer, buildCityId, wonderId, bus);
+        const targetCity = gameState.cities[buildCityId];
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        if (targetCity?.productionQueue[0] === `legendary:${wonderId}`) {
+          showNotification(`${targetCity.name}: started ${getProductionDisplayName(`legendary:${wonderId}`)}`, 'info');
+        }
+        openWonderPanelForCity(buildCityId);
+      },
+      onClose: () => {
+        document.getElementById('wonder-panel')?.remove();
+      },
+    });
+  };
+```
+
+Then wire the city-panel callback to the helper:
+
+```ts
+    onOpenWonderPanel: openWonderPanelForCity,
+```
+
+The final code must keep this helper inside `openCityPanelForCity`, because it closes over the live `gameState`, `renderLoop`, `updateHUD`, and `showNotification`.
+
+- [ ] **Step 5: Run panel tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-panel.test.ts tests/ui/city-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+Run:
+
+```bash
+git add src/ui/wonder-panel.ts src/main.ts tests/ui/wonder-panel.test.ts tests/ui/city-panel.test.ts
+git commit -m "feat(wonders): refresh journal wonder panel"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Tighten Notifications And Advisor Copy
+
+**Files:**
+- Modify: `src/ui/legendary-wonder-notifications.ts`
+- Modify: `tests/ui/legendary-wonder-notifications.test.ts`
+- Review or modify: `src/ui/advisor-system.ts`
+- Review or modify: `tests/ui/advisor-system.test.ts`
+- Test: `tests/ui/legendary-wonder-notifications.test.ts`
+
+- [ ] **Step 1: Add notification copy tests**
+
+In `tests/ui/legendary-wonder-notifications.test.ts`, add:
+
+```ts
+  it('tells the owning player which city can start a ready wonder', () => {
+    const state = makeLegendaryWonderFixture();
+    state.cities['city-river'].name = 'Athens';
+
+    const notification = getLegendaryWonderNotification(state, 'player', {
+      type: 'wonder:legendary-ready',
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+    });
+
+    expect(notification?.message).toBe('Athens can start Oracle of Delphi from its Wonders panel.');
+    expect(notification?.type).toBe('info');
+  });
+
+  it('keeps rival start intel scoped to observers with spy reports', () => {
+    const state = makeLegendaryWonderFixture();
+
+    const notification = getLegendaryWonderNotification(state, 'player', {
+      type: 'wonder:legendary-race-revealed',
+      observerId: 'observer',
+      civId: 'rival',
+      cityId: 'city-rival',
+      wonderId: 'grand-canal',
+    });
+
+    expect(notification).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/legendary-wonder-notifications.test.ts
+```
+
+Expected: FAIL because copy still uses the older message.
+
+- [ ] **Step 3: Update notification copy**
+
+In `src/ui/legendary-wonder-notifications.ts`, update only message text:
+
+```ts
+  if (event.type === 'wonder:legendary-ready') {
+    return {
+      message: `${city.name} can start ${wonder?.name ?? event.wonderId} from its Wonders panel.`,
+      type: 'info',
+      turn: state.turn,
+    };
+  }
+```
+
+Keep existing completion, lost, and race-revealed gates intact. If lost copy still says `abandoned`, change it to:
+
+```ts
+    message: `${city.name} lost the race for ${wonder?.name ?? event.wonderId}. +${event.goldRefund} gold and ${event.transferableProduction} carryover recovered.`,
+```
+
+- [ ] **Step 4: Review Artisan copy**
+
+Run:
+
+```bash
+rg -n "artisan_wonder|wonder" src/ui/advisor-system.ts tests/ui/advisor-system.test.ts
+```
+
+If `artisan_wonder_available` already points to choosing the city/action clearly, leave it unchanged. If it does not, update only the affected message to:
+
+```ts
+message: 'A legendary wonder is ready. Open the city Wonders panel and choose whether to make it our active construction.',
+```
+
+If `src/ui/advisor-system.ts` changes, add a focused assertion in `tests/ui/advisor-system.test.ts` that the visible advice includes `city Wonders panel`.
+
+- [ ] **Step 5: Run notification/advisor tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/legendary-wonder-notifications.test.ts tests/ui/advisor-system.test.ts
+```
+
+Expected: PASS. If `advisor-system.ts` was not changed and the advisor test file is unrelated, it is still fine to run it as a small guard.
+
+- [ ] **Step 6: Commit Task 5**
+
+Run:
+
+```bash
+git add src/ui/legendary-wonder-notifications.ts tests/ui/legendary-wonder-notifications.test.ts src/ui/advisor-system.ts tests/ui/advisor-system.test.ts
+git commit -m "fix(wonders): clarify wonder notifications"
+```
+
+Expected: commit succeeds. If advisor files were unchanged, Git ignores them.
+
+---
+
+### Task 6: Rule Checks, Wonder Regression Pack, Build, And Final Review
+
+**Files:**
+- Verify all changed `src/` files
+- Verify all changed tests
+- Verify spec and plan remain aligned
+
+- [ ] **Step 1: Run source rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/legendary-wonder-presentation.ts src/systems/legendary-wonder-system.ts src/systems/city-system.ts src/ui/city-panel.ts src/ui/wonder-panel.ts src/ui/legendary-wonder-notifications.ts src/main.ts
+```
+
+Expected: PASS with no rule violations. If `src/ui/advisor-system.ts` changed, include it in the same command.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-system.test.ts tests/systems/city-system.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/advisor-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run wonder regression pack**
+
+Run:
+
+```bash
+./scripts/run-wonder-regressions.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS with TypeScript and Vite build success.
+
+- [ ] **Step 5: Inspect branch and local diffs**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff
+```
+
+Expected: committed branch delta contains only the planned wonder UI/system/test/docs changes; local uncommitted diff is empty or intentionally documented.
+
+- [ ] **Step 6: Final commit for verification updates if any**
+
+If Task 6 required code/test fixes, commit them:
+
+```bash
+git add src tests docs
+git commit -m "test(wonders): cover legendary wonder ui flow"
+```
+
+Expected: commit succeeds only if files changed.
+
+---
+
+## Final Acceptance Checklist
+
+- [ ] City Build list shows relevant legendary wonder cards between buildings and units.
+- [ ] Compact card click opens the Wonder panel and does not mutate production.
+- [ ] Wonder panel has top close control, city title, Crafted Journal treatment, section buckets, and complete ambitions reachability.
+- [ ] Start Construction is available only when current system eligibility is valid.
+- [ ] Start Construction makes the wonder active and preserves prior queue entries behind it.
+- [ ] Current production and queue rows show legendary wonder names, icon, cost, ETA, and no raw `legendary:` ids.
+- [ ] Far-future blocked wonders do not crowd the compact Build list.
+- [ ] Stale ready projects cannot start if tech/resource/city requirements are no longer satisfied.
+- [ ] Rival intel remains viewer-safe in hot-seat and espionage cases.
+- [ ] Targeted tests, wonder regressions, rule checks, and build pass.

--- a/docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md
+++ b/docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md
@@ -1,0 +1,337 @@
+# Legendary Wonder UI And Spectacle Design
+
+**Issue:** [#217 — Bug: legendary wonder ui off](https://github.com/a1flecke/conquestoria/issues/217)
+**Date:** 2026-05-20
+
+## Overview
+
+Legendary wonders currently exist as real gameplay objects, but the player-facing experience makes them feel detached from ordinary city production. The immediate issue is practical: the wonder UI is confusing, visually inconsistent, lacks an obvious close affordance, and available wonders should be discoverable from the normal city build flow.
+
+This design uses a two-stage approach:
+
+1. **Stage 1: City build doorway** — fix issue #217 by surfacing relevant legendary wonders in the normal city Build list, then opening a clearer Crafted Journal-style detail panel for quest, race, reward, and start/queue actions.
+2. **Stage 2: Wonder spectacle** — a designed follow-up phase for wonder SVG identities, natural-wonder map treatments, ambient animation, completion moments, and an empire legacy gallery.
+
+Stage 1 is the implementation target for the first plan. Stage 2 is specified enough to preserve the product direction, but should be implemented as a separate phase.
+
+---
+
+## Goals
+
+- Make legendary wonders visible from the same city surface where players already choose buildings and units.
+- Keep the build list compact while still making wonder state understandable.
+- Preserve a complete, reachable catalog of city-specific wonder ambitions.
+- Replace vague IDs and technical requirements with human-readable names, labels, cost, ETA, quest progress, and reward summaries.
+- Keep existing wonder race, quest, intel, and production rules authoritative in system helpers rather than UI-only logic.
+- Establish a Crafted Journal visual direction for wonders without turning Stage 1 into an art overhaul.
+
+## Non-Goals
+
+- Stage 1 does not redesign natural wonder placement, effects, or map generation.
+- Stage 1 does not add a full empire-level wonder gallery.
+- Stage 1 does not create final SVG art for every wonder.
+- Stage 1 does not relax current tech/resource/city/quest gates.
+- Stage 1 does not reveal rival wonder data without earned discovery or espionage intel.
+
+---
+
+## Stage 1 — City Build Doorway
+
+### City Build List Integration
+
+`src/ui/city-panel.ts` should add a compact **Legendary Wonders** subsection inside the normal `Build` list, between buildings and units.
+
+The subsection appears when the selected city has one or more relevant legendary wonder entries:
+
+| Wonder state | Build-list treatment |
+|---|---|
+| `ready_to_build` | High-priority card with a clear "Ready" state and a prompt to open details/start. |
+| `questing` | Card showing quest progress and the next incomplete step. |
+| `building` | Card showing current construction progress, cost, ETA, and race status. |
+| `lost_race` | Recovery card showing carryover production and refund context. |
+| Near-eligible | De-emphasized card if only a small number of requirements are missing. |
+| Fully blocked | Hidden from the compact build-list subsection, but still reachable from the full wonder panel. |
+
+"Near-eligible" means the city/civ is close enough that surfacing the wonder helps planning rather than creating noise. The first implementation should define this conservatively as no more than two missing conditions after evaluating techs, resources, and city requirement.
+
+Each build-list wonder card must show:
+
+- compact wonder identity icon or medallion placeholder
+- human-readable wonder name
+- state label such as `Ready`, `Questing`, `Building`, `Recovered`, or `Blocked`
+- quest progress, for example `Quest 1/2`
+- missing requirement chips for near-eligible wonders
+- production cost and ETA when the city can currently build or is building the wonder
+- short reward teaser
+
+Clicking a wonder card opens the selected city's wonder detail panel. The compact card should not attempt to show every quest/race/intel detail.
+
+### Production Queue Display
+
+Legendary wonder queue items continue to use `legendary:<wonderId>` ids. Stage 1 must make those ids display cleanly anywhere city production is shown:
+
+- current production header
+- follow-up queue rows
+- ETA calculation
+- reorder/remove rows
+- build-list cards
+
+The display label must be the legendary wonder's human-readable name, not the raw `legendary:` id. The icon should use a temporary wonder production icon or medallion placeholder until Stage 2 supplies final SVG identities.
+
+Starting or queueing a wonder must preserve the existing production queue contract:
+
+- no silent destructive replacement of queued work
+- visible active item and queued follow-ups
+- visible ETA/order feedback
+- immediate panel refresh after the action
+
+### Wonder Detail Panel
+
+`src/ui/wonder-panel.ts` remains the detailed surface, but it should be redesigned as a focused Crafted Journal panel instead of a plain full-screen list.
+
+The panel must include:
+
+- obvious close control at the top
+- city name and clear title, for example `Athens Wonders`
+- short explanation of the selected city's legendary ambitions
+- sections for `Ready`, `Questing`, `Building`, `Blocked`, `Recovered`, and `Rival Intel`
+- "Show all ambitions" or an equivalent complete catalog affordance if recommendations are limited
+- human-readable tech, resource, city, and quest requirements
+- current quest step status with completed and pending states
+- reward summary
+- race/progress summary
+- rival intel only through `getLegendaryWonderIntelForViewer` or equivalent viewer-safe helper
+
+The panel should keep all selected-city wonder projects reachable. Recommendation sections may prioritize a small number of wonders, but lower-ranked actionable or informational entries cannot disappear without an explicit complete-section affordance.
+
+### Notifications And Advisors
+
+Wonder notifications should point players toward the live city flow:
+
+- `wonder:legendary-ready` should make clear which city can act and which wonder is ready.
+- `wonder:legendary-completed` should remain a global accomplishment message.
+- `wonder:legendary-lost` should explain recovered gold/carryover in player language.
+- `wonder:legendary-race-revealed` should remain gated by earned espionage intel.
+
+Advisor nudges, especially Artisan advice, should speak in terms of city action and player choice. They should not be the only place a player learns that a wonder is available.
+
+---
+
+## Shared Presentation Helper
+
+Stage 1 should add or extract a shared helper for city-scoped legendary wonder presentation. This helper prevents `city-panel.ts` and `wonder-panel.ts` from duplicating eligibility, sorting, missing requirement, and display-name logic.
+
+The helper should be system-adjacent rather than DOM-specific. It may live in `src/systems/legendary-wonder-presentation.ts` or another focused module with a similar boundary.
+
+It should return entries shaped around UI needs while preserving system ownership of truth:
+
+```ts
+interface LegendaryWonderPresentationEntry {
+  wonderId: string;
+  queueItemId: `legendary:${string}`;
+  projectKey: string;
+  name: string;
+  cityId: string;
+  ownerId: string;
+  visibleState: 'ready' | 'questing' | 'building' | 'blocked' | 'recovered' | 'completed' | 'lost';
+  eligibilityState: 'buildable' | 'questing' | 'near-eligible' | 'blocked' | 'in-progress' | 'resolved';
+  missingRequirements: string[];
+  questCompleted: number;
+  questTotal: number;
+  nextQuestStep: string | null;
+  rewardSummary: string;
+  productionCost: number;
+  turnsRemaining: number | null;
+  investedProduction: number;
+  transferableProduction: number;
+  canStartBuild: boolean;
+  canQueueBuild: boolean;
+  sortBucket: 'ready' | 'active' | 'questing' | 'near' | 'blocked' | 'resolved';
+}
+```
+
+The exact TypeScript names may change during implementation, but the responsibilities should stay the same.
+
+System helpers remain authoritative for:
+
+- project seeding and normalization
+- tech/resource/city requirement truth
+- quest completion truth
+- starting a build
+- race completion and loss
+- rival intel masking
+- global uniqueness and no self-competition
+
+UI code should render the presentation entries and call existing mutation helpers such as `startLegendaryWonderBuild`.
+
+---
+
+## Stage 2 — Wonder Spectacle Follow-Up
+
+Stage 2 uses the **Crafted Journal** visual direction for everyday wonder surfaces, with theatrical treatment reserved for discoveries and completions.
+
+### Wonder Visual Catalog
+
+Add a focused wonder visual catalog, likely under `src/renderer/wonders/` or a comparable module. It should define stable visual identity for both natural and legendary wonders:
+
+- compact icon or medallion
+- palette
+- emblem shape
+- optional large illustration/structure SVG
+- completed-wonder silhouette or map/city marker treatment
+
+Stage 2 should not overload the existing unit/building sprite catalog unless implementation proves that is the best fit. Wonders have different usage: map features, panel medallions, achievement entries, and completion art.
+
+### Natural Wonder Map Presence
+
+Natural wonders should move beyond the generic glowing `✦` marker. Each natural wonder should get a distinct map treatment that remains readable at multiple zoom levels and does not interfere with unit/city interactions.
+
+Examples:
+
+- Great Volcano: warm crater glow and subtle smoke flicker
+- Crystal Caverns: faceted gem shimmer
+- Ancient Forest: oversized ancient canopy mark
+- Coral Reef: bright reef pattern on coast
+- Aurora Fields: pale sky-ribbon shimmer
+
+Discovery state must remain viewer-safe. Unexplored tiles show nothing. Fog and last-seen behavior should follow existing visibility rules.
+
+### Legendary Wonder Completion Presence
+
+Completed legendary wonders should become visible achievements:
+
+- in the host city detail context
+- in the future Empire Legacy gallery
+- in notifications and completion celebration
+- optionally on the map/city renderer if a non-obstructive marker is designed
+
+Rival completed wonders may be shown only at the detail level the player has earned through contact, discovery, or espionage.
+
+### Animation
+
+Wonder animation should be modest during normal play and more expressive at major moments.
+
+Normal play:
+
+- ambient shimmer for discovered natural wonders
+- subtle medallion pulse for newly ready wonders
+- gentle construction/race progress flourish
+
+Major moments:
+
+- short discovery reveal
+- short legendary completion celebration
+- journal-style achievement entry unlock
+
+Animations must keep the map usable and should respect reduced-motion settings if the project has or adds such a setting.
+
+### Empire Legacy Gallery
+
+The gallery is a Stage 2 surface that shows:
+
+- completed wonders owned by the current player
+- lost races and recovered effort
+- known rival masterpieces with earned intel only
+- undiscovered or unknown wonders as masked silhouettes when appropriate
+
+The gallery is not the primary way to start wonders. It is a record of legacy, rivalry, and discovery.
+
+---
+
+## Data Flow
+
+Stage 1 data flow:
+
+1. City panel opens for `state.currentPlayer`.
+2. The city flow initializes or refreshes legendary projects for the selected city.
+3. The shared presentation helper converts system state into city-scoped wonder presentation entries.
+4. `city-panel.ts` renders a compact Legendary Wonders subsection from those entries.
+5. Clicking a card opens `wonder-panel.ts` for the same city.
+6. `wonder-panel.ts` renders full project detail from the same presentation helper plus viewer-safe rival intel.
+7. Starting or queueing a wonder calls shared system mutation helpers.
+8. The visible panel refreshes immediately from the updated state.
+9. Turn processing continues to resolve quest readiness, construction progress, completion, race loss, and notifications through existing event paths.
+
+This flow keeps the gameplay source of truth in systems and the player-visible explanation in UI presentation helpers.
+
+---
+
+## Error Handling And Edge Cases
+
+- Missing wonder definitions render a safe fallback label and do not crash the city panel.
+- Missing city/civ references omit the affected entry from actionable sections and should be covered by tests if a helper can encounter them.
+- Completed global wonders are removed from competing actionable lists except for the winner's completed/resolved record.
+- A civ cannot race against itself in two cities unless a later spec explicitly changes that rule.
+- Seeded placeholder projects must not be treated as buildable merely because they exist.
+- Rival race intel must remain masked unless stored under the current viewer's earned intel.
+- Near-eligible cards must be de-emphasized and must not expose a start/queue action.
+- A `legendary:<wonderId>` queue item for an unknown wonder should display a fallback label and fallback cost behavior rather than breaking queue rendering.
+
+---
+
+## Testing Requirements
+
+### City Panel Tests
+
+Add or update tests in `tests/ui/city-panel.test.ts`:
+
+- relevant legendary wonders appear in the normal Build list for the selected city
+- blocked far-future wonders do not crowd the compact build list
+- the build list shows human-readable name, state label, quest progress, missing requirement chips, cost/ETA when relevant, and reward teaser
+- clicking a wonder card opens the wonder detail panel callback for the selected city
+- `legendary:<wonderId>` displays as the wonder name in current production and queue rows
+- starting or queueing a wonder preserves existing queue entries
+- the visible city panel refreshes immediately after a wonder action
+
+### Wonder Panel Tests
+
+Add or update tests in `tests/ui/wonder-panel.test.ts`:
+
+- panel includes an obvious close control
+- entries are grouped into ready, questing, building, blocked, recovered, and rival intel sections as applicable
+- "Show all ambitions" or equivalent complete catalog affordance keeps all selected-city wonders reachable
+- current-player scoping works in hot seat
+- rival intel remains hidden without earned intel
+- rival intel uses viewer-safe data when earned
+- recommended sections do not hide lower-ranked actionable items
+- human-readable requirements replace raw technical ids where display helpers exist
+
+### System And Presentation Tests
+
+Add or update tests in `tests/systems/legendary-wonder-system.test.ts` or a new mirrored presentation test:
+
+- eligible vs near-eligible vs blocked entries are classified correctly
+- questing vs ready vs building vs lost/resolved states map to correct presentation states
+- seeded placeholder projects are not treated as actionable
+- global uniqueness prevents completed wonders from appearing as buildable for rivals
+- the same owner cannot actively race the same wonder from two cities
+- `legendary:<wonderId>` metadata returns name, cost, icon/placeholder, and fallback values
+
+### Required Checks
+
+For Stage 1 implementation, run:
+
+```bash
+scripts/check-src-rule-violations.sh src/ui/city-panel.ts src/ui/wonder-panel.ts src/systems/legendary-wonder-system.ts
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/systems/legendary-wonder-system.test.ts
+./scripts/run-wonder-regressions.sh
+```
+
+If additional `src/` files change, include them in `scripts/check-src-rule-violations.sh` and run their mirrored or smallest relevant tests. Run `./scripts/run-with-mise.sh yarn build` before push, PR creation, or merge.
+
+---
+
+## Acceptance Criteria
+
+Stage 1 is complete when:
+
+- a player can discover relevant legendary wonders from the normal city Build list
+- the build list remains compact and understandable
+- clicking a wonder opens a clear, closable, city-scoped detail panel
+- ready wonders can be started or queued without silently destroying existing queue work
+- current production and queue rows show human-readable legendary wonder names
+- all selected-city wonder ambitions remain reachable
+- rival wonder details obey earned-intel rules
+- targeted city-panel, wonder-panel, system/presentation, and wonder regression checks pass
+
+Stage 2 is ready for its own implementation plan when Stage 1 is merged or otherwise accepted, and the follow-up plan can focus on visuals, animation, completion ceremony, and gallery work without reopening the core build-flow contract.

--- a/docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md
+++ b/docs/superpowers/specs/2026-05-20-legendary-wonder-ui-and-spectacle-design.md
@@ -45,14 +45,19 @@ The subsection appears when the selected city has one or more relevant legendary
 
 | Wonder state | Build-list treatment |
 |---|---|
-| `ready_to_build` | High-priority card with a clear "Ready" state and a prompt to open details/start. |
+| `ready_to_build` | High-priority card with a clear "Ready" state and a prompt to open details/start construction. |
 | `questing` | Card showing quest progress and the next incomplete step. |
 | `building` | Card showing current construction progress, cost, ETA, and race status. |
 | `lost_race` | Recovery card showing carryover production and refund context. |
 | Near-eligible | De-emphasized card if only a small number of requirements are missing. |
 | Fully blocked | Hidden from the compact build-list subsection, but still reachable from the full wonder panel. |
 
-"Near-eligible" means the city/civ is close enough that surfacing the wonder helps planning rather than creating noise. The first implementation should define this conservatively as no more than two missing conditions after evaluating techs, resources, and city requirement.
+"Near-eligible" means the city/civ is close enough that surfacing the wonder helps planning rather than creating noise. The first implementation should define this conservatively as both:
+
+- the wonder's era is no later than the current game era or the next era
+- no more than two conditions are missing after evaluating techs, resources, and city requirement
+
+Far-future wonders outside that era window must stay out of the compact build-list subsection even if they happen to have only one or two formal requirements.
 
 Each build-list wonder card must show:
 
@@ -64,7 +69,7 @@ Each build-list wonder card must show:
 - production cost and ETA when the city can currently build or is building the wonder
 - short reward teaser
 
-Clicking a wonder card opens the selected city's wonder detail panel. The compact card should not attempt to show every quest/race/intel detail.
+Clicking a wonder card opens the selected city's wonder detail panel. The compact card should not attempt to show every quest/race/intel detail. Stage 1 should not start a legendary wonder directly from the compact build-list card; the detail panel is the confirmation surface where the player sees what the action will do.
 
 ### Production Queue Display
 
@@ -78,12 +83,16 @@ Legendary wonder queue items continue to use `legendary:<wonderId>` ids. Stage 1
 
 The display label must be the legendary wonder's human-readable name, not the raw `legendary:` id. The icon should use a temporary wonder production icon or medallion placeholder until Stage 2 supplies final SVG identities.
 
-Starting or queueing a wonder must preserve the existing production queue contract:
+Stage 1 implements one construction action: **Start Construction** from the wonder detail panel. Starting construction makes the wonder the active production item by inserting `legendary:<wonderId>` at the front of the selected city's production queue, while preserving the previous active item and follow-up queue behind it. The button copy or nearby helper text must make that reprioritization explicit before the click, for example: `Start Construction - current queue continues after this wonder.`
+
+Starting construction must preserve the existing production queue contract:
 
 - no silent destructive replacement of queued work
 - visible active item and queued follow-ups
 - visible ETA/order feedback
 - immediate panel refresh after the action
+
+A separate "Queue after current" action is out of scope for Stage 1. If a later implementation adds that action, it must get its own visible queue-position text and replay tests.
 
 ### Wonder Detail Panel
 
@@ -145,7 +154,7 @@ interface LegendaryWonderPresentationEntry {
   investedProduction: number;
   transferableProduction: number;
   canStartBuild: boolean;
-  canQueueBuild: boolean;
+  startActionLabel: string | null;
   sortBucket: 'ready' | 'active' | 'questing' | 'near' | 'blocked' | 'resolved';
 }
 ```
@@ -157,12 +166,14 @@ System helpers remain authoritative for:
 - project seeding and normalization
 - tech/resource/city requirement truth
 - quest completion truth
-- starting a build
+- starting construction
 - race completion and loss
 - rival intel masking
 - global uniqueness and no self-competition
 
 UI code should render the presentation entries and call existing mutation helpers such as `startLegendaryWonderBuild`.
+
+The construction mutation must re-check current tech, resource, city, global-uniqueness, and same-owner active-build eligibility. UI eligibility is guidance, not authority; stale DOM or a direct system call must not start a wonder that is no longer valid.
 
 ---
 
@@ -248,7 +259,7 @@ Stage 1 data flow:
 4. `city-panel.ts` renders a compact Legendary Wonders subsection from those entries.
 5. Clicking a card opens `wonder-panel.ts` for the same city.
 6. `wonder-panel.ts` renders full project detail from the same presentation helper plus viewer-safe rival intel.
-7. Starting or queueing a wonder calls shared system mutation helpers.
+7. Starting construction calls shared system mutation helpers.
 8. The visible panel refreshes immediately from the updated state.
 9. Turn processing continues to resolve quest readiness, construction progress, completion, race loss, and notifications through existing event paths.
 
@@ -263,6 +274,7 @@ This flow keeps the gameplay source of truth in systems and the player-visible e
 - Completed global wonders are removed from competing actionable lists except for the winner's completed/resolved record.
 - A civ cannot race against itself in two cities unless a later spec explicitly changes that rule.
 - Seeded placeholder projects must not be treated as buildable merely because they exist.
+- A stale `ready_to_build` project must not start construction if the city/civ no longer satisfies required techs, resources, or city terrain.
 - Rival race intel must remain masked unless stored under the current viewer's earned intel.
 - Near-eligible cards must be de-emphasized and must not expose a start/queue action.
 - A `legendary:<wonderId>` queue item for an unknown wonder should display a fallback label and fallback cost behavior rather than breaking queue rendering.
@@ -280,7 +292,7 @@ Add or update tests in `tests/ui/city-panel.test.ts`:
 - the build list shows human-readable name, state label, quest progress, missing requirement chips, cost/ETA when relevant, and reward teaser
 - clicking a wonder card opens the wonder detail panel callback for the selected city
 - `legendary:<wonderId>` displays as the wonder name in current production and queue rows
-- starting or queueing a wonder preserves existing queue entries
+- starting construction preserves existing queue entries behind the active wonder
 - the visible city panel refreshes immediately after a wonder action
 
 ### Wonder Panel Tests
@@ -305,6 +317,7 @@ Add or update tests in `tests/systems/legendary-wonder-system.test.ts` or a new 
 - seeded placeholder projects are not treated as actionable
 - global uniqueness prevents completed wonders from appearing as buildable for rivals
 - the same owner cannot actively race the same wonder from two cities
+- `startLegendaryWonderBuild` refuses stale ready projects when a tech, resource, or city requirement is no longer satisfied
 - `legendary:<wonderId>` metadata returns name, cost, icon/placeholder, and fallback values
 
 ### Required Checks
@@ -328,7 +341,7 @@ Stage 1 is complete when:
 - a player can discover relevant legendary wonders from the normal city Build list
 - the build list remains compact and understandable
 - clicking a wonder opens a clear, closable, city-scoped detail panel
-- ready wonders can be started or queued without silently destroying existing queue work
+- ready wonders can be started without silently destroying existing queue work
 - current production and queue rows show human-readable legendary wonder names
 - all selected-city wonder ambitions remain reachable
 - rival wonder details obey earned-intel rules

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
 import { scanIdCounters } from '@/core/id-counters';
-import { foundCity, BUILDINGS, getUnplacedBuildings, placeBuilding } from '@/systems/city-system';
+import { foundCity, BUILDINGS, getProductionDisplayName, getUnplacedBuildings, placeBuilding } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
 import { formatCityFoundingBlockerMessage, getCityFoundingBlockers, recalculateTerritory } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
@@ -543,7 +543,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
         try {
           gameState.cities[cityId] = enqueueCityProduction(targetCity, itemId);
           renderLoop.setGameState(gameState);
-          showNotification(`${targetCity.name}: queued ${itemId}`, 'info');
+          showNotification(`${targetCity.name}: queued ${getProductionDisplayName(itemId)}`, 'info');
         } catch (error) {
           const message = error instanceof Error ? error.message : 'Queue limit reached';
           showNotification(`${targetCity.name}: ${message}`, 'warning');
@@ -567,18 +567,31 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       renderLoop.setGameState(gameState);
     },
     onOpenWonderPanel: (selectedCityId) => {
+      const openWonderPanel = () => {
+        document.getElementById('wonder-panel')?.remove();
+        createWonderPanel(uiLayer, gameState, selectedCityId, {
+          onStartBuild: (buildCityId, wonderId) => {
+            gameState = startLegendaryWonderBuild(gameState, gameState.currentPlayer, buildCityId, wonderId, bus);
+            const targetCity = gameState.cities[buildCityId];
+            if (targetCity) {
+              renderLoop.setGameState(gameState);
+              updateHUD();
+              const productionItemId = `legendary:${wonderId}`;
+              if (targetCity.productionQueue[0] === productionItemId) {
+                showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
+              } else {
+                showNotification(`${targetCity.name}: ${getProductionDisplayName(productionItemId)} is not ready to start.`, 'warning');
+              }
+              openWonderPanel();
+            }
+          },
+          onClose: () => {
+            document.getElementById('wonder-panel')?.remove();
+          },
+        });
+      };
       gameState = initializeLegendaryWonderProjectsForCity(gameState, gameState.currentPlayer, selectedCityId);
-      createWonderPanel(uiLayer, gameState, selectedCityId, {
-        onStartBuild: (buildCityId, wonderId) => {
-          gameState = startLegendaryWonderBuild(gameState, gameState.currentPlayer, buildCityId, wonderId, bus);
-          const targetCity = gameState.cities[buildCityId];
-          if (targetCity) {
-            renderLoop.setGameState(gameState);
-            showNotification(`${targetCity.name}: preparing ${wonderId}`, 'info');
-          }
-        },
-        onClose: () => {},
-      });
+      openWonderPanel();
     },
     onSetCityFocus: (cityId, focus) => {
       const result = assignCityFocus(gameState, cityId, focus);

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -4,6 +4,11 @@ import { hexKey, hexesInRange, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
 import { findOptimalSlot, isSlotUnlocked } from './adjacency-system';
+import {
+  getLegendaryWonderDisplayName,
+  getLegendaryWonderProductionCost,
+  getLegendaryWonderQueueItemMetadata,
+} from './legendary-wonder-presentation';
 
 export const CITY_NAMES = DEFAULT_CITY_NAMES;
 
@@ -134,6 +139,9 @@ export function getSettlerProductionCost(era: number = 1): number {
 }
 
 export function getCatalogProductionCost(itemId: string, era: number = 1): number {
+  const legendaryCost = getLegendaryWonderProductionCost(itemId);
+  if (legendaryCost !== null) return legendaryCost;
+
   const building = BUILDINGS[itemId];
   if (building) return building.productionCost;
 
@@ -213,6 +221,23 @@ export const PRODUCTION_ICONS: Record<string, string> = {
 };
 
 export const PRODUCTION_ICON_FALLBACK = '🏗️';
+
+export function getProductionDisplayName(itemId: string): string {
+  const legendaryName = getLegendaryWonderDisplayName(itemId);
+  if (legendaryName) return legendaryName;
+
+  const building = BUILDINGS[itemId];
+  if (building) return building.name;
+
+  const unit = TRAINABLE_UNITS.find(candidate => candidate.type === itemId);
+  return unit?.name ?? itemId;
+}
+
+export function getProductionIconForItem(itemId: string): string {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.icon
+    ?? PRODUCTION_ICONS[itemId]
+    ?? PRODUCTION_ICON_FALLBACK;
+}
 
 export function getTrainableUnitsForCiv(completedTechs: string[], civType?: string): TrainableUnitEntry[] {
   const replacedForCiv = new Set(

--- a/src/systems/legendary-wonder-presentation.ts
+++ b/src/systems/legendary-wonder-presentation.ts
@@ -1,0 +1,314 @@
+import type { GameState, LegendaryWonderProject } from '@/core/types';
+import { getLegendaryWonderDefinition, getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import {
+  getEligibleLegendaryWonders,
+  initializeLegendaryWonderProjectsForCity,
+} from '@/systems/legendary-wonder-system';
+import { getTechById } from '@/systems/tech-system';
+
+export const LEGENDARY_WONDER_PRODUCTION_PREFIX = 'legendary:';
+export const LEGENDARY_WONDER_PRODUCTION_ICON = '*';
+
+export type LegendaryWonderVisibleState =
+  | 'ready'
+  | 'questing'
+  | 'building'
+  | 'completed'
+  | 'recovered'
+  | 'near'
+  | 'blocked';
+
+export type LegendaryWonderEligibilityState = 'buildable' | 'near' | 'blocked' | 'complete';
+
+export interface LegendaryWonderQueueItemMetadata {
+  icon: string;
+  name: string;
+  productionCost: number;
+  wonderId: string;
+}
+
+export interface LegendaryWonderPresentationEntry {
+  wonderId: string;
+  queueItemId: string;
+  name: string;
+  era: number;
+  productionCost: number;
+  rewardSummary: string;
+  visibleState: LegendaryWonderVisibleState;
+  eligibilityState: LegendaryWonderEligibilityState;
+  phase: LegendaryWonderProject['phase'] | 'unseeded';
+  questCompleted: number;
+  questTotal: number;
+  questSteps: LegendaryWonderProject['questSteps'];
+  investedProduction: number;
+  transferableProduction: number;
+  missingRequirements: string[];
+  canStartBuild: boolean;
+  startActionLabel: string | null;
+}
+
+function isLegendaryQueueItem(itemId: string): boolean {
+  return itemId.startsWith(LEGENDARY_WONDER_PRODUCTION_PREFIX);
+}
+
+function getWonderIdFromQueueItem(itemId: string): string {
+  return itemId.slice(LEGENDARY_WONDER_PRODUCTION_PREFIX.length);
+}
+
+function titleCaseId(value: string): string {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function getOwnedResources(state: GameState, cityId: string): Set<string> {
+  const city = state.cities[cityId];
+  if (!city) {
+    return new Set();
+  }
+
+  return new Set(
+    city.ownedTiles
+      .map(coord => state.map.tiles[`${coord.q},${coord.r}`]?.resource)
+      .filter((resource): resource is string => resource !== null),
+  );
+}
+
+function hasCityRequirement(state: GameState, cityId: string, requirement: 'river' | 'coastal' | 'any'): boolean {
+  const city = state.cities[cityId];
+  if (!city) {
+    return false;
+  }
+
+  if (requirement === 'river') {
+    return city.ownedTiles.some(coord => state.map.tiles[`${coord.q},${coord.r}`]?.hasRiver);
+  }
+
+  if (requirement === 'coastal') {
+    return city.ownedTiles.some(coord => {
+      const tile = state.map.tiles[`${coord.q},${coord.r}`];
+      return tile?.terrain === 'coast' || tile?.terrain === 'ocean';
+    });
+  }
+
+  return true;
+}
+
+function isWonderAlreadyCompleted(state: GameState, wonderId: string): boolean {
+  return Boolean(state.completedLegendaryWonders?.[wonderId]);
+}
+
+function hasSameOwnerActiveBuild(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  wonderId: string,
+): boolean {
+  return Object.values(state.legendaryWonderProjects ?? {}).some(project =>
+    project.ownerId === civId
+    && project.cityId !== cityId
+    && project.wonderId === wonderId
+    && project.phase === 'building',
+  );
+}
+
+function getMissingRequirements(state: GameState, civId: string, cityId: string, wonderId: string): string[] {
+  const definition = getLegendaryWonderDefinition(wonderId);
+  const civ = state.civilizations[civId];
+  if (!definition || !civ || !state.cities[cityId]) {
+    return ['Requirements unavailable'];
+  }
+
+  const ownedResources = getOwnedResources(state, cityId);
+  const missing = [
+    ...definition.requiredTechs
+      .filter(techId => !civ.techState.completed.includes(techId))
+      .map(techId => getTechById(techId)?.name ?? titleCaseId(techId)),
+    ...definition.requiredResources
+      .filter(resource => !ownedResources.has(resource))
+      .map(titleCaseId),
+  ];
+
+  if (!hasCityRequirement(state, cityId, definition.cityRequirement)) {
+    missing.push(definition.cityRequirement === 'river' ? 'River city' : 'Coastal city');
+  }
+
+  if (isWonderAlreadyCompleted(state, wonderId)) {
+    missing.push('Already completed elsewhere');
+  }
+
+  if (hasSameOwnerActiveBuild(state, civId, cityId, wonderId)) {
+    missing.push('Already under construction in another city');
+  }
+
+  return missing;
+}
+
+function isNearEligible(state: GameState, missingRequirements: string[], era: number): boolean {
+  const currentEra = typeof state.era === 'number' ? state.era : 1;
+  return era <= currentEra + 1 && missingRequirements.length <= 2;
+}
+
+function isCompactEligible(entry: LegendaryWonderPresentationEntry, state: GameState): boolean {
+  if (entry.visibleState === 'ready' || entry.visibleState === 'building' || entry.visibleState === 'recovered') {
+    return true;
+  }
+  if (entry.visibleState === 'completed' || entry.visibleState === 'blocked') {
+    return false;
+  }
+  return isNearEligible(state, entry.missingRequirements, entry.era);
+}
+
+function getVisibleState(
+  state: GameState,
+  project: LegendaryWonderProject | undefined,
+  missingRequirements: string[],
+  canStartBuild: boolean,
+  era: number,
+): LegendaryWonderVisibleState {
+  if (project?.phase === 'completed') {
+    return 'completed';
+  }
+  if (project?.phase === 'lost_race') {
+    return 'recovered';
+  }
+  if (project?.phase === 'building') {
+    return 'building';
+  }
+  if (project?.phase === 'ready_to_build') {
+    return canStartBuild ? 'ready' : 'blocked';
+  }
+  if (project?.phase === 'questing') {
+    return 'questing';
+  }
+  return isNearEligible(state, missingRequirements, era) ? 'near' : 'blocked';
+}
+
+function getEligibilityState(
+  visibleState: LegendaryWonderVisibleState,
+  canStartBuild: boolean,
+): LegendaryWonderEligibilityState {
+  if (visibleState === 'completed') {
+    return 'complete';
+  }
+  if (canStartBuild) {
+    return 'buildable';
+  }
+  if (visibleState === 'near' || visibleState === 'questing') {
+    return 'near';
+  }
+  return 'blocked';
+}
+
+function getDefaultQuestSteps(wonderId: string): LegendaryWonderProject['questSteps'] {
+  return getLegendaryWonderDefinition(wonderId)?.questSteps.map(step => ({
+    id: step.id,
+    description: step.description ?? titleCaseId(step.id),
+    completed: false,
+  })) ?? [];
+}
+
+export function getLegendaryWonderQueueItemId(wonderId: string): string {
+  return `${LEGENDARY_WONDER_PRODUCTION_PREFIX}${wonderId}`;
+}
+
+export function getLegendaryWonderQueueItemMetadata(itemId: string): LegendaryWonderQueueItemMetadata | null {
+  if (!isLegendaryQueueItem(itemId)) {
+    return null;
+  }
+
+  const wonderId = getWonderIdFromQueueItem(itemId);
+  const definition = getLegendaryWonderDefinition(wonderId);
+  return {
+    icon: LEGENDARY_WONDER_PRODUCTION_ICON,
+    name: definition?.name ?? 'Unknown Legendary Wonder',
+    productionCost: definition?.productionCost ?? 0,
+    wonderId,
+  };
+}
+
+export function getLegendaryWonderDisplayName(itemId: string): string | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.name ?? null;
+}
+
+export function getLegendaryWonderProductionCost(itemId: string): number | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.productionCost ?? null;
+}
+
+export function getLegendaryWonderPresentationForCity(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  maxEntries?: number,
+): LegendaryWonderPresentationEntry[] {
+  const seededState = initializeLegendaryWonderProjectsForCity(state, civId, cityId);
+  const projectByWonder = new Map<string, LegendaryWonderProject>();
+  for (const project of Object.values(seededState.legendaryWonderProjects ?? {})) {
+    if (project.ownerId === civId && project.cityId === cityId && !projectByWonder.has(project.wonderId)) {
+      projectByWonder.set(project.wonderId, project);
+    }
+  }
+
+  const eligibleWonderIds = new Set(getEligibleLegendaryWonders(seededState, civId, cityId));
+
+  const entries = getLegendaryWonderDefinitions().map(definition => {
+    const project = projectByWonder.get(definition.id);
+    const missingRequirements = getMissingRequirements(seededState, civId, cityId, definition.id);
+    const canStartBuild = project?.phase === 'ready_to_build'
+      && eligibleWonderIds.has(definition.id)
+      && missingRequirements.length === 0;
+    const visibleState = getVisibleState(seededState, project, missingRequirements, canStartBuild, definition.era);
+    const questSteps = project?.questSteps ?? getDefaultQuestSteps(definition.id);
+    const questCompleted = questSteps.filter(step => step.completed).length;
+
+    return {
+      wonderId: definition.id,
+      queueItemId: getLegendaryWonderQueueItemId(definition.id),
+      name: definition.name,
+      era: definition.era,
+      productionCost: definition.productionCost,
+      rewardSummary: definition.reward.summary,
+      visibleState,
+      eligibilityState: getEligibilityState(visibleState, canStartBuild),
+      phase: project?.phase ?? 'unseeded',
+      questCompleted,
+      questTotal: questSteps.length,
+      questSteps,
+      investedProduction: project?.investedProduction ?? 0,
+      transferableProduction: project?.transferableProduction ?? 0,
+      missingRequirements,
+      canStartBuild,
+      startActionLabel: canStartBuild ? 'Start Construction' : null,
+    } satisfies LegendaryWonderPresentationEntry;
+  });
+
+  const sorted = entries.sort((left, right) => {
+    const stateOrder: Record<LegendaryWonderVisibleState, number> = {
+      ready: 0,
+      building: 1,
+      recovered: 2,
+      questing: 3,
+      near: 4,
+      blocked: 5,
+      completed: 6,
+    };
+    return stateOrder[left.visibleState] - stateOrder[right.visibleState]
+      || left.era - right.era
+      || left.name.localeCompare(right.name);
+  });
+
+  return typeof maxEntries === 'number' ? sorted.slice(0, maxEntries) : sorted;
+}
+
+export function getCompactLegendaryWonderEntriesForCity(
+  state: GameState,
+  civId: string,
+  cityId: string,
+  maxEntries: number = 4,
+): LegendaryWonderPresentationEntry[] {
+  return getLegendaryWonderPresentationForCity(state, civId, cityId)
+    .filter(entry => isCompactEligible(entry, state))
+    .slice(0, maxEntries);
+}

--- a/src/systems/legendary-wonder-system.ts
+++ b/src/systems/legendary-wonder-system.ts
@@ -589,6 +589,7 @@ export function startLegendaryWonderBuild(
     || !project
     || project.phase !== 'ready_to_build'
     || !isLegendaryWonderStillAvailable(seededState, wonderId)
+    || !getEligibleLegendaryWonders(seededState, civId, cityId).includes(wonderId)
     || hasActiveLegendaryWonderBuildForCiv(seededState, civId, wonderId, cityId)
   ) {
     return seededState;

--- a/src/ui/advisor-system.ts
+++ b/src/ui/advisor-system.ts
@@ -402,7 +402,7 @@ const ADVISOR_MESSAGES: AdvisorMessage[] = [
     id: 'artisan_legendary_ready',
     advisor: 'artisan',
     icon: '🎨',
-    message: 'A legendary wonder now lies within our grasp. Choose the city carefully. Greatness needs the right stage.',
+    message: 'A legendary wonder now lies within our grasp. Open that city\'s Build list, choose its Wonder Ambitions card, then Start Construction.',
     trigger: (state: GameState) => Object.values(state.legendaryWonderProjects ?? {}).some(
       project => project.ownerId === state.currentPlayer && project.phase === 'ready_to_build',
     ),

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -1,5 +1,14 @@
 import type { City, CityFocus, GameState, HexCoord } from '@/core/types';
-import { getAvailableBuildings, BUILDINGS, TRAINABLE_UNITS, getTrainableUnitsForCiv, getProductionCostForItem, PRODUCTION_ICONS, PRODUCTION_ICON_FALLBACK } from '@/systems/city-system';
+import {
+  getAvailableBuildings,
+  BUILDINGS,
+  TRAINABLE_UNITS,
+  getTrainableUnitsForCiv,
+  getProductionCostForItem,
+  getProductionDisplayName,
+  getProductionIconForItem,
+} from '@/systems/city-system';
+import { getCompactLegendaryWonderEntriesForCity } from '@/systems/legendary-wonder-presentation';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
@@ -32,6 +41,23 @@ export interface CityPanelCallbacks {
 }
 
 type CityPanelTab = 'list' | 'grid';
+
+function getWonderBuildListStatus(state: string): string {
+  switch (state) {
+    case 'ready':
+      return 'Ready to build';
+    case 'building':
+      return 'Under construction';
+    case 'recovered':
+      return 'Carryover recovered';
+    case 'questing':
+      return 'Quest in progress';
+    case 'near':
+      return 'Available soon';
+    default:
+      return 'Open journal';
+  }
+}
 
 function getRushBuyReasonText(reason: RushBuyDisabledReason | null): string | null {
   switch (reason) {
@@ -82,6 +108,7 @@ export function createCityPanel(
     era: state.era,
   });
   const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map.tiles);
+  const compactWonderEntries = getCompactLegendaryWonderEntriesForCity(state, state.currentPlayer, city.id, 4);
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
   const economyStatus = calculateCivEconomy(state, city.owner);
   const cityMaintenance = calculateCityBuildingMaintenance(state, city);
@@ -125,7 +152,7 @@ export function createCityPanel(
     const futureUpkeep = getFutureBuildingUpkeep(b.id);
     const upkeepStr = futureUpkeep > 0 ? ` · Upkeep: -${futureUpkeep}/turn` : ' · Free support';
     buildItemPlaceholders += `<div class="build-item" data-item-id="${b.id}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
-      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[b.id] ?? PRODUCTION_ICON_FALLBACK} <span data-text="build-name-${idx}"></span></div>
+      <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(b.id)} <span data-text="build-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">${yieldStr}${turns} turns${upkeepStr}</div>
       <div style="font-size:10px;opacity:0.5;" data-text="build-desc-${idx}"></div>
     </div>`;
@@ -140,10 +167,34 @@ export function createCityPanel(
     const cost = getDisplayedCost(u.type);
     const turns = yields.production > 0 ? Math.ceil(cost / yields.production) : '∞';
     unitPlaceholders += `<div class="build-item" data-item-id="${u.type}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
-      <div style="font-weight:bold;font-size:13px;">${PRODUCTION_ICONS[u.type] ?? PRODUCTION_ICON_FALLBACK} <span data-text="unit-name-${idx}"></span></div>
+      <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(u.type)} <span data-text="unit-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
     </div>`;
   }
+
+  let compactWonderHtml = '';
+  for (let idx = 0; idx < compactWonderEntries.length; idx++) {
+    const entry = compactWonderEntries[idx];
+    const turns = yields.production > 0 ? Math.ceil(entry.productionCost / yields.production) : '∞';
+    compactWonderHtml += `
+      <div data-wonder-card="${entry.wonderId}" style="background:rgba(232,193,112,0.12);border:1px solid rgba(232,193,112,0.34);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
+        <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(entry.queueItemId)} <span data-text="wonder-name-${idx}"></span></div>
+        <div style="font-size:11px;color:#e8c170;"><span data-text="wonder-state-${idx}"></span> · ${entry.productionCost} production · ${turns} turns</div>
+        <div style="font-size:10px;opacity:0.65;" data-text="wonder-summary-${idx}"></div>
+      </div>
+    `;
+  }
+  const compactWonderSectionHtml = `
+    <div data-section="compact-wonder-build-list" style="margin-top:12px;margin-bottom:12px;">
+      <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;">
+        <h3 style="font-size:14px;margin:0;">Wonder Ambitions</h3>
+        <button type="button" data-open-wonder-panel="true" style="min-height:44px;padding:7px 10px;background:rgba(232,193,112,0.16);border:1px solid rgba(232,193,112,0.45);border-radius:6px;color:#f0d897;cursor:pointer;font-size:12px;">Show all ambitions</button>
+      </div>
+      ${compactWonderEntries.length > 0
+        ? compactWonderHtml
+        : '<div style="font-size:12px;opacity:0.65;">No near-term legendary wonders fit this city yet.</div>'}
+    </div>
+  `;
 
   // Idle production selector — always visible; conversion only fires when queue is empty.
   const activeMode = city.idleProduction ?? 'none';
@@ -177,7 +228,7 @@ export function createCityPanel(
 
     currentProductionHtml = `
       <div style="background:rgba(255,255,255,0.1);border-radius:10px;padding:12px;margin-bottom:16px;">
-        <div style="font-weight:bold;color:#e8c170;">Producing: ${PRODUCTION_ICONS[currentItem] ?? PRODUCTION_ICON_FALLBACK} <span data-text="prod-name"></span></div>
+        <div style="font-weight:bold;color:#e8c170;">Producing: ${getProductionIconForItem(currentItem)} <span data-text="prod-name"></span></div>
         <div style="font-size:12px;opacity:0.7;"><span data-text="prod-turns"></span> turns remaining</div>
         <div style="background:rgba(0,0,0,0.3);border-radius:4px;height:8px;margin-top:8px;">
           <div style="background:#6b9b4b;border-radius:4px;height:8px;width:${progress}%;"></div>
@@ -223,7 +274,7 @@ export function createCityPanel(
     queueRowsHtml += `
       <div data-queue-index="${idx}" style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;background:rgba(255,255,255,0.06);border-radius:8px;padding:8px;">
         <div>
-          <div style="font-weight:bold;">${PRODUCTION_ICONS[city.productionQueue[idx]] ?? PRODUCTION_ICON_FALLBACK} <span data-text="queue-name-${idx}"></span></div>
+          <div style="font-weight:bold;">${getProductionIconForItem(city.productionQueue[idx])} <span data-text="queue-name-${idx}"></span></div>
           <div style="font-size:11px;opacity:0.7;">${slotLabel}</div>
         </div>
         <div style="display:flex;gap:6px;">
@@ -281,6 +332,7 @@ export function createCityPanel(
       ${city.buildings.length > 0 ? `<div style="margin-bottom:16px;"><h3 style="font-size:14px;margin:0 0 8px;">Buildings</h3>${buildingPlaceholders}</div>` : ''}
       <div><h3 style="font-size:14px;margin:0 0 8px;">Build</h3>
         ${buildItemPlaceholders}
+        ${compactWonderSectionHtml}
         <div style="margin-top:12px;font-size:12px;opacity:0.5;margin-bottom:8px;">Units</div>
         ${unitPlaceholders}
       </div>
@@ -312,11 +364,9 @@ export function createCityPanel(
 
   if (city.productionQueue.length > 0) {
     const currentItem = city.productionQueue[0];
-    const building = BUILDINGS[currentItem];
-    const unit = TRAINABLE_UNITS.find(u => u.type === currentItem);
     const totalCost = getDisplayedCost(currentItem);
     const turnsLeft = yields.production > 0 ? Math.ceil((totalCost - city.productionProgress) / yields.production) : '∞';
-    setText('prod-name', building?.name ?? unit?.name ?? currentItem);
+    setText('prod-name', getProductionDisplayName(currentItem));
     setText('prod-turns', String(turnsLeft));
     if (rushBuyReason) {
       setText('rush-reason', rushBuyReason);
@@ -356,7 +406,18 @@ export function createCityPanel(
   });
 
   city.productionQueue.forEach((itemId, index) => {
-    setText(`queue-name-${index}`, BUILDINGS[itemId]?.name ?? TRAINABLE_UNITS.find(unit => unit.type === itemId)?.name ?? itemId);
+    setText(`queue-name-${index}`, getProductionDisplayName(itemId));
+  });
+
+  compactWonderEntries.forEach((entry, index) => {
+    setText(`wonder-name-${index}`, entry.name);
+    setText(`wonder-state-${index}`, getWonderBuildListStatus(entry.visibleState));
+    const missing = entry.missingRequirements.slice(0, 2).join(', ');
+    setText(`wonder-summary-${index}`, entry.canStartBuild
+      ? 'Open the journal to start construction.'
+      : missing
+        ? `Needs ${missing}.`
+        : entry.rewardSummary);
   });
 
   container.appendChild(panel);
@@ -398,6 +459,18 @@ export function createCityPanel(
       callbacks.onBuild(city.id, itemId);
       rerenderPanel();
     });
+  });
+
+  panel.querySelectorAll<HTMLElement>('[data-wonder-card]').forEach(el => {
+    el.addEventListener('click', () => {
+      callbacks.onOpenWonderPanel(city.id);
+      panel.remove();
+    });
+  });
+
+  panel.querySelector<HTMLElement>('[data-open-wonder-panel]')?.addEventListener('click', () => {
+    callbacks.onOpenWonderPanel(city.id);
+    panel.remove();
   });
 
   panel.querySelectorAll('[data-queue-action]').forEach(el => {

--- a/src/ui/legendary-wonder-notifications.ts
+++ b/src/ui/legendary-wonder-notifications.ts
@@ -52,7 +52,7 @@ export function getLegendaryWonderNotification(
 
   if (event.type === 'wonder:legendary-ready') {
     return {
-      message: `${city.name} is ready to begin ${wonder?.name ?? event.wonderId}.`,
+      message: `${city.name} can start ${wonder?.name ?? event.wonderId}. Open the city Build list, choose its Wonder Ambitions card, then Start Construction.`,
       type: 'info',
       turn: state.turn,
     };

--- a/src/ui/wonder-panel.ts
+++ b/src/ui/wonder-panel.ts
@@ -1,4 +1,9 @@
 import type { GameState, LegendaryWonderIntelEntry } from '@/core/types';
+import {
+  getLegendaryWonderPresentationForCity,
+  type LegendaryWonderPresentationEntry,
+  type LegendaryWonderVisibleState,
+} from '@/systems/legendary-wonder-presentation';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 import { createGameButton } from '@/ui/ui-kit';
@@ -8,135 +13,75 @@ export interface WonderPanelCallbacks {
   onClose: () => void;
 }
 
-function getOwnedResources(state: GameState, cityId: string): Set<string> {
-  const city = state.cities[cityId];
-  if (!city) {
-    return new Set();
+function getVisibleStateLabel(state: LegendaryWonderVisibleState): string {
+  switch (state) {
+    case 'ready':
+      return 'Ready to build';
+    case 'questing':
+      return 'Quest in progress';
+    case 'building':
+      return 'Under construction';
+    case 'completed':
+      return 'Completed';
+    case 'recovered':
+      return 'Race lost';
+    case 'near':
+      return 'Available soon';
+    case 'blocked':
+      return 'Blocked';
   }
-
-  return new Set(
-    city.ownedTiles
-      .map(coord => state.map.tiles[`${coord.q},${coord.r}`]?.resource)
-      .filter((resource): resource is string => resource !== null),
-  );
 }
 
-function getMissingConditions(state: GameState, cityId: string, ownerId: string, wonderId: string): string[] {
-  const definition = getLegendaryWonderDefinition(wonderId);
-  const city = state.cities[cityId];
-  const civ = state.civilizations[ownerId];
-  if (!definition || !city || !civ) {
-    return ['requirements unavailable'];
-  }
-
-  const missingTechs = definition.requiredTechs.filter(tech => !civ.techState.completed.includes(tech));
-  const ownedResources = getOwnedResources(state, cityId);
-  const missingResources = definition.requiredResources.filter(resource => !ownedResources.has(resource));
-  const missingConditions = [
-    ...missingTechs.map(tech => `tech ${tech}`),
-    ...missingResources.map(resource => `resource ${resource}`),
-  ];
-
-  if (definition.cityRequirement === 'river'
-    && !city.ownedTiles.some(coord => state.map.tiles[`${coord.q},${coord.r}`]?.hasRiver)) {
-    missingConditions.push('river city');
-  }
-
-  if (definition.cityRequirement === 'coastal'
-    && !city.ownedTiles.some(coord => {
-      const tile = state.map.tiles[`${coord.q},${coord.r}`];
-      return tile?.terrain === 'coast' || tile?.terrain === 'ocean';
-    })) {
-    missingConditions.push('coastal city');
-  }
-
-  return missingConditions;
-}
-
-function getProjectPriority(state: GameState, cityId: string, wonderId: string, phase: string): number {
-  const definition = getLegendaryWonderDefinition(wonderId);
-  const missingConditions = getMissingConditions(state, cityId, state.currentPlayer, wonderId);
-  const phaseBonus = phase === 'ready_to_build' ? 120 : phase === 'questing' ? 70 : phase === 'building' ? 40 : 0;
-  const missingPenalty = missingConditions.length * 15;
-  const costPenalty = Math.floor((definition?.productionCost ?? 300) / 50);
-  return phaseBonus - missingPenalty - costPenalty;
+function appendText(parent: HTMLElement, tagName: keyof HTMLElementTagNameMap, text: string): HTMLElement {
+  const element = document.createElement(tagName);
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
 }
 
 function appendProjectCard(
-  state: GameState,
-  project: NonNullable<GameState['legendaryWonderProjects']>[string],
+  entry: LegendaryWonderPresentationEntry,
   section: HTMLElement,
   callbacks: WonderPanelCallbacks,
+  cityId: string,
   options: { recommended?: boolean } = {},
 ): void {
-  const definition = getLegendaryWonderDefinition(project.wonderId);
-  const city = state.cities[project.cityId];
-  const civ = state.civilizations[project.ownerId];
   const article = document.createElement('article');
-  article.dataset.projectCard = project.wonderId;
+  article.dataset.projectCard = entry.wonderId;
+  article.style.cssText = 'background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);border-radius:8px;padding:12px;margin-bottom:10px;';
   if (options.recommended) {
     article.dataset.recommendedProject = 'true';
   }
 
-  const header = document.createElement('h3');
-  header.textContent = definition?.name ?? project.wonderId;
-  article.appendChild(header);
+  appendText(article, 'h3', entry.name);
+  appendText(article, 'p', getVisibleStateLabel(entry.visibleState));
+  appendText(article, 'p', `Requires ${entry.productionCost} production.`);
+  appendText(article, 'p', entry.missingRequirements.length > 0
+    ? `Missing: ${entry.missingRequirements.join(', ')}.`
+    : 'Missing: none.');
+  appendText(article, 'p', `Quest steps: ${entry.questCompleted}/${entry.questTotal} complete.`);
 
-  const phase = document.createElement('p');
-  phase.textContent = `Phase: ${project.phase.replaceAll('_', ' ')}`;
-  article.appendChild(phase);
-
-  const requirements = document.createElement('p');
-  requirements.textContent = definition
-    ? `Requires ${definition.requiredTechs.join(', ') || 'no extra techs'} and ${definition.productionCost} production.`
-    : 'Wonder requirements unavailable.';
-  article.appendChild(requirements);
-
-  const eligibility = document.createElement('p');
-  const missingConditions = getMissingConditions(state, project.cityId, project.ownerId, project.wonderId);
-  eligibility.textContent = missingConditions.length > 0
-    ? `Missing: ${missingConditions.join(', ')}.`
-    : 'Missing: none.';
-  article.appendChild(eligibility);
-
-  const progress = document.createElement('p');
-  progress.textContent = project.questSteps.length > 0
-    ? `Quest steps: ${project.questSteps.filter(step => step.completed).length}/${project.questSteps.length} complete.`
-    : 'Quest steps complete.';
-  article.appendChild(progress);
-
-  for (const step of project.questSteps) {
-    const stepLine = document.createElement('p');
-    stepLine.textContent = `${step.completed ? 'Done' : 'Pending'}: ${step.description}`;
-    article.appendChild(stepLine);
+  for (const step of entry.questSteps) {
+    appendText(article, 'p', `${step.completed ? 'Done' : 'Pending'}: ${step.description}`);
   }
 
-  const reward = document.createElement('p');
-  reward.textContent = `Reward: ${definition?.reward.summary ?? 'Unavailable.'}`;
-  article.appendChild(reward);
+  appendText(article, 'p', `Reward: ${entry.rewardSummary}`);
 
-  const race = document.createElement('p');
-  if (project.phase === 'building') {
-    race.textContent = `Race status: ${project.investedProduction}/${definition?.productionCost ?? 0} production invested.`;
-  } else if (project.phase === 'completed') {
-    race.textContent = 'Race status: won.';
-  } else if (project.phase === 'lost_race') {
-    race.textContent = `Race status: lost. ${project.transferableProduction} carryover remains in this city.`;
+  if (entry.visibleState === 'building') {
+    appendText(article, 'p', `Race status: ${entry.investedProduction}/${entry.productionCost} production invested.`);
+  } else if (entry.visibleState === 'completed') {
+    appendText(article, 'p', 'Race status: won.');
+  } else if (entry.visibleState === 'recovered') {
+    appendText(article, 'p', `Race status: lost. ${entry.transferableProduction} carryover remains in this city.`);
   } else {
-    race.textContent = 'Race status: not yet in construction.';
+    appendText(article, 'p', 'Race status: not yet in construction.');
   }
-  article.appendChild(race);
 
-  if (project.phase === 'ready_to_build') {
-    const startBuild = createGameButton('Start Build', 'primary');
-    startBuild.addEventListener('click', () => callbacks.onStartBuild(project.cityId, project.wonderId));
+  if (entry.canStartBuild && entry.startActionLabel) {
+    appendText(article, 'p', 'Starting now makes this the active production; current queue continues after this wonder.');
+    const startBuild = createGameButton(entry.startActionLabel, 'primary');
+    startBuild.addEventListener('click', () => callbacks.onStartBuild(cityId, entry.wonderId));
     article.appendChild(startBuild);
-  }
-
-  if (city && civ && project.ownerId !== state.currentPlayer) {
-    const rival = document.createElement('p');
-    rival.textContent = `${civ.name} is pursuing this in ${city.name}.`;
-    article.appendChild(rival);
   }
 
   section.appendChild(article);
@@ -149,22 +94,12 @@ function appendRivalIntelCard(
   const definition = getLegendaryWonderDefinition(intel.wonderId);
   const article = document.createElement('article');
   article.dataset.rivalIntelCard = intel.wonderId;
+  article.style.cssText = 'background:rgba(255,255,255,0.06);border:1px solid rgba(255,255,255,0.12);border-radius:8px;padding:12px;margin-bottom:10px;';
 
-  const header = document.createElement('h3');
-  header.textContent = definition?.name ?? intel.wonderId;
-  article.appendChild(header);
-
-  const source = document.createElement('p');
-  source.textContent = `${intel.civName} is pursuing this in ${intel.cityName}.`;
-  article.appendChild(source);
-
-  const reveal = document.createElement('p');
-  reveal.textContent = `Spy report from turn ${intel.revealedTurn}.`;
-  article.appendChild(reveal);
-
-  const limits = document.createElement('p');
-  limits.textContent = 'Current progress unknown without fresh infiltration.';
-  article.appendChild(limits);
+  appendText(article, 'h3', definition?.name ?? intel.wonderId);
+  appendText(article, 'p', `${intel.civName} is pursuing this in ${intel.cityName}.`);
+  appendText(article, 'p', `Spy report from turn ${intel.revealedTurn}.`);
+  appendText(article, 'p', 'Current progress unknown without fresh infiltration.');
 
   section.appendChild(article);
 }
@@ -173,24 +108,23 @@ function appendProjectSection(
   panel: HTMLElement,
   heading: string,
   dataSection: string,
-  projects: Array<NonNullable<GameState['legendaryWonderProjects']>[string]>,
-  state: GameState,
+  entries: LegendaryWonderPresentationEntry[],
   callbacks: WonderPanelCallbacks,
+  cityId: string,
   options: { recommended?: boolean } = {},
 ): void {
-  if (projects.length === 0) {
+  if (entries.length === 0) {
     return;
   }
 
   const section = document.createElement('section');
   section.dataset.section = dataSection;
+  section.style.cssText = 'margin-top:16px;';
 
-  const header = document.createElement('h3');
-  header.textContent = heading;
-  section.appendChild(header);
+  appendText(section, 'h3', heading);
 
-  for (const project of projects) {
-    appendProjectCard(state, project, section, callbacks, options);
+  for (const entry of entries) {
+    appendProjectCard(entry, section, callbacks, cityId, options);
   }
 
   panel.appendChild(section);
@@ -208,10 +142,9 @@ function appendRivalIntelSection(
 
   const section = document.createElement('section');
   section.dataset.section = dataSection;
+  section.style.cssText = 'margin-top:16px;';
 
-  const header = document.createElement('h3');
-  header.textContent = heading;
-  section.appendChild(header);
+  appendText(section, 'h3', heading);
 
   for (const entry of entries) {
     appendRivalIntelCard(entry, section);
@@ -230,58 +163,62 @@ export function createWonderPanel(
   panel.id = 'wonder-panel';
   panel.style.cssText = 'position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(15,15,25,0.95);z-index:31;overflow-y:auto;padding:16px;padding-bottom:80px;';
 
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;';
   const title = document.createElement('h2');
   title.textContent = 'Legendary Wonders';
-  panel.appendChild(title);
+  title.style.margin = '0';
+  header.appendChild(title);
 
-  const appendSection = (heading: string, body: string) => {
+  const topClose = createGameButton('Close', 'ghost');
+  topClose.dataset.wonderPanelClose = 'top';
+  topClose.addEventListener('click', () => callbacks.onClose());
+  header.appendChild(topClose);
+  panel.appendChild(header);
+
+  const city = state.cities[cityId];
+  const civilization = state.civilizations[state.currentPlayer];
+  if (city || civilization) {
+    appendText(panel, 'p', `${civilization?.name ?? state.currentPlayer} - ${city?.name ?? cityId}`);
+  }
+
+  const appendIntroSection = (heading: string, body: string) => {
     const section = document.createElement('section');
-    const header = document.createElement('h3');
-    header.textContent = heading;
-    const copy = document.createElement('p');
-    copy.textContent = body;
-    section.appendChild(header);
-    section.appendChild(copy);
+    section.style.cssText = 'margin-bottom:10px;';
+    appendText(section, 'h3', heading);
+    appendText(section, 'p', body);
     panel.appendChild(section);
   };
 
-  appendSection(
+  appendIntroSection(
     'Eligibility',
-    'Required techs, resources, and city conditions.',
+    'Required techs, resources, and city conditions must still be true when construction starts.',
   );
-  appendSection('Quest', 'Complete every step before construction unlocks.');
-  appendSection('Construction Race', 'Losing returns 25% coins and 25% carryover.');
+  appendIntroSection('Quest', 'Complete every step before construction unlocks.');
+  appendIntroSection('Construction Race', 'Losing returns 25% coins and 25% carryover.');
 
-  const cityProjects = Object.values(state.legendaryWonderProjects ?? {})
-    .filter(project => project.ownerId === state.currentPlayer && project.cityId === cityId);
+  const cityEntries = getLegendaryWonderPresentationForCity(state, state.currentPlayer, cityId);
   const rivalIntel = getLegendaryWonderIntelForViewer(state, state.currentPlayer);
 
-  if (cityProjects.length === 0) {
-    const empty = document.createElement('p');
-    empty.textContent = 'No legendary wonders are available in this city yet.';
-    panel.appendChild(empty);
+  if (cityEntries.length === 0) {
+    appendText(panel, 'p', 'No legendary wonders are available in this city yet.');
   }
 
-  const sortedCityProjects = [...cityProjects].sort((left, right) =>
-    getProjectPriority(state, cityId, right.wonderId, right.phase)
-    - getProjectPriority(state, cityId, left.wonderId, left.phase),
-  );
-  const recommendedProjects = sortedCityProjects
-    .filter(project => project.phase === 'ready_to_build' || project.phase === 'questing')
+  const recommendedEntries = cityEntries
+    .filter(entry => entry.visibleState !== 'blocked' && entry.visibleState !== 'completed')
     .slice(0, 3);
-  const recommendedIds = new Set(recommendedProjects.map(project => project.wonderId));
-  const laterProjects = sortedCityProjects
-    .filter(project => !recommendedIds.has(project.wonderId));
+  const recommendedIds = new Set(recommendedEntries.map(entry => entry.wonderId));
+  const laterEntries = cityEntries.filter(entry => !recommendedIds.has(entry.wonderId));
 
-  appendProjectSection(panel, 'Best fits right now', 'recommended-wonders', recommendedProjects, state, callbacks, {
+  appendProjectSection(panel, 'Best fits right now', 'recommended-wonders', recommendedEntries, callbacks, cityId, {
     recommended: true,
   });
-  appendProjectSection(panel, 'All ambitions in this city', 'all-city-wonders', laterProjects, state, callbacks);
+  appendProjectSection(panel, 'All ambitions in this city', 'all-city-wonders', laterEntries, callbacks, cityId);
   appendRivalIntelSection(panel, 'In progress elsewhere', 'rival-wonders', rivalIntel.slice(0, 3));
 
-  const close = createGameButton('Close', 'ghost');
-  close.addEventListener('click', () => callbacks.onClose());
-  panel.appendChild(close);
+  const bottomClose = createGameButton('Close', 'ghost');
+  bottomClose.addEventListener('click', () => callbacks.onClose());
+  panel.appendChild(bottomClose);
 
   container.appendChild(panel);
   return panel;

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -12,6 +12,9 @@ import {
   CITY_NAMES,
   TRAINABLE_UNITS,
   PRODUCTION_ICONS,
+  getCatalogProductionCost,
+  getProductionDisplayName,
+  getProductionIconForItem,
 } from '@/systems/city-system';
 import type { City, GameMap } from '@/core/types';
 import { generateMap } from '@/systems/map-generator';
@@ -521,5 +524,19 @@ describe('PRODUCTION_ICONS coverage', () => {
       expect(typeof icon, `icon for "${id}" must be string`).toBe('string');
       expect(icon.length, `icon for "${id}" must be non-empty`).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('legendary wonder production metadata', () => {
+  it('uses legendary wonder definitions for queued production cost and display', () => {
+    expect(getCatalogProductionCost('legendary:oracle-of-delphi')).toBe(120);
+    expect(getProductionDisplayName('legendary:oracle-of-delphi')).toBe('Oracle of Delphi');
+    expect(getProductionIconForItem('legendary:oracle-of-delphi')).toBe('*');
+  });
+
+  it('uses a safe fallback for unknown legendary queue ids', () => {
+    expect(getCatalogProductionCost('legendary:missing-wonder')).toBe(0);
+    expect(getProductionDisplayName('legendary:missing-wonder')).toBe('Unknown Legendary Wonder');
+    expect(getProductionIconForItem('legendary:missing-wonder')).toBe('*');
   });
 });

--- a/tests/systems/legendary-wonder-presentation.test.ts
+++ b/tests/systems/legendary-wonder-presentation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getCompactLegendaryWonderEntriesForCity,
+  getLegendaryWonderDisplayName,
+  getLegendaryWonderPresentationForCity,
+  getLegendaryWonderProductionCost,
+  getLegendaryWonderQueueItemMetadata,
+} from '@/systems/legendary-wonder-presentation';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-presentation', () => {
+  it('classifies selected-city wonder entries and exposes safe start labels', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages', 'city-planning', 'printing'],
+      resources: ['stone'],
+      oracleStepsCompleted: 2,
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+    state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+    state.legendaryWonderProjects!['sun-spire:player:city-river'] = {
+      wonderId: 'sun-spire',
+      ownerId: 'player',
+      cityId: 'city-river',
+      phase: 'building',
+      investedProduction: 70,
+      transferableProduction: 0,
+      questSteps: [
+        { id: 'complete-sacred-route', description: 'Establish a sacred trade route.', completed: true },
+        { id: 'defeat-nearby-stronghold', description: 'Clear a nearby barbarian stronghold.', completed: true },
+      ],
+    };
+    state.cities['city-river'].productionQueue = ['legendary:sun-spire'];
+    state.cities['city-river'].productionProgress = 70;
+
+    const entries = getLegendaryWonderPresentationForCity(state, 'player', 'city-river', 10);
+
+    expect(entries.find(entry => entry.wonderId === 'oracle-of-delphi')).toMatchObject({
+      name: 'Oracle of Delphi',
+      visibleState: 'ready',
+      eligibilityState: 'buildable',
+      canStartBuild: true,
+      startActionLabel: 'Start Construction',
+      queueItemId: 'legendary:oracle-of-delphi',
+    });
+    expect(entries.find(entry => entry.wonderId === 'grand-canal')).toMatchObject({
+      visibleState: 'recovered',
+      transferableProduction: 24,
+    });
+    expect(entries.find(entry => entry.wonderId === 'sun-spire')).toMatchObject({
+      visibleState: 'building',
+      investedProduction: 70,
+    });
+  });
+
+  it('keeps stale ready projects build-blocked when requirements are no longer met', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages'],
+      resources: [],
+      oracleStepsCompleted: 2,
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+
+    const oracle = getLegendaryWonderPresentationForCity(state, 'player', 'city-river')
+      .find(entry => entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({
+      visibleState: 'blocked',
+      eligibilityState: 'blocked',
+      canStartBuild: false,
+      startActionLabel: null,
+    });
+    expect(oracle?.missingRequirements).toContain('Stone');
+  });
+
+  it('keeps far-future blocked wonders out of the compact build-list surface', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.era = 1;
+    state.legendaryWonderProjects = undefined;
+
+    const compact = getCompactLegendaryWonderEntriesForCity(state, 'player', 'city-river', 20);
+
+    expect(compact.map(entry => entry.wonderId)).not.toContain('oracle-of-delphi');
+    expect(compact.map(entry => entry.wonderId)).not.toContain('internet');
+    expect(compact.map(entry => entry.wonderId)).not.toContain('manhattan-project');
+    expect(compact.every(entry => entry.era <= 2)).toBe(true);
+  });
+
+  it('exposes legendary queue metadata for production rows', () => {
+    expect(getLegendaryWonderQueueItemMetadata('legendary:oracle-of-delphi')).toEqual({
+      icon: '*',
+      name: 'Oracle of Delphi',
+      productionCost: 120,
+      wonderId: 'oracle-of-delphi',
+    });
+    expect(getLegendaryWonderDisplayName('legendary:oracle-of-delphi')).toBe('Oracle of Delphi');
+    expect(getLegendaryWonderProductionCost('legendary:oracle-of-delphi')).toBe(120);
+    expect(getLegendaryWonderQueueItemMetadata('legendary:unknown')).toEqual({
+      icon: '*',
+      name: 'Unknown Legendary Wonder',
+      productionCost: 0,
+      wonderId: 'unknown',
+    });
+  });
+});

--- a/tests/systems/legendary-wonder-system.test.ts
+++ b/tests/systems/legendary-wonder-system.test.ts
@@ -179,7 +179,7 @@ describe('legendary-wonder-system', () => {
   });
 
   it('moves a ready project into the building phase when construction starts', () => {
-    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
 
     const result = startLegendaryWonderBuild(state, 'player', 'city-river', 'oracle-of-delphi');
@@ -187,8 +187,22 @@ describe('legendary-wonder-system', () => {
     expect(result.legendaryWonderProjects!['oracle-of-delphi'].phase).toBe('building');
   });
 
+  it('does not start a stale ready project when current resources no longer satisfy eligibility', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages'],
+      resources: [],
+      oracleStepsCompleted: 2,
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+
+    const result = startLegendaryWonderBuild(state, 'player', 'city-river', 'oracle-of-delphi');
+
+    expect(result.legendaryWonderProjects!['oracle-of-delphi'].phase).toBe('ready_to_build');
+    expect(result.cities['city-river'].productionQueue).toEqual([]);
+  });
+
   it('does not allow the same civilization to start the same wonder in two cities', () => {
-    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     state.cities['city-second'] = {
       ...state.cities['city-river'],
       id: 'city-second',
@@ -241,7 +255,7 @@ describe('legendary-wonder-system', () => {
   });
 
   it('surfaces a build-start event to observers with stationed spies in the target city', () => {
-    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     const bus = new EventBus();
     const revealedEvents: Array<{ observerId: string; civId: string; cityId: string; wonderId: string }> = [];
     bus.on('wonder:legendary-race-revealed', event => revealedEvents.push(event));
@@ -310,7 +324,7 @@ describe('legendary-wonder-system', () => {
   });
 
   it('preserves every queued city item when a legendary wonder starts, even from a full queue', () => {
-    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
     state.cities['city-river'].productionQueue = ['library', 'warrior', 'worker', 'shrine'];
 

--- a/tests/ui/advisor-system.test.ts
+++ b/tests/ui/advisor-system.test.ts
@@ -318,7 +318,8 @@ describe('AdvisorSystem', () => {
 
     expect(messages).toHaveLength(1);
     expect(messages[0].advisor).toBe('artisan');
-    expect(messages[0].message).toMatch(/wonder/i);
+    expect(messages[0].message).toMatch(/Build list/i);
+    expect(messages[0].message).toMatch(/Start Construction/i);
   });
 
   it('warns when a current-player wonder race is underway', () => {

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -36,6 +36,64 @@ describe('city-panel legendary wonders', () => {
     expect(rendered).toContain('Legendary Wonders');
     expect(rendered).toContain('Wonder carryover');
   });
+
+  it('shows compact legendary wonder cards in the normal Build list and opens the detail panel', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    const onOpenWonderPanel = vi.fn();
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel,
+      onClose: () => {},
+    });
+
+    expect(collectText(panel)).toContain('Wonder Ambitions');
+    expect(collectText(panel)).toContain('Oracle of Delphi');
+
+    clickElement(panel.querySelector('[data-wonder-card="oracle-of-delphi"]'));
+
+    expect(onOpenWonderPanel).toHaveBeenCalledWith('city-river');
+    expect(panel.isConnected).toBe(false);
+  });
+
+  it('does not crowd the compact Build list with far-future blocked wonders', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.era = 1;
+    state.civilizations.player.techState.completed = [];
+    state.legendaryWonderProjects = undefined;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const compactSection = panel.querySelector('[data-section="compact-wonder-build-list"]');
+
+    expect(compactSection?.textContent).not.toContain('Internet');
+    expect(compactSection?.textContent).not.toContain('Manhattan Project');
+  });
+
+  it('renders legendary active production and queued follow-ups with human-readable names and ETA', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.productionQueue = ['legendary:oracle-of-delphi', 'library'];
+    city.productionProgress = 60;
+    city.focus = 'production';
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onMoveQueueItem: () => {},
+      onRemoveQueueItem: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const rendered = collectText(panel);
+
+    expect(rendered).toContain('Producing: * Oracle of Delphi');
+    expect(rendered).toContain('Library');
+    expect(rendered).toContain('Starts in');
+    expect(rendered).not.toContain('legendary:oracle-of-delphi');
+  });
 });
 
 describe('city-panel navigation', () => {

--- a/tests/ui/legendary-wonder-notifications.test.ts
+++ b/tests/ui/legendary-wonder-notifications.test.ts
@@ -3,6 +3,21 @@ import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notificati
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 
 describe('legendary-wonder-notifications', () => {
+  it('points ready wonders back to the city Build list and journal action', () => {
+    const state = makeLegendaryWonderFixture();
+
+    const visible = getLegendaryWonderNotification(state, 'player', {
+      type: 'wonder:legendary-ready',
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+    });
+
+    expect(visible?.message).toContain('city-river');
+    expect(visible?.message).toContain('Build list');
+    expect(visible?.message).toContain('Start Construction');
+  });
+
   it('only shows race-revealed notifications to the observing current player', () => {
     const state = makeLegendaryWonderFixture();
 

--- a/tests/ui/wonder-panel.test.ts
+++ b/tests/ui/wonder-panel.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { initializeLegendaryWonderProjectsForCity } from '@/systems/legendary-wonder-system';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { makeWonderPanelFixture, collectText } from './helpers/wonder-panel-fixture';
@@ -57,7 +57,8 @@ describe('wonder-panel', () => {
 
     const rendered = collectText(panel);
     expect(rendered).toContain('World Archive');
-    expect(rendered).not.toContain('Oracle of Delphi');
+    expect(rendered).toContain('Second Player');
+    expect(rendered).not.toContain('Rival is pursuing this');
   });
 
   it('shows concrete eligibility failures and reward summary for the selected project', () => {
@@ -72,7 +73,7 @@ describe('wonder-panel', () => {
 
     const rendered = collectText(panel);
     expect(rendered).toContain('Missing');
-    expect(rendered).toContain('pilgrimages');
+    expect(rendered).toContain('Pilgrimages');
     expect(rendered).toContain('Reward');
   });
 
@@ -88,9 +89,9 @@ describe('wonder-panel', () => {
 
     const rendered = collectText(panel);
     expect(rendered).toContain('Manhattan Project');
-    expect(rendered).toContain('Missing: tech nuclear-theory');
+    expect(rendered).toContain('Missing: Nuclear Theory');
     expect(rendered).toContain('Internet');
-    expect(rendered).toContain('Missing: tech mass-media, tech global-logistics');
+    expect(rendered).toContain('Missing: Mass Media, Global Logistics');
   });
 
   it('does not overwhelm the player with an undifferentiated list of wonders', () => {
@@ -180,9 +181,44 @@ describe('wonder-panel', () => {
     });
 
     expect(panel.textContent).toContain('Oracle of Delphi');
-    expect(panel.textContent).toContain('Phase: ready to build');
+    expect(panel.textContent).toContain('Ready to build');
     expect(panel.textContent).toContain('Quest steps: 2/2 complete.');
-    expect(Array.from(panel.querySelectorAll('button')).some(button => button.textContent === 'Start Build')).toBe(true);
+    expect(Array.from(panel.querySelectorAll('button')).some(button => button.textContent === 'Start Construction')).toBe(true);
+    expect(panel.textContent).toContain('current queue continues after this wonder');
+  });
+
+  it('starts construction from the selected city and keeps the panel action explicit', () => {
+    const { container, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    const onStartBuild = vi.fn();
+
+    const panel = createWonderPanel(container, state, 'city-river', {
+      onStartBuild,
+      onClose: () => {},
+    });
+
+    const start = Array.from(panel.querySelectorAll('button')).find(button => button.textContent === 'Start Construction');
+    expect(start).toBeTruthy();
+    expect(panel.textContent).toContain('current queue continues after this wonder');
+
+    start!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onStartBuild).toHaveBeenCalledWith('city-river', 'oracle-of-delphi');
+  });
+
+  it('keeps a close control available at the top of the journal', () => {
+    const { container, state } = makeWonderPanelFixture();
+    const onClose = vi.fn();
+
+    const panel = createWonderPanel(container, state, 'city-river', {
+      onStartBuild: () => {},
+      onClose,
+    });
+    const close = panel.querySelector('[data-wonder-panel-close="top"]');
+
+    expect(close).toBeTruthy();
+    close!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it('shows grand canal as incomplete when only another city is developed', () => {
@@ -331,7 +367,7 @@ describe('wonder-panel', () => {
     expect(rivalSection?.textContent).not.toContain('Connect two cities');
   });
 
-  it('Start Build and Close buttons have styled background and color', () => {
+  it('Start Construction and Close buttons have styled background and color', () => {
     const { container, state } = makeWonderPanelFixture();
     state.civilizations.player.techState.completed = ['masonry', 'writing', 'calendar'];
     state.wonderDiscoverers = { 'natural-1': ['player'] };


### PR DESCRIPTION
## Summary
- Adds the reviewed spec and GPT-5.4 medium implementation plan for issue #217.
- Surfaces legendary wonders in the city Build list through a compact Wonder Ambitions doorway.
- Rebuilds the wonder journal from shared presentation helpers with explicit Start Construction behavior, queue preservation, safer stale-eligibility handling, readable production labels, and updated notifications/advisor copy.

## Test Plan
- [x] scripts/check-src-rule-violations.sh src/systems/legendary-wonder-presentation.ts src/systems/legendary-wonder-system.ts src/systems/city-system.ts src/ui/city-panel.ts src/ui/wonder-panel.ts src/ui/legendary-wonder-notifications.ts src/ui/advisor-system.ts src/main.ts
- [x] ./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-system.test.ts tests/systems/city-system.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/advisor-system.test.ts
- [x] ./scripts/run-wonder-regressions.sh
- [x] ./scripts/run-with-mise.sh yarn build
- [x] ./scripts/run-with-mise.sh yarn test

## Notes
- Browser smoke was skipped after the private-window Computer Use permission flow stalled.
- `run-wonder-regressions.sh` emitted a mise cache write warning, but exited 0.

Closes #217