### PR TITLE
feat(wonders): add legendary city presence

### DIFF
--- a/docs/superpowers/plans/2026-05-22-legendary-wonder-city-presence.md
+++ b/docs/superpowers/plans/2026-05-22-legendary-wonder-city-presence.md
@@ -1,0 +1,1298 @@
+# Legendary Wonder City Presence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task inline. Do not use subagents unless the user explicitly re-authorizes them for this slice. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement Stage 2C city-first legendary wonder presence: clearer city construction state, owner-only completion ceremony, minimal Atlas labels, and viewer-safe completed landmarks around host cities.
+
+**Architecture:** Core legendary systems remain authoritative for mutation. System-adjacent presentation helpers derive viewer-safe UI and map entries; DOM modules render ceremonies and city/Atlas surfaces; Canvas renderer draws only ready-to-draw landmark entries. `main.ts` subscribes to events and delegates orchestration to focused queue modules.
+
+**Tech Stack:** TypeScript, Vitest, jsdom UI tests, Canvas 2D renderer, existing EventBus, existing Wonder Atlas, city panel, wonder panel, and renderer modules. Designed for GPT-5.4 on medium effort.
+
+---
+
+## Scope Check
+
+This is one cohesive implementation slice. It touches multiple layers, but they are sequentially dependent: completion event payload -> presentation helpers -> city UI/ceremony -> Atlas/map presentation -> renderer wiring. Do not split these into independent PRs unless the PR body explicitly lists omitted player-visible surfaces and proves no dead-end UX ships.
+
+## File Structure
+
+- Modify `src/core/types.ts`
+  - Add `turnCompleted` to `wonder:legendary-completed` event payload.
+- Modify `src/systems/legendary-wonder-system.ts`
+  - Emit `turnCompleted` from the mutation source.
+- Modify `src/ui/legendary-wonder-notifications.ts`
+  - Accept the widened completion event shape without leaking `turnCompleted`.
+- Modify `src/ui/notification-routing.ts`
+  - Accept the widened completion event shape.
+- Modify `src/systems/legendary-wonder-presentation.ts`
+  - Add city-facing milestone, progress, ETA, race/recovery, queue-continuity, and production-resumed labels.
+- Create `src/systems/legendary-wonder-completion-presentation.ts`
+  - Build owner-safe ceremony items from event payloads.
+- Create `src/ui/legendary-wonder-completion-ceremony.ts`
+  - Render the owner-only skippable overlay.
+- Create `src/ui/legendary-wonder-completion-queue.ts`
+  - Queue and sequence completion ceremonies.
+- Modify `src/ui/city-panel.ts`
+  - Render compact active legendary construction/recovery/completion state.
+- Modify `src/ui/wonder-panel.ts`
+  - Align Journal state with new presentation fields.
+- Modify `src/systems/wonder-atlas-presentation.ts`
+  - Add minimal safe legendary state labels.
+- Modify `src/ui/wonder-atlas-panel.ts`
+  - Render those labels without adding full detail pages.
+- Modify `src/systems/wonder-visual-catalog.ts`
+  - Add legendary completed landmark metadata.
+- Create `src/systems/legendary-wonder-map-presentation.ts`
+  - Return viewer-safe landmark entries.
+- Create `src/renderer/wonders/legendary-wonder-slots.ts`
+  - Pure deterministic around-city slot helper.
+- Create `src/renderer/wonders/legendary-wonder-renderer.ts`
+  - Draw viewer-safe completed landmarks.
+- Modify `src/renderer/city-renderer.ts`
+  - Draw completed legendary landmarks near city rendering without stealing input.
+- Modify `src/renderer/render-loop.ts`
+  - Pass the existing reduced-motion setting into city rendering.
+- Modify `src/ui/territory-inspection-panel.ts`
+  - Mention completed legendary wonders when safely visible.
+- Modify `src/main.ts`
+  - Wire completion queue, event delegation, Atlas refresh, and renderer refresh.
+- Tests:
+  - `tests/systems/legendary-wonder-system.test.ts`
+  - `tests/systems/legendary-wonder-presentation.test.ts`
+  - `tests/systems/legendary-wonder-completion-presentation.test.ts`
+  - `tests/systems/wonder-atlas-presentation.test.ts`
+  - `tests/systems/legendary-wonder-map-presentation.test.ts`
+  - `tests/ui/city-panel.test.ts`
+  - `tests/ui/wonder-panel.test.ts`
+  - `tests/ui/legendary-wonder-completion-ceremony.test.ts`
+  - `tests/ui/legendary-wonder-completion-queue.test.ts`
+  - `tests/ui/wonder-atlas-panel.test.ts`
+  - `tests/ui/territory-inspection-panel.test.ts`
+  - `tests/renderer/legendary-wonder-slots.test.ts`
+  - `tests/renderer/legendary-wonder-renderer.test.ts`
+  - `tests/renderer/city-renderer.test.ts`
+
+## Player Truth Table
+
+| Before | Action | Internal change | Immediate visible result | Must remain reachable |
+| --- | --- | --- | --- | --- |
+| City panel shows a `Ready` legendary wonder in Wonder Ambitions | Click `Start Construction` in Journal | `startLegendaryWonderBuild` inserts `legendary:<id>` at active production | City panel rerenders with active legendary medallion, progress, ETA, `Foundation laid`, and queue-continuity copy | Queue follow-ups, Wonder Journal, Build list |
+| City panel shows active legendary wonder at 60% | End turn / production ticks | Existing production progress increases | City row updates milestone to `Final works` and ETA decreases | Journal detail, queue controls |
+| City completes legendary wonder | Completion event fires | Core state records completion and queue resumes | Owner sees completion ceremony; after resolving, city shows `Reward active` and production-resumed copy | Open City/Open Journal secondary path |
+| Another human player is current viewer when owner completes | Completion event fires | State completes wonder | No ceremony appears for the wrong viewer | Owner ceremony may show later only when safe |
+| Rival has no earned intel | Open Atlas or view map | No new intel state | No rival city/reward/progress/landmark detail appears | Masked legendary slot |
+| City has 7 completed visible legendary wonders | Render map | Slot helper assigns first 5 plus overflow | Five landmarks plus `+2` medallion render around city | Full list remains in city/Journal; deeper archive waits for 2D |
+| Lost race becomes `lost_race` | Open city panel | Existing recovery data is read | City shows `Effort recovered`, carryover/refund, and production-resumed copy | Wonder Journal with full recovery context |
+
+## Misleading UI Risks
+
+- `Available` in Atlas must mean an owned/city-visible presentation helper says the wonder is ready or buildable. Near or blocked wonders must not be labelled `Available`.
+- `Under construction` must mean the viewer owns the project or has earned an existing viewer-safe intel record for that state. Raw rival project state is not enough.
+- `Known rival completed` is a roadmap label, not a Stage 2C label. Current `LegendaryWonderIntelEntry` only records `intelLevel: 'started'`, so Stage 2C must keep rival completions at `Legendary wonder` until a later intel schema explicitly stores viewer-scoped completion knowledge. It must not reveal host city, reward, progress, completion turn, or map landmark.
+- `Construction underway` must be neutral when no rival intel exists. Do not use `Uncontested`.
+- `Race at risk` must require existing earned rival intel. Add a negative test proving no-intel active builds do not show it.
+- `Reward active` must appear only after a completed state is recorded for the owner, not merely when production progress passes the cost.
+
+## Interaction Replay Checklist
+
+- Start construction from Journal, then reopen city panel and confirm active legendary row.
+- Repeat-click `Start Construction` using stale DOM; mutation helper must still reject invalid duplicate starts.
+- Resolve completion ceremony with `Continue`, then verify overlay removed and city state visible.
+- Resolve completion ceremony with `Skip`, then verify overlay removed and state visible.
+- Resolve completion ceremony with `Open City` and `Open Journal`, including fallback when target city is missing.
+- Reopen Atlas after hot-seat current-player switch and confirm labels refresh.
+- Re-render city/map after city capture or raze and confirm unsafe landmarks disappear.
+
+## Queue And ETA Checklist
+
+- Active item is shown in city production row.
+- Follow-up queue rows remain visible below active production.
+- Active legendary ETA uses the same effective production calculation as the city panel yields.
+- Follow-up queue ETA/order text stays intact after starting a legendary wonder.
+- Completion and lost-race recovery both show production-resumed copy.
+- Legendary wonders remain blocked from rush-buy; existing rush-buy copy remains visible.
+
+---
+
+### Task 1: Event Payload And City Presentation Foundation
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/legendary-wonder-system.ts`
+- Modify: `src/ui/legendary-wonder-notifications.ts`
+- Modify: `src/ui/notification-routing.ts`
+- Modify: `src/systems/legendary-wonder-presentation.ts`
+- Test: `tests/systems/legendary-wonder-system.test.ts`
+- Test: `tests/systems/legendary-wonder-presentation.test.ts`
+
+- [ ] **Step 1: Write failing event payload test**
+
+Add this test to `tests/systems/legendary-wonder-system.test.ts` near the existing completion tests:
+
+```ts
+it('emits the completion turn in legendary completion events', () => {
+  const state = makeLegendaryWonderFixture({
+    completedTechs: ['philosophy', 'pilgrimages', 'city-planning', 'printing'],
+    resources: ['stone'],
+    oracleStepsCompleted: 2,
+  });
+  state.turn = 41;
+  state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+  state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+  state.cities['city-river'].productionProgress = 120;
+  const events: Array<{ civId: string; cityId: string; wonderId: string; turnCompleted: number }> = [];
+  const bus = new EventBus();
+  bus.on('wonder:legendary-completed', event => events.push(event));
+
+  tickLegendaryWonderProjects(state, bus);
+
+  expect(events).toEqual([
+    { civId: 'player', cityId: 'city-river', wonderId: 'oracle-of-delphi', turnCompleted: 41 },
+  ]);
+});
+```
+
+- [ ] **Step 2: Run failing event test**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts
+```
+
+Expected: TypeScript/Vitest failure because `turnCompleted` is not in the emitted event payload.
+
+- [ ] **Step 3: Implement event payload**
+
+In `src/core/types.ts`, change the event map entry:
+
+```ts
+'wonder:legendary-completed': { civId: string; cityId: string; wonderId: string; turnCompleted: number };
+```
+
+In `src/systems/legendary-wonder-system.ts`, update the emission inside `tickLegendaryWonderProjects`:
+
+```ts
+_bus.emit('wonder:legendary-completed', {
+  civId: project.ownerId,
+  cityId: project.cityId,
+  wonderId: project.wonderId,
+  turnCompleted: state.turn,
+});
+```
+
+In `src/ui/legendary-wonder-notifications.ts` and `src/ui/notification-routing.ts`, widen the local union type for `wonder:legendary-completed` to include `turnCompleted: number`. Do not show `turnCompleted` in rival messages.
+
+- [ ] **Step 4: Write failing city presentation tests**
+
+Extend `tests/systems/legendary-wonder-presentation.test.ts`:
+
+```ts
+it('derives legendary construction milestones, ETA, and queue continuity without mutating state', () => {
+  const state = makeLegendaryWonderFixture({
+    completedTechs: ['philosophy', 'pilgrimages'],
+    resources: ['stone'],
+  });
+  state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+  state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi', 'library'];
+  state.cities['city-river'].productionProgress = 72;
+  state.cities['city-river'].focus = 'production';
+  const before = structuredClone(state.legendaryWonderProjects);
+
+  const oracle = getLegendaryWonderPresentationForCity(state, 'player', 'city-river')
+    .find(entry => entry.wonderId === 'oracle-of-delphi');
+
+  expect(oracle).toMatchObject({
+    visibleState: 'building',
+    progressPercent: 60,
+    milestoneLabel: 'Final works',
+    queueContinuityLabel: 'Queue resumes after this wonder.',
+    raceTensionLabel: 'Construction underway',
+  });
+  expect(oracle?.turnsRemaining).toBeGreaterThan(0);
+  expect(state.legendaryWonderProjects).toEqual(before);
+});
+
+it('derives recovery and completed production-resumed copy', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+  state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 50 },
+  };
+
+  const entries = getLegendaryWonderPresentationForCity(state, 'player', 'city-river');
+  expect(entries.find(entry => entry.wonderId === 'grand-canal')).toMatchObject({
+    visibleState: 'recovered',
+    recoveryLabel: 'Effort recovered: 24 production carryover preserved.',
+    productionResumedLabel: 'Normal production has resumed.',
+  });
+  expect(entries.find(entry => entry.wonderId === 'oracle-of-delphi')).toMatchObject({
+    visibleState: 'completed',
+    productionResumedLabel: 'Normal production has resumed.',
+  });
+});
+
+it('does not label no-intel builds as safe or uncontested', () => {
+  const state = makeLegendaryWonderFixture({
+    completedTechs: ['architecture-arts', 'theology-tech'],
+    resources: ['stone'],
+  });
+  state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+  state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+  state.cities['city-river'].productionProgress = 10;
+
+  const oracle = getLegendaryWonderPresentationForCity(state, 'player', 'city-river')
+    .find(entry => entry.wonderId === 'oracle-of-delphi');
+
+  expect(oracle?.raceTensionLabel).toBe('Construction underway');
+  expect(oracle?.raceTensionLabel).not.toMatch(/uncontested/i);
+});
+```
+
+- [ ] **Step 5: Run failing presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-presentation.test.ts
+```
+
+Expected: FAIL because new fields do not exist.
+
+- [ ] **Step 6: Implement presentation fields**
+
+In `src/systems/legendary-wonder-presentation.ts`, add these exports and fields:
+
+```ts
+export type LegendaryWonderMilestoneLabel =
+  | 'Foundation laid'
+  | 'Rising'
+  | 'Final works'
+  | 'Nearly complete';
+
+export function getLegendaryWonderConstructionMilestone(investedProduction: number, productionCost: number): LegendaryWonderMilestoneLabel {
+  const progress = productionCost > 0 ? Math.floor((investedProduction / productionCost) * 100) : 0;
+  if (progress >= 90) return 'Nearly complete';
+  if (progress >= 60) return 'Final works';
+  if (progress >= 25) return 'Rising';
+  return 'Foundation laid';
+}
+```
+
+Extend `LegendaryWonderPresentationEntry`:
+
+```ts
+progressPercent: number;
+turnsRemaining: number | null;
+milestoneLabel: LegendaryWonderMilestoneLabel | null;
+queueContinuityLabel: string | null;
+productionResumedLabel: string | null;
+recoveryLabel: string | null;
+raceTensionLabel: string | null;
+```
+
+Add helper logic:
+
+```ts
+function progressPercent(investedProduction: number, productionCost: number): number {
+  if (productionCost <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.floor((investedProduction / productionCost) * 100)));
+}
+
+function turnsRemaining(cityProductionPerTurn: number, investedProduction: number, productionCost: number): number | null {
+  if (cityProductionPerTurn <= 0) return null;
+  return Math.max(0, Math.ceil(Math.max(0, productionCost - investedProduction) / cityProductionPerTurn));
+}
+
+function cityProductionPerTurn(state: GameState, cityId: string): number {
+  const city = state.cities[cityId];
+  if (!city) return 0;
+  const base = calculateProjectedCityYields(state, cityId);
+  const multiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city));
+  return Math.floor(base.production * multiplier);
+}
+```
+
+Import `calculateProjectedCityYields`, `getUnrestYieldMultiplier`, and `getOccupiedCityYieldMultiplier`. Populate the new fields when building each entry. For `building` entries, use `city.productionProgress` when the active queue item is `legendary:<wonderId>`; otherwise use `project.investedProduction`.
+
+- [ ] **Step 7: Run task tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-presentation.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/notification-routing.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 1**
+
+```bash
+git add src/core/types.ts src/systems/legendary-wonder-system.ts src/systems/legendary-wonder-presentation.ts src/ui/legendary-wonder-notifications.ts src/ui/notification-routing.ts tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-presentation.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/notification-routing.test.ts
+git commit -m "feat(wonders): derive legendary construction presentation"
+```
+
+---
+
+### Task 2: City Production And Journal UI
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/ui/wonder-panel.ts`
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/ui/wonder-panel.test.ts`
+
+**Player Truth Table:**
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Active item is `legendary:oracle-of-delphi` | Open city panel | Current production row shows Oracle name, medallion, progress, milestone, ETA, reward teaser, `Queue resumes after this wonder.` |
+| Project is `lost_race` | Open city panel | Compact wonder area shows `Effort recovered`, carryover, and `Normal production has resumed.` |
+| Project is completed | Open Journal | Completed card shows `Reward active` and production-resumed copy |
+
+**Misleading UI Risks:**
+
+- Do not hide the Wonder Journal link; it is the only full detail surface.
+- Do not duplicate long quest/reward text in the compact city row.
+- Do not use `innerHTML` for dynamic wonder names, rewards, or recovery text.
+
+- [ ] **Step 1: Write failing city UI tests**
+
+Add to `tests/ui/city-panel.test.ts`:
+
+```ts
+it('shows active legendary construction as a compact living production row', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+  city.productionQueue = ['legendary:oracle-of-delphi', 'library'];
+  city.productionProgress = 72;
+
+  const panel = createCityPanel(container, city, state, {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  });
+  const text = collectText(panel);
+
+  expect(text).toContain('Producing: * Oracle of Delphi');
+  expect(text).toContain('Final works');
+  expect(text).toContain('Queue resumes after this wonder.');
+  expect(text).toContain('Construction underway');
+  expect(text).toContain('Open Journal');
+  expect(text).not.toContain('legendary:oracle-of-delphi');
+});
+
+it('shows recovered legendary effort and production resume copy in the city flow', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+  state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+
+  const panel = createCityPanel(container, city, state, {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  });
+  const text = collectText(panel);
+
+  expect(text).toContain('Effort recovered');
+  expect(text).toContain('24 production carryover preserved');
+  expect(text).toContain('Normal production has resumed.');
+});
+```
+
+- [ ] **Step 2: Write failing Journal UI tests**
+
+Add to `tests/ui/wonder-panel.test.ts`:
+
+```ts
+it('shows construction milestone and reward-active completion copy from presentation entries', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+  city.productionQueue = ['legendary:oracle-of-delphi'];
+  city.productionProgress = 72;
+  state.completedLegendaryWonders = {
+    'grand-canal': { ownerId: 'player', cityId: city.id, turnCompleted: 44 },
+  };
+
+  const panel = createWonderPanel(container, state, city.id, {
+    onStartBuild: () => {},
+    onClose: () => {},
+  });
+  const text = collectText(panel);
+
+  expect(text).toContain('Final works');
+  expect(text).toContain('Reward active');
+  expect(text).toContain('Normal production has resumed.');
+});
+```
+
+- [ ] **Step 3: Run failing UI tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts
+```
+
+Expected: FAIL because new copy is absent.
+
+- [ ] **Step 4: Implement compact city row**
+
+In `src/ui/city-panel.ts`, import `getLegendaryWonderQueueItemMetadata` and `getLegendaryWonderPresentationForCity`. Build a `activeLegendaryEntry` near current production:
+
+```ts
+const cityWonderEntries = getLegendaryWonderPresentationForCity(state, state.currentPlayer, city.id);
+const activeLegendaryEntry = city.productionQueue[0]?.startsWith('legendary:')
+  ? cityWonderEntries.find(entry => entry.queueItemId === city.productionQueue[0])
+  : null;
+```
+
+In `currentProductionHtml`, when `activeLegendaryEntry` exists, add static placeholders:
+
+```html
+<div data-active-legendary="true" style="margin-top:10px;border-top:1px solid rgba(232,193,112,0.22);padding-top:10px;">
+  <div style="font-size:12px;color:#e8c170;" data-text="legendary-milestone"></div>
+  <div style="font-size:12px;opacity:0.82;" data-text="legendary-reward-teaser"></div>
+  <div style="font-size:12px;opacity:0.82;" data-text="legendary-race-tension"></div>
+  <div style="font-size:12px;opacity:0.82;" data-text="legendary-queue-continuity"></div>
+  <button type="button" data-open-active-wonder-journal="true" style="min-height:44px;margin-top:8px;padding:7px 10px;background:rgba(232,193,112,0.16);border:1px solid rgba(232,193,112,0.45);border-radius:6px;color:#f0d897;cursor:pointer;font-size:12px;">Open Journal</button>
+</div>
+```
+
+Set dynamic text with `setText`:
+
+```ts
+if (activeLegendaryEntry) {
+  setText('legendary-milestone', activeLegendaryEntry.milestoneLabel ?? '');
+  setText('legendary-reward-teaser', `Reward: ${activeLegendaryEntry.rewardSummary}`);
+  setText('legendary-race-tension', activeLegendaryEntry.raceTensionLabel ?? 'Construction underway');
+  setText('legendary-queue-continuity', activeLegendaryEntry.queueContinuityLabel ?? '');
+}
+```
+
+Wire the Journal button:
+
+```ts
+panel.querySelector<HTMLElement>('[data-open-active-wonder-journal]')?.addEventListener('click', () => {
+  callbacks.onOpenWonderPanel(city.id);
+  panel.remove();
+});
+```
+
+- [ ] **Step 5: Implement recovered/completed compact copy**
+
+When rendering `compactWonderEntries`, add placeholders for recovery and production-resumed labels:
+
+```html
+<div style="font-size:10px;opacity:0.72;" data-text="wonder-recovery-${idx}"></div>
+<div style="font-size:10px;opacity:0.72;" data-text="wonder-resumed-${idx}"></div>
+```
+
+Set:
+
+```ts
+setText(`wonder-recovery-${index}`, entry.recoveryLabel ?? '');
+setText(`wonder-resumed-${index}`, entry.productionResumedLabel ?? '');
+```
+
+- [ ] **Step 6: Update Wonder Journal cards**
+
+In `appendProjectCard` in `src/ui/wonder-panel.ts`, add:
+
+```ts
+if (entry.milestoneLabel) appendText(article, 'p', `Construction: ${entry.milestoneLabel}.`);
+if (entry.turnsRemaining !== null) appendText(article, 'p', `${entry.turnsRemaining} turns remaining.`);
+if (entry.raceTensionLabel) appendText(article, 'p', entry.raceTensionLabel);
+if (entry.productionResumedLabel) appendText(article, 'p', entry.productionResumedLabel);
+if (entry.visibleState === 'completed') appendText(article, 'p', 'Reward active.');
+if (entry.recoveryLabel) appendText(article, 'p', entry.recoveryLabel);
+```
+
+- [ ] **Step 7: Run UI tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 2**
+
+```bash
+git add src/ui/city-panel.ts src/ui/wonder-panel.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts
+git commit -m "feat(wonders): show legendary construction in city UI"
+```
+
+---
+
+### Task 3: Owner-Only Completion Ceremony And Queue
+
+**Files:**
+- Create: `src/systems/legendary-wonder-completion-presentation.ts`
+- Create: `src/ui/legendary-wonder-completion-ceremony.ts`
+- Create: `src/ui/legendary-wonder-completion-queue.ts`
+- Modify: `src/main.ts`
+- Test: `tests/systems/legendary-wonder-completion-presentation.test.ts`
+- Test: `tests/ui/legendary-wonder-completion-ceremony.test.ts`
+- Test: `tests/ui/legendary-wonder-completion-queue.test.ts`
+
+**Player Truth Table:**
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Owner completes wonder and no blocking UI is active | Event enqueued | Ceremony appears with `Continue`, `Open City`, `Open Journal`, `Skip` |
+| Ceremony visible | Click any action repeatedly | Overlay resolves once and removes |
+| Wrong hot-seat viewer active | Event enqueued | No ceremony appears for wrong viewer |
+
+- [ ] **Step 1: Write failing completion presentation tests**
+
+Create `tests/systems/legendary-wonder-completion-presentation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-completion-presentation', () => {
+  it('builds owner-safe ceremony items from event payloads', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'player';
+
+    const item = buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+    });
+
+    expect(item).toMatchObject({
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+      title: 'Legendary Wonder Completed',
+      name: 'Oracle of Delphi',
+      cityName: 'city-river',
+      rewardActiveLabel: 'Reward active',
+    });
+  });
+
+  it('returns null for wrong-viewer and unknown-wonder events', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'ai-1';
+
+    expect(buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+    })).toBeNull();
+
+    state.currentPlayer = 'player';
+    expect(buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'missing-wonder',
+      turnCompleted: 42,
+    })).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Implement completion presentation helper**
+
+Create `src/systems/legendary-wonder-completion-presentation.ts`:
+
+```ts
+import type { GameState, GameEventMap } from '@/core/types';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface LegendaryWonderCompletionCeremonyItem {
+  title: 'Legendary Wonder Completed';
+  civId: string;
+  cityId: string;
+  wonderId: string;
+  turnCompleted: number;
+  name: string;
+  cityName: string;
+  achievementLine: string;
+  rewardSummary: string;
+  rewardActiveLabel: 'Reward active';
+  visual: WonderVisualDefinition;
+}
+
+export function buildLegendaryWonderCompletionCeremonyItem(
+  state: GameState,
+  event: GameEventMap['wonder:legendary-completed'],
+): LegendaryWonderCompletionCeremonyItem | null {
+  if (state.currentPlayer !== event.civId) return null;
+  const definition = getLegendaryWonderDefinition(event.wonderId);
+  const city = state.cities[event.cityId];
+  if (!definition || !city || city.owner !== event.civId) return null;
+
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: event.civId,
+    cityId: event.cityId,
+    wonderId: event.wonderId,
+    turnCompleted: event.turnCompleted,
+    name: definition.name,
+    cityName: city.name,
+    achievementLine: `${city.name} has completed a work that will shape its legacy.`,
+    rewardSummary: definition.reward.summary,
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition(event.wonderId),
+  };
+}
+```
+
+- [ ] **Step 3: Write failing ceremony UI tests**
+
+Create `tests/ui/legendary-wonder-completion-ceremony.test.ts` mirroring the discovery ceremony tests:
+
+```ts
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLegendaryWonderCompletionCeremony } from '@/ui/legendary-wonder-completion-ceremony';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+
+function item(): LegendaryWonderCompletionCeremonyItem {
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: 'player',
+    cityId: 'city-river',
+    wonderId: 'oracle-of-delphi',
+    turnCompleted: 42,
+    name: 'Oracle of Delphi',
+    cityName: 'city-river',
+    achievementLine: 'city-river has completed a work that will shape its legacy.',
+    rewardSummary: '+20% science in this city',
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition('oracle-of-delphi'),
+  };
+}
+
+describe('legendary-wonder-completion-ceremony', () => {
+  beforeEach(() => { document.body.innerHTML = ''; });
+
+  it('renders completion copy and actions', () => {
+    createLegendaryWonderCompletionCeremony(document.body, item(), { onResolve: () => {} }, { reducedMotion: false });
+    expect(document.body.textContent).toContain('Legendary Wonder Completed');
+    expect(document.body.textContent).toContain('Oracle of Delphi');
+    expect(document.body.textContent).toContain('city-river');
+    expect(document.body.textContent).toContain('Reward active');
+    expect(document.querySelector('[data-legendary-completion-action="continue"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="open-city"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="open-journal"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="skip"]')).toBeTruthy();
+  });
+
+  it('resolves exactly once for repeated clicks', () => {
+    const onResolve = vi.fn();
+    createLegendaryWonderCompletionCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+    document.querySelector('[data-legendary-completion-action="continue"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    document.querySelector('[data-legendary-completion-action="skip"]')!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith('continue');
+    expect(document.querySelector('#legendary-wonder-completion-ceremony')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 4: Implement ceremony UI**
+
+Create `src/ui/legendary-wonder-completion-ceremony.ts` using the discovery ceremony pattern. Export:
+
+```ts
+export type LegendaryWonderCompletionCeremonyAction = 'continue' | 'skip' | 'open-city' | 'open-journal';
+```
+
+Use `createGameButton`, `textContent`, and a `resolved` boolean. Set `overlay.dataset.legendaryCompletionMotion` to `static` or `animated`.
+
+- [ ] **Step 5: Write and implement queue tests**
+
+Create `tests/ui/legendary-wonder-completion-queue.test.ts` with tests for:
+
+```ts
+it('waits for action settlement and blocking UI before presenting');
+it('opens city or journal after the ceremony resolves');
+it('does not present wrong-viewer items');
+it('deduplicates repeat enqueue for the same civ/wonder/turn');
+```
+
+Implement `src/ui/legendary-wonder-completion-queue.ts` with options:
+
+```ts
+export interface LegendaryWonderCompletionQueueOptions {
+  container: HTMLElement;
+  isInteractionBlocked: () => boolean;
+  reducedMotion: () => boolean;
+  openCity: (cityId: string) => void;
+  openJournal: (cityId: string, wonderId: string) => void;
+  present?: (item: LegendaryWonderCompletionCeremonyItem) => Promise<LegendaryWonderCompletionCeremonyAction>;
+  setBlockingOverlay?: (id: string | null) => void;
+}
+```
+
+Follow the `createWonderDiscoveryRevealQueue` structure, but use key `${item.civId}:${item.wonderId}:${item.turnCompleted}`.
+
+- [ ] **Step 6: Wire `main.ts`**
+
+In `src/main.ts`, import the queue and presentation helper. Create `legendaryCompletionQueue` near `wonderDiscoveryQueue`. In the `wonder:legendary-completed` listener:
+
+```ts
+bus.on('wonder:legendary-completed', event => {
+  routeLegendaryWonder(gameState, { type: 'wonder:legendary-completed', ...event }, appendToCivLog);
+  const ceremonyItem = buildLegendaryWonderCompletionCeremonyItem(gameState, event);
+  if (ceremonyItem) {
+    legendaryCompletionQueue?.enqueue(ceremonyItem);
+    legendaryCompletionQueue?.notifyActionSettled();
+  }
+});
+```
+
+Use existing open-city/open-wonder-panel behavior for secondary actions. If a target city is missing, resolve like `Continue`.
+
+- [ ] **Step 7: Run ceremony tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-completion-presentation.test.ts tests/ui/legendary-wonder-completion-ceremony.test.ts tests/ui/legendary-wonder-completion-queue.test.ts tests/ui/notification-routing.test.ts tests/ui/legendary-wonder-notifications.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+```bash
+git add src/main.ts src/systems/legendary-wonder-completion-presentation.ts src/ui/legendary-wonder-completion-ceremony.ts src/ui/legendary-wonder-completion-queue.ts tests/systems/legendary-wonder-completion-presentation.test.ts tests/ui/legendary-wonder-completion-ceremony.test.ts tests/ui/legendary-wonder-completion-queue.test.ts
+git commit -m "feat(wonders): add legendary completion ceremony"
+```
+
+---
+
+### Task 4: Minimal Legendary Atlas Labels
+
+**Files:**
+- Modify: `src/systems/wonder-atlas-presentation.ts`
+- Modify: `src/ui/wonder-atlas-panel.ts`
+- Test: `tests/systems/wonder-atlas-presentation.test.ts`
+- Test: `tests/ui/wonder-atlas-panel.test.ts`
+
+**Misleading UI Risks:**
+
+- Stage 2C must not ship `Known rival completed`; the current intel shape has only `intelLevel: 'started'`, so there is no safe completed-rival source yet.
+- `Available` must not appear for blocked/near/far-future wonders.
+
+- [ ] **Step 1: Write failing Atlas presentation tests**
+
+Add:
+
+```ts
+it('derives minimal safe legendary state labels for owned entries', () => {
+  const state = makeState();
+  state.legendaryWonderProjects = {
+    'oracle-of-delphi:player:city-river': {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'city-river',
+      phase: 'building',
+      investedProduction: 40,
+      transferableProduction: 0,
+      questSteps: [],
+    },
+  };
+
+  const oracle = getWonderAtlasEntries(state, 'player')
+    .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+  expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Under construction' });
+});
+
+it('does not leak rival legendary progress through Atlas labels', () => {
+  const state = makeState();
+  state.legendaryWonderProjects = {
+    'oracle-rival': {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'ai-1',
+      cityId: 'rival-city',
+      phase: 'building',
+      investedProduction: 90,
+      transferableProduction: 0,
+      questSteps: [],
+    },
+  };
+
+  const oracle = getWonderAtlasEntries(state, 'player')
+    .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+  expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Legendary wonder' });
+  expect(JSON.stringify(oracle)).not.toContain('rival-city');
+  expect(JSON.stringify(oracle)).not.toContain('90');
+});
+```
+
+- [ ] **Step 2: Implement Atlas labels**
+
+Extend `LegendaryWonderAtlasEntry`:
+
+```ts
+stateLabel: 'Available' | 'Under construction' | 'Completed' | 'Recovered' | 'Legendary wonder';
+```
+
+Add a helper that checks only owned projects/completions for the viewer. For rival completions, always return `Legendary wonder` in Stage 2C. Add a comment in the helper noting that a future 2D/3-stage intel expansion can add a `Known rival completed` label after the state model stores explicit viewer-scoped completion intel.
+
+- [ ] **Step 3: Update Atlas UI**
+
+In `src/ui/wonder-atlas-panel.ts`, display `entry.stateLabel` for legendary entries instead of only generic masked copy. The detail panel must still avoid full lore/detail pages.
+
+- [ ] **Step 4: Run Atlas tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-atlas-presentation.test.ts tests/ui/wonder-atlas-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/systems/wonder-atlas-presentation.ts src/ui/wonder-atlas-panel.ts tests/systems/wonder-atlas-presentation.test.ts tests/ui/wonder-atlas-panel.test.ts
+git commit -m "feat(wonders): add safe legendary atlas labels"
+```
+
+---
+
+### Task 5: Landmark Map Presentation, Slots, And Renderer
+
+**Files:**
+- Modify: `src/systems/wonder-visual-catalog.ts`
+- Create: `src/systems/legendary-wonder-map-presentation.ts`
+- Create: `src/renderer/wonders/legendary-wonder-slots.ts`
+- Create: `src/renderer/wonders/legendary-wonder-renderer.ts`
+- Modify: `src/renderer/city-renderer.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Test: `tests/systems/legendary-wonder-map-presentation.test.ts`
+- Test: `tests/renderer/legendary-wonder-slots.test.ts`
+- Test: `tests/renderer/legendary-wonder-renderer.test.ts`
+- Test: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write slot helper tests**
+
+Create `tests/renderer/legendary-wonder-slots.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
+
+describe('legendary-wonder-slots', () => {
+  it('assigns stable slots sorted by turnCompleted then wonderId', () => {
+    const slots = assignLegendaryWonderSlots([
+      { wonderId: 'sun-spire', turnCompleted: 12 },
+      { wonderId: 'oracle-of-delphi', turnCompleted: 10 },
+      { wonderId: 'grand-canal', turnCompleted: 10 },
+    ]);
+
+    expect(slots.map(slot => slot.wonderId)).toEqual(['grand-canal', 'oracle-of-delphi', 'sun-spire']);
+    expect(slots.map(slot => slot.slotIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('uses first five plus overflow when more than six wonders are visible', () => {
+    const slots = assignLegendaryWonderSlots([
+      'a', 'b', 'c', 'd', 'e', 'f', 'g',
+    ].map((wonderId, index) => ({ wonderId, turnCompleted: index + 1 })));
+
+    expect(slots).toHaveLength(6);
+    expect(slots[5]).toMatchObject({ kind: 'overflow', overflowCount: 2 });
+  });
+});
+```
+
+- [ ] **Step 2: Implement slot helper**
+
+Create `src/renderer/wonders/legendary-wonder-slots.ts`:
+
+```ts
+export interface LegendaryWonderSlotInput {
+  wonderId: string;
+  turnCompleted: number;
+}
+
+export type LegendaryWonderSlot =
+  | { kind: 'landmark'; wonderId: string; turnCompleted: number; slotIndex: number; dx: number; dy: number }
+  | { kind: 'overflow'; slotIndex: number; overflowCount: number; dx: number; dy: number };
+
+const OFFSETS = [
+  { dx: 0, dy: -0.78 },
+  { dx: 0.66, dy: -0.38 },
+  { dx: 0.66, dy: 0.34 },
+  { dx: 0, dy: 0.74 },
+  { dx: -0.66, dy: 0.34 },
+  { dx: -0.66, dy: -0.38 },
+];
+
+export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[]): LegendaryWonderSlot[] {
+  const sorted = [...inputs].sort((a, b) => a.turnCompleted - b.turnCompleted || a.wonderId.localeCompare(b.wonderId));
+  const visible = sorted.length > 6 ? sorted.slice(0, 5) : sorted.slice(0, 6);
+  const slots: LegendaryWonderSlot[] = visible.map((input, index) => ({
+    kind: 'landmark',
+    wonderId: input.wonderId,
+    turnCompleted: input.turnCompleted,
+    slotIndex: index,
+    ...OFFSETS[index],
+  }));
+  if (sorted.length > 6) {
+    slots.push({ kind: 'overflow', slotIndex: 5, overflowCount: sorted.length - 5, ...OFFSETS[5] });
+  }
+  return slots;
+}
+```
+
+- [ ] **Step 3: Write map presentation tests**
+
+Create `tests/systems/legendary-wonder-map-presentation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getLegendaryWonderMapEntries } from '@/systems/legendary-wonder-map-presentation';
+import { hexKey } from '@/systems/hex-utils';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-map-presentation', () => {
+  it('returns owner-safe completed landmark entries for visible owned host cities', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'player';
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 20 },
+    };
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+
+    const entries = getLegendaryWonderMapEntries(state, 'player');
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        wonderId: 'oracle-of-delphi',
+        cityId: 'city-river',
+        coord: state.cities['city-river'].position,
+        turnCompleted: 20,
+      }),
+    ]);
+  });
+
+  it('does not expose rival completed landmarks without earned visibility', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'ai-1', cityId: 'rival-city', turnCompleted: 20 },
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 4: Implement map presentation**
+
+Create `src/systems/legendary-wonder-map-presentation.ts`:
+
+```ts
+import type { GameState, HexCoord } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface LegendaryWonderMapEntry {
+  wonderId: string;
+  cityId: string;
+  coord: HexCoord;
+  ownerId: string;
+  relationship: 'owned';
+  turnCompleted: number;
+  label: string;
+  visual: WonderVisualDefinition;
+}
+
+export function getLegendaryWonderMapEntries(state: GameState, viewerId: string): LegendaryWonderMapEntry[] {
+  const visibility = state.civilizations[viewerId]?.visibility;
+  if (!visibility) return [];
+
+  return Object.entries(state.completedLegendaryWonders ?? {})
+    .flatMap(([wonderId, completion]) => {
+      if (completion.ownerId !== viewerId) return [];
+      const city = state.cities[completion.cityId];
+      if (!city) return [];
+      if (getVisibility(visibility, city.position) !== 'visible') return [];
+      const definition = getLegendaryWonderDefinition(wonderId);
+      return [{
+        wonderId,
+        cityId: city.id,
+        coord: { ...city.position },
+        ownerId: completion.ownerId,
+        relationship: 'owned' as const,
+        turnCompleted: completion.turnCompleted,
+        label: definition?.name ?? 'Legendary wonder',
+        visual: getWonderVisualDefinition(wonderId),
+      }];
+    });
+}
+```
+
+- [ ] **Step 5: Implement visual catalog and renderer**
+
+Extend `WonderVisualDefinition` with:
+
+```ts
+legendaryLandmark?: 'spire' | 'arch' | 'dome' | 'obelisk' | 'citadel' | 'archive' | 'masked';
+```
+
+For initial 2C, derive a stable landmark type from the wonder id, not object insertion order:
+
+```ts
+const LEGENDARY_LANDMARK_TYPES = ['spire', 'arch', 'dome', 'obelisk', 'citadel', 'archive'] as const;
+
+function landmarkTypeForLegendaryWonder(wonderId: string): typeof LEGENDARY_LANDMARK_TYPES[number] {
+  const hash = [...wonderId].reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return LEGENDARY_LANDMARK_TYPES[hash % LEGENDARY_LANDMARK_TYPES.length];
+}
+```
+
+Create `src/renderer/wonders/legendary-wonder-renderer.ts` with:
+
+```ts
+export interface LegendaryWonderRenderEntry {
+  wonderId: string;
+  label: string;
+  turnCompleted: number;
+  visual: WonderVisualDefinition;
+}
+
+export function drawLegendaryWonderLandmarks(options: {
+  ctx: CanvasRenderingContext2D;
+  cx: number;
+  cy: number;
+  size: number;
+  entries: LegendaryWonderRenderEntry[];
+  reducedMotion: boolean;
+  lowZoom: boolean;
+}): void {
+  const slots = assignLegendaryWonderSlots(options.entries);
+  // Draw simple geometric silhouettes and +N overflow medallion.
+}
+```
+
+Use canvas primitives only; no emoji for the completed landmark silhouettes.
+
+- [ ] **Step 6: Wire city renderer**
+
+In `src/renderer/city-renderer.ts`, compute grouped entries once:
+
+```ts
+const landmarksByCity = new Map<string, LegendaryWonderMapEntry[]>();
+for (const entry of getLegendaryWonderMapEntries(state, playerCivId)) {
+  landmarksByCity.set(entry.cityId, [...(landmarksByCity.get(entry.cityId) ?? []), entry]);
+}
+```
+
+Inside each live city draw, after city circle/name but before production/idle badges:
+
+```ts
+const legendaryEntries = projection.liveCityId ? landmarksByCity.get(projection.liveCityId) ?? [] : [];
+if (legendaryEntries.length > 0) {
+  drawLegendaryWonderLandmarks({
+    ctx,
+    cx: screen.x,
+    cy: screen.y,
+    size,
+    entries: legendaryEntries,
+    reducedMotion: false,
+    lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+  });
+}
+```
+
+Add a fifth `reducedMotion: boolean = false` parameter to `drawCities`. In `src/renderer/render-loop.ts`, add a tiny local helper that reads `window.matchMedia('(prefers-reduced-motion: reduce)')` in browser contexts and returns `false` in test/non-window contexts, then pass that boolean into `drawCities`. Keep the default `false` for renderer tests that call `drawCities` directly.
+
+- [ ] **Step 7: Run renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 5**
+
+```bash
+git add src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(wonders): render completed legendary landmarks"
+```
+
+---
+
+### Task 6: Inspection Copy And Final Wiring
+
+**Files:**
+- Modify: `src/ui/territory-inspection-panel.ts`
+- Modify: `src/main.ts`
+- Test: `tests/ui/territory-inspection-panel.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+
+- [ ] **Step 1: Write failing inspection test**
+
+Add to `tests/ui/territory-inspection-panel.test.ts`:
+
+```ts
+import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
+
+it('mentions completed legendary wonders for safely visible owned host cities', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 20 },
+  };
+  const panel = createTerritoryInspectionPanel(state, state.cities['city-river'].position, 'player', () => {});
+
+  expect(panel.textContent).toContain('Completed legendary wonders');
+  expect(panel.textContent).toContain('Oracle of Delphi');
+});
+```
+
+- [ ] **Step 2: Implement inspection copy**
+
+In `src/ui/territory-inspection-panel.ts`, after city/wonder lines, add owner-safe completed wonder text:
+
+```ts
+const completedInCity = Object.entries(state.completedLegendaryWonders ?? {})
+  .filter(([, completion]) => completion.ownerId === state.currentPlayer && completion.cityId === city?.id)
+  .map(([wonderId]) => getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder');
+if (completedInCity.length > 0) {
+  addLine(panel, 'Completed legendary wonders', completedInCity.join(', '));
+}
+```
+
+Use the actual city variable available in the file; if the panel only has a tile, resolve a city at the inspected coord through `Object.values(state.cities).find(candidate => same coord)`.
+
+- [ ] **Step 3: Final `main.ts` wiring review**
+
+Confirm:
+
+- `wonder:legendary-completed` listener routes notifications and enqueues ceremony.
+- Queue uses current `blockingOverlay` or existing interaction-blocking predicate.
+- `Open City` opens the host city panel.
+- `Open Journal` opens the host city's `createWonderPanel`; selecting a specific wonder inside the Journal is out of scope unless the existing API already supports it without new state.
+- Wrong-viewer completion events do not open ceremony.
+- No landmark click/input path was added.
+
+- [ ] **Step 4: Run wiring and UI tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/legendary-wonder-completion-queue.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 6**
+
+```bash
+git add src/main.ts src/ui/territory-inspection-panel.ts tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/legendary-wonder-completion-queue.test.ts
+git commit -m "feat(wonders): wire legendary presence inspection"
+```
+
+---
+
+### Task 7: Final Regression, Review, And PR Prep
+
+**Files:**
+- Review all changed files.
+- No new source files expected unless a prior task found a necessary focused helper.
+
+- [ ] **Step 1: Run source rule checks**
+
+Run with the actual changed `src` files:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/legendary-wonder-system.ts src/systems/legendary-wonder-presentation.ts src/systems/legendary-wonder-completion-presentation.ts src/systems/wonder-atlas-presentation.ts src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/ui/city-panel.ts src/ui/wonder-panel.ts src/ui/wonder-atlas-panel.ts src/ui/legendary-wonder-completion-ceremony.ts src/ui/legendary-wonder-completion-queue.ts src/ui/territory-inspection-panel.ts src/ui/legendary-wonder-notifications.ts src/ui/notification-routing.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/main.ts
+```
+
+Expected: no violations.
+
+- [ ] **Step 2: Run targeted tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-completion-presentation.test.ts tests/systems/wonder-atlas-presentation.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/wonder-atlas-panel.test.ts tests/ui/legendary-wonder-completion-ceremony.test.ts tests/ui/legendary-wonder-completion-queue.test.ts tests/ui/territory-inspection-panel.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/notification-routing.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run wonder regressions**
+
+```bash
+./scripts/run-wonder-regressions.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build and full tests**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Inspect diffs**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- src docs tests
+git diff -- src docs tests
+```
+
+Expected:
+
+- branch diff contains only Stage 2C spec/plan and implementation files
+- working tree diff is empty or only intentional final edits
+- no `.superpowers/` files staged
+
+- [ ] **Step 6: Final commit for review fixes**
+
+If Task 7 produced test-only or review fixes, stage the concrete changed files from `src/`, `tests/`, and `docs/superpowers/plans/`:
+
+```bash
+git add src tests docs/superpowers/plans/2026-05-22-legendary-wonder-city-presence.md
+git commit -m "fix(wonders): polish legendary presence regressions"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - City construction identity: Tasks 1-2.
+  - Completion ceremony: Task 3.
+  - Minimal Atlas labels: Task 4.
+  - Multiple completed landmarks and overflow: Task 5.
+  - Inspection text and final wiring: Task 6.
+  - Verification: Task 7.
+- Placeholder scan:
+  - Search this plan for red-flag placeholder language before execution; no ambiguous fill-in instructions should remain.
+- Type consistency:
+  - `turnCompleted` exists in event payload, completion item, map entries, and slot input.
+  - Completion ceremony action ids are `continue`, `skip`, `open-city`, `open-journal`.
+  - Atlas `stateLabel` union matches UI tests.
+- Regression risks:
+  - Existing natural wonder Atlas and discovery reveal paths stay untouched except shared visual catalog type additions.
+  - Existing notification routing should continue to fan out completion notifications with redacted rival text.
+  - Existing rush-buy block for legendary wonders stays intact.

--- a/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
+++ b/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
@@ -313,13 +313,17 @@ Stage 2A is complete when:
 
 Add short first-discovery reveal treatments for natural wonders. These should reuse Stage 2A medallions and vignette identity, while remaining separate from ordinary map scanning.
 
-### Stage 2C: Legendary Construction And Completion Presence
+### Stage 2C: City-First Legendary Presence
 
-Add richer legendary wonder identity in construction UI, construction-stage presentation, completion ceremony/presence, and clearer distinction between available, underway, completed, and rival-known legendary wonders.
+Make city production the primary living surface for legendary wonders. This slice owns active construction identity, progress, ETA, milestone copy, lost-race recovery presentation, owner-only completion ceremonies, completed mini landmarks around host cities, deterministic multiple-wonder city slots, and minimal safe Atlas state labels.
 
 ### Stage 2D: Full 2D Atlas Expansion
 
-Expand the Atlas with lore/history/detail pages, better browsing/filtering, known rival records where intel allows, and a legacy-style archive for completed/discovered wonders. This stage remains 2D.
+Expand the Atlas with lore/history/detail pages, better browsing/filtering, owned legendary detail pages, completed/lost/underway archive records, known rival records where intel allows, city-to-Atlas and Atlas-to-city review flows, and broader 2D visual browsing. This stage remains 2D.
+
+### Stage 2E: Landmark Art Expansion
+
+Later art slice for richer bespoke landmark silhouettes, variants, and per-wonder visual depth after Stage 2C's generic-but-distinct around-city landmark slot model ships.
 
 ### Stage 3: Real Video Spike
 

--- a/docs/superpowers/specs/2026-05-22-legendary-wonder-city-presence-design.md
+++ b/docs/superpowers/specs/2026-05-22-legendary-wonder-city-presence-design.md
@@ -1,0 +1,430 @@
+# Legendary Wonder City Presence Design
+
+**Issue:** [#217 - Bug: legendary wonder ui off](https://github.com/a1flecke/conquestoria/issues/217)
+**Date:** 2026-05-22
+**Stage:** 2C - City-First Legendary Presence
+
+## Overview
+
+Stage 2C makes legendary wonders feel like living city projects. Stage 1 made them reachable from the city build flow. Stage 2A gave wonders a shared visual catalog and Atlas foundation. Stage 2B added natural wonder discovery reveal moments. Stage 2C now focuses on legendary construction and completion presence, with the city production surface as the player's primary source of truth.
+
+This stage remains presentation-first. It does not rebalance legendary wonder costs, rewards, eligibility, AI strategy, quest rules, race resolution, or save semantics. It presents existing legendary wonder state more clearly and gives completed legendary wonders a lasting, viewer-safe city presence.
+
+---
+
+## Goals
+
+- Make city production the main living surface for legendary wonder construction.
+- Show medallion identity, progress, ETA, construction milestone, race/recovery state, reward teaser, and queue continuity for active legendary wonders.
+- Add a short, owner-only legendary completion ceremony.
+- Render completed legendary wonders as mini landmarks around the host city.
+- Support multiple completed legendary wonders in the same city with deterministic around-city slots.
+- Show lost-race recovery clearly so recovered effort and resumed production are understandable.
+- Add minimal, safe legendary state labels to the Wonder Atlas without turning Stage 2C into the full Atlas expansion.
+- Preserve hot-seat and espionage privacy: no rich rival progress, city, reward, ceremony, or map landmark detail leaks through presentation.
+- Keep the city production row compact enough for mobile while making deeper detail reachable through the Wonder Journal.
+
+## Non-Goals
+
+- Stage 2C does not add full Atlas lore, history, filtering, rival record pages, or a legacy archive. That is Stage 2D.
+- Stage 2C does not add real video assets. That remains the Stage 3 video spike.
+- Stage 2C does not add bespoke final landmark art for every wonder beyond the small 2D landmark types needed for this slice. Deeper art variation belongs in Stage 2E.
+- Stage 2C does not change legendary wonder construction, quest, race, global uniqueness, AI, reward, or lost-race mechanics.
+- Stage 2C does not persist completion ceremony queues or replay old ceremonies after reload.
+- Stage 2C does not reveal rival information beyond existing earned-intel rules.
+- Stage 2C does not add a new map input mode, landmark click target, or city-selection priority rule.
+
+---
+
+## Roadmap Placement
+
+Stage 2C is the **City-First Legendary Presence** slice:
+
+- city production identity and progress
+- completion ceremony
+- completed mini landmarks around the host city
+- multiple-wonder city slotting
+- minimal Atlas state labels
+- lost-race recovery presentation
+
+Deferred work is explicitly assigned:
+
+- **Stage 2D: Full 2D Atlas Expansion** - owned legendary detail pages, completed/lost/underway archive, lore/history pages, richer filters, rival-known records from earned intel, city-to-Atlas and Atlas-to-city review flows, and expanded 2D browsing surfaces.
+- **Stage 2E: Landmark Art Expansion** - later slice for richer bespoke landmark silhouettes, variants, and per-wonder art depth after the slot model ships.
+- **Stage 3: Real Video Spike** - 3-5 second video or loop experiments, asset-size review, offline/PWA cost review, macOS/Tauri behavior review, and a production recommendation.
+
+---
+
+## Player Experience
+
+When a player starts a legendary wonder, the city production area becomes the first place to understand the project. The active production row should feel distinct from normal units and buildings while still fitting the existing city UI. It shows:
+
+- medallion identity
+- human-readable wonder name
+- construction progress and ETA
+- invested production
+- construction milestone copy such as `Foundation laid`, `Rising`, `Final works`, or `Nearly complete`
+- quest-complete state when relevant
+- coarse race/recovery state
+- short reward teaser
+- clear copy that the existing production queue resumes after the wonder
+- a link or action to open the Wonder Journal for full detail
+
+The city row should use progressive disclosure. The always-visible row shows identity, progress, ETA, milestone, and queue-continuity copy. Secondary details such as full reward text, complete quest history, and longer race explanations stay in the Journal or an expandable city detail area. On narrow screens, the row must stack cleanly without overlapping buttons, progress text, or medallions.
+
+The Wonder Journal remains the deeper support surface. It explains quest steps, requirements, reward, race state, lost-race recovery, and construction status, but the player should not need to open it just to understand what the city is building.
+
+When the owner completes a legendary wonder, they get a short skippable ceremony after production resolution and blocking UI settle. The ceremony confirms the wonder, host city, achievement line, reward summary, and `Reward active` state. The default action is `Continue`; secondary actions can open the host city or the Journal entry.
+
+After completion, the host city gains a completed mini landmark in an around-city slot. If that same city completes more legendary wonders later, each completed wonder gets a stable slot. This makes cities visually transform through long-term accomplishments.
+
+Lost races receive player-friendly recovery framing. The city should say `Effort recovered`, then explain carryover/refund and normal production resumption. Losing should feel like a strategic setback with preserved value, not like silent work deletion.
+
+---
+
+## UI And UX
+
+### City Production States
+
+The city surface should distinguish these visible states:
+
+| State | Required presentation |
+| --- | --- |
+| `Ready` | Medallion identity, start action, cost/ETA preview, queue continuity copy. |
+| `Building` | Progress, ETA, invested production, reward teaser, Journal link, and construction milestone copy. |
+| `Building with intel` | Coarse race tension only, such as `Rival activity reported` or `Race at risk`, when existing intel allows it. Do not show exact rival progress unless an existing intel surface already permits that exact detail. |
+| `Completed` | Completed badge, `Reward active` copy, production-resumed copy, and map landmark reference. |
+| `Recovered` | Lost-race recovery framed as preserved effort, with refund/carryover and production-resumed copy. |
+| `Blocked/Near` | Only where Stage 1 already surfaces the wonder, with missing requirement chips. |
+
+Construction milestones are presentation labels derived from the owner's own progress:
+
+- early progress: `Foundation laid`
+- middle progress: `Rising`
+- late progress: `Final works`
+- near completion: `Nearly complete`
+
+Milestone thresholds are deterministic: `Foundation laid` at 0-24% progress, `Rising` at 25-59%, `Final works` at 60-89%, and `Nearly complete` at 90% or higher.
+
+If no earned rival intel exists, the city surface should avoid implying that the race is safe. Use neutral owner-only language such as `Construction underway`.
+
+### Completion Ceremony
+
+The owner-only completion ceremony includes:
+
+- title: `Legendary Wonder Completed`
+- wonder name
+- host city
+- short achievement line
+- reward summary
+- `Reward active`
+- primary `Continue`
+- secondary `Open City` or `Open Journal`
+- immediate `Skip`
+- reduced-motion static version
+
+The ceremony resolves exactly once even if buttons are clicked repeatedly. It must wait until production resolution, movement animation, turn handoff, and other blocking UI are clear. It must not appear on another hot-seat player's screen.
+
+Ceremony eligibility is explicit:
+
+- AI completions never open a ceremony.
+- A human completion opens a ceremony only when `state.currentPlayer === civId` and the viewer is in that player's safe viewing moment.
+- If a human wonder completes while another hot-seat player is the active viewer, the ceremony waits until the owner is the active viewer or is skipped if the session cannot safely present it.
+- Reconstructed save data and final-state scans never create old ceremonies.
+
+### Map And Inspection
+
+Completed landmarks are decorative by default. They must not steal unit, city, tile, movement, attack, or selection input. Host-city selection keeps priority.
+
+City or tile inspection should mention completed legendary wonders when safely visible. Without inspection text, the mini landmark risks becoming decoration without understanding.
+
+Around-city slots support multiple completed wonders:
+
+- render up to 6 landmark positions around a city
+- if more than 6 completed wonders exist, render the first 5 plus a `+N` medallion
+- low zoom uses simplified silhouettes or compact markers
+- reduced motion disables pulsing or animated effects
+- landmark drawing must stay within the city visual footprint and must not obscure unit sprites, health bars, city labels, or primary selection affordances
+
+### Atlas
+
+The Wonder Atlas gets minimal safe legendary state labels only:
+
+- `Available`
+- `Under construction`
+- `Completed`
+- `Recovered`
+- `Known rival completed`
+- `Legendary wonder`
+
+Labels are derived from existing state and viewer-safe helpers. Stage 2C must not add persistent Atlas state or full legendary detail pages.
+
+`Known rival completed` appears only when existing notification, contact, or espionage rules already make that completion known to the viewer. It must not include host city, reward, progress, completion turn, map landmark, or owner detail unless another existing viewer-safe intel helper allows that exact detail.
+
+---
+
+## Privacy And Gameplay Rules
+
+Owner-only rich detail is the default.
+
+The owner may see:
+
+- construction progress
+- ETA
+- reward summary
+- host city
+- ceremony
+- completed landmarks for their own known/visible cities
+- lost-race recovery details
+
+Rivals may see only what existing contact, visibility, or espionage intel already permits. Stage 2C must not add a new global fame reveal. Rival views must not expose raw progress, reward details, host city, completion ceremony, Atlas detail, or map landmarks unless a viewer-safe helper says that detail is earned.
+
+If a rival can see a city on the map but has not earned legendary wonder intel, Stage 2C does not show rich legendary landmark detail for that city. The world can become reactive later through explicit 2D or intel work; 2C prioritizes leakage safety.
+
+Gameplay rules remain unchanged:
+
+- no cost/reward changes
+- no eligibility changes
+- no quest/race rule changes
+- no AI behavior changes
+- no save-format change solely for presentation
+- existing core systems remain authoritative for mutation
+
+---
+
+## Architecture
+
+Stage 2C extends the existing wonder stack while keeping orchestration, visibility, and rendering boundaries explicit.
+
+### City Presentation
+
+`src/systems/legendary-wonder-presentation.ts` remains the shared city-facing presentation source. It should provide or be extended to provide:
+
+- state labels
+- progress
+- ETA
+- milestone copy
+- race/recovery copy
+- completed status
+- reward summary
+- queue metadata
+- production-resumed copy where relevant
+
+UI code renders these entries and calls existing mutation helpers. UI eligibility remains guidance, not authority.
+
+Presentation helpers must not mutate the input `GameState`. If they need normalized legendary project data, they may call existing pure helpers that return a cloned or derived state, then return presentation entries from that derived state.
+
+### Visual Catalog
+
+`src/systems/wonder-visual-catalog.ts` gains richer legendary visual metadata:
+
+- medallion identity
+- completed-landmark type or shape
+- palette tokens
+- reduced-motion/static fallback
+
+The catalog stores presentation identity only. It must not duplicate gameplay effects, rewards, requirements, or quest rules.
+
+### Completion Ceremony Presentation
+
+Add `src/systems/legendary-wonder-completion-presentation.ts`.
+
+This helper builds owner-safe ceremony items from `wonder:legendary-completed` events plus safe state. It does not scan final state to invent ceremonies. If the event lacks required source fields, the event should be augmented at the mutation source.
+
+Completion events must carry enough data for ceremonies and notifications:
+
+- `civId`
+- `cityId`
+- `wonderId`
+- `turnCompleted`
+
+The implementation should augment `wonder:legendary-completed` with `turnCompleted` instead of asking the ceremony helper to discover timing by scanning `completedLegendaryWonders`. If the event is emitted before completed state is committed, the event payload is still the ceremony source of truth.
+
+### Completion Queue And Ceremony UI
+
+Add `src/ui/legendary-wonder-completion-queue.ts`.
+
+This module owns:
+
+- completion queueing
+- blocking-UI checks
+- ceremony sequencing
+- repeat-click protection
+- post-ceremony actions
+- continuation to the next queued ceremony
+- hot-seat viewer safety
+
+`main.ts` only subscribes and delegates.
+
+Add `src/ui/legendary-wonder-completion-ceremony.ts` for the skippable owner-only overlay. It should follow the same general interaction discipline as the natural wonder discovery ceremony while using legendary-specific copy and actions.
+
+### Viewer-Safe Map Presentation
+
+Add `src/systems/legendary-wonder-map-presentation.ts`.
+
+This helper returns completed landmark entries visible to `state.currentPlayer`. It must not expose raw rival completed-wonder or project state directly to the renderer.
+
+The renderer receives only ready-to-draw, viewer-safe landmark entries.
+
+Map presentation entries should include only the drawing data the renderer needs: host city coordinate, wonder id, display-safe label or fallback label, visual id/type, completion ordering key, and viewer-safe ownership relationship. They should not include raw project objects, rival city objects, or full completed-wonder records.
+
+### Renderer And Slots
+
+Add `src/renderer/wonders/legendary-wonder-renderer.ts`.
+
+This renderer draws completed legendary landmark entries around the host city. It does not decide visibility, ownership, completion truth, or intel truth.
+
+Add a pure tested slot helper at `src/renderer/wonders/legendary-wonder-slots.ts`.
+
+Slotting rules:
+
+- sort by `turnCompleted`, then `wonderId`
+- return stable slot indexes and offsets
+- handle 1, 2, 3+, 6, and overflow cases
+- support low-zoom simplification
+- keep offsets deterministic across reloads and independent of object insertion order
+
+### Atlas Presentation
+
+`src/systems/wonder-atlas-presentation.ts` derives minimal legendary state labels from existing state and viewer-safe helpers. It stores no new Atlas state and does not render full legendary detail pages.
+
+### City Capture And Raze
+
+Completed wonder ownership and reward behavior remain governed by existing core systems.
+
+Map landmark rendering appears only when the viewer can safely know the host city/wonder relationship. If the host city no longer exists, cannot be resolved, or cannot be shown safely, the map landmark is omitted while city, Journal, notification, or Atlas surfaces fall back to safe text.
+
+---
+
+## Data Flow
+
+Construction flow:
+
+1. The player starts construction through existing legendary wonder mutation helpers.
+2. Existing city production queue state stores `legendary:<wonderId>` as active production.
+3. City UI requests legendary presentation entries.
+4. `legendary-wonder-presentation` derives city-safe state, progress, ETA, milestone, race/recovery copy, and queue continuity.
+5. City UI renders the active legendary production state and refreshes immediately after actions.
+
+Completion flow:
+
+1. Existing production/race logic completes a legendary wonder and emits `wonder:legendary-completed` with `civId`, `cityId`, `wonderId`, and `turnCompleted`.
+2. Existing notifications/logging continue to run.
+3. `main.ts` delegates the event to the completion presentation/queue modules.
+4. The presentation helper returns `null` unless the event is eligible for a human viewer whose active `state.currentPlayer` matches the event `civId`.
+5. The queue waits for blocking UI to clear.
+6. The ceremony resolves through `Continue`, `Open City`, `Open Journal`, or `Skip`.
+7. The city panel, Atlas labels, and renderer refresh from derived state.
+
+Map flow:
+
+1. The render path asks the viewer-safe map presentation helper for completed landmark entries.
+2. The helper returns only entries safe for `state.currentPlayer`.
+3. Slot helper assigns stable around-city offsets.
+4. Renderer draws simplified or detailed landmarks based on zoom and reduced-motion state.
+5. Renderer does not mutate state or decide visibility.
+
+Atlas flow:
+
+1. Atlas requests entries for `state.currentPlayer`.
+2. Atlas presentation derives minimal legendary labels from existing state.
+3. Legendary entries remain compact and masked except for safe status labels.
+
+---
+
+## Error Handling And Edge Cases
+
+- Unknown legendary wonder ids use safe fallback names/visuals.
+- Missing visual metadata uses a safe fallback medallion and static landmark.
+- Unknown or unsafe host city omits map landmark rendering.
+- Captured or razed host cities do not leak hidden city/wonder relationships.
+- Multiple completed wonders in one city use deterministic slots.
+- More than 6 visible completed wonders use first 5 plus `+N` overflow.
+- Lost-race recovery shows refund/carryover and production-resumed copy.
+- Completion ceremonies are not reconstructed after reload.
+- Repeat-clicks on ceremony actions resolve only once.
+- Reduced-motion users receive static ceremonies and non-animated landmarks.
+- Low zoom uses simplified markers or silhouettes.
+- Hot-seat ceremonies display only when `state.currentPlayer` matches the completed wonder owner's `civId`.
+- Human completion events that cannot be presented safely are dropped rather than shown to the wrong viewer.
+- Rival Atlas, map, city, and notification surfaces never expose rich detail unless existing earned-intel rules allow it.
+
+---
+
+## Testing Requirements
+
+### System And Presentation Tests
+
+- City presentation returns correct labels for `Ready`, `Building`, `Completed`, `Recovered`, `Blocked`, and `Near`.
+- Construction milestones are deterministic at threshold boundaries.
+- ETA/progress/reward/queue metadata render from owned state.
+- Lost-race recovery copy includes refund/carryover and production-resumed meaning.
+- Completion presentation builds ceremony items from event payloads.
+- Completion event typing includes `turnCompleted`, and tests prove ceremony timing comes from the event payload rather than a final-state scan.
+- Completion presentation returns `null` for AI events, wrong-viewer events, stale/reconstructed state, missing event source data, and ineligible hot-seat viewers.
+- Atlas presentation derives only minimal safe legendary labels.
+- Atlas presentation negative tests prove rival progress, city, reward, and completion detail remain hidden without earned intel.
+- Map presentation returns only viewer-safe completed landmark entries.
+
+### UI Tests
+
+- City production shows active legendary medallion, progress, ETA, milestone, race/recovery copy, reward teaser, and queue continuity.
+- City production remains readable on narrow/mobile layouts without text, buttons, medallions, or progress bars overlapping.
+- City production refreshes immediately after starting a legendary wonder.
+- Completion/recovery states show production-resumed copy.
+- Wonder Journal agrees with city state and remains the full-detail support surface.
+- Completion ceremony renders owner-only title, wonder name, host city, reward summary, `Reward active`, `Continue`, secondary action, and `Skip`.
+- Ceremony buttons resolve exactly once.
+- Secondary ceremony action opens the correct city or Journal entry when the target exists; if the target is unavailable, it resolves like `Continue` and does not break the ceremony.
+- Reduced-motion ceremony renders static content.
+- Hot-seat tests prove another human player does not see the owner's completion ceremony.
+- City or tile inspection mentions completed legendary wonders only when safely visible.
+
+### Renderer And Input Tests
+
+- Slot helper returns stable offsets for 1, 2, 3+, and 6 landmarks.
+- Overflow renders first 5 plus `+N` when more than 6 completed wonders are visible.
+- Slot sorting uses `turnCompleted`, then `wonderId`.
+- Slot order remains stable after reload when completed wonder object insertion order changes.
+- Renderer draws completed landmarks from viewer-safe entries only.
+- Renderer keeps landmarks from obscuring units, city labels, health bars, and selection affordances.
+- Low zoom uses simplified markers or silhouettes.
+- Reduced motion disables animated landmark effects.
+- Landmarks do not steal unit, city, movement, attack, tile, or selection input.
+- Hidden/rival landmarks do not render without earned visibility.
+
+### Regression And Verification
+
+For Stage 2C implementation, run:
+
+```bash
+scripts/check-src-rule-violations.sh <changed src files>
+./scripts/run-with-mise.sh yarn test --run <mirrored or smallest relevant tests>
+./scripts/run-wonder-regressions.sh
+./scripts/run-with-mise.sh yarn build
+```
+
+Before push, PR creation, or merge, also run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+---
+
+## Acceptance Criteria
+
+Stage 2C is complete when:
+
+- active legendary construction is clear from the city production surface
+- active construction shows identity, progress, ETA, milestone, reward teaser, race/recovery copy, and queue continuity
+- completed and recovered states show production-resumed meaning
+- completion ceremonies are owner-only, skippable, reduced-motion safe, and hot-seat safe
+- completed legendary wonders render as mini landmarks around the host city
+- one city can safely display multiple completed legendary wonders through deterministic slots
+- overflow beyond 6 visible landmarks is handled by a `+N` marker
+- city/tile inspection explains completed landmarks when safely visible
+- Atlas legendary entries show only minimal safe state labels
+- rivals do not receive rich progress, city, reward, ceremony, Atlas, or map landmark detail without existing earned intel
+- no gameplay costs, rewards, eligibility, AI, race rules, or save semantics are changed
+- targeted tests, wonder regressions, build, and full tests pass

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1133,7 +1133,7 @@ export interface GameEvents {
   'wonder:discovered': { civId: string; wonderId: string; position: HexCoord; isFirstDiscoverer: boolean };
   'wonder:eruption': { wonderId: string; position: HexCoord; tilesAffected: HexCoord[] };
   'wonder:legendary-ready': { civId: string; cityId: string; wonderId: string };
-  'wonder:legendary-completed': { civId: string; cityId: string; wonderId: string };
+  'wonder:legendary-completed': { civId: string; cityId: string; wonderId: string; turnCompleted: number };
   'wonder:legendary-lost': { civId: string; cityId: string; wonderId: string; goldRefund: number; transferableProduction: number };
   'wonder:legendary-race-revealed': { observerId: string; civId: string; cityId: string; wonderId: string };
   'village:visited': { civId: string; position: HexCoord; outcome: VillageOutcomeType; message: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -150,6 +150,8 @@ import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { calculateCivEconomy, formatGoldHudText, formatMaintenanceTooltip, rushBuyActiveProduction } from '@/systems/economy-system';
 import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
+import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { createLegendaryWonderCompletionQueue } from '@/ui/legendary-wonder-completion-queue';
 
 // --- App State ---
 let gameState: GameState;
@@ -195,11 +197,13 @@ const canvas = document.getElementById('game-canvas') as HTMLCanvasElement;
 const uiLayer = document.getElementById('ui-layer') as HTMLDivElement;
 const renderLoop = new RenderLoop(canvas);
 let wonderDiscoveryQueue: ReturnType<typeof createWonderDiscoveryRevealQueue> | null = null;
+let legendaryCompletionQueue: ReturnType<typeof createLegendaryWonderCompletionQueue> | null = null;
 
 function setBlockingOverlay(id: string | null): void {
   uiInteractions.setBlockingOverlay(id);
   if (id === null) {
     wonderDiscoveryQueue?.pump();
+    legendaryCompletionQueue?.pump();
   }
 }
 
@@ -216,6 +220,20 @@ wonderDiscoveryQueue = createWonderDiscoveryRevealQueue({
   },
   openAtlas: wonderId => openWonderAtlas(wonderId),
   reducedMotion: prefersReducedMotion,
+  setBlockingOverlay,
+});
+
+legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
+  container: uiLayer,
+  isInteractionBlocked: () => uiInteractions.isInteractionBlocked(),
+  reducedMotion: prefersReducedMotion,
+  openCity: cityId => {
+    const city = gameState.cities[cityId];
+    if (city) openCityPanelForCity(city);
+  },
+  openJournal: cityId => {
+    if (gameState.cities[cityId]) openWonderPanelForCityId(cityId);
+  },
   setBlockingOverlay,
 });
 
@@ -582,6 +600,36 @@ function executeUpgrade(unitId: string, targetType: import('@/core/types').UnitT
   updateHUD();
 }
 
+function openWonderPanelForCityId(selectedCityId: string): void {
+  if (!gameState.cities[selectedCityId]) return;
+
+  const openWonderPanel = () => {
+    document.getElementById('wonder-panel')?.remove();
+    createWonderPanel(uiLayer, gameState, selectedCityId, {
+      onStartBuild: (buildCityId, wonderId) => {
+        gameState = startLegendaryWonderBuild(gameState, gameState.currentPlayer, buildCityId, wonderId, bus);
+        const targetCity = gameState.cities[buildCityId];
+        if (targetCity) {
+          renderLoop.setGameState(gameState);
+          updateHUD();
+          const productionItemId = `legendary:${wonderId}`;
+          if (targetCity.productionQueue[0] === productionItemId) {
+            showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
+          } else {
+            showNotification(`${targetCity.name}: ${getProductionDisplayName(productionItemId)} is not ready to start.`, 'warning');
+          }
+          openWonderPanel();
+        }
+      },
+      onClose: () => {
+        document.getElementById('wonder-panel')?.remove();
+      },
+    });
+  };
+  gameState = initializeLegendaryWonderProjectsForCity(gameState, gameState.currentPlayer, selectedCityId);
+  openWonderPanel();
+}
+
 function openCityPanelForCity(city: import('@/core/types').City): void {
   if (city.owner !== gameState.currentPlayer) return;
   const playerCities = currentCiv().cities;
@@ -619,31 +667,7 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
       renderLoop.setGameState(gameState);
     },
     onOpenWonderPanel: (selectedCityId) => {
-      const openWonderPanel = () => {
-        document.getElementById('wonder-panel')?.remove();
-        createWonderPanel(uiLayer, gameState, selectedCityId, {
-          onStartBuild: (buildCityId, wonderId) => {
-            gameState = startLegendaryWonderBuild(gameState, gameState.currentPlayer, buildCityId, wonderId, bus);
-            const targetCity = gameState.cities[buildCityId];
-            if (targetCity) {
-              renderLoop.setGameState(gameState);
-              updateHUD();
-              const productionItemId = `legendary:${wonderId}`;
-              if (targetCity.productionQueue[0] === productionItemId) {
-                showNotification(`${targetCity.name}: preparing ${getProductionDisplayName(productionItemId)}`, 'info');
-              } else {
-                showNotification(`${targetCity.name}: ${getProductionDisplayName(productionItemId)} is not ready to start.`, 'warning');
-              }
-              openWonderPanel();
-            }
-          },
-          onClose: () => {
-            document.getElementById('wonder-panel')?.remove();
-          },
-        });
-      };
-      gameState = initializeLegendaryWonderProjectsForCity(gameState, gameState.currentPlayer, selectedCityId);
-      openWonderPanel();
+      openWonderPanelForCityId(selectedCityId);
     },
     onSetCityFocus: (cityId, focus) => {
       const result = assignCityFocus(gameState, cityId, focus);
@@ -2554,7 +2578,13 @@ bus.on('wonder:legendary-ready', ({ civId, cityId, wonderId }) => {
 });
 
 bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId, turnCompleted }) => {
-  routeLegendaryWonder(gameState, { type: 'wonder:legendary-completed', civId, cityId, wonderId, turnCompleted }, appendToCivLog);
+  const event = { civId, cityId, wonderId, turnCompleted };
+  routeLegendaryWonder(gameState, { type: 'wonder:legendary-completed', ...event }, appendToCivLog);
+  const ceremonyItem = buildLegendaryWonderCompletionCeremonyItem(gameState, event);
+  if (ceremonyItem) {
+    legendaryCompletionQueue?.enqueue(ceremonyItem);
+    legendaryCompletionQueue?.notifyActionSettled();
+  }
 });
 
 bus.on('wonder:legendary-lost', ({ civId, cityId, wonderId, goldRefund, transferableProduction }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2553,8 +2553,8 @@ bus.on('wonder:legendary-ready', ({ civId, cityId, wonderId }) => {
   routeLegendaryWonder(gameState, { type: 'wonder:legendary-ready', civId, cityId, wonderId }, appendToCivLog);
 });
 
-bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId }) => {
-  routeLegendaryWonder(gameState, { type: 'wonder:legendary-completed', civId, cityId, wonderId }, appendToCivLog);
+bus.on('wonder:legendary-completed', ({ civId, cityId, wonderId, turnCompleted }) => {
+  routeLegendaryWonder(gameState, { type: 'wonder:legendary-completed', civId, cityId, wonderId, turnCompleted }, appendToCivLog);
 });
 
 bus.on('wonder:legendary-lost', ({ civId, cityId, wonderId, goldRefund, transferableProduction }) => {

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -8,6 +8,11 @@ import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { spriteCache } from './sprites/sprite-loader';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
+import {
+  getLegendaryWonderMapEntries,
+  type LegendaryWonderMapEntry,
+} from '@/systems/legendary-wonder-map-presentation';
+import { drawLegendaryWonderLandmarks } from '@/renderer/wonders/legendary-wonder-renderer';
 
 export function getProductionBadgeIcon(city: { productionQueue: string[] }): string | null {
   if (city.productionQueue.length === 0) return null;
@@ -72,9 +77,14 @@ export function drawCities(
   state: GameState,
   camera: Camera,
   playerCivId: string,
+  reducedMotion: boolean = false,
 ): void {
   const vis = state.civilizations[playerCivId]?.visibility;
   if (!vis) return;
+  const landmarksByCity = new Map<string, LegendaryWonderMapEntry[]>();
+  for (const entry of getLegendaryWonderMapEntries(state, playerCivId)) {
+    landmarksByCity.set(entry.cityId, [...(landmarksByCity.get(entry.cityId) ?? []), entry]);
+  }
 
   for (const projection of getCityRenderProjection(state, playerCivId)) {
     const city = projection.liveCityId ? state.cities[projection.liveCityId] : undefined;
@@ -125,6 +135,19 @@ export function drawCities(
       ctx.textAlign = 'center';
       ctx.textBaseline = 'top';
       ctx.fillText(`${projection.name} (${projection.population})`, screen.x, screen.y + size * 0.5);
+
+      const legendaryEntries = projection.liveCityId ? landmarksByCity.get(projection.liveCityId) ?? [] : [];
+      if (legendaryEntries.length > 0) {
+        drawLegendaryWonderLandmarks({
+          ctx,
+          cx: screen.x,
+          cy: screen.y,
+          size,
+          entries: legendaryEntries,
+          reducedMotion,
+          lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+        });
+      }
 
       if (projection.isLive && city && breakaway) {
         ctx.font = `${size * 0.28}px system-ui`;

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -30,6 +30,12 @@ const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
   'worker-foreign-blocked': 'rgba(217, 74, 74, 0.35)',
 };
 
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
 export class RenderLoop {
   private ctx: CanvasRenderingContext2D;
   private canvas: HTMLCanvasElement;
@@ -190,7 +196,7 @@ export class RenderLoop {
     }
 
     // Draw cities
-    drawCities(this.ctx, this.state, this.camera, viewerId);
+    drawCities(this.ctx, this.state, this.camera, viewerId, prefersReducedMotion());
     this.drawInfiltratedSpyIndicators();
     this.drawEmbeddedSpyIndicators();
 

--- a/src/renderer/wonders/legendary-wonder-renderer.ts
+++ b/src/renderer/wonders/legendary-wonder-renderer.ts
@@ -1,0 +1,109 @@
+import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
+
+export interface LegendaryWonderRenderEntry {
+  wonderId: string;
+  label: string;
+  turnCompleted: number;
+  visual: WonderVisualDefinition;
+}
+
+function drawSilhouette(
+  ctx: CanvasRenderingContext2D,
+  kind: WonderVisualDefinition['legendaryLandmark'],
+  cx: number,
+  cy: number,
+  radius: number,
+): void {
+  ctx.beginPath();
+  switch (kind) {
+    case 'arch':
+      ctx.arc(cx, cy + radius * 0.35, radius * 0.62, Math.PI, Math.PI * 2);
+      ctx.lineTo(cx + radius * 0.48, cy + radius * 0.72);
+      ctx.lineTo(cx - radius * 0.48, cy + radius * 0.72);
+      break;
+    case 'dome':
+      ctx.arc(cx, cy + radius * 0.2, radius * 0.7, Math.PI, Math.PI * 2);
+      ctx.lineTo(cx + radius * 0.7, cy + radius * 0.65);
+      ctx.lineTo(cx - radius * 0.7, cy + radius * 0.65);
+      break;
+    case 'obelisk':
+      ctx.moveTo(cx, cy - radius * 0.82);
+      ctx.lineTo(cx + radius * 0.34, cy + radius * 0.7);
+      ctx.lineTo(cx - radius * 0.34, cy + radius * 0.7);
+      break;
+    case 'citadel':
+      ctx.rect(cx - radius * 0.62, cy - radius * 0.34, radius * 1.24, radius * 1.02);
+      ctx.moveTo(cx - radius * 0.62, cy - radius * 0.34);
+      ctx.lineTo(cx - radius * 0.38, cy - radius * 0.68);
+      ctx.lineTo(cx - radius * 0.12, cy - radius * 0.34);
+      ctx.lineTo(cx + radius * 0.12, cy - radius * 0.68);
+      ctx.lineTo(cx + radius * 0.38, cy - radius * 0.34);
+      break;
+    case 'archive':
+      ctx.rect(cx - radius * 0.66, cy - radius * 0.5, radius * 1.32, radius * 1.08);
+      ctx.moveTo(cx - radius * 0.44, cy - radius * 0.5);
+      ctx.lineTo(cx - radius * 0.44, cy + radius * 0.58);
+      ctx.moveTo(cx, cy - radius * 0.5);
+      ctx.lineTo(cx, cy + radius * 0.58);
+      ctx.moveTo(cx + radius * 0.44, cy - radius * 0.5);
+      ctx.lineTo(cx + radius * 0.44, cy + radius * 0.58);
+      break;
+    case 'spire':
+    default:
+      ctx.moveTo(cx, cy - radius * 0.84);
+      ctx.lineTo(cx + radius * 0.54, cy + radius * 0.68);
+      ctx.lineTo(cx, cy + radius * 0.38);
+      ctx.lineTo(cx - radius * 0.54, cy + radius * 0.68);
+      break;
+  }
+  ctx.closePath();
+}
+
+export function drawLegendaryWonderLandmarks(options: {
+  ctx: CanvasRenderingContext2D;
+  cx: number;
+  cy: number;
+  size: number;
+  entries: LegendaryWonderRenderEntry[];
+  reducedMotion: boolean;
+  lowZoom: boolean;
+}): void {
+  if (options.entries.length === 0) return;
+  const slots = assignLegendaryWonderSlots(options.entries);
+  const entryByWonderId = new Map(options.entries.map(entry => [entry.wonderId, entry]));
+  const radius = options.size * (options.lowZoom ? 0.13 : 0.16);
+  const orbit = options.size * 0.74;
+
+  options.ctx.save();
+  for (const slot of slots) {
+    const x = options.cx + slot.dx * orbit;
+    const y = options.cy + slot.dy * orbit;
+    options.ctx.beginPath();
+    options.ctx.arc(x, y, radius, 0, Math.PI * 2);
+    options.ctx.fillStyle = 'rgba(16,16,24,0.92)';
+    options.ctx.fill();
+    options.ctx.strokeStyle = 'rgba(232,193,112,0.78)';
+    options.ctx.lineWidth = Math.max(1, radius * 0.14);
+    options.ctx.stroke();
+
+    if (slot.kind === 'overflow') {
+      options.ctx.font = `bold ${Math.max(8, radius * 0.82)}px system-ui`;
+      options.ctx.textAlign = 'center';
+      options.ctx.textBaseline = 'middle';
+      options.ctx.fillStyle = '#f8e7af';
+      options.ctx.fillText(`+${slot.overflowCount}`, x, y);
+      continue;
+    }
+
+    const entry = entryByWonderId.get(slot.wonderId);
+    if (!entry) continue;
+    drawSilhouette(options.ctx, entry.visual.legendaryLandmark, x, y, radius * 0.72);
+    options.ctx.fillStyle = entry.visual.palette.accent;
+    options.ctx.fill();
+    options.ctx.strokeStyle = entry.visual.palette.glow;
+    options.ctx.lineWidth = Math.max(1, radius * 0.08);
+    options.ctx.stroke();
+  }
+  options.ctx.restore();
+}

--- a/src/renderer/wonders/legendary-wonder-slots.ts
+++ b/src/renderer/wonders/legendary-wonder-slots.ts
@@ -1,0 +1,33 @@
+export interface LegendaryWonderSlotInput {
+  wonderId: string;
+  turnCompleted: number;
+}
+
+export type LegendaryWonderSlot =
+  | { kind: 'landmark'; wonderId: string; turnCompleted: number; slotIndex: number; dx: number; dy: number }
+  | { kind: 'overflow'; slotIndex: number; overflowCount: number; dx: number; dy: number };
+
+const OFFSETS = [
+  { dx: 0, dy: -0.78 },
+  { dx: 0.66, dy: -0.38 },
+  { dx: 0.66, dy: 0.34 },
+  { dx: 0, dy: 0.74 },
+  { dx: -0.66, dy: 0.34 },
+  { dx: -0.66, dy: -0.38 },
+];
+
+export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[]): LegendaryWonderSlot[] {
+  const sorted = [...inputs].sort((a, b) => a.turnCompleted - b.turnCompleted || a.wonderId.localeCompare(b.wonderId));
+  const visible = sorted.length > 6 ? sorted.slice(0, 5) : sorted.slice(0, 6);
+  const slots: LegendaryWonderSlot[] = visible.map((input, index) => ({
+    kind: 'landmark',
+    wonderId: input.wonderId,
+    turnCompleted: input.turnCompleted,
+    slotIndex: index,
+    ...OFFSETS[index],
+  }));
+  if (sorted.length > 6) {
+    slots.push({ kind: 'overflow', slotIndex: 5, overflowCount: sorted.length - 5, ...OFFSETS[5] });
+  }
+  return slots;
+}

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -8,7 +8,7 @@ import {
   getLegendaryWonderDisplayName,
   getLegendaryWonderProductionCost,
   getLegendaryWonderQueueItemMetadata,
-} from './legendary-wonder-presentation';
+} from './legendary-wonder-production';
 
 export const CITY_NAMES = DEFAULT_CITY_NAMES;
 

--- a/src/systems/legendary-wonder-completion-presentation.ts
+++ b/src/systems/legendary-wonder-completion-presentation.ts
@@ -1,0 +1,41 @@
+import type { GameEventMap, GameState } from '@/core/types';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface LegendaryWonderCompletionCeremonyItem {
+  title: 'Legendary Wonder Completed';
+  civId: string;
+  cityId: string;
+  wonderId: string;
+  turnCompleted: number;
+  name: string;
+  cityName: string;
+  achievementLine: string;
+  rewardSummary: string;
+  rewardActiveLabel: 'Reward active';
+  visual: WonderVisualDefinition;
+}
+
+export function buildLegendaryWonderCompletionCeremonyItem(
+  state: GameState,
+  event: GameEventMap['wonder:legendary-completed'],
+): LegendaryWonderCompletionCeremonyItem | null {
+  if (state.currentPlayer !== event.civId) return null;
+  const definition = getLegendaryWonderDefinition(event.wonderId);
+  const city = state.cities[event.cityId];
+  if (!definition || !city || city.owner !== event.civId) return null;
+
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: event.civId,
+    cityId: event.cityId,
+    wonderId: event.wonderId,
+    turnCompleted: event.turnCompleted,
+    name: definition.name,
+    cityName: city.name,
+    achievementLine: `${city.name} has completed a work that will shape its legacy.`,
+    rewardSummary: definition.reward.summary,
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition(event.wonderId),
+  };
+}

--- a/src/systems/legendary-wonder-completion-presentation.ts
+++ b/src/systems/legendary-wonder-completion-presentation.ts
@@ -1,4 +1,4 @@
-import type { GameEventMap, GameState } from '@/core/types';
+import type { GameEvents, GameState } from '@/core/types';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 
@@ -18,7 +18,7 @@ export interface LegendaryWonderCompletionCeremonyItem {
 
 export function buildLegendaryWonderCompletionCeremonyItem(
   state: GameState,
-  event: GameEventMap['wonder:legendary-completed'],
+  event: GameEvents['wonder:legendary-completed'],
 ): LegendaryWonderCompletionCeremonyItem | null {
   if (state.currentPlayer !== event.civId) return null;
   const definition = getLegendaryWonderDefinition(event.wonderId);

--- a/src/systems/legendary-wonder-map-presentation.ts
+++ b/src/systems/legendary-wonder-map-presentation.ts
@@ -1,0 +1,39 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+export interface LegendaryWonderMapEntry {
+  wonderId: string;
+  cityId: string;
+  coord: HexCoord;
+  ownerId: string;
+  relationship: 'owned';
+  turnCompleted: number;
+  label: string;
+  visual: WonderVisualDefinition;
+}
+
+export function getLegendaryWonderMapEntries(state: GameState, viewerId: string): LegendaryWonderMapEntry[] {
+  const visibility = state.civilizations[viewerId]?.visibility;
+  if (!visibility) return [];
+
+  return Object.entries(state.completedLegendaryWonders ?? {})
+    .flatMap(([wonderId, completion]) => {
+      if (completion.ownerId !== viewerId) return [];
+      const city = state.cities[completion.cityId];
+      if (!city) return [];
+      if (getVisibility(visibility, city.position) !== 'visible') return [];
+      const definition = getLegendaryWonderDefinition(wonderId);
+      return [{
+        wonderId,
+        cityId: city.id,
+        coord: { ...city.position },
+        ownerId: completion.ownerId,
+        relationship: 'owned' as const,
+        turnCompleted: completion.turnCompleted,
+        label: definition?.name ?? 'Legendary wonder',
+        visual: getWonderVisualDefinition(wonderId),
+      }];
+    });
+}

--- a/src/systems/legendary-wonder-presentation.ts
+++ b/src/systems/legendary-wonder-presentation.ts
@@ -5,9 +5,19 @@ import {
   initializeLegendaryWonderProjectsForCity,
 } from '@/systems/legendary-wonder-system';
 import { getTechById } from '@/systems/tech-system';
-
-export const LEGENDARY_WONDER_PRODUCTION_PREFIX = 'legendary:';
-export const LEGENDARY_WONDER_PRODUCTION_ICON = '*';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { getUnrestYieldMultiplier } from '@/systems/faction-system';
+import { getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
+import { getLegendaryWonderQueueItemId } from '@/systems/legendary-wonder-production';
+export {
+  LEGENDARY_WONDER_PRODUCTION_ICON,
+  LEGENDARY_WONDER_PRODUCTION_PREFIX,
+  getLegendaryWonderDisplayName,
+  getLegendaryWonderProductionCost,
+  getLegendaryWonderQueueItemId,
+  getLegendaryWonderQueueItemMetadata,
+  type LegendaryWonderQueueItemMetadata,
+} from '@/systems/legendary-wonder-production';
 
 export type LegendaryWonderVisibleState =
   | 'ready'
@@ -20,12 +30,11 @@ export type LegendaryWonderVisibleState =
 
 export type LegendaryWonderEligibilityState = 'buildable' | 'near' | 'blocked' | 'complete';
 
-export interface LegendaryWonderQueueItemMetadata {
-  icon: string;
-  name: string;
-  productionCost: number;
-  wonderId: string;
-}
+export type LegendaryWonderMilestoneLabel =
+  | 'Foundation laid'
+  | 'Rising'
+  | 'Final works'
+  | 'Nearly complete';
 
 export interface LegendaryWonderPresentationEntry {
   wonderId: string;
@@ -45,14 +54,24 @@ export interface LegendaryWonderPresentationEntry {
   missingRequirements: string[];
   canStartBuild: boolean;
   startActionLabel: string | null;
+  progressPercent: number;
+  turnsRemaining: number | null;
+  milestoneLabel: LegendaryWonderMilestoneLabel | null;
+  queueContinuityLabel: string | null;
+  productionResumedLabel: string | null;
+  recoveryLabel: string | null;
+  raceTensionLabel: string | null;
 }
 
-function isLegendaryQueueItem(itemId: string): boolean {
-  return itemId.startsWith(LEGENDARY_WONDER_PRODUCTION_PREFIX);
-}
-
-function getWonderIdFromQueueItem(itemId: string): string {
-  return itemId.slice(LEGENDARY_WONDER_PRODUCTION_PREFIX.length);
+export function getLegendaryWonderConstructionMilestone(
+  investedProduction: number,
+  productionCost: number,
+): LegendaryWonderMilestoneLabel {
+  const progress = productionCost > 0 ? Math.floor((investedProduction / productionCost) * 100) : 0;
+  if (progress >= 90) return 'Nearly complete';
+  if (progress >= 60) return 'Final works';
+  if (progress >= 25) return 'Rising';
+  return 'Foundation laid';
 }
 
 function titleCaseId(value: string): string {
@@ -210,31 +229,22 @@ function getDefaultQuestSteps(wonderId: string): LegendaryWonderProject['questSt
   })) ?? [];
 }
 
-export function getLegendaryWonderQueueItemId(wonderId: string): string {
-  return `${LEGENDARY_WONDER_PRODUCTION_PREFIX}${wonderId}`;
+function progressPercent(investedProduction: number, productionCost: number): number {
+  if (productionCost <= 0) return 0;
+  return Math.max(0, Math.min(100, Math.floor((investedProduction / productionCost) * 100)));
 }
 
-export function getLegendaryWonderQueueItemMetadata(itemId: string): LegendaryWonderQueueItemMetadata | null {
-  if (!isLegendaryQueueItem(itemId)) {
-    return null;
-  }
-
-  const wonderId = getWonderIdFromQueueItem(itemId);
-  const definition = getLegendaryWonderDefinition(wonderId);
-  return {
-    icon: LEGENDARY_WONDER_PRODUCTION_ICON,
-    name: definition?.name ?? 'Unknown Legendary Wonder',
-    productionCost: definition?.productionCost ?? 0,
-    wonderId,
-  };
+function turnsRemaining(cityProductionPerTurn: number, investedProduction: number, productionCost: number): number | null {
+  if (cityProductionPerTurn <= 0) return null;
+  return Math.max(0, Math.ceil(Math.max(0, productionCost - investedProduction) / cityProductionPerTurn));
 }
 
-export function getLegendaryWonderDisplayName(itemId: string): string | null {
-  return getLegendaryWonderQueueItemMetadata(itemId)?.name ?? null;
-}
-
-export function getLegendaryWonderProductionCost(itemId: string): number | null {
-  return getLegendaryWonderQueueItemMetadata(itemId)?.productionCost ?? null;
+function cityProductionPerTurn(state: GameState, cityId: string): number {
+  const city = state.cities[cityId];
+  if (!city) return 0;
+  const base = calculateProjectedCityYields(state, cityId);
+  const multiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city));
+  return Math.floor(base.production * multiplier);
 }
 
 export function getLegendaryWonderPresentationForCity(
@@ -255,32 +265,62 @@ export function getLegendaryWonderPresentationForCity(
 
   const entries = getLegendaryWonderDefinitions().map(definition => {
     const project = projectByWonder.get(definition.id);
+    const completedHere = seededState.completedLegendaryWonders?.[definition.id]?.ownerId === civId
+      && seededState.completedLegendaryWonders?.[definition.id]?.cityId === cityId;
     const missingRequirements = getMissingRequirements(seededState, civId, cityId, definition.id);
     const canStartBuild = project?.phase === 'ready_to_build'
       && eligibleWonderIds.has(definition.id)
       && missingRequirements.length === 0;
-    const visibleState = getVisibleState(seededState, project, missingRequirements, canStartBuild, definition.era);
+    const visibleState = completedHere
+      ? 'completed'
+      : getVisibleState(seededState, project, missingRequirements, canStartBuild, definition.era);
     const questSteps = project?.questSteps ?? getDefaultQuestSteps(definition.id);
     const questCompleted = questSteps.filter(step => step.completed).length;
+    const city = seededState.cities[cityId];
+    const queueItemId = getLegendaryWonderQueueItemId(definition.id);
+    const isActiveLegendaryBuild = project?.phase === 'building' && city?.productionQueue[0] === queueItemId;
+    const investedProduction = completedHere
+      ? definition.productionCost
+      : isActiveLegendaryBuild
+        ? city.productionProgress
+        : project?.investedProduction ?? 0;
+    const buildingProgress = visibleState === 'building' ? investedProduction : 0;
 
     return {
       wonderId: definition.id,
-      queueItemId: getLegendaryWonderQueueItemId(definition.id),
+      queueItemId,
       name: definition.name,
       era: definition.era,
       productionCost: definition.productionCost,
       rewardSummary: definition.reward.summary,
       visibleState,
       eligibilityState: getEligibilityState(visibleState, canStartBuild),
-      phase: project?.phase ?? 'unseeded',
+      phase: completedHere ? 'completed' : project?.phase ?? 'unseeded',
       questCompleted,
       questTotal: questSteps.length,
       questSteps,
-      investedProduction: project?.investedProduction ?? 0,
+      investedProduction,
       transferableProduction: project?.transferableProduction ?? 0,
       missingRequirements,
       canStartBuild,
       startActionLabel: canStartBuild ? 'Start Construction' : null,
+      progressPercent: progressPercent(investedProduction, definition.productionCost),
+      turnsRemaining: visibleState === 'building'
+        ? turnsRemaining(cityProductionPerTurn(seededState, cityId), buildingProgress, definition.productionCost)
+        : null,
+      milestoneLabel: visibleState === 'building'
+        ? getLegendaryWonderConstructionMilestone(buildingProgress, definition.productionCost)
+        : null,
+      queueContinuityLabel: visibleState === 'building' && (city?.productionQueue.length ?? 0) > 1
+        ? 'Queue resumes after this wonder.'
+        : null,
+      productionResumedLabel: visibleState === 'completed' || visibleState === 'recovered'
+        ? 'Normal production has resumed.'
+        : null,
+      recoveryLabel: visibleState === 'recovered' && (project?.transferableProduction ?? 0) > 0
+        ? `Effort recovered: ${project?.transferableProduction ?? 0} production carryover preserved.`
+        : null,
+      raceTensionLabel: visibleState === 'building' ? 'Construction underway' : null,
     } satisfies LegendaryWonderPresentationEntry;
   });
 

--- a/src/systems/legendary-wonder-production.ts
+++ b/src/systems/legendary-wonder-production.ts
@@ -1,0 +1,46 @@
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+
+export const LEGENDARY_WONDER_PRODUCTION_PREFIX = 'legendary:';
+export const LEGENDARY_WONDER_PRODUCTION_ICON = '*';
+
+export interface LegendaryWonderQueueItemMetadata {
+  icon: string;
+  name: string;
+  productionCost: number;
+  wonderId: string;
+}
+
+export function isLegendaryQueueItem(itemId: string): boolean {
+  return itemId.startsWith(LEGENDARY_WONDER_PRODUCTION_PREFIX);
+}
+
+export function getWonderIdFromQueueItem(itemId: string): string {
+  return itemId.slice(LEGENDARY_WONDER_PRODUCTION_PREFIX.length);
+}
+
+export function getLegendaryWonderQueueItemId(wonderId: string): string {
+  return `${LEGENDARY_WONDER_PRODUCTION_PREFIX}${wonderId}`;
+}
+
+export function getLegendaryWonderQueueItemMetadata(itemId: string): LegendaryWonderQueueItemMetadata | null {
+  if (!isLegendaryQueueItem(itemId)) {
+    return null;
+  }
+
+  const wonderId = getWonderIdFromQueueItem(itemId);
+  const definition = getLegendaryWonderDefinition(wonderId);
+  return {
+    icon: LEGENDARY_WONDER_PRODUCTION_ICON,
+    name: definition?.name ?? 'Unknown Legendary Wonder',
+    productionCost: definition?.productionCost ?? 0,
+    wonderId,
+  };
+}
+
+export function getLegendaryWonderDisplayName(itemId: string): string | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.name ?? null;
+}
+
+export function getLegendaryWonderProductionCost(itemId: string): number | null {
+  return getLegendaryWonderQueueItemMetadata(itemId)?.productionCost ?? null;
+}

--- a/src/systems/legendary-wonder-system.ts
+++ b/src/systems/legendary-wonder-system.ts
@@ -470,6 +470,7 @@ export function tickLegendaryWonderProjects(state: GameState, _bus: EventBus): G
           civId: project.ownerId,
           cityId: project.cityId,
           wonderId: project.wonderId,
+          turnCompleted: state.turn,
         });
         updatedProjects[projectId] = {
           ...project,

--- a/src/systems/wonder-atlas-presentation.ts
+++ b/src/systems/wonder-atlas-presentation.ts
@@ -1,5 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderPresentationForCity } from '@/systems/legendary-wonder-presentation';
 import { formatNaturalWonderEffectSummary } from '@/systems/wonder-presentation-formatting';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
@@ -76,7 +77,11 @@ function getLegendaryStateLabel(
     return 'Legendary wonder';
   }
 
-  if (ownedProject.phase === 'ready_to_build') return 'Available';
+  if (ownedProject.phase === 'ready_to_build') {
+    const cityEntry = getLegendaryWonderPresentationForCity(state, viewerId, ownedProject.cityId)
+      .find(entry => entry.wonderId === wonderId);
+    return cityEntry?.canStartBuild ? 'Available' : 'Legendary wonder';
+  }
   if (ownedProject.phase === 'building') return 'Under construction';
   if (ownedProject.phase === 'completed') return 'Completed';
   if (ownedProject.phase === 'lost_race') return 'Recovered';

--- a/src/systems/wonder-atlas-presentation.ts
+++ b/src/systems/wonder-atlas-presentation.ts
@@ -26,6 +26,7 @@ export interface LegendaryWonderAtlasEntry {
   visibility: 'masked';
   name: string;
   maskedLabel: string;
+  stateLabel: 'Available' | 'Under construction' | 'Completed' | 'Recovered' | 'Legendary wonder';
   canViewOnMap: false;
   visual: WonderVisualDefinition;
 }
@@ -57,7 +58,32 @@ function naturalWonderEntry(state: GameState, wonderId: string): NaturalWonderAt
   };
 }
 
-function legendaryWonderEntry(wonderId: string, name: string): LegendaryWonderAtlasEntry {
+function getLegendaryStateLabel(
+  state: GameState,
+  viewerId: string,
+  wonderId: string,
+): LegendaryWonderAtlasEntry['stateLabel'] {
+  const completion = state.completedLegendaryWonders?.[wonderId];
+  if (completion?.ownerId === viewerId) {
+    return 'Completed';
+  }
+
+  const ownedProject = Object.values(state.legendaryWonderProjects ?? {}).find(project =>
+    project.ownerId === viewerId && project.wonderId === wonderId,
+  );
+  if (!ownedProject) {
+    // Stage 2C has no viewer-scoped completion intel; rival completions stay masked.
+    return 'Legendary wonder';
+  }
+
+  if (ownedProject.phase === 'ready_to_build') return 'Available';
+  if (ownedProject.phase === 'building') return 'Under construction';
+  if (ownedProject.phase === 'completed') return 'Completed';
+  if (ownedProject.phase === 'lost_race') return 'Recovered';
+  return 'Legendary wonder';
+}
+
+function legendaryWonderEntry(state: GameState, viewerId: string, wonderId: string, name: string): LegendaryWonderAtlasEntry {
   const visual = getWonderVisualDefinition(wonderId);
   return {
     kind: 'legendary',
@@ -65,6 +91,7 @@ function legendaryWonderEntry(wonderId: string, name: string): LegendaryWonderAt
     visibility: 'masked',
     name,
     maskedLabel: visual.maskedLabel ?? 'Legendary wonder',
+    stateLabel: getLegendaryStateLabel(state, viewerId, wonderId),
     canViewOnMap: false,
     visual,
   };
@@ -77,7 +104,7 @@ export function getWonderAtlasEntries(state: GameState, viewerId: string): Wonde
     .filter((entry): entry is NaturalWonderAtlasEntry => entry !== null);
 
   const legendaryEntries = getLegendaryWonderDefinitions().map(definition =>
-    legendaryWonderEntry(definition.id, definition.name),
+    legendaryWonderEntry(state, viewerId, definition.id, definition.name),
   );
 
   return [...naturalEntries, ...legendaryEntries];

--- a/src/systems/wonder-visual-catalog.ts
+++ b/src/systems/wonder-visual-catalog.ts
@@ -21,6 +21,7 @@ export type WonderMapLandmark =
   | 'masked';
 
 export type WonderVignette = WonderMapLandmark;
+export type LegendaryWonderLandmark = 'spire' | 'arch' | 'dome' | 'obelisk' | 'citadel' | 'archive' | 'masked';
 
 export interface WonderVisualDefinition {
   id: string;
@@ -36,6 +37,14 @@ export interface WonderVisualDefinition {
   supportsAmbientAnimation: boolean;
   reducedMotionFallback: 'static-landmark' | 'static-medallion';
   maskedLabel?: string;
+  legendaryLandmark?: LegendaryWonderLandmark;
+}
+
+const LEGENDARY_LANDMARK_TYPES = ['spire', 'arch', 'dome', 'obelisk', 'citadel', 'archive'] as const;
+
+function landmarkTypeForLegendaryWonder(wonderId: string): LegendaryWonderLandmark {
+  const hash = [...wonderId].reduce((sum, char) => sum + char.charCodeAt(0), 0);
+  return LEGENDARY_LANDMARK_TYPES[hash % LEGENDARY_LANDMARK_TYPES.length];
 }
 
 const NATURAL_WONDER_VISUALS: Record<string, WonderVisualDefinition> = {
@@ -73,6 +82,7 @@ const LEGENDARY_WONDER_VISUALS: Record<string, WonderVisualDefinition> = Object.
       supportsAmbientAnimation: false,
       reducedMotionFallback: 'static-medallion',
       maskedLabel: 'Legendary wonder',
+      legendaryLandmark: landmarkTypeForLegendaryWonder(definition.id),
     } satisfies WonderVisualDefinition,
   ]),
 );
@@ -90,6 +100,7 @@ const FALLBACK_WONDER_VISUAL: Omit<WonderVisualDefinition, 'id'> = {
   supportsAmbientAnimation: false,
   reducedMotionFallback: 'static-medallion',
   maskedLabel: 'Unknown wonder',
+  legendaryLandmark: 'masked',
 };
 
 const WONDER_VISUAL_CATALOG: Record<string, WonderVisualDefinition> = {

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -8,7 +8,10 @@ import {
   getProductionDisplayName,
   getProductionIconForItem,
 } from '@/systems/city-system';
-import { getCompactLegendaryWonderEntriesForCity } from '@/systems/legendary-wonder-presentation';
+import {
+  getCompactLegendaryWonderEntriesForCity,
+  getLegendaryWonderPresentationForCity,
+} from '@/systems/legendary-wonder-presentation';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
@@ -108,7 +111,11 @@ export function createCityPanel(
     era: state.era,
   });
   const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map.tiles);
+  const cityWonderEntries = getLegendaryWonderPresentationForCity(state, state.currentPlayer, city.id);
   const compactWonderEntries = getCompactLegendaryWonderEntriesForCity(state, state.currentPlayer, city.id, 4);
+  const activeLegendaryEntry = city.productionQueue[0]?.startsWith('legendary:')
+    ? cityWonderEntries.find(entry => entry.queueItemId === city.productionQueue[0]) ?? null
+    : null;
   const cityWonderProject = Object.values(state.legendaryWonderProjects ?? {}).find(project => project.cityId === city.id);
   const economyStatus = calculateCivEconomy(state, city.owner);
   const cityMaintenance = calculateCityBuildingMaintenance(state, city);
@@ -181,6 +188,8 @@ export function createCityPanel(
         <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(entry.queueItemId)} <span data-text="wonder-name-${idx}"></span></div>
         <div style="font-size:11px;color:#e8c170;"><span data-text="wonder-state-${idx}"></span> · ${entry.productionCost} production · ${turns} turns</div>
         <div style="font-size:10px;opacity:0.65;" data-text="wonder-summary-${idx}"></div>
+        <div style="font-size:10px;opacity:0.72;" data-text="wonder-recovery-${idx}"></div>
+        <div style="font-size:10px;opacity:0.72;" data-text="wonder-resumed-${idx}"></div>
       </div>
     `;
   }
@@ -233,6 +242,15 @@ export function createCityPanel(
         <div style="background:rgba(0,0,0,0.3);border-radius:4px;height:8px;margin-top:8px;">
           <div style="background:#6b9b4b;border-radius:4px;height:8px;width:${progress}%;"></div>
         </div>
+        ${activeLegendaryEntry ? `
+          <div data-active-legendary="true" style="margin-top:10px;border-top:1px solid rgba(232,193,112,0.22);padding-top:10px;">
+            <div style="font-size:12px;color:#e8c170;" data-text="legendary-milestone"></div>
+            <div style="font-size:12px;opacity:0.82;" data-text="legendary-reward-teaser"></div>
+            <div style="font-size:12px;opacity:0.82;" data-text="legendary-race-tension"></div>
+            <div style="font-size:12px;opacity:0.82;" data-text="legendary-queue-continuity"></div>
+            <button type="button" data-open-active-wonder-journal="true" style="min-height:44px;margin-top:8px;padding:7px 10px;background:rgba(232,193,112,0.16);border:1px solid rgba(232,193,112,0.45);border-radius:6px;color:#f0d897;cursor:pointer;font-size:12px;">Open Journal</button>
+          </div>
+        ` : ''}
         <div style="display:flex;align-items:center;gap:8px;margin-top:10px;flex-wrap:wrap;">
           <button type="button" data-rush-buy="active" ${rushDisabledAttr} title="" style="min-height:44px;padding:7px 10px;border-radius:6px;font-size:12px;font-weight:bold;${rushButtonStyle}">${rushBuyLabel}</button>
           ${rushBuyReason ? '<span style="font-size:11px;color:#d9a25c;" data-text="rush-reason"></span>' : ''}
@@ -371,6 +389,12 @@ export function createCityPanel(
     if (rushBuyReason) {
       setText('rush-reason', rushBuyReason);
     }
+    if (activeLegendaryEntry) {
+      setText('legendary-milestone', activeLegendaryEntry.milestoneLabel ?? '');
+      setText('legendary-reward-teaser', `Reward: ${activeLegendaryEntry.rewardSummary}`);
+      setText('legendary-race-tension', activeLegendaryEntry.raceTensionLabel ?? 'Construction underway');
+      setText('legendary-queue-continuity', activeLegendaryEntry.queueContinuityLabel ?? '');
+    }
     const rushButton = panel.querySelector<HTMLElement>('[data-rush-buy]');
     if (rushButton && rushBuyReason) rushButton.title = rushBuyReason;
   }
@@ -418,6 +442,8 @@ export function createCityPanel(
       : missing
         ? `Needs ${missing}.`
         : entry.rewardSummary);
+    setText(`wonder-recovery-${index}`, entry.recoveryLabel ?? '');
+    setText(`wonder-resumed-${index}`, entry.productionResumedLabel ?? '');
   });
 
   container.appendChild(panel);
@@ -469,6 +495,11 @@ export function createCityPanel(
   });
 
   panel.querySelector<HTMLElement>('[data-open-wonder-panel]')?.addEventListener('click', () => {
+    callbacks.onOpenWonderPanel(city.id);
+    panel.remove();
+  });
+
+  panel.querySelector<HTMLElement>('[data-open-active-wonder-journal]')?.addEventListener('click', () => {
     callbacks.onOpenWonderPanel(city.id);
     panel.remove();
   });

--- a/src/ui/legendary-wonder-completion-ceremony.ts
+++ b/src/ui/legendary-wonder-completion-ceremony.ts
@@ -1,0 +1,116 @@
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { createGameButton } from '@/ui/ui-kit';
+import { createWonderVisualVignette } from '@/ui/wonder-vignette';
+
+export type LegendaryWonderCompletionCeremonyAction = 'continue' | 'skip' | 'open-city' | 'open-journal';
+
+export interface LegendaryWonderCompletionCeremonyCallbacks {
+  onResolve: (action: LegendaryWonderCompletionCeremonyAction) => void;
+}
+
+export interface LegendaryWonderCompletionCeremonyOptions {
+  reducedMotion?: boolean;
+}
+
+function appendText(parent: HTMLElement, tag: keyof HTMLElementTagNameMap, text: string, style: string): HTMLElement {
+  const element = document.createElement(tag);
+  element.textContent = text;
+  element.style.cssText = style;
+  parent.appendChild(element);
+  return element;
+}
+
+export function createLegendaryWonderCompletionCeremony(
+  container: HTMLElement,
+  item: LegendaryWonderCompletionCeremonyItem,
+  callbacks: LegendaryWonderCompletionCeremonyCallbacks,
+  options: LegendaryWonderCompletionCeremonyOptions = {},
+): HTMLElement {
+  container.querySelector('#legendary-wonder-completion-ceremony')?.remove();
+  const reducedMotion = options.reducedMotion ?? false;
+  let resolved = false;
+
+  const overlay = document.createElement('section');
+  overlay.id = 'legendary-wonder-completion-ceremony';
+  overlay.tabIndex = -1;
+  overlay.dataset.legendaryCompletionMotion = reducedMotion ? 'static' : 'animated';
+  overlay.style.cssText = [
+    'position:absolute',
+    'inset:0',
+    'z-index:82',
+    'background:rgba(4,7,13,0.8)',
+    'color:#f8f1df',
+    'display:grid',
+    'place-items:center',
+    'padding:18px',
+    'pointer-events:auto',
+  ].join(';');
+
+  const panel = document.createElement('div');
+  panel.style.cssText = [
+    'width:min(560px,calc(100vw - 28px))',
+    'border:1px solid rgba(232,193,112,0.46)',
+    'border-radius:8px',
+    `background:linear-gradient(180deg,rgba(20,24,32,0.98),${item.visual.palette.base})`,
+    'box-shadow:0 22px 70px rgba(0,0,0,0.62)',
+    'padding:22px',
+    'display:flex',
+    'flex-direction:column',
+    'align-items:center',
+    'gap:14px',
+    'text-align:center',
+  ].join(';');
+
+  const skipRow = document.createElement('div');
+  skipRow.style.cssText = 'display:flex;justify-content:flex-end;width:100%;';
+  const skip = createGameButton('Skip', 'ghost');
+  skip.dataset.legendaryCompletionAction = 'skip';
+  skipRow.appendChild(skip);
+
+  const vignette = createWonderVisualVignette(item.name, item.visual, { reducedMotion, kind: 'legendary' });
+  vignette.style.width = '148px';
+  vignette.style.height = '148px';
+  vignette.style.flexBasis = '148px';
+
+  const facts = document.createElement('div');
+  facts.style.cssText = 'display:grid;grid-template-columns:1fr;gap:8px;width:100%;text-align:left;';
+  appendText(facts, 'p', item.rewardSummary, 'margin:0;padding:10px;border-radius:8px;background:rgba(232,193,112,0.12);font-size:13px;line-height:1.35;color:#ffe2a1;');
+  appendText(facts, 'p', item.rewardActiveLabel, 'margin:0;padding:10px;border-radius:8px;background:rgba(255,255,255,0.07);font-size:13px;line-height:1.35;');
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;gap:10px;justify-content:center;flex-wrap:wrap;width:100%;';
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.dataset.legendaryCompletionAction = 'continue';
+  const cityButton = createGameButton('Open City', 'secondary');
+  cityButton.dataset.legendaryCompletionAction = 'open-city';
+  const journalButton = createGameButton('Open Journal', 'secondary');
+  journalButton.dataset.legendaryCompletionAction = 'open-journal';
+  actions.append(continueButton, cityButton, journalButton);
+
+  function resolve(action: LegendaryWonderCompletionCeremonyAction): void {
+    if (resolved) return;
+    resolved = true;
+    overlay.remove();
+    callbacks.onResolve(action);
+  }
+
+  skip.addEventListener('click', () => resolve('skip'));
+  continueButton.addEventListener('click', () => resolve('continue'));
+  cityButton.addEventListener('click', () => resolve('open-city'));
+  journalButton.addEventListener('click', () => resolve('open-journal'));
+  overlay.addEventListener('keydown', event => {
+    if (event.key === 'Escape') resolve('skip');
+  });
+
+  panel.append(skipRow, vignette);
+  appendText(panel, 'p', item.title, 'margin:0;color:#e8c170;font-size:12px;letter-spacing:0;text-transform:uppercase;font-weight:700;');
+  appendText(panel, 'h2', item.name, 'margin:0;font-size:32px;line-height:1.05;letter-spacing:0;');
+  appendText(panel, 'p', item.cityName, 'margin:0;color:#f0d897;font-size:14px;line-height:1.35;');
+  appendText(panel, 'p', item.achievementLine, 'margin:0;font-size:15px;line-height:1.45;max-width:46ch;');
+  panel.append(facts, actions);
+  overlay.appendChild(panel);
+  container.appendChild(overlay);
+  overlay.focus();
+
+  return overlay;
+}

--- a/src/ui/legendary-wonder-completion-queue.ts
+++ b/src/ui/legendary-wonder-completion-queue.ts
@@ -1,0 +1,96 @@
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import {
+  createLegendaryWonderCompletionCeremony,
+  type LegendaryWonderCompletionCeremonyAction,
+} from '@/ui/legendary-wonder-completion-ceremony';
+
+export interface LegendaryWonderCompletionQueueOptions {
+  container: HTMLElement;
+  isInteractionBlocked: () => boolean;
+  reducedMotion: () => boolean;
+  openCity: (cityId: string) => void;
+  openJournal: (cityId: string, wonderId: string) => void;
+  present?: (item: LegendaryWonderCompletionCeremonyItem) => Promise<LegendaryWonderCompletionCeremonyAction>;
+  setBlockingOverlay?: (id: string | null) => void;
+}
+
+export interface LegendaryWonderCompletionQueue {
+  enqueue(item: LegendaryWonderCompletionCeremonyItem | null): void;
+  notifyActionSettled(): void;
+  pump(): void;
+  pendingCount(): number;
+}
+
+function keyFor(item: LegendaryWonderCompletionCeremonyItem): string {
+  return `${item.civId}:${item.wonderId}:${item.turnCompleted}`;
+}
+
+export function createLegendaryWonderCompletionQueue(
+  options: LegendaryWonderCompletionQueueOptions,
+): LegendaryWonderCompletionQueue {
+  const pending: LegendaryWonderCompletionCeremonyItem[] = [];
+  const seen = new Set<string>();
+  let presenting = false;
+  let actionSettled = false;
+
+  const present = options.present ?? ((item: LegendaryWonderCompletionCeremonyItem) => new Promise<LegendaryWonderCompletionCeremonyAction>(resolve => {
+    createLegendaryWonderCompletionCeremony(
+      options.container,
+      item,
+      { onResolve: resolve },
+      { reducedMotion: options.reducedMotion() },
+    );
+  }));
+
+  async function play(item: LegendaryWonderCompletionCeremonyItem): Promise<void> {
+    presenting = true;
+    options.setBlockingOverlay?.('legendary-wonder-completion-ceremony');
+    let action: LegendaryWonderCompletionCeremonyAction = 'continue';
+
+    try {
+      action = await present(item);
+    } catch {
+      action = 'continue';
+    } finally {
+      options.setBlockingOverlay?.(null);
+    }
+
+    if (action === 'open-city') {
+      options.openCity(item.cityId);
+    } else if (action === 'open-journal') {
+      options.openJournal(item.cityId, item.wonderId);
+    }
+
+    presenting = false;
+    pump();
+  }
+
+  function pump(): void {
+    if (!actionSettled || presenting || options.isInteractionBlocked()) return;
+    const next = pending.shift();
+    if (!next) return;
+    void play(next);
+  }
+
+  return {
+    enqueue(item) {
+      if (!item) return;
+      const key = keyFor(item);
+      if (seen.has(key)) return;
+      seen.add(key);
+      if (!presenting && pending.length === 0) {
+        actionSettled = false;
+      }
+      pending.push(item);
+      pump();
+    },
+    notifyActionSettled() {
+      actionSettled = true;
+      pump();
+    },
+    pump,
+    pendingCount() {
+      return pending.length;
+    },
+  };
+}

--- a/src/ui/legendary-wonder-notifications.ts
+++ b/src/ui/legendary-wonder-notifications.ts
@@ -5,7 +5,7 @@ import { hasMetCivilization } from '@/systems/discovery-system';
 
 type LegendaryWonderNotificationEvent =
   | { type: 'wonder:legendary-ready'; civId: string; cityId: string; wonderId: string }
-  | { type: 'wonder:legendary-completed'; civId: string; cityId: string; wonderId: string }
+  | { type: 'wonder:legendary-completed'; civId: string; cityId: string; wonderId: string; turnCompleted: number }
   | { type: 'wonder:legendary-lost'; civId: string; cityId: string; wonderId: string; goldRefund: number; transferableProduction: number }
   | { type: 'wonder:legendary-race-revealed'; observerId: string; civId: string; cityId: string; wonderId: string };
 

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -259,7 +259,7 @@ export function routeCombatRewardEarned(
 
 type LegendaryWonderRoutingEvent =
   | { type: 'wonder:legendary-ready'; civId: string; cityId: string; wonderId: string }
-  | { type: 'wonder:legendary-completed'; civId: string; cityId: string; wonderId: string }
+  | { type: 'wonder:legendary-completed'; civId: string; cityId: string; wonderId: string; turnCompleted: number }
   | { type: 'wonder:legendary-lost'; civId: string; cityId: string; wonderId: string; goldRefund: number; transferableProduction: number }
   | { type: 'wonder:legendary-race-revealed'; observerId: string; civId: string; cityId: string; wonderId: string };
 

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -4,6 +4,7 @@ import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { TERRITORY_PRESSURE_BALANCE } from '@/systems/city-territory-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
 import { createGameButton } from '@/ui/ui-kit';
 import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
@@ -113,6 +114,14 @@ export function createTerritoryInspectionPanel(
 
   const owner = tile.owner ? state.civilizations[tile.owner] : undefined;
   addLine(panel, 'Owner', owner?.name ?? tile.owner ?? 'Unclaimed');
+
+  const cityAtCoord = Object.values(state.cities).find(candidate => hexKey(candidate.position) === key);
+  const completedInCity = Object.entries(state.completedLegendaryWonders ?? {})
+    .filter(([, completion]) => completion.ownerId === viewerId && completion.cityId === cityAtCoord?.id)
+    .map(([wonderId]) => getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder');
+  if (completedInCity.length > 0) {
+    addLine(panel, 'Completed legendary wonders', completedInCity.join(', '));
+  }
 
   const frontier = state.territoryFrontiers?.[key];
   if (frontier) {

--- a/src/ui/wonder-atlas-panel.ts
+++ b/src/ui/wonder-atlas-panel.ts
@@ -45,7 +45,7 @@ function createEntryButton(entry: WonderAtlasEntry, selected: boolean): HTMLButt
 
   const copy = document.createElement('span');
   const title = document.createElement('strong');
-  title.textContent = entry.kind === 'legendary' ? entry.maskedLabel : entry.name;
+  title.textContent = entry.kind === 'legendary' ? entry.stateLabel : entry.name;
   title.style.cssText = 'display:block;font-size:13px;';
   copy.appendChild(title);
 
@@ -182,7 +182,7 @@ export function createWonderAtlasPanel(
         copy.appendChild(view);
       }
     } else {
-      appendText(copy, 'p', entry.maskedLabel, 'margin:0;font-size:12px;color:#e8c170;');
+      appendText(copy, 'p', entry.stateLabel, 'margin:0;font-size:12px;color:#e8c170;');
       appendText(copy, 'p', 'A legendary ambition recorded for future construction and completion presence.', 'margin:0;font-size:13px;line-height:1.45;opacity:0.78;');
     }
 

--- a/src/ui/wonder-panel.ts
+++ b/src/ui/wonder-panel.ts
@@ -66,6 +66,12 @@ function appendProjectCard(
   }
 
   appendText(article, 'p', `Reward: ${entry.rewardSummary}`);
+  if (entry.milestoneLabel) appendText(article, 'p', `Construction: ${entry.milestoneLabel}.`);
+  if (entry.turnsRemaining !== null) appendText(article, 'p', `${entry.turnsRemaining} turns remaining.`);
+  if (entry.raceTensionLabel) appendText(article, 'p', entry.raceTensionLabel);
+  if (entry.productionResumedLabel) appendText(article, 'p', entry.productionResumedLabel);
+  if (entry.visibleState === 'completed') appendText(article, 'p', 'Reward active.');
+  if (entry.recoveryLabel) appendText(article, 'p', entry.recoveryLabel);
 
   if (entry.visibleState === 'building') {
     appendText(article, 'p', `Race status: ${entry.investedProduction}/${entry.productionCost} production invested.`);

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -648,7 +648,7 @@ describe('processTurn', () => {
   it('emits a legendary-completed event when a wonder finishes during turn processing', () => {
     const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2 });
     const bus = new EventBus();
-    const completedEvents: Array<{ civId: string; cityId: string; wonderId: string }> = [];
+    const completedEvents: Array<{ civId: string; cityId: string; wonderId: string; turnCompleted: number }> = [];
     const oracle = getLegendaryWonderDefinition('oracle-of-delphi');
 
     bus.on('wonder:legendary-completed', event => completedEvents.push(event));
@@ -659,7 +659,7 @@ describe('processTurn', () => {
     processTurn(state, bus);
 
     expect(completedEvents).toEqual([
-      { civId: 'player', cityId: 'city-river', wonderId: 'oracle-of-delphi' },
+      { civId: 'player', cityId: 'city-river', wonderId: 'oracle-of-delphi', turnCompleted: 40 },
     ]);
   });
 

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -9,6 +9,7 @@ import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
 class MockCanvasContext {
+  operations: string[] = [];
   fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
   fillStyle = '';
   strokeStyle = '';
@@ -17,12 +18,19 @@ class MockCanvasContext {
   textAlign: CanvasTextAlign = 'start';
   textBaseline: CanvasTextBaseline = 'alphabetic';
 
-  beginPath(): void {}
-  arc(): void {}
-  fill(): void {}
-  stroke(): void {}
+  save(): void { this.operations.push('save'); }
+  restore(): void { this.operations.push('restore'); }
+  beginPath(): void { this.operations.push('beginPath'); }
+  arc(): void { this.operations.push('arc'); }
+  rect(): void { this.operations.push('rect'); }
+  moveTo(): void { this.operations.push('moveTo'); }
+  lineTo(): void { this.operations.push('lineTo'); }
+  closePath(): void { this.operations.push('closePath'); }
+  fill(): void { this.operations.push(`fill:${this.fillStyle}`); }
+  stroke(): void { this.operations.push(`stroke:${this.strokeStyle}`); }
   fillText(text: string, x: number, y: number): void {
     this.fillTextCalls.push({ text, x, y });
+    this.operations.push(`text:${text}`);
   }
 }
 
@@ -417,5 +425,22 @@ describe('drawCities — top-left idle badge', () => {
     const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(c => c.text);
     expect(texts).not.toContain('💰');
     expect(texts).not.toContain('🔬');
+  });
+
+  it('draws completed legendary landmarks for visible owned host cities', () => {
+    const state = createNewGame(undefined, 'legendary-city-render-test');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 20 },
+    };
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player');
+
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('save');
   });
 });

--- a/tests/renderer/legendary-wonder-renderer.test.ts
+++ b/tests/renderer/legendary-wonder-renderer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { drawLegendaryWonderLandmarks } from '@/renderer/wonders/legendary-wonder-renderer';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+
+class MockCanvasContext {
+  operations: string[] = [];
+  fillStyle = '';
+  strokeStyle = '';
+  lineWidth = 0;
+  font = '';
+  textAlign: CanvasTextAlign = 'start';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+
+  save(): void { this.operations.push('save'); }
+  restore(): void { this.operations.push('restore'); }
+  beginPath(): void { this.operations.push('beginPath'); }
+  arc(): void { this.operations.push('arc'); }
+  rect(): void { this.operations.push('rect'); }
+  moveTo(): void { this.operations.push('moveTo'); }
+  lineTo(): void { this.operations.push('lineTo'); }
+  closePath(): void { this.operations.push('closePath'); }
+  fill(): void { this.operations.push(`fill:${this.fillStyle}`); }
+  stroke(): void { this.operations.push(`stroke:${this.strokeStyle}`); }
+  fillText(text: string): void { this.operations.push(`text:${text}`); }
+}
+
+describe('legendary-wonder-renderer', () => {
+  it('draws completed legendary landmarks with canvas primitives', () => {
+    const ctx = new MockCanvasContext();
+
+    drawLegendaryWonderLandmarks({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 80,
+      cy: 80,
+      size: 48,
+      reducedMotion: false,
+      lowZoom: false,
+      entries: [
+        { wonderId: 'oracle-of-delphi', label: 'Oracle of Delphi', turnCompleted: 20, visual: getWonderVisualDefinition('oracle-of-delphi') },
+      ],
+    });
+
+    expect(ctx.operations).toContain('save');
+    expect(ctx.operations).toContain('restore');
+    expect(ctx.operations.some(operation => operation.startsWith('fill:'))).toBe(true);
+    expect(ctx.operations).not.toContain('text:✦');
+  });
+
+  it('draws an overflow medallion when many wonders share a city', () => {
+    const ctx = new MockCanvasContext();
+
+    drawLegendaryWonderLandmarks({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 80,
+      cy: 80,
+      size: 48,
+      reducedMotion: true,
+      lowZoom: true,
+      entries: ['a', 'b', 'c', 'd', 'e', 'f', 'g'].map((wonderId, index) => ({
+        wonderId,
+        label: wonderId,
+        turnCompleted: index + 1,
+        visual: getWonderVisualDefinition('oracle-of-delphi'),
+      })),
+    });
+
+    expect(ctx.operations).toContain('text:+2');
+  });
+});

--- a/tests/renderer/legendary-wonder-slots.test.ts
+++ b/tests/renderer/legendary-wonder-slots.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
+
+describe('legendary-wonder-slots', () => {
+  it('assigns stable slots sorted by turnCompleted then wonderId', () => {
+    const slots = assignLegendaryWonderSlots([
+      { wonderId: 'sun-spire', turnCompleted: 12 },
+      { wonderId: 'oracle-of-delphi', turnCompleted: 10 },
+      { wonderId: 'grand-canal', turnCompleted: 10 },
+    ]);
+
+    expect(slots.map(slot => slot.kind === 'landmark' ? slot.wonderId : 'overflow')).toEqual([
+      'grand-canal',
+      'oracle-of-delphi',
+      'sun-spire',
+    ]);
+    expect(slots.map(slot => slot.slotIndex)).toEqual([0, 1, 2]);
+  });
+
+  it('uses first five plus overflow when more than six wonders are visible', () => {
+    const slots = assignLegendaryWonderSlots([
+      'a', 'b', 'c', 'd', 'e', 'f', 'g',
+    ].map((wonderId, index) => ({ wonderId, turnCompleted: index + 1 })));
+
+    expect(slots).toHaveLength(6);
+    expect(slots[5]).toMatchObject({ kind: 'overflow', overflowCount: 2 });
+  });
+});

--- a/tests/systems/legendary-wonder-completion-presentation.test.ts
+++ b/tests/systems/legendary-wonder-completion-presentation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-completion-presentation', () => {
+  it('builds owner-safe ceremony items from event payloads', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'player';
+
+    const item = buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+    });
+
+    expect(item).toMatchObject({
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+      title: 'Legendary Wonder Completed',
+      name: 'Oracle of Delphi',
+      cityName: 'city-river',
+      rewardActiveLabel: 'Reward active',
+    });
+  });
+
+  it('returns null for wrong-viewer and unknown-wonder events', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'ai-1';
+
+    expect(buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+      turnCompleted: 42,
+    })).toBeNull();
+
+    state.currentPlayer = 'player';
+    expect(buildLegendaryWonderCompletionCeremonyItem(state, {
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'missing-wonder',
+      turnCompleted: 42,
+    })).toBeNull();
+  });
+});

--- a/tests/systems/legendary-wonder-map-presentation.test.ts
+++ b/tests/systems/legendary-wonder-map-presentation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { getLegendaryWonderMapEntries } from '@/systems/legendary-wonder-map-presentation';
+import { hexKey } from '@/systems/hex-utils';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-map-presentation', () => {
+  it('returns owner-safe completed landmark entries for visible owned host cities', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'player';
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 20 },
+    };
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+
+    const entries = getLegendaryWonderMapEntries(state, 'player');
+
+    expect(entries).toEqual([
+      expect.objectContaining({
+        wonderId: 'oracle-of-delphi',
+        cityId: 'city-river',
+        coord: state.cities['city-river'].position,
+        turnCompleted: 20,
+      }),
+    ]);
+  });
+
+  it('does not expose rival completed landmarks without earned visibility', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'ai-1', cityId: 'rival-city', turnCompleted: 20 },
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
+  });
+});

--- a/tests/systems/legendary-wonder-presentation.test.ts
+++ b/tests/systems/legendary-wonder-presentation.test.ts
@@ -102,4 +102,65 @@ describe('legendary-wonder-presentation', () => {
       wonderId: 'unknown',
     });
   });
+
+  it('derives legendary construction milestones, ETA, and queue continuity without mutating state', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages'],
+      resources: ['stone'],
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi', 'library'];
+    state.cities['city-river'].productionProgress = 72;
+    state.cities['city-river'].focus = 'production';
+    const before = structuredClone(state.legendaryWonderProjects);
+
+    const oracle = getLegendaryWonderPresentationForCity(state, 'player', 'city-river')
+      .find(entry => entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({
+      visibleState: 'building',
+      progressPercent: 60,
+      milestoneLabel: 'Final works',
+      queueContinuityLabel: 'Queue resumes after this wonder.',
+      raceTensionLabel: 'Construction underway',
+    });
+    expect(oracle?.turnsRemaining).toBeGreaterThan(0);
+    expect(state.legendaryWonderProjects).toEqual(before);
+  });
+
+  it('derives recovery and completed production-resumed copy', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+    state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 50 },
+    };
+
+    const entries = getLegendaryWonderPresentationForCity(state, 'player', 'city-river');
+    expect(entries.find(entry => entry.wonderId === 'grand-canal')).toMatchObject({
+      visibleState: 'recovered',
+      recoveryLabel: 'Effort recovered: 24 production carryover preserved.',
+      productionResumedLabel: 'Normal production has resumed.',
+    });
+    expect(entries.find(entry => entry.wonderId === 'oracle-of-delphi')).toMatchObject({
+      visibleState: 'completed',
+      productionResumedLabel: 'Normal production has resumed.',
+    });
+  });
+
+  it('does not label no-intel builds as safe or uncontested', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['architecture-arts', 'theology-tech'],
+      resources: ['stone'],
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+    state.cities['city-river'].productionProgress = 10;
+
+    const oracle = getLegendaryWonderPresentationForCity(state, 'player', 'city-river')
+      .find(entry => entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle?.raceTensionLabel).toBe('Construction underway');
+    expect(oracle?.raceTensionLabel).not.toMatch(/uncontested/i);
+  });
 });

--- a/tests/systems/legendary-wonder-system.test.ts
+++ b/tests/systems/legendary-wonder-system.test.ts
@@ -178,6 +178,27 @@ describe('legendary-wonder-system', () => {
     ]);
   });
 
+  it('emits the completion turn in legendary completion events', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages', 'city-planning', 'printing'],
+      resources: ['stone'],
+      oracleStepsCompleted: 2,
+    });
+    state.turn = 41;
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+    state.cities['city-river'].productionProgress = 120;
+    const events: Array<{ civId: string; cityId: string; wonderId: string; turnCompleted: number }> = [];
+    const bus = new EventBus();
+    bus.on('wonder:legendary-completed', event => events.push(event));
+
+    tickLegendaryWonderProjects(state, bus);
+
+    expect(events).toEqual([
+      { civId: 'player', cityId: 'city-river', wonderId: 'oracle-of-delphi', turnCompleted: 41 },
+    ]);
+  });
+
   it('moves a ready project into the building phase when construction starts', () => {
     const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
     state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';

--- a/tests/systems/wonder-atlas-presentation.test.ts
+++ b/tests/systems/wonder-atlas-presentation.test.ts
@@ -4,6 +4,7 @@ import type { GameState } from '@/core/types';
 import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
 import { hexKey } from '@/systems/hex-utils';
 import { getWonderAtlasEntries } from '@/systems/wonder-atlas-presentation';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
 
 function makeAtlasState(): GameState {
   const state = createNewGame(undefined, 'wonder-atlas-presentation-test');
@@ -125,6 +126,16 @@ describe('wonder-atlas-presentation', () => {
       .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
 
     expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Under construction' });
+  });
+
+  it('does not label blocked ready-to-build legendary projects as available', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+
+    const oracle = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Legendary wonder' });
   });
 
   it('does not leak rival legendary progress through Atlas labels', () => {

--- a/tests/systems/wonder-atlas-presentation.test.ts
+++ b/tests/systems/wonder-atlas-presentation.test.ts
@@ -106,4 +106,46 @@ describe('wonder-atlas-presentation', () => {
     });
     expect('canStartBuild' in legendaryEntries[0]).toBe(false);
   });
+
+  it('derives minimal safe legendary state labels for owned entries', () => {
+    const state = makeAtlasState();
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:player:city-river': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'city-river',
+        phase: 'building',
+        investedProduction: 40,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    const oracle = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Under construction' });
+  });
+
+  it('does not leak rival legendary progress through Atlas labels', () => {
+    const state = makeAtlasState();
+    state.legendaryWonderProjects = {
+      'oracle-rival': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'ai-1',
+        cityId: 'rival-city',
+        phase: 'building',
+        investedProduction: 90,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    const oracle = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({ kind: 'legendary', stateLabel: 'Legendary wonder' });
+    expect(JSON.stringify(oracle)).not.toContain('rival-city');
+    expect(JSON.stringify(oracle)).not.toContain('90');
+  });
 });

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -94,6 +94,44 @@ describe('city-panel legendary wonders', () => {
     expect(rendered).toContain('Starts in');
     expect(rendered).not.toContain('legendary:oracle-of-delphi');
   });
+
+  it('shows active legendary construction as a compact living production row', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+    city.productionQueue = ['legendary:oracle-of-delphi', 'library'];
+    city.productionProgress = 72;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const text = collectText(panel);
+
+    expect(text).toContain('Producing: * Oracle of Delphi');
+    expect(text).toContain('Final works');
+    expect(text).toContain('Queue resumes after this wonder.');
+    expect(text).toContain('Construction underway');
+    expect(text).toContain('Open Journal');
+    expect(text).not.toContain('legendary:oracle-of-delphi');
+  });
+
+  it('shows recovered legendary effort and production resume copy in the city flow', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['grand-canal'].phase = 'lost_race';
+    state.legendaryWonderProjects!['grand-canal'].transferableProduction = 24;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+    const text = collectText(panel);
+
+    expect(text).toContain('Effort recovered');
+    expect(text).toContain('24 production carryover preserved');
+    expect(text).toContain('Normal production has resumed.');
+  });
 });
 
 describe('city-panel navigation', () => {

--- a/tests/ui/legendary-wonder-completion-ceremony.test.ts
+++ b/tests/ui/legendary-wonder-completion-ceremony.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import { createLegendaryWonderCompletionCeremony } from '@/ui/legendary-wonder-completion-ceremony';
+
+function item(): LegendaryWonderCompletionCeremonyItem {
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: 'player',
+    cityId: 'city-river',
+    wonderId: 'oracle-of-delphi',
+    turnCompleted: 42,
+    name: 'Oracle of Delphi',
+    cityName: 'city-river',
+    achievementLine: 'city-river has completed a work that will shape its legacy.',
+    rewardSummary: '+20% science in this city',
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition('oracle-of-delphi'),
+  };
+}
+
+describe('legendary-wonder-completion-ceremony', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders completion copy and actions', () => {
+    createLegendaryWonderCompletionCeremony(document.body, item(), { onResolve: () => {} }, { reducedMotion: false });
+
+    expect(document.body.textContent).toContain('Legendary Wonder Completed');
+    expect(document.body.textContent).toContain('Oracle of Delphi');
+    expect(document.body.textContent).toContain('city-river');
+    expect(document.body.textContent).toContain('Reward active');
+    expect(document.querySelector('[data-legendary-completion-action="continue"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="open-city"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="open-journal"]')).toBeTruthy();
+    expect(document.querySelector('[data-legendary-completion-action="skip"]')).toBeTruthy();
+  });
+
+  it('resolves exactly once for repeated clicks', () => {
+    const onResolve = vi.fn();
+    createLegendaryWonderCompletionCeremony(document.body, item(), { onResolve }, { reducedMotion: false });
+    const continueButton = document.querySelector('[data-legendary-completion-action="continue"]')!;
+    const skipButton = document.querySelector('[data-legendary-completion-action="skip"]')!;
+
+    continueButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    skipButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith('continue');
+    expect(document.querySelector('#legendary-wonder-completion-ceremony')).toBeNull();
+  });
+});

--- a/tests/ui/legendary-wonder-completion-queue.test.ts
+++ b/tests/ui/legendary-wonder-completion-queue.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import type { LegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
+import type { LegendaryWonderCompletionCeremonyAction } from '@/ui/legendary-wonder-completion-ceremony';
+import { createLegendaryWonderCompletionQueue } from '@/ui/legendary-wonder-completion-queue';
+
+function item(overrides: Partial<LegendaryWonderCompletionCeremonyItem> = {}): LegendaryWonderCompletionCeremonyItem {
+  return {
+    title: 'Legendary Wonder Completed',
+    civId: 'player',
+    cityId: 'city-river',
+    wonderId: 'oracle-of-delphi',
+    turnCompleted: 42,
+    name: 'Oracle of Delphi',
+    cityName: 'city-river',
+    achievementLine: 'city-river has completed a work that will shape its legacy.',
+    rewardSummary: '+60 research immediately',
+    rewardActiveLabel: 'Reward active',
+    visual: getWonderVisualDefinition('oracle-of-delphi'),
+    ...overrides,
+  };
+}
+
+describe('legendary-wonder-completion-queue', () => {
+  it('waits for action settlement and blocking UI before presenting', () => {
+    let blocked = true;
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => blocked,
+      reducedMotion: () => false,
+      openCity: vi.fn(),
+      openJournal: vi.fn(),
+      present,
+    });
+
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+    expect(present).not.toHaveBeenCalled();
+
+    blocked = false;
+    queue.pump();
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens city or journal after the ceremony resolves', async () => {
+    const calls: string[] = [];
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      reducedMotion: () => false,
+      openCity: cityId => calls.push(`city:${cityId}`),
+      openJournal: (cityId, wonderId) => calls.push(`journal:${cityId}:${wonderId}`),
+      present: () => Promise.resolve('open-journal'),
+    });
+
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(calls).toEqual(['journal:city-river:oracle-of-delphi']);
+
+    const cityQueue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      reducedMotion: () => false,
+      openCity: cityId => calls.push(`city:${cityId}`),
+      openJournal: vi.fn(),
+      present: () => Promise.resolve('open-city'),
+    });
+    cityQueue.enqueue(item({ turnCompleted: 43 }));
+    cityQueue.notifyActionSettled();
+    await Promise.resolve();
+
+    expect(calls).toContain('city:city-river');
+  });
+
+  it('does not present wrong-viewer items represented by null presentation output', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as const));
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      reducedMotion: () => false,
+      openCity: vi.fn(),
+      openJournal: vi.fn(),
+      present,
+    });
+
+    queue.enqueue(null);
+    queue.notifyActionSettled();
+
+    expect(present).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates repeat enqueue for the same civ/wonder/turn', () => {
+    const present = vi.fn(() => Promise.resolve('continue' as LegendaryWonderCompletionCeremonyAction));
+    const queue = createLegendaryWonderCompletionQueue({
+      container: document.body,
+      isInteractionBlocked: () => false,
+      reducedMotion: () => false,
+      openCity: vi.fn(),
+      openJournal: vi.fn(),
+      present,
+    });
+
+    queue.enqueue(item());
+    queue.enqueue(item());
+    queue.notifyActionSettled();
+
+    expect(queue.pendingCount()).toBe(0);
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ui/legendary-wonder-notifications.test.ts
+++ b/tests/ui/legendary-wonder-notifications.test.ts
@@ -64,12 +64,14 @@ describe('legendary-wonder-notifications', () => {
       civId: 'player',
       cityId: 'city-river',
       wonderId: 'oracle-of-delphi',
+      turnCompleted: 40,
     });
     const observerView = getLegendaryWonderNotification(state, 'rival', {
       type: 'wonder:legendary-completed',
       civId: 'player',
       cityId: 'city-river',
       wonderId: 'oracle-of-delphi',
+      turnCompleted: 40,
     });
 
     expect(builderView?.message).toMatch(/completed/i);

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -246,7 +246,7 @@ describe('notification routing', () => {
     const { sink, calls } = makeSink();
     routeLegendaryWonder(
       state,
-      { type: 'wonder:legendary-completed', civId: 'p1', cityId: 'c1', wonderId: 'great-wall' },
+      { type: 'wonder:legendary-completed', civId: 'p1', cityId: 'c1', wonderId: 'great-wall', turnCompleted: 40 },
       sink,
     );
     const byCiv = Object.fromEntries(calls.map(c => [c.civId, c]));

--- a/tests/ui/territory-inspection-panel.test.ts
+++ b/tests/ui/territory-inspection-panel.test.ts
@@ -4,6 +4,7 @@ import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
 import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel';
+import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -169,5 +170,17 @@ describe('createTerritoryInspectionPanel', () => {
     close?.click();
 
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('mentions completed legendary wonders for safely visible owned host cities', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'city-river', turnCompleted: 20 },
+    };
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+    const panel = createTerritoryInspectionPanel(state, state.cities['city-river'].position, 'player', () => {});
+
+    expect(panel.textContent).toContain('Completed legendary wonders');
+    expect(panel.textContent).toContain('Oracle of Delphi');
   });
 });

--- a/tests/ui/wonder-atlas-panel.test.ts
+++ b/tests/ui/wonder-atlas-panel.test.ts
@@ -109,6 +109,41 @@ describe('wonder-atlas-panel', () => {
     expect(panel.textContent).not.toContain('Start Construction');
   });
 
+  it('renders safe legendary Atlas state labels without exposing rival progress', () => {
+    const state = makeState();
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:player:city-river': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'city-river',
+        phase: 'building',
+        investedProduction: 40,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+      'grand-canal:rival:rival-city': {
+        wonderId: 'grand-canal',
+        ownerId: 'ai-1',
+        cityId: 'rival-city',
+        phase: 'building',
+        investedProduction: 90,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    const panel = createWonderAtlasPanel(document.body, state, {
+      onViewOnMap: () => {},
+      onClose: () => {},
+    });
+    click(panel.querySelector('[data-atlas-tab="legendary"]'));
+
+    expect(panel.textContent).toContain('Under construction');
+    expect(panel.textContent).toContain('Legendary wonder');
+    expect(panel.textContent).not.toContain('rival-city');
+    expect(panel.textContent).not.toContain('90');
+  });
+
   it('uses a static vignette when reduced motion is requested', () => {
     const state = makeState();
     state.discoveredWonders.great_volcano = 'player';

--- a/tests/ui/wonder-panel.test.ts
+++ b/tests/ui/wonder-panel.test.ts
@@ -23,6 +23,26 @@ describe('wonder-panel', () => {
     expect(rendered).toContain('Discover a natural wonder');
   });
 
+  it('shows construction milestone and reward-active completion copy from presentation entries', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'building';
+    city.productionQueue = ['legendary:oracle-of-delphi'];
+    city.productionProgress = 72;
+    state.completedLegendaryWonders = {
+      'grand-canal': { ownerId: 'player', cityId: city.id, turnCompleted: 44 },
+    };
+
+    const panel = createWonderPanel(container, state, city.id, {
+      onStartBuild: () => {},
+      onClose: () => {},
+    });
+    const text = collectText(panel);
+
+    expect(text).toContain('Final works');
+    expect(text).toContain('Reward active');
+    expect(text).toContain('Normal production has resumed.');
+  });
+
   it('shows only the current players selected-city projects in hot seat', () => {
     const { container, state } = makeWonderPanelFixture();
 


### PR DESCRIPTION
## Summary
- Implements Stage 2C legendary wonder city presence: active city construction state, owner-only completion ceremony, and safe Atlas labels.
- Adds viewer-safe completed landmark presentation/rendering around host cities with deterministic multiple-wonder slots and overflow.
- Documents the Stage 2C spec/plan and adds regression coverage for city UI, ceremony queues, Atlas privacy, map rendering, and completion events.

## Review fixes
- Fixed stale ceremony event typing caught by build.
- Tightened Atlas Available labels so raw ready_to_build phase is not enough without city build eligibility.

## Test Plan
- scripts/check-src-rule-violations.sh src/core/types.ts src/main.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/wonders/legendary-wonder-slots.ts src/systems/city-system.ts src/systems/legendary-wonder-completion-presentation.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-presentation.ts src/systems/legendary-wonder-production.ts src/systems/legendary-wonder-system.ts src/systems/wonder-atlas-presentation.ts src/systems/wonder-visual-catalog.ts src/ui/city-panel.ts src/ui/legendary-wonder-completion-ceremony.ts src/ui/legendary-wonder-completion-queue.ts src/ui/legendary-wonder-notifications.ts src/ui/notification-routing.ts src/ui/territory-inspection-panel.ts src/ui/wonder-atlas-panel.ts src/ui/wonder-panel.ts
- ./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-presentation.test.ts tests/systems/legendary-wonder-completion-presentation.test.ts tests/systems/wonder-atlas-presentation.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/ui/city-panel.test.ts tests/ui/wonder-panel.test.ts tests/ui/wonder-atlas-panel.test.ts tests/ui/legendary-wonder-completion-ceremony.test.ts tests/ui/legendary-wonder-completion-queue.test.ts tests/ui/territory-inspection-panel.test.ts tests/ui/legendary-wonder-notifications.test.ts tests/ui/notification-routing.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts tests/core/turn-manager.test.ts
- ./scripts/run-wonder-regressions.sh
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test

Refs #217