### PR TITLE
feat(S1): tech-gated resources on map — icons, legend, inspection panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 .env
 .env.local
 .worktrees/
+
+# Brainstorming visual-companion scratch files
+.superpowers/

--- a/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-1-data.md
+++ b/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-1-data.md
@@ -1,0 +1,370 @@
+# S1 Plan 1 — Data Foundation: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `tech` and `icon` fields to `ResourceDefinition`, populate all 10 resource entries, derive `RESOURCE_ICONS` and `RESOURCE_TECH` lookup records, and add "Reveal X resource" text to the `unlocks` array of the 9 enabling techs that don't already have it.
+
+**Architecture:** Pure data change — no new files, no state fields, no save migration. `trade-system.ts` is the single source of truth; lookup records are derived by a loop at module init time. `tech-definitions.ts` gets text additions only. Plans 2 and 3 both import from these files, so this plan must be merged first.
+
+**Tech Stack:** TypeScript, Vitest
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/systems/trade-system.ts` | Add `tech` + `icon` to `ResourceDefinition` interface; populate all 10 entries; derive `RESOURCE_ICONS` and `RESOURCE_TECH` |
+| `src/systems/tech-definitions.ts` | Add `'Reveal X resource'` to `unlocks` for 9 techs |
+| `tests/systems/trade-system.test.ts` | Add catalog-integrity `describe` block |
+| `tests/systems/tech-definitions.test.ts` | Add resource-reveal unlock-text `describe` block |
+
+---
+
+### Task 1: Write failing catalog-integrity tests
+
+**Files:**
+- Modify: `tests/systems/trade-system.test.ts`
+
+- [ ] **Step 1: Add imports and new describe block to the test file**
+
+At the top of `tests/systems/trade-system.test.ts`, extend the imports to include `RESOURCE_ICONS` and `RESOURCE_TECH` (both don't exist yet — the imports will cause the test run to error, which counts as failing):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  RESOURCE_DEFINITIONS,
+  RESOURCE_ICONS,
+  RESOURCE_TECH,
+  BASE_PRICES,
+  createMarketplaceState,
+  calculatePrice,
+  detectMonopoly,
+  calculateTradeRouteGold,
+  updatePrices,
+  processFashionCycle,
+  processTradeRouteIncome,
+} from '@/systems/trade-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
+```
+
+Then add a new `describe` block inside the outer `describe('trade-system', ...)`, after the existing `RESOURCE_DEFINITIONS` describe block:
+
+```ts
+  describe('catalog integrity — tech and icon fields', () => {
+    it('every ResourceDefinition entry has a non-empty tech field', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(r.tech, `${r.id} missing tech`).toBeTruthy();
+      }
+    });
+
+    it('every tech field references a real tech id in TECH_TREE', () => {
+      const techIds = new Set(TECH_TREE.map(t => t.id));
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(techIds.has(r.tech), `${r.id}.tech "${r.tech}" not found in TECH_TREE`).toBe(true);
+      }
+    });
+
+    it('every ResourceDefinition entry has a non-empty icon field', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(r.icon, `${r.id} missing icon`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_ICONS has a non-empty entry for every resource id', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_ICONS[r.id], `RESOURCE_ICONS missing "${r.id}"`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_TECH has a non-empty entry for every resource id', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_TECH[r.id], `RESOURCE_TECH missing "${r.id}"`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_ICONS values match icon fields on RESOURCE_DEFINITIONS', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_ICONS[r.id]).toBe(r.icon);
+      }
+    });
+
+    it('RESOURCE_TECH values match tech fields on RESOURCE_DEFINITIONS', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_TECH[r.id]).toBe(r.tech);
+      }
+    });
+  });
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/trade-system.test.ts
+```
+
+Expected: `RESOURCE_ICONS` and `RESOURCE_TECH` are not exported yet → import error or property-access error. Tests fail. ✓
+
+---
+
+### Task 2: Implement ResourceDefinition fields + lookup records
+
+**Files:**
+- Modify: `src/systems/trade-system.ts`
+
+- [ ] **Step 3: Update the ResourceDefinition interface**
+
+Replace the existing `ResourceDefinition` interface:
+
+```ts
+export interface ResourceDefinition {
+  id: ResourceType;
+  name: string;
+  type: 'luxury' | 'strategic';
+  terrain: string;       // terrain it spawns on
+  basePrice: number;
+  tech: string;          // enabling tech id — added by S1
+  icon: string;          // emoji for map rendering and legend — added by S1
+}
+```
+
+- [ ] **Step 4: Populate all 10 entries with tech and icon**
+
+Replace the `RESOURCE_DEFINITIONS` array:
+
+```ts
+export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
+  // Luxury
+  { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland', basePrice: 8,  tech: 'irrigation',       icon: '🧵' },
+  { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',    basePrice: 7,  tech: 'pottery',          icon: '🍇' },
+  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',    basePrice: 10, tech: 'cartography',      icon: '🌶️' },
+  { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',     basePrice: 12, tech: 'mining-tech',      icon: '💎' },
+  { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',    basePrice: 9,  tech: 'foraging',         icon: '🐘' },
+  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',    basePrice: 6,  tech: 'currency',         icon: '🕯️' },
+  // Strategic
+  { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',     basePrice: 5,  tech: 'stone-weapons',    icon: '🪙' },
+  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',     basePrice: 8,  tech: 'bronze-working',   icon: '⚙️' },
+  { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',    basePrice: 7,  tech: 'animal-husbandry', icon: '🐎' },
+  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',  basePrice: 4,  tech: 'gathering',        icon: '🪨' },
+];
+```
+
+- [ ] **Step 5: Add RESOURCE_ICONS and RESOURCE_TECH derivation after RESOURCE_DEFINITIONS**
+
+After the existing `BASE_PRICES` derivation loop, add:
+
+```ts
+export const RESOURCE_ICONS: Record<string, string> = {};
+export const RESOURCE_TECH: Record<string, string> = {};
+for (const r of RESOURCE_DEFINITIONS) {
+  RESOURCE_ICONS[r.id] = r.icon;
+  RESOURCE_TECH[r.id] = r.tech;
+}
+```
+
+- [ ] **Step 6: Run the tests to confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/trade-system.test.ts
+```
+
+Expected: all catalog-integrity tests pass; all previously passing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/trade-system.ts tests/systems/trade-system.test.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): add tech+icon fields to ResourceDefinition; derive RESOURCE_ICONS/RESOURCE_TECH
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Write failing tech-unlock tests
+
+**Files:**
+- Modify: `tests/systems/tech-definitions.test.ts`
+
+- [ ] **Step 8: Add the resource-reveal unlock test block**
+
+Append a new `describe` block inside the outer `describe` in `tests/systems/tech-definitions.test.ts`:
+
+```ts
+  describe('resource reveal unlock text', () => {
+    const EXPECTED_REVEALS = [
+      { techId: 'gathering',        resourceName: 'Stone'   },
+      { techId: 'stone-weapons',    resourceName: 'Copper'  },
+      { techId: 'foraging',         resourceName: 'Ivory'   },
+      { techId: 'pottery',          resourceName: 'Wine'    },
+      { techId: 'cartography',      resourceName: 'Spices'  },
+      { techId: 'irrigation',       resourceName: 'Silk'    },
+      { techId: 'bronze-working',   resourceName: 'Iron'    },
+      { techId: 'animal-husbandry', resourceName: 'Horses'  },
+      { techId: 'mining-tech',      resourceName: 'Gems'    },
+      { techId: 'currency',         resourceName: 'Incense' },
+    ];
+
+    for (const { techId, resourceName } of EXPECTED_REVEALS) {
+      it(`${techId} includes "Reveal ${resourceName} resource" in unlocks`, () => {
+        const tech = TECH_TREE.find(t => t.id === techId);
+        expect(tech, `tech "${techId}" not found`).toBeDefined();
+        const hasReveal = tech?.unlocks.some(u => u === `Reveal ${resourceName} resource`);
+        expect(
+          hasReveal,
+          `${techId} missing "Reveal ${resourceName} resource" in unlocks: [${tech?.unlocks.join(', ')}]`,
+        ).toBe(true);
+      });
+    }
+  });
+```
+
+- [ ] **Step 9: Run the tests to confirm they fail (all except animal-husbandry)**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/tech-definitions.test.ts
+```
+
+Expected: 9 tests fail (all except `animal-husbandry includes "Reveal Horses resource" in unlocks`).
+
+---
+
+### Task 4: Add "Reveal X resource" to 9 techs
+
+**Files:**
+- Modify: `src/systems/tech-definitions.ts`
+
+- [ ] **Step 10: Update the 9 tech entries**
+
+In `src/systems/tech-definitions.ts`, find each of the following tech entries (they are on specific lines — search by `id:`) and append the reveal string to their `unlocks` array. `animal-husbandry` already has it; do not change it.
+
+**`gathering`** — currently `unlocks: ['Foundational economy knowledge']`:
+```ts
+{ id: 'gathering', name: 'Gathering', track: 'economy', cost: 4, prerequisites: [], unlocks: ['Foundational economy knowledge', 'Reveal Stone resource'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
+```
+
+**`stone-weapons`** — currently `unlocks: ['Warriors deal +2 damage']`:
+```ts
+{ id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 4, prerequisites: [], unlocks: ['Warriors deal +2 damage', 'Reveal Copper resource'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
+```
+
+**`foraging`** — currently `unlocks: ['Food storage']`:
+```ts
+{ id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 5, prerequisites: [], unlocks: ['Food storage', 'Reveal Ivory resource'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
+```
+
+Wait — check whether `foraging` has a `pacing` field. Look at the actual file. The instructions above give the complete replacement lines for each tech. If a tech doesn't have `pacing`, omit it. Use the `Edit` tool to make a targeted replacement — replace only the `unlocks` array in each tech entry, not the whole line, to avoid disturbing `pacing` or other fields.
+
+Use **one Edit per tech**, replacing only the `unlocks` array value. Examples:
+
+For `gathering` — replace:
+```
+unlocks: ['Foundational economy knowledge']
+```
+with:
+```
+unlocks: ['Foundational economy knowledge', 'Reveal Stone resource']
+```
+
+For `stone-weapons` — replace:
+```
+unlocks: ['Warriors deal +2 damage']
+```
+with:
+```
+unlocks: ['Warriors deal +2 damage', 'Reveal Copper resource']
+```
+
+For `foraging` — replace:
+```
+unlocks: ['Food storage']
+```
+with:
+```
+unlocks: ['Food storage', 'Reveal Ivory resource']
+```
+
+For `pottery` — replace:
+```
+unlocks: ['Foundational ceramics knowledge']
+```
+with:
+```
+unlocks: ['Foundational ceramics knowledge', 'Reveal Wine resource']
+```
+
+For `cartography` — replace:
+```
+unlocks: ['Reveal map edges']
+```
+with:
+```
+unlocks: ['Reveal map edges', 'Reveal Spices resource']
+```
+
+For `irrigation` — replace:
+```
+unlocks: ['Farms yield +1 food']
+```
+with:
+```
+unlocks: ['Farms yield +1 food', 'Reveal Silk resource']
+```
+
+For `bronze-working` — replace:
+```
+unlocks: ['Unlock Swordsman unit']
+```
+with:
+```
+unlocks: ['Unlock Swordsman unit', 'Reveal Iron resource']
+```
+
+For `mining-tech` — replace:
+```
+unlocks: ['Mines yield +1 production']
+```
+with:
+```
+unlocks: ['Mines yield +1 production', 'Reveal Gems resource']
+```
+
+For `currency` — replace:
+```
+unlocks: ['Unlock Marketplace building']
+```
+with:
+```
+unlocks: ['Unlock Marketplace building', 'Reveal Incense resource']
+```
+
+- [ ] **Step 11: Run the tests to confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/tech-definitions.test.ts
+```
+
+Expected: all 10 resource-reveal tests pass; the total tech count test (`expect(TECH_TREE.length).toBe(125)`) still passes (no new techs added). All other existing tests pass.
+
+- [ ] **Step 12: Run the full build to check for type errors**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+
+Expected: exits 0. No TypeScript errors from adding `tech`/`icon` fields (they're populated on every entry so `ResourceDefinition` stays concrete).
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/systems/tech-definitions.ts tests/systems/tech-definitions.test.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): add Reveal X resource unlock text to 9 enabling techs
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-2-renderer.md
+++ b/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-2-renderer.md
@@ -1,0 +1,532 @@
+# S1 Plan 2 — Map Renderer: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread `viewerTechs: ReadonlySet<string>` through the renderer call chain (`drawHexMap` → `drawTileAtScreen` → `drawHex`), draw tech-gated resource icons on hex tiles, and wire `viewerTechs` derivation into `render-loop.ts`.
+
+**Architecture:** `viewerTechs` is a new optional parameter with a default of `new Set()` at every function boundary, so callers that don't pass it (tests that pre-date this plan) continue to compile and pass with no resource icons drawn. The resource icon drawing block checks the presentation tile — unexplored and unknown-fog tiles already have `resource: null` from the `unknownTile()` helper, so no explicit fog guard is needed. Last-seen tiles carry the snapshot resource and draw it when the viewer has the tech (the player remembers what they saw).
+
+**Depends on:** Plan 1 merged first — imports `RESOURCE_ICONS` and `RESOURCE_TECH` from `@/systems/trade-system`.
+
+**Tech Stack:** TypeScript, Canvas 2D, Vitest
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/renderer/hex-renderer.ts` | Add import; add `viewerTechs` parameter to `drawHexMap`, `drawTileAtScreen`, and `drawHex`; thread it through; insert resource icon drawing block |
+| `src/renderer/render-loop.ts` | Derive `viewerTechs` from `this.state`; pass as 7th arg to `drawHexMap` |
+| `tests/renderer/hex-renderer.test.ts` | Extend `MockCanvasContext` to record `fillText` coordinates; add 7 resource-icon test cases |
+
+---
+
+### Task 1: Extend mock and write failing tests
+
+**Files:**
+- Modify: `tests/renderer/hex-renderer.test.ts`
+
+- [ ] **Step 1: Extend MockCanvasContext to record fillText calls with coordinates**
+
+The current `MockCanvasContext.fillText(text: string)` only records the text string. The position tests need (text, x, y). Replace the `fillText` method and add `fillTextCalls`:
+
+```ts
+class MockCanvasContext {
+  strokeCalls: string[] = [];
+  textCalls: string[] = [];
+  fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+  fillStyle = '';
+  strokeStyle = '';
+  lineWidth = 0;
+  font = '';
+  textAlign: CanvasTextAlign = 'start';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+  globalAlpha = 1;
+  shadowColor = '';
+  shadowBlur = 0;
+
+  save(): void {}
+  restore(): void {}
+  beginPath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  bezierCurveTo(): void {}
+  arc(): void {}
+  closePath(): void {}
+  fill(): void {}
+  fillText(text: string, x: number = 0, y: number = 0): void {
+    this.textCalls.push(text);
+    this.fillTextCalls.push({ text, x, y });
+  }
+  stroke(): void {
+    this.strokeCalls.push(this.strokeStyle);
+  }
+}
+```
+
+All existing tests still pass — `textCalls` is unchanged, `fillTextCalls` is additive.
+
+- [ ] **Step 2: Add a makeResourceMap helper and 7 new test cases**
+
+Add `makeResourceMap` after the existing `makeCamera` function, and a new `describe` block:
+
+```ts
+function makeResourceMap(opts: {
+  resource?: string | null;
+  improvement?: string;
+  improvementTurnsLeft?: number;
+} = {}): GameMap {
+  return {
+    width: 1,
+    height: 1,
+    wrapsHorizontally: false,
+    rivers: [],
+    tiles: {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'mountain',
+        elevation: 'highland',
+        movementCost: 2,
+        owner: null,
+        improvement: opts.improvement ?? 'none',
+        improvementTurnsLeft: opts.improvementTurnsLeft ?? 0,
+        resource: opts.resource ?? null,
+        hasRiver: false,
+        wonder: null,
+      },
+    },
+  } as unknown as GameMap;
+}
+
+describe('resource icon rendering', () => {
+  const visibleAll: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+  it('draws resource icon when viewer has the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).toContain('🪨');
+  });
+
+  it('does not draw resource icon when viewer lacks the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set());
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+
+  it('draws resource icon at top-left corner when a completed improvement is present', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone', improvement: 'mine', improvementTurnsLeft: 0 });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    // For tile at q=0,r=0: hexToPixel gives {x:0,y:0}; worldToScreen is identity.
+    // scaledSize = hexSize(48) * zoom(1) = 48.
+    // Corner position: cx - size*0.3 = 0 - 14.4 = -14.4
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    const call = mockCtx.fillTextCalls.find(c => c.text === '🪨');
+    expect(call).toBeDefined();
+    expect(call!.x).toBeCloseTo(-14.4);
+    expect(call!.y).toBeCloseTo(-14.4);
+  });
+
+  it('draws resource icon at center when improvement is still under construction', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    // improvementTurnsLeft > 0 means construction in progress — improvement icon is NOT shown
+    const map = makeResourceMap({ resource: 'stone', improvement: 'mine', improvementTurnsLeft: 2 });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    // No completed improvement visible → resource draws centered at cx=0, cy=0
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    const call = mockCtx.fillTextCalls.find(c => c.text === '🪨');
+    expect(call).toBeDefined();
+    expect(call!.x).toBeCloseTo(0);
+    expect(call!.y).toBeCloseTo(0);
+  });
+
+  it('does not draw resource icon for unexplored tiles (presentation layer nullifies resource)', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const unexplored: VisibilityMap = { tiles: { '0,0': 'unexplored' } };
+
+    // viewerTechs has 'gathering' — but the presentation tile has resource:null from unknownTile()
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', unexplored, new Set(['gathering']));
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+
+  it('draws resource icon on last-seen tile when viewer has the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const fog: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'mountain',
+          elevation: 'highland',
+          resource: 'stone',
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', fog, new Set(['gathering']));
+
+    // Player remembers what they last saw — resource shows if they have the tech
+    expect((ctx as unknown as MockCanvasContext).textCalls).toContain('🪨');
+  });
+
+  it('does not draw resource icon on last-seen tile when viewer lacks the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const fog: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'mountain',
+          elevation: 'highland',
+          resource: 'stone',
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', fog, new Set());
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/hex-renderer.test.ts
+```
+
+Expected: the 7 new resource-icon tests fail (`drawHexMap` signature now accepts 7 args but implementation still has 6, and no resource icon logic exists yet). Existing tests pass.
+
+---
+
+### Task 2: Update hex-renderer.ts
+
+**Files:**
+- Modify: `src/renderer/hex-renderer.ts`
+
+- [ ] **Step 4: Add the import for RESOURCE_ICONS and RESOURCE_TECH**
+
+At the top of `src/renderer/hex-renderer.ts`, add after the existing imports:
+
+```ts
+import { RESOURCE_ICONS, RESOURCE_TECH } from '@/systems/trade-system';
+```
+
+- [ ] **Step 5: Add viewerTechs parameter to drawHexMap**
+
+`drawHexMap` currently has 6 parameters. Add `viewerTechs` as the 7th optional parameter with a default:
+
+Replace the current signature:
+```ts
+export function drawHexMap(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  villagePositions?: Set<string>,
+  currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
+): void {
+```
+
+with:
+```ts
+export function drawHexMap(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  villagePositions?: Set<string>,
+  currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
+  viewerTechs: ReadonlySet<string> = new Set(),
+): void {
+```
+
+- [ ] **Step 6: Thread viewerTechs into the drawTileAtScreen call inside drawHexMap**
+
+Inside `drawHexMap`, the `drawTileAtScreen` call currently passes 11 arguments. Add `viewerTechs` as the 12th:
+
+Replace:
+```ts
+      drawTileAtScreen(
+        ctx,
+        screen,
+        scaledSize,
+        presentation.tile,
+        isVillage && presentation.kind === 'live',
+        currentPlayer,
+        viewerVisibility,
+        camera.zoom,
+        presentation.kind,
+        nowMs,
+        reducedMotion,
+      );
+```
+
+with:
+```ts
+      drawTileAtScreen(
+        ctx,
+        screen,
+        scaledSize,
+        presentation.tile,
+        isVillage && presentation.kind === 'live',
+        currentPlayer,
+        viewerVisibility,
+        camera.zoom,
+        presentation.kind,
+        nowMs,
+        reducedMotion,
+        viewerTechs,
+      );
+```
+
+- [ ] **Step 7: Add viewerTechs parameter to drawTileAtScreen**
+
+`drawTileAtScreen` currently has 11 parameters. Add `viewerTechs` as the 12th:
+
+Replace the current signature:
+```ts
+function drawTileAtScreen(
+  ctx: CanvasRenderingContext2D,
+  screen: { x: number; y: number },
+  scaledSize: number,
+  tile: HexTile,
+  isVillage: boolean,
+  currentPlayer: string | undefined,
+  viewerVisibility: VisibilityMap | undefined,
+  zoom: number,
+  presentationKind: TilePresentationKind,
+  nowMs: number,
+  reducedMotion: boolean,
+): void {
+```
+
+with:
+```ts
+function drawTileAtScreen(
+  ctx: CanvasRenderingContext2D,
+  screen: { x: number; y: number },
+  scaledSize: number,
+  tile: HexTile,
+  isVillage: boolean,
+  currentPlayer: string | undefined,
+  viewerVisibility: VisibilityMap | undefined,
+  zoom: number,
+  presentationKind: TilePresentationKind,
+  nowMs: number,
+  reducedMotion: boolean,
+  viewerTechs: ReadonlySet<string> = new Set(),
+): void {
+```
+
+- [ ] **Step 8: Thread viewerTechs into the drawHex call inside drawTileAtScreen**
+
+Inside `drawTileAtScreen`, the `drawHex` call currently passes 11 arguments. Add `viewerTechs` as the 12th:
+
+Replace:
+```ts
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion);
+```
+
+with:
+```ts
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, viewerTechs);
+```
+
+- [ ] **Step 9: Add viewerTechs parameter to drawHex**
+
+`drawHex` currently has 11 parameters. Add `viewerTechs` as the 12th optional parameter after `reducedMotion`:
+
+Replace the current signature:
+```ts
+function drawHex(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  size: number,
+  tile: HexTile,
+  isVillage: boolean = false,
+  currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
+  presentationKind: TilePresentationKind = 'live',
+  nowMs: number = 0,
+  reducedMotion: boolean = false,
+): void {
+```
+
+with:
+```ts
+function drawHex(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  size: number,
+  tile: HexTile,
+  isVillage: boolean = false,
+  currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
+  presentationKind: TilePresentationKind = 'live',
+  nowMs: number = 0,
+  reducedMotion: boolean = false,
+  viewerTechs: ReadonlySet<string> = new Set(),
+): void {
+```
+
+- [ ] **Step 10: Insert the resource icon drawing block in drawHex**
+
+In `drawHex`, the current drawing order is:
+1. Terrain fill + border
+2. Completed-improvement block (`if (tile.improvement !== 'none' && tile.improvementTurnsLeft === 0)`)
+3. In-progress construction block (`if (tile.improvement !== 'none' && tile.improvementTurnsLeft > 0)`)
+4. Wonder block (`if (tile.wonder)`)
+5. Village block (`if (isVillage && !tile.wonder)`)
+6. Ownership border
+
+Insert the resource icon block between the construction block and the wonder block. Find this exact section (the end of the construction block):
+
+```ts
+    ctx.fillText(`${tile.improvementTurnsLeft}t`, cx, cy + size * 0.25);
+  }
+
+  // Draw wonder indicator
+  if (tile.wonder) {
+```
+
+Replace it with:
+
+```ts
+    ctx.fillText(`${tile.improvementTurnsLeft}t`, cx, cy + size * 0.25);
+  }
+
+  // Draw resource icon (tech-gated).
+  // No explicit visibility guard needed: drawHex receives presentation.tile, which
+  // already has resource: null for unexplored/unknown-fog tiles (via unknownTile()).
+  // Last-seen tiles carry the resource from the snapshot — showing it is correct
+  // (the player remembers what they saw). Tech gate still applies.
+  if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
+    const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
+    const hasVisibleImprovement =
+      tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
+
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    if (hasVisibleImprovement) {
+      // Option B: small icon at top-left corner; improvement stays centered
+      ctx.font = `${size * 0.3}px system-ui`;
+      ctx.fillText(icon, cx - size * 0.3, cy - size * 0.3);
+    } else {
+      // No improvement competing — centered at full icon size
+      ctx.font = `${size * 0.5}px system-ui`;
+      ctx.fillText(icon, cx, cy);
+    }
+  }
+
+  // Draw wonder indicator
+  if (tile.wonder) {
+```
+
+- [ ] **Step 11: Run the renderer tests to confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/hex-renderer.test.ts
+```
+
+Expected: all 7 new resource-icon tests pass; all existing tests still pass.
+
+---
+
+### Task 3: Wire viewerTechs in render-loop.ts
+
+**Files:**
+- Modify: `src/renderer/render-loop.ts`
+
+- [ ] **Step 12: Derive viewerTechs and pass to drawHexMap**
+
+In `render-loop.ts`, the `render()` method currently starts with:
+
+```ts
+  private render(): void {
+    if (!this.state) return;
+    const viewerId = this.state.currentPlayer;
+    const viewerVisibility = this.state.civilizations[viewerId]?.visibility;
+```
+
+Add `viewerTechs` derivation immediately after `viewerVisibility`:
+
+```ts
+    const viewerTechs = new Set<string>(
+      this.state.civilizations[viewerId]?.techState.completed ?? []
+    );
+```
+
+Then update the `drawHexMap` call (currently 6 args) to pass `viewerTechs` as the 7th:
+
+Replace:
+```ts
+    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility);
+```
+
+with:
+```ts
+    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility, viewerTechs);
+```
+
+- [ ] **Step 13: Run the full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: exits 0. All tests pass.
+
+- [ ] **Step 14: Run the full build to check for type errors**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+
+Expected: exits 0. No TypeScript errors.
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add src/renderer/hex-renderer.ts src/renderer/render-loop.ts tests/renderer/hex-renderer.test.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): draw tech-gated resource icons on hex tiles
+
+Thread viewerTechs through drawHexMap→drawTileAtScreen→drawHex;
+insert resource icon block (Option B: corner overlap, center solo);
+derive viewerTechs in render-loop.ts.
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```

--- a/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-3-panels.md
+++ b/docs/superpowers/plans/2026-05-22-marketplace-s1-plan-3-panels.md
@@ -1,0 +1,427 @@
+# S1 Plan 3 — Panels & Legend: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the territory inspection panel's resource row behind the viewer's tech, enrich it with resource name + type, add a dynamic tech-filtered resource section to the map legend, and re-wire `main.ts` so the legend rebuilds on each show with current techs.
+
+**Architecture:** `createTerritoryInspectionPanel` derives `viewerTechs` internally — its public signature is unchanged, so no call-site changes in `main.ts` for the panel. `createIconLegendOverlay` gains a `viewerTechs` parameter; `main.ts` switches from pre-building it once at startup to rebuilding on each toggle. `toggleIconLegend` becomes dead and is removed.
+
+**Depends on:** Plan 1 merged first — imports `RESOURCE_DEFINITIONS` from `@/systems/trade-system`.
+
+**Tech Stack:** TypeScript, DOM, Vitest
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/ui/territory-inspection-panel.ts` | Import `RESOURCE_DEFINITIONS`; derive `viewerTechs`; replace unconditional resource line with tech-gated name+type display |
+| `src/ui/icon-legend.ts` | Add `viewerTechs` param; change initial `display` to `block` (overlay is now only created when about to be shown); add dynamic resource section; remove `toggleIconLegend` export |
+| `src/main.ts` | Remove `toggleIconLegend` import; remove pre-built `iconLegendOverlay` from `createGameShell` call; replace `onToggleIconLegend` callback with inline rebuild handler |
+| `tests/ui/territory-inspection-panel.test.ts` | Add two tech-gated resource display tests |
+| `tests/ui/icon-legend.test.ts` | New test file — two tests for resource section presence/absence |
+
+---
+
+### Task 1: Tech-gated resource display in inspection panel
+
+**Files:**
+- Modify: `tests/ui/territory-inspection-panel.test.ts`
+- Modify: `src/ui/territory-inspection-panel.ts`
+
+- [ ] **Step 1: Write failing inspection panel tests**
+
+The existing test uses `resource: 'wheat'` (not a valid `ResourceType`). The new tests use `resource: 'gems'` (luxury, enabling tech `'mining-tech'`). Add two tests inside the existing `describe('createTerritoryInspectionPanel', ...)`, after the existing test cases:
+
+```ts
+  it('shows resource name and type when viewer has the enabling tech', () => {
+    const state = makeInspectionState();
+    // Replace resource with a valid ResourceType
+    state.map.tiles['6,5'] = { ...state.map.tiles['6,5'], resource: 'gems' };
+    // Grant the enabling tech (gems → mining-tech)
+    state.civilizations.player.techState.completed = ['mining-tech'];
+
+    const panel = createTerritoryInspectionPanel(state, { q: 6, r: 5 }, 'player');
+
+    expect(panel.textContent).toContain('Gems (luxury)');
+  });
+
+  it('hides resource row when viewer lacks the enabling tech', () => {
+    const state = makeInspectionState();
+    state.map.tiles['6,5'] = { ...state.map.tiles['6,5'], resource: 'gems' };
+    // techState.completed defaults to [] from createNewGame — no tech granted
+
+    const panel = createTerritoryInspectionPanel(state, { q: 6, r: 5 }, 'player');
+
+    expect(panel.textContent).not.toContain('Gems');
+    expect(panel.textContent).not.toContain('luxury');
+  });
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/territory-inspection-panel.test.ts
+```
+
+Expected: "shows resource name and type" fails (current code unconditionally calls `addLine(panel, 'Resource', titleCase(tile.resource))` — no tech check, wrong format). "hides resource row" may pass accidentally if tile has `resource: 'wheat'` (not found in RESOURCE_DEFINITIONS) — but after this plan, both tests must pass for the correct reasons. Run to establish baseline.
+
+- [ ] **Step 3: Update territory-inspection-panel.ts**
+
+**Add import** — at the top of `src/ui/territory-inspection-panel.ts`, add alongside the existing imports:
+
+```ts
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+```
+
+**Derive viewerTechs** — inside `createTerritoryInspectionPanel`, after the `const viewer = state.civilizations[viewerId];` line (which is already there), add:
+
+```ts
+  const viewerTechs = new Set(viewer?.techState.completed ?? []);
+```
+
+**Replace the unconditional resource line** — find and replace line 95:
+
+```ts
+  if (tile.resource) addLine(panel, 'Resource', titleCase(tile.resource));
+```
+
+with:
+
+```ts
+  const resDef = tile.resource
+    ? RESOURCE_DEFINITIONS.find(r => r.id === tile.resource)
+    : null;
+  if (resDef && viewerTechs.has(resDef.tech)) {
+    addLine(panel, 'Resource', `${resDef.name} (${resDef.type})`);
+  }
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/territory-inspection-panel.test.ts
+```
+
+Expected: all tests pass — including the two new ones and all existing tests (the existing test uses `resource: 'wheat'` which won't be found in RESOURCE_DEFINITIONS, so `resDef` is null and no resource line is rendered, which the existing test doesn't assert either way).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/territory-inspection-panel.ts tests/ui/territory-inspection-panel.test.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): gate inspection panel resource row on tech; show name+type
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Dynamic resource section in icon legend
+
+**Files:**
+- Create: `tests/ui/icon-legend.test.ts`
+- Modify: `src/ui/icon-legend.ts`
+
+- [ ] **Step 6: Create failing icon-legend tests**
+
+Create `tests/ui/icon-legend.test.ts`:
+
+```ts
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createIconLegendOverlay } from '@/ui/icon-legend';
+
+class MockElement {
+  children: MockElement[] = [];
+  style: Record<string, string> = { cssText: '' };
+  id = '';
+  private ownText = '';
+
+  get textContent(): string {
+    return `${this.ownText}${this.children.map(child => child.textContent).join('')}`;
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+  }
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class MockDocument {
+  createElement(): MockElement {
+    return new MockElement();
+  }
+}
+
+describe('createIconLegendOverlay', () => {
+  const originalDocument = globalThis.document;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'document', {
+      value: new MockDocument() as unknown as Document,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'document', {
+      value: originalDocument,
+      configurable: true,
+    });
+  });
+
+  it('includes resource icon and name when viewer has the enabling tech', () => {
+    // animal-husbandry reveals Horses (🐎, strategic)
+    const overlay = createIconLegendOverlay(new Set(['animal-husbandry']));
+    expect((overlay as unknown as MockElement).textContent).toContain('🐎');
+    expect((overlay as unknown as MockElement).textContent).toContain('Horses');
+  });
+
+  it('omits the Resources section entirely when viewer has no resource techs', () => {
+    const overlay = createIconLegendOverlay(new Set());
+    expect((overlay as unknown as MockElement).textContent).not.toContain('Resources');
+    expect((overlay as unknown as MockElement).textContent).not.toContain('🐎');
+    expect((overlay as unknown as MockElement).textContent).not.toContain('Horses');
+  });
+});
+```
+
+- [ ] **Step 7: Run the tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/icon-legend.test.ts
+```
+
+Expected: both tests fail — `createIconLegendOverlay` currently takes no parameters and has no resource section.
+
+- [ ] **Step 8: Update icon-legend.ts**
+
+Replace the entire `src/ui/icon-legend.ts` with the new implementation:
+
+```ts
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+
+const LEGEND_ITEMS = [
+  { icon: '🏛️', label: 'City' },
+  { icon: '⚠️', label: 'Unrest' },
+  { icon: '🔥', label: 'Revolt' },
+  { icon: '✦', label: 'Natural Wonder' },
+  { icon: '🏕️', label: 'Tribal Village' },
+  { icon: '🌾', label: 'Farm' },
+  { icon: '⛏️', label: 'Mine' },
+];
+
+export function createIconLegendOverlay(viewerTechs: ReadonlySet<string> = new Set()): HTMLDivElement {
+  const overlay = document.createElement('div');
+  overlay.id = 'icon-legend';
+  // display:block — this function is now only called when about to show the overlay
+  overlay.style.cssText = 'position:absolute;top:84px;right:12px;z-index:24;width:180px;padding:12px;border-radius:12px;background:rgba(8,12,20,0.92);border:1px solid rgba(255,255,255,0.14);box-shadow:0 10px 30px rgba(0,0,0,0.35);display:block;';
+
+  const title = document.createElement('div');
+  title.textContent = 'Map Legend';
+  title.style.cssText = 'font-size:12px;font-weight:700;color:#f4f1e8;letter-spacing:0.04em;text-transform:uppercase;margin-bottom:8px;';
+  overlay.appendChild(title);
+
+  for (const item of LEGEND_ITEMS) {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:8px;color:#d7dce6;font-size:12px;padding:3px 0;';
+
+    const icon = document.createElement('span');
+    icon.textContent = item.icon;
+    icon.style.cssText = 'display:inline-flex;width:20px;justify-content:center;';
+    row.appendChild(icon);
+
+    const label = document.createElement('span');
+    label.textContent = item.label;
+    row.appendChild(label);
+
+    overlay.appendChild(row);
+  }
+
+  // Dynamic resource section — only shown when viewer has at least one resource tech
+  const unlockedResources = RESOURCE_DEFINITIONS.filter(r => viewerTechs.has(r.tech));
+  if (unlockedResources.length > 0) {
+    const resourceHeader = document.createElement('div');
+    resourceHeader.style.cssText = 'font-size:12px;font-weight:700;color:#f4f1e8;letter-spacing:0.04em;text-transform:uppercase;margin-top:10px;margin-bottom:4px;';
+    resourceHeader.textContent = 'Resources';
+    overlay.appendChild(resourceHeader);
+
+    const luxuries = unlockedResources.filter(r => r.type === 'luxury');
+    const strategics = unlockedResources.filter(r => r.type === 'strategic');
+
+    const groups: Array<[string, typeof unlockedResources]> = [
+      ['Luxury', luxuries],
+      ['Strategic', strategics],
+    ];
+
+    for (const [groupLabel, group] of groups) {
+      if (group.length === 0) continue;
+
+      const subHeader = document.createElement('div');
+      subHeader.style.cssText = 'font-size:10px;color:rgba(244,241,232,0.5);text-transform:uppercase;letter-spacing:0.05em;margin-top:4px;margin-bottom:2px;';
+      subHeader.textContent = groupLabel;
+      overlay.appendChild(subHeader);
+
+      for (const r of group) {
+        const row = document.createElement('div');
+        row.style.cssText = 'display:flex;align-items:center;gap:8px;color:#d7dce6;font-size:12px;padding:3px 0;';
+
+        const iconSpan = document.createElement('span');
+        iconSpan.textContent = r.icon;
+        iconSpan.style.cssText = 'display:inline-flex;width:20px;justify-content:center;';
+        row.appendChild(iconSpan);
+
+        const labelSpan = document.createElement('span');
+        labelSpan.textContent = r.name;
+        row.appendChild(labelSpan);
+
+        overlay.appendChild(row);
+      }
+    }
+  }
+
+  return overlay;
+}
+```
+
+Note: `toggleIconLegend` is removed — `main.ts` handles visibility directly.
+
+- [ ] **Step 9: Run the tests to confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/icon-legend.test.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/icon-legend.ts tests/ui/icon-legend.test.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): add dynamic tech-filtered resource section to map legend
+
+createIconLegendOverlay now accepts viewerTechs; appends luxury and
+strategic sub-sections for unlocked resources; removes toggleIconLegend
+(main.ts handles show/hide directly).
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Re-wire main.ts
+
+**Files:**
+- Modify: `src/main.ts`
+
+There are no dedicated automated tests for the `main.ts` wiring changes — the build (`yarn build`) is the type-checker, and the manual smoke test confirms end-to-end behavior. The three edits below are straightforward removals and substitutions.
+
+- [ ] **Step 11: Remove toggleIconLegend from the import**
+
+Find line 81 (the icon-legend import):
+
+```ts
+import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
+```
+
+Replace with:
+
+```ts
+import { createIconLegendOverlay } from '@/ui/icon-legend';
+```
+
+- [ ] **Step 12: Replace the onToggleIconLegend callback**
+
+Find line 221 (inside the `createGameShell` call options):
+
+```ts
+    onToggleIconLegend: () => toggleIconLegend(),
+```
+
+Replace with the inline rebuild handler:
+
+```ts
+    onToggleIconLegend: () => {
+      const existing = document.getElementById('icon-legend');
+      if (existing && existing.style.display !== 'none') {
+        // Already visible — hide it
+        existing.style.display = 'none';
+        return;
+      }
+      // Stale or absent — remove old, rebuild fresh with current techs
+      existing?.remove();
+      const viewerTechs = new Set<string>(
+        gameState.civilizations[gameState.currentPlayer]?.techState.completed ?? []
+      );
+      const overlay = createIconLegendOverlay(viewerTechs);
+      uiLayer.appendChild(overlay);
+    },
+```
+
+- [ ] **Step 13: Remove the pre-built iconLegendOverlay from createGameShell**
+
+Find line 236 (the last property of the `createGameShell` options object):
+
+```ts
+    iconLegendOverlay: createIconLegendOverlay(),
+```
+
+Remove this line entirely. The `iconLegendOverlay` prop in `game-shell.ts` is optional (`?`), so removing it from the call site causes no TypeScript error.
+
+- [ ] **Step 14: Run the full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: exits 0. All tests pass.
+
+- [ ] **Step 15: Run the full build to check for type errors**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+
+Expected: exits 0. TypeScript finds no errors — the removed `toggleIconLegend` import is no longer referenced, and the new inline handler type-checks correctly against the `onToggleIconLegend: () => void` callback type in game-shell.
+
+- [ ] **Step 16: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "$(cat <<'EOF'
+feat(S1): rebuild icon legend on each toggle with current viewer techs
+
+Remove pre-built overlay from createGameShell; replace toggleIconLegend
+with an inline handler that creates a fresh overlay per show, ensuring
+the resource list always reflects the player's current tech state.
+
+Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Manual smoke test (after all three plans merged)
+
+1. `bash scripts/run-with-mise.sh yarn dev`
+2. Start a new game.
+3. Open the map legend — confirm no "Resources" section.
+4. Tap a mountain tile — confirm no Resource row in the inspection panel.
+5. Research `gathering` (enables Stone 🪨).
+6. Open the map legend — confirm a "Resources" section appears with "Strategic" sub-heading and "🪨 Stone".
+7. Tap a mountain tile — confirm the Resource row reads "Stone (strategic)".
+8. Research `animal-husbandry` (enables Horses 🐎).
+9. Open the map legend — confirm "🐎 Horses" appears under "Strategic".
+10. Tap a plains tile that has Horses — confirm "Horses (strategic)" in the inspection panel.
+11. Save and reload — confirm resource display is consistent after reload.

--- a/docs/superpowers/plans/2026-05-22-marketplace-s1-resources-on-map.md
+++ b/docs/superpowers/plans/2026-05-22-marketplace-s1-resources-on-map.md
@@ -1,0 +1,41 @@
+# S1 — Resources on the Map: Implementation Plan Index
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship tech-gated resource icons on the hex map, a tech-filtered inspection panel, and a dynamic map legend — completing roadmap slice S1.
+
+**Architecture:** Three independent plans share a common dependency (Plan 1 data). Plans 2 and 3 both require Plan 1 to be merged first but are otherwise independent of each other and can be done in any order after that.
+
+**Target model:** sonnet 4.5
+
+---
+
+## Plans
+
+| Plan | File | Depends on | What ships |
+|------|------|-----------|-----------|
+| **Plan 1 — Data Foundation** | `2026-05-22-marketplace-s1-plan-1-data.md` | nothing | `tech` + `icon` fields on `ResourceDefinition`; resource-reveal text in tech tree |
+| **Plan 2 — Map Renderer** | `2026-05-22-marketplace-s1-plan-2-renderer.md` | Plan 1 | Resource icons drawn on hex tiles, tech-gated, fog-safe |
+| **Plan 3 — Panels & Legend** | `2026-05-22-marketplace-s1-plan-3-panels.md` | Plan 1 | Inspection panel shows resource name+type; map legend lists unlocked resources |
+
+## Execution order
+
+```
+Plan 1 → Plan 2
+       → Plan 3
+```
+
+Merge Plan 1 first. Plans 2 and 3 can then be worked in parallel or sequentially.
+
+## Spec reference
+
+`docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md`
+
+## Verification (after all three plans merged)
+
+```bash
+bash scripts/run-with-mise.sh yarn build   # must exit 0 (only path that runs tsc)
+bash scripts/run-with-mise.sh yarn test    # must exit 0
+```
+
+Manual smoke: start a new game → confirm no resource icons visible → research `gathering` → confirm 🪨 Stone appears on mountain tiles.

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -2,7 +2,7 @@
 
 **Origin:** GitHub issue [#234](https://github.com/a1flecke/conquestoria/issues/234) — "Create proper marketplace ui and system. Make ui meaningful."
 
-**Goal:** Turn the existing read-only marketplace stub into a real, legible trade system: resources visible on the map; clear tech + improvement requirements to own a tradeable resource; an age-appropriate caravan unit that establishes trade routes; relationship-gated trading; and actual transactions (sell/buy for gold or barter resource-for-resource).
+**Goal:** Turn the existing read-only marketplace stub into a real, legible trade system: resources visible on the map; clear tech + improvement requirements to own a tradeable resource; resources that actually do something; an age-appropriate progression of trade units that establish and run trade routes; relationship-gated trading; and actual transactions (sell/buy for gold or barter resource-for-resource).
 
 This file is the **index** and is intentionally deliverable #1 so the high-level plan survives context compaction. Each slice becomes its own brainstorm → spec → plan → PR cycle; per-slice decisions get recorded back here (see Living-doc protocol).
 
@@ -24,137 +24,168 @@ This file is the **index** and is intentionally deliverable #1 so the high-level
 |---|---|---|
 | Resource types (6 luxury, 4 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert). Strategic: copper(hills), iron(hills), horses(plains), stone(mountain). |
 | Resources placed on map tiles (`tile.resource`) | ✅ exists | `map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`; geo maps via `geo-map-loader.ts`. |
-| Per-turn price engine (supply/demand) + history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388. Note: `updatePrices` hardcodes `isMonopoly=false` (S10). |
+| Per-turn price engine (supply/demand) + history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388. Note: `updatePrices` hardcodes `isMonopoly=false` (S12). |
 | Marketplace **building** | ✅ exists | `city-system.ts` L59 `marketplace` (gold +3, cost 50, `techRequired: 'currency'`, icon 🏪). |
 | Marketplace **panel** (prices, sparklines, "you own", fashion banner) | ⚠️ read-only | `src/ui/marketplace-panel.ts`; opened via `onOpenMarketplace → togglePanel('marketplace')` in `main.ts`. Counts resources by raw `ownedTiles` (`countPlayerResources`), not by acquisition rules. |
 | `TradeRoute` type + per-turn income + embargo enforcement + wonder-route checks | ✅ plumbing exists | `types.ts` (`TradeRoute` has `fromCityId`,`toCityId`,`goldPerTurn`,`foreignCivId?`), `turn-manager.ts` income ~L391 / embargo ~L700, `diplomacy-system.ts` `enforceEmbargoes`, `trade-route-classification.ts`. |
 | Economy techs | ✅ exists | `tech-definitions.ts`: `currency`(era3, "Unlock Marketplace building"), **`trade-routes`(era4, "Enable trade routes between cities")**, `banking`, `global-logistics`; `wheel`(era2). |
-| Resource discovery mechanism | ✅ exists (espionage) | `identify_resources` is a **spy mission** (`espionage-system.ts`, `espionage-panel.ts`), NOT a tech node. Reveals resources in target territory. Relevant to Q5. |
+| Resource discovery mechanism | ✅ exists (espionage) | `identify_resources` is a **spy mission** (`espionage-system.ts`, `espionage-panel.ts`), NOT a tech node. Reveals resources in target territory. Relevant to D-Q5. |
+| Relationship bands in use | ✅ exists | Major-civ relationships are a **numeric score −100…+100** (`Civilization.diplomacy.relationships`) + `atWarWith`. Existing thresholds: trade-treaty `>0` (AI `>10`), alliance `>50`, "not too hostile" `>-20` (`ai-diplomacy.ts`, `diplomacy-system.ts`). |
 | Resources **drawn on the map** | ❌ MISSING | `hex-renderer.ts` `drawHex` (~L239–277) draws improvements/wonders/villages but **never** resources. `tile-presentation.ts` already carries `resource` through. |
-| Trade routes **ever created** | ❌ MISSING / DEAD | `marketplace.tradeRoutes` inits to `[]`; **nothing pushes to it**. The `trade-routes` tech unlock ("Enable trade routes between cities") is a **dead promise** — no creation path exists. Panel says "Build a Market to establish routes" but no code does. |
-| Caravan unit | ❌ MISSING | not in `UnitType` union (`types.ts` L230). |
+| Trade routes **ever created** | ❌ MISSING / DEAD | `marketplace.tradeRoutes` inits to `[]`; **nothing pushes to it**. The `trade-routes` tech unlock is a **dead promise** — no creation path. |
+| Caravan / trade unit | ❌ MISSING | not in `UnitType` union (`types.ts` L230). |
 | Tech-gated marketplace display | ❌ MISSING | panel lists all `RESOURCE_DEFINITIONS` regardless of tech. |
-| "Improvement on tile required to own a resource" rule | ❌ MISSING, **and blocked** | nothing computes per-civ owned resources from improvements. **Only 4 improvements exist** (`farm`,`mine`,`lumber_camp`,`watermill` — `types.ts` L165). `mine` covers hills/mountain (gems/copper/iron/stone). **No resource-appropriate improvement exists for grassland/plains/jungle/forest/desert luxuries+horses; desert has no improvement at all.** S2 likely must ADD improvements (see Q2). |
-| Relationship gating on trade | ❌ MISSING | major-civ relationships are a **numeric score −100…+100** (`Civilization.diplomacy.relationships: Record<civId, number>`) + an `atWarWith` array — there is **no named "neutral"/"angry" enum** for majors (named states are minor-civ only). "Neutral"/"angry" must be defined as score thresholds (Q8). |
+| "Improvement on tile required to own a resource" rule | ❌ MISSING, **and blocked** | **Only 4 improvements exist** (`farm`,`mine`,`lumber_camp`,`watermill` — `types.ts` L165). `mine` covers hills/mountain (gems/copper/iron/stone). **No resource-appropriate improvement for grassland/plains/jungle/forest/desert luxuries+horses; desert has none.** S2 adds the missing improvements (D-Q2). |
+| Relationship gating on trade | ❌ MISSING | must be implemented as score thresholds (D-Q8). |
 | Actual buy / sell / barter | ❌ MISSING | panel has no transaction actions. |
-| Gameplay effect of owning a resource | ❌ effectively NONE | `tile.resource` is only read by: marketplace supply, map-gen balancing, legendary-wonder diversity counts, espionage intel. Owning a resource confers **no happiness/unit/yield benefit today** → buying (S7) is meaningless until this is designed (Q1). |
+| Gameplay effect of owning a resource | ❌ NONE today | `tile.resource` only read by marketplace supply, map-gen balancing, wonder diversity counts, espionage intel. Owning a resource confers no benefit → S4 adds effects (D-Q1). |
 
 **Gotcha:** `src/systems/resource-system.ts` is misnamed — it computes **city tile yields**, not resources. Trade/resource logic lives in `trade-system.ts`. Put the new acquisition system in a clearly named new file (e.g. `resource-acquisition-system.ts`).
 
+## Shared foundation (used by S1–S4)
+
+A small data addition consumed by several early slices: give each entry in `RESOURCE_DEFINITIONS` a **`tech`** (enabling tech id), a **`requiredImprovement`** (the improvement that harvests it), and an **`effect`** descriptor (D-Q1). S1 needs `tech` (reveal), S2 needs `requiredImprovement` (acquisition), S3 needs `tech` (display filter), S4 needs `effect`. Land this data with S1 and extend it as later slices need it.
+
 ## Locked-in decisions
 
-| Decision | Choice | Notes |
+| Decision | Choice | Source |
 |---|---|---|
-| Delivery style | **Fine-grained vertical slices** | User preference: very fleshed-out, discrete deliverables that each add value and build on each other, over scattered half-built pieces. |
-| Decomposition | **10 slices + 1 candidate, in 4 phases** | Each slice = one brainstorm → spec → plan → PR. Ship in order. |
-| Roadmap-first | **This index is deliverable #1** | Committed before code so the plan survives context loss. |
-| No dead-end UX | **Every slice ships self-contained value** | Per `.claude/rules/incremental-mr-completion.md`: never ship a button/unit/queue entry that does nothing. S4 therefore bundles the establish-route action with the caravan. |
-| Caravan tech gate | **`trade-routes` tech** (S4 makes its dead unlock real) | Confirms req. 8 "age-appropriate"; era 4. Final tier model is Q4. |
+| Delivery style | **Fine-grained vertical slices**, each shipping self-contained value | user |
+| Decomposition | **12 slices in 5 phases** (below) | this roadmap |
+| Roadmap-first | **This index is deliverable #1** | user |
+| No dead-end UX | every slice ships working value (no inert buttons/units) | `.claude/rules/incremental-mr-completion.md` |
+| Resource effects | **mixed per-resource**: some happiness, some gold, some production; strategic resources are **prerequisites for certain buildings/units** (iron → swordsman) | D-Q1 |
+| Improvements | **add resource-specific improvements** (plantation, pasture, camp, quarry, …) | D-Q2 |
+| Route scope | **domestic + foreign**; relationship gating applies to **foreign only** | D-Q3 |
+| Trade units | **per-age progression** incl. a **naval trader** for overseas | D-Q4 |
+| Map reveal | **tech-gated**: a resource appears only with its enabling tech (spy mission may still reveal earlier) | D-Q5 |
+| Route capacity | **per-city**, scaling with **tech and buildings** | D-Q6 |
+| Caravan fate | **committed to the route**, travels back and forth; losing/disbanding it ends the route (caravans are raidable) | D-Q7 |
+| Trade thresholds | foreign trade **establishes at relationship ≥ 0**; **terminates when < −25 or at war** | D-Q8 |
 
 ## Conventions every slice MUST follow
 
-These apply to all slices; per-slice sections below only note *additions*.
+Per-slice sections below only note *additions*.
 
-- **Verify before any push/PR:** `bash scripts/run-with-mise.sh yarn build` (this is the only `tsc` path) **and** `bash scripts/run-with-mise.sh yarn test` must both exit 0. The `require-green-before-push` hook enforces this; catch it locally first.
-- **Branch/PR workflow:** never commit to `main`; work on a branch/worktree and open a PR. If a PR ships only a subset of a slice, follow `.claude/rules/incremental-mr-completion.md` (subset title, "Out of scope" list, "why safe to merge partial" paragraph naming every player-visible surface).
-- **Hot-seat:** use `state.currentPlayer` everywhere; never hardcode `'player'`. Renderer/UI take `currentPlayer`.
+- **Verify before any push/PR:** `bash scripts/run-with-mise.sh yarn build` (the only `tsc` path) **and** `bash scripts/run-with-mise.sh yarn test` must both exit 0. The `require-green-before-push` hook enforces this; catch it locally first.
+- **Branch/PR workflow:** never commit to `main`; branch/worktree + PR. Partial slices follow `.claude/rules/incremental-mr-completion.md` (subset title, "Out of scope" list, "why safe to merge partial" paragraph).
+- **Hot-seat:** use `state.currentPlayer`; never hardcode `'player'`.
 - **Determinism:** seeded RNG only; never `Math.random()`.
-- **Immutable turn processing:** turn/system functions return a new `GameState` via spread-copy; never mutate `state.cities[id]=…` etc. (`.claude/rules/game-systems.md`).
-- **UI:** mobile-first touch (≥44px targets); buttons via `createGameButton()` (no bare buttons); dynamic text via `textContent`/`createTextNode()` (never `innerHTML` with game strings); a panel that mutates state it renders must refresh; never silently discard a player-visible list.
-- **End-to-end wiring:** computed data must render; new units need all 6 wirings (`.claude/rules/end-to-end-wiring.md`); shared consequences must be actor-complete (human **and** AI/turn paths) with parity tests.
-- **Save compatibility:** the game has multiple save slots in active family use. New `MarketplaceState` fields, new `ImprovementType`s, new `UnitType`s, and `RESOURCE_DEFINITIONS` shape changes must tolerate old saves (optional fields / defensive defaults / migration). Add a load-old-save regression where state shape changes.
+- **Immutable turn processing:** systems return a new `GameState` via spread-copy (`.claude/rules/game-systems.md`).
+- **UI:** mobile-first touch (≥44px); `createGameButton()` (no bare buttons); `textContent`/`createTextNode()` only (no `innerHTML` with game strings); panels that mutate state they render must refresh; never silently discard a player-visible list.
+- **End-to-end wiring:** computed data must render; new units need all 6 wirings (`.claude/rules/end-to-end-wiring.md`); shared consequences actor-complete (human **and** AI/turn) with parity tests.
+- **Save compatibility:** multiple save slots are in active family use. New `MarketplaceState`/`TradeRoute` fields, new `ImprovementType`s, new `UnitType`s, and `RESOURCE_DEFINITIONS` shape changes must tolerate old saves (optional fields / defaults / migration). Add a load-old-save regression when state shape changes.
 - **AI parity:** any player-affecting trade consequence must also be exercised/usable by AI civs.
 
-## Decomposition — slices
+## Decomposition — 12 slices
 
-Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-marketplace-sN-<topic>-design.md`, its plan at `docs/superpowers/plans/…`.
+Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-marketplace-sN-<topic>-design.md`, its plan under `docs/superpowers/plans/`.
 
-### Phase 1 — Honest visibility
+### Phase 1 — Visibility & ownership
 
-**S1 — Resources on the map.**
-*Scope:* draw a distinct, legible icon per `ResourceType` on its tile; tap-to-inspect surfaces resource name + type; add a legend entry. Decide Q5 (always-visible vs. discovered-only via the existing `identify_resources` mechanism / exploration).
-*Files:* `hex-renderer.ts` `drawHex` (mirror the improvement/wonder icon pattern); a resource→icon map (add `icon` to `RESOURCE_DEFINITIONS` in `trade-system.ts`, or a small new module); `src/ui/icon-legend.ts`; tile/territory inspection (`src/ui/territory-inspection-panel.ts` and/or selected-tile info). `tile-presentation.ts` already carries `resource`.
-*Done when:* every resource type renders its icon on visible tiles; inspection shows name+type; legend lists them; if Q5=discovered-only, fog/unexplored tiles do **not** leak resources.
-*Tests:* every `ResourceType` has an icon (catalog test); inspection surfaces name+type; negative fog-leak test if discovered-only.
-*Extra rules:* ui-panels privacy (mask under fog per presentation kind); `sprites.md` if using sprites vs. emoji.
+**S1 — Resources on the map (tech-gated reveal).**
+*Scope:* add `tech` to `RESOURCE_DEFINITIONS`; draw a distinct icon per `ResourceType` on tiles **only when the viewer has the enabling tech** (D-Q5); tap-to-inspect shows resource name + type; legend entry. The `identify_resources` spy mission may still reveal un-tech'd resources (intel edge).
+*Files:* `hex-renderer.ts` `drawHex` (mirror improvement/wonder icon pattern); resource→icon + `tech` data in `trade-system.ts`; `src/ui/icon-legend.ts`; tile/territory inspection (`territory-inspection-panel.ts`/selected-tile info). `tile-presentation.ts` already carries `resource`.
+*Done when:* resources render only for tech-holders; inspection shows name+type; legend lists them; fog/unexplored and un-tech'd tiles do **not** leak resources.
+*Tests:* every resource has icon+tech (catalog test); reveal appears only with tech (negative without tech); fog-leak negative; spy-reveal still works.
+*Extra rules:* ui-panels privacy; `sprites.md` if using sprites.
 
-**S2 — Acquisition model + per-civ inventory.**
-*Scope:* a pure helper `getCivAvailableResources(state, civId)` returning the resources a civ can trade, applying **(tech known AND qualifying improvement built on the tile, `improvementTurnsLeft===0)`**, EXCEPT a resource on a **city-center** tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") + in tile inspection ("To use: needs Mining + a Mine here — ✓/✗"). **Resolve Q2** (resource→tech→improvement mapping; almost certainly add improvements — desert/incense currently has none).
-*Files:* new `src/systems/resource-acquisition-system.ts`; add `tech` + `requiredImprovement` to `RESOURCE_DEFINITIONS` (`trade-system.ts`); if adding improvements: `types.ts` `ImprovementType`, `improvement-system.ts`, `worker-action-system.ts`, `hex-renderer.ts` icons, `resource-system.ts` yields; inventory UI in city/territory panel.
-*Done when:* helper returns correct sets for all civs; UI shows owned vs. needs-improvement; iterates **all** cities (not `cities[0]`).
-*Tests (spec-fidelity conjunction):* tech-without-improvement → unavailable; improvement-without-tech → unavailable; both → available; city-tile + tech-only → available without improvement; resource not under city + tech-only → unavailable.
+**S2 — Acquisition model + resource-specific improvements + inventory.**
+*Scope:* add the new improvements from D-Q2 (e.g. plantation, pasture, camp, quarry) wired end-to-end (terrain rules, worker action, icon, yields); add `requiredImprovement` to resource data; a pure helper `getCivAvailableResources(state, civId)` applying **(tech known AND the required improvement built, `improvementTurnsLeft===0)`**, EXCEPT a resource on a **city-center** tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") + tile inspection ("To use: needs Mining + a Mine here — ✓/✗").
+*Files:* new `src/systems/resource-acquisition-system.ts`; `types.ts` `ImprovementType`; `improvement-system.ts`, `worker-action-system.ts`, `hex-renderer.ts` icons, `resource-system.ts` yields; `trade-system.ts` resource data; inventory UI.
+*Done when:* every resource has a buildable harvesting improvement; helper returns correct sets across **all** cities (not `cities[0]`); UI shows owned vs. needs-improvement.
+*Tests (spec-fidelity conjunction):* tech-without-improvement → unavailable; improvement-without-tech → unavailable; both → available; city-tile + tech-only → available; resource off-city + tech-only → unavailable; new improvements buildable only on correct terrain.
 
 **S3 — Marketplace tells the truth.**
-*Scope:* filter the panel to resources whose enabling tech the current player has (req. 2); replace `countPlayerResources` with S2's helper for owned/available counts.
+*Scope:* filter the panel to resources whose enabling tech the current player has (req. 2); replace `countPlayerResources` with S2's helper.
 *Files:* `src/ui/marketplace-panel.ts`.
-*Done when:* only tech-available resources are listed; counts come from S2; uses `state.currentPlayer`.
-*Tests:* a no-tech resource is absent (negative); a tech-available resource is present and its count matches S2; all tech-available resources remain reachable (catalog completeness).
+*Done when:* only tech-available resources listed; counts from S2; uses `state.currentPlayer`.
+*Tests:* no-tech resource absent (negative); tech-available present with matching count; all tech-available remain reachable (catalog completeness).
 
-### Phase 2 — Caravans & routes
+### Phase 2 — Resources matter
 
-**S4 — Caravan unit + establish a trade route.**
-*Scope:* add `'caravan'` `UnitType`, wired end-to-end (all 6 points of the unit rule + `PRODUCTION_ICONS`), trainable gated on `trade-routes` tech (makes that dead unlock real). Player moves a caravan to a valid target city to open a `TradeRoute`; gating = **not at war AND relationship ≥ neutral threshold** (Q8). Route persists in `marketplace.tradeRoutes`, renders on map + panel, pays existing gold/turn income. AI trains and uses caravans. **Resolve Q3** (domestic vs. foreign), **Q4** (single vs. tiered), **Q7** (consumed on establish?), **Q8** (thresholds), **Q6** (route limits).
-*Files:* `types.ts` (`UnitType`, maybe events); `unit-system.ts` (`UNIT_DEFINITIONS`+`UNIT_DESCRIPTIONS`); `unit-renderer.ts` (icon); `city-system.ts` (`TRAINABLE_UNITS`+`PRODUCTION_ICONS`+tech gate); `turn-manager.ts` (production side-effects + tech-gated dequeue); `main.ts` (establish-route interaction + death cleanup); `basic-ai.ts` (queue + use); route-creation helper in `trade-system.ts`; establish-route UI.
-*Done when:* caravan is trainable/visible/AI-used; establishing a route succeeds at neutral+ and **fails** when at war or below threshold; route renders and pays income.
-*Tests:* full unit-wiring coverage; establish success (positive) + at-war/below-threshold (negatives); AI-parity (AI establishes a route); route renders/persists.
+**S4 — Resource effects (D-Q1).**
+*Scope:* owning/acquiring a resource confers a **per-resource effect** — some grant happiness, some gold, some production; **strategic resources gate certain buildings/units** (e.g. iron required to train swordsman). Add an `effect` descriptor to resource data; apply happiness/yield effects in city processing; enforce resource prerequisites in `city-system.ts` training/building gating (alongside existing `techRequired`).
+*Files:* `trade-system.ts` (effect data); `resource-system.ts`/city yield + happiness processing; `city-system.ts` (`TRAINABLE_UNITS`/`BUILDINGS` gating reads available resources from S2); city panel surfaces the effect + "requires iron" gating reason.
+*Done when:* having a resource changes happiness/yields; a unit/building that requires a resource is **blocked without it** and trainable with it; the requirement is shown in the city panel.
+*Tests:* effect applied per resource type; prerequisite gating positive+negative (no iron → swordsman untrainable; iron → trainable); spec-fidelity negative coverage.
 
-**S5 — Route lifecycle.**
-*Scope:* declaring war or relationship dropping to "angry" terminates affected routes that same turn (req. 6); create/terminate emit persistent notification-log entries (with turn #); integrate with `enforceEmbargoes`; income stops same turn.
-*Files:* `turn-manager.ts` (lifecycle pass), `diplomacy-system.ts` (scrub routes on war / relationship change — actor-complete), notification routing.
-*Done when:* war/angry terminates the route and stops income same turn; peace/neutral keeps it.
-*Tests:* war terminates + stops income (positive); neutral keeps it (negative); termination fires once (not re-fired every steady-state turn); actor-complete (human-declared AND AI-declared war both terminate).
+### Phase 3 — Caravans & routes
 
-### Phase 3 — Transactions
+**S5 — First trade unit + establish a route.**
+*Scope:* add the first-tier trade `UnitType` wired end-to-end (6 points + `PRODUCTION_ICONS`), gated on `trade-routes` tech (makes the dead unlock real). Move it to a target city to establish a `TradeRoute`. **Domestic** (own cities, no relationship gate) **and foreign** (D-Q3) — foreign requires **not at war AND relationship ≥ 0** (D-Q8). Per-city route **capacity** scaling with tech + buildings (D-Q6); the unit is **committed to the route** (D-Q7 — stationed for this slice; physical travel lands in S6). Route persists, renders on map + panel, pays existing gold/turn income. AI trains + uses it.
+*Files:* `types.ts`; `unit-system.ts`; `unit-renderer.ts`; `city-system.ts` (TRAINABLE_UNITS+PRODUCTION_ICONS+tech gate, capacity helper); `turn-manager.ts` (dequeue/side-effects); `main.ts` (establish interaction + death cleanup); `basic-ai.ts`; route-creation + capacity helpers in `trade-system.ts`; establish-route UI.
+*Done when:* unit trainable/visible/AI-used; domestic route works ungated; foreign route succeeds at ≥0 + not-at-war and **fails** otherwise; capacity cap enforced; route renders + pays income.
+*Tests:* unit-wiring coverage; domestic success; foreign success (positive) + at-war/below-0 (negatives); capacity-cap negative; AI-parity; route renders/persists.
 
-**Sx (candidate) — Resource effects.** *Resolves Q1; insert before S7 if Q1 says resources should confer benefits.* Owning/acquiring a resource grants an effect (e.g. luxuries→happiness, strategic→unit unlock/strength). Without this, buying is meaningless. Scope decided in its own brainstorm.
+**S6 — Route lifecycle + caravan route-running.**
+*Scope:* the committed trade unit **travels back and forth** between the two cities along the route (D-Q7) and is **raidable**; a route terminates when its unit is destroyed/disbanded, when foreign relations drop **< −25 or war** (D-Q8), or via embargo; create/terminate emit persistent notification-log entries (turn #). Integrate with `enforceEmbargoes`. Income stops the same turn.
+*Files:* `unit-movement-system.ts` / route-runner (back-and-forth pathing), `turn-manager.ts` (lifecycle pass), `diplomacy-system.ts` (scrub on war/relationship — actor-complete), combat/raid hooks (unit loss → route end), notification routing.
+*Done when:* unit visibly runs the route; killing it ends the route + income; foreign relations <−25/war terminates same turn; domestic routes unaffected by relations.
+*Tests:* travel movement; unit-loss ends route; war/<−25 terminates + stops income (positive) and ≥0 keeps it (negative); termination fires once; actor-complete (human + AI war both terminate).
 
-**S6 — Sell a resource for gold.**
-*Scope:* with an available resource (S2) + active route (S4) + neutral+ relations, sell at the live price; gold credited; supply/price adjust; panel refreshes.
-*Files:* `marketplace-panel.ts`, transaction helper in `trade-system.ts`, `main.ts` wiring.
-*Done when:* sell works and is gated on ownership+route+relationship; panel re-renders post-sale.
-*Tests:* sell gated (negatives for missing route / non-neutral / not owned); panel rerender; price/supply update.
+**S7 — Trade-unit tiers + naval trader (D-Q4).**
+*Scope:* per-age progression of trade units (caravan → merchant → …) with upgrades, plus a **naval trader** enabling overseas/coastal routes. Tech-gated per era; upgrade path via existing unit-upgrade system.
+*Files:* `unit-system.ts`, `unit-upgrade-system.ts`, `unit-renderer.ts`, `city-system.ts`, `basic-ai.ts`, `trade-route-classification.ts` (overseas routes already partly modeled).
+*Done when:* later eras unlock stronger/faster traders; overseas routes possible via the naval trader; upgrade path works.
+*Tests:* tier tech-gating; overseas route requires naval trader; upgrade path; AI uses tiers.
 
-**S7 — Buy a resource for gold.** *Gated on the resource-effects slice (Q1).* Spend gold to acquire a resource you lack; it must confer a real benefit. Tests: buy gated; effect applied.
+### Phase 4 — Transactions
 
-**S8 — Barter resource-for-resource.** *Req. 9.* Propose/accept swap with another civ (analogous to diplomacy treaties); both inventories update bilaterally; AI evaluates offers. Tests: bilateral update; AI accept/reject; relationship+route gating.
+**S8 — Sell a resource for gold.**
+*Scope:* with an available resource (S2) + active route (S5) + (foreign) neutral+ relations, sell at the live price; gold credited; supply/price adjust; panel refreshes.
+*Files:* `marketplace-panel.ts`, transaction helper in `trade-system.ts`, `main.ts`.
+*Done when:* sell works and is gated on ownership+route+relationship; panel re-renders.
+*Tests:* sell gated (negatives for missing route / non-neutral / not owned); rerender; price/supply update.
 
-### Phase 4 — Depth & parity
+**S9 — Buy a resource for gold.** *Now meaningful via S4 effects.* Spend gold to acquire a resource you lack; its effect applies (happiness/yield, or unlocks a gated unit/building). Tests: buy gated; effect applied.
 
-**S9 — AI trades too.** Full parity: AI establishes routes, sells surplus, buys needs, handles barter. Tests: AI visibly participates; parity regressions. (Some AI wiring lands per-slice; this guarantees strategy + completeness.)
+**S10 — Barter resource-for-resource (req. 9).** Propose/accept swap with another civ (analogous to diplomacy treaties); both inventories update bilaterally; AI evaluates offers. Tests: bilateral update; AI accept/reject; relationship+route gating.
 
-**S10 — Price-algorithm refinement (req. 7).** Real monopoly detection with per-player supply share (`calculatePrice` already accepts `isMonopoly`; `updatePrices` must compute it), demand tied to resource effects, fashion interplay. Tests: monopoly raises price; balance tests with seeded statistical sampling.
+### Phase 5 — Depth & parity
+
+**S11 — AI trades too.** Full parity: AI builds traders, establishes routes, sells surplus, buys needs, handles barter. Tests: AI visibly participates; parity regressions.
+
+**S12 — Price-algorithm refinement (req. 7).** Real monopoly detection with per-player supply share (`calculatePrice` already accepts `isMonopoly`; `updatePrices` must compute it), demand tied to resource effects, fashion interplay. Tests: monopoly raises price; balance tests with seeded statistical sampling.
 
 ## Sequencing & milestones
 
-Linear; each phase gates the next. 1) Roadmap (done). 2) S1 → S2 → S3 (honest visibility). 3) S4 → S5 (caravans/routes). 4) resource-effects (if Q1 requires) → S6 → S7 → S8 (transactions). 5) S9, S10 (depth; may fold into earlier AI/price work if cleaner during planning).
+Linear; each phase gates the next.
+1. Roadmap (done).
+2. **S1 → S2 → S3** — visibility & honest marketplace.
+3. **S4** — resources gain effects + unit/building prerequisites (value even before trade).
+4. **S5 → S6 → S7** — trade units, routes, lifecycle, tiers/naval.
+5. **S8 → S9 → S10** — transactions.
+6. **S11, S12** — parity & price depth (may fold into earlier AI/price work if cleaner during planning).
 
-## Cross-cutting deferred questions
+## Resolved design decisions (Q&A, 2026-05-20)
 
-Deferred by the user at roadmap time (2026-05-20). Each is owned by the slice that must resolve it.
+- **D-Q1 — Resource effects.** Mixed per-resource: some happiness, some gold, some production. Strategic resources are **prerequisites for certain buildings/units** (e.g. iron → swordsman). → S4 (+ city-system gating).
+- **D-Q2 — Improvements.** Add resource-specific improvements (plantation, pasture, camp, quarry, …) wired end-to-end. → S2.
+- **D-Q3 — Route scope.** Both domestic and foreign; relationship gating **foreign only**. → S5/S6.
+- **D-Q4 — Trade units.** Per-age progression incl. a naval trader for overseas. → S5 (first tier), S7 (tiers + naval).
+- **D-Q5 — Map reveal.** Tech-gated; the `identify_resources` spy mission may still reveal earlier. → S1.
+- **D-Q6 — Route capacity.** Per-city, scaling with tech and buildings. → S5.
+- **D-Q7 — Caravan fate.** Committed to the route, travels back and forth; losing/disbanding it ends the route (raidable). → S5 (commit), S6 (travel + loss).
+- **D-Q8 — Thresholds.** Foreign trade establishes at relationship ≥ 0; terminates when < −25 or at war. → S5/S6.
 
-- **Q1 — What do resources actually DO?** Verified: today owning a resource confers **no** mechanical benefit. Luxuries→happiness? strategic→unit unlocks? May warrant its own slice. **Resolve before S7** (gates buying's meaning).
-- **Q2 — Resource → tech → improvement mapping.** Only 4 improvements exist; `mine` covers hills/mountain; **grassland/plains/jungle/forest/desert resources have no fitting improvement (desert none at all)**. Decide: add plantation/pasture/camp (and a desert option), or one generic "trading post", or map to existing improvements. **Resolve in S2.**
-- **Q3 — Trade scope.** Domestic routes (between your own cities) too, or only foreign-civ routes (`TradeRoute.foreignCivId`)? **Resolve in S4.**
-- **Q4 — Caravan tiers.** One upgradeable caravan, or per-age tier (caravan → merchant ship → …)? Gate confirmed as `trade-routes` tech minimum. **Resolve in S4.**
-- **Q5 — Map reveal model.** Always draw resources, or hide until discovered (the `identify_resources` spy mission already reveals them; exploration could too)? **Resolve in S1.**
-- **Q6 — Route limits.** Max routes per city / per caravan / empire-wide? **Resolve in S4.**
-- **Q7 — Caravan consumption.** Does establishing a route consume the caravan (Civ-style), or does it persist / return / run the route repeatedly? **Resolve in S4.**
-- **Q8 — Relationship thresholds.** Relationships are numeric −100…+100. What score is "neutral" (minimum to trade) and "angry" (terminate)? Note `atWarWith` is separate from score. **Resolve in S4/S5.**
+### Open at slice level (resolve in each slice's brainstorm)
+Exact happiness/yield magnitudes per resource; the resource→improvement and resource→effect tables; which units/buildings require which strategic resource; naval-trader tech gate and overseas-route rules; route-capacity formula constants; barter UI (propose/accept vs. instant).
 
 ## Rejected items
 
-*(none yet — record here when something is considered and deliberately not pursued, with the reason, so future-us doesn't relitigate.)*
+*(none yet — record here when something is considered and deliberately not pursued, with the reason.)*
 
 ## Living-doc protocol
 
-Single source of truth for locked vs. open. Update when: a slice is locked (record decisions + child-spec path); a locked decision changes (note date/reason); a deferred question resolves (move it into its slice); scope shifts in a slice (record under it); a new item is deferred (add to the list); an item is rejected (move to Rejected with reason). Commit updates alongside the change that triggered them.
+Single source of truth for locked vs. open. Update when: a slice is locked (record decisions + child-spec path); a locked decision changes (note date/reason); a slice-level open question resolves; scope shifts in a slice; a new item is deferred; an item is rejected. Commit updates alongside the change that triggered them.
 
 ## Runbook — picking up the next slice (for a future session)
 
 1. Read this roadmap top to bottom.
 2. Find the next unstarted slice in **Sequencing**.
 3. **Re-verify** the Current-state rows for the files that slice touches — code may have moved since `84f9182`.
-4. Invoke `superpowers:brainstorming` for that slice; resolve its assigned deferred question(s) with the user.
+4. Invoke `superpowers:brainstorming` for that slice; resolve its slice-level open questions with the user.
 5. Write the slice spec (`docs/superpowers/specs/`), then the plan (`docs/superpowers/plans/`), then implement with TDD.
 6. Verify (`yarn build` + `yarn test` both green), open a PR per the Conventions.
 7. Record the slice's locked decisions + child-spec path back in this roadmap.

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -1,0 +1,144 @@
+# Marketplace & Trade Roadmap — Index
+
+**Origin:** GitHub issue [#234](https://github.com/a1flecke/conquestoria/issues/234) — "Create proper marketplace ui and system. Make ui meaningful."
+
+**Goal:** Turn the existing read-only marketplace stub into a real, legible trade system: resources visible on the map; clear tech + improvement requirements to own a tradeable resource; an age-appropriate caravan unit that establishes trade routes; relationship-gated trading; and actual transactions (sell/buy for gold or barter resource-for-resource).
+
+This file is the **index**. It is intentionally the first deliverable so the high-level plan survives context compaction. Each slice below becomes its own brainstorm → plan → PR cycle; per-slice decisions get recorded back here.
+
+## Issue requirements (verbatim, from #234 + comments)
+
+1. Make the marketplace UI meaningful (it is currently read-only — shows prices but does nothing).
+2. Do not show items we do not have the tech for.
+3. Show resources on the map.
+4. Must have tech **and** map improvements to acquire resources (e.g. must have Mining **and** have built a Mine on top of Iron to have Iron to trade).
+5. Exception: if the resource is on the same square as a city, **just tech** is required.
+6. Trading requires a trade route **and** at least a neutral relationship. War and angry relations terminate trade.
+7. Need algorithms for prices.
+8. Need a caravan unit, age-appropriate, for establishing trade routes and for doing the actual trade.
+9. Trade can be for straight money **or** in exchange for another resource.
+
+## Current state (what already exists — do not rebuild)
+
+Findings from the codebase as of this roadmap (commit base `84f9182`):
+
+| Area | Status | Location |
+|---|---|---|
+| Resource types (6 luxury, 4 strategic) + base prices | ✅ exists | `src/systems/trade-system.ts` `RESOURCE_DEFINITIONS` |
+| Resources placed on map tiles (`tile.resource`) | ✅ exists | map generators (`map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`) |
+| Per-turn price engine (supply vs. demand) + price history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388 |
+| Marketplace panel (prices, sparklines, "you own" counts, fashion banner) | ⚠️ read-only | `src/ui/marketplace-panel.ts`; opened via `togglePanel('marketplace')` in `main.ts` |
+| `TradeRoute` type + per-turn gold income + embargo enforcement + wonder-route checks | ✅ type/plumbing exists | `types.ts`, `turn-manager.ts` ~L700, `diplomacy-system.ts` `enforceEmbargoes`, `trade-route-classification.ts` |
+| Resources **drawn on the map** | ❌ missing | `hex-renderer.ts` `drawHex` draws improvements/wonders/villages but **never** resources |
+| Trade routes **ever created** | ❌ missing | `marketplace.tradeRoutes` is initialized to `[]` and nothing pushes to it — the list is always empty |
+| Caravan unit | ❌ missing | not in `UnitType` union (`types.ts` L230) |
+| Tech-gated marketplace display | ❌ missing | panel shows all `RESOURCE_DEFINITIONS` regardless of tech |
+| "Need improvement on the tile to own a resource" rule | ❌ missing | nothing computes per-civ owned/available resources from improvements |
+| Relationship gating on trade | ❌ missing | no neutral+ check; no war/angry termination of trade actions |
+| Actual buy / sell / barter | ❌ missing | panel has no transaction actions |
+| Tech effect `identify_resources` (reveal strategic resources in territory) | ✅ defined, unused-ish | `types.ts` L559 — relevant to deferred Q5 |
+
+**Key gotcha:** `src/systems/resource-system.ts` is misleadingly named — it computes **city tile yields**, not resources. The resource/trade logic lives in `trade-system.ts`.
+
+## Locked-in decisions
+
+| Decision | Choice | Notes |
+|---|---|---|
+| Delivery style | **Fine-grained vertical slices** | User preference: very fleshed-out, discrete deliverables that each add value and build on each other, over scattered half-built pieces. |
+| Decomposition | **10 slices in 4 phases** (below) | Each slice = one brainstorm → plan → PR. Ship in order. |
+| Roadmap-first | **This index doc is deliverable #1** | Committed before any code so the plan survives context loss. |
+| No dead-end UX | **Every slice ships self-contained value** | Per `.claude/rules/incremental-mr-completion.md`: never ship a button/unit/queue entry that does nothing. The caravan slice (S4) therefore includes the establish-route action. |
+
+## Decomposition — 10 slices, 4 phases
+
+Ship in order. Each slice gets its own `docs/superpowers/specs/` design and `docs/superpowers/plans/` plan when it is brainstormed.
+
+### Phase 1 — Honest visibility
+
+**S1 — Resources on the map.**
+Draw a distinct icon per resource on its tile in `hex-renderer.ts` (luxury vs. strategic readable at a glance); tap-to-inspect surfaces resource name + type. Carries `resource` already present in `TilePresentation`.
+*Value:* players can finally see where resources are.
+*Honors:* end-to-end-wiring (computed `resource` must render); ui-panels privacy (respect fog/last-seen presentation kind).
+
+**S2 — Acquisition model + per-civ resource inventory.**
+A system computes, per civ, which resources are actually **owned/available** = required tech known **AND** the right improvement built on the resource tile — with the exception that a resource on a city-center tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") and in tile inspection ("To use: needs Mining + a Mine here"). Requires the resource→tech→improvement mapping (deferred Q2).
+*Value:* the rules become legible; foundation for every later slice.
+*Honors:* spec-fidelity conjunction (tech AND improvement; add negative tests for tech-without-improvement, improvement-without-tech, and the city-tile exception).
+
+**S3 — Marketplace tells the truth.**
+Filter the existing read-only panel to resources the civ has the tech for (req. 2); show real owned/available counts from S2 instead of the current raw tile count.
+*Value:* no more phantom items.
+*Honors:* ui-panels catalog rules; XSS-safe `textContent` rendering (already followed in the panel).
+
+### Phase 2 — Caravans & routes
+
+**S4 — Caravan unit + establish a trade route.**
+Add an age-appropriate caravan `UnitType`, wired end-to-end per `.claude/rules/end-to-end-wiring.md` (definitions + descriptions, renderer icon, trainable + tech gate, AI usage, tech-gated dequeue, production icon). Player sends the caravan to a valid target city to open a route; requires **at least neutral** relations (req. 6 + 8). Routes render on the map + in the panel and pay the already-wired gold/turn income.
+*Value:* the always-empty trade-route list becomes real.
+*Honors:* unit end-to-end wiring (all 6 points); no-dead-end-UX (unit ships with a working action); no-bare-buttons in any new UI.
+
+**S5 — Route lifecycle.**
+War or angry relations terminate routes (req. 6); create/terminate notifications via the persistent log; integrate with existing `enforceEmbargoes`. Bilateral diplomacy rules apply.
+*Value:* trade reacts to diplomacy — no stale phantom income.
+*Honors:* game-systems immutable turn processing; transition-events-fire-once.
+
+### Phase 3 — Transactions
+
+**S6 — Sell a resource for gold.**
+Needs an available resource (S2) + an active route (S4) + neutral+ relations. Uses the live price from the existing engine. Panel refreshes after the action (ui-panels rerender rule).
+*Value:* first real transaction; the UI becomes meaningful.
+
+**S7 — Buy a resource for gold.**
+Spend gold to acquire a resource you lack. **Gated on deferred Q1** ("what do resources DO?") — buying is only meaningful if owning a resource has an effect.
+*Value:* completes the money side of trade.
+
+**S8 — Barter resource-for-resource.**
+Swap with another civ instead of paying gold (req. 9). Likely a propose/accept flow analogous to diplomacy treaties.
+*Value:* completes the trade vision from the issue.
+
+### Phase 4 — Depth & parity
+
+**S9 — AI trades too.**
+AI establishes routes and buys/sells so the economy is not player-only. (Some AI wiring lands per-slice in S4/S6; this slice ensures full parity and strategy.)
+*Honors:* shared-state-mutations-actor-complete; AI-combat/at-war checks already exist for route gating.
+
+**S10 — Price-algorithm refinement.**
+Real monopoly detection with per-player context (today `updatePrices` hardcodes `isMonopoly=false`), fashion interplay, and demand tied to resource effects (req. 7).
+
+## Sequencing & milestones
+
+Linear order; each phase is a hard gate for the next.
+
+1. **Roadmap (this doc)** — deliverable #1. Committed.
+2. **S1 brainstorm → plan → PR.** Begin next.
+3. **S2**, then **S3** — completes "honest visibility."
+4. **S4**, then **S5** — caravans + routes.
+5. **S6 → S7 → S8** — transactions. S7 waits on Q1 being resolved (its own mini-brainstorm or a dedicated "resource effects" slice inserted before S7).
+6. **S9, S10** — depth & parity; can be reordered or merged into earlier slices' AI/price work if that proves cleaner during planning.
+
+## Cross-cutting deferred questions
+
+Recorded here (user deferred at roadmap time, 2026-05-20). Each is assigned to the slice that must resolve it.
+
+- **Q1 — What do resources actually DO?** Today they only feed marketplace prices. For *buying* (S7) to matter they need an effect: luxuries→happiness? strategic→unit unlocks? May warrant its own slice inserted before S7. **Resolve before S7.**
+- **Q2 — Resource → tech → improvement mapping.** Reuse mine/farm, or add plantation / pasture / camp improvements for silk, wine, horses, ivory, incense, spices? **Resolve in S2.**
+- **Q3 — Trade scope.** Domestic routes (between your own cities) too, or only foreign-civ routes? **Resolve in S4.**
+- **Q4 — Caravan tiers.** One upgradeable caravan, or a per-age tier (caravan → merchant ship → …)? "Age-appropriate" (req. 8) at minimum means a sensible tech gate. **Resolve in S4.**
+- **Q5 — Tech-gated map reveal.** Should resources be hidden until discovered (the existing `identify_resources` tech effect), or always drawn? **Resolve in S1.**
+
+## Rejected items
+
+*(none yet — record here when something is considered and deliberately not pursued, with the reason, so future-us doesn't relitigate.)*
+
+## Living-doc protocol
+
+This roadmap is the single source of truth for what is locked vs. open. Update it when:
+
+- A slice is brainstormed and locked → record the slice's locked decisions and the path to its child spec.
+- A locked decision changes → update it and note the date/reason.
+- A deferred question is resolved → move it from the deferred list into its slice.
+- Scope shifts during a slice's plan/PR → record it under that slice.
+- A new item must be deferred → add it to the deferred list.
+- An item is rejected → move it to "Rejected items" with the reason.
+
+Updates are committed alongside whatever change triggered them.

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -44,14 +44,14 @@ This file is the **index** and is intentionally deliverable #1 so the high-level
 
 ## Shared foundation (used by S1–S4)
 
-A small data addition consumed by several early slices: give each entry in `RESOURCE_DEFINITIONS` a **`tech`** (enabling tech id), a **`requiredImprovement`** (the improvement that harvests it), and an **`effect`** descriptor (D-Q1). S1 needs `tech` (reveal), S2 needs `requiredImprovement` (acquisition), S3 needs `tech` (display filter), S4 needs `effect`. Land this data with S1 and extend it as later slices need it.
+A small data addition consumed by several early slices: give each entry in `RESOURCE_DEFINITIONS` a **`tech`** (enabling tech id), a **`requiredImprovement`** (the improvement that harvests it), and an **`effect`** descriptor (D-Q1). S1 needs `tech` (reveal), S2a needs `requiredImprovement` (improvement wiring), S2b needs it for the acquisition helper, S3 needs `tech` (display filter), S4a needs `effect` (yields/happiness), S4b needs a `prerequisiteFor` field (unit/building gates). Land `tech` with S1 and extend the shape as later slices need it.
 
 ## Locked-in decisions
 
 | Decision | Choice | Source |
 |---|---|---|
 | Delivery style | **Fine-grained vertical slices**, each shipping self-contained value | user |
-| Decomposition | **12 slices in 5 phases** (below) | this roadmap |
+| Decomposition | **15 slices in 5 phases** (below) | this roadmap |
 | Roadmap-first | **This index is deliverable #1** | user |
 | No dead-end UX | every slice ships working value (no inert buttons/units) | `.claude/rules/incremental-mr-completion.md` |
 | Resource effects | **mixed per-resource**: some happiness, some gold, some production; strategic resources are **prerequisites for certain buildings/units** (iron → swordsman) | D-Q1 |
@@ -77,7 +77,7 @@ Per-slice sections below only note *additions*.
 - **Save compatibility:** multiple save slots are in active family use. New `MarketplaceState`/`TradeRoute` fields, new `ImprovementType`s, new `UnitType`s, and `RESOURCE_DEFINITIONS` shape changes must tolerate old saves (optional fields / defaults / migration). Add a load-old-save regression when state shape changes.
 - **AI parity:** any player-affecting trade consequence must also be exercised/usable by AI civs.
 
-## Decomposition — 12 slices
+## Decomposition — 15 slices
 
 Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-marketplace-sN-<topic>-design.md`, its plan under `docs/superpowers/plans/`.
 
@@ -90,55 +90,74 @@ Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-market
 *Tests:* every resource has icon+tech (catalog test); reveal appears only with tech (negative without tech); fog-leak negative; spy-reveal still works.
 *Extra rules:* ui-panels privacy; `sprites.md` if using sprites.
 
-**S2 — Acquisition model + resource-specific improvements + inventory.**
-*Scope:* add the new improvements from D-Q2 (e.g. plantation, pasture, camp, quarry) wired end-to-end (terrain rules, worker action, icon, yields); add `requiredImprovement` to resource data; a pure helper `getCivAvailableResources(state, civId)` applying **(tech known AND the required improvement built, `improvementTurnsLeft===0)`**, EXCEPT a resource on a **city-center** tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") + tile inspection ("To use: needs Mining + a Mine here — ✓/✗").
-*Files:* new `src/systems/resource-acquisition-system.ts`; `types.ts` `ImprovementType`; `improvement-system.ts`, `worker-action-system.ts`, `hex-renderer.ts` icons, `resource-system.ts` yields; `trade-system.ts` resource data; inventory UI.
-*Done when:* every resource has a buildable harvesting improvement; helper returns correct sets across **all** cities (not `cities[0]`); UI shows owned vs. needs-improvement.
-*Tests (spec-fidelity conjunction):* tech-without-improvement → unavailable; improvement-without-tech → unavailable; both → available; city-tile + tech-only → available; resource off-city + tech-only → unavailable; new improvements buildable only on correct terrain.
+**S2a — Resource-specific improvements (end-to-end).**
+*Scope:* add D-Q2 improvements (plantation, pasture, camp, quarry, …) wired end-to-end. Each new `ImprovementType` needs: terrain-validity rules, a worker-action entry in `worker-action-system.ts`, a `hex-renderer.ts` icon, yield contributions in `resource-system.ts`, and save-migration (old saves lack the new enum members — default to no improvement). Also add `requiredImprovement` to each `RESOURCE_DEFINITION` entry.
+*Files:* `types.ts` `ImprovementType` union; `worker-action-system.ts`; `hex-renderer.ts`; `resource-system.ts` (yields); `trade-system.ts` (resource data `requiredImprovement`); save-load migration.
+*Done when:* every tradeable resource has a buildable harvesting improvement; improvements only build on valid terrain; icons render correctly; old saves load without error.
+*Tests:* every resource has a `requiredImprovement` entry (catalog test); each improvement only buildable on its terrain (positive + negatives); icons render (visual catalog); old-save load regression.
+
+**S2b — Acquisition model + inventory UI.**
+*Scope:* (depends on S2a) a pure helper `getCivAvailableResources(state, civId)` applying **(tech known AND the required improvement built, `improvementTurnsLeft===0`)**, EXCEPT a resource on a **city-center** tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") panel + tile inspection ("To use: needs Mining + a Mine here — ✓/✗"). Covers **all** cities, not `cities[0]`.
+*Files:* new `src/systems/resource-acquisition-system.ts`; inventory UI (new panel section or sidebar); tile/territory inspection panel update.
+*Done when:* helper returns correct sets; UI shows owned vs. needs-improvement; city-tile exception works.
+*Tests (spec-fidelity conjunction):* tech-without-improvement → unavailable; improvement-without-tech → unavailable; both → available; city-tile + tech-only → available; resource off-city + tech-only → unavailable; multi-city coverage (not cities[0] only).
 
 **S3 — Marketplace tells the truth.**
-*Scope:* filter the panel to resources whose enabling tech the current player has (req. 2); replace `countPlayerResources` with S2's helper.
+*Scope:* filter the panel to resources whose enabling tech the current player has (req. 2); replace `countPlayerResources` with S2b's `getCivAvailableResources` helper.
 *Files:* `src/ui/marketplace-panel.ts`.
-*Done when:* only tech-available resources listed; counts from S2; uses `state.currentPlayer`.
+*Done when:* only tech-available resources listed; counts from S2b helper; uses `state.currentPlayer`.
 *Tests:* no-tech resource absent (negative); tech-available present with matching count; all tech-available remain reachable (catalog completeness).
 
 ### Phase 2 — Resources matter
 
-**S4 — Resource effects (D-Q1).**
-*Scope:* owning/acquiring a resource confers a **per-resource effect** — some grant happiness, some gold, some production; **strategic resources gate certain buildings/units** (e.g. iron required to train swordsman). Add an `effect` descriptor to resource data; apply happiness/yield effects in city processing; enforce resource prerequisites in `city-system.ts` training/building gating (alongside existing `techRequired`).
-*Files:* `trade-system.ts` (effect data); `resource-system.ts`/city yield + happiness processing; `city-system.ts` (`TRAINABLE_UNITS`/`BUILDINGS` gating reads available resources from S2); city panel surfaces the effect + "requires iron" gating reason.
-*Done when:* having a resource changes happiness/yields; a unit/building that requires a resource is **blocked without it** and trainable with it; the requirement is shown in the city panel.
-*Tests:* effect applied per resource type; prerequisite gating positive+negative (no iron → swordsman untrainable; iron → trainable); spec-fidelity negative coverage.
+**S4a — Per-resource yield & happiness effects (D-Q1, part 1).**
+*Scope:* (depends on S2b) owning a resource (per `getCivAvailableResources`) confers a **per-resource passive effect** — some luxuries grant happiness, some resources add gold or production. Add an `effect` descriptor to each `RESOURCE_DEFINITION` entry; apply effects in city yield + happiness processing each turn.
+*Files:* `trade-system.ts` (effect data); `resource-acquisition-system.ts` (effect applicator); city yield / happiness processing (`resource-system.ts`, `city-system.ts`); city panel shows the active bonus ("Silk → +1 happiness").
+*Done when:* having a resource changes happiness or yield; the bonus is visible in the city panel; losing the resource (improvement destroyed / tech lost) removes the bonus.
+*Tests:* each resource type grants the correct effect (positive); no resource → no effect (negative); effect removed when resource lost; effect applies across all cities (not cities[0]); seeded RNG only.
+
+**S4b — Strategic resource prerequisites for units & buildings (D-Q1, part 2).**
+*Scope:* (depends on S4a — resource tracking in place) strategic resources **gate** certain units and buildings: e.g. iron required to train swordsman, horses required to train cavalry. Enforce in `city-system.ts` TRAINABLE_UNITS/BUILDINGS gating alongside existing `techRequired`. City panel shows a locked state + reason ("requires Iron — build a Mine on an Iron tile").
+*Files:* `trade-system.ts` (prerequisite data field on resource definitions); `city-system.ts` (gating logic + TRAINABLE_UNITS/BUILDINGS); city panel locked-state UI; save-compat (no new state — reads from `getCivAvailableResources`).
+*Done when:* a unit/building that requires a resource is **blocked without it** and trainable with it; the requirement reason is shown in the city panel.
+*Tests (spec-fidelity conjunctions):* no resource + tech → blocked; resource + no tech → blocked; both → trainable (positive); city panel displays lock reason; AI respects gating (does not attempt to train blocked unit).
 
 ### Phase 3 — Caravans & routes
 
 **S5 — First trade unit + establish a route.**
-*Scope:* add the first-tier trade `UnitType` wired end-to-end (6 points + `PRODUCTION_ICONS`), gated on `trade-routes` tech (makes the dead unlock real). Move it to a target city to establish a `TradeRoute`. **Domestic** (own cities, no relationship gate) **and foreign** (D-Q3) — foreign requires **not at war AND relationship ≥ 0** (D-Q8). Per-city route **capacity** scaling with tech + buildings (D-Q6); the unit is **committed to the route** (D-Q7 — stationed for this slice; physical travel lands in S6). Route persists, renders on map + panel, pays existing gold/turn income. AI trains + uses it.
+*Scope:* (depends on S4b — resource tracking stable) add the first-tier trade `UnitType` wired end-to-end (6 points + `PRODUCTION_ICONS`), gated on `trade-routes` tech (makes the dead unlock real). Move it to a target city to establish a `TradeRoute`. **Domestic** (own cities, no relationship gate) **and foreign** (D-Q3) — foreign requires **not at war AND relationship ≥ 0** (D-Q8). Per-city route **capacity** scaling with tech + buildings (D-Q6); the unit is **committed to the route** (D-Q7 — stationed for this slice; physical travel lands in S6a). Route persists, renders on map + panel, pays existing gold/turn income. AI trains + uses it.
 *Files:* `types.ts`; `unit-system.ts`; `unit-renderer.ts`; `city-system.ts` (TRAINABLE_UNITS+PRODUCTION_ICONS+tech gate, capacity helper); `turn-manager.ts` (dequeue/side-effects); `main.ts` (establish interaction + death cleanup); `basic-ai.ts`; route-creation + capacity helpers in `trade-system.ts`; establish-route UI.
 *Done when:* unit trainable/visible/AI-used; domestic route works ungated; foreign route succeeds at ≥0 + not-at-war and **fails** otherwise; capacity cap enforced; route renders + pays income.
 *Tests:* unit-wiring coverage; domestic success; foreign success (positive) + at-war/below-0 (negatives); capacity-cap negative; AI-parity; route renders/persists.
 
-**S6 — Route lifecycle + caravan route-running.**
-*Scope:* the committed trade unit **travels back and forth** between the two cities along the route (D-Q7) and is **raidable**; a route terminates when its unit is destroyed/disbanded, when foreign relations drop **< −25 or war** (D-Q8), or via embargo; create/terminate emit persistent notification-log entries (turn #). Integrate with `enforceEmbargoes`. Income stops the same turn.
-*Files:* `unit-movement-system.ts` / route-runner (back-and-forth pathing), `turn-manager.ts` (lifecycle pass), `diplomacy-system.ts` (scrub on war/relationship — actor-complete), combat/raid hooks (unit loss → route end), notification routing.
-*Done when:* unit visibly runs the route; killing it ends the route + income; foreign relations <−25/war terminates same turn; domestic routes unaffected by relations.
-*Tests:* travel movement; unit-loss ends route; war/<−25 terminates + stops income (positive) and ≥0 keeps it (negative); termination fires once; actor-complete (human + AI war both terminate).
+**S6a — Route lifecycle (termination conditions + notifications).**
+*Scope:* (depends on S5) a route terminates when: its caravan unit is destroyed or disbanded; foreign relations drop **< −25** (D-Q8); war is declared (D-Q8); or an embargo is enforced. Integrate with `enforceEmbargoes`. Income stops the **same turn**. Create and terminate events emit persistent notification-log entries (turn #). Domestic routes are unaffected by relation thresholds. Actor-complete: human AND AI war declarations both terminate affected routes.
+*Files:* `turn-manager.ts` (lifecycle pass — scrub routes each turn); `diplomacy-system.ts` (hook into `declareWar` + relation-drop path, actor-complete); `diplomacy-system.ts`/`enforceEmbargoes` integration; unit-death cleanup (route scrub when caravan dies); notification routing.
+*Done when:* war terminates foreign routes that turn; relations <−25 terminates that turn; unit-loss terminates; domestic routes unaffected; notifications fire once per event.
+*Tests:* war → route terminated + income stops (positive); ≥0 + no war → keeps route (negative); relations drop to −26 → terminated; unit-loss → terminated; domestic route unaffected by any relation change; termination notification fires exactly once; actor-complete (AI-declared war also terminates human's route).
+
+**S6b — Physical caravan route-running + raidable (D-Q7).**
+*Scope:* (depends on S6a — termination hooks already in place) the committed trade unit **visibly travels back and forth** between its two cities each turn along a shortest path; it is **raidable** (enemy units may attack it in transit using the existing combat system); losing the unit in combat ends the route via S6a's unit-loss hook (no new termination logic needed here).
+*Files:* `unit-movement-system.ts` (route-runner: back-and-forth path calculation, per-turn step); `hex-renderer.ts` (unit position updates, route path visualisation); `turn-manager.ts` (advance route-runner on each turn).
+*Done when:* caravan unit visibly moves along the route each turn; reaches the destination city and turns back; enemy unit can attack and kill it; route + income end on death (via S6a hook).
+*Tests:* caravan advances one step per turn toward destination; reverses on arrival; combat kill removes unit and ends route (regression on S6a unit-loss path); route path does not cross impassable terrain.
 
 **S7 — Trade-unit tiers + naval trader (D-Q4).**
-*Scope:* per-age progression of trade units (caravan → merchant → …) with upgrades, plus a **naval trader** enabling overseas/coastal routes. Tech-gated per era; upgrade path via existing unit-upgrade system.
+*Scope:* (depends on S6b — caravan movement in place) per-age progression of trade units (caravan → merchant → …) with upgrades, plus a **naval trader** enabling overseas/coastal routes. Tech-gated per era; upgrade path via existing unit-upgrade system.
 *Files:* `unit-system.ts`, `unit-upgrade-system.ts`, `unit-renderer.ts`, `city-system.ts`, `basic-ai.ts`, `trade-route-classification.ts` (overseas routes already partly modeled).
 *Done when:* later eras unlock stronger/faster traders; overseas routes possible via the naval trader; upgrade path works.
 *Tests:* tier tech-gating; overseas route requires naval trader; upgrade path; AI uses tiers.
+*Note:* If S7 grows during brainstorming, split into **S7a** (land tiers + upgrades) and **S7b** (naval trader + overseas route classification). Decide at S7's brainstorm.
 
 ### Phase 4 — Transactions
 
 **S8 — Sell a resource for gold.**
-*Scope:* with an available resource (S2) + active route (S5) + (foreign) neutral+ relations, sell at the live price; gold credited; supply/price adjust; panel refreshes.
+*Scope:* with an available resource (S2b) + active route (S5) + (foreign) neutral+ relations, sell at the live price; gold credited; supply/price adjust; panel refreshes.
 *Files:* `marketplace-panel.ts`, transaction helper in `trade-system.ts`, `main.ts`.
 *Done when:* sell works and is gated on ownership+route+relationship; panel re-renders.
 *Tests:* sell gated (negatives for missing route / non-neutral / not owned); rerender; price/supply update.
 
-**S9 — Buy a resource for gold.** *Now meaningful via S4 effects.* Spend gold to acquire a resource you lack; its effect applies (happiness/yield, or unlocks a gated unit/building). Tests: buy gated; effect applied.
+**S9 — Buy a resource for gold.** *Now meaningful via S4a effects.* Spend gold to acquire a resource you lack; its effect applies (happiness/yield, or unlocks a gated unit/building per S4b). Tests: buy gated; effect applied; S4a effect activates; S4b gate lifts if strategic resource acquired.
 
 **S10 — Barter resource-for-resource (req. 9).** Propose/accept swap with another civ (analogous to diplomacy treaties); both inventories update bilaterally; AI evaluates offers. Tests: bilateral update; AI accept/reject; relationship+route gating.
 
@@ -152,9 +171,9 @@ Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-market
 
 Linear; each phase gates the next.
 1. Roadmap (done).
-2. **S1 → S2 → S3** — visibility & honest marketplace.
-3. **S4** — resources gain effects + unit/building prerequisites (value even before trade).
-4. **S5 → S6 → S7** — trade units, routes, lifecycle, tiers/naval.
+2. **S1 → S2a → S2b → S3** — visibility & honest marketplace.
+3. **S4a → S4b** — resources gain effects + unit/building prerequisites (value even before trade).
+4. **S5 → S6a → S6b → S7** — trade units, routes, lifecycle, tiers/naval.
 5. **S8 → S9 → S10** — transactions.
 6. **S11, S12** — parity & price depth (may fold into earlier AI/price work if cleaner during planning).
 

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -4,7 +4,7 @@
 
 **Goal:** Turn the existing read-only marketplace stub into a real, legible trade system: resources visible on the map; clear tech + improvement requirements to own a tradeable resource; an age-appropriate caravan unit that establishes trade routes; relationship-gated trading; and actual transactions (sell/buy for gold or barter resource-for-resource).
 
-This file is the **index**. It is intentionally the first deliverable so the high-level plan survives context compaction. Each slice below becomes its own brainstorm → plan → PR cycle; per-slice decisions get recorded back here.
+This file is the **index** and is intentionally deliverable #1 so the high-level plan survives context compaction. Each slice becomes its own brainstorm → spec → plan → PR cycle; per-slice decisions get recorded back here (see Living-doc protocol).
 
 ## Issue requirements (verbatim, from #234 + comments)
 
@@ -18,113 +18,128 @@ This file is the **index**. It is intentionally the first deliverable so the hig
 8. Need a caravan unit, age-appropriate, for establishing trade routes and for doing the actual trade.
 9. Trade can be for straight money **or** in exchange for another resource.
 
-## Current state (what already exists — do not rebuild)
+## Current state (verified against commit base `84f9182` — do not rebuild)
 
-Findings from the codebase as of this roadmap (commit base `84f9182`):
-
-| Area | Status | Location |
+| Area | Status | Location / detail |
 |---|---|---|
-| Resource types (6 luxury, 4 strategic) + base prices | ✅ exists | `src/systems/trade-system.ts` `RESOURCE_DEFINITIONS` |
-| Resources placed on map tiles (`tile.resource`) | ✅ exists | map generators (`map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`) |
-| Per-turn price engine (supply vs. demand) + price history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388 |
-| Marketplace panel (prices, sparklines, "you own" counts, fashion banner) | ⚠️ read-only | `src/ui/marketplace-panel.ts`; opened via `togglePanel('marketplace')` in `main.ts` |
-| `TradeRoute` type + per-turn gold income + embargo enforcement + wonder-route checks | ✅ type/plumbing exists | `types.ts`, `turn-manager.ts` ~L700, `diplomacy-system.ts` `enforceEmbargoes`, `trade-route-classification.ts` |
-| Resources **drawn on the map** | ❌ missing | `hex-renderer.ts` `drawHex` draws improvements/wonders/villages but **never** resources |
-| Trade routes **ever created** | ❌ missing | `marketplace.tradeRoutes` is initialized to `[]` and nothing pushes to it — the list is always empty |
-| Caravan unit | ❌ missing | not in `UnitType` union (`types.ts` L230) |
-| Tech-gated marketplace display | ❌ missing | panel shows all `RESOURCE_DEFINITIONS` regardless of tech |
-| "Need improvement on the tile to own a resource" rule | ❌ missing | nothing computes per-civ owned/available resources from improvements |
-| Relationship gating on trade | ❌ missing | no neutral+ check; no war/angry termination of trade actions |
-| Actual buy / sell / barter | ❌ missing | panel has no transaction actions |
-| Tech effect `identify_resources` (reveal strategic resources in territory) | ✅ defined, unused-ish | `types.ts` L559 — relevant to deferred Q5 |
+| Resource types (6 luxury, 4 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert). Strategic: copper(hills), iron(hills), horses(plains), stone(mountain). |
+| Resources placed on map tiles (`tile.resource`) | ✅ exists | `map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`; geo maps via `geo-map-loader.ts`. |
+| Per-turn price engine (supply/demand) + history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388. Note: `updatePrices` hardcodes `isMonopoly=false` (S10). |
+| Marketplace **building** | ✅ exists | `city-system.ts` L59 `marketplace` (gold +3, cost 50, `techRequired: 'currency'`, icon 🏪). |
+| Marketplace **panel** (prices, sparklines, "you own", fashion banner) | ⚠️ read-only | `src/ui/marketplace-panel.ts`; opened via `onOpenMarketplace → togglePanel('marketplace')` in `main.ts`. Counts resources by raw `ownedTiles` (`countPlayerResources`), not by acquisition rules. |
+| `TradeRoute` type + per-turn income + embargo enforcement + wonder-route checks | ✅ plumbing exists | `types.ts` (`TradeRoute` has `fromCityId`,`toCityId`,`goldPerTurn`,`foreignCivId?`), `turn-manager.ts` income ~L391 / embargo ~L700, `diplomacy-system.ts` `enforceEmbargoes`, `trade-route-classification.ts`. |
+| Economy techs | ✅ exists | `tech-definitions.ts`: `currency`(era3, "Unlock Marketplace building"), **`trade-routes`(era4, "Enable trade routes between cities")**, `banking`, `global-logistics`; `wheel`(era2). |
+| Resource discovery mechanism | ✅ exists (espionage) | `identify_resources` is a **spy mission** (`espionage-system.ts`, `espionage-panel.ts`), NOT a tech node. Reveals resources in target territory. Relevant to Q5. |
+| Resources **drawn on the map** | ❌ MISSING | `hex-renderer.ts` `drawHex` (~L239–277) draws improvements/wonders/villages but **never** resources. `tile-presentation.ts` already carries `resource` through. |
+| Trade routes **ever created** | ❌ MISSING / DEAD | `marketplace.tradeRoutes` inits to `[]`; **nothing pushes to it**. The `trade-routes` tech unlock ("Enable trade routes between cities") is a **dead promise** — no creation path exists. Panel says "Build a Market to establish routes" but no code does. |
+| Caravan unit | ❌ MISSING | not in `UnitType` union (`types.ts` L230). |
+| Tech-gated marketplace display | ❌ MISSING | panel lists all `RESOURCE_DEFINITIONS` regardless of tech. |
+| "Improvement on tile required to own a resource" rule | ❌ MISSING, **and blocked** | nothing computes per-civ owned resources from improvements. **Only 4 improvements exist** (`farm`,`mine`,`lumber_camp`,`watermill` — `types.ts` L165). `mine` covers hills/mountain (gems/copper/iron/stone). **No resource-appropriate improvement exists for grassland/plains/jungle/forest/desert luxuries+horses; desert has no improvement at all.** S2 likely must ADD improvements (see Q2). |
+| Relationship gating on trade | ❌ MISSING | major-civ relationships are a **numeric score −100…+100** (`Civilization.diplomacy.relationships: Record<civId, number>`) + an `atWarWith` array — there is **no named "neutral"/"angry" enum** for majors (named states are minor-civ only). "Neutral"/"angry" must be defined as score thresholds (Q8). |
+| Actual buy / sell / barter | ❌ MISSING | panel has no transaction actions. |
+| Gameplay effect of owning a resource | ❌ effectively NONE | `tile.resource` is only read by: marketplace supply, map-gen balancing, legendary-wonder diversity counts, espionage intel. Owning a resource confers **no happiness/unit/yield benefit today** → buying (S7) is meaningless until this is designed (Q1). |
 
-**Key gotcha:** `src/systems/resource-system.ts` is misleadingly named — it computes **city tile yields**, not resources. The resource/trade logic lives in `trade-system.ts`.
+**Gotcha:** `src/systems/resource-system.ts` is misnamed — it computes **city tile yields**, not resources. Trade/resource logic lives in `trade-system.ts`. Put the new acquisition system in a clearly named new file (e.g. `resource-acquisition-system.ts`).
 
 ## Locked-in decisions
 
 | Decision | Choice | Notes |
 |---|---|---|
 | Delivery style | **Fine-grained vertical slices** | User preference: very fleshed-out, discrete deliverables that each add value and build on each other, over scattered half-built pieces. |
-| Decomposition | **10 slices in 4 phases** (below) | Each slice = one brainstorm → plan → PR. Ship in order. |
-| Roadmap-first | **This index doc is deliverable #1** | Committed before any code so the plan survives context loss. |
-| No dead-end UX | **Every slice ships self-contained value** | Per `.claude/rules/incremental-mr-completion.md`: never ship a button/unit/queue entry that does nothing. The caravan slice (S4) therefore includes the establish-route action. |
+| Decomposition | **10 slices + 1 candidate, in 4 phases** | Each slice = one brainstorm → spec → plan → PR. Ship in order. |
+| Roadmap-first | **This index is deliverable #1** | Committed before code so the plan survives context loss. |
+| No dead-end UX | **Every slice ships self-contained value** | Per `.claude/rules/incremental-mr-completion.md`: never ship a button/unit/queue entry that does nothing. S4 therefore bundles the establish-route action with the caravan. |
+| Caravan tech gate | **`trade-routes` tech** (S4 makes its dead unlock real) | Confirms req. 8 "age-appropriate"; era 4. Final tier model is Q4. |
 
-## Decomposition — 10 slices, 4 phases
+## Conventions every slice MUST follow
 
-Ship in order. Each slice gets its own `docs/superpowers/specs/` design and `docs/superpowers/plans/` plan when it is brainstormed.
+These apply to all slices; per-slice sections below only note *additions*.
+
+- **Verify before any push/PR:** `bash scripts/run-with-mise.sh yarn build` (this is the only `tsc` path) **and** `bash scripts/run-with-mise.sh yarn test` must both exit 0. The `require-green-before-push` hook enforces this; catch it locally first.
+- **Branch/PR workflow:** never commit to `main`; work on a branch/worktree and open a PR. If a PR ships only a subset of a slice, follow `.claude/rules/incremental-mr-completion.md` (subset title, "Out of scope" list, "why safe to merge partial" paragraph naming every player-visible surface).
+- **Hot-seat:** use `state.currentPlayer` everywhere; never hardcode `'player'`. Renderer/UI take `currentPlayer`.
+- **Determinism:** seeded RNG only; never `Math.random()`.
+- **Immutable turn processing:** turn/system functions return a new `GameState` via spread-copy; never mutate `state.cities[id]=…` etc. (`.claude/rules/game-systems.md`).
+- **UI:** mobile-first touch (≥44px targets); buttons via `createGameButton()` (no bare buttons); dynamic text via `textContent`/`createTextNode()` (never `innerHTML` with game strings); a panel that mutates state it renders must refresh; never silently discard a player-visible list.
+- **End-to-end wiring:** computed data must render; new units need all 6 wirings (`.claude/rules/end-to-end-wiring.md`); shared consequences must be actor-complete (human **and** AI/turn paths) with parity tests.
+- **Save compatibility:** the game has multiple save slots in active family use. New `MarketplaceState` fields, new `ImprovementType`s, new `UnitType`s, and `RESOURCE_DEFINITIONS` shape changes must tolerate old saves (optional fields / defensive defaults / migration). Add a load-old-save regression where state shape changes.
+- **AI parity:** any player-affecting trade consequence must also be exercised/usable by AI civs.
+
+## Decomposition — slices
+
+Ship in order. Each slice's spec lives at `docs/superpowers/specs/2026-..-marketplace-sN-<topic>-design.md`, its plan at `docs/superpowers/plans/…`.
 
 ### Phase 1 — Honest visibility
 
 **S1 — Resources on the map.**
-Draw a distinct icon per resource on its tile in `hex-renderer.ts` (luxury vs. strategic readable at a glance); tap-to-inspect surfaces resource name + type. Carries `resource` already present in `TilePresentation`.
-*Value:* players can finally see where resources are.
-*Honors:* end-to-end-wiring (computed `resource` must render); ui-panels privacy (respect fog/last-seen presentation kind).
+*Scope:* draw a distinct, legible icon per `ResourceType` on its tile; tap-to-inspect surfaces resource name + type; add a legend entry. Decide Q5 (always-visible vs. discovered-only via the existing `identify_resources` mechanism / exploration).
+*Files:* `hex-renderer.ts` `drawHex` (mirror the improvement/wonder icon pattern); a resource→icon map (add `icon` to `RESOURCE_DEFINITIONS` in `trade-system.ts`, or a small new module); `src/ui/icon-legend.ts`; tile/territory inspection (`src/ui/territory-inspection-panel.ts` and/or selected-tile info). `tile-presentation.ts` already carries `resource`.
+*Done when:* every resource type renders its icon on visible tiles; inspection shows name+type; legend lists them; if Q5=discovered-only, fog/unexplored tiles do **not** leak resources.
+*Tests:* every `ResourceType` has an icon (catalog test); inspection surfaces name+type; negative fog-leak test if discovered-only.
+*Extra rules:* ui-panels privacy (mask under fog per presentation kind); `sprites.md` if using sprites vs. emoji.
 
-**S2 — Acquisition model + per-civ resource inventory.**
-A system computes, per civ, which resources are actually **owned/available** = required tech known **AND** the right improvement built on the resource tile — with the exception that a resource on a city-center tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") and in tile inspection ("To use: needs Mining + a Mine here"). Requires the resource→tech→improvement mapping (deferred Q2).
-*Value:* the rules become legible; foundation for every later slice.
-*Honors:* spec-fidelity conjunction (tech AND improvement; add negative tests for tech-without-improvement, improvement-without-tech, and the city-tile exception).
+**S2 — Acquisition model + per-civ inventory.**
+*Scope:* a pure helper `getCivAvailableResources(state, civId)` returning the resources a civ can trade, applying **(tech known AND qualifying improvement built on the tile, `improvementTurnsLeft===0)`**, EXCEPT a resource on a **city-center** tile needs **tech only** (req. 4 + 5). Surface read-only ("Your resources") + in tile inspection ("To use: needs Mining + a Mine here — ✓/✗"). **Resolve Q2** (resource→tech→improvement mapping; almost certainly add improvements — desert/incense currently has none).
+*Files:* new `src/systems/resource-acquisition-system.ts`; add `tech` + `requiredImprovement` to `RESOURCE_DEFINITIONS` (`trade-system.ts`); if adding improvements: `types.ts` `ImprovementType`, `improvement-system.ts`, `worker-action-system.ts`, `hex-renderer.ts` icons, `resource-system.ts` yields; inventory UI in city/territory panel.
+*Done when:* helper returns correct sets for all civs; UI shows owned vs. needs-improvement; iterates **all** cities (not `cities[0]`).
+*Tests (spec-fidelity conjunction):* tech-without-improvement → unavailable; improvement-without-tech → unavailable; both → available; city-tile + tech-only → available without improvement; resource not under city + tech-only → unavailable.
 
 **S3 — Marketplace tells the truth.**
-Filter the existing read-only panel to resources the civ has the tech for (req. 2); show real owned/available counts from S2 instead of the current raw tile count.
-*Value:* no more phantom items.
-*Honors:* ui-panels catalog rules; XSS-safe `textContent` rendering (already followed in the panel).
+*Scope:* filter the panel to resources whose enabling tech the current player has (req. 2); replace `countPlayerResources` with S2's helper for owned/available counts.
+*Files:* `src/ui/marketplace-panel.ts`.
+*Done when:* only tech-available resources are listed; counts come from S2; uses `state.currentPlayer`.
+*Tests:* a no-tech resource is absent (negative); a tech-available resource is present and its count matches S2; all tech-available resources remain reachable (catalog completeness).
 
 ### Phase 2 — Caravans & routes
 
 **S4 — Caravan unit + establish a trade route.**
-Add an age-appropriate caravan `UnitType`, wired end-to-end per `.claude/rules/end-to-end-wiring.md` (definitions + descriptions, renderer icon, trainable + tech gate, AI usage, tech-gated dequeue, production icon). Player sends the caravan to a valid target city to open a route; requires **at least neutral** relations (req. 6 + 8). Routes render on the map + in the panel and pay the already-wired gold/turn income.
-*Value:* the always-empty trade-route list becomes real.
-*Honors:* unit end-to-end wiring (all 6 points); no-dead-end-UX (unit ships with a working action); no-bare-buttons in any new UI.
+*Scope:* add `'caravan'` `UnitType`, wired end-to-end (all 6 points of the unit rule + `PRODUCTION_ICONS`), trainable gated on `trade-routes` tech (makes that dead unlock real). Player moves a caravan to a valid target city to open a `TradeRoute`; gating = **not at war AND relationship ≥ neutral threshold** (Q8). Route persists in `marketplace.tradeRoutes`, renders on map + panel, pays existing gold/turn income. AI trains and uses caravans. **Resolve Q3** (domestic vs. foreign), **Q4** (single vs. tiered), **Q7** (consumed on establish?), **Q8** (thresholds), **Q6** (route limits).
+*Files:* `types.ts` (`UnitType`, maybe events); `unit-system.ts` (`UNIT_DEFINITIONS`+`UNIT_DESCRIPTIONS`); `unit-renderer.ts` (icon); `city-system.ts` (`TRAINABLE_UNITS`+`PRODUCTION_ICONS`+tech gate); `turn-manager.ts` (production side-effects + tech-gated dequeue); `main.ts` (establish-route interaction + death cleanup); `basic-ai.ts` (queue + use); route-creation helper in `trade-system.ts`; establish-route UI.
+*Done when:* caravan is trainable/visible/AI-used; establishing a route succeeds at neutral+ and **fails** when at war or below threshold; route renders and pays income.
+*Tests:* full unit-wiring coverage; establish success (positive) + at-war/below-threshold (negatives); AI-parity (AI establishes a route); route renders/persists.
 
 **S5 — Route lifecycle.**
-War or angry relations terminate routes (req. 6); create/terminate notifications via the persistent log; integrate with existing `enforceEmbargoes`. Bilateral diplomacy rules apply.
-*Value:* trade reacts to diplomacy — no stale phantom income.
-*Honors:* game-systems immutable turn processing; transition-events-fire-once.
+*Scope:* declaring war or relationship dropping to "angry" terminates affected routes that same turn (req. 6); create/terminate emit persistent notification-log entries (with turn #); integrate with `enforceEmbargoes`; income stops same turn.
+*Files:* `turn-manager.ts` (lifecycle pass), `diplomacy-system.ts` (scrub routes on war / relationship change — actor-complete), notification routing.
+*Done when:* war/angry terminates the route and stops income same turn; peace/neutral keeps it.
+*Tests:* war terminates + stops income (positive); neutral keeps it (negative); termination fires once (not re-fired every steady-state turn); actor-complete (human-declared AND AI-declared war both terminate).
 
 ### Phase 3 — Transactions
 
+**Sx (candidate) — Resource effects.** *Resolves Q1; insert before S7 if Q1 says resources should confer benefits.* Owning/acquiring a resource grants an effect (e.g. luxuries→happiness, strategic→unit unlock/strength). Without this, buying is meaningless. Scope decided in its own brainstorm.
+
 **S6 — Sell a resource for gold.**
-Needs an available resource (S2) + an active route (S4) + neutral+ relations. Uses the live price from the existing engine. Panel refreshes after the action (ui-panels rerender rule).
-*Value:* first real transaction; the UI becomes meaningful.
+*Scope:* with an available resource (S2) + active route (S4) + neutral+ relations, sell at the live price; gold credited; supply/price adjust; panel refreshes.
+*Files:* `marketplace-panel.ts`, transaction helper in `trade-system.ts`, `main.ts` wiring.
+*Done when:* sell works and is gated on ownership+route+relationship; panel re-renders post-sale.
+*Tests:* sell gated (negatives for missing route / non-neutral / not owned); panel rerender; price/supply update.
 
-**S7 — Buy a resource for gold.**
-Spend gold to acquire a resource you lack. **Gated on deferred Q1** ("what do resources DO?") — buying is only meaningful if owning a resource has an effect.
-*Value:* completes the money side of trade.
+**S7 — Buy a resource for gold.** *Gated on the resource-effects slice (Q1).* Spend gold to acquire a resource you lack; it must confer a real benefit. Tests: buy gated; effect applied.
 
-**S8 — Barter resource-for-resource.**
-Swap with another civ instead of paying gold (req. 9). Likely a propose/accept flow analogous to diplomacy treaties.
-*Value:* completes the trade vision from the issue.
+**S8 — Barter resource-for-resource.** *Req. 9.* Propose/accept swap with another civ (analogous to diplomacy treaties); both inventories update bilaterally; AI evaluates offers. Tests: bilateral update; AI accept/reject; relationship+route gating.
 
 ### Phase 4 — Depth & parity
 
-**S9 — AI trades too.**
-AI establishes routes and buys/sells so the economy is not player-only. (Some AI wiring lands per-slice in S4/S6; this slice ensures full parity and strategy.)
-*Honors:* shared-state-mutations-actor-complete; AI-combat/at-war checks already exist for route gating.
+**S9 — AI trades too.** Full parity: AI establishes routes, sells surplus, buys needs, handles barter. Tests: AI visibly participates; parity regressions. (Some AI wiring lands per-slice; this guarantees strategy + completeness.)
 
-**S10 — Price-algorithm refinement.**
-Real monopoly detection with per-player context (today `updatePrices` hardcodes `isMonopoly=false`), fashion interplay, and demand tied to resource effects (req. 7).
+**S10 — Price-algorithm refinement (req. 7).** Real monopoly detection with per-player supply share (`calculatePrice` already accepts `isMonopoly`; `updatePrices` must compute it), demand tied to resource effects, fashion interplay. Tests: monopoly raises price; balance tests with seeded statistical sampling.
 
 ## Sequencing & milestones
 
-Linear order; each phase is a hard gate for the next.
-
-1. **Roadmap (this doc)** — deliverable #1. Committed.
-2. **S1 brainstorm → plan → PR.** Begin next.
-3. **S2**, then **S3** — completes "honest visibility."
-4. **S4**, then **S5** — caravans + routes.
-5. **S6 → S7 → S8** — transactions. S7 waits on Q1 being resolved (its own mini-brainstorm or a dedicated "resource effects" slice inserted before S7).
-6. **S9, S10** — depth & parity; can be reordered or merged into earlier slices' AI/price work if that proves cleaner during planning.
+Linear; each phase gates the next. 1) Roadmap (done). 2) S1 → S2 → S3 (honest visibility). 3) S4 → S5 (caravans/routes). 4) resource-effects (if Q1 requires) → S6 → S7 → S8 (transactions). 5) S9, S10 (depth; may fold into earlier AI/price work if cleaner during planning).
 
 ## Cross-cutting deferred questions
 
-Recorded here (user deferred at roadmap time, 2026-05-20). Each is assigned to the slice that must resolve it.
+Deferred by the user at roadmap time (2026-05-20). Each is owned by the slice that must resolve it.
 
-- **Q1 — What do resources actually DO?** Today they only feed marketplace prices. For *buying* (S7) to matter they need an effect: luxuries→happiness? strategic→unit unlocks? May warrant its own slice inserted before S7. **Resolve before S7.**
-- **Q2 — Resource → tech → improvement mapping.** Reuse mine/farm, or add plantation / pasture / camp improvements for silk, wine, horses, ivory, incense, spices? **Resolve in S2.**
-- **Q3 — Trade scope.** Domestic routes (between your own cities) too, or only foreign-civ routes? **Resolve in S4.**
-- **Q4 — Caravan tiers.** One upgradeable caravan, or a per-age tier (caravan → merchant ship → …)? "Age-appropriate" (req. 8) at minimum means a sensible tech gate. **Resolve in S4.**
-- **Q5 — Tech-gated map reveal.** Should resources be hidden until discovered (the existing `identify_resources` tech effect), or always drawn? **Resolve in S1.**
+- **Q1 — What do resources actually DO?** Verified: today owning a resource confers **no** mechanical benefit. Luxuries→happiness? strategic→unit unlocks? May warrant its own slice. **Resolve before S7** (gates buying's meaning).
+- **Q2 — Resource → tech → improvement mapping.** Only 4 improvements exist; `mine` covers hills/mountain; **grassland/plains/jungle/forest/desert resources have no fitting improvement (desert none at all)**. Decide: add plantation/pasture/camp (and a desert option), or one generic "trading post", or map to existing improvements. **Resolve in S2.**
+- **Q3 — Trade scope.** Domestic routes (between your own cities) too, or only foreign-civ routes (`TradeRoute.foreignCivId`)? **Resolve in S4.**
+- **Q4 — Caravan tiers.** One upgradeable caravan, or per-age tier (caravan → merchant ship → …)? Gate confirmed as `trade-routes` tech minimum. **Resolve in S4.**
+- **Q5 — Map reveal model.** Always draw resources, or hide until discovered (the `identify_resources` spy mission already reveals them; exploration could too)? **Resolve in S1.**
+- **Q6 — Route limits.** Max routes per city / per caravan / empire-wide? **Resolve in S4.**
+- **Q7 — Caravan consumption.** Does establishing a route consume the caravan (Civ-style), or does it persist / return / run the route repeatedly? **Resolve in S4.**
+- **Q8 — Relationship thresholds.** Relationships are numeric −100…+100. What score is "neutral" (minimum to trade) and "angry" (terminate)? Note `atWarWith` is separate from score. **Resolve in S4/S5.**
 
 ## Rejected items
 
@@ -132,13 +147,14 @@ Recorded here (user deferred at roadmap time, 2026-05-20). Each is assigned to t
 
 ## Living-doc protocol
 
-This roadmap is the single source of truth for what is locked vs. open. Update it when:
+Single source of truth for locked vs. open. Update when: a slice is locked (record decisions + child-spec path); a locked decision changes (note date/reason); a deferred question resolves (move it into its slice); scope shifts in a slice (record under it); a new item is deferred (add to the list); an item is rejected (move to Rejected with reason). Commit updates alongside the change that triggered them.
 
-- A slice is brainstormed and locked → record the slice's locked decisions and the path to its child spec.
-- A locked decision changes → update it and note the date/reason.
-- A deferred question is resolved → move it from the deferred list into its slice.
-- Scope shifts during a slice's plan/PR → record it under that slice.
-- A new item must be deferred → add it to the deferred list.
-- An item is rejected → move it to "Rejected items" with the reason.
+## Runbook — picking up the next slice (for a future session)
 
-Updates are committed alongside whatever change triggered them.
+1. Read this roadmap top to bottom.
+2. Find the next unstarted slice in **Sequencing**.
+3. **Re-verify** the Current-state rows for the files that slice touches — code may have moved since `84f9182`.
+4. Invoke `superpowers:brainstorming` for that slice; resolve its assigned deferred question(s) with the user.
+5. Write the slice spec (`docs/superpowers/specs/`), then the plan (`docs/superpowers/plans/`), then implement with TDD.
+6. Verify (`yarn build` + `yarn test` both green), open a PR per the Conventions.
+7. Record the slice's locked decisions + child-spec path back in this roadmap.

--- a/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
+++ b/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
@@ -161,7 +161,7 @@ function drawHex(
 ): void
 ```
 
-**Resource icon drawing block** — inserted after the improvement block (lines ~264), before the wonder block:
+**Resource icon drawing block** — inserted after *both* improvement-related blocks (completed-improvement block AND construction-in-progress block), before the wonder block. There are two improvement blocks in `drawHex`: the first renders the completed improvement icon (~lines 251–264); the second renders the 🔨 in-progress indicator (~lines 267–276). The resource block must go after both so it draws on top of any in-progress construction indicator, not between the two improvement blocks:
 
 ```ts
 // Draw resource icon (tech-gated).
@@ -171,6 +171,9 @@ function drawHex(
 // (the player remembers what they saw). Tech gate still applies.
 if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
   const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
+  // hasVisibleImprovement: only the *completed* improvement icon occupies center.
+  // An in-progress improvement (improvementTurnsLeft > 0) shows 🔨 above/below center;
+  // in that case hasVisibleImprovement is false and the resource draws centered.
   const hasVisibleImprovement =
     tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
 
@@ -179,11 +182,11 @@ if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
   ctx.textBaseline = 'middle';
 
   if (hasVisibleImprovement) {
-    // Option B: small icon at top-left corner
+    // Option B: small icon at top-left corner; improvement stays centered
     ctx.font = `${size * 0.3}px system-ui`;
     ctx.fillText(icon, cx - size * 0.3, cy - size * 0.3);
   } else {
-    // No improvement competing — centered at full icon size
+    // No completed improvement icon at center — draw resource centered
     ctx.font = `${size * 0.5}px system-ui`;
     ctx.fillText(icon, cx, cy);
   }
@@ -252,6 +255,8 @@ No call-site change in `main.ts` — the function signature is unchanged.
 ### `src/ui/icon-legend.ts`
 
 `createIconLegendOverlay(viewerTechs: ReadonlySet<string>): HTMLDivElement` — add the parameter. Append a "Resources" section after the existing static items, listing only resources the viewer has tech for, split into luxury and strategic sub-groups. If the viewer has no resource techs, the Resources section is omitted entirely.
+
+**Also change `display:none` → `display:block`** in the overlay's initial `style.cssText`. The old code pre-built the overlay at startup and hid it; the new toggle pattern only ever calls `createIconLegendOverlay` when it is about to be shown. Starting hidden would make the first toggle a no-op (the check `existing.style.display !== 'none'` would see an empty-display element as "visible" and immediately hide it without showing anything). Starting as `display:block` means the freshly-created overlay is immediately visible when appended by the toggle handler.
 
 The export `toggleIconLegend` becomes dead (main.ts will no longer use it) — remove it.
 
@@ -331,7 +336,7 @@ Use a minimal mock canvas context. All tile states hand-built (no RNG).
 
 | Test | Assertion |
 |---|---|
-| Panel with viewer-has-tech | Resource row present, shows "Gems (strategic)" format |
+| Panel with viewer-has-tech | Resource row present, shows "Gems (luxury)" format |
 | Panel with viewer-lacks-tech | Resource row absent (negative) |
 
 ### `tests/ui/icon-legend.test.ts`

--- a/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
+++ b/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
@@ -1,0 +1,271 @@
+# S1 — Resources on the Map (Tech-Gated Reveal) — Design Spec
+
+**Roadmap slice:** S1 of `2026-05-20-marketplace-trade-roadmap.md`
+**Origin:** GitHub issue [#234](https://github.com/a1flecke/conquestoria/issues/234)
+**Value shipped:** Resources are finally visible on the map — but only once you've researched the enabling tech. The map layer goes from "flat terrain" to "terrain + discoverable resources."
+
+---
+
+## Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Hidden state (no tech) | **Nothing** — pure terrain, resource absent from map and inspection panel |
+| Icon overlap (resource + improvement on same tile) | **B** — resource icon small (~30% size) at top-left corner; improvement icon centered at full size |
+| Spy mission `identify_resources` | **Out of scope** — that mission reveals what a foreign civ *owns* (an S2b/acquisition concern), not tile-level icons. No map-render interaction in S1. |
+| New state needed | **None** — renderer checks `viewerTechs: ReadonlySet<string>` passed in from `main.ts` |
+| Tech `unlocks` text | All 9 remaining techs get a "Reveal X resource" line added to their `unlocks` array (matching the existing `animal-husbandry` pattern) |
+
+---
+
+## Resource catalog
+
+### Icons
+
+| Resource | Icon | Type | Terrain |
+|---|---|---|---|
+| Silk | 🧵 | luxury | grassland |
+| Wine | 🍇 | luxury | plains |
+| Spices | 🌶️ | luxury | jungle |
+| Gems | 💎 | luxury | hills |
+| Ivory | 🐘 | luxury | forest |
+| Incense | 🕯️ | luxury | desert |
+| Copper | 🪙 | strategic | hills |
+| Iron | ⚙️ | strategic | hills |
+| Horses | 🐎 | strategic | plains |
+| Stone | 🪨 | strategic | mountain |
+
+### Tech-to-resource mapping
+
+| Tech ID | Era | Resource revealed |
+|---|---|---|
+| `gathering` | 1 | Stone |
+| `stone-weapons` | 1 | Copper |
+| `foraging` | 1 | Ivory |
+| `pottery` | 1 | Wine |
+| `cartography` | 1 | Spices |
+| `irrigation` | 2 | Silk |
+| `bronze-working` | 2 | Iron |
+| `animal-husbandry` | 2 | Horses *(already in `unlocks` text)* |
+| `mining-tech` | 3 | Gems |
+| `currency` | 3 | Incense |
+
+---
+
+## Data changes
+
+### `src/systems/trade-system.ts`
+
+Add `tech: string` to `ResourceDefinition` (the shared foundation field consumed by S1; `requiredImprovement` added by S2a, `effect` added by S4a):
+
+```ts
+export interface ResourceDefinition {
+  id: ResourceType;
+  name: string;
+  type: 'luxury' | 'strategic';
+  terrain: string;
+  basePrice: number;
+  tech: string;   // enabling tech id — added by S1
+}
+```
+
+Populate all 10 entries with their tech from the locked mapping above.
+
+Derive two lookup records from `RESOURCE_DEFINITIONS` (single source of truth — no duplication):
+
+```ts
+export const RESOURCE_ICONS: Record<string, string> = {};
+export const RESOURCE_TECH: Record<string, string> = {};
+for (const r of RESOURCE_DEFINITIONS) {
+  RESOURCE_ICONS[r.id] = /* icon per catalog above */;
+  RESOURCE_TECH[r.id] = r.tech;
+}
+```
+
+### `src/systems/tech-definitions.ts`
+
+Add a "Reveal X resource" string to the `unlocks` array of each of the 9 techs that don't already have it (mirror the `animal-husbandry` pattern). Example:
+
+```ts
+{ id: 'gathering', ..., unlocks: ['Foundational economy knowledge', 'Reveal Stone resource'] },
+{ id: 'stone-weapons', ..., unlocks: ['Warriors deal +2 damage', 'Reveal Copper resource'] },
+// … etc.
+```
+
+---
+
+## Renderer changes
+
+### `src/renderer/hex-renderer.ts`
+
+**`drawHexMap` signature** — one new optional parameter at the end:
+
+```ts
+export function drawHexMap(
+  ctx: CanvasRenderingContext2D,
+  // … existing params …
+  viewerTechs: ReadonlySet<string> = new Set(),  // ← new
+): void
+```
+
+Thread `viewerTechs` into each `drawHex` call.
+
+**`drawHex` signature** — matching new parameter:
+
+```ts
+function drawHex(
+  // … existing params …
+  viewerTechs: ReadonlySet<string> = new Set(),  // ← new
+): void
+```
+
+**Resource icon drawing block** — inserted after the improvement block (lines ~264), before the wonder block:
+
+```ts
+// Draw resource icon (tech-gated + visibility-gated)
+// viewerVisibility guard mirrors the ownership-border guard below (~L302).
+// drawHex is called for every tile; fog is a separate overlay — we must
+// not draw through it, so skip if the tile is outside the viewer's vision.
+const tileIsVisible = !viewerVisibility ||
+  viewerVisibility[`${tile.coord.q},${tile.coord.r}`] === 'visible';
+
+if (tileIsVisible && tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
+  const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
+  const hasVisibleImprovement =
+    tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
+
+  ctx.fillStyle = 'rgba(255,255,255,0.85)';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+
+  if (hasVisibleImprovement) {
+    // Option B: small icon at top-left corner
+    ctx.font = `${size * 0.3}px system-ui`;
+    ctx.fillText(icon, cx - size * 0.3, cy - size * 0.3);
+  } else {
+    // No improvement competing — centered at full icon size
+    ctx.font = `${size * 0.5}px system-ui`;
+    ctx.fillText(icon, cx, cy);
+  }
+}
+```
+
+> **Implementation note:** verify the exact `VisibilityMap` key format and `'visible'` value against `src/renderer/render-visibility.ts` before coding — use the same pattern as the ownership-border guard at lines ~302-309 of `hex-renderer.ts`.
+
+**`main.ts` call site** — build viewer techs once per render and pass in:
+
+```ts
+const viewerTechs = new Set(
+  state.civilizations[state.currentPlayer]?.techState.completed ?? []
+);
+// pass viewerTechs to drawHexMap(...)
+```
+
+---
+
+## Inspection panel changes
+
+### `src/ui/territory-inspection-panel.ts`
+
+`createTerritoryInspectionPanel` receives one new parameter `viewerTechs: ReadonlySet<string>`.
+
+Replace line 95:
+
+```ts
+// Before (leaks un-tech'd resources):
+if (tile.resource) addLine(panel, 'Resource', titleCase(tile.resource));
+
+// After (gated + shows type):
+const resDef = tile.resource
+  ? RESOURCE_DEFINITIONS.find(r => r.id === tile.resource)
+  : null;
+if (resDef && viewerTechs.has(resDef.tech)) {
+  addLine(panel, 'Resource', `${resDef.name} (${resDef.type})`);
+}
+```
+
+`openTerritoryInspectionPanel` in `main.ts` passes the same `viewerTechs` set.
+
+---
+
+## Legend changes
+
+### `src/ui/icon-legend.ts`
+
+`createIconLegendOverlay` accepts `viewerTechs: ReadonlySet<string>`. It builds the existing static items then appends a "Resources" section listing only the resources the viewer has tech for, split into luxury and strategic sub-groups.
+
+If the viewer has no resource techs, the Resources section is omitted.
+
+The legend is rebuilt (not toggled from cache) each time the legend button is tapped, so it always reflects current tech state. The `toggleIconLegend` call in `main.ts` becomes a re-create-and-show pattern instead of a visibility toggle — or, if the panel is open, close it; if closed, rebuild and show.
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `src/systems/trade-system.ts` | Add `tech` to `ResourceDefinition`; populate all 10 entries; derive `RESOURCE_ICONS` and `RESOURCE_TECH` |
+| `src/systems/tech-definitions.ts` | Add "Reveal X resource" to `unlocks` for 9 techs |
+| `src/renderer/hex-renderer.ts` | Add `viewerTechs` param to `drawHexMap` + `drawHex`; add resource icon drawing block |
+| `src/ui/territory-inspection-panel.ts` | Add `viewerTechs` param; gate + enrich resource display |
+| `src/ui/icon-legend.ts` | Add `viewerTechs` param; add dynamic resource section |
+| `src/main.ts` | Build `viewerTechs` set; pass to all three above |
+
+**No new files required.** No new `GameState` fields. No save migration needed.
+
+---
+
+## Tests
+
+### `tests/systems/trade-system.test.ts`
+
+**Catalog integrity:**
+- Every `ResourceDefinition` entry has a non-empty `tech` that exists in the tech tree
+- `RESOURCE_ICONS` has an entry for every `ResourceType` value (no missing keys)
+- `RESOURCE_TECH` has an entry for every `ResourceType` value
+
+### `tests/renderer/hex-renderer.test.ts`
+
+Use a minimal mock canvas context. All tile states hand-built (no RNG).
+
+| Test | Assertion |
+|---|---|
+| Resource tile, viewer has tech | Resource icon text drawn |
+| Resource tile, viewer lacks tech | Resource icon text absent (negative — spec-fidelity) |
+| Resource + completed improvement, viewer has tech | Resource drawn at corner position (`cx - size * 0.3`); improvement drawn at center |
+| Resource + in-progress improvement (`improvementTurnsLeft > 0`), viewer has tech | Resource drawn centered (improvement not shown, no corner split) |
+| Fog tile (outside visibility) | No resource icon regardless of tech (privacy negative) |
+
+### `tests/ui/territory-inspection-panel.test.ts`
+
+| Test | Assertion |
+|---|---|
+| Panel with viewer-has-tech | Resource row present, shows "Gems (strategic)" format |
+| Panel with viewer-lacks-tech | Resource row absent (negative) |
+
+### `tests/ui/icon-legend.test.ts`
+
+| Test | Assertion |
+|---|---|
+| `viewerTechs` contains `animal-husbandry` | Legend HTML contains "🐎" and "Horses" |
+| Empty `viewerTechs` | No resource section in legend |
+
+---
+
+## Done when
+
+- Resources render on tiles **only** for tech-holders; un-tech'd and fogged tiles show nothing
+- Tile inspection shows resource name + type (luxury/strategic) for tech-holders only
+- Map legend lists only the resources the current player has tech for
+- Tech panel `unlocks` text for all 10 enabling techs mentions the resource they reveal
+- `yarn build` and `yarn test` both exit 0
+- Manual smoke: start a game, confirm no resources visible; research `gathering`; confirm Stone appears on mountain tiles
+
+## Out of scope (handled by later slices)
+
+- `requiredImprovement` field on `ResourceDefinition` → S2a
+- `effect` field → S4a
+- `getCivAvailableResources` acquisition helper → S2b
+- `identify_resources` spy mission map interaction → S2b (the mission reveals a civ's *owned* resources, not tile icons)
+- Marketplace panel tech-filter → S3
+- Resource-specific improvements (plantation, pasture, camp, quarry) → S2a

--- a/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
+++ b/docs/superpowers/specs/2026-05-21-marketplace-s1-resources-on-map-design.md
@@ -13,7 +13,7 @@
 | Hidden state (no tech) | **Nothing** — pure terrain, resource absent from map and inspection panel |
 | Icon overlap (resource + improvement on same tile) | **B** — resource icon small (~30% size) at top-left corner; improvement icon centered at full size |
 | Spy mission `identify_resources` | **Out of scope** — that mission reveals what a foreign civ *owns* (an S2b/acquisition concern), not tile-level icons. No map-render interaction in S1. |
-| New state needed | **None** — renderer checks `viewerTechs: ReadonlySet<string>` passed in from `main.ts` |
+| New state needed | **None** — renderer receives `viewerTechs: ReadonlySet<string>` built in `render-loop.ts`; inspection panel derives it internally from `state` |
 | Tech `unlocks` text | All 9 remaining techs get a "Reveal X resource" line added to their `unlocks` array (matching the existing `animal-husbandry` pattern) |
 
 ---
@@ -56,7 +56,7 @@
 
 ### `src/systems/trade-system.ts`
 
-Add `tech: string` to `ResourceDefinition` (the shared foundation field consumed by S1; `requiredImprovement` added by S2a, `effect` added by S4a):
+Add `tech` and `icon` to `ResourceDefinition`. Both fields land in S1; `requiredImprovement` is added by S2a, `effect` by S4a:
 
 ```ts
 export interface ResourceDefinition {
@@ -66,18 +66,32 @@ export interface ResourceDefinition {
   terrain: string;
   basePrice: number;
   tech: string;   // enabling tech id — added by S1
+  icon: string;   // emoji for map rendering and legend — added by S1
 }
 ```
 
-Populate all 10 entries with their tech from the locked mapping above.
+Populate all 10 entries with `tech` and `icon` from the locked catalog:
 
-Derive two lookup records from `RESOURCE_DEFINITIONS` (single source of truth — no duplication):
+```ts
+{ id: 'silk',    name: 'Silk',    type: 'luxury',   terrain: 'grassland', basePrice: 8,  tech: 'irrigation',      icon: '🧵' },
+{ id: 'wine',    name: 'Wine',    type: 'luxury',   terrain: 'plains',    basePrice: 7,  tech: 'pottery',         icon: '🍇' },
+{ id: 'spices',  name: 'Spices',  type: 'luxury',   terrain: 'jungle',    basePrice: 10, tech: 'cartography',     icon: '🌶️' },
+{ id: 'gems',    name: 'Gems',    type: 'luxury',   terrain: 'hills',     basePrice: 12, tech: 'mining-tech',     icon: '💎' },
+{ id: 'ivory',   name: 'Ivory',   type: 'luxury',   terrain: 'forest',    basePrice: 9,  tech: 'foraging',        icon: '🐘' },
+{ id: 'incense', name: 'Incense', type: 'luxury',   terrain: 'desert',    basePrice: 6,  tech: 'currency',        icon: '🕯️' },
+{ id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',    basePrice: 5,  tech: 'stone-weapons',   icon: '🪙' },
+{ id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',    basePrice: 8,  tech: 'bronze-working',  icon: '⚙️' },
+{ id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',   basePrice: 7,  tech: 'animal-husbandry',icon: '🐎' },
+{ id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain', basePrice: 4,  tech: 'gathering',       icon: '🪨' },
+```
+
+Derive lookup records from `RESOURCE_DEFINITIONS` (single source of truth — no duplication):
 
 ```ts
 export const RESOURCE_ICONS: Record<string, string> = {};
 export const RESOURCE_TECH: Record<string, string> = {};
 for (const r of RESOURCE_DEFINITIONS) {
-  RESOURCE_ICONS[r.id] = /* icon per catalog above */;
+  RESOURCE_ICONS[r.id] = r.icon;
   RESOURCE_TECH[r.id] = r.tech;
 }
 ```
@@ -98,23 +112,51 @@ Add a "Reveal X resource" string to the `unlocks` array of each of the 9 techs t
 
 ### `src/renderer/hex-renderer.ts`
 
+**Call chain:** `drawHexMap` → `drawTileAtScreen` → `drawHex`. All three are in `hex-renderer.ts`; `viewerTechs` must be threaded through all three.
+
 **`drawHexMap` signature** — one new optional parameter at the end:
 
 ```ts
 export function drawHexMap(
   ctx: CanvasRenderingContext2D,
-  // … existing params …
+  map: GameMap,
+  camera: Camera,
+  villagePositions?: Set<string>,
+  currentPlayer?: string,
+  viewerVisibility?: VisibilityMap,
   viewerTechs: ReadonlySet<string> = new Set(),  // ← new
 ): void
 ```
 
-Thread `viewerTechs` into each `drawHex` call.
+Thread `viewerTechs` into the `drawTileAtScreen` call inside the loop.
 
-**`drawHex` signature** — matching new parameter:
+**`drawTileAtScreen` signature** — matching new parameter:
+
+```ts
+function drawTileAtScreen(
+  ctx: CanvasRenderingContext2D,
+  screen: { x: number; y: number },
+  scaledSize: number,
+  tile: HexTile,
+  isVillage: boolean,
+  currentPlayer: string | undefined,
+  viewerVisibility: VisibilityMap | undefined,
+  zoom: number,
+  presentationKind: TilePresentationKind,
+  nowMs: number,
+  reducedMotion: boolean,
+  viewerTechs: ReadonlySet<string> = new Set(),  // ← new
+): void
+```
+
+Thread `viewerTechs` into the `drawHex` call inside `drawTileAtScreen`.
+
+**`drawHex` signature** — matching new parameter at the end (after `reducedMotion`):
 
 ```ts
 function drawHex(
   // … existing params …
+  reducedMotion: boolean = false,
   viewerTechs: ReadonlySet<string> = new Set(),  // ← new
 ): void
 ```
@@ -122,14 +164,12 @@ function drawHex(
 **Resource icon drawing block** — inserted after the improvement block (lines ~264), before the wonder block:
 
 ```ts
-// Draw resource icon (tech-gated + visibility-gated)
-// viewerVisibility guard mirrors the ownership-border guard below (~L302).
-// drawHex is called for every tile; fog is a separate overlay — we must
-// not draw through it, so skip if the tile is outside the viewer's vision.
-const tileIsVisible = !viewerVisibility ||
-  viewerVisibility[`${tile.coord.q},${tile.coord.r}`] === 'visible';
-
-if (tileIsVisible && tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
+// Draw resource icon (tech-gated).
+// No explicit visibility guard needed: drawHex receives presentation.tile, which
+// already has resource: null for unexplored / unknown-fog tiles (via unknownTile()).
+// Last-seen tiles carry the resource from the snapshot — showing it is correct
+// (the player remembers what they saw). Tech gate still applies.
+if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
   const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
   const hasVisibleImprovement =
     tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
@@ -150,15 +190,25 @@ if (tileIsVisible && tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resourc
 }
 ```
 
-> **Implementation note:** verify the exact `VisibilityMap` key format and `'visible'` value against `src/renderer/render-visibility.ts` before coding — use the same pattern as the ownership-border guard at lines ~302-309 of `hex-renderer.ts`.
+**Import** — add to the top of `hex-renderer.ts`:
+```ts
+import { RESOURCE_ICONS, RESOURCE_TECH } from '@/systems/trade-system';
+```
 
-**`main.ts` call site** — build viewer techs once per render and pass in:
+**`render-loop.ts` call site** — `drawHexMap` is called from `render-loop.ts` `render()` method (line ~123), not from `main.ts`. Build `viewerTechs` alongside the existing `viewerVisibility` derivation:
 
 ```ts
-const viewerTechs = new Set(
-  state.civilizations[state.currentPlayer]?.techState.completed ?? []
+// In RenderLoop.render() — existing lines:
+const viewerId = this.state.currentPlayer;
+const viewerVisibility = this.state.civilizations[viewerId]?.visibility;
+
+// New line — add immediately after:
+const viewerTechs = new Set<string>(
+  this.state.civilizations[viewerId]?.techState.completed ?? []
 );
-// pass viewerTechs to drawHexMap(...)
+
+// Updated drawHexMap call (was 6 args, now 7):
+drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility, viewerTechs);
 ```
 
 ---
@@ -167,15 +217,24 @@ const viewerTechs = new Set(
 
 ### `src/ui/territory-inspection-panel.ts`
 
-`createTerritoryInspectionPanel` receives one new parameter `viewerTechs: ReadonlySet<string>`.
+No new parameter needed — `createTerritoryInspectionPanel` already receives `state` and `viewerId`, so it can derive the viewer's tech set internally.
 
-Replace line 95:
-
+**New import** (add alongside the existing imports):
 ```ts
-// Before (leaks un-tech'd resources):
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+```
+
+**Derive tech set** — add near the top of the function body (after the `viewer` line):
+```ts
+const viewerTechs = new Set(viewer?.techState.completed ?? []);
+```
+
+**Replace line 95** (the unconditional resource display):
+```ts
+// Before (leaks un-tech'd resources, no type label):
 if (tile.resource) addLine(panel, 'Resource', titleCase(tile.resource));
 
-// After (gated + shows type):
+// After (gated on tech; shows name + type; works for both live and last-seen tiles):
 const resDef = tile.resource
   ? RESOURCE_DEFINITIONS.find(r => r.id === tile.resource)
   : null;
@@ -184,7 +243,7 @@ if (resDef && viewerTechs.has(resDef.tech)) {
 }
 ```
 
-`openTerritoryInspectionPanel` in `main.ts` passes the same `viewerTechs` set.
+No call-site change in `main.ts` — the function signature is unchanged.
 
 ---
 
@@ -192,11 +251,40 @@ if (resDef && viewerTechs.has(resDef.tech)) {
 
 ### `src/ui/icon-legend.ts`
 
-`createIconLegendOverlay` accepts `viewerTechs: ReadonlySet<string>`. It builds the existing static items then appends a "Resources" section listing only the resources the viewer has tech for, split into luxury and strategic sub-groups.
+`createIconLegendOverlay(viewerTechs: ReadonlySet<string>): HTMLDivElement` — add the parameter. Append a "Resources" section after the existing static items, listing only resources the viewer has tech for, split into luxury and strategic sub-groups. If the viewer has no resource techs, the Resources section is omitted entirely.
 
-If the viewer has no resource techs, the Resources section is omitted.
+The export `toggleIconLegend` becomes dead (main.ts will no longer use it) — remove it.
 
-The legend is rebuilt (not toggled from cache) each time the legend button is tapped, so it always reflects current tech state. The `toggleIconLegend` call in `main.ts` becomes a re-create-and-show pattern instead of a visibility toggle — or, if the panel is open, close it; if closed, rebuild and show.
+### `src/main.ts` — legend wiring changes
+
+The overlay is currently pre-built once and handed to `createGameShell` as `iconLegendOverlay: createIconLegendOverlay()` (line 236). This can no longer work because it needs current techs at show-time, not at startup. Two changes:
+
+**1. Remove the pre-built overlay** from the `createGameShell` call:
+```ts
+// Remove this line:
+iconLegendOverlay: createIconLegendOverlay(),
+```
+
+**2. Replace the `onToggleIconLegend` callback** (line 221) with one that rebuilds on each show:
+```ts
+onToggleIconLegend: () => {
+  const existing = document.getElementById('icon-legend');
+  if (existing && existing.style.display !== 'none') {
+    // Already visible — hide it
+    existing.style.display = 'none';
+    return;
+  }
+  // Stale or absent — remove old, create fresh with current techs
+  existing?.remove();
+  const viewerTechs = new Set<string>(
+    gameState.civilizations[gameState.currentPlayer]?.techState.completed ?? []
+  );
+  const overlay = createIconLegendOverlay(viewerTechs);
+  uiLayer.appendChild(overlay);
+},
+```
+
+`uiLayer` is already in scope at the `createGameShell` call site. `toggleIconLegend` is no longer imported.
 
 ---
 
@@ -204,12 +292,13 @@ The legend is rebuilt (not toggled from cache) each time the legend button is ta
 
 | File | Change |
 |---|---|
-| `src/systems/trade-system.ts` | Add `tech` to `ResourceDefinition`; populate all 10 entries; derive `RESOURCE_ICONS` and `RESOURCE_TECH` |
+| `src/systems/trade-system.ts` | Add `tech` + `icon` to `ResourceDefinition`; populate all 10 entries; derive `RESOURCE_ICONS` and `RESOURCE_TECH` |
 | `src/systems/tech-definitions.ts` | Add "Reveal X resource" to `unlocks` for 9 techs |
-| `src/renderer/hex-renderer.ts` | Add `viewerTechs` param to `drawHexMap` + `drawHex`; add resource icon drawing block |
-| `src/ui/territory-inspection-panel.ts` | Add `viewerTechs` param; gate + enrich resource display |
-| `src/ui/icon-legend.ts` | Add `viewerTechs` param; add dynamic resource section |
-| `src/main.ts` | Build `viewerTechs` set; pass to all three above |
+| `src/renderer/hex-renderer.ts` | Add `viewerTechs` param to `drawHexMap`, `drawTileAtScreen`, and `drawHex`; add resource icon drawing block; add import from `trade-system` |
+| `src/renderer/render-loop.ts` | Derive `viewerTechs` from `this.state`; pass as 7th arg to `drawHexMap` |
+| `src/ui/territory-inspection-panel.ts` | Derive `viewerTechs` internally; gate resource display on tech; enrich with name + type; add import from `trade-system` |
+| `src/ui/icon-legend.ts` | Add `viewerTechs` param to `createIconLegendOverlay`; add dynamic resource section; remove `toggleIconLegend` export |
+| `src/main.ts` | Remove pre-built `iconLegendOverlay` from `createGameShell` call; replace `onToggleIconLegend` with inline rebuild handler; remove `toggleIconLegend` import |
 
 **No new files required.** No new `GameState` fields. No save migration needed.
 
@@ -230,11 +319,13 @@ Use a minimal mock canvas context. All tile states hand-built (no RNG).
 
 | Test | Assertion |
 |---|---|
-| Resource tile, viewer has tech | Resource icon text drawn |
+| Resource tile (`presentationKind: 'live'`), viewer has tech | Resource icon text drawn |
 | Resource tile, viewer lacks tech | Resource icon text absent (negative — spec-fidelity) |
 | Resource + completed improvement, viewer has tech | Resource drawn at corner position (`cx - size * 0.3`); improvement drawn at center |
 | Resource + in-progress improvement (`improvementTurnsLeft > 0`), viewer has tech | Resource drawn centered (improvement not shown, no corner split) |
-| Fog tile (outside visibility) | No resource icon regardless of tech (privacy negative) |
+| Unexplored tile (`resource: null` via `unknownTile`) | No resource icon — `tile.resource` is null, so the guard `if (tile.resource && ...)` naturally skips it; no explicit visibility check required |
+| Last-seen tile (`presentationKind: 'last-seen'`) with resource, viewer has tech | Resource icon IS drawn — player remembers what they last saw; tech gate still applies |
+| Last-seen tile with resource, viewer lacks tech | Resource icon absent (negative) |
 
 ### `tests/ui/territory-inspection-panel.test.ts`
 
@@ -254,7 +345,7 @@ Use a minimal mock canvas context. All tile states hand-built (no RNG).
 
 ## Done when
 
-- Resources render on tiles **only** for tech-holders; un-tech'd and fogged tiles show nothing
+- Resources render on tiles **only** for tech-holders; un-tech'd tiles show nothing; unexplored/unknown-fog tiles show nothing (their `tile.resource` is `null` from the presentation system); last-seen tiles show the resource if the viewer has the tech
 - Tile inspection shows resource name + type (luxury/strategic) for tech-holders only
 - Map legend lists only the resources the current player has tech for
 - Tech panel `unlocks` text for all 10 enabling techs mentions the resource they reveal

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,7 +78,7 @@ import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentati
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
 import { registerMinorCivNotificationListeners } from '@/ui/minor-civ-notification-listeners';
 import { conquestMinorCiv, applyDiplomaticReaction } from '@/systems/minor-civ-system';
-import { createIconLegendOverlay, toggleIconLegend } from '@/ui/icon-legend';
+import { createIconLegendOverlay } from '@/ui/icon-legend';
 import { showVictoryPanel } from '@/ui/victory-panel';
 import { buildUnitOccupancy, hasHostileUnitAtCoord } from '@/systems/unit-occupancy';
 import {
@@ -244,7 +244,21 @@ function createUI(): void {
     onEndTurn: () => endTurn(),
     onNextUnit: () => selectNextUnit(),
     onOpenNotificationLog: () => toggleNotificationLog(),
-    onToggleIconLegend: () => toggleIconLegend(),
+    onToggleIconLegend: () => {
+      const existing = document.getElementById('icon-legend');
+      if (existing && existing.style.display !== 'none') {
+        // Already visible — hide it
+        existing.style.display = 'none';
+        return;
+      }
+      // Stale or absent — remove old, rebuild fresh with current techs
+      existing?.remove();
+      const viewerTechs = new Set<string>(
+        gameState.civilizations[gameState.currentPlayer]?.techState.completed ?? []
+      );
+      const overlay = createIconLegendOverlay(viewerTechs);
+      uiLayer.appendChild(overlay);
+    },
     onOpenWonderAtlas: () => openWonderAtlas(),
     onOpenMenu: () => {
       showPauseMenu(uiLayer, {
@@ -259,7 +273,6 @@ function createUI(): void {
         autoSave: () => autoSave(gameState),
       });
     },
-    iconLegendOverlay: createIconLegendOverlay(),
   });
 }
 

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -5,6 +5,7 @@ import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
 import { resolveTilePresentationForViewer, type TilePresentationKind } from './tile-presentation';
 import { drawNaturalWonderLandmark } from './wonders/natural-wonder-renderer';
+import { RESOURCE_ICONS, RESOURCE_TECH } from '@/systems/trade-system';
 
 // --- Terrain labels ---
 
@@ -62,8 +63,9 @@ function drawTileAtScreen(
   presentationKind: TilePresentationKind,
   nowMs: number,
   reducedMotion: boolean,
+  viewerTechs: ReadonlySet<string> = new Set(),
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, viewerTechs);
   if (shouldShowTerrainLabel(zoom)) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -81,6 +83,7 @@ export function drawHexMap(
   villagePositions?: Set<string>,
   currentPlayer?: string,
   viewerVisibility?: VisibilityMap,
+  viewerTechs: ReadonlySet<string> = new Set(),
 ): void {
   const size = camera.hexSize;
   const nowMs = typeof performance !== 'undefined' ? performance.now() : 0;
@@ -113,6 +116,7 @@ export function drawHexMap(
         presentation.kind,
         nowMs,
         reducedMotion,
+        viewerTechs,
       );
     }
   }
@@ -227,6 +231,7 @@ function drawHex(
   presentationKind: TilePresentationKind = 'live',
   nowMs: number = 0,
   reducedMotion: boolean = false,
+  viewerTechs: ReadonlySet<string> = new Set(),
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -273,6 +278,31 @@ function drawHex(
     ctx.font = `bold ${size * 0.22}px sans-serif`;
     ctx.fillStyle = 'rgba(255,255,255,0.9)';
     ctx.fillText(`${tile.improvementTurnsLeft}t`, cx, cy + size * 0.25);
+  }
+
+  // Draw resource icon (tech-gated).
+  // No explicit visibility guard needed: drawHex receives presentation.tile, which
+  // already has resource: null for unexplored/unknown-fog tiles (via unknownTile()).
+  // Last-seen tiles carry the resource from the snapshot — showing it is correct
+  // (the player remembers what they saw). Tech gate still applies.
+  if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
+    const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
+    const hasVisibleImprovement =
+      tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
+
+    ctx.fillStyle = 'rgba(255,255,255,0.85)';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+
+    if (hasVisibleImprovement) {
+      // Option B: small icon at top-left corner; improvement stays centered
+      ctx.font = `${size * 0.3}px system-ui`;
+      ctx.fillText(icon, cx - size * 0.3, cy - size * 0.3);
+    } else {
+      // No improvement competing — centered at full icon size
+      ctx.font = `${size * 0.5}px system-ui`;
+      ctx.fillText(icon, cx, cy);
+    }
   }
 
   // Draw wonder indicator

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -285,21 +285,24 @@ function drawHex(
   // already has resource: null for unexplored/unknown-fog tiles (via unknownTile()).
   // Last-seen tiles carry the resource from the snapshot — showing it is correct
   // (the player remembers what they saw). Tech gate still applies.
-  if (tile.resource && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
+  // Suppressed on wonder tiles — the wonder landmark visual takes priority and
+  // the resource is accessible via the inspection panel tap.
+  if (tile.resource && !tile.wonder && viewerTechs.has(RESOURCE_TECH[tile.resource] ?? '')) {
     const icon = RESOURCE_ICONS[tile.resource] ?? '◆';
-    const hasVisibleImprovement =
-      tile.improvement !== 'none' && tile.improvementTurnsLeft === 0;
+    // Corner layout when a completed improvement OR a village glyph will occupy the center
+    const needsCornerLayout =
+      (tile.improvement !== 'none' && tile.improvementTurnsLeft === 0) || isVillage;
 
     ctx.fillStyle = 'rgba(255,255,255,0.85)';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
 
-    if (hasVisibleImprovement) {
-      // Option B: small icon at top-left corner; improvement stays centered
+    if (needsCornerLayout) {
+      // Option B: small icon at top-left corner; other glyph stays centered
       ctx.font = `${size * 0.3}px system-ui`;
       ctx.fillText(icon, cx - size * 0.3, cy - size * 0.3);
     } else {
-      // No improvement competing — centered at full icon size
+      // No competing glyph — centered at full icon size
       ctx.font = `${size * 0.5}px system-ui`;
       ctx.fillText(icon, cx, cy);
     }

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -131,6 +131,9 @@ export class RenderLoop {
     if (!this.state) return;
     const viewerId = this.state.currentPlayer;
     const viewerVisibility = this.state.civilizations[viewerId]?.visibility;
+    const viewerTechs = new Set<string>(
+      this.state.civilizations[viewerId]?.techState?.completed ?? []
+    );
 
     const { width, height } = this.canvas.getBoundingClientRect();
     this.ctx.clearRect(0, 0, width, height);
@@ -143,7 +146,7 @@ export class RenderLoop {
     const villagePositions = new Set(
       Object.values(this.state.tribalVillages ?? {}).map(v => `${v.position.q},${v.position.r}`),
     );
-    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility);
+    drawHexMap(this.ctx, this.state.map, this.camera, villagePositions, viewerId, viewerVisibility, viewerTechs);
 
     // Draw rivers
     drawRivers(this.ctx, this.state.map, this.camera, viewerVisibility);

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -2,9 +2,9 @@ import type { Tech } from '@/core/types';
 
 export const TECH_TREE: Tech[] = [
   // === MILITARY TRACK (8 techs, existing) ===
-  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 4, prerequisites: [], unlocks: ['Warriors deal +2 damage'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
+  { id: 'stone-weapons', name: 'Stone Weapons', track: 'military', cost: 4, prerequisites: [], unlocks: ['Warriors deal +2 damage', 'Reveal Copper resource'], era: 1, pacing: { band: 'starter', role: 'foundational-military', impact: 1.05, scope: 'military', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1 } },
   { id: 'archery', name: 'Archery', track: 'military', cost: 10, prerequisites: ['stone-weapons'], unlocks: ['Unlock Archer unit'], era: 1 },
-  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 10, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit'], era: 2 },
+  { id: 'bronze-working', name: 'Bronze Working', track: 'military', cost: 10, prerequisites: ['stone-weapons'], unlocks: ['Unlock Swordsman unit', 'Reveal Iron resource'], era: 2 },
   { id: 'horseback-riding', name: 'Horseback Riding', track: 'military', cost: 55, prerequisites: ['animal-husbandry'], unlocks: ['Unlock Stable, mounted units'], era: 2 },
   { id: 'fortification', name: 'Fortification', track: 'military', cost: 60, prerequisites: ['bronze-working'], unlocks: ['Unlock Walls building', 'pikeman'], era: 3 },
   { id: 'iron-forging', name: 'Iron Forging', track: 'military', cost: 80, prerequisites: ['bronze-working', 'mining-tech'], unlocks: ['Stronger melee units'], era: 3 },
@@ -12,12 +12,12 @@ export const TECH_TREE: Tech[] = [
   { id: 'tactics', name: 'Tactics', track: 'military', cost: 100, prerequisites: ['iron-forging'], unlocks: ['Units get +10% combat bonus', 'musketeer'], era: 4 },
 
   // === ECONOMY TRACK (9 techs, with Slice 3 late-era scaffolding) ===
-  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 4, prerequisites: [], unlocks: ['Foundational economy knowledge'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
-  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 10, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge'], era: 1 },
+  { id: 'gathering', name: 'Gathering', track: 'economy', cost: 4, prerequisites: [], unlocks: ['Foundational economy knowledge', 'Reveal Stone resource'], era: 1, pacing: { band: 'starter', role: 'foundational-economy', impact: 1, scope: 'empire', snowball: 1.1, urgency: 1.05, situationality: 1, unlockBreadth: 1.05 } },
+  { id: 'pottery', name: 'Pottery', track: 'economy', cost: 10, prerequisites: ['gathering'], unlocks: ['Foundational ceramics knowledge', 'Reveal Wine resource'], era: 1 },
   { id: 'animal-husbandry', name: 'Animal Husbandry', track: 'economy', cost: 12, prerequisites: ['gathering'], unlocks: ['Reveal Horses resource'], era: 2 },
-  { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 45, prerequisites: ['pottery'], unlocks: ['Farms yield +1 food'], era: 2 },
-  { id: 'currency', name: 'Currency', track: 'economy', cost: 60, prerequisites: ['pottery'], unlocks: ['Unlock Marketplace building'], era: 3 },
-  { id: 'mining-tech', name: 'Advanced Mining', track: 'economy', cost: 65, prerequisites: ['animal-husbandry'], unlocks: ['Mines yield +1 production'], era: 3 },
+  { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 45, prerequisites: ['pottery'], unlocks: ['Farms yield +1 food', 'Reveal Silk resource'], era: 2 },
+  { id: 'currency', name: 'Currency', track: 'economy', cost: 60, prerequisites: ['pottery'], unlocks: ['Unlock Marketplace building', 'Reveal Incense resource'], era: 3 },
+  { id: 'mining-tech', name: 'Advanced Mining', track: 'economy', cost: 65, prerequisites: ['animal-husbandry'], unlocks: ['Mines yield +1 production', 'Reveal Gems resource'], era: 3 },
   { id: 'trade-routes', name: 'Trade Routes', track: 'economy', cost: 85, prerequisites: ['currency'], unlocks: ['Enable trade routes between cities'], era: 4 },
   { id: 'banking', name: 'Banking', track: 'economy', cost: 95, prerequisites: ['trade-routes', 'mathematics'], unlocks: ['+20% gold in all cities'], era: 4 },
   { id: 'global-logistics', name: 'Global Logistics', track: 'economy', cost: 155, prerequisites: ['trade-routes', 'banking'], unlocks: ['Late-era supply chains and wonder distribution requirements'], era: 5, countsForEraAdvancement: false, countsForCityMaturity: true },
@@ -45,7 +45,7 @@ export const TECH_TREE: Tech[] = [
 
   // === EXPLORATION TRACK (8 techs, existing) ===
   { id: 'pathfinding', name: 'Pathfinding', track: 'exploration', cost: 4, prerequisites: [], unlocks: ['Scouts get +1 vision'], era: 1, pacing: { band: 'starter', role: 'foundational-exploration', impact: 1, scope: 'military', snowball: 1, urgency: 1.1, situationality: 1, unlockBreadth: 1 } },
-  { id: 'cartography', name: 'Cartography', track: 'exploration', cost: 10, prerequisites: ['pathfinding'], unlocks: ['Reveal map edges'], era: 1 },
+  { id: 'cartography', name: 'Cartography', track: 'exploration', cost: 10, prerequisites: ['pathfinding'], unlocks: ['Reveal map edges', 'Reveal Spices resource'], era: 1 },
   { id: 'sailing', name: 'Sailing', track: 'exploration', cost: 10, prerequisites: ['pathfinding'], unlocks: ['Units can embark on coast'], era: 2 },
   { id: 'celestial-navigation', name: 'Celestial Navigation', track: 'exploration', cost: 55, prerequisites: ['sailing', 'fire'], unlocks: ['Units can cross ocean'], era: 2 },
   { id: 'road-building', name: 'Road Building', track: 'exploration', cost: 50, prerequisites: ['wheel', 'pathfinding'], unlocks: ['Workers can build roads'], era: 3 },
@@ -54,7 +54,7 @@ export const TECH_TREE: Tech[] = [
   { id: 'military-logistics', name: 'Military Logistics', track: 'exploration', cost: 100, prerequisites: ['road-building', 'tactics'], unlocks: ['Units move +1 on roads'], era: 4 },
 
   // === AGRICULTURE TRACK (8 techs, new) ===
-  { id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 5, prerequisites: [], unlocks: ['Food storage'], era: 1 },
+  { id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 5, prerequisites: [], unlocks: ['Food storage', 'Reveal Ivory resource'], era: 1 },
   { id: 'domestication', name: 'Domestication', track: 'agriculture', cost: 10, prerequisites: ['foraging'], unlocks: ['Animal pens'], era: 1 },
   { id: 'crop-rotation', name: 'Crop Rotation', track: 'agriculture', cost: 45, prerequisites: ['domestication', 'irrigation'], unlocks: ['Improved farms'], era: 2 },
   { id: 'granary-design', name: 'Granary Design', track: 'agriculture', cost: 10, prerequisites: ['foraging'], unlocks: ['Granary upgrade'], era: 2 },

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -14,15 +14,15 @@ export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
   // Luxury
   { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland', basePrice: 8,  tech: 'irrigation',       icon: '🧵' },
   { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',    basePrice: 7,  tech: 'pottery',          icon: '🍇' },
-  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',    basePrice: 10, tech: 'cartography',      icon: '🌶️' },
+  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',    basePrice: 10, tech: 'cartography',      icon: '🌶' },
   { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',     basePrice: 12, tech: 'mining-tech',      icon: '💎' },
   { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',    basePrice: 9,  tech: 'foraging',         icon: '🐘' },
-  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',    basePrice: 6,  tech: 'currency',         icon: '🕯️' },
+  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',    basePrice: 6,  tech: 'currency',         icon: '🕯' },
   // Strategic
   { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',     basePrice: 5,  tech: 'stone-weapons',    icon: '🪙' },
-  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',     basePrice: 8,  tech: 'bronze-working',   icon: '⚙️' },
+  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',     basePrice: 8,  tech: 'bronze-working',   icon: '⚙' },
   { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',    basePrice: 7,  tech: 'animal-husbandry', icon: '🐎' },
-  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',  basePrice: 4,  tech: 'gathering',        icon: '🪨' },
+  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'hills',     basePrice: 4,  tech: 'gathering',        icon: '🪨' },
 ];
 
 export const BASE_PRICES: Record<string, number> = {};

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -6,26 +6,35 @@ export interface ResourceDefinition {
   type: 'luxury' | 'strategic';
   terrain: string;       // terrain it spawns on
   basePrice: number;
+  tech: string;          // enabling tech id — added by S1
+  icon: string;          // emoji for map rendering and legend — added by S1
 }
 
 export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
   // Luxury
-  { id: 'silk', name: 'Silk', type: 'luxury', terrain: 'grassland', basePrice: 8 },
-  { id: 'wine', name: 'Wine', type: 'luxury', terrain: 'plains', basePrice: 7 },
-  { id: 'spices', name: 'Spices', type: 'luxury', terrain: 'jungle', basePrice: 10 },
-  { id: 'gems', name: 'Gems', type: 'luxury', terrain: 'hills', basePrice: 12 },
-  { id: 'ivory', name: 'Ivory', type: 'luxury', terrain: 'forest', basePrice: 9 },
-  { id: 'incense', name: 'Incense', type: 'luxury', terrain: 'desert', basePrice: 6 },
+  { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland', basePrice: 8,  tech: 'irrigation',       icon: '🧵' },
+  { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',    basePrice: 7,  tech: 'pottery',          icon: '🍇' },
+  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',    basePrice: 10, tech: 'cartography',      icon: '🌶️' },
+  { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',     basePrice: 12, tech: 'mining-tech',      icon: '💎' },
+  { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',    basePrice: 9,  tech: 'foraging',         icon: '🐘' },
+  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',    basePrice: 6,  tech: 'currency',         icon: '🕯️' },
   // Strategic
-  { id: 'copper', name: 'Copper', type: 'strategic', terrain: 'hills', basePrice: 5 },
-  { id: 'iron', name: 'Iron', type: 'strategic', terrain: 'hills', basePrice: 8 },
-  { id: 'horses', name: 'Horses', type: 'strategic', terrain: 'plains', basePrice: 7 },
-  { id: 'stone', name: 'Stone', type: 'strategic', terrain: 'mountain', basePrice: 4 },
+  { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',     basePrice: 5,  tech: 'stone-weapons',    icon: '🪙' },
+  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',     basePrice: 8,  tech: 'bronze-working',   icon: '⚙️' },
+  { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',    basePrice: 7,  tech: 'animal-husbandry', icon: '🐎' },
+  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',  basePrice: 4,  tech: 'gathering',        icon: '🪨' },
 ];
 
 export const BASE_PRICES: Record<string, number> = {};
 for (const r of RESOURCE_DEFINITIONS) {
   BASE_PRICES[r.id] = r.basePrice;
+}
+
+export const RESOURCE_ICONS: Record<string, string> = {};
+export const RESOURCE_TECH: Record<string, string> = {};
+for (const r of RESOURCE_DEFINITIONS) {
+  RESOURCE_ICONS[r.id] = r.icon;
+  RESOURCE_TECH[r.id] = r.tech;
 }
 
 export function createMarketplaceState(): MarketplaceState {

--- a/src/ui/icon-legend.ts
+++ b/src/ui/icon-legend.ts
@@ -14,7 +14,7 @@ export function createIconLegendOverlay(viewerTechs: ReadonlySet<string> = new S
   const overlay = document.createElement('div');
   overlay.id = 'icon-legend';
   // display:block — this function is now only called when about to show the overlay
-  overlay.style.cssText = 'position:absolute;top:84px;right:12px;z-index:24;width:180px;padding:12px;border-radius:12px;background:rgba(8,12,20,0.92);border:1px solid rgba(255,255,255,0.14);box-shadow:0 10px 30px rgba(0,0,0,0.35);display:block;';
+  overlay.style.cssText = 'position:absolute;top:84px;right:12px;z-index:24;width:180px;max-height:calc(100vh - 100px);overflow-y:auto;padding:12px;border-radius:12px;background:rgba(8,12,20,0.92);border:1px solid rgba(255,255,255,0.14);box-shadow:0 10px 30px rgba(0,0,0,0.35);display:block;';
 
   const title = document.createElement('div');
   title.textContent = 'Map Legend';

--- a/src/ui/icon-legend.ts
+++ b/src/ui/icon-legend.ts
@@ -1,3 +1,5 @@
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+
 const LEGEND_ITEMS = [
   { icon: '🏛️', label: 'City' },
   { icon: '⚠️', label: 'Unrest' },
@@ -8,10 +10,11 @@ const LEGEND_ITEMS = [
   { icon: '⛏️', label: 'Mine' },
 ];
 
-export function createIconLegendOverlay(): HTMLDivElement {
+export function createIconLegendOverlay(viewerTechs: ReadonlySet<string> = new Set()): HTMLDivElement {
   const overlay = document.createElement('div');
   overlay.id = 'icon-legend';
-  overlay.style.cssText = 'position:absolute;top:84px;right:12px;z-index:24;width:180px;padding:12px;border-radius:12px;background:rgba(8,12,20,0.92);border:1px solid rgba(255,255,255,0.14);box-shadow:0 10px 30px rgba(0,0,0,0.35);display:none;';
+  // display:block — this function is now only called when about to show the overlay
+  overlay.style.cssText = 'position:absolute;top:84px;right:12px;z-index:24;width:180px;padding:12px;border-radius:12px;background:rgba(8,12,20,0.92);border:1px solid rgba(255,255,255,0.14);box-shadow:0 10px 30px rgba(0,0,0,0.35);display:block;';
 
   const title = document.createElement('div');
   title.textContent = 'Map Legend';
@@ -34,11 +37,47 @@ export function createIconLegendOverlay(): HTMLDivElement {
     overlay.appendChild(row);
   }
 
-  return overlay;
-}
+  // Dynamic resource section — only shown when viewer has at least one resource tech
+  const unlockedResources = RESOURCE_DEFINITIONS.filter(r => viewerTechs.has(r.tech));
+  if (unlockedResources.length > 0) {
+    const resourceHeader = document.createElement('div');
+    resourceHeader.style.cssText = 'font-size:12px;font-weight:700;color:#f4f1e8;letter-spacing:0.04em;text-transform:uppercase;margin-top:10px;margin-bottom:4px;';
+    resourceHeader.textContent = 'Resources';
+    overlay.appendChild(resourceHeader);
 
-export function toggleIconLegend(): void {
-  const overlay = document.getElementById('icon-legend');
-  if (!overlay) return;
-  overlay.style.display = overlay.style.display === 'none' ? 'block' : 'none';
+    const luxuries = unlockedResources.filter(r => r.type === 'luxury');
+    const strategics = unlockedResources.filter(r => r.type === 'strategic');
+
+    const groups: Array<[string, typeof unlockedResources]> = [
+      ['Luxury', luxuries],
+      ['Strategic', strategics],
+    ];
+
+    for (const [groupLabel, group] of groups) {
+      if (group.length === 0) continue;
+
+      const subHeader = document.createElement('div');
+      subHeader.style.cssText = 'font-size:10px;color:rgba(244,241,232,0.5);text-transform:uppercase;letter-spacing:0.05em;margin-top:4px;margin-bottom:2px;';
+      subHeader.textContent = groupLabel;
+      overlay.appendChild(subHeader);
+
+      for (const r of group) {
+        const row = document.createElement('div');
+        row.style.cssText = 'display:flex;align-items:center;gap:8px;color:#d7dce6;font-size:12px;padding:3px 0;';
+
+        const iconSpan = document.createElement('span');
+        iconSpan.textContent = r.icon;
+        iconSpan.style.cssText = 'display:inline-flex;width:20px;justify-content:center;';
+        row.appendChild(iconSpan);
+
+        const labelSpan = document.createElement('span');
+        labelSpan.textContent = r.name;
+        row.appendChild(labelSpan);
+
+        overlay.appendChild(row);
+      }
+    }
+  }
+
+  return overlay;
 }

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -6,6 +6,7 @@ import { TERRITORY_PRESSURE_BALANCE } from '@/systems/city-territory-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
 import { createGameButton } from '@/ui/ui-kit';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
 
 function titleCase(value: string): string {
   return value
@@ -40,6 +41,7 @@ export function createTerritoryInspectionPanel(
   const key = hexKey(coord);
   const tile = state.map.tiles[key];
   const viewer = state.civilizations[viewerId];
+  const viewerTechs = new Set(viewer?.techState.completed ?? []);
   const visibility = viewer?.visibility
     ? getVisibility(viewer.visibility, coord)
     : 'unexplored';
@@ -92,7 +94,12 @@ export function createTerritoryInspectionPanel(
 
   addLine(panel, 'Terrain', titleCase(tile.terrain));
   addLine(panel, 'Elevation', titleCase(tile.elevation));
-  if (tile.resource) addLine(panel, 'Resource', titleCase(tile.resource));
+  const resDef = tile.resource
+    ? RESOURCE_DEFINITIONS.find(r => r.id === tile.resource)
+    : null;
+  if (resDef && viewerTechs.has(resDef.tech)) {
+    addLine(panel, 'Resource', `${resDef.name} (${resDef.type})`);
+  }
   if (tile.improvement !== 'none') addLine(panel, 'Improvement', getImprovementDisplayName(tile.improvement));
   if (tile.wonder) addLine(panel, 'Wonder', getWonderDefinition(tile.wonder)?.name ?? tile.wonder);
 

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -41,7 +41,7 @@ export function createTerritoryInspectionPanel(
   const key = hexKey(coord);
   const tile = state.map.tiles[key];
   const viewer = state.civilizations[viewerId];
-  const viewerTechs = new Set(viewer?.techState.completed ?? []);
+  const viewerTechs = new Set(viewer?.techState?.completed ?? []);
   const visibility = viewer?.visibility
     ? getVisibility(viewer.visibility, coord)
     : 'unexplored';

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -272,6 +272,32 @@ describe('resource icon rendering', () => {
     expect((ctx as unknown as MockCanvasContext).textCalls).toContain('🪨');
   });
 
+  it('does not draw resource icon when tile has a wonder (wonder visual takes priority)', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    map.tiles['0,0'].wonder = 'great_volcano';
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+
+  it('draws resource icon at top-left corner when tile has a village', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    // Pass coord as a village position — the village glyph would occupy the center
+    const villagePositions = new Set(['0,0']);
+
+    drawHexMap(ctx, map, makeCamera(), villagePositions, 'player', visibleAll, new Set(['gathering']));
+
+    // Village causes corner layout: cx - size*0.3 = 0 - 14.4 = -14.4
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    const call = mockCtx.fillTextCalls.find(c => c.text === '🪨');
+    expect(call).toBeDefined();
+    expect(call!.x).toBeCloseTo(-14.4);
+    expect(call!.y).toBeCloseTo(-14.4);
+  });
+
   it('does not draw resource icon on last-seen tile when viewer lacks the enabling tech', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     const map = makeResourceMap({ resource: 'stone' });

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -6,6 +6,7 @@ import type { GameMap, VisibilityMap } from '@/core/types';
 class MockCanvasContext {
   strokeCalls: string[] = [];
   textCalls: string[] = [];
+  fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
   fillStyle = '';
   strokeStyle = '';
   lineWidth = 0;
@@ -25,8 +26,9 @@ class MockCanvasContext {
   arc(): void {}
   closePath(): void {}
   fill(): void {}
-  fillText(text: string): void {
+  fillText(text: string, x: number = 0, y: number = 0): void {
     this.textCalls.push(text);
+    this.fillTextCalls.push({ text, x, y });
   }
   stroke(): void {
     this.strokeCalls.push(this.strokeStyle);
@@ -151,5 +153,147 @@ describe('hex renderer privacy', () => {
 
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeLessThan(19);
+  });
+});
+
+function makeResourceMap(opts: {
+  resource?: string | null;
+  improvement?: string;
+  improvementTurnsLeft?: number;
+} = {}): GameMap {
+  return {
+    width: 1,
+    height: 1,
+    wrapsHorizontally: false,
+    rivers: [],
+    tiles: {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'mountain',
+        elevation: 'highland',
+        movementCost: 2,
+        owner: null,
+        improvement: opts.improvement ?? 'none',
+        improvementTurnsLeft: opts.improvementTurnsLeft ?? 0,
+        resource: opts.resource ?? null,
+        hasRiver: false,
+        wonder: null,
+      },
+    },
+  } as unknown as GameMap;
+}
+
+describe('resource icon rendering', () => {
+  const visibleAll: VisibilityMap = { tiles: { '0,0': 'visible' } };
+
+  it('draws resource icon when viewer has the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).toContain('🪨');
+  });
+
+  it('does not draw resource icon when viewer lacks the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set());
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+
+  it('draws resource icon at top-left corner when a completed improvement is present', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone', improvement: 'mine', improvementTurnsLeft: 0 });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    // For tile at q=0,r=0: hexToPixel gives {x:0,y:0}; worldToScreen is identity.
+    // scaledSize = hexSize(48) * zoom(1) = 48.
+    // Corner position: cx - size*0.3 = 0 - 14.4 = -14.4
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    const call = mockCtx.fillTextCalls.find(c => c.text === '🪨');
+    expect(call).toBeDefined();
+    expect(call!.x).toBeCloseTo(-14.4);
+    expect(call!.y).toBeCloseTo(-14.4);
+  });
+
+  it('draws resource icon at center when improvement is still under construction', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    // improvementTurnsLeft > 0 means construction in progress — improvement icon is NOT shown
+    const map = makeResourceMap({ resource: 'stone', improvement: 'mine', improvementTurnsLeft: 2 });
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', visibleAll, new Set(['gathering']));
+
+    // No completed improvement visible → resource draws centered at cx=0, cy=0
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    const call = mockCtx.fillTextCalls.find(c => c.text === '🪨');
+    expect(call).toBeDefined();
+    expect(call!.x).toBeCloseTo(0);
+    expect(call!.y).toBeCloseTo(0);
+  });
+
+  it('does not draw resource icon for unexplored tiles (presentation layer nullifies resource)', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const unexplored: VisibilityMap = { tiles: { '0,0': 'unexplored' } };
+
+    // viewerTechs has 'gathering' — but the presentation tile has resource:null from unknownTile()
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', unexplored, new Set(['gathering']));
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
+  });
+
+  it('draws resource icon on last-seen tile when viewer has the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const fog: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'mountain',
+          elevation: 'highland',
+          resource: 'stone',
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', fog, new Set(['gathering']));
+
+    // Player remembers what they last saw — resource shows if they have the tech
+    expect((ctx as unknown as MockCanvasContext).textCalls).toContain('🪨');
+  });
+
+  it('does not draw resource icon on last-seen tile when viewer lacks the enabling tech', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const map = makeResourceMap({ resource: 'stone' });
+    const fog: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'mountain',
+          elevation: 'highland',
+          resource: 'stone',
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: null,
+          hasRiver: false,
+          wonder: null,
+        },
+      },
+    };
+
+    drawHexMap(ctx, map, makeCamera(), undefined, 'player', fog, new Set());
+
+    expect((ctx as unknown as MockCanvasContext).textCalls).not.toContain('🪨');
   });
 });

--- a/tests/systems/tech-definitions.test.ts
+++ b/tests/systems/tech-definitions.test.ts
@@ -211,4 +211,31 @@ describe('opening research pacing data', () => {
     expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeGreaterThanOrEqual(5);
     expect(estimateTurnsToComplete({ cost: bronze!.cost, outputPerTurn: 2 })).toBeLessThanOrEqual(7);
   });
+
+  describe('resource reveal unlock text', () => {
+    const EXPECTED_REVEALS = [
+      { techId: 'gathering',        resourceName: 'Stone'   },
+      { techId: 'stone-weapons',    resourceName: 'Copper'  },
+      { techId: 'foraging',         resourceName: 'Ivory'   },
+      { techId: 'pottery',          resourceName: 'Wine'    },
+      { techId: 'cartography',      resourceName: 'Spices'  },
+      { techId: 'irrigation',       resourceName: 'Silk'    },
+      { techId: 'bronze-working',   resourceName: 'Iron'    },
+      { techId: 'animal-husbandry', resourceName: 'Horses'  },
+      { techId: 'mining-tech',      resourceName: 'Gems'    },
+      { techId: 'currency',         resourceName: 'Incense' },
+    ];
+
+    for (const { techId, resourceName } of EXPECTED_REVEALS) {
+      it(`${techId} includes "Reveal ${resourceName} resource" in unlocks`, () => {
+        const tech = TECH_TREE.find(t => t.id === techId);
+        expect(tech, `tech "${techId}" not found`).toBeDefined();
+        const hasReveal = tech?.unlocks.some(u => u === `Reveal ${resourceName} resource`);
+        expect(
+          hasReveal,
+          `${techId} missing "Reveal ${resourceName} resource" in unlocks: [${tech?.unlocks.join(', ')}]`,
+        ).toBe(true);
+      });
+    }
+  });
 });

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   RESOURCE_DEFINITIONS,
+  RESOURCE_ICONS,
+  RESOURCE_TECH,
   BASE_PRICES,
   createMarketplaceState,
   calculatePrice,
@@ -10,6 +12,7 @@ import {
   processFashionCycle,
   processTradeRouteIncome,
 } from '@/systems/trade-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
 
 describe('trade-system', () => {
   describe('RESOURCE_DEFINITIONS', () => {
@@ -22,6 +25,51 @@ describe('trade-system', () => {
     it('each resource has a positive base price', () => {
       for (const r of RESOURCE_DEFINITIONS) {
         expect(r.basePrice).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe('catalog integrity — tech and icon fields', () => {
+    it('every ResourceDefinition entry has a non-empty tech field', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(r.tech, `${r.id} missing tech`).toBeTruthy();
+      }
+    });
+
+    it('every tech field references a real tech id in TECH_TREE', () => {
+      const techIds = new Set(TECH_TREE.map(t => t.id));
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(techIds.has(r.tech), `${r.id}.tech "${r.tech}" not found in TECH_TREE`).toBe(true);
+      }
+    });
+
+    it('every ResourceDefinition entry has a non-empty icon field', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(r.icon, `${r.id} missing icon`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_ICONS has a non-empty entry for every resource id', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_ICONS[r.id], `RESOURCE_ICONS missing "${r.id}"`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_TECH has a non-empty entry for every resource id', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_TECH[r.id], `RESOURCE_TECH missing "${r.id}"`).toBeTruthy();
+      }
+    });
+
+    it('RESOURCE_ICONS values match icon fields on RESOURCE_DEFINITIONS', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_ICONS[r.id]).toBe(r.icon);
+      }
+    });
+
+    it('RESOURCE_TECH values match tech fields on RESOURCE_DEFINITIONS', () => {
+      for (const r of RESOURCE_DEFINITIONS) {
+        expect(RESOURCE_TECH[r.id]).toBe(r.tech);
       }
     });
   });

--- a/tests/ui/icon-legend.test.ts
+++ b/tests/ui/icon-legend.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createIconLegendOverlay } from '@/ui/icon-legend';
+
+class MockElement {
+  children: MockElement[] = [];
+  style: Record<string, string> = { cssText: '' };
+  id = '';
+  private ownText = '';
+
+  get textContent(): string {
+    return `${this.ownText}${this.children.map(child => child.textContent).join('')}`;
+  }
+
+  set textContent(value: string) {
+    this.ownText = value;
+  }
+
+  appendChild(child: MockElement): MockElement {
+    this.children.push(child);
+    return child;
+  }
+}
+
+class MockDocument {
+  createElement(): MockElement {
+    return new MockElement();
+  }
+}
+
+describe('createIconLegendOverlay', () => {
+  const originalDocument = globalThis.document;
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'document', {
+      value: new MockDocument() as unknown as Document,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'document', {
+      value: originalDocument,
+      configurable: true,
+    });
+  });
+
+  it('includes resource icon and name when viewer has the enabling tech', () => {
+    // animal-husbandry reveals Horses (🐎, strategic)
+    const overlay = createIconLegendOverlay(new Set(['animal-husbandry']));
+    expect((overlay as unknown as MockElement).textContent).toContain('🐎');
+    expect((overlay as unknown as MockElement).textContent).toContain('Horses');
+  });
+
+  it('omits the Resources section entirely when viewer has no resource techs', () => {
+    const overlay = createIconLegendOverlay(new Set());
+    expect((overlay as unknown as MockElement).textContent).not.toContain('Resources');
+    expect((overlay as unknown as MockElement).textContent).not.toContain('🐎');
+    expect((overlay as unknown as MockElement).textContent).not.toContain('Horses');
+  });
+});

--- a/tests/ui/territory-inspection-panel.test.ts
+++ b/tests/ui/territory-inspection-panel.test.ts
@@ -134,6 +134,29 @@ describe('createTerritoryInspectionPanel', () => {
     expect(panel.textContent).not.toContain('Progress: 8/10');
   });
 
+  it('shows resource name and type when viewer has the enabling tech', () => {
+    const state = makeInspectionState();
+    // Replace resource with a valid ResourceType
+    state.map.tiles['6,5'] = { ...state.map.tiles['6,5'], resource: 'gems' };
+    // Grant the enabling tech (gems → mining-tech)
+    state.civilizations.player.techState.completed = ['mining-tech'];
+
+    const panel = createTerritoryInspectionPanel(state, { q: 6, r: 5 }, 'player');
+
+    expect(panel.textContent).toContain('Gems (luxury)');
+  });
+
+  it('hides resource row when viewer lacks the enabling tech', () => {
+    const state = makeInspectionState();
+    state.map.tiles['6,5'] = { ...state.map.tiles['6,5'], resource: 'gems' };
+    // techState.completed defaults to [] from createNewGame — no tech granted
+
+    const panel = createTerritoryInspectionPanel(state, { q: 6, r: 5 }, 'player');
+
+    expect(panel.textContent).not.toContain('Gems');
+    expect(panel.textContent).not.toContain('luxury');
+  });
+
   it('wires the close action when provided', () => {
     const state = makeInspectionState();
     const onClose = vi.fn();


### PR DESCRIPTION
## Summary

- **Data layer**: Added `tech` and `icon` fields to all 10 `ResourceDefinition` entries; derived `RESOURCE_ICONS` / `RESOURCE_TECH` lookup maps; added `'Reveal X resource'` to the `unlocks` array of each gating tech in the tech tree
- **Renderer**: Threaded `viewerTechs: ReadonlySet<string>` from `render-loop.ts` → `drawHexMap` → `drawTileAtScreen` → `drawHex`; draws tech-gated resource emoji on hex tiles (corner layout when improvement or village present, centered otherwise; suppressed on wonder tiles)
- **Panels**: Tech-gated resource row in the territory inspection panel (`'Name (type)'` format); dynamic resource section in the map legend rebuilt on every toggle with the viewer's current techs

## Review fixes applied

- Stripped U+FE0F variation selectors from `spices`/`incense`/`iron` icons to prevent inconsistent canvas rendering
- Corrected `stone` terrain metadata `'mountain'` → `'hills'` to match the map generator
- Hardened `viewer?.techState?.completed` optional chain in the inspection panel
- Added `max-height` + `overflow-y: auto` to the legend overlay for mobile viewport safety
- Suppressed resource icon on natural wonder tiles (wonder landmark takes priority; resource accessible via inspection panel)
- Village tiles get corner resource layout (same rule as completed improvements) to avoid glyph overlap

## Test plan

- [x] 2251 tests pass, zero failures
- [x] `yarn build` exits 0 (TypeScript clean)
- [x] 7 new hex-renderer tests covering has-tech / lacks-tech / corner / center / unexplored / last-seen+tech / last-seen+no-tech + 2 new tests for wonder suppression and village corner
- [x] 10 tech-definitions tests verifying `'Reveal X resource'` in each gating tech's unlocks
- [x] 7 trade-system catalog integrity tests (tech field, icon field, RESOURCE_ICONS/TECH consistency)
- [x] 2 territory-inspection-panel tests (shows with tech, hides without)
- [x] 2 icon-legend tests (resource section present/absent based on techs)
- [ ] Manual smoke test: start game → research `gathering` → open map legend (Resources section appears with Stone) → tap mountain/hills tile → inspection panel shows `Stone (strategic)` → verify icon shows on tile

## Out of scope (Plans 2–3 are included; S2 roadmap items are not)

Marketplace trade window, price dynamics, and espionage resource intel are deferred to later slices per the marketplace roadmap.

## Why this is safe to merge partial

All player-visible surfaces introduced (map icons, legend section, inspection panel row) are fully wired and read from live `techState`. No button or surface is shown without its backing data. The legend correctly shows nothing for new games where the player has no resource techs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)