### PR TITLE
[codex] Add wonder discovery reveal ceremonies

### DIFF
--- a/docs/superpowers/plans/2026-05-21-wonder-discovery-reveal.md
+++ b/docs/superpowers/plans/2026-05-21-wonder-discovery-reveal.md
@@ -1,0 +1,1356 @@
+# Wonder Discovery Reveal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Stage 2B natural wonder discovery ceremonies: a skippable full-screen medallion reveal for eligible human discoveries, followed by a map pulse and optional Wonder Atlas deep link.
+
+**Architecture:** Keep gameplay mutation in the existing wonder discovery path and add presentation-only layers around the emitted `wonder:discovered` event. A pure system helper builds viewer-safe reveal items, DOM UI renders and resolves the ceremony once, a queue coordinator controls ordering and blocking, and the render loop owns the non-mutating map pulse.
+
+**Tech Stack:** TypeScript, Vitest, jsdom UI tests, Canvas 2D render loop, existing EventBus, existing Wonder Atlas and vignette modules. Designed for GPT-5.4 on medium effort.
+
+---
+
+## File Structure
+
+- Create `src/systems/wonder-presentation-formatting.ts`
+  - Shared formatting for natural wonder yield/effect and discovery reward summaries.
+  - Prevents duplicating effect summary logic between Atlas and discovery reveal.
+- Modify `src/systems/wonder-atlas-presentation.ts`
+  - Use `formatNaturalWonderEffectSummary` from the shared formatting helper.
+- Modify `src/core/types.ts`
+  - Add optional `revealLine?: string` to `WonderDefinition`.
+- Create `src/systems/wonder-discovery-reveal.ts`
+  - Pure helper that converts an eligible `wonder:discovered` event into a viewer-safe reveal item.
+  - Returns `null` for AI, wrong viewer, unknown wonder, or unusable coordinates.
+- Create `tests/systems/wonder-discovery-reveal.test.ts`
+  - Covers eligibility, privacy, summaries, event coordinates, and the future motion hook.
+- Modify `src/ui/wonder-vignette.ts`
+  - Export a small `createWonderVisualVignette` helper so the ceremony can reuse Stage 2A medallion identity without constructing a fake Atlas entry.
+- Create `src/ui/wonder-discovery-ceremony.ts`
+  - Full-screen DOM overlay with `Continue`, `Open Atlas`, `Skip`, reduced-motion static mode, and exactly-once resolution.
+- Create `tests/ui/wonder-discovery-ceremony.test.ts`
+  - Covers rendered text/actions, repeat clicks, reduced motion, safe text insertion, and selected actions.
+- Create `src/ui/wonder-discovery-queue.ts`
+  - Session-only queue for reveal items. Waits for action-settled and blocking-UI clearance, presents one ceremony at a time, requests map highlight, and opens Atlas after highlight request when selected.
+- Create `tests/ui/wonder-discovery-queue.test.ts`
+  - Covers queue order, blocking, dedupe, action-settled gating, pulse requests, Atlas callback, and no state mutation.
+- Modify `src/renderer/animation-system.ts`
+  - Add `wonder-discovery-pulse` and `wonder-discovery-static-highlight` render cases.
+- Modify `src/renderer/render-loop.ts`
+  - Add `requestWonderDiscoveryHighlight(coord, visual, options)` that centers the camera, converts the event coordinate to pixels, and schedules the render-only highlight.
+- Create `tests/renderer/wonder-discovery-highlight.test.ts`
+  - Covers animated and reduced-motion highlight requests and verifies selected highlights/state are not mutated.
+- Modify `src/main.ts`
+  - Instantiate the queue, build reveal items inside the existing `wonder:discovered` listener after current log behavior, notify queue when movement animation settles, and wire `Open Atlas` to `openWonderAtlas(wonderId)`.
+
+## Player Truth Table
+
+| Before | Action | Internal State | Immediate Visible Result | Must Remain Reachable |
+|---|---|---|---|---|
+| Scout movement reveals a natural wonder for the active human civ | Movement finishes | Existing discovery state and rewards are already applied by `processWonderDiscovery`; reveal item is queued | Ceremony appears after the movement animation settles | Map, notification log, Atlas button |
+| Ceremony is visible and animation is still playing | Click `Skip` | No gameplay state changes; ceremony resolves with action `skip` | Overlay disappears, camera centers on event coordinate, map highlight appears | Existing selection/movement state is not changed |
+| Ceremony is visible | Click `Continue` | No gameplay state changes; ceremony resolves with action `continue` | Overlay disappears, camera centers on event coordinate, map highlight appears | Wonder Atlas remains available from shell |
+| Ceremony is visible | Click `Open Atlas` | No gameplay state changes; ceremony resolves with action `open-atlas` | Overlay disappears, map highlight request fires, Atlas opens to the discovered entry | Atlas close and View on map still work |
+| Two wonders are discovered in one action | Resolve first ceremony | Queue shifts first item only | Second ceremony appears only after first resolution and highlight request | No second overlay overlaps the first |
+| Another blocking overlay is active | Discovery event arrives | Reveal item remains queued | No wonder ceremony stacks on top | Existing blocking overlay remains in control |
+| Reduced motion is enabled | Discovery event resolves | No gameplay state changes | Static ceremony card appears; static map highlight is requested | Continue, Open Atlas, Skip all remain present |
+| AI discovers a natural wonder | Event is emitted | Existing discovery/log behavior remains | No ceremony appears for the human viewer | Human player receives no hidden location or identity leak |
+
+## Misleading UI Risks
+
+- `Natural Wonder Discovered` must mean the active human-controlled civilization just discovered that natural wonder from a live `wonder:discovered` event. AI events, wrong-viewer events, Atlas browsing, last-seen data, and save reconstruction stay out.
+- The map pulse must represent the event payload coordinate. It must not search hidden map state for an alternate coordinate.
+- `Open Atlas` must open only a wonder that is already visible to `state.currentPlayer` through `wonderDiscoverers`; the queue does not add Atlas visibility.
+- The ceremony text must use static wonder definition fields and visual catalog metadata, not live tile terrain, owner, units, city data, or rival activity.
+- Negative tests must prove wrong-viewer and AI events return `null` and do not enqueue.
+
+## Interaction Replay Checklist
+
+- Add first reveal item, mark action settled, verify one ceremony appears.
+- Add second reveal item before the first resolves, verify the second waits.
+- Resolve first with `Continue`, verify first highlight and then second ceremony.
+- Resolve second with `Open Atlas`, verify second highlight and Atlas callback.
+- Repeat-click `Continue`, `Skip`, and `Open Atlas` after first resolution, verify callbacks fire once.
+- Block the UI, enqueue, mark settled, verify no ceremony until block clears and `pump()` runs.
+- Reopen unrelated panels after a ceremony resolves, verify the resolved ceremony does not replay.
+
+## Queue And ETA Checklist
+
+- Stage 2B does not display a player-visible queue or ETA. It intentionally shows one active ceremony at a time.
+- Queue order still matters internally and must be tested with two reveal items.
+- No reorder/remove controls are introduced in Stage 2B.
+- If a queued item becomes unpresentable because the Atlas callback or render highlight callback is unavailable, the queue resolves it like `Continue` and advances.
+
+---
+
+### Task 1: Shared Wonder Reveal Presentation Helper
+
+**Files:**
+- Create: `src/systems/wonder-presentation-formatting.ts`
+- Create: `src/systems/wonder-discovery-reveal.ts`
+- Modify: `src/systems/wonder-atlas-presentation.ts`
+- Modify: `src/core/types.ts`
+- Test: `tests/systems/wonder-discovery-reveal.test.ts`
+
+- [ ] **Step 1: Write the failing reveal-helper tests**
+
+Create `tests/systems/wonder-discovery-reveal.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameEvents, GameState } from '@/core/types';
+import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { hexKey } from '@/systems/hex-utils';
+
+function makeState(): GameState {
+  const state = createNewGame(undefined, 'wonder-discovery-reveal-test');
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.wonder = null;
+    tile.owner = null;
+  }
+  state.map.tiles[hexKey({ q: 2, r: 3 })].wonder = 'great_volcano';
+  state.discoveredWonders = { great_volcano: 'ai-1' };
+  state.wonderDiscoverers = { great_volcano: ['ai-1', 'player'] };
+  return state;
+}
+
+function event(overrides: Partial<GameEvents['wonder:discovered']> = {}): GameEvents['wonder:discovered'] {
+  return {
+    civId: 'player',
+    wonderId: 'great_volcano',
+    position: { q: 2, r: 3 },
+    isFirstDiscoverer: false,
+    ...overrides,
+  };
+}
+
+describe('wonder-discovery-reveal', () => {
+  it('builds a reveal item for the active human viewer using the event coordinate', () => {
+    const state = makeState();
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event());
+
+    expect(item).toMatchObject({
+      title: 'Natural Wonder Discovered',
+      wonderId: 'great_volcano',
+      civId: 'player',
+      coord: { q: 2, r: 3 },
+      name: 'Great Volcano',
+      motionAssetId: null,
+    });
+    expect(item?.effectSummary).toContain('Yields');
+    expect(item?.rewardSummary).toBe('+30 Science discovery reward');
+    expect(item?.visual.mapLandmark).toBe('volcano');
+  });
+
+  it('does not require first-ever world discovery for a human civ reveal', () => {
+    const state = makeState();
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event({ isFirstDiscoverer: false }));
+
+    expect(item?.wonderId).toBe('great_volcano');
+  });
+
+  it('returns null for AI discoveries and wrong active viewers', () => {
+    const state = makeState();
+
+    expect(buildWonderDiscoveryRevealItem(state, 'ai-1', event({ civId: 'ai-1' }))).toBeNull();
+    expect(buildWonderDiscoveryRevealItem(state, 'player-2', event({ civId: 'player' }))).toBeNull();
+  });
+
+  it('allows separate human civs to receive their own reveal on their own turn', () => {
+    const state = makeState();
+    state.civilizations['player-2'] = { ...state.civilizations.player, id: 'player-2', name: 'Second Human', isHuman: true };
+    state.currentPlayer = 'player-2';
+    state.wonderDiscoverers.great_volcano.push('player-2');
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player-2', event({ civId: 'player-2' }));
+
+    expect(item?.civId).toBe('player-2');
+  });
+
+  it('does not expose hidden live tile details', () => {
+    const state = makeState();
+    state.map.tiles[hexKey({ q: 2, r: 3 })].terrain = 'volcanic';
+    state.map.tiles[hexKey({ q: 2, r: 3 })].owner = 'ai-1';
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event());
+
+    expect(item).toBeTruthy();
+    expect('terrain' in (item as object)).toBe(false);
+    expect('owner' in (item as object)).toBe(false);
+  });
+
+  it('uses description fallback when revealLine metadata is absent', () => {
+    const item = buildWonderDiscoveryRevealItem(makeState(), 'player', event());
+
+    expect(item?.revealLine).toBe('A massive volcano that occasionally erupts, destroying nearby improvements.');
+  });
+
+  it('returns null for unknown wonders or unusable event coordinates', () => {
+    const state = makeState();
+
+    expect(buildWonderDiscoveryRevealItem(state, 'player', event({ wonderId: 'missing_wonder' }))).toBeNull();
+    expect(buildWonderDiscoveryRevealItem(state, 'player', event({ position: { q: Number.NaN, r: 0 } }))).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing helper tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-discovery-reveal.test.ts
+```
+
+Expected: fail because `src/systems/wonder-discovery-reveal.ts` does not exist.
+
+- [ ] **Step 3: Add shared formatting and reveal item implementation**
+
+Add `revealLine?: string;` to `WonderDefinition` in `src/core/types.ts`.
+
+Create `src/systems/wonder-presentation-formatting.ts`:
+
+```ts
+import type { ResourceYield } from '@/core/types';
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+
+export function formatWonderYieldSummary(yields: ResourceYield): string {
+  const parts = [
+    ['Food', yields.food],
+    ['Production', yields.production],
+    ['Gold', yields.gold],
+    ['Science', yields.science],
+  ]
+    .filter(([, value]) => typeof value === 'number' && value > 0)
+    .map(([label, value]) => `+${value} ${label}`);
+
+  return parts.length > 0 ? `Yields ${parts.join(', ')}` : 'No direct tile yields';
+}
+
+export function formatNaturalWonderEffectSummary(wonderId: string): string {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return 'Unknown wonder effect';
+
+  const yieldSummary = formatWonderYieldSummary(definition.yields);
+  switch (definition.effect.type) {
+    case 'adjacent_yield_bonus':
+      return `${yieldSummary}. Improves adjacent tile yields.`;
+    case 'combat_bonus':
+      return `${yieldSummary}. Grants a defensive combat bonus.`;
+    case 'eruption':
+      return `${yieldSummary}. May erupt and damage nearby improvements.`;
+    case 'healing':
+      return `${yieldSummary}. Heals units on the wonder tile.`;
+    case 'vision':
+      return `${yieldSummary}. Extends vision nearby.`;
+    case 'none':
+    default:
+      return yieldSummary;
+  }
+}
+
+export function formatWonderDiscoveryRewardSummary(wonderId: string): string {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return 'No discovery reward';
+  const rewardType = definition.discoveryBonus.type;
+  const rewardLabel = rewardType.charAt(0).toUpperCase() + rewardType.slice(1);
+  return `+${definition.discoveryBonus.amount} ${rewardLabel} discovery reward`;
+}
+```
+
+Modify `src/systems/wonder-atlas-presentation.ts` to import `formatNaturalWonderEffectSummary` and replace its local `formatYieldSummary`/`formatEffectSummary` helpers with that shared function.
+
+Create `src/systems/wonder-discovery-reveal.ts`:
+
+```ts
+import type { GameEvents, GameState, HexCoord } from '@/core/types';
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { formatNaturalWonderEffectSummary, formatWonderDiscoveryRewardSummary } from '@/systems/wonder-presentation-formatting';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface WonderDiscoveryRevealItem {
+  wonderId: string;
+  civId: string;
+  coord: HexCoord;
+  name: string;
+  title: 'Natural Wonder Discovered';
+  revealLine: string;
+  effectSummary: string;
+  rewardSummary: string;
+  visual: WonderVisualDefinition;
+  motionAssetId: string | null;
+}
+
+function validCoord(coord: HexCoord): boolean {
+  return Number.isFinite(coord.q) && Number.isFinite(coord.r);
+}
+
+export function buildWonderDiscoveryRevealItem(
+  state: GameState,
+  activeViewerId: string,
+  event: GameEvents['wonder:discovered'],
+): WonderDiscoveryRevealItem | null {
+  if (event.civId !== activeViewerId) return null;
+  const civ = state.civilizations[event.civId];
+  if (!civ?.isHuman) return null;
+  if (!validCoord(event.position)) return null;
+
+  const definition = getWonderDefinition(event.wonderId);
+  if (!definition) return null;
+
+  return {
+    wonderId: event.wonderId,
+    civId: event.civId,
+    coord: { ...event.position },
+    name: definition.name,
+    title: 'Natural Wonder Discovered',
+    revealLine: definition.revealLine ?? definition.description,
+    effectSummary: formatNaturalWonderEffectSummary(event.wonderId),
+    rewardSummary: formatWonderDiscoveryRewardSummary(event.wonderId),
+    visual: getWonderVisualDefinition(event.wonderId),
+    motionAssetId: null,
+  };
+}
+```
+
+- [ ] **Step 4: Run helper and Atlas presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-discovery-reveal.test.ts tests/systems/wonder-atlas-presentation.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add src/core/types.ts src/systems/wonder-presentation-formatting.ts src/systems/wonder-atlas-presentation.ts src/systems/wonder-discovery-reveal.ts tests/systems/wonder-discovery-reveal.test.ts
+git commit -m "feat: add wonder discovery reveal presentation"
+```
+
+### Task 2: Ceremony Overlay UI
+
+**Files:**
+- Modify: `src/ui/wonder-vignette.ts`
+- Create: `src/ui/wonder-discovery-ceremony.ts`
+- Test: `tests/ui/wonder-discovery-ceremony.test.ts`
+
+- [ ] **Step 1: Write failing ceremony tests**
+
+Create `tests/ui/wonder-discovery-ceremony.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { createWonderDiscoveryCeremony } from '@/ui/wonder-discovery-ceremony';
+
+function item(overrides: Partial<WonderDiscoveryRevealItem> = {}): WonderDiscoveryRevealItem {
+  return {
+    title: 'Natural Wonder Discovered',
+    wonderId: 'great_volcano',
+    civId: 'player',
+    coord: { q: 2, r: 3 },
+    name: 'Great Volcano',
+    revealLine: 'The earth opens and the sky remembers.',
+    effectSummary: 'Yields +3 Production, +1 Science. May erupt and damage nearby improvements.',
+    rewardSummary: '+30 Science discovery reward',
+    visual: getWonderVisualDefinition('great_volcano'),
+    motionAssetId: null,
+    ...overrides,
+  };
+}
+
+function click(selector: string): void {
+  const element = document.querySelector(selector);
+  expect(element).toBeTruthy();
+  element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+describe('wonder-discovery-ceremony', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  it('renders the reveal copy, actions, and animated medallion mode', () => {
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve: () => {} }, { reducedMotion: false });
+
+    expect(document.body.textContent).toContain('Natural Wonder Discovered');
+    expect(document.body.textContent).toContain('Great Volcano');
+    expect(document.body.textContent).toContain('The earth opens');
+    expect(document.body.textContent).toContain('Yields +3 Production');
+    expect(document.body.textContent).toContain('+30 Science discovery reward');
+    expect(document.querySelector('[data-wonder-discovery-action="continue"]')).toBeTruthy();
+    expect(document.querySelector('[data-wonder-discovery-action="open-atlas"]')).toBeTruthy();
+    expect(document.querySelector('[data-wonder-discovery-action="skip"]')).toBeTruthy();
+    expect(document.querySelector('[data-vignette-motion="ambient"]')).toBeTruthy();
+  });
+
+  it('resolves exactly once for repeated action clicks', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+
+    click('[data-wonder-discovery-action="continue"]');
+    click('[data-wonder-discovery-action="skip"]');
+    click('[data-wonder-discovery-action="open-atlas"]');
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith('continue');
+    expect(document.querySelector('#wonder-discovery-ceremony')).toBeNull();
+  });
+
+  it('returns open-atlas when the Atlas action is selected', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+
+    click('[data-wonder-discovery-action="open-atlas"]');
+
+    expect(onResolve).toHaveBeenCalledWith('open-atlas');
+  });
+
+  it('uses static mode for reduced motion and keeps actions available before timers run', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: true });
+
+    expect(document.querySelector('[data-wonder-discovery-motion="static"]')).toBeTruthy();
+    expect(document.querySelector('[data-vignette-motion="static"]')).toBeTruthy();
+    click('[data-wonder-discovery-action="skip"]');
+    expect(onResolve).toHaveBeenCalledWith('skip');
+  });
+
+  it('inserts dynamic text safely', () => {
+    createWonderDiscoveryCeremony(
+      document.body,
+      item({ name: '<img src=x onerror=alert(1)>', revealLine: '<script>alert(1)</script>' }),
+      { onResolve: () => {} },
+      { reducedMotion: false },
+    );
+
+    expect(document.body.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(document.body.innerHTML).not.toContain('<script>alert(1)</script>');
+  });
+});
+```
+
+- [ ] **Step 2: Run failing ceremony tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-discovery-ceremony.test.ts
+```
+
+Expected: fail because `src/ui/wonder-discovery-ceremony.ts` does not exist.
+
+- [ ] **Step 3: Export reusable vignette helper**
+
+Modify `src/ui/wonder-vignette.ts` by extracting the existing SVG creation into:
+
+```ts
+export function createWonderVisualVignette(
+  name: string,
+  visual: WonderVisualDefinition,
+  options: WonderVignetteOptions & { kind?: 'natural' | 'legendary' } = {},
+): HTMLElement {
+  const reducedMotion = options.reducedMotion ?? prefersReducedMotion();
+  const wrapper = document.createElement('div');
+  wrapper.dataset.vignetteMotion = reducedMotion ? 'static' : 'ambient';
+  wrapper.style.cssText = 'position:relative;width:118px;height:118px;flex:0 0 118px;display:grid;place-items:center;';
+
+  const svg = createSvgElement('svg') as SVGSVGElement;
+  svg.setAttribute('viewBox', '0 0 100 100');
+  svg.setAttribute('role', 'img');
+  svg.style.cssText = `width:112px;height:112px;filter:drop-shadow(0 0 12px ${visual.palette.glow});`;
+  svg.setAttribute('aria-label', `${name} vignette`);
+  appendShape(svg, visual, reducedMotion || options.kind === 'legendary');
+  wrapper.appendChild(svg);
+
+  const glyph = document.createElement('div');
+  glyph.textContent = visual.medallionGlyph;
+  glyph.style.cssText = 'position:absolute;inset:0;display:grid;place-items:center;font-size:30px;font-weight:700;color:white;text-shadow:0 2px 8px rgba(0,0,0,0.65);';
+  wrapper.appendChild(glyph);
+
+  return wrapper;
+}
+```
+
+Then make `createWonderVignette(entry, options)` return:
+
+```ts
+return createWonderVisualVignette(entry.name, entry.visual, { ...options, kind: entry.kind });
+```
+
+- [ ] **Step 4: Implement ceremony overlay**
+
+Create `src/ui/wonder-discovery-ceremony.ts`:
+
+```ts
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { createGameButton } from '@/ui/ui-kit';
+import { createWonderVisualVignette } from '@/ui/wonder-vignette';
+
+export type WonderDiscoveryCeremonyAction = 'continue' | 'skip' | 'open-atlas';
+
+export interface WonderDiscoveryCeremonyCallbacks {
+  onResolve: (action: WonderDiscoveryCeremonyAction) => void;
+}
+
+export interface WonderDiscoveryCeremonyOptions {
+  reducedMotion?: boolean;
+  revealDurationMs?: number;
+}
+
+function appendText(parent: HTMLElement, tag: keyof HTMLElementTagNameMap, text: string, style: string): HTMLElement {
+  const element = document.createElement(tag);
+  element.textContent = text;
+  element.style.cssText = style;
+  parent.appendChild(element);
+  return element;
+}
+
+export function createWonderDiscoveryCeremony(
+  container: HTMLElement,
+  item: WonderDiscoveryRevealItem,
+  callbacks: WonderDiscoveryCeremonyCallbacks,
+  options: WonderDiscoveryCeremonyOptions = {},
+): HTMLElement {
+  container.querySelector('#wonder-discovery-ceremony')?.remove();
+  const reducedMotion = options.reducedMotion ?? false;
+  let resolved = false;
+
+  const overlay = document.createElement('section');
+  overlay.id = 'wonder-discovery-ceremony';
+  overlay.tabIndex = -1;
+  overlay.dataset.wonderDiscoveryMotion = reducedMotion ? 'static' : 'animated';
+  overlay.style.cssText = [
+    'position:absolute',
+    'inset:0',
+    'z-index:80',
+    'background:rgba(4,7,13,0.78)',
+    'color:#f8f1df',
+    'display:grid',
+    'place-items:center',
+    'padding:18px',
+    'pointer-events:auto',
+  ].join(';');
+
+  const panel = document.createElement('div');
+  panel.style.cssText = [
+    'width:min(560px,calc(100vw - 28px))',
+    'border:1px solid rgba(232,193,112,0.42)',
+    'border-radius:8px',
+    `background:linear-gradient(180deg,rgba(20,24,32,0.98),${item.visual.palette.base})`,
+    'box-shadow:0 22px 70px rgba(0,0,0,0.62)',
+    'padding:22px',
+    'display:flex',
+    'flex-direction:column',
+    'align-items:center',
+    'gap:14px',
+    'text-align:center',
+  ].join(';');
+
+  const skip = createGameButton('Skip', 'ghost');
+  skip.dataset.wonderDiscoveryAction = 'skip';
+  skip.style.alignSelf = 'flex-end';
+
+  const vignette = createWonderVisualVignette(item.name, item.visual, { reducedMotion, kind: 'natural' });
+  vignette.style.width = '148px';
+  vignette.style.height = '148px';
+  vignette.style.flexBasis = '148px';
+
+  appendText(panel, 'p', item.title, 'margin:0;color:#e8c170;font-size:12px;letter-spacing:0;text-transform:uppercase;font-weight:700;');
+  appendText(panel, 'h2', item.name, 'margin:0;font-size:clamp(24px,4vw,38px);line-height:1.05;letter-spacing:0;');
+  appendText(panel, 'p', item.revealLine, 'margin:0;font-size:15px;line-height:1.45;max-width:46ch;');
+
+  const facts = document.createElement('div');
+  facts.style.cssText = 'display:grid;grid-template-columns:1fr;gap:8px;width:100%;text-align:left;';
+  appendText(facts, 'p', item.effectSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(255,255,255,0.07);font-size:13px;line-height:1.35;');
+  appendText(facts, 'p', item.rewardSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(232,193,112,0.12);font-size:13px;line-height:1.35;color:#ffe2a1;');
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;gap:10px;justify-content:center;flex-wrap:wrap;width:100%;';
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.dataset.wonderDiscoveryAction = 'continue';
+  const atlasButton = createGameButton('Open Atlas', 'secondary');
+  atlasButton.dataset.wonderDiscoveryAction = 'open-atlas';
+  actions.append(continueButton, atlasButton);
+
+  function resolve(action: WonderDiscoveryCeremonyAction): void {
+    if (resolved) return;
+    resolved = true;
+    overlay.remove();
+    callbacks.onResolve(action);
+  }
+
+  skip.addEventListener('click', () => resolve('skip'));
+  continueButton.addEventListener('click', () => resolve('continue'));
+  atlasButton.addEventListener('click', () => resolve('open-atlas'));
+  overlay.addEventListener('keydown', event => {
+    if (event.key === 'Escape') resolve('skip');
+  });
+
+  panel.prepend(skip);
+  panel.append(vignette, facts, actions);
+  overlay.appendChild(panel);
+  container.appendChild(overlay);
+  overlay.focus();
+
+  window.setTimeout(() => {
+    overlay.dataset.wonderDiscoveryPhase = 'settled';
+  }, reducedMotion ? 0 : options.revealDurationMs ?? 3600);
+
+  return overlay;
+}
+```
+
+- [ ] **Step 5: Run ceremony and Atlas UI tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-discovery-ceremony.test.ts tests/ui/wonder-atlas-panel.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 2**
+
+```bash
+git add src/ui/wonder-vignette.ts src/ui/wonder-discovery-ceremony.ts tests/ui/wonder-discovery-ceremony.test.ts
+git commit -m "feat: add wonder discovery ceremony ui"
+```
+
+### Task 3: Reveal Queue Coordinator
+
+**Files:**
+- Create: `src/ui/wonder-discovery-queue.ts`
+- Test: `tests/ui/wonder-discovery-queue.test.ts`
+
+- [ ] **Step 1: Write failing queue tests**
+
+Create `tests/ui/wonder-discovery-queue.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
+import type { WonderDiscoveryCeremonyAction } from '@/ui/wonder-discovery-ceremony';
+
+function item(wonderId: string, q: number): WonderDiscoveryRevealItem {
+  return {
+    title: 'Natural Wonder Discovered',
+    wonderId,
+    civId: 'player',
+    coord: { q, r: 0 },
+    name: wonderId === 'great_volcano' ? 'Great Volcano' : 'Crystal Caverns',
+    revealLine: 'A discovery line.',
+    effectSummary: 'Yields +1 Science',
+    rewardSummary: '+30 Science discovery reward',
+    visual: getWonderVisualDefinition(wonderId),
+    motionAssetId: null,
+  };
+}
+
+describe('wonder-discovery-queue', () => {
+  it('waits for action-settled before presenting the first ceremony', () => {
+    const presented: WonderDiscoveryRevealItem[] = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: reveal => { presented.push(reveal); return Promise.resolve('continue'); },
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.pump();
+    expect(presented).toHaveLength(0);
+
+    queue.notifyActionSettled();
+    expect(presented).toHaveLength(1);
+  });
+
+  it('plays multiple items one at a time in event order', async () => {
+    const resolvers: Array<(action: WonderDiscoveryCeremonyAction) => void> = [];
+    const requestMapHighlight = vi.fn();
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: reveal => new Promise(resolve => { resolvers.push(resolve); document.body.dataset.activeWonder = reveal.wonderId; }),
+      requestMapHighlight,
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.enqueue(item('crystal_caverns', 4));
+    queue.notifyActionSettled();
+
+    expect(document.body.dataset.activeWonder).toBe('great_volcano');
+    resolvers[0]('continue');
+    await Promise.resolve();
+    expect(requestMapHighlight).toHaveBeenCalledWith(expect.objectContaining({ wonderId: 'great_volcano' }), false);
+    expect(document.body.dataset.activeWonder).toBe('crystal_caverns');
+  });
+
+  it('waits while another blocking UI is active and resumes when pumped', () => {
+    let blocked = true;
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => blocked,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    expect(present).not.toHaveBeenCalled();
+
+    blocked = false;
+    queue.pump();
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens Atlas after requesting the map highlight for open-atlas resolution', async () => {
+    const calls: string[] = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: () => Promise.resolve('open-atlas'),
+      requestMapHighlight: reveal => { calls.push(`highlight:${reveal.wonderId}`); },
+      openAtlas: wonderId => { calls.push(`atlas:${wonderId}`); },
+      reducedMotion: () => true,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['highlight:great_volcano', 'atlas:great_volcano']);
+  });
+
+  it('dedupes a same-session civ and wonder reveal after one is queued', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+
+    expect(queue.pendingCount()).toBe(0);
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires a fresh action-settled signal for a later discovery after the queue drains', async () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.enqueue(item('crystal_caverns', 4));
+    queue.pump();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.notifyActionSettled();
+    expect(present).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks the ceremony as blocking only while the reveal is active', async () => {
+    const overlays: Array<string | null> = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: () => Promise.resolve('continue'),
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+      setBlockingOverlay: id => overlays.push(id),
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(overlays).toEqual(['wonder-discovery-ceremony', null]);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing queue tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-discovery-queue.test.ts
+```
+
+Expected: fail because `src/ui/wonder-discovery-queue.ts` does not exist.
+
+- [ ] **Step 3: Implement the queue coordinator**
+
+Create `src/ui/wonder-discovery-queue.ts`:
+
+```ts
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { createWonderDiscoveryCeremony, type WonderDiscoveryCeremonyAction } from '@/ui/wonder-discovery-ceremony';
+
+export interface WonderDiscoveryRevealQueueOptions {
+  container: HTMLElement;
+  isInteractionBlocked: () => boolean;
+  requestMapHighlight: (item: WonderDiscoveryRevealItem, reducedMotion: boolean) => void;
+  openAtlas: (wonderId: string) => void;
+  reducedMotion: () => boolean;
+  present?: (item: WonderDiscoveryRevealItem) => Promise<WonderDiscoveryCeremonyAction>;
+  onRevealStarted?: (item: WonderDiscoveryRevealItem) => void;
+  setBlockingOverlay?: (id: string | null) => void;
+}
+
+export interface WonderDiscoveryRevealQueue {
+  enqueue(item: WonderDiscoveryRevealItem): void;
+  notifyActionSettled(): void;
+  pump(): void;
+  pendingCount(): number;
+}
+
+function keyFor(item: WonderDiscoveryRevealItem): string {
+  return `${item.civId}:${item.wonderId}`;
+}
+
+export function createWonderDiscoveryRevealQueue(options: WonderDiscoveryRevealQueueOptions): WonderDiscoveryRevealQueue {
+  const pending: WonderDiscoveryRevealItem[] = [];
+  const seen = new Set<string>();
+  let presenting = false;
+  let actionSettled = false;
+
+  const present = options.present ?? ((item: WonderDiscoveryRevealItem) => new Promise<WonderDiscoveryCeremonyAction>(resolve => {
+    createWonderDiscoveryCeremony(
+      options.container,
+      item,
+      { onResolve: resolve },
+      { reducedMotion: options.reducedMotion() },
+    );
+  }));
+
+  async function play(item: WonderDiscoveryRevealItem): Promise<void> {
+    presenting = true;
+    options.setBlockingOverlay?.('wonder-discovery-ceremony');
+    options.onRevealStarted?.(item);
+    const reducedMotion = options.reducedMotion();
+    let action: WonderDiscoveryCeremonyAction = 'continue';
+    try {
+      action = await present(item);
+    } finally {
+      options.setBlockingOverlay?.(null);
+    }
+    options.requestMapHighlight(item, reducedMotion);
+    if (action === 'open-atlas') {
+      options.openAtlas(item.wonderId);
+    }
+    presenting = false;
+    pump();
+  }
+
+  function pump(): void {
+    if (!actionSettled || presenting || options.isInteractionBlocked()) return;
+    const next = pending.shift();
+    if (!next) return;
+    void play(next);
+  }
+
+  return {
+    enqueue(item) {
+      const key = keyFor(item);
+      if (seen.has(key)) return;
+      seen.add(key);
+      if (!presenting && pending.length === 0) {
+        actionSettled = false;
+      }
+      pending.push(item);
+      pump();
+    },
+    notifyActionSettled() {
+      actionSettled = true;
+      pump();
+    },
+    pump,
+    pendingCount() {
+      return pending.length;
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run queue and ceremony tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-discovery-queue.test.ts tests/ui/wonder-discovery-ceremony.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit Task 3**
+
+```bash
+git add src/ui/wonder-discovery-queue.ts tests/ui/wonder-discovery-queue.test.ts
+git commit -m "feat: queue wonder discovery reveals"
+```
+
+### Task 4: Map Pulse And Highlight Rendering
+
+**Files:**
+- Modify: `src/renderer/animation-system.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Test: `tests/renderer/wonder-discovery-highlight.test.ts`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Create `tests/renderer/wonder-discovery-highlight.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { RenderLoop } from '@/renderer/render-loop';
+import type { GameState } from '@/core/types';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+function canvas(): HTMLCanvasElement {
+  const ctx = {
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+  } as unknown as CanvasRenderingContext2D;
+
+  return {
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width: 320, height: 240 }),
+  } as unknown as HTMLCanvasElement;
+}
+
+function state(): GameState {
+  return {
+    turn: 1,
+    currentPlayer: 'player',
+    map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    tribalVillages: {},
+    minorCivs: {},
+    cities: {},
+    units: {},
+    civilizations: {
+      player: {
+        color: '#4a90d9',
+        visibility: { tiles: { '2,0': 'visible' } },
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('wonder discovery highlight', () => {
+  it('centers the camera and schedules an animated pulse at the event coordinate', () => {
+    const loop = new RenderLoop(canvas());
+    loop.setGameState(state());
+    const add = vi.spyOn(loop.animations, 'add');
+    const center = vi.spyOn(loop.camera, 'centerOn');
+
+    loop.requestWonderDiscoveryHighlight({ q: 2, r: 0 }, getWonderVisualDefinition('great_volcano'), { reducedMotion: false });
+
+    expect(center).toHaveBeenCalledWith({ q: 2, r: 0 });
+    expect(add).toHaveBeenCalledWith(
+      'wonder-discovery-pulse',
+      900,
+      expect.objectContaining({ accent: expect.any(String), glow: expect.any(String) }),
+    );
+  });
+
+  it('uses a static highlight for reduced motion without replacing selection highlights', () => {
+    const loop = new RenderLoop(canvas());
+    loop.setGameState(state());
+    loop.setHighlights([{ coord: { q: 1, r: 0 }, type: 'move' }]);
+    const add = vi.spyOn(loop.animations, 'add');
+
+    loop.requestWonderDiscoveryHighlight({ q: 2, r: 0 }, getWonderVisualDefinition('great_volcano'), { reducedMotion: true });
+
+    expect(add).toHaveBeenCalledWith(
+      'wonder-discovery-static-highlight',
+      900,
+      expect.objectContaining({ accent: expect.any(String) }),
+    );
+    expect((loop as unknown as { highlights: unknown[] }).highlights).toEqual([{ coord: { q: 1, r: 0 }, type: 'move' }]);
+  });
+});
+```
+
+- [ ] **Step 2: Run failing renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/wonder-discovery-highlight.test.ts
+```
+
+Expected: fail because `requestWonderDiscoveryHighlight` is not defined.
+
+- [ ] **Step 3: Add animation render cases**
+
+Modify `src/renderer/animation-system.ts` inside `renderAnimation`:
+
+```ts
+      case 'wonder-discovery-pulse': {
+        const { x, y, size, accent, glow } = anim.data;
+        const alpha = 1 - progress;
+        ctx.save();
+        ctx.strokeStyle = glow;
+        ctx.globalAlpha = Math.max(0.15, alpha);
+        ctx.lineWidth = Math.max(2, size * 0.06);
+        ctx.beginPath();
+        ctx.arc(x, y, size * (0.48 + progress * 0.72), 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = Math.max(0.10, alpha * 0.35);
+        ctx.fillStyle = accent;
+        ctx.beginPath();
+        ctx.arc(x, y, size * (0.32 + progress * 0.18), 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        break;
+      }
+      case 'wonder-discovery-static-highlight': {
+        const { x, y, size, accent } = anim.data;
+        ctx.save();
+        ctx.strokeStyle = accent;
+        ctx.globalAlpha = 0.85;
+        ctx.lineWidth = Math.max(2, size * 0.05);
+        ctx.beginPath();
+        ctx.arc(x, y, size * 0.62, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+        break;
+      }
+```
+
+- [ ] **Step 4: Add render-loop highlight request method**
+
+Modify `src/renderer/render-loop.ts`:
+
+```ts
+import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+```
+
+Add this public method to `RenderLoop`:
+
+```ts
+  requestWonderDiscoveryHighlight(
+    coord: HexCoord,
+    visual: WonderVisualDefinition,
+    options: { reducedMotion: boolean },
+  ): void {
+    this.camera.centerOn(coord);
+    const pixel = hexToPixel(coord, this.camera.hexSize);
+    const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+    const size = this.camera.hexSize * this.camera.zoom;
+    this.animations.add(
+      options.reducedMotion ? 'wonder-discovery-static-highlight' : 'wonder-discovery-pulse',
+      900,
+      {
+        x: screen.x,
+        y: screen.y,
+        size,
+        accent: visual.palette.accent,
+        glow: visual.palette.glow,
+      },
+    );
+  }
+```
+
+- [ ] **Step 5: Run renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/wonder-discovery-highlight.test.ts tests/renderer/render-loop-wrap.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git add src/renderer/animation-system.ts src/renderer/render-loop.ts tests/renderer/wonder-discovery-highlight.test.ts
+git commit -m "feat: add wonder discovery map highlight"
+```
+
+### Task 5: Live Event Wiring In Main
+
+**Files:**
+- Modify: `src/main.ts`
+- Test: `tests/ui/wonder-discovery-queue.test.ts`
+- Test: `tests/systems/unit-movement-system.test.ts`
+
+- [ ] **Step 1: Add an integration-oriented movement event assertion**
+
+In `tests/systems/unit-movement-system.test.ts`, add or extend coverage around the existing movement discovery event so the payload remains sufficient for Stage 2B:
+
+```ts
+it('emits wonder discovery with the revealed event coordinate for presentation wiring', () => {
+  const { state, unitId } = makeAutoExploreFixture({ wonderNorth: 'grand_canyon', safeFogNorth: true });
+  const target = { q: 1, r: 0 };
+  const bus = new EventBus();
+  const events: Array<GameEvents['wonder:discovered']> = [];
+  bus.on('wonder:discovered', event => events.push(event));
+
+  executeUnitMove(state, unitId, target, { actor: 'player', civId: 'player', bus });
+
+  expect(events).toContainEqual(expect.objectContaining({
+    civId: 'player',
+    wonderId: 'grand_canyon',
+    position: target,
+  }));
+});
+```
+
+- [ ] **Step 2: Run the targeted movement test**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/unit-movement-system.test.ts
+```
+
+Expected: pass if existing payload is already correct; fail only if the fixture needs adjustment.
+
+- [ ] **Step 3: Wire queue creation and event listener in `src/main.ts`**
+
+Add imports:
+
+```ts
+import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
+```
+
+Create the queue after `renderLoop`, `uiLayer`, and `openWonderAtlas` are available:
+
+```ts
+const wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
+  container: uiLayer,
+  isInteractionBlocked: () => uiInteractions.isInteractionBlocked(),
+  requestMapHighlight: (item, reducedMotion) => {
+    renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
+  },
+  openAtlas: wonderId => openWonderAtlas(wonderId),
+  reducedMotion: () => typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  setBlockingOverlay: id => uiInteractions.setBlockingOverlay(id),
+});
+```
+
+Modify the existing `bus.on('wonder:discovered', ...)` listener without changing the current log message:
+
+```ts
+bus.on('wonder:discovered', event => {
+  const wonderDef = getWonderDefinition(event.wonderId);
+  if (!wonderDef) return;
+  const message = event.isFirstDiscoverer
+    ? `Discovered ${wonderDef.name}! +${wonderDef.discoveryBonus.amount} ${wonderDef.discoveryBonus.type}`
+    : `Found ${wonderDef.name}!`;
+  appendToCivLog(event.civId, message, event.isFirstDiscoverer ? 'success' : 'info');
+
+  const revealItem = buildWonderDiscoveryRevealItem(gameState, gameState.currentPlayer, event);
+  if (revealItem) {
+    wonderDiscoveryQueue.enqueue(revealItem);
+  }
+});
+```
+
+Modify `animateMovedUnit` completion callback so discovery ceremonies wait until movement settles:
+
+```ts
+  renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
+    renderLoop.setGameState(gameState);
+    updateHUD();
+    wonderDiscoveryQueue.notifyActionSettled();
+    const unit = gameState.units[unitId];
+    if (!unit || unit.owner !== gameState.currentPlayer) return;
+    if ((unit.movementPointsLeft ?? 0) <= 0) {
+      selectNextUnit();
+    } else if (selectedUnitId === unitId) {
+      selectUnit(unitId);
+    }
+  });
+```
+
+For non-animated future event sources, call `wonderDiscoveryQueue.notifyActionSettled()` after their state update and visible feedback complete.
+
+- [ ] **Step 4: Keep blocking overlay ownership in the queue**
+
+The queue owns ceremony blocking through `setBlockingOverlay`. The main wiring passes the existing `uiInteractions.setBlockingOverlay` callback, and `tests/ui/wonder-discovery-queue.test.ts` proves the callback receives `'wonder-discovery-ceremony'` before presentation and `null` after resolution. Existing blocking overlays in `main.ts` remain unchanged.
+
+- [ ] **Step 5: Run live wiring tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/unit-movement-system.test.ts tests/ui/wonder-discovery-queue.test.ts tests/systems/wonder-discovery-reveal.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add src/main.ts tests/systems/unit-movement-system.test.ts tests/ui/wonder-discovery-queue.test.ts
+git commit -m "feat: wire wonder discovery ceremonies"
+```
+
+### Task 6: Regression Sweep And Spec Review
+
+**Files:**
+- Review: `docs/superpowers/specs/2026-05-21-wonder-discovery-reveal-design.md`
+- Review: committed and uncommitted diffs
+
+- [ ] **Step 1: Run source rule checks for changed source files**
+
+Run with the exact changed `src/` files:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/wonder-presentation-formatting.ts src/systems/wonder-atlas-presentation.ts src/systems/wonder-discovery-reveal.ts src/ui/wonder-vignette.ts src/ui/wonder-discovery-ceremony.ts src/ui/wonder-discovery-queue.ts src/renderer/animation-system.ts src/renderer/render-loop.ts src/main.ts
+```
+
+Expected: pass with no rule violations.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-discovery-reveal.test.ts tests/systems/wonder-atlas-presentation.test.ts tests/ui/wonder-discovery-ceremony.test.ts tests/ui/wonder-discovery-queue.test.ts tests/ui/wonder-atlas-panel.test.ts tests/renderer/wonder-discovery-highlight.test.ts tests/renderer/render-loop-wrap.test.ts tests/systems/unit-movement-system.test.ts
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run wonder regression bundle**
+
+Run:
+
+```bash
+./scripts/run-wonder-regressions.sh
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: pass; this is the TypeScript check.
+
+- [ ] **Step 5: Run full test suite before push or PR**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Review diffs against spec and base**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- docs/superpowers/specs/2026-05-21-wonder-discovery-reveal-design.md src tests
+git diff -- src tests
+```
+
+Confirm:
+
+- No gameplay reward, placement, AI, fog, save-format, or legendary construction rules changed.
+- No ceremony can be built from Atlas browsing, save reconstruction, last-seen data, or hidden map scans.
+- `Continue` is primary/default, `Open Atlas` is secondary, and `Skip` is immediate.
+- AI and wrong-viewer discoveries do not enqueue or render.
+- The event coordinate is the only map pulse target.
+- Reduced-motion mode has no dependency on animation completion.
+- No new sound or video loading is shipped.
+- No player-visible queue or dead-end action was introduced.
+
+- [ ] **Step 7: Commit regression-fix changes when verification changes files**
+
+When verification changes files, commit them separately:
+
+```bash
+git add <changed-files>
+git commit -m "fix: harden wonder discovery reveal"
+```
+
+## Self-Review
+
+### Spec Coverage
+
+- Full ceremony after human natural wonder discovery: Tasks 1, 2, 3, and 5.
+- First discovery per human civ, not first-ever world discovery: Task 1 tests `isFirstDiscoverer: false` human event.
+- No AI or wrong-viewer leak: Task 1 and Task 3 negative tests.
+- Queue one at a time: Task 3.
+- Wait until triggering action settles: Task 3 and Task 5.
+- Continue, Skip, Open Atlas: Task 2 and Task 3.
+- Map pulse/highlight at event coordinate: Task 4 and Task 5.
+- Reduced motion static ceremony/highlight: Task 2, Task 3, and Task 4.
+- Optional reveal line fallback: Task 1.
+- Video-ready hook without real video: Task 1 `motionAssetId: null`.
+- No sound with later hook preservation: Task 3 `onRevealStarted` hook; no audio call.
+- No save-format or gameplay mutation changes: Task 6 diff review and targeted tests.
+
+### Placeholder Scan
+
+The plan contains concrete paths, commands, expected outcomes, and code snippets for each code-writing step. It intentionally does not use placeholder markers.
+
+### Type Consistency
+
+- `WonderDiscoveryRevealItem` is defined once in `src/systems/wonder-discovery-reveal.ts`.
+- `WonderDiscoveryCeremonyAction` is defined once in `src/ui/wonder-discovery-ceremony.ts` and reused by the queue tests.
+- Queue callbacks use `requestMapHighlight(item, reducedMotion)` and `openAtlas(wonderId)` consistently across tests and wiring.

--- a/docs/superpowers/specs/2026-05-21-wonder-discovery-reveal-design.md
+++ b/docs/superpowers/specs/2026-05-21-wonder-discovery-reveal-design.md
@@ -1,0 +1,348 @@
+# Wonder Discovery Reveal Design
+
+**Issue:** [#217 - Bug: legendary wonder ui off](https://github.com/a1flecke/conquestoria/issues/217)
+**Date:** 2026-05-21
+**Stage:** 2B - Discovery Reveal Moments
+
+## Overview
+
+Stage 2A gave wonders persistent identity through the Wonder Atlas, natural wonder medallions/vignettes, masked legendary slots, tile-integrated map landmarks, and map-to-Atlas deep links. Stage 2B adds the missing moment of discovery: when a human-controlled civilization finds a natural wonder for the first time, the game briefly celebrates it with a skippable full-screen ceremony, then anchors the discovery back to the world map.
+
+This stage remains presentation-only. It does not change natural wonder placement, discovery rules, rewards, yields, AI behavior, save format, or legendary wonder construction.
+
+---
+
+## Goals
+
+- Make natural wonder discovery feel like a major moment, not only a toast notification.
+- Reuse Stage 2A visual identity: medallions, vignettes, visual catalog metadata, and Atlas integration.
+- Play a full cinematic medallion-style ceremony for each human-controlled civ's first discovery of a natural wonder.
+- Queue multiple discovery ceremonies one at a time.
+- Let players skip the ceremony immediately.
+- Finish every ceremony with a map tile pulse/highlight at the discovered coordinate.
+- Preserve `Continue` as the primary/default action and provide `Open Atlas` as a secondary action.
+- Respect reduced-motion settings with a static reveal card and instant map highlight.
+- Keep AI discoveries and other-player discoveries from leaking through the ceremony layer.
+
+## Non-Goals
+
+- Stage 2B does not add real video assets. The API may be video-ready, but implementation uses CSS/SVG/game UI animation.
+- Stage 2B does not add sound. Later work may add age-specific wonder discovery stings through an explicit audio hook.
+- Stage 2B does not add full Atlas history/lore pages.
+- Stage 2B does not change discovery bonuses or wonder effects.
+- Stage 2B does not persist reveal queue state across reloads.
+- Stage 2B does not add legendary wonder construction or completion ceremonies. That remains Stage 2C.
+
+---
+
+## Player Experience
+
+When a human-controlled civ discovers a natural wonder for the first time, the game waits until the triggering action settles. Movement, visibility refresh, combat resolution, or other immediate action feedback must finish first. Then the reveal ceremony appears.
+
+The ceremony uses a full-screen overlay with a darkened game backdrop. It opens with a cinematic medallion/vignette animation using the Stage 2A wonder visual identity. The player sees:
+
+- title: `Natural Wonder Discovered`
+- wonder name
+- short flavor/reveal line
+- effect summary
+- discovery reward summary
+- primary `Continue`
+- secondary `Open Atlas`
+- immediate `Skip` affordance
+
+The reveal lasts about 3-5 seconds if the player lets it play. `Skip` resolves it immediately. `Continue` is the default action after the reveal has landed. `Open Atlas` is optional and opens the Wonder Atlas directly to the discovered wonder entry after the ceremony resolves.
+
+Whether the player continues, skips, or opens the Atlas, the discovery should first anchor back to the world with a pulse/highlight at the discovered map tile. The pulse uses the actual event coordinate and existing map/camera systems. It does not select units, change city focus, alter ownership, mutate tile state, or change gameplay rules.
+
+If multiple natural wonders are discovered in one action, ceremonies queue and play one at a time. The player can skip each ceremony individually.
+
+In reduced-motion mode, the ceremony shows the same text and actions in a static reveal card. It uses an instant map highlight instead of animated medallion bloom or map pulse.
+
+---
+
+## Rules And Eligibility
+
+Reveal eligibility is player-scoped:
+
+- A reveal fires for each human-controlled civ the first time that civ discovers a natural wonder.
+- A reveal does not require the wonder to be the first-ever world discovery.
+- A reveal must not fire for AI discoveries.
+- A reveal must not fire for another human civ unless that civ is the active viewer when its discovery event is being handled.
+- A reveal must not fire from reconstructed save data, Atlas browsing, map deep-linking, or last-seen rendering.
+
+The reveal item is derived from the discovery event and existing safe data:
+
+- `wonder:discovered` event payload, including `civId`, `wonderId`, `position`, and `isFirstDiscoverer`
+- current `GameState`
+- existing natural wonder definitions
+- Stage 2A `wonder-visual-catalog`
+- optional `revealLine` metadata with the wonder description as fallback
+- discovery reward summary from the natural wonder definition
+
+The reveal must use the event `position` for the map pulse/highlight. It must not search hidden live map state to determine location or reveal terrain, ownership, units, cities, rival activity, or other hidden details.
+
+The reveal queue is UI/session state only. If the player closes or reloads after discovery but before seeing a reveal, Stage 2B does not reconstruct old ceremonies from save state. This avoids replaying stale reveals and avoids adding save-format surface area.
+
+---
+
+## Architecture
+
+Stage 2B adds a reveal layer on top of the existing discovery event path.
+
+### Reveal Presentation Helper
+
+Add a focused helper. The default module path is:
+
+```text
+src/systems/wonder-discovery-reveal.ts
+```
+
+Responsibilities:
+
+- Convert eligible `wonder:discovered` events into viewer-safe reveal items.
+- Use `wonder-visual-catalog` metadata for medallion/vignette identity.
+- Use optional reveal-line metadata and fallback to the existing wonder description.
+- Format effect and discovery reward summaries for display.
+- Return `null` for AI discoveries, wrong-viewer discoveries, unknown wonder ids, or ineligible events.
+
+This helper does not mutate state, grant rewards, emit events, or decide discovery truth.
+
+Example reveal item shape:
+
+```ts
+interface WonderDiscoveryRevealItem {
+  wonderId: string;
+  civId: string;
+  coord: HexCoord;
+  name: string;
+  title: 'Natural Wonder Discovered';
+  revealLine: string;
+  effectSummary: string;
+  rewardSummary: string;
+  visual: WonderVisualDefinition;
+  motionAssetId: string | null;
+}
+```
+
+`motionAssetId` is a future video-ready hook. Stage 2B sets it to `null` or a stable non-video id; no real video loading is required.
+
+### Ceremony Overlay
+
+Add a DOM UI module. The default module path is:
+
+```text
+src/ui/wonder-discovery-ceremony.ts
+```
+
+Responsibilities:
+
+- Render the full-screen ceremony overlay.
+- Use DOM-safe text APIs for all game-generated names/descriptions.
+- Play the CSS/SVG/game UI medallion reveal when reduced motion is off.
+- Render a static card when reduced motion is on.
+- Expose `Continue`, `Open Atlas`, and `Skip`.
+- Resolve exactly once, even if buttons are clicked repeatedly.
+- Temporarily block underlying map input while visible.
+
+The overlay must not directly mutate game state. It reports the selected resolution action to the coordinator.
+
+### Reveal Queue Coordinator
+
+Add a small queue module or main-level coordinator. The default module path is:
+
+```text
+src/ui/wonder-discovery-queue.ts
+```
+
+or an equivalent focused helper if the implementation can keep it isolated.
+
+Responsibilities:
+
+- Receive reveal items from the `wonder:discovered` listener.
+- Queue multiple reveal items in event order.
+- Wait until the triggering action has settled and no blocking UI should take precedence.
+- Play one ceremony at a time.
+- After each ceremony resolves, request a map pulse/highlight.
+- If the player chose `Open Atlas`, open the Atlas to that wonder after the pulse/highlight request.
+- Continue to the next queued reveal.
+
+The queue must not stack overlays on top of city panels, combat previews, turn handoff screens, or other blocking UI. If another blocking UI is active, it waits until the UI is clear.
+
+### Map Pulse / Highlight
+
+Add a short render/highlight path using existing renderer/camera systems. This may extend the existing render highlight model or add a focused visual effect helper.
+
+Responsibilities:
+
+- Pulse/highlight the event coordinate after the ceremony resolves.
+- Use Stage 2A wonder visual identity where practical.
+- Respect reduced motion by showing an instant static highlight.
+- Never change selected unit, movement range, city panel state, ownership, or tile state.
+
+### Audio Hook
+
+Stage 2B has no sound requirement. The design leaves an explicit hook for later age-specific wonder discovery stings, for example a callback/event name such as `wonderDiscoveryRevealStarted`. The hook must not play new audio in 2B.
+
+---
+
+## Data Flow
+
+1. `processWonderDiscovery` mutates existing discovery state and emits `wonder:discovered`.
+2. The existing `wonder:discovered` listener keeps current notification/log behavior.
+3. The listener or nearby coordinator asks `wonder-discovery-reveal` to build a reveal item.
+4. The helper returns `null` unless the event is eligible for the active human viewer.
+5. Eligible reveal items are enqueued.
+6. After the triggering action settles and blocking UI is clear, the queue opens `wonder-discovery-ceremony`.
+7. Player waits, clicks `Continue`, clicks `Skip`, or clicks `Open Atlas`.
+8. Ceremony resolves exactly once.
+9. Coordinator requests map pulse/highlight at the event coordinate.
+10. If `Open Atlas` was chosen, the Wonder Atlas opens directly to the discovered wonder entry.
+11. Queue advances to the next reveal item.
+
+---
+
+## UI And UX Details
+
+The ceremony should feel like the world briefly pauses to acknowledge discovery. It is intentionally more dramatic than a notification, but it must remain respectful of player flow.
+
+Required overlay behavior:
+
+- darkened game backdrop
+- centered medallion/vignette
+- `Natural Wonder Discovered` title
+- wonder name as the main headline
+- flavor/reveal line
+- compact effect summary
+- compact discovery reward summary
+- primary `Continue`
+- secondary `Open Atlas`
+- immediate `Skip`
+- keyboard-friendly close path through `Escape` or the same skip/continue behavior if existing UI patterns support it
+
+Button behavior:
+
+- `Continue` resolves the ceremony, then requests map pulse/highlight.
+- `Skip` resolves immediately and still requests map pulse/highlight.
+- `Open Atlas` resolves the ceremony, requests map pulse/highlight, then opens the Atlas entry.
+- Repeat-clicks after the first resolution do nothing.
+
+Reduced motion:
+
+- no medallion bloom
+- no animated map pulse
+- same title, name, flavor, effect, reward, and actions
+- instant map highlight still occurs
+
+Blocking behavior:
+
+- While the overlay is visible, map input is blocked.
+- If another blocking UI is already active, the reveal waits rather than stacking.
+- Closing/reopening unrelated panels must not replay an already resolved ceremony.
+
+---
+
+## Error Handling And Edge Cases
+
+- Unknown natural wonder ids do not crash; they return `null` or a safe fallback reveal only if display can remain truthful.
+- Missing visual metadata uses the Stage 2A fallback visual.
+- Missing reveal line uses the wonder definition description.
+- Missing event coordinate prevents the ceremony from being enqueued; Stage 2B does not scan hidden map state to recover it.
+- If the Atlas cannot open, `Open Atlas` falls back to the same resolution as `Continue`.
+- If the map pulse target is no longer renderable, the ceremony still resolves and no gameplay state changes.
+- Multiple discoveries queue in event order and do not overlap.
+- Reduced-motion mode must not rely on timers or animation completion to make the UI usable.
+
+---
+
+## Testing Requirements
+
+### System / Presentation Tests
+
+Add tests for the reveal helper:
+
+- human-controlled active viewer discovery returns a reveal item
+- AI discovery returns `null`
+- wrong active viewer returns `null`
+- same natural wonder discovered by two human civs can produce separate reveal items for each civ on its own turn
+- reveal item uses event coordinate
+- reveal item does not expose live hidden tile details
+- reveal item includes name, reveal line or description fallback, effect summary, reward summary, and visual metadata
+- unknown wonder id is handled safely
+- `motionAssetId` exists as a future hook but does not require real video
+
+### UI Tests
+
+Add tests for the ceremony overlay:
+
+- overlay renders title, wonder name, flavor, effect, reward, `Continue`, `Open Atlas`, and `Skip`
+- `Continue` resolves once and requests map pulse/highlight
+- `Skip` resolves once and requests map pulse/highlight
+- `Open Atlas` resolves once, requests map pulse/highlight, and calls the Atlas callback
+- repeat-clicking actions does not double-resolve
+- reduced-motion rendering uses static mode
+- dynamic text is inserted safely through DOM APIs
+
+### Queue / Integration Tests
+
+Add tests for the reveal queue/coordinator:
+
+- multiple reveal items play one at a time in order
+- no second overlay appears until the first resolves
+- queue waits while blocking UI is active
+- queue resumes after blocking UI clears
+- AI discoveries do not enqueue
+- existing notification/log behavior still occurs for `wonder:discovered`
+- no gameplay state changes occur from showing or resolving the ceremony
+
+### Renderer / Highlight Tests
+
+Add tests for map pulse/highlight behavior:
+
+- resolving a ceremony requests a pulse/highlight at the event coordinate
+- reduced motion requests an instant static highlight
+- pulse/highlight does not mutate selected unit, movement range, ownership, tile data, or city state
+- missing/non-renderable coordinate resolves safely
+
+### Required Checks
+
+For Stage 2B implementation, run:
+
+```bash
+scripts/check-src-rule-violations.sh <changed src files>
+./scripts/run-with-mise.sh yarn test --run <mirrored or smallest relevant tests>
+./scripts/run-wonder-regressions.sh
+./scripts/run-with-mise.sh yarn build
+```
+
+Before push, PR creation, or merge, also run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+---
+
+## Acceptance Criteria
+
+Stage 2B is complete when:
+
+- discovering a natural wonder as a human-controlled active player shows a full discovery ceremony after the triggering action settles
+- the ceremony is skippable immediately
+- `Continue` is the primary/default action
+- `Open Atlas` is available as a secondary action and opens the discovered wonder entry
+- every ceremony resolves into a map pulse/highlight at the event coordinate
+- multiple discoveries queue one at a time
+- reduced-motion users receive a static reveal card and instant map highlight
+- AI discoveries and other-player discoveries do not leak through ceremonies
+- existing discovery rewards, notifications, logs, Atlas visibility, map landmarks, and discovery rules continue to work
+- no save-format changes are required
+- targeted tests, wonder regressions, build, and full test suite pass
+
+---
+
+## Later Roadmap Preservation
+
+- **Stage 2C:** legendary construction and completion presence remains separate.
+- **Stage 2D:** full 2D Atlas expansion remains separate.
+- **Stage 3:** real video support remains a spike. Stage 2B leaves a video-ready metadata hook but must not ship video assets.
+- **Deferred audio:** age-specific wonder discovery stings should be considered in a later audio pass. Stage 2B preserves a hook but does not implement sound.

--- a/scripts/run-wonder-regressions.sh
+++ b/scripts/run-wonder-regressions.sh
@@ -3,7 +3,7 @@ set -eu
 
 cd "$(dirname "$0")/.."
 
-./scripts/run-with-mise.sh yarn test --run \
+./scripts/run-with-mise.sh yarn vitest run \
   tests/systems/legendary-wonder-system.test.ts \
   tests/systems/legendary-wonder-definitions.test.ts \
   tests/systems/wonder-system.test.ts \

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -49,6 +49,7 @@ export interface WonderDefinition {
   id: string;
   name: string;
   description: string;
+  revealLine?: string;
   yields: ResourceYield;
   discoveryBonus: { type: 'gold' | 'science' | 'production'; amount: number };
   effect: WonderEffect;

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,7 @@ import {
 import { getCouncilInterrupt } from '@/systems/council-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { canUpgradeUnit, applyUpgrade } from '@/systems/unit-upgrade-system';
-import { executeUnitMove, isWorkerBusy } from '@/systems/unit-movement-system';
+import { executeUnitMove, isWorkerBusy, type ExecuteUnitMoveResult } from '@/systems/unit-movement-system';
 import type { GameEvents, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
 import {
   appendNotification,
@@ -162,6 +162,7 @@ let councilPanelOpen = false;
 let persistedSettings: GameState['settings'] | undefined;
 let pacingDebugOpen = false;
 let pendingCityCaptureChoice: PendingCityCaptureChoice | null = null;
+let deferWonderDiscoveryRevealUntilMoveSettles = false;
 
 function mergePersistedSettings(loadedSettings?: GameState['settings']): GameState['settings'] {
   const baseSettings = loadedSettings ?? persistedSettings ?? createDefaultSettings('small');
@@ -1360,6 +1361,7 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
   renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
     renderLoop.setGameState(gameState);
     updateHUD();
+    deferWonderDiscoveryRevealUntilMoveSettles = false;
     wonderDiscoveryQueue?.notifyActionSettled();
     const unit = gameState.units[unitId];
     if (!unit || unit.owner !== gameState.currentPlayer) return;
@@ -1369,6 +1371,18 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
       selectUnit(unitId);
     }
   });
+}
+
+function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult {
+  deferWonderDiscoveryRevealUntilMoveSettles = true;
+  try {
+    const moveResult = move();
+    animateMovedUnit(unitId, moveResult.from, moveResult.to);
+    return moveResult;
+  } catch (error) {
+    deferWonderDiscoveryRevealUntilMoveSettles = false;
+    throw error;
+  }
 }
 
 function startAutoExplore(unitId: string): void {
@@ -2008,12 +2022,11 @@ function handleHexTap(rawCoord: HexCoord): void {
         if (mc && !mc.isDestroyed) {
           const cityName = gameState.cities[tapIntent.cityId]?.name ?? 'City-State';
           // Move the unit onto the city hex (updates fog, position, movement cost).
-          const moveResult = executeUnitMove(gameState, selectedUnitId, coord, {
+          executeAnimatedUnitMove(selectedUnitId, () => executeUnitMove(gameState, selectedUnitId!, coord, {
             actor: 'player',
             civId: gameState.currentPlayer,
             bus,
-          });
-          animateMovedUnit(selectedUnitId, moveResult.from, moveResult.to);
+          }));
           // Conquering a city ends the unit's turn regardless of remaining movement.
           const movedUnit = gameState.units[selectedUnitId];
           if (movedUnit) {
@@ -2044,12 +2057,11 @@ function handleHexTap(rawCoord: HexCoord): void {
           turnsLeft: taskTile?.improvementTurnsLeft ?? 1,
           onCancel: () => selectUnit(selectedId),
           onConfirm: () => {
-            const moveResult = confirmBusyWorkerMove(gameState, selectedId, coord, {
+            executeAnimatedUnitMove(selectedId, () => confirmBusyWorkerMove(gameState, selectedId, coord, {
               actor: 'player',
               civId: gameState.currentPlayer,
               bus,
-            });
-            animateMovedUnit(selectedId, moveResult.from, moveResult.to);
+            }));
             SFX.tap();
             renderLoop.setGameState(gameState);
             updateHUD();
@@ -2058,12 +2070,11 @@ function handleHexTap(rawCoord: HexCoord): void {
         return;
       }
 
-      const moveResult = executeUnitMove(gameState, selectedUnitId, coord, {
+      executeAnimatedUnitMove(selectedUnitId, () => executeUnitMove(gameState, selectedUnitId!, coord, {
         actor: 'player',
         civId: gameState.currentPlayer,
         bus,
-      });
-      animateMovedUnit(selectedUnitId, moveResult.from, moveResult.to);
+      }));
       SFX.tap();
     }
 
@@ -2519,6 +2530,9 @@ bus.on('wonder:discovered', event => {
   const revealItem = buildWonderDiscoveryRevealItem(gameState, gameState.currentPlayer, event);
   if (revealItem) {
     wonderDiscoveryQueue?.enqueue(revealItem);
+    if (!deferWonderDiscoveryRevealUntilMoveSettles) {
+      wonderDiscoveryQueue?.notifyActionSettled();
+    }
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,8 +66,8 @@ import {
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import { visitVillage } from '@/systems/village-system';
-import { processWonderDiscovery } from '@/systems/wonder-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs } from '@/systems/tech-system';
 import { getNextPlayer, getAIPlayers, isRoundComplete } from '@/core/turn-cycling';
 import { showTurnHandoff } from '@/ui/turn-handoff';
@@ -149,6 +149,7 @@ import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecyc
 import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { calculateCivEconomy, formatGoldHudText, formatMaintenanceTooltip, rushBuyActiveProduction } from '@/systems/economy-system';
+import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
 
 // --- App State ---
 let gameState: GameState;
@@ -192,6 +193,30 @@ const uiInteractions = createUiInteractionState();
 const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
+let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
+
+function setBlockingOverlay(id: string | null): void {
+  uiInteractions.setBlockingOverlay(id);
+  if (id === null) {
+    wonderDiscoveryQueue?.pump();
+  }
+}
+
+function prefersReducedMotion(): boolean {
+  return typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
+  container: uiLayer,
+  isInteractionBlocked: () => uiInteractions.isInteractionBlocked(),
+  requestMapHighlight: (item, reducedMotion) => {
+    renderLoop.requestWonderDiscoveryHighlight(item.coord, item.visual, { reducedMotion });
+  },
+  openAtlas: wonderId => openWonderAtlas(wonderId),
+  reducedMotion: prefersReducedMotion,
+  setBlockingOverlay,
+});
 
 // --- Resize ---
 window.addEventListener('resize', () => renderLoop.resizeCanvas());
@@ -695,7 +720,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
 
 function closeRequiredChoicePanel(): void {
   document.getElementById('required-choice-panel')?.remove();
-  uiInteractions.setBlockingOverlay(null);
+  setBlockingOverlay(null);
 }
 
 function refreshRequiredChoicesAfterAction(): void {
@@ -754,7 +779,7 @@ function showRequiredChoicesIfNeeded(): boolean {
     })
     .filter((choice): choice is NonNullable<typeof choice> => choice !== null);
 
-  uiInteractions.setBlockingOverlay('required-choice');
+  setBlockingOverlay('required-choice');
   createRequiredChoicePanel(uiLayer, {
     researchChoices,
     cityChoices,
@@ -1335,6 +1360,7 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
   renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
     renderLoop.setGameState(gameState);
     updateHUD();
+    wonderDiscoveryQueue?.notifyActionSettled();
     const unit = gameState.units[unitId];
     if (!unit || unit.owner !== gameState.currentPlayer) return;
     if ((unit.movementPointsLeft ?? 0) <= 0) {
@@ -1424,7 +1450,7 @@ function getUnitTurnFlow() {
     setRenderState: state => renderLoop.setGameState(state),
     updateHUD,
     showNotification,
-    setBlockingOverlay: id => uiInteractions.setBlockingOverlay(id),
+    setBlockingOverlay,
     endTurn: options => { void endTurn(options); },
   });
 }
@@ -2129,14 +2155,14 @@ function handleVictoryIfNeeded(): boolean {
   if (!gameState.gameOver || !gameState.winner) return false;
   const winnerCiv = gameState.civilizations[gameState.winner];
   const winnerName = winnerCiv?.name ?? gameState.winner;
-  uiInteractions.setBlockingOverlay('victory');
+  setBlockingOverlay('victory');
   showVictoryPanel(uiLayer, {
     winnerName,
     victoryType: 'Domination Victory',
     turn: gameState.turn,
     onNewGame: () => {
       document.getElementById('victory-panel')?.remove();
-      uiInteractions.setBlockingOverlay(null);
+      setBlockingOverlay(null);
       showGameModeSelection();
     },
   });
@@ -2184,10 +2210,10 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       await autoSave(gameState);
 
       // Show handoff screen
-      uiInteractions.setBlockingOverlay('turn-handoff');
+      setBlockingOverlay('turn-handoff');
       showTurnHandoff(uiLayer, gameState, nextSlotId, nextPlayer?.name ?? 'Player', {
         onReady: () => {
-          uiInteractions.setBlockingOverlay(null);
+          setBlockingOverlay(null);
           centerOnCurrentPlayer();
           renderLoop.setGameState(gameState);
           updateHUD();
@@ -2482,13 +2508,18 @@ bus.on('village:visited', ({ civId, outcome, message }) => {
   appendToCivLog(civId, message, outcome === 'ambush' || outcome === 'illness' ? 'warning' : 'success');
 });
 
-bus.on('wonder:discovered', ({ civId, wonderId, isFirstDiscoverer }) => {
-  const wonderDef = getWonderDefinition(wonderId);
+bus.on('wonder:discovered', event => {
+  const wonderDef = getWonderDefinition(event.wonderId);
   if (!wonderDef) return;
-  const message = isFirstDiscoverer
+  const message = event.isFirstDiscoverer
     ? `Discovered ${wonderDef.name}! +${wonderDef.discoveryBonus.amount} ${wonderDef.discoveryBonus.type}`
     : `Found ${wonderDef.name}!`;
-  appendToCivLog(civId, message, isFirstDiscoverer ? 'success' : 'info');
+  appendToCivLog(event.civId, message, event.isFirstDiscoverer ? 'success' : 'info');
+
+  const revealItem = buildWonderDiscoveryRevealItem(gameState, gameState.currentPlayer, event);
+  if (revealItem) {
+    wonderDiscoveryQueue?.enqueue(revealItem);
+  }
 });
 
 bus.on('wonder:legendary-ready', ({ civId, cityId, wonderId }) => {

--- a/src/renderer/animation-system.ts
+++ b/src/renderer/animation-system.ts
@@ -69,6 +69,36 @@ export class AnimationSystem {
         ctx.fill();
         break;
       }
+      case 'wonder-discovery-pulse': {
+        const { x, y, size, accent, glow } = anim.data;
+        const alpha = 1 - progress;
+        ctx.save();
+        ctx.strokeStyle = glow;
+        ctx.globalAlpha = Math.max(0.15, alpha);
+        ctx.lineWidth = Math.max(2, size * 0.06);
+        ctx.beginPath();
+        ctx.arc(x, y, size * (0.48 + progress * 0.72), 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.globalAlpha = Math.max(0.10, alpha * 0.35);
+        ctx.fillStyle = accent;
+        ctx.beginPath();
+        ctx.arc(x, y, size * (0.32 + progress * 0.18), 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        break;
+      }
+      case 'wonder-discovery-static-highlight': {
+        const { x, y, size, accent } = anim.data;
+        ctx.save();
+        ctx.strokeStyle = accent;
+        ctx.globalAlpha = 0.85;
+        ctx.lineWidth = Math.max(2, size * 0.05);
+        ctx.beginPath();
+        ctx.arc(x, y, size * 0.62, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.restore();
+        break;
+      }
     }
   }
 }

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -15,6 +15,7 @@ import { resolveUnitVisual } from './unit-visual-resolver';
 import { drawUnitGlyph } from './unit-renderer';
 import { spriteCache } from './sprites/sprite-loader';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
+import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 
 export interface HexHighlight {
   coord: HexCoord;
@@ -46,6 +47,28 @@ export class RenderLoop {
 
   clearHighlights(): void {
     this.highlights = [];
+  }
+
+  requestWonderDiscoveryHighlight(
+    coord: HexCoord,
+    visual: WonderVisualDefinition,
+    options: { reducedMotion: boolean },
+  ): void {
+    this.camera.centerOn(coord);
+    const pixel = hexToPixel(coord, this.camera.hexSize);
+    const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+    const size = this.camera.hexSize * this.camera.zoom;
+    this.animations.add(
+      options.reducedMotion ? 'wonder-discovery-static-highlight' : 'wonder-discovery-pulse',
+      900,
+      {
+        x: screen.x,
+        y: screen.y,
+        size,
+        accent: visual.palette.accent,
+        glow: visual.palette.glow,
+      },
+    );
   }
 
   animateUnitMove(unit: Unit, from: HexCoord, to: HexCoord, onComplete?: () => void): void {

--- a/src/systems/wonder-atlas-presentation.ts
+++ b/src/systems/wonder-atlas-presentation.ts
@@ -1,5 +1,6 @@
-import type { GameState, HexCoord, ResourceYield } from '@/core/types';
+import type { GameState, HexCoord } from '@/core/types';
 import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { formatNaturalWonderEffectSummary } from '@/systems/wonder-presentation-formatting';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 
@@ -38,41 +39,6 @@ function formatLocation(coord: HexCoord | null): string {
   return coord ? `Q${coord.q}, R${coord.r}` : 'Location unknown';
 }
 
-function formatYieldSummary(yields: ResourceYield): string {
-  const parts = [
-    ['Food', yields.food],
-    ['Production', yields.production],
-    ['Gold', yields.gold],
-    ['Science', yields.science],
-  ]
-    .filter(([, value]) => typeof value === 'number' && value > 0)
-    .map(([label, value]) => `+${value} ${label}`);
-
-  return parts.length > 0 ? `Yields ${parts.join(', ')}` : 'No direct tile yields';
-}
-
-function formatEffectSummary(wonderId: string): string {
-  const definition = getWonderDefinition(wonderId);
-  if (!definition) return 'Unknown wonder effect';
-
-  const yieldSummary = formatYieldSummary(definition.yields);
-  switch (definition.effect.type) {
-    case 'adjacent_yield_bonus':
-      return `${yieldSummary}. Improves adjacent tile yields.`;
-    case 'combat_bonus':
-      return `${yieldSummary}. Grants a defensive combat bonus.`;
-    case 'eruption':
-      return `${yieldSummary}. May erupt and damage nearby improvements.`;
-    case 'healing':
-      return `${yieldSummary}. Heals units on the wonder tile.`;
-    case 'vision':
-      return `${yieldSummary}. Extends vision nearby.`;
-    case 'none':
-    default:
-      return yieldSummary;
-  }
-}
-
 function naturalWonderEntry(state: GameState, wonderId: string): NaturalWonderAtlasEntry | null {
   const definition = getWonderDefinition(wonderId);
   if (!definition) return null;
@@ -83,7 +49,7 @@ function naturalWonderEntry(state: GameState, wonderId: string): NaturalWonderAt
     wonderId,
     visibility: 'discovered',
     name: definition.name,
-    effectSummary: formatEffectSummary(wonderId),
+    effectSummary: formatNaturalWonderEffectSummary(wonderId),
     locationLabel: formatLocation(coord),
     coord,
     canViewOnMap: coord !== null,

--- a/src/systems/wonder-discovery-reveal.ts
+++ b/src/systems/wonder-discovery-reveal.ts
@@ -1,0 +1,48 @@
+import type { GameEvents, GameState, HexCoord } from '@/core/types';
+import { formatNaturalWonderEffectSummary, formatWonderDiscoveryRewardSummary } from '@/systems/wonder-presentation-formatting';
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface WonderDiscoveryRevealItem {
+  wonderId: string;
+  civId: string;
+  coord: HexCoord;
+  name: string;
+  title: 'Natural Wonder Discovered';
+  revealLine: string;
+  effectSummary: string;
+  rewardSummary: string;
+  visual: WonderVisualDefinition;
+  motionAssetId: string | null;
+}
+
+function validCoord(coord: HexCoord): boolean {
+  return Number.isFinite(coord.q) && Number.isFinite(coord.r);
+}
+
+export function buildWonderDiscoveryRevealItem(
+  state: GameState,
+  activeViewerId: string,
+  event: GameEvents['wonder:discovered'],
+): WonderDiscoveryRevealItem | null {
+  if (event.civId !== activeViewerId) return null;
+  const civ = state.civilizations[event.civId];
+  if (!civ?.isHuman) return null;
+  if (!validCoord(event.position)) return null;
+
+  const definition = getWonderDefinition(event.wonderId);
+  if (!definition) return null;
+
+  return {
+    wonderId: event.wonderId,
+    civId: event.civId,
+    coord: { ...event.position },
+    name: definition.name,
+    title: 'Natural Wonder Discovered',
+    revealLine: definition.revealLine ?? definition.description,
+    effectSummary: formatNaturalWonderEffectSummary(event.wonderId),
+    rewardSummary: formatWonderDiscoveryRewardSummary(event.wonderId),
+    visual: getWonderVisualDefinition(event.wonderId),
+    motionAssetId: null,
+  };
+}

--- a/src/systems/wonder-discovery-reveal.ts
+++ b/src/systems/wonder-discovery-reveal.ts
@@ -29,6 +29,7 @@ export function buildWonderDiscoveryRevealItem(
   const civ = state.civilizations[event.civId];
   if (!civ?.isHuman) return null;
   if (!validCoord(event.position)) return null;
+  if (!state.wonderDiscoverers[event.wonderId]?.includes(event.civId)) return null;
 
   const definition = getWonderDefinition(event.wonderId);
   if (!definition) return null;

--- a/src/systems/wonder-presentation-formatting.ts
+++ b/src/systems/wonder-presentation-formatting.ts
@@ -1,0 +1,46 @@
+import type { ResourceYield } from '@/core/types';
+import { getWonderDefinition } from '@/systems/wonder-definitions';
+
+export function formatWonderYieldSummary(yields: ResourceYield): string {
+  const parts = [
+    ['Food', yields.food],
+    ['Production', yields.production],
+    ['Gold', yields.gold],
+    ['Science', yields.science],
+  ]
+    .filter(([, value]) => typeof value === 'number' && value > 0)
+    .map(([label, value]) => `+${value} ${label}`);
+
+  return parts.length > 0 ? `Yields ${parts.join(', ')}` : 'No direct tile yields';
+}
+
+export function formatNaturalWonderEffectSummary(wonderId: string): string {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return 'Unknown wonder effect';
+
+  const yieldSummary = formatWonderYieldSummary(definition.yields);
+  switch (definition.effect.type) {
+    case 'adjacent_yield_bonus':
+      return `${yieldSummary}. Improves adjacent tile yields.`;
+    case 'combat_bonus':
+      return `${yieldSummary}. Grants a defensive combat bonus.`;
+    case 'eruption':
+      return `${yieldSummary}. May erupt and damage nearby improvements.`;
+    case 'healing':
+      return `${yieldSummary}. Heals units on the wonder tile.`;
+    case 'vision':
+      return `${yieldSummary}. Extends vision nearby.`;
+    case 'none':
+    default:
+      return yieldSummary;
+  }
+}
+
+export function formatWonderDiscoveryRewardSummary(wonderId: string): string {
+  const definition = getWonderDefinition(wonderId);
+  if (!definition) return 'No discovery reward';
+
+  const rewardType = definition.discoveryBonus.type;
+  const rewardLabel = rewardType.charAt(0).toUpperCase() + rewardType.slice(1);
+  return `+${definition.discoveryBonus.amount} ${rewardLabel} discovery reward`;
+}

--- a/src/ui/wonder-discovery-ceremony.ts
+++ b/src/ui/wonder-discovery-ceremony.ts
@@ -73,10 +73,6 @@ export function createWonderDiscoveryCeremony(
   vignette.style.height = '148px';
   vignette.style.flexBasis = '148px';
 
-  appendText(panel, 'p', item.title, 'margin:0;color:#e8c170;font-size:12px;letter-spacing:0;text-transform:uppercase;font-weight:700;');
-  appendText(panel, 'h2', item.name, 'margin:0;font-size:clamp(24px,4vw,38px);line-height:1.05;letter-spacing:0;');
-  appendText(panel, 'p', item.revealLine, 'margin:0;font-size:15px;line-height:1.45;max-width:46ch;');
-
   const facts = document.createElement('div');
   facts.style.cssText = 'display:grid;grid-template-columns:1fr;gap:8px;width:100%;text-align:left;';
   appendText(facts, 'p', item.effectSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(255,255,255,0.07);font-size:13px;line-height:1.35;');
@@ -104,7 +100,11 @@ export function createWonderDiscoveryCeremony(
     if (event.key === 'Escape') resolve('skip');
   });
 
-  panel.append(skipRow, vignette, facts, actions);
+  panel.append(skipRow, vignette);
+  appendText(panel, 'p', item.title, 'margin:0;color:#e8c170;font-size:12px;letter-spacing:0;text-transform:uppercase;font-weight:700;');
+  appendText(panel, 'h2', item.name, 'margin:0;font-size:32px;line-height:1.05;letter-spacing:0;');
+  appendText(panel, 'p', item.revealLine, 'margin:0;font-size:15px;line-height:1.45;max-width:46ch;');
+  panel.append(facts, actions);
   overlay.appendChild(panel);
   container.appendChild(overlay);
   overlay.focus();

--- a/src/ui/wonder-discovery-ceremony.ts
+++ b/src/ui/wonder-discovery-ceremony.ts
@@ -1,0 +1,117 @@
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { createGameButton } from '@/ui/ui-kit';
+import { createWonderVisualVignette } from '@/ui/wonder-vignette';
+
+export type WonderDiscoveryCeremonyAction = 'continue' | 'skip' | 'open-atlas';
+
+export interface WonderDiscoveryCeremonyCallbacks {
+  onResolve: (action: WonderDiscoveryCeremonyAction) => void;
+}
+
+export interface WonderDiscoveryCeremonyOptions {
+  reducedMotion?: boolean;
+  revealDurationMs?: number;
+}
+
+function appendText(parent: HTMLElement, tag: keyof HTMLElementTagNameMap, text: string, style: string): HTMLElement {
+  const element = document.createElement(tag);
+  element.textContent = text;
+  element.style.cssText = style;
+  parent.appendChild(element);
+  return element;
+}
+
+export function createWonderDiscoveryCeremony(
+  container: HTMLElement,
+  item: WonderDiscoveryRevealItem,
+  callbacks: WonderDiscoveryCeremonyCallbacks,
+  options: WonderDiscoveryCeremonyOptions = {},
+): HTMLElement {
+  container.querySelector('#wonder-discovery-ceremony')?.remove();
+  const reducedMotion = options.reducedMotion ?? false;
+  let resolved = false;
+
+  const overlay = document.createElement('section');
+  overlay.id = 'wonder-discovery-ceremony';
+  overlay.tabIndex = -1;
+  overlay.dataset.wonderDiscoveryMotion = reducedMotion ? 'static' : 'animated';
+  overlay.style.cssText = [
+    'position:absolute',
+    'inset:0',
+    'z-index:80',
+    'background:rgba(4,7,13,0.78)',
+    'color:#f8f1df',
+    'display:grid',
+    'place-items:center',
+    'padding:18px',
+    'pointer-events:auto',
+  ].join(';');
+
+  const panel = document.createElement('div');
+  panel.style.cssText = [
+    'width:min(560px,calc(100vw - 28px))',
+    'border:1px solid rgba(232,193,112,0.42)',
+    'border-radius:8px',
+    `background:linear-gradient(180deg,rgba(20,24,32,0.98),${item.visual.palette.base})`,
+    'box-shadow:0 22px 70px rgba(0,0,0,0.62)',
+    'padding:22px',
+    'display:flex',
+    'flex-direction:column',
+    'align-items:center',
+    'gap:14px',
+    'text-align:center',
+  ].join(';');
+
+  const skipRow = document.createElement('div');
+  skipRow.style.cssText = 'display:flex;justify-content:flex-end;width:100%;';
+  const skip = createGameButton('Skip', 'ghost');
+  skip.dataset.wonderDiscoveryAction = 'skip';
+  skipRow.appendChild(skip);
+
+  const vignette = createWonderVisualVignette(item.name, item.visual, { reducedMotion, kind: 'natural' });
+  vignette.style.width = '148px';
+  vignette.style.height = '148px';
+  vignette.style.flexBasis = '148px';
+
+  appendText(panel, 'p', item.title, 'margin:0;color:#e8c170;font-size:12px;letter-spacing:0;text-transform:uppercase;font-weight:700;');
+  appendText(panel, 'h2', item.name, 'margin:0;font-size:clamp(24px,4vw,38px);line-height:1.05;letter-spacing:0;');
+  appendText(panel, 'p', item.revealLine, 'margin:0;font-size:15px;line-height:1.45;max-width:46ch;');
+
+  const facts = document.createElement('div');
+  facts.style.cssText = 'display:grid;grid-template-columns:1fr;gap:8px;width:100%;text-align:left;';
+  appendText(facts, 'p', item.effectSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(255,255,255,0.07);font-size:13px;line-height:1.35;');
+  appendText(facts, 'p', item.rewardSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(232,193,112,0.12);font-size:13px;line-height:1.35;color:#ffe2a1;');
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;gap:10px;justify-content:center;flex-wrap:wrap;width:100%;';
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.dataset.wonderDiscoveryAction = 'continue';
+  const atlasButton = createGameButton('Open Atlas', 'secondary');
+  atlasButton.dataset.wonderDiscoveryAction = 'open-atlas';
+  actions.append(continueButton, atlasButton);
+
+  function resolve(action: WonderDiscoveryCeremonyAction): void {
+    if (resolved) return;
+    resolved = true;
+    overlay.remove();
+    callbacks.onResolve(action);
+  }
+
+  skip.addEventListener('click', () => resolve('skip'));
+  continueButton.addEventListener('click', () => resolve('continue'));
+  atlasButton.addEventListener('click', () => resolve('open-atlas'));
+  overlay.addEventListener('keydown', event => {
+    if (event.key === 'Escape') resolve('skip');
+  });
+
+  panel.append(skipRow, vignette, facts, actions);
+  overlay.appendChild(panel);
+  container.appendChild(overlay);
+  overlay.focus();
+
+  window.setTimeout(() => {
+    overlay.dataset.wonderDiscoveryPhase = 'settled';
+  }, reducedMotion ? 0 : options.revealDurationMs ?? 3600);
+
+  return overlay;
+}

--- a/src/ui/wonder-discovery-queue.ts
+++ b/src/ui/wonder-discovery-queue.ts
@@ -1,0 +1,91 @@
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { createWonderDiscoveryCeremony, type WonderDiscoveryCeremonyAction } from '@/ui/wonder-discovery-ceremony';
+
+export interface WonderDiscoveryRevealQueueOptions {
+  container: HTMLElement;
+  isInteractionBlocked: () => boolean;
+  requestMapHighlight: (item: WonderDiscoveryRevealItem, reducedMotion: boolean) => void;
+  openAtlas: (wonderId: string) => void;
+  reducedMotion: () => boolean;
+  present?: (item: WonderDiscoveryRevealItem) => Promise<WonderDiscoveryCeremonyAction>;
+  onRevealStarted?: (item: WonderDiscoveryRevealItem) => void;
+  setBlockingOverlay?: (id: string | null) => void;
+}
+
+export interface WonderDiscoveryRevealQueue {
+  enqueue(item: WonderDiscoveryRevealItem): void;
+  notifyActionSettled(): void;
+  pump(): void;
+  pendingCount(): number;
+}
+
+function keyFor(item: WonderDiscoveryRevealItem): string {
+  return `${item.civId}:${item.wonderId}`;
+}
+
+export function createWonderDiscoveryRevealQueue(options: WonderDiscoveryRevealQueueOptions): WonderDiscoveryRevealQueue {
+  const pending: WonderDiscoveryRevealItem[] = [];
+  const seen = new Set<string>();
+  let presenting = false;
+  let actionSettled = false;
+
+  const present = options.present ?? ((item: WonderDiscoveryRevealItem) => new Promise<WonderDiscoveryCeremonyAction>(resolve => {
+    createWonderDiscoveryCeremony(
+      options.container,
+      item,
+      { onResolve: resolve },
+      { reducedMotion: options.reducedMotion() },
+    );
+  }));
+
+  async function play(item: WonderDiscoveryRevealItem): Promise<void> {
+    presenting = true;
+    options.setBlockingOverlay?.('wonder-discovery-ceremony');
+    options.onRevealStarted?.(item);
+    const reducedMotion = options.reducedMotion();
+    let action: WonderDiscoveryCeremonyAction = 'continue';
+
+    try {
+      action = await present(item);
+    } catch {
+      action = 'continue';
+    } finally {
+      options.setBlockingOverlay?.(null);
+    }
+
+    options.requestMapHighlight(item, reducedMotion);
+    if (action === 'open-atlas') {
+      options.openAtlas(item.wonderId);
+    }
+    presenting = false;
+    pump();
+  }
+
+  function pump(): void {
+    if (!actionSettled || presenting || options.isInteractionBlocked()) return;
+    const next = pending.shift();
+    if (!next) return;
+    void play(next);
+  }
+
+  return {
+    enqueue(item) {
+      const key = keyFor(item);
+      if (seen.has(key)) return;
+      seen.add(key);
+      if (!presenting && pending.length === 0) {
+        actionSettled = false;
+      }
+      pending.push(item);
+      pump();
+    },
+    notifyActionSettled() {
+      actionSettled = true;
+      pump();
+    },
+    pump,
+    pendingCount() {
+      return pending.length;
+    },
+  };
+}

--- a/src/ui/wonder-vignette.ts
+++ b/src/ui/wonder-vignette.ts
@@ -61,7 +61,11 @@ function appendShape(svg: SVGSVGElement, visual: WonderVisualDefinition, reduced
   svg.appendChild(glow);
 }
 
-export function createWonderVignette(entry: WonderAtlasEntry, options: WonderVignetteOptions = {}): HTMLElement {
+export function createWonderVisualVignette(
+  name: string,
+  visual: WonderVisualDefinition,
+  options: WonderVignetteOptions & { kind?: 'natural' | 'legendary' } = {},
+): HTMLElement {
   const reducedMotion = options.reducedMotion ?? prefersReducedMotion();
   const wrapper = document.createElement('div');
   wrapper.dataset.vignetteMotion = reducedMotion ? 'static' : 'ambient';
@@ -70,15 +74,19 @@ export function createWonderVignette(entry: WonderAtlasEntry, options: WonderVig
   const svg = createSvgElement('svg') as SVGSVGElement;
   svg.setAttribute('viewBox', '0 0 100 100');
   svg.setAttribute('role', 'img');
-  svg.style.cssText = `width:112px;height:112px;filter:drop-shadow(0 0 12px ${entry.visual.palette.glow});`;
-  svg.setAttribute('aria-label', `${entry.name} vignette`);
-  appendShape(svg, entry.visual, reducedMotion || entry.kind === 'legendary');
+  svg.style.cssText = `width:112px;height:112px;filter:drop-shadow(0 0 12px ${visual.palette.glow});`;
+  svg.setAttribute('aria-label', `${name} vignette`);
+  appendShape(svg, visual, reducedMotion || options.kind === 'legendary');
   wrapper.appendChild(svg);
 
   const glyph = document.createElement('div');
-  glyph.textContent = entry.visual.medallionGlyph;
+  glyph.textContent = visual.medallionGlyph;
   glyph.style.cssText = 'position:absolute;inset:0;display:grid;place-items:center;font-size:30px;font-weight:700;color:white;text-shadow:0 2px 8px rgba(0,0,0,0.65);';
   wrapper.appendChild(glyph);
 
   return wrapper;
+}
+
+export function createWonderVignette(entry: WonderAtlasEntry, options: WonderVignetteOptions = {}): HTMLElement {
+  return createWonderVisualVignette(entry.name, entry.visual, { ...options, kind: entry.kind });
 }

--- a/tests/renderer/wonder-discovery-highlight.test.ts
+++ b/tests/renderer/wonder-discovery-highlight.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GameState } from '@/core/types';
+import { RenderLoop } from '@/renderer/render-loop';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+function canvas(): HTMLCanvasElement {
+  const ctx = {
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    stroke: vi.fn(),
+    fill: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    scale: vi.fn(),
+    fillStyle: '',
+    globalAlpha: 1,
+    lineWidth: 0,
+    strokeStyle: '',
+  } as unknown as CanvasRenderingContext2D;
+
+  return {
+    getContext: () => ctx,
+    getBoundingClientRect: () => ({ width: 320, height: 240 }),
+  } as unknown as HTMLCanvasElement;
+}
+
+function state(): GameState {
+  return {
+    turn: 1,
+    currentPlayer: 'player',
+    map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    tribalVillages: {},
+    minorCivs: {},
+    cities: {},
+    units: {},
+    civilizations: {
+      player: {
+        color: '#4a90d9',
+        visibility: { tiles: { '2,0': 'visible' } },
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('wonder discovery highlight', () => {
+  (globalThis as typeof globalThis & { window?: unknown }).window = { devicePixelRatio: 1 } as Window & typeof globalThis;
+
+  it('centers the camera and schedules an animated pulse at the event coordinate', () => {
+    const loop = new RenderLoop(canvas());
+    loop.setGameState(state());
+    const add = vi.spyOn(loop.animations, 'add');
+    const center = vi.spyOn(loop.camera, 'centerOn');
+
+    loop.requestWonderDiscoveryHighlight({ q: 2, r: 0 }, getWonderVisualDefinition('great_volcano'), { reducedMotion: false });
+
+    expect(center).toHaveBeenCalledWith({ q: 2, r: 0 });
+    expect(add).toHaveBeenCalledWith(
+      'wonder-discovery-pulse',
+      900,
+      expect.objectContaining({ accent: expect.any(String), glow: expect.any(String) }),
+    );
+  });
+
+  it('uses a static highlight for reduced motion without replacing selection highlights', () => {
+    const loop = new RenderLoop(canvas());
+    loop.setGameState(state());
+    loop.setHighlights([{ coord: { q: 1, r: 0 }, type: 'move' }]);
+    const add = vi.spyOn(loop.animations, 'add');
+
+    loop.requestWonderDiscoveryHighlight({ q: 2, r: 0 }, getWonderVisualDefinition('great_volcano'), { reducedMotion: true });
+
+    expect(add).toHaveBeenCalledWith(
+      'wonder-discovery-static-highlight',
+      900,
+      expect.objectContaining({ accent: expect.any(String) }),
+    );
+    expect((loop as unknown as { highlights: unknown[] }).highlights).toEqual([{ coord: { q: 1, r: 0 }, type: 'move' }]);
+  });
+});

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -1,4 +1,5 @@
 import { EventBus } from '@/core/event-bus';
+import type { GameEvents } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
 import { abandonWorkerTask, executeUnitMove } from '@/systems/unit-movement-system';
@@ -61,6 +62,26 @@ describe('unit-movement-system', () => {
     expect(result.discoveredWonders).toEqual([
       expect.objectContaining({ wonderId: 'grand_canyon' }),
     ]);
+  });
+
+  it('emits wonder discovery with the revealed event coordinate for presentation wiring', () => {
+    const { state, unitId } = makeAutoExploreFixture({ wonderNorth: 'grand_canyon', safeFogNorth: true });
+    const target = { q: 1, r: 0 };
+    const bus = new EventBus();
+    const events: Array<GameEvents['wonder:discovered']> = [];
+    bus.on('wonder:discovered', event => events.push(event));
+
+    executeUnitMove(state, unitId, target, {
+      actor: 'player',
+      civId: 'player',
+      bus,
+    });
+
+    expect(events).toContainEqual(expect.objectContaining({
+      civId: 'player',
+      wonderId: 'grand_canyon',
+      position: target,
+    }));
   });
 
   it('returns canonical wrapped revealed tiles after moving through the seam', () => {

--- a/tests/systems/wonder-discovery-reveal.test.ts
+++ b/tests/systems/wonder-discovery-reveal.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameEvents, GameState } from '@/core/types';
+import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { hexKey } from '@/systems/hex-utils';
+
+function makeState(): GameState {
+  const state = createNewGame(undefined, 'wonder-discovery-reveal-test');
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.wonder = null;
+    tile.owner = null;
+  }
+  state.map.tiles[hexKey({ q: 2, r: 3 })].wonder = 'great_volcano';
+  state.discoveredWonders = { great_volcano: 'ai-1' };
+  state.wonderDiscoverers = { great_volcano: ['ai-1', 'player'] };
+  return state;
+}
+
+function event(overrides: Partial<GameEvents['wonder:discovered']> = {}): GameEvents['wonder:discovered'] {
+  return {
+    civId: 'player',
+    wonderId: 'great_volcano',
+    position: { q: 2, r: 3 },
+    isFirstDiscoverer: false,
+    ...overrides,
+  };
+}
+
+describe('wonder-discovery-reveal', () => {
+  it('builds a reveal item for the active human viewer using the event coordinate', () => {
+    const state = makeState();
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event());
+
+    expect(item).toMatchObject({
+      title: 'Natural Wonder Discovered',
+      wonderId: 'great_volcano',
+      civId: 'player',
+      coord: { q: 2, r: 3 },
+      name: 'Great Volcano',
+      motionAssetId: null,
+    });
+    expect(item?.effectSummary).toContain('Yields');
+    expect(item?.rewardSummary).toBe('+30 Science discovery reward');
+    expect(item?.visual.mapLandmark).toBe('volcano');
+  });
+
+  it('does not require first-ever world discovery for a human civ reveal', () => {
+    const state = makeState();
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event({ isFirstDiscoverer: false }));
+
+    expect(item?.wonderId).toBe('great_volcano');
+  });
+
+  it('returns null for AI discoveries and wrong active viewers', () => {
+    const state = makeState();
+
+    expect(buildWonderDiscoveryRevealItem(state, 'ai-1', event({ civId: 'ai-1' }))).toBeNull();
+    expect(buildWonderDiscoveryRevealItem(state, 'player-2', event({ civId: 'player' }))).toBeNull();
+  });
+
+  it('allows separate human civs to receive their own reveal on their own turn', () => {
+    const state = makeState();
+    state.civilizations['player-2'] = { ...state.civilizations.player, id: 'player-2', name: 'Second Human', isHuman: true };
+    state.currentPlayer = 'player-2';
+    state.wonderDiscoverers.great_volcano.push('player-2');
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player-2', event({ civId: 'player-2' }));
+
+    expect(item?.civId).toBe('player-2');
+  });
+
+  it('does not expose hidden live tile details', () => {
+    const state = makeState();
+    state.map.tiles[hexKey({ q: 2, r: 3 })].terrain = 'volcanic';
+    state.map.tiles[hexKey({ q: 2, r: 3 })].owner = 'ai-1';
+
+    const item = buildWonderDiscoveryRevealItem(state, 'player', event());
+
+    expect(item).toBeTruthy();
+    expect('terrain' in (item as object)).toBe(false);
+    expect('owner' in (item as object)).toBe(false);
+  });
+
+  it('uses description fallback when revealLine metadata is absent', () => {
+    const item = buildWonderDiscoveryRevealItem(makeState(), 'player', event());
+
+    expect(item?.revealLine).toBe('A massive volcano that occasionally erupts, destroying nearby improvements.');
+  });
+
+  it('returns null for unknown wonders or unusable event coordinates', () => {
+    const state = makeState();
+
+    expect(buildWonderDiscoveryRevealItem(state, 'player', event({ wonderId: 'missing_wonder' }))).toBeNull();
+    expect(buildWonderDiscoveryRevealItem(state, 'player', event({ position: { q: Number.NaN, r: 0 } }))).toBeNull();
+  });
+});

--- a/tests/systems/wonder-discovery-reveal.test.ts
+++ b/tests/systems/wonder-discovery-reveal.test.ts
@@ -83,6 +83,13 @@ describe('wonder-discovery-reveal', () => {
     expect('owner' in (item as object)).toBe(false);
   });
 
+  it('returns null when the viewer has not earned Atlas visibility for the wonder', () => {
+    const state = makeState();
+    state.wonderDiscoverers.great_volcano = ['ai-1'];
+
+    expect(buildWonderDiscoveryRevealItem(state, 'player', event())).toBeNull();
+  });
+
   it('uses description fallback when revealLine metadata is absent', () => {
     const item = buildWonderDiscoveryRevealItem(makeState(), 'player', event());
 

--- a/tests/ui/wonder-discovery-ceremony.test.ts
+++ b/tests/ui/wonder-discovery-ceremony.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { createWonderDiscoveryCeremony } from '@/ui/wonder-discovery-ceremony';
+
+function item(overrides: Partial<WonderDiscoveryRevealItem> = {}): WonderDiscoveryRevealItem {
+  return {
+    title: 'Natural Wonder Discovered',
+    wonderId: 'great_volcano',
+    civId: 'player',
+    coord: { q: 2, r: 3 },
+    name: 'Great Volcano',
+    revealLine: 'The earth opens and the sky remembers.',
+    effectSummary: 'Yields +3 Production, +1 Science. May erupt and damage nearby improvements.',
+    rewardSummary: '+30 Science discovery reward',
+    visual: getWonderVisualDefinition('great_volcano'),
+    motionAssetId: null,
+    ...overrides,
+  };
+}
+
+function click(selector: string): void {
+  const element = document.querySelector(selector);
+  expect(element).toBeTruthy();
+  element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+describe('wonder-discovery-ceremony', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.useFakeTimers();
+  });
+
+  it('renders the reveal copy, actions, and animated medallion mode', () => {
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve: () => {} }, { reducedMotion: false });
+
+    expect(document.body.textContent).toContain('Natural Wonder Discovered');
+    expect(document.body.textContent).toContain('Great Volcano');
+    expect(document.body.textContent).toContain('The earth opens');
+    expect(document.body.textContent).toContain('Yields +3 Production');
+    expect(document.body.textContent).toContain('+30 Science discovery reward');
+    expect(document.querySelector('[data-wonder-discovery-action="continue"]')).toBeTruthy();
+    expect(document.querySelector('[data-wonder-discovery-action="open-atlas"]')).toBeTruthy();
+    expect(document.querySelector('[data-wonder-discovery-action="skip"]')).toBeTruthy();
+    expect(document.querySelector('[data-vignette-motion="ambient"]')).toBeTruthy();
+  });
+
+  it('resolves exactly once for repeated action clicks', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+    const continueButton = document.querySelector('[data-wonder-discovery-action="continue"]')!;
+    const skipButton = document.querySelector('[data-wonder-discovery-action="skip"]')!;
+    const atlasButton = document.querySelector('[data-wonder-discovery-action="open-atlas"]')!;
+
+    continueButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    skipButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    atlasButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith('continue');
+    expect(document.querySelector('#wonder-discovery-ceremony')).toBeNull();
+  });
+
+  it('returns open-atlas when the Atlas action is selected', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+
+    click('[data-wonder-discovery-action="open-atlas"]');
+
+    expect(onResolve).toHaveBeenCalledWith('open-atlas');
+  });
+
+  it('uses static mode for reduced motion and keeps actions available before timers run', () => {
+    const onResolve = vi.fn();
+    createWonderDiscoveryCeremony(document.body, item(), { onResolve }, { reducedMotion: true });
+
+    expect(document.querySelector('[data-wonder-discovery-motion="static"]')).toBeTruthy();
+    expect(document.querySelector('[data-vignette-motion="static"]')).toBeTruthy();
+    click('[data-wonder-discovery-action="skip"]');
+    expect(onResolve).toHaveBeenCalledWith('skip');
+  });
+
+  it('inserts dynamic text safely', () => {
+    createWonderDiscoveryCeremony(
+      document.body,
+      item({ name: '<img src=x onerror=alert(1)>', revealLine: '<script>alert(1)</script>' }),
+      { onResolve: () => {} },
+      { reducedMotion: false },
+    );
+
+    expect(document.body.textContent).toContain('<img src=x onerror=alert(1)>');
+    expect(document.body.innerHTML).not.toContain('<script>alert(1)</script>');
+  });
+});

--- a/tests/ui/wonder-discovery-queue.test.ts
+++ b/tests/ui/wonder-discovery-queue.test.ts
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import type { WonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import type { WonderDiscoveryCeremonyAction } from '@/ui/wonder-discovery-ceremony';
+import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
+
+function item(wonderId: string, q: number): WonderDiscoveryRevealItem {
+  return {
+    title: 'Natural Wonder Discovered',
+    wonderId,
+    civId: 'player',
+    coord: { q, r: 0 },
+    name: wonderId === 'great_volcano' ? 'Great Volcano' : 'Crystal Caverns',
+    revealLine: 'A discovery line.',
+    effectSummary: 'Yields +1 Science',
+    rewardSummary: '+30 Science discovery reward',
+    visual: getWonderVisualDefinition(wonderId),
+    motionAssetId: null,
+  };
+}
+
+describe('wonder-discovery-queue', () => {
+  it('waits for action-settled before presenting the first ceremony', () => {
+    const presented: WonderDiscoveryRevealItem[] = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: reveal => { presented.push(reveal); return Promise.resolve('continue'); },
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.pump();
+    expect(presented).toHaveLength(0);
+
+    queue.notifyActionSettled();
+    expect(presented).toHaveLength(1);
+  });
+
+  it('plays multiple items one at a time in event order', async () => {
+    const resolvers: Array<(action: WonderDiscoveryCeremonyAction) => void> = [];
+    const requestMapHighlight = vi.fn();
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: reveal => new Promise(resolve => { resolvers.push(resolve); document.body.dataset.activeWonder = reveal.wonderId; }),
+      requestMapHighlight,
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.enqueue(item('crystal_caverns', 4));
+    queue.notifyActionSettled();
+
+    expect(document.body.dataset.activeWonder).toBe('great_volcano');
+    resolvers[0]('continue');
+    await Promise.resolve();
+    expect(requestMapHighlight).toHaveBeenCalledWith(expect.objectContaining({ wonderId: 'great_volcano' }), false);
+    expect(document.body.dataset.activeWonder).toBe('crystal_caverns');
+  });
+
+  it('waits while another blocking UI is active and resumes when pumped', () => {
+    let blocked = true;
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => blocked,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    expect(present).not.toHaveBeenCalled();
+
+    blocked = false;
+    queue.pump();
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens Atlas after requesting the map highlight for open-atlas resolution', async () => {
+    const calls: string[] = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: () => Promise.resolve('open-atlas'),
+      requestMapHighlight: reveal => { calls.push(`highlight:${reveal.wonderId}`); },
+      openAtlas: wonderId => { calls.push(`atlas:${wonderId}`); },
+      reducedMotion: () => true,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['highlight:great_volcano', 'atlas:great_volcano']);
+  });
+
+  it('dedupes a same-session civ and wonder reveal after one is queued', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+
+    expect(queue.pendingCount()).toBe(0);
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires a fresh action-settled signal for a later discovery after the queue drains', async () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present,
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.enqueue(item('crystal_caverns', 4));
+    queue.pump();
+    expect(present).toHaveBeenCalledTimes(1);
+
+    queue.notifyActionSettled();
+    expect(present).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks the ceremony as blocking only while the reveal is active', async () => {
+    const overlays: Array<string | null> = [];
+    const queue = createWonderDiscoveryRevealQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      present: () => Promise.resolve('continue'),
+      requestMapHighlight: vi.fn(),
+      openAtlas: vi.fn(),
+      reducedMotion: () => false,
+      setBlockingOverlay: id => overlays.push(id),
+    });
+
+    queue.enqueue(item('great_volcano', 2));
+    queue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(overlays).toEqual(['wonder-discovery-ceremony', null]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Stage 2B natural wonder discovery reveal ceremonies for eligible human discoveries.
- Reuses Wonder Atlas visual identity for the ceremony, queues reveals one at a time, and anchors each resolution with a map highlight.
- Hardens viewer gating so AI/wrong-viewer events and unearned Atlas visibility do not leak discovery details.
- Fixes the wonder regression script to run the intended Vitest file list directly.

## Review fixes included
- Non-animated human discovery events now settle the reveal queue immediately, while manual movement discoveries defer until movement animation completes.
- Ceremony heading no longer uses viewport-scaled font sizing.
- Reveal helper requires the discovering civ to be present in `wonderDiscoverers` before creating an Atlas-capable reveal.

## Test Plan
- `scripts/check-src-rule-violations.sh src/main.ts src/systems/wonder-discovery-reveal.ts src/ui/wonder-discovery-ceremony.ts`
- `./scripts/run-with-mise.sh yarn vitest run tests/systems/wonder-discovery-reveal.test.ts tests/ui/wonder-discovery-ceremony.test.ts tests/ui/wonder-discovery-queue.test.ts tests/systems/unit-movement-system.test.ts`
- `./scripts/run-wonder-regressions.sh`
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test`
- `./scripts/run-with-mise.sh yarn test:web-smoke`

## Out of scope
- Real video assets remain Stage 3.
- Sound or age-specific wonder discovery stings remain deferred.
- Legendary wonder construction/completion ceremonies remain Stage 2C.
