### PR TITLE
feat(wonders): add Wonder Atlas map identity

### DIFF
--- a/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
+++ b/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
@@ -1,0 +1,326 @@
+# Wonder Atlas And Map Identity Design
+
+**Issue:** [#217 - Bug: legendary wonder ui off](https://github.com/a1flecke/conquestoria/issues/217)
+**Date:** 2026-05-21
+
+## Overview
+
+Stage 1 of the wonder work made legendary wonder construction more visible from the city flow. Stage 2A makes wonders feel like a recognizable part of the world: discovered natural wonders get a visual identity on the map and in a global catalog, while legendary wonders get masked visual identity slots that set up later construction and completion spectacle.
+
+This design is presentation-first. It does not change natural wonder placement, discovery rules, yields, legendary wonder eligibility, AI behavior, save format, or construction rules. It creates the shared visual and presentation foundations needed for later reveal moments, legendary ceremonies, Atlas expansion, and real video experiments.
+
+---
+
+## Goals
+
+- Add a global **Wonder Atlas** where players can revisit discovered natural wonders and see masked legendary wonder slots from the normal game shell.
+- Replace generic natural wonder map markers with distinctive, tile-integrated miniature landmarks.
+- Give each natural wonder a medallion identity and short animated SVG/CSS vignette for the Atlas.
+- Give each legendary wonder masked medallion metadata so the category feels intentional before Stage 2C spectacle.
+- Keep all Atlas visibility viewer-safe for hot-seat and rival-intel scenarios.
+- Keep the normal map usable: wonder art must not interfere with unit, city, selection, or tile inspection interactions.
+- Respect reduced-motion preferences with static equivalents for vignettes and map animation.
+
+## Non-Goals
+
+- Stage 2A does not implement first-discovery reveal ceremonies.
+- Stage 2A does not redesign legendary wonder construction, questing, race, completion, or reward rules.
+- Stage 2A does not add real video assets.
+- Stage 2A does not add full lore/history pages, filtering, rival records, or an empire legacy archive.
+- Stage 2A does not reveal undiscovered natural wonder names, locations, counts, categories, or effects.
+- Stage 2A does not add new natural wonders or alter existing natural wonder effects.
+
+---
+
+## Player Experience
+
+The player gets a global **Wonder Atlas** entry point from the main game UI, added through the existing game shell rather than the city-scoped legendary wonder panel. The Atlas is a gameplay panel, not a marketing-style landing page. It should feel like a compact field journal that lets the player scan what they have discovered and inspect a wonder without leaving the strategy layer.
+
+The first Stage 2A Atlas view includes:
+
+- discovered natural wonders as vivid medallion entries
+- undiscovered natural wonders omitted entirely
+- legendary wonders as masked medallion slots
+
+Selecting a discovered natural wonder opens a **Vignette Card** in the Atlas. The card shows:
+
+- medallion identity
+- animated SVG/CSS vignette
+- human-readable wonder name
+- discovered location
+- yield or effect summary
+- `View on map` action when the discovered coordinate can still be resolved
+
+The vignette animation should be ambient and loopable. It is not a modal ceremony and should not block play.
+
+On the map, discovered natural wonders render as tile-integrated miniature landmarks instead of a generic marker. Clicking or tapping a known wonder tile can deep-link into that Atlas entry, but only after normal unit, city, and tile-selection priorities are respected. Wonder deep-linking enriches tile inspection; it must not steal primary map controls.
+
+Legendary wonders appear in Stage 2A as masked slots only. They should communicate that legendary wonders belong in the Atlas roadmap, but the rich construction and completion experience remains Stage 2C.
+
+---
+
+## UI And UX
+
+The Atlas should be compact and scannable. It should use tabs or segmented filters for:
+
+- `Known Natural`
+- `Legendary`
+- future `History` or `All` surfaces in Stage 2D
+
+Natural wonder cards use the medallion as the primary visual anchor. A selected card expands into the animated vignette/detail area. Desktop may use a two-pane panel with catalog entries beside the selected detail. Mobile should use a stacked layout or selected-detail view that preserves reachability for every visible entry.
+
+Unknown natural wonders must not appear as silhouettes or disabled cards. Hiding them entirely is required because showing silhouettes leaks count and category information. Legendary wonders may appear as masked slots because they are civilization-level aspirations rather than hidden map facts.
+
+Map landmark art should remain readable at normal zoom and calm at low zoom. At close zoom, it can show miniature landmark shape and subtle ambient motion. At far zoom, it may simplify to a medallion-like marker or silhouette if the detailed landmark would become noisy. Labels should use existing hover, selection, or tile-inspection affordances instead of always-on map text.
+
+UX requirements:
+
+- Atlas is reachable globally, without selecting a city, through a styled touch-sized shell control with an accessible label/title.
+- Every visible Atlas item is clickable or clearly disabled with a reason.
+- Selecting an Atlas item updates the detail/vignette area immediately.
+- `View on map` pans to or selects the correct discovered wonder tile without changing gameplay state.
+- Reduced-motion users see static vignettes and non-animated map art.
+- Atlas presentation never exposes undiscovered natural wonder names, locations, counts, categories, or effects.
+- Closing and reopening the Atlas preserves ordinary game controls and does not leave map input in a special wonder mode.
+
+---
+
+## Architecture
+
+The architecture uses shared definitions and viewer-safe presentation helpers, while keeping Canvas rendering, DOM rendering, and input handling in their own layers.
+
+### Shared Visual Catalog
+
+Add a shared visual catalog outside renderer internals. The default module path is:
+
+```text
+src/systems/wonder-visual-catalog.ts
+```
+
+The catalog defines presentation metadata used by both Canvas and DOM surfaces:
+
+- wonder id
+- wonder kind: natural or legendary
+- medallion icon/emblem data
+- palette tokens
+- map landmark type
+- vignette type
+- animation capability
+- reduced-motion fallback metadata
+- masked placeholder metadata for legendary wonders
+
+The visual catalog must not duplicate gameplay effects from `wonder-definitions` or legendary wonder definitions. Existing gameplay definitions remain authoritative for yields, requirements, construction, questing, and rewards.
+
+The catalog should use typed drawing and vignette ids rather than storing large ad hoc HTML strings. Static SVG data may be generated from trusted catalog metadata, but game-generated names, locations, and effect text must still be inserted through DOM-safe text APIs.
+
+### Viewer-Safe Atlas Presentation
+
+Add a system-adjacent helper. The default module path is:
+
+```text
+src/systems/wonder-atlas-presentation.ts
+```
+
+This helper derives current-player Atlas entries from existing game state. It is responsible for viewer-safe masking:
+
+- natural wonders are visible only when discovered by `state.currentPlayer`
+- discovered natural wonders include safe static details such as name, known/discovered location, and effect summary
+- undiscovered natural wonders are omitted, not greyed out
+- legendary wonders appear as masked slots by default
+- richer legendary state is included only when existing player-visible progress, eligibility, or earned intel allows it
+- rival information is included only from viewer-scoped intel, never from raw live rival objects
+
+UI panels should render Atlas entries from this helper instead of reading raw map or rival state directly.
+
+For natural wonders, the helper should derive discovery from existing `wonderDiscoverers`/`discoveredWonders` state and resolve the matching wonder tile only to the extent needed to recover the discovered coordinate. It must not expose live terrain, unit, city, ownership, or rival activity from a tile that is outside the current player's current visibility. If a discovered wonder's coordinate cannot be resolved from existing state, the Atlas entry may show the wonder without `View on map`.
+
+### Canvas Map Renderer
+
+Add renderer-only helpers. The default module path is:
+
+```text
+src/renderer/wonders/natural-wonder-renderer.ts
+```
+
+This module draws tile-integrated natural wonder landmarks from:
+
+- the tile presentation/snapshot already allowed by render visibility
+- current-player render visibility context
+- shared visual catalog metadata
+- render time for ambient animation
+
+The renderer must not decide discovery truth, eligibility, ownership truth, or Atlas visibility. It does not mutate game state. In fog or last-seen contexts, it must render only from the same viewer-safe tile presentation used by the rest of the map, not from richer live tile objects.
+
+### Atlas UI
+
+Add DOM UI modules. The default module paths are:
+
+```text
+src/ui/wonder-atlas-panel.ts
+src/ui/wonder-vignette.ts
+```
+
+`wonder-atlas-panel.ts` owns the global Atlas panel, filters, entry list, selected detail state, and `View on map` callback wiring.
+
+`wonder-vignette.ts` renders SVG/CSS vignette content for a selected Atlas entry. It consumes a viewer-safe Atlas entry plus visual catalog metadata. It should use DOM-safe APIs for dynamic text and avoid `innerHTML` for game-generated content.
+
+The live game shell must delegate to `wonder-atlas-panel.ts` in the same implementation slice. A new Atlas module without a real shell entry point is incomplete.
+
+### Map Deep-Link Intent
+
+Wonder deep-link handling belongs outside the renderer. The default helper path is:
+
+```text
+src/input/wonder-atlas-intent.ts
+```
+
+If implementation finds an existing tile-intent module that already owns this exact responsibility, the plan may extend that module instead of adding the default file. The renderer must still remain uninvolved in input decisions.
+
+The intent helper should run only after higher-priority unit and city interactions. It opens or focuses the Atlas only when the clicked/tapped tile contains a natural wonder already discovered by the current player and inspectable through the current tile presentation.
+
+---
+
+## Data Flow
+
+Atlas flow:
+
+1. Player opens the global Wonder Atlas.
+2. UI requests Atlas entries for `state.currentPlayer`.
+3. `wonder-atlas-presentation` reads existing natural wonder discovery state, legendary wonder state, and viewer-scoped intel.
+4. The helper returns masked, viewer-safe entries.
+5. `wonder-atlas-panel` renders the visible entries.
+6. Selecting an entry renders the matching `wonder-vignette` detail.
+7. `View on map` pans/selects the discovered coordinate through existing map control wiring without mutating gameplay state or exposing hidden live tile contents.
+
+Map rendering flow:
+
+1. Existing render visibility decides whether a tile's current content can be shown to `state.currentPlayer`.
+2. The tile render path receives a viewer-safe tile presentation that contains a natural wonder.
+3. `natural-wonder-renderer` draws the matching landmark using shared visual catalog metadata.
+4. Ambient animation uses render time only and does not write to state.
+
+Map deep-link flow:
+
+1. Player clicks or taps a map tile.
+2. Existing unit, city, selection, and tile-inspection priorities resolve first.
+3. If the remaining tile intent is an inspectable natural wonder already discovered by the current player, the Atlas opens to that wonder entry.
+4. If the wonder is unknown to the current player, no Atlas entry opens and no hidden information is exposed.
+
+---
+
+## Error Handling And Edge Cases
+
+- Missing visual catalog metadata uses a safe fallback medallion and static marker rather than crashing.
+- A natural wonder id that is not in the gameplay definitions should not render actionable Atlas details.
+- A natural wonder tile outside current-player discovery must not appear in the Atlas.
+- A natural wonder tile outside current-player render visibility must not draw current live details on the map.
+- A discovered natural wonder whose tile can no longer be resolved should remain listed only if existing state preserves enough safe discovery data; otherwise omit `View on map`.
+- Legendary masked slots must not imply construction availability unless the existing legendary presentation state says availability is visible.
+- Reduced-motion mode uses `prefers-reduced-motion` at minimum and disables looping vignette and map landmark animation.
+- Input deep-linking must not override selecting units, selecting cities, moving units, attacking, or other primary map actions.
+- Hot-seat current-player switching must refresh Atlas visibility.
+- The Atlas must handle an empty `Known Natural` tab with useful text and no fake unknown wonder cards.
+
+---
+
+## Testing Requirements
+
+### System And Presentation Tests
+
+Add mirrored or focused tests for the shared catalog and Atlas presentation:
+
+- every natural wonder definition has visual catalog metadata
+- every legendary wonder definition has masked medallion metadata
+- Atlas presentation hides undiscovered natural wonders completely
+- Atlas presentation shows discovered natural wonders with safe details
+- Atlas presentation does not leak unknown natural wonder count, names, locations, categories, or effects
+- Atlas presentation scopes visibility to `state.currentPlayer`
+- Atlas presentation does not expose live hidden tile details for a discovered wonder outside current visibility
+- Atlas presentation includes rival legendary information only when existing viewer-scoped intel allows it
+- masked legendary slots do not imply buildability unless existing visible state supports it
+
+### UI Tests
+
+Add tests for the Atlas panel and vignette behavior:
+
+- Atlas is globally reachable
+- all visible Atlas entries render and are reachable
+- the live shell entry point opens the real Atlas panel module
+- selecting a visible entry updates the vignette/detail area immediately
+- discovered natural wonder details show medallion, name, location, and effect summary
+- undiscovered natural wonders do not render as hidden cards, silhouettes, or disabled placeholders
+- legendary wonders render as masked medallion slots
+- `View on map` invokes the correct pan/select callback for a discovered wonder
+- `View on map` is absent or disabled when a discovered wonder lacks a resolvable coordinate
+- reduced-motion rendering uses a static vignette state
+- hot-seat current-player changes refresh the visible Atlas entries
+
+### Renderer And Input Tests
+
+Add targeted tests around map rendering and deep-link behavior:
+
+- discovered natural wonder tiles invoke the natural wonder landmark renderer
+- undiscovered or non-visible natural wonder tiles do not render current live details
+- last-seen/fogged wonder rendering uses viewer-safe tile presentation rather than live tile state
+- renderer fallback handles missing visual metadata safely
+- ambient animation uses render time without mutating game state
+- deep-link intent opens the Atlas for a discovered natural wonder tile
+- deep-link intent does not fire for unknown natural wonders
+- deep-link intent does not override unit or city interaction priority
+- deep-link coordinates follow existing map wrapping/normalization behavior
+
+### Required Checks
+
+For Stage 2A implementation, run:
+
+```bash
+scripts/check-src-rule-violations.sh <changed src files>
+./scripts/run-with-mise.sh yarn test --run <mirrored or smallest relevant tests>
+./scripts/run-wonder-regressions.sh
+./scripts/run-with-mise.sh yarn build
+```
+
+Before push, PR creation, or merge, also run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+---
+
+## Acceptance Criteria
+
+Stage 2A is complete when:
+
+- a player can open a global Wonder Atlas
+- the Atlas is opened through the live game shell, not only through an isolated test helper
+- discovered natural wonders appear as medallion entries in the Atlas
+- undiscovered natural wonders are absent from the Atlas
+- legendary wonders appear as masked medallion slots
+- selecting a discovered natural wonder shows an animated SVG/CSS vignette card with safe details
+- reduced-motion users receive static equivalents
+- discovered natural wonders render as distinctive tile-integrated map landmarks
+- known wonder tiles can deep-link into the Atlas without breaking unit/city/map controls
+- Atlas and map visibility are scoped to `state.currentPlayer`
+- no gameplay rules, yields, discovery mechanics, AI behavior, or save format are changed
+- catalog, presentation, UI, renderer, input, wonder regression, build, and full test checks pass
+
+---
+
+## Later Roadmap
+
+### Stage 2B: Discovery Reveal Moments
+
+Add short first-discovery reveal treatments for natural wonders. These should reuse Stage 2A medallions and vignette identity, while remaining separate from ordinary map scanning.
+
+### Stage 2C: Legendary Construction And Completion Presence
+
+Add richer legendary wonder identity in construction UI, construction-stage presentation, completion ceremony/presence, and clearer distinction between available, underway, completed, and rival-known legendary wonders.
+
+### Stage 2D: Full 2D Atlas Expansion
+
+Expand the Atlas with lore/history/detail pages, better browsing/filtering, known rival records where intel allows, and a legacy-style archive for completed/discovered wonders. This stage remains 2D.
+
+### Stage 3: Real Video Spike
+
+Prototype 3-5 second video or loop support for selected catalog entries. The spike should evaluate asset size, tooling, offline/PWA cost, macOS/Tauri behavior, and maintenance burden before any production commitment.

--- a/src/input/wonder-atlas-intent.ts
+++ b/src/input/wonder-atlas-intent.ts
@@ -1,0 +1,39 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { resolveTilePresentationForViewer } from '@/renderer/tile-presentation';
+import { wrapHexCoord } from '@/systems/hex-utils';
+
+export type WonderAtlasIntent =
+  | { type: 'open-atlas'; wonderId: string; coord: HexCoord }
+  | { type: 'none' };
+
+export function resolveWonderAtlasIntent(
+  state: GameState,
+  viewerId: string,
+  rawCoord: HexCoord,
+): WonderAtlasIntent {
+  const coord = state.map.wrapsHorizontally
+    ? wrapHexCoord(rawCoord, state.map.width)
+    : rawCoord;
+  const visibility = state.civilizations[viewerId]?.visibility;
+  const presentation = resolveTilePresentationForViewer(state.map, visibility, coord);
+
+  if (presentation.kind !== 'live' && presentation.kind !== 'last-seen') {
+    return { type: 'none' };
+  }
+
+  const wonderId = presentation.tile.wonder;
+  if (!wonderId) {
+    return { type: 'none' };
+  }
+
+  const discoverers = state.wonderDiscoverers?.[wonderId] ?? [];
+  if (!discoverers.includes(viewerId)) {
+    return { type: 'none' };
+  }
+
+  return {
+    type: 'open-atlas',
+    wonderId,
+    coord: { ...coord },
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ import {
   shouldPromptForPlayerCityCapture,
 } from '@/input/city-assault-flow';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
+import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
 import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
 import {
   initializeLegendaryWonderProjectsForCity,
@@ -2058,6 +2059,14 @@ function handleHexTap(rawCoord: HexCoord): void {
     document.getElementById('council-panel')?.remove();
     deselectUnit();
     openCityPanelForCity(cityAtHex);
+    return;
+  }
+
+  const wonderAtlasIntent = resolveWonderAtlasIntent(gameState, gameState.currentPlayer, coord);
+  if (wonderAtlasIntent.type === 'open-atlas') {
+    deselectUnit();
+    openWonderAtlas(wonderAtlasIntent.wonderId);
+    SFX.tap();
     return;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ import { createCityCapturePanel } from '@/ui/city-capture-panel';
 import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
 import { createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
+import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { resolveCombat, getTerrainDefenseBonus, selectDefenderForAttack } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
@@ -217,6 +218,7 @@ function createUI(): void {
     onNextUnit: () => selectNextUnit(),
     onOpenNotificationLog: () => toggleNotificationLog(),
     onToggleIconLegend: () => toggleIconLegend(),
+    onOpenWonderAtlas: () => openWonderAtlas(),
     onOpenMenu: () => {
       showPauseMenu(uiLayer, {
         turn: gameState.turn,
@@ -231,6 +233,16 @@ function createUI(): void {
       });
     },
     iconLegendOverlay: createIconLegendOverlay(),
+  });
+}
+
+function openWonderAtlas(initialWonderId?: string): void {
+  createWonderAtlasPanel(uiLayer, gameState, {
+    initialWonderId,
+    onViewOnMap: coord => {
+      renderLoop.camera.centerOn(coord);
+    },
+    onClose: () => {},
   });
 }
 

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -4,6 +4,7 @@ import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
 import { resolveTilePresentationForViewer, type TilePresentationKind } from './tile-presentation';
+import { drawNaturalWonderLandmark } from './wonders/natural-wonder-renderer';
 
 // --- Terrain labels ---
 
@@ -59,8 +60,10 @@ function drawTileAtScreen(
   viewerVisibility: VisibilityMap | undefined,
   zoom: number,
   presentationKind: TilePresentationKind,
+  nowMs: number,
+  reducedMotion: boolean,
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion);
   if (shouldShowTerrainLabel(zoom)) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -80,6 +83,10 @@ export function drawHexMap(
   viewerVisibility?: VisibilityMap,
 ): void {
   const size = camera.hexSize;
+  const nowMs = typeof performance !== 'undefined' ? performance.now() : 0;
+  const reducedMotion = typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   for (const tile of Object.values(map.tiles)) {
     const renderCoords = map.wrapsHorizontally
@@ -104,6 +111,8 @@ export function drawHexMap(
         viewerVisibility,
         camera.zoom,
         presentation.kind,
+        nowMs,
+        reducedMotion,
       );
     }
   }
@@ -216,6 +225,8 @@ function drawHex(
   currentPlayer?: string,
   viewerVisibility?: VisibilityMap,
   presentationKind: TilePresentationKind = 'live',
+  nowMs: number = 0,
+  reducedMotion: boolean = false,
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -266,14 +277,16 @@ function drawHex(
 
   // Draw wonder indicator
   if (tile.wonder) {
-    ctx.font = `bold ${size * 0.55}px system-ui`;
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.shadowColor = '#e8c170';
-    ctx.shadowBlur = size * 0.3;
-    ctx.fillStyle = '#e8c170';
-    ctx.fillText('✦', cx, cy);
-    ctx.shadowBlur = 0;
+    drawNaturalWonderLandmark({
+      ctx,
+      cx,
+      cy,
+      size,
+      wonderId: tile.wonder,
+      presentationKind,
+      nowMs,
+      reducedMotion,
+    });
   }
 
   // Draw village indicator

--- a/src/renderer/wonders/natural-wonder-renderer.ts
+++ b/src/renderer/wonders/natural-wonder-renderer.ts
@@ -1,0 +1,121 @@
+import type { TilePresentationKind } from '@/renderer/tile-presentation';
+import { getWonderVisualDefinition, type WonderMapLandmark } from '@/systems/wonder-visual-catalog';
+
+export interface NaturalWonderRenderOptions {
+  ctx: CanvasRenderingContext2D;
+  cx: number;
+  cy: number;
+  size: number;
+  wonderId: string;
+  presentationKind: TilePresentationKind;
+  nowMs: number;
+  reducedMotion: boolean;
+}
+
+function pulse(nowMs: number, reducedMotion: boolean): number {
+  return reducedMotion ? 0 : Math.sin(nowMs / 700) * 0.08;
+}
+
+function drawPeak(ctx: CanvasRenderingContext2D, cx: number, cy: number, size: number, accent: string): void {
+  ctx.beginPath();
+  ctx.moveTo(cx - size * 0.42, cy + size * 0.32);
+  ctx.lineTo(cx - size * 0.08, cy - size * 0.36);
+  ctx.lineTo(cx + size * 0.08, cy - size * 0.08);
+  ctx.lineTo(cx + size * 0.28, cy - size * 0.28);
+  ctx.lineTo(cx + size * 0.48, cy + size * 0.32);
+  ctx.closePath();
+  ctx.fillStyle = accent;
+  ctx.fill();
+}
+
+function drawWave(ctx: CanvasRenderingContext2D, cx: number, cy: number, size: number, accent: string): void {
+  ctx.beginPath();
+  ctx.moveTo(cx - size * 0.45, cy);
+  ctx.bezierCurveTo(cx - size * 0.25, cy - size * 0.22, cx - size * 0.08, cy + size * 0.22, cx + size * 0.12, cy);
+  ctx.bezierCurveTo(cx + size * 0.28, cy - size * 0.18, cx + size * 0.38, cy + size * 0.16, cx + size * 0.48, cy - size * 0.04);
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = Math.max(2, size * 0.08);
+  ctx.stroke();
+}
+
+function drawCrystal(ctx: CanvasRenderingContext2D, cx: number, cy: number, size: number, accent: string): void {
+  ctx.beginPath();
+  ctx.moveTo(cx, cy - size * 0.42);
+  ctx.lineTo(cx + size * 0.3, cy - size * 0.04);
+  ctx.lineTo(cx + size * 0.12, cy + size * 0.4);
+  ctx.lineTo(cx - size * 0.26, cy + size * 0.18);
+  ctx.lineTo(cx - size * 0.18, cy - size * 0.16);
+  ctx.closePath();
+  ctx.fillStyle = accent;
+  ctx.fill();
+}
+
+function drawLandmarkShape(
+  ctx: CanvasRenderingContext2D,
+  landmark: WonderMapLandmark,
+  cx: number,
+  cy: number,
+  size: number,
+  accent: string,
+): void {
+  if (landmark === 'volcano' || landmark === 'mountain' || landmark === 'canyon') {
+    drawPeak(ctx, cx, cy, size, accent);
+    return;
+  }
+  if (landmark === 'crystal' || landmark === 'bones' || landmark === 'ruins') {
+    drawCrystal(ctx, cx, cy, size, accent);
+    return;
+  }
+  if (landmark === 'reef' || landmark === 'bay' || landmark === 'lake' || landmark === 'falls' || landmark === 'storm') {
+    drawWave(ctx, cx, cy, size, accent);
+    return;
+  }
+  if (landmark === 'forest' || landmark === 'islands') {
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - size * 0.45);
+    ctx.lineTo(cx + size * 0.38, cy + size * 0.22);
+    ctx.lineTo(cx + size * 0.12, cy + size * 0.22);
+    ctx.lineTo(cx + size * 0.28, cy + size * 0.44);
+    ctx.lineTo(cx - size * 0.28, cy + size * 0.44);
+    ctx.lineTo(cx - size * 0.12, cy + size * 0.22);
+    ctx.lineTo(cx - size * 0.38, cy + size * 0.22);
+    ctx.closePath();
+    ctx.fillStyle = accent;
+    ctx.fill();
+    return;
+  }
+  if (landmark === 'aurora' || landmark === 'sands') {
+    drawWave(ctx, cx, cy - size * 0.12, size, accent);
+    drawWave(ctx, cx, cy + size * 0.14, size * 0.8, accent);
+    return;
+  }
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, size * 0.26, 0, Math.PI * 2);
+  ctx.fillStyle = accent;
+  ctx.fill();
+}
+
+export function drawNaturalWonderLandmark(options: NaturalWonderRenderOptions): void {
+  const { ctx, cx, cy, size, wonderId, presentationKind, nowMs, reducedMotion } = options;
+  const visual = getWonderVisualDefinition(wonderId);
+  const anim = pulse(nowMs, reducedMotion);
+  const radius = size * (0.32 + anim);
+
+  ctx.save();
+  ctx.globalAlpha = presentationKind === 'last-seen' ? 0.72 : 1;
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+  ctx.fillStyle = visual.palette.base;
+  ctx.fill();
+
+  ctx.beginPath();
+  ctx.arc(cx, cy, size * 0.42, 0, Math.PI * 2);
+  ctx.strokeStyle = visual.palette.glow;
+  ctx.lineWidth = Math.max(1.5, size * 0.045);
+  ctx.stroke();
+
+  drawLandmarkShape(ctx, visual.mapLandmark, cx, cy, size, visual.palette.accent);
+  ctx.restore();
+}

--- a/src/systems/wonder-atlas-presentation.ts
+++ b/src/systems/wonder-atlas-presentation.ts
@@ -1,0 +1,118 @@
+import type { GameState, HexCoord, ResourceYield } from '@/core/types';
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export type WonderAtlasEntry =
+  | NaturalWonderAtlasEntry
+  | LegendaryWonderAtlasEntry;
+
+export interface NaturalWonderAtlasEntry {
+  kind: 'natural';
+  wonderId: string;
+  visibility: 'discovered';
+  name: string;
+  effectSummary: string;
+  locationLabel: string;
+  coord: HexCoord | null;
+  canViewOnMap: boolean;
+  visual: WonderVisualDefinition;
+}
+
+export interface LegendaryWonderAtlasEntry {
+  kind: 'legendary';
+  wonderId: string;
+  visibility: 'masked';
+  name: string;
+  maskedLabel: string;
+  canViewOnMap: false;
+  visual: WonderVisualDefinition;
+}
+
+function findWonderCoord(state: GameState, wonderId: string): HexCoord | null {
+  const tile = Object.values(state.map.tiles).find(candidate => candidate.wonder === wonderId);
+  return tile ? { ...tile.coord } : null;
+}
+
+function formatLocation(coord: HexCoord | null): string {
+  return coord ? `Q${coord.q}, R${coord.r}` : 'Location unknown';
+}
+
+function formatYieldSummary(yields: ResourceYield): string {
+  const parts = [
+    ['Food', yields.food],
+    ['Production', yields.production],
+    ['Gold', yields.gold],
+    ['Science', yields.science],
+  ]
+    .filter(([, value]) => typeof value === 'number' && value > 0)
+    .map(([label, value]) => `+${value} ${label}`);
+
+  return parts.length > 0 ? `Yields ${parts.join(', ')}` : 'No direct tile yields';
+}
+
+function formatEffectSummary(wonderId: string): string {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return 'Unknown wonder effect';
+
+  const yieldSummary = formatYieldSummary(definition.yields);
+  switch (definition.effect.type) {
+    case 'adjacent_yield_bonus':
+      return `${yieldSummary}. Improves adjacent tile yields.`;
+    case 'combat_bonus':
+      return `${yieldSummary}. Grants a defensive combat bonus.`;
+    case 'eruption':
+      return `${yieldSummary}. May erupt and damage nearby improvements.`;
+    case 'healing':
+      return `${yieldSummary}. Heals units on the wonder tile.`;
+    case 'vision':
+      return `${yieldSummary}. Extends vision nearby.`;
+    case 'none':
+    default:
+      return yieldSummary;
+  }
+}
+
+function naturalWonderEntry(state: GameState, wonderId: string): NaturalWonderAtlasEntry | null {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return null;
+
+  const coord = findWonderCoord(state, wonderId);
+  return {
+    kind: 'natural',
+    wonderId,
+    visibility: 'discovered',
+    name: definition.name,
+    effectSummary: formatEffectSummary(wonderId),
+    locationLabel: formatLocation(coord),
+    coord,
+    canViewOnMap: coord !== null,
+    visual: getWonderVisualDefinition(wonderId),
+  };
+}
+
+function legendaryWonderEntry(wonderId: string, name: string): LegendaryWonderAtlasEntry {
+  const visual = getWonderVisualDefinition(wonderId);
+  return {
+    kind: 'legendary',
+    wonderId,
+    visibility: 'masked',
+    name,
+    maskedLabel: visual.maskedLabel ?? 'Legendary wonder',
+    canViewOnMap: false,
+    visual,
+  };
+}
+
+export function getWonderAtlasEntries(state: GameState, viewerId: string): WonderAtlasEntry[] {
+  const naturalEntries = Object.entries(state.wonderDiscoverers ?? {})
+    .filter(([, discoverers]) => discoverers.includes(viewerId))
+    .map(([wonderId]) => naturalWonderEntry(state, wonderId))
+    .filter((entry): entry is NaturalWonderAtlasEntry => entry !== null);
+
+  const legendaryEntries = getLegendaryWonderDefinitions().map(definition =>
+    legendaryWonderEntry(definition.id, definition.name),
+  );
+
+  return [...naturalEntries, ...legendaryEntries];
+}

--- a/src/systems/wonder-visual-catalog.ts
+++ b/src/systems/wonder-visual-catalog.ts
@@ -1,0 +1,129 @@
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+
+export type WonderVisualKind = 'natural' | 'legendary';
+
+export type WonderMapLandmark =
+  | 'volcano'
+  | 'mountain'
+  | 'crystal'
+  | 'forest'
+  | 'reef'
+  | 'canyon'
+  | 'aurora'
+  | 'falls'
+  | 'bones'
+  | 'sands'
+  | 'ruins'
+  | 'islands'
+  | 'bay'
+  | 'lake'
+  | 'storm'
+  | 'masked';
+
+export type WonderVignette = WonderMapLandmark;
+
+export interface WonderVisualDefinition {
+  id: string;
+  kind: WonderVisualKind;
+  medallionGlyph: string;
+  palette: {
+    base: string;
+    accent: string;
+    glow: string;
+  };
+  mapLandmark: WonderMapLandmark;
+  vignette: WonderVignette;
+  supportsAmbientAnimation: boolean;
+  reducedMotionFallback: 'static-landmark' | 'static-medallion';
+  maskedLabel?: string;
+}
+
+const NATURAL_WONDER_VISUALS: Record<string, WonderVisualDefinition> = {
+  great_volcano: naturalVisual('great_volcano', '◆', 'volcano', '#4c1f24', '#f0643a', '#ffc46b'),
+  sacred_mountain: naturalVisual('sacred_mountain', '△', 'mountain', '#34405a', '#d5d8ff', '#eef0ff'),
+  crystal_caverns: naturalVisual('crystal_caverns', '◇', 'crystal', '#27324f', '#74e6ff', '#c9fbff'),
+  ancient_forest: naturalVisual('ancient_forest', '♣', 'forest', '#1f3f2a', '#7ccf6b', '#c5f7a7'),
+  coral_reef: naturalVisual('coral_reef', '◌', 'reef', '#174b5c', '#ff9eb5', '#8ef4ff'),
+  grand_canyon: naturalVisual('grand_canyon', '▱', 'canyon', '#5d3825', '#e28d4c', '#ffd28a'),
+  aurora_fields: naturalVisual('aurora_fields', '≈', 'aurora', '#24324d', '#9cf5d4', '#d4f7ff'),
+  frozen_falls: naturalVisual('frozen_falls', '❄', 'falls', '#29435a', '#aee8ff', '#effbff'),
+  dragon_bones: naturalVisual('dragon_bones', '✶', 'bones', '#3f342b', '#e4d5bd', '#fff2d3'),
+  singing_sands: naturalVisual('singing_sands', '∿', 'sands', '#6a4b25', '#f1cf73', '#fff0aa'),
+  sunken_ruins: naturalVisual('sunken_ruins', '⌂', 'ruins', '#173c52', '#6fd4c8', '#bdf7ef'),
+  floating_islands: naturalVisual('floating_islands', '⬡', 'islands', '#39405b', '#b8d77a', '#eef7b4'),
+  bioluminescent_bay: naturalVisual('bioluminescent_bay', '●', 'bay', '#123f55', '#39e6cb', '#b6fff4'),
+  bottomless_lake: naturalVisual('bottomless_lake', '◉', 'lake', '#17394a', '#5cb8ff', '#d0edff'),
+  eternal_storm: naturalVisual('eternal_storm', 'ϟ', 'storm', '#202943', '#b7c7ff', '#f1f5ff'),
+};
+
+const LEGENDARY_WONDER_VISUALS: Record<string, WonderVisualDefinition> = Object.fromEntries(
+  getLegendaryWonderDefinitions().map(definition => [
+    definition.id,
+    {
+      id: definition.id,
+      kind: 'legendary',
+      medallionGlyph: '✦',
+      palette: {
+        base: '#2b2633',
+        accent: '#e8c170',
+        glow: '#fff0b8',
+      },
+      mapLandmark: 'masked',
+      vignette: 'masked',
+      supportsAmbientAnimation: false,
+      reducedMotionFallback: 'static-medallion',
+      maskedLabel: 'Legendary wonder',
+    } satisfies WonderVisualDefinition,
+  ]),
+);
+
+const FALLBACK_WONDER_VISUAL: Omit<WonderVisualDefinition, 'id'> = {
+  kind: 'natural',
+  medallionGlyph: '?',
+  palette: {
+    base: '#2f3338',
+    accent: '#d8dde6',
+    glow: '#ffffff',
+  },
+  mapLandmark: 'masked',
+  vignette: 'masked',
+  supportsAmbientAnimation: false,
+  reducedMotionFallback: 'static-medallion',
+  maskedLabel: 'Unknown wonder',
+};
+
+const WONDER_VISUAL_CATALOG: Record<string, WonderVisualDefinition> = {
+  ...NATURAL_WONDER_VISUALS,
+  ...LEGENDARY_WONDER_VISUALS,
+};
+
+function naturalVisual(
+  id: string,
+  medallionGlyph: string,
+  mapLandmark: Exclude<WonderMapLandmark, 'masked'>,
+  base: string,
+  accent: string,
+  glow: string,
+): WonderVisualDefinition {
+  return {
+    id,
+    kind: 'natural',
+    medallionGlyph,
+    palette: { base, accent, glow },
+    mapLandmark,
+    vignette: mapLandmark,
+    supportsAmbientAnimation: true,
+    reducedMotionFallback: 'static-landmark',
+  };
+}
+
+export function getWonderVisualDefinition(wonderId: string): WonderVisualDefinition {
+  return WONDER_VISUAL_CATALOG[wonderId] ?? { ...FALLBACK_WONDER_VISUAL, id: wonderId };
+}
+
+export function getWonderVisualDefinitions(): WonderVisualDefinition[] {
+  return Object.values(WONDER_VISUAL_CATALOG).map(visual => ({
+    ...visual,
+    palette: { ...visual.palette },
+  }));
+}

--- a/src/ui/game-shell.ts
+++ b/src/ui/game-shell.ts
@@ -4,12 +4,13 @@ export interface GameShellCallbacks extends PrimaryActionBarCallbacks {
   onNextUnit: () => void;
   onOpenNotificationLog: () => void;
   onToggleIconLegend: () => void;
+  onOpenWonderAtlas: () => void;
   onOpenMenu: () => void;
   iconLegendOverlay?: HTMLElement;
 }
 
 function removeExistingShell(container: HTMLElement): void {
-  for (const id of ['game-shell', 'hud', 'bottom-bar', 'btn-next-unit', 'btn-notif-log', 'btn-icon-legend', 'notifications', 'info-panel', 'icon-legend']) {
+  for (const id of ['game-shell', 'hud', 'bottom-bar', 'btn-next-unit', 'btn-notif-log', 'btn-icon-legend', 'btn-wonder-atlas', 'notifications', 'info-panel', 'icon-legend']) {
     container.querySelector(`#${id}`)?.remove();
   }
 }
@@ -27,7 +28,7 @@ function createFloatingButton(id: string, text: string, title: string, right: nu
   button.type = 'button';
   button.textContent = text;
   button.title = title;
-  button.style.cssText = `position:absolute;top:44px;right:${right}px;z-index:21;background:rgba(0,0,0,0.6);border:1px solid rgba(255,255,255,0.2);border-radius:8px;color:white;font-size:14px;padding:4px 8px;cursor:pointer;`;
+  button.style.cssText = `position:absolute;top:44px;right:${right}px;z-index:21;min-height:44px;min-width:40px;background:rgba(0,0,0,0.6);border:1px solid rgba(255,255,255,0.2);border-radius:8px;color:white;font-size:14px;padding:4px 8px;cursor:pointer;`;
   button.addEventListener('click', () => onClick());
   return button;
 }
@@ -48,7 +49,8 @@ export function createGameShell(container: HTMLElement, callbacks: GameShellCall
 
   shell.appendChild(createFloatingButton('btn-notif-log', '📜', 'View message log', 52, callbacks.onOpenNotificationLog));
   shell.appendChild(createFloatingButton('btn-icon-legend', '🗺️', 'Toggle icon legend', 92, callbacks.onToggleIconLegend));
-  shell.appendChild(createFloatingButton('btn-pause-menu', '☰', 'Pause menu', 132, callbacks.onOpenMenu));
+  shell.appendChild(createFloatingButton('btn-wonder-atlas', '✦', 'Open Wonder Atlas', 132, callbacks.onOpenWonderAtlas));
+  shell.appendChild(createFloatingButton('btn-pause-menu', '☰', 'Pause menu', 172, callbacks.onOpenMenu));
 
   if (callbacks.iconLegendOverlay) {
     shell.appendChild(callbacks.iconLegendOverlay);

--- a/src/ui/wonder-atlas-panel.ts
+++ b/src/ui/wonder-atlas-panel.ts
@@ -1,0 +1,201 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { getWonderAtlasEntries, type NaturalWonderAtlasEntry, type WonderAtlasEntry } from '@/systems/wonder-atlas-presentation';
+import { createWonderVignette } from '@/ui/wonder-vignette';
+
+export interface WonderAtlasCallbacks {
+  onViewOnMap: (coord: HexCoord, wonderId: string) => void;
+  onClose: () => void;
+  initialWonderId?: string;
+  reducedMotion?: boolean;
+}
+
+type AtlasTab = 'natural' | 'legendary';
+
+function appendText(parent: HTMLElement, tag: keyof HTMLElementTagNameMap, text: string, style?: string): HTMLElement {
+  const el = document.createElement(tag);
+  el.textContent = text;
+  if (style) el.style.cssText = style;
+  parent.appendChild(el);
+  return el;
+}
+
+function createButton(text: string, style: string): HTMLButtonElement {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.textContent = text;
+  button.style.cssText = `min-height:44px;background:rgba(232,193,112,0.16);color:#f5e4b3;border:1px solid rgba(232,193,112,0.42);border-radius:8px;padding:8px 12px;cursor:pointer;${style}`;
+  return button;
+}
+
+function createEntryButton(entry: WonderAtlasEntry, selected: boolean): HTMLButtonElement {
+  const button = createButton('', selected ? 'background:rgba(232,193,112,0.28);' : 'background:rgba(255,255,255,0.06);color:#f7f1df;');
+  button.dataset.wonderEntry = entry.wonderId;
+  button.dataset.wonderKind = entry.kind;
+  button.style.display = 'grid';
+  button.style.gridTemplateColumns = '34px 1fr';
+  button.style.gap = '8px';
+  button.style.alignItems = 'center';
+  button.style.width = '100%';
+  button.style.textAlign = 'left';
+
+  const medallion = document.createElement('span');
+  medallion.textContent = entry.visual.medallionGlyph;
+  medallion.style.cssText = `width:34px;height:34px;border-radius:50%;display:grid;place-items:center;background:${entry.visual.palette.base};color:#fff;box-shadow:0 0 10px ${entry.visual.palette.glow};`;
+  button.appendChild(medallion);
+
+  const copy = document.createElement('span');
+  const title = document.createElement('strong');
+  title.textContent = entry.kind === 'legendary' ? entry.maskedLabel : entry.name;
+  title.style.cssText = 'display:block;font-size:13px;';
+  copy.appendChild(title);
+
+  const subtitle = document.createElement('span');
+  subtitle.textContent = entry.kind === 'legendary' ? entry.name : entry.locationLabel;
+  subtitle.style.cssText = 'display:block;font-size:11px;opacity:0.72;margin-top:2px;';
+  copy.appendChild(subtitle);
+  button.appendChild(copy);
+
+  return button;
+}
+
+function naturalEntries(entries: WonderAtlasEntry[]): NaturalWonderAtlasEntry[] {
+  return entries.filter((entry): entry is NaturalWonderAtlasEntry => entry.kind === 'natural');
+}
+
+function clearElement(el: HTMLElement): void {
+  el.textContent = '';
+}
+
+export function createWonderAtlasPanel(
+  container: HTMLElement,
+  state: GameState,
+  callbacks: WonderAtlasCallbacks,
+): HTMLElement {
+  container.querySelector('#wonder-atlas-panel')?.remove();
+
+  const entries = getWonderAtlasEntries(state, state.currentPlayer);
+  let activeTab: AtlasTab = callbacks.initialWonderId
+    && entries.some(entry => entry.kind === 'legendary' && entry.wonderId === callbacks.initialWonderId)
+    ? 'legendary'
+    : 'natural';
+  let selectedWonderId = callbacks.initialWonderId
+    ?? naturalEntries(entries)[0]?.wonderId
+    ?? entries.find(entry => entry.kind === 'legendary')?.wonderId
+    ?? null;
+
+  const panel = document.createElement('section');
+  panel.id = 'wonder-atlas-panel';
+  panel.style.cssText = 'position:absolute;top:72px;right:12px;bottom:92px;width:min(720px,calc(100vw - 24px));z-index:35;background:rgba(17,20,28,0.96);border:1px solid rgba(232,193,112,0.36);border-radius:10px;color:#f8f1df;box-shadow:0 18px 42px rgba(0,0,0,0.42);display:flex;flex-direction:column;overflow:hidden;';
+
+  const header = document.createElement('header');
+  header.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 14px;border-bottom:1px solid rgba(255,255,255,0.10);';
+  const titleBlock = document.createElement('div');
+  appendText(titleBlock, 'h2', 'Wonder Atlas', 'margin:0;font-size:18px;');
+  appendText(titleBlock, 'p', 'Discovered marvels and masked legendary ambitions.', 'margin:2px 0 0;font-size:12px;opacity:0.72;');
+  header.appendChild(titleBlock);
+  const close = createButton('Close', 'background:rgba(255,255,255,0.08);color:#fff;border-color:rgba(255,255,255,0.24);');
+  close.dataset.wonderAtlasClose = 'true';
+  close.addEventListener('click', () => {
+    panel.remove();
+    callbacks.onClose();
+  });
+  header.appendChild(close);
+  panel.appendChild(header);
+
+  const tabs = document.createElement('div');
+  tabs.style.cssText = 'display:flex;gap:8px;padding:10px 14px;border-bottom:1px solid rgba(255,255,255,0.08);';
+  panel.appendChild(tabs);
+
+  const body = document.createElement('div');
+  body.style.cssText = 'display:grid;grid-template-columns:minmax(210px,280px) 1fr;min-height:0;flex:1;';
+  panel.appendChild(body);
+
+  const list = document.createElement('div');
+  list.style.cssText = 'padding:12px;overflow:auto;border-right:1px solid rgba(255,255,255,0.08);display:flex;flex-direction:column;gap:8px;';
+  body.appendChild(list);
+
+  const detail = document.createElement('div');
+  detail.dataset.wonderDetail = 'true';
+  detail.style.cssText = 'padding:16px;overflow:auto;display:flex;gap:16px;align-items:flex-start;';
+  body.appendChild(detail);
+
+  function visibleEntries(): WonderAtlasEntry[] {
+    return entries.filter(entry => activeTab === 'natural' ? entry.kind === 'natural' : entry.kind === 'legendary');
+  }
+
+  function selectedEntry(): WonderAtlasEntry | null {
+    return entries.find(entry => entry.wonderId === selectedWonderId) ?? visibleEntries()[0] ?? null;
+  }
+
+  function renderTabs(): void {
+    clearElement(tabs);
+    for (const [tab, label] of [['natural', 'Known Natural'], ['legendary', 'Legendary']] as const) {
+      const button = createButton(label, activeTab === tab ? 'background:rgba(232,193,112,0.28);' : 'background:rgba(255,255,255,0.05);color:#f8f1df;border-color:rgba(255,255,255,0.18);');
+      button.dataset.atlasTab = tab;
+      button.addEventListener('click', () => {
+        activeTab = tab;
+        selectedWonderId = visibleEntries()[0]?.wonderId ?? null;
+        render();
+      });
+      tabs.appendChild(button);
+    }
+  }
+
+  function renderList(): void {
+    clearElement(list);
+    const visible = visibleEntries();
+    if (visible.length === 0 && activeTab === 'natural') {
+      appendText(list, 'p', 'No natural wonders discovered yet.', 'font-size:13px;opacity:0.74;margin:0;');
+      return;
+    }
+
+    for (const entry of visible) {
+      const button = createEntryButton(entry, entry.wonderId === selectedWonderId);
+      button.addEventListener('click', () => {
+        selectedWonderId = entry.wonderId;
+        render();
+      });
+      list.appendChild(button);
+    }
+  }
+
+  function renderDetail(): void {
+    clearElement(detail);
+    const entry = selectedEntry();
+    if (!entry) {
+      appendText(detail, 'p', activeTab === 'natural' ? 'No natural wonders discovered yet.' : 'No legendary wonders recorded.', 'margin:0;opacity:0.72;');
+      return;
+    }
+
+    detail.appendChild(createWonderVignette(entry, { reducedMotion: callbacks.reducedMotion }));
+    const copy = document.createElement('div');
+    copy.style.cssText = 'min-width:0;display:flex;flex-direction:column;gap:8px;';
+    appendText(copy, 'h3', entry.name, 'margin:0;font-size:20px;');
+
+    if (entry.kind === 'natural') {
+      appendText(copy, 'p', entry.locationLabel, 'margin:0;font-size:12px;color:#e8c170;');
+      appendText(copy, 'p', entry.effectSummary, 'margin:0;font-size:13px;line-height:1.45;');
+      if (entry.coord) {
+        const view = createButton('View on map', 'align-self:flex-start;margin-top:6px;');
+        view.dataset.viewWonderOnMap = entry.wonderId;
+        view.addEventListener('click', () => callbacks.onViewOnMap(entry.coord!, entry.wonderId));
+        copy.appendChild(view);
+      }
+    } else {
+      appendText(copy, 'p', entry.maskedLabel, 'margin:0;font-size:12px;color:#e8c170;');
+      appendText(copy, 'p', 'A legendary ambition recorded for future construction and completion presence.', 'margin:0;font-size:13px;line-height:1.45;opacity:0.78;');
+    }
+
+    detail.appendChild(copy);
+  }
+
+  function render(): void {
+    renderTabs();
+    renderList();
+    renderDetail();
+  }
+
+  render();
+  container.appendChild(panel);
+  return panel;
+}

--- a/src/ui/wonder-atlas-panel.ts
+++ b/src/ui/wonder-atlas-panel.ts
@@ -80,7 +80,6 @@ export function createWonderAtlasPanel(
     : 'natural';
   let selectedWonderId = callbacks.initialWonderId
     ?? naturalEntries(entries)[0]?.wonderId
-    ?? entries.find(entry => entry.kind === 'legendary')?.wonderId
     ?? null;
 
   const panel = document.createElement('section');
@@ -124,7 +123,8 @@ export function createWonderAtlasPanel(
   }
 
   function selectedEntry(): WonderAtlasEntry | null {
-    return entries.find(entry => entry.wonderId === selectedWonderId) ?? visibleEntries()[0] ?? null;
+    const visible = visibleEntries();
+    return visible.find(entry => entry.wonderId === selectedWonderId) ?? visible[0] ?? null;
   }
 
   function renderTabs(): void {

--- a/src/ui/wonder-vignette.ts
+++ b/src/ui/wonder-vignette.ts
@@ -1,0 +1,84 @@
+import type { WonderAtlasEntry } from '@/systems/wonder-atlas-presentation';
+import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface WonderVignetteOptions {
+  reducedMotion?: boolean;
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function createSvgElement(name: string): SVGElement {
+  return document.createElementNS('http://www.w3.org/2000/svg', name);
+}
+
+function appendShape(svg: SVGSVGElement, visual: WonderVisualDefinition, reducedMotion: boolean): void {
+  const base = createSvgElement('circle');
+  base.setAttribute('cx', '50');
+  base.setAttribute('cy', '50');
+  base.setAttribute('r', '34');
+  base.setAttribute('fill', visual.palette.base);
+  base.setAttribute('opacity', '0.92');
+  svg.appendChild(base);
+
+  const accent = createSvgElement('path');
+  const shapeByVignette: Record<string, string> = {
+    aurora: 'M18 56 C34 22, 54 82, 82 28',
+    bay: 'M18 56 C30 42, 46 66, 62 50 S80 54, 88 40',
+    bones: 'M24 66 L74 34 M32 30 L80 72',
+    canyon: 'M18 36 L40 62 L55 38 L82 68',
+    crystal: 'M50 16 L74 46 L58 84 L28 66 L34 34 Z',
+    falls: 'M36 18 L66 18 L58 78 L42 78 Z',
+    forest: 'M50 16 L74 54 H62 L80 78 H20 L38 54 H26 Z',
+    islands: 'M28 60 L42 34 L56 60 M48 54 L66 24 L82 54',
+    lake: 'M20 55 C32 35, 68 35, 80 55 C68 76, 32 76, 20 55',
+    mountain: 'M18 74 L46 24 L58 48 L70 30 L88 74 Z',
+    reef: 'M25 70 C28 42, 42 64, 42 34 M50 74 C50 40, 66 64, 72 34',
+    ruins: 'M24 74 H78 M32 74 V32 H70 V74 M44 74 V44 H58 V74',
+    sands: 'M16 58 C34 42, 50 74, 84 50 M18 72 C42 54, 58 82, 86 66',
+    storm: 'M56 14 L28 54 H48 L38 86 L76 42 H54 Z',
+    volcano: 'M18 78 L40 26 L50 54 L60 26 L84 78 Z',
+  };
+  accent.setAttribute('d', shapeByVignette[visual.vignette] ?? shapeByVignette.crystal);
+  accent.setAttribute('fill', 'none');
+  accent.setAttribute('stroke', visual.palette.accent);
+  accent.setAttribute('stroke-width', '7');
+  accent.setAttribute('stroke-linecap', 'round');
+  accent.setAttribute('stroke-linejoin', 'round');
+  svg.appendChild(accent);
+
+  const glow = createSvgElement('circle');
+  glow.setAttribute('cx', '50');
+  glow.setAttribute('cy', '50');
+  glow.setAttribute('r', reducedMotion ? '38' : '41');
+  glow.setAttribute('fill', 'none');
+  glow.setAttribute('stroke', visual.palette.glow);
+  glow.setAttribute('stroke-width', '3');
+  glow.setAttribute('opacity', reducedMotion ? '0.45' : '0.72');
+  svg.appendChild(glow);
+}
+
+export function createWonderVignette(entry: WonderAtlasEntry, options: WonderVignetteOptions = {}): HTMLElement {
+  const reducedMotion = options.reducedMotion ?? prefersReducedMotion();
+  const wrapper = document.createElement('div');
+  wrapper.dataset.vignetteMotion = reducedMotion ? 'static' : 'ambient';
+  wrapper.style.cssText = 'position:relative;width:118px;height:118px;flex:0 0 118px;display:grid;place-items:center;';
+
+  const svg = createSvgElement('svg') as SVGSVGElement;
+  svg.setAttribute('viewBox', '0 0 100 100');
+  svg.setAttribute('role', 'img');
+  svg.style.cssText = `width:112px;height:112px;filter:drop-shadow(0 0 12px ${entry.visual.palette.glow});`;
+  svg.setAttribute('aria-label', `${entry.name} vignette`);
+  appendShape(svg, entry.visual, reducedMotion || entry.kind === 'legendary');
+  wrapper.appendChild(svg);
+
+  const glyph = document.createElement('div');
+  glyph.textContent = entry.visual.medallionGlyph;
+  glyph.style.cssText = 'position:absolute;inset:0;display:grid;place-items:center;font-size:30px;font-weight:700;color:white;text-shadow:0 2px 8px rgba(0,0,0,0.65);';
+  wrapper.appendChild(glyph);
+
+  return wrapper;
+}

--- a/tests/input/wonder-atlas-intent.test.ts
+++ b/tests/input/wonder-atlas-intent.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, VisibilityMap } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
+
+function makeState(): GameState {
+  const state = createNewGame(undefined, 'wonder-atlas-intent-test');
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.wonder = null;
+  }
+  state.map.tiles[hexKey({ q: 0, r: 0 })].wonder = 'great_volcano';
+  state.discoveredWonders = { great_volcano: 'player' };
+  state.wonderDiscoverers = { great_volcano: ['player'] };
+  state.civilizations.player.visibility = {
+    tiles: { '0,0': 'visible' },
+  } as VisibilityMap;
+  return state;
+}
+
+describe('wonder-atlas-intent', () => {
+  it('opens the Atlas for a discovered visible natural wonder tile', () => {
+    const state = makeState();
+
+    expect(resolveWonderAtlasIntent(state, 'player', { q: 0, r: 0 })).toEqual({
+      type: 'open-atlas',
+      wonderId: 'great_volcano',
+      coord: { q: 0, r: 0 },
+    });
+  });
+
+  it('does not open the Atlas for a wonder unknown to the viewer', () => {
+    const state = makeState();
+    state.wonderDiscoverers.great_volcano = ['ai-1'];
+
+    expect(resolveWonderAtlasIntent(state, 'player', { q: 0, r: 0 })).toEqual({ type: 'none' });
+  });
+
+  it('does not open the Atlas for unexplored wonder tiles', () => {
+    const state = makeState();
+    state.civilizations.player.visibility = {
+      tiles: { '0,0': 'unexplored' },
+    } as VisibilityMap;
+
+    expect(resolveWonderAtlasIntent(state, 'player', { q: 0, r: 0 })).toEqual({ type: 'none' });
+  });
+
+  it('opens from last-seen fog when the viewer-safe snapshot contains the discovered wonder', () => {
+    const state = makeState();
+    state.map.tiles[hexKey({ q: 0, r: 0 })].wonder = null;
+    state.civilizations.player.visibility = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'volcanic',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: 'great_volcano',
+        },
+      },
+    } as VisibilityMap;
+
+    expect(resolveWonderAtlasIntent(state, 'player', { q: 0, r: 0 })).toMatchObject({
+      type: 'open-atlas',
+      wonderId: 'great_volcano',
+    });
+  });
+
+  it('normalizes wrapped coordinates before resolving the wonder', () => {
+    const state = makeState();
+    state.map.wrapsHorizontally = true;
+    state.map.width = 4;
+
+    expect(resolveWonderAtlasIntent(state, 'player', { q: 4, r: 0 })).toEqual({
+      type: 'open-atlas',
+      wonderId: 'great_volcano',
+      coord: { q: 0, r: 0 },
+    });
+  });
+});

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -5,6 +5,7 @@ import type { GameMap, VisibilityMap } from '@/core/types';
 
 class MockCanvasContext {
   strokeCalls: string[] = [];
+  textCalls: string[] = [];
   fillStyle = '';
   strokeStyle = '';
   lineWidth = 0;
@@ -15,12 +16,18 @@ class MockCanvasContext {
   shadowColor = '';
   shadowBlur = 0;
 
+  save(): void {}
+  restore(): void {}
   beginPath(): void {}
   moveTo(): void {}
   lineTo(): void {}
+  bezierCurveTo(): void {}
+  arc(): void {}
   closePath(): void {}
   fill(): void {}
-  fillText(): void {}
+  fillText(text: string): void {
+    this.textCalls.push(text);
+  }
   stroke(): void {
     this.strokeCalls.push(this.strokeStyle);
   }
@@ -105,6 +112,17 @@ describe('hex renderer privacy', () => {
     drawHexMap(ctx, makeMap(), makeCamera(), undefined, 'player', visibility);
 
     expect((ctx as unknown as MockCanvasContext).strokeCalls).toContain('rgba(74,144,217,0.5)');
+  });
+
+  it('does not draw the old generic star glyph for natural wonders', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeMap();
+    map.tiles['0,0'].wonder = 'great_volcano';
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible', '1,0': 'visible' } };
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibility);
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('✦');
   });
 
   it('draws only visible minor-civ territory hexes', () => {

--- a/tests/renderer/natural-wonder-renderer.test.ts
+++ b/tests/renderer/natural-wonder-renderer.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { drawNaturalWonderLandmark } from '@/renderer/wonders/natural-wonder-renderer';
+
+class MockCanvasContext {
+  operations: string[] = [];
+  fillStyle = '';
+  strokeStyle = '';
+  lineWidth = 0;
+  globalAlpha = 1;
+
+  save(): void { this.operations.push('save'); }
+  restore(): void { this.operations.push('restore'); }
+  beginPath(): void { this.operations.push('beginPath'); }
+  moveTo(): void { this.operations.push('moveTo'); }
+  lineTo(): void { this.operations.push('lineTo'); }
+  quadraticCurveTo(): void { this.operations.push('quadraticCurveTo'); }
+  bezierCurveTo(): void { this.operations.push('bezierCurveTo'); }
+  arc(): void { this.operations.push('arc'); }
+  ellipse(): void { this.operations.push('ellipse'); }
+  closePath(): void { this.operations.push('closePath'); }
+  fill(): void { this.operations.push(`fill:${this.fillStyle}`); }
+  stroke(): void { this.operations.push(`stroke:${this.strokeStyle}`); }
+}
+
+describe('natural-wonder-renderer', () => {
+  it('draws a known natural wonder landmark without throwing', () => {
+    const ctx = new MockCanvasContext();
+
+    drawNaturalWonderLandmark({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 40,
+      cy: 40,
+      size: 32,
+      wonderId: 'great_volcano',
+      presentationKind: 'live',
+      nowMs: 1200,
+      reducedMotion: false,
+    });
+
+    expect(ctx.operations).toContain('save');
+    expect(ctx.operations).toContain('restore');
+    expect(ctx.operations.some(operation => operation.startsWith('fill:'))).toBe(true);
+  });
+
+  it('uses a safe fallback for unknown wonder visuals', () => {
+    const ctx = new MockCanvasContext();
+
+    drawNaturalWonderLandmark({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 40,
+      cy: 40,
+      size: 32,
+      wonderId: 'missing-wonder',
+      presentationKind: 'last-seen',
+      nowMs: 2400,
+      reducedMotion: true,
+    });
+
+    expect(ctx.operations).toContain('save');
+    expect(ctx.operations).toContain('restore');
+  });
+});

--- a/tests/systems/wonder-atlas-presentation.test.ts
+++ b/tests/systems/wonder-atlas-presentation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { hexKey } from '@/systems/hex-utils';
+import { getWonderAtlasEntries } from '@/systems/wonder-atlas-presentation';
+
+function makeAtlasState(): GameState {
+  const state = createNewGame(undefined, 'wonder-atlas-presentation-test');
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.wonder = null;
+    tile.owner = null;
+  }
+
+  const tile = state.map.tiles[hexKey({ q: 0, r: 0 })];
+  tile.wonder = 'great_volcano';
+  tile.owner = 'ai-1';
+  state.discoveredWonders = {};
+  state.wonderDiscoverers = {};
+  return state;
+}
+
+describe('wonder-atlas-presentation', () => {
+  it('omits undiscovered natural wonders without leaking their count or details', () => {
+    const state = makeAtlasState();
+
+    const entries = getWonderAtlasEntries(state, 'player');
+
+    expect(entries.filter(entry => entry.kind === 'natural')).toHaveLength(0);
+    expect(entries.some(entry => entry.wonderId === 'great_volcano')).toBe(false);
+  });
+
+  it('shows discovered natural wonders with safe static details', () => {
+    const state = makeAtlasState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+
+    const entries = getWonderAtlasEntries(state, 'player');
+    const volcano = entries.find(entry => entry.kind === 'natural' && entry.wonderId === 'great_volcano');
+
+    expect(volcano).toMatchObject({
+      kind: 'natural',
+      visibility: 'discovered',
+      name: 'Great Volcano',
+      locationLabel: 'Q0, R0',
+      canViewOnMap: true,
+      coord: { q: 0, r: 0 },
+    });
+    expect(volcano?.effectSummary).toContain('Yields');
+  });
+
+  it('scopes natural wonder visibility to the requested viewer', () => {
+    const state = makeAtlasState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['ai-1'];
+
+    expect(getWonderAtlasEntries(state, 'player').some(entry => entry.wonderId === 'great_volcano')).toBe(false);
+    expect(getWonderAtlasEntries(state, 'ai-1').some(entry => entry.wonderId === 'great_volcano')).toBe(true);
+  });
+
+  it('does not expose live hidden tile details for discovered natural wonders', () => {
+    const state = makeAtlasState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+    state.map.tiles[hexKey({ q: 0, r: 0 })].terrain = 'volcanic';
+    state.map.tiles[hexKey({ q: 0, r: 0 })].owner = 'ai-1';
+
+    const volcano = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'natural' && entry.wonderId === 'great_volcano');
+
+    expect(volcano).toBeTruthy();
+    expect('terrain' in (volcano as object)).toBe(false);
+    expect('owner' in (volcano as object)).toBe(false);
+  });
+
+  it('omits View on map when a discovered wonder has no resolvable coordinate', () => {
+    const state = makeAtlasState();
+    state.map.tiles[hexKey({ q: 0, r: 0 })].wonder = null;
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+
+    const volcano = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'natural' && entry.wonderId === 'great_volcano');
+
+    expect(volcano).toMatchObject({
+      coord: null,
+      canViewOnMap: false,
+      locationLabel: 'Location unknown',
+    });
+  });
+
+  it('includes masked legendary slots without implying buildability', () => {
+    const state = makeAtlasState();
+
+    const legendaryEntries = getWonderAtlasEntries(state, 'player')
+      .filter(entry => entry.kind === 'legendary');
+
+    expect(legendaryEntries).toHaveLength(getLegendaryWonderDefinitions().length);
+    expect(legendaryEntries[0]).toMatchObject({
+      kind: 'legendary',
+      visibility: 'masked',
+      canViewOnMap: false,
+      maskedLabel: 'Legendary wonder',
+    });
+    expect('canStartBuild' in legendaryEntries[0]).toBe(false);
+  });
+});

--- a/tests/systems/wonder-atlas-presentation.test.ts
+++ b/tests/systems/wonder-atlas-presentation.test.ts
@@ -46,7 +46,9 @@ describe('wonder-atlas-presentation', () => {
       canViewOnMap: true,
       coord: { q: 0, r: 0 },
     });
-    expect(volcano?.effectSummary).toContain('Yields');
+    expect(volcano?.kind).toBe('natural');
+    if (volcano?.kind !== 'natural') throw new Error('expected natural wonder entry');
+    expect(volcano.effectSummary).toContain('Yields');
   });
 
   it('scopes natural wonder visibility to the requested viewer', () => {

--- a/tests/systems/wonder-visual-catalog.test.ts
+++ b/tests/systems/wonder-visual-catalog.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { WONDER_DEFINITIONS } from '@/systems/wonder-definitions';
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+describe('wonder visual catalog', () => {
+  it('covers every natural wonder with map and vignette identity', () => {
+    for (const wonder of WONDER_DEFINITIONS) {
+      const visual = getWonderVisualDefinition(wonder.id);
+
+      expect(visual.id).toBe(wonder.id);
+      expect(visual.kind).toBe('natural');
+      expect(visual.medallionGlyph.length).toBeGreaterThan(0);
+      expect(visual.mapLandmark).not.toBe('masked');
+      expect(visual.vignette).not.toBe('masked');
+      expect(visual.palette.base).toMatch(/^#/);
+      expect(visual.palette.accent).toMatch(/^#/);
+      expect(visual.palette.glow).toMatch(/^#/);
+      expect(visual.reducedMotionFallback).toBe('static-landmark');
+    }
+  });
+
+  it('covers every legendary wonder with masked medallion metadata', () => {
+    for (const wonder of getLegendaryWonderDefinitions()) {
+      const visual = getWonderVisualDefinition(wonder.id);
+
+      expect(visual.id).toBe(wonder.id);
+      expect(visual.kind).toBe('legendary');
+      expect(visual.medallionGlyph.length).toBeGreaterThan(0);
+      expect(visual.mapLandmark).toBe('masked');
+      expect(visual.vignette).toBe('masked');
+      expect(visual.maskedLabel).toBeTruthy();
+      expect(visual.reducedMotionFallback).toBe('static-medallion');
+    }
+  });
+
+  it('returns a safe static fallback for unknown wonder ids', () => {
+    const visual = getWonderVisualDefinition('missing-wonder');
+
+    expect(visual.id).toBe('missing-wonder');
+    expect(visual.kind).toBe('natural');
+    expect(visual.mapLandmark).toBe('masked');
+    expect(visual.vignette).toBe('masked');
+    expect(visual.supportsAmbientAnimation).toBe(false);
+  });
+});

--- a/tests/ui/game-shell.test.ts
+++ b/tests/ui/game-shell.test.ts
@@ -20,6 +20,7 @@ describe('game-shell', () => {
       onNextUnit: () => {},
       onOpenNotificationLog: () => {},
       onToggleIconLegend: () => {},
+      onOpenWonderAtlas: () => {},
       onOpenMenu: () => {},
     });
 
@@ -34,6 +35,7 @@ describe('game-shell', () => {
       onNextUnit: () => {},
       onOpenNotificationLog: () => {},
       onToggleIconLegend: () => {},
+      onOpenWonderAtlas: () => {},
       onOpenMenu: () => {},
     });
 
@@ -42,5 +44,31 @@ describe('game-shell', () => {
     expect(shell.textContent).toContain('Council');
     expect(shell.textContent).toContain('End Turn');
     expect(shell.querySelector('#btn-next-unit')).toBeTruthy();
+  });
+
+  it('exposes the Wonder Atlas from the live shell', () => {
+    let opened = false;
+    const shell = createGameShell(document.body, {
+      onOpenCouncil: () => {},
+      onOpenTech: () => {},
+      onOpenCity: () => {},
+      onOpenEspionage: () => {},
+      onOpenDiplomacy: () => {},
+      onOpenMarketplace: () => {},
+      onEndTurn: () => {},
+      onNextUnit: () => {},
+      onOpenNotificationLog: () => {},
+      onToggleIconLegend: () => {},
+      onOpenWonderAtlas: () => { opened = true; },
+      onOpenMenu: () => {},
+    });
+
+    const button = shell.querySelector<HTMLButtonElement>('#btn-wonder-atlas');
+    expect(button).toBeTruthy();
+    expect(button?.title).toBe('Open Wonder Atlas');
+
+    button!.click();
+
+    expect(opened).toBe(true);
   });
 });

--- a/tests/ui/wonder-atlas-panel.test.ts
+++ b/tests/ui/wonder-atlas-panel.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
+
+function click(element: Element | null | undefined): void {
+  expect(element).toBeTruthy();
+  element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+function makeState(): GameState {
+  const state = createNewGame(undefined, 'wonder-atlas-ui-test');
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.wonder = null;
+  }
+  state.map.tiles[hexKey({ q: 0, r: 0 })].wonder = 'great_volcano';
+  state.discoveredWonders = {};
+  state.wonderDiscoverers = {};
+  return state;
+}
+
+describe('wonder-atlas-panel', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false, addEventListener: vi.fn(), removeEventListener: vi.fn() }),
+    });
+  });
+
+  it('renders a useful empty Known Natural state without fake unknown wonder cards', () => {
+    const state = makeState();
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.id).toBe('wonder-atlas-panel');
+    expect(panel.textContent).toContain('No natural wonders discovered yet.');
+    expect(panel.textContent).not.toContain('Great Volcano');
+    expect(panel.querySelectorAll('[data-wonder-kind="natural"]')).toHaveLength(0);
+  });
+
+  it('selects a discovered natural wonder and updates the vignette immediately', () => {
+    const state = makeState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+
+    click(panel.querySelector('[data-wonder-entry="great_volcano"]'));
+
+    expect(panel.querySelector('[data-wonder-detail]')?.textContent).toContain('Great Volcano');
+    expect(panel.querySelector('[data-wonder-detail]')?.textContent).toContain('Q0, R0');
+    expect(panel.querySelector('[data-wonder-detail]')?.textContent).toContain('Yields');
+  });
+
+  it('calls View on map for a discovered wonder with a coordinate', () => {
+    const state = makeState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+    const onViewOnMap = vi.fn();
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap,
+      onClose: () => {},
+    });
+    click(panel.querySelector('[data-wonder-entry="great_volcano"]'));
+    click(panel.querySelector('[data-view-wonder-on-map="great_volcano"]'));
+
+    expect(onViewOnMap).toHaveBeenCalledWith({ q: 0, r: 0 }, 'great_volcano');
+  });
+
+  it('omits View on map when the discovered coordinate is unavailable', () => {
+    const state = makeState();
+    state.map.tiles[hexKey({ q: 0, r: 0 })].wonder = null;
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+    click(panel.querySelector('[data-wonder-entry="great_volcano"]'));
+
+    expect(panel.querySelector('[data-view-wonder-on-map="great_volcano"]')).toBeNull();
+    expect(panel.textContent).toContain('Location unknown');
+  });
+
+  it('renders legendary wonders as masked slots only', () => {
+    const state = makeState();
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+    click(panel.querySelector('[data-atlas-tab="legendary"]'));
+
+    expect(panel.querySelectorAll('[data-wonder-kind="legendary"]').length).toBeGreaterThan(0);
+    expect(panel.textContent).toContain('Legendary wonder');
+    expect(panel.textContent).not.toContain('Start Construction');
+  });
+
+  it('uses a static vignette when reduced motion is requested', () => {
+    const state = makeState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['player'];
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+      reducedMotion: true,
+    });
+    click(panel.querySelector('[data-wonder-entry="great_volcano"]'));
+
+    expect(panel.querySelector('[data-vignette-motion="static"]')).toBeTruthy();
+  });
+
+  it('refreshes visibility when reopened for a different current player', () => {
+    const state = makeState();
+    state.discoveredWonders.great_volcano = 'player';
+    state.wonderDiscoverers.great_volcano = ['ai-1'];
+
+    createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+    expect(document.body.textContent).not.toContain('Great Volcano');
+
+    state.currentPlayer = 'ai-1';
+    createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+
+    expect(document.querySelectorAll('#wonder-atlas-panel')).toHaveLength(1);
+    expect(document.body.textContent).toContain('Great Volcano');
+  });
+});

--- a/tests/ui/wonder-atlas-panel.test.ts
+++ b/tests/ui/wonder-atlas-panel.test.ts
@@ -42,6 +42,7 @@ describe('wonder-atlas-panel', () => {
     expect(panel.id).toBe('wonder-atlas-panel');
     expect(panel.textContent).toContain('No natural wonders discovered yet.');
     expect(panel.textContent).not.toContain('Great Volcano');
+    expect(panel.querySelector('[data-wonder-detail]')?.textContent).not.toContain('Legendary wonder');
     expect(panel.querySelectorAll('[data-wonder-kind="natural"]')).toHaveLength(0);
   });
 


### PR DESCRIPTION
## Summary
- Adds the Stage 2A Wonder Atlas spec and implementation foundations.
- Adds viewer-safe Atlas presentation, medallion/vignette visuals, masked legendary slots, and a live shell entry point.
- Replaces the generic natural-wonder map star with Canvas landmark rendering and adds discovered-wonder map deep-links.

## Gameplay / UX Impact
- Players can open a global Wonder Atlas from the game shell.
- Discovered natural wonders are inspectable with safe details and `View on map`; undiscovered natural wonders remain fully hidden.
- Legendary wonders appear as masked Atlas slots only, without implying buildability.

## Out of scope
- Stage 2B discovery reveal ceremonies.
- Stage 2C legendary construction/completion spectacle.
- Stage 2D full 2D Atlas expansion.
- Stage 3 real video spike.
- Any changes to natural wonder placement, yields, discovery rules, AI behavior, save format, or legendary construction rules.

## Why this is safe to merge partial
This PR ships complete player-visible surfaces for Stage 2A: the shell Atlas button opens a real Atlas panel, visible Atlas entries are selectable, `View on map` is wired for discovered coordinates, and map landmarks render through the live Canvas path. Later stages add spectacle and richer content, but no Stage 2A button or catalog entry points to an omitted dead-end flow.

## Test Plan
- [x] `scripts/check-src-rule-violations.sh src/systems/wonder-visual-catalog.ts src/systems/wonder-atlas-presentation.ts src/ui/wonder-vignette.ts src/ui/wonder-atlas-panel.ts src/ui/game-shell.ts src/main.ts src/renderer/wonders/natural-wonder-renderer.ts src/renderer/hex-renderer.ts src/input/wonder-atlas-intent.ts`
- [x] `./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-visual-catalog.test.ts tests/systems/wonder-atlas-presentation.test.ts tests/ui/wonder-atlas-panel.test.ts tests/ui/game-shell.test.ts tests/renderer/natural-wonder-renderer.test.ts tests/renderer/hex-renderer.test.ts tests/input/wonder-atlas-intent.test.ts`
- [x] `./scripts/run-wonder-regressions.sh`
- [x] `./scripts/run-with-mise.sh yarn build`
- [x] `./scripts/run-with-mise.sh yarn test`