### PR TITLE
feat(s4a): per-resource yield & happiness effects (Marketplace S4a)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-marketplace-s4a-resource-effects.md
+++ b/docs/superpowers/plans/2026-05-23-marketplace-s4a-resource-effects.md
@@ -1,0 +1,1968 @@
+# Marketplace S4a — Per-Resource Yield & Happiness Effects Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add passive empire-wide effects to all 16 resources (happiness or yield bonuses), wire them into turn processing and faction unrest, surface them in city panel / HUD / marketplace, and fix earth-map resource placement for the 6 resources added in S2a plus missing geographic zones for existing resources.
+
+**Architecture:** Static `ResourceEffect` type on `RESOURCE_DEFINITIONS` (no GameState fields). Two pure helpers in `resource-acquisition-system.ts` compute bonuses fresh from `getCivAvailableResources`. Turn-manager calls yield helper once per civ; faction-system pre-builds a happiness map before its city loop to avoid O(cities²) scans.
+
+**Tech Stack:** TypeScript, Vitest, DOM (textContent only), `scripts/generate-earth-maps.ts` for map regeneration.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `src/systems/trade-system.ts` | Add `ResourceEffect` interface + `effect` field to all 16 definitions |
+| Modify | `src/systems/resource-acquisition-system.ts` | Add `getCivResourceYieldBonus` and `getCivHappinessFromResources` |
+| Modify | `src/core/turn-manager.ts` | Call yield bonus once per civ before city loop |
+| Modify | `src/systems/faction-system.ts` | `ownerHappiness=0` param on `computeUnrestPressure`; civHappiness map in `processFactionTurn` |
+| Modify | `src/ui/city-panel.ts` | Empire bonuses / City bonuses resource section |
+| Modify | `src/main.ts` | Happiness chip in `updateHUD()` |
+| Modify | `src/ui/marketplace-panel.ts` | Effect badge per resource row |
+| Modify | `scripts/generate-earth-maps.ts` | Add all missing RESOURCE_ZONES + fix stone fallback |
+| Regenerate | `src/systems/earth-map-data.ts` (auto-generated) | Run `yarn generate-maps` |
+| Create | `tests/systems/resource-effects.test.ts` | Tests #1–16, #30 |
+| Create | `tests/systems/faction-happiness.test.ts` | Tests #17–20 |
+| Create | `tests/ui/city-panel-resources.test.ts` | Tests #21–25 |
+| Create | `tests/ui/hud-happiness.test.ts` | Tests #26–27 |
+| Create | `tests/ui/marketplace-panel-effects.test.ts` | Tests #28–29 |
+| Create | `tests/systems/earth-map-geo.test.ts` | Test #31 |
+
+---
+
+## Task 1: Add `ResourceEffect` to `trade-system.ts`
+
+**Files:**
+- Modify: `src/systems/trade-system.ts`
+- Test (catalog only, in next task's file): `tests/systems/resource-effects.test.ts`
+
+- [ ] **Step 1: Add `ResourceEffect` interface and `effect` field to `ResourceDefinition`**
+
+Open `src/systems/trade-system.ts` and make these changes:
+
+```typescript
+// Add after the BuildableImprovementType/MarketplaceState/ResourceType/TradeRoute import line:
+export interface ResourceEffect {
+  type: 'happiness' | 'gold' | 'production' | 'food';
+  amount: number; // always 1 in S4a
+}
+
+// Update ResourceDefinition interface:
+export interface ResourceDefinition {
+  id: ResourceType;
+  name: string;
+  type: 'luxury' | 'strategic';
+  terrain: string | string[];
+  basePrice: number;
+  tech: string;
+  icon: string;
+  requiredImprovement: BuildableImprovementType;
+  effect: ResourceEffect | null; // null = no S4a passive (copper/iron/horses/stone)
+}
+```
+
+- [ ] **Step 2: Update all 16 RESOURCE_DEFINITIONS entries with `effect` field**
+
+Replace the entire `RESOURCE_DEFINITIONS` array:
+
+```typescript
+export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
+  // Luxury — happiness
+  { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland',             basePrice: 8,  tech: 'irrigation',       icon: '🧵', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',                basePrice: 7,  tech: 'pottery',           icon: '🍇', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',                basePrice: 9,  tech: 'foraging',          icon: '🐘', requiredImprovement: 'camp',       effect: { type: 'happiness', amount: 1 } },
+  { id: 'furs',    name: 'Furs',    type: 'luxury',    terrain: ['forest', 'tundra'],    basePrice: 9,  tech: 'foraging',          icon: '🦊', requiredImprovement: 'camp',       effect: { type: 'happiness', amount: 1 } },
+  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',                basePrice: 6,  tech: 'currency',          icon: '🕯️', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  // Luxury — gold/turn
+  { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',                 basePrice: 12, tech: 'mining-tech',       icon: '💎', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'gold',    name: 'Gold',    type: 'luxury',    terrain: 'hills',                 basePrice: 15, tech: 'currency',          icon: '⭐', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'silver',  name: 'Silver',  type: 'luxury',    terrain: 'hills',                 basePrice: 11, tech: 'mining-tech',       icon: '🥈', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',                basePrice: 10, tech: 'cartography',       icon: '🌶️', requiredImprovement: 'plantation', effect: { type: 'gold', amount: 1 } },
+  // Luxury — production/turn
+  { id: 'sheep',   name: 'Sheep',   type: 'luxury',    terrain: ['hills', 'plains'],     basePrice: 7,  tech: 'animal-husbandry',  icon: '🐑', requiredImprovement: 'pasture',    effect: { type: 'production', amount: 1 } },
+  // Strategic — food/turn
+  { id: 'cattle',  name: 'Cattle',  type: 'strategic', terrain: ['grassland', 'plains'], basePrice: 5,  tech: 'domestication',     icon: '🐄', requiredImprovement: 'pasture',    effect: { type: 'food', amount: 1 } },
+  // Strategic — gold/turn
+  { id: 'salt',    name: 'Salt',    type: 'strategic', terrain: 'hills',                 basePrice: 5,  tech: 'pottery',           icon: '🧂', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  // Strategic — null (S4b gating)
+  { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',                 basePrice: 5,  tech: 'stone-weapons',     icon: '🪙', requiredImprovement: 'mine',       effect: null },
+  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',                 basePrice: 8,  tech: 'bronze-working',    icon: '⚙️', requiredImprovement: 'mine',       effect: null },
+  { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',                basePrice: 7,  tech: 'animal-husbandry',  icon: '🐎', requiredImprovement: 'pasture',    effect: null },
+  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',              basePrice: 4,  tech: 'gathering',         icon: '🪨', requiredImprovement: 'quarry',     effect: null },
+];
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -20
+```
+
+Expected: No errors referencing `trade-system.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/systems/trade-system.ts
+git commit -m "feat(s4a): add ResourceEffect type and effect field to all 16 RESOURCE_DEFINITIONS"
+```
+
+---
+
+## Task 2: Add `getCivResourceYieldBonus` and `getCivHappinessFromResources`
+
+**Files:**
+- Modify: `src/systems/resource-acquisition-system.ts`
+- Create: `tests/systems/resource-effects.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/systems/resource-effects.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+import {
+  getCivAvailableResources,
+  getCivResourceYieldBonus,
+  getCivHappinessFromResources,
+} from '@/systems/resource-acquisition-system';
+import type { GameState } from '@/core/types';
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function makeTechState(completed: string[] = []) {
+  return {
+    completed,
+    currentResearch: null,
+    researchQueue: [],
+    researchProgress: 0,
+    trackPriorities: {} as never,
+  };
+}
+
+/**
+ * Builds a minimal GameState where 'player' owns a single city at (3,3) and
+ * one additional resource tile at (4,3) (unless tileIsCity=true).
+ */
+function makeState(overrides: {
+  tileResource?: string | null;
+  tileImprovement?: string;
+  tileImprovementTurnsLeft?: number;
+  tileTerrain?: string;
+  tileIsCity?: boolean;
+  completed?: string[];
+}): GameState {
+  const {
+    tileResource = null,
+    tileImprovement = 'none',
+    tileImprovementTurnsLeft = 0,
+    tileTerrain = 'grassland',
+    tileIsCity = false,
+    completed = [],
+  } = overrides;
+
+  const cityPos = { q: 3, r: 3 };
+  const tileCoord = tileIsCity ? cityPos : { q: 4, r: 3 };
+
+  const tiles: Record<string, unknown> = {
+    '3,3': {
+      coord: cityPos, terrain: 'grassland', elevation: 'lowland',
+      resource: tileIsCity ? tileResource : null,
+      improvement: tileIsCity ? tileImprovement : 'none',
+      improvementTurnsLeft: tileIsCity ? tileImprovementTurnsLeft : 0,
+      hasRiver: false, wonder: null, owner: null,
+    },
+  };
+
+  if (!tileIsCity) {
+    tiles['4,3'] = {
+      coord: tileCoord, terrain: tileTerrain, elevation: 'lowland',
+      resource: tileResource, improvement: tileImprovement,
+      improvementTurnsLeft: tileImprovementTurnsLeft,
+      hasRiver: false, wonder: null, owner: null,
+    };
+  }
+
+  const ownedTiles = tileIsCity ? [cityPos] : [cityPos, tileCoord];
+
+  return {
+    map: { width: 10, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'TestCity', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, production: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [],
+        specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+      } as unknown as never,
+    },
+    civilizations: {
+      'player': {
+        id: 'player',
+        cities: ['city-1'],
+        techState: makeTechState(completed),
+      } as unknown as never,
+    },
+  } as unknown as GameState;
+}
+
+/** State with two off-center tiles having different resources */
+function makeMultiResourceState(resources: Array<{
+  resource: string;
+  improvement: string;
+  tech: string;
+  terrain: string;
+}>): GameState {
+  const cityPos = { q: 3, r: 3 };
+  const tiles: Record<string, unknown> = {
+    '3,3': {
+      coord: cityPos, terrain: 'grassland', elevation: 'lowland',
+      resource: null, improvement: 'none', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: null,
+    },
+  };
+  const ownedTiles = [cityPos];
+  const completed: string[] = [];
+
+  resources.forEach((r, i) => {
+    const coord = { q: 4 + i, r: 3 };
+    tiles[`${coord.q},${coord.r}`] = {
+      coord, terrain: r.terrain, elevation: 'lowland',
+      resource: r.resource, improvement: r.improvement,
+      improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: null,
+    };
+    ownedTiles.push(coord);
+    if (!completed.includes(r.tech)) completed.push(r.tech);
+  });
+
+  return {
+    map: { width: 10, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'TestCity', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, production: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [],
+        specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+      } as unknown as never,
+    },
+    civilizations: {
+      'player': {
+        id: 'player',
+        cities: ['city-1'],
+        techState: makeTechState(completed),
+      } as unknown as never,
+    },
+  } as unknown as GameState;
+}
+
+// ── Catalog test ─────────────────────────────────────────────────────────────
+
+describe('RESOURCE_DEFINITIONS catalog', () => {
+  it('test 1: every entry has effect defined (not undefined — may be null)', () => {
+    for (const def of RESOURCE_DEFINITIONS) {
+      expect(def.effect, `${def.id} is missing effect field`).not.toBeUndefined();
+    }
+  });
+});
+
+// ── getCivHappinessFromResources ──────────────────────────────────────────────
+
+describe('getCivHappinessFromResources', () => {
+  it('test 2: returns 1 for a civ owning silk (plantation complete, irrigation known)', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0, completed: ['irrigation'],
+    });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(1);
+  });
+
+  it('test 7: three silk tiles → returns 1 (same-resource non-stacking)', () => {
+    // Build state manually with 3 silk tiles in owned territory
+    const cityPos = { q: 3, r: 3 };
+    const silkTile = (q: number) => ({
+      coord: { q, r: 3 }, terrain: 'grassland', elevation: 'lowland',
+      resource: 'silk', improvement: 'plantation', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: null,
+    });
+    const state: GameState = {
+      map: {
+        width: 10, height: 10, wrapsHorizontally: false, rivers: [],
+        tiles: {
+          '3,3': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: null },
+          '4,3': silkTile(4),
+          '5,3': silkTile(5),
+          '6,3': silkTile(6),
+        },
+      } as unknown as never,
+      cities: {
+        'city-1': {
+          id: 'city-1', name: 'TestCity', owner: 'player',
+          position: cityPos,
+          ownedTiles: [cityPos, { q: 4, r: 3 }, { q: 5, r: 3 }, { q: 6, r: 3 }],
+          population: 1, food: 0, production: 0, gold: 0,
+          buildings: [], productionQueue: [], workedTiles: [],
+          specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+        } as unknown as never,
+      },
+      civilizations: {
+        'player': {
+          id: 'player', cities: ['city-1'],
+          techState: makeTechState(['irrigation']),
+        } as unknown as never,
+      },
+    } as unknown as GameState;
+
+    expect(getCivHappinessFromResources(state, 'player')).toBe(1);
+  });
+
+  it('test 8: silk AND wine → returns 2 (different resources accumulate)', () => {
+    const state = makeMultiResourceState([
+      { resource: 'silk',  improvement: 'plantation', tech: 'irrigation', terrain: 'grassland' },
+      { resource: 'wine',  improvement: 'plantation', tech: 'pottery',    terrain: 'plains'    },
+    ]);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(2);
+  });
+
+  it('test 10: civ with no owned resources → returns 0', () => {
+    const state = makeState({ tileResource: null });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+
+  it('test 11: copper/iron/horses/stone (null effect) → returns 0', () => {
+    for (const resourceId of ['copper', 'iron', 'horses', 'stone']) {
+      const def = RESOURCE_DEFINITIONS.find(d => d.id === resourceId)!;
+      const terrain = Array.isArray(def.terrain) ? def.terrain[0] : def.terrain;
+      const state = makeState({
+        tileResource: resourceId,
+        tileImprovement: def.requiredImprovement,
+        tileImprovementTurnsLeft: 0,
+        tileTerrain: terrain,
+        completed: [def.tech],
+      });
+      expect(getCivHappinessFromResources(state, 'player'), `${resourceId} should give 0 happiness`).toBe(0);
+    }
+  });
+
+  it('test 13: improvement destroyed (improvementTurnsLeft > 0) → returns 0', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 2, completed: ['irrigation'],
+    });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+});
+
+// ── getCivResourceYieldBonus ──────────────────────────────────────────────────
+
+describe('getCivResourceYieldBonus', () => {
+  it('test 3: gems → { gold: 1, food: 0, production: 0, science: 0 }', () => {
+    const state = makeState({
+      tileResource: 'gems', tileImprovement: 'mine',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'hills',
+      completed: ['mining-tech'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(1);
+    expect(bonus.food).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+
+  it('test 4: sheep → { production: 1, ... }', () => {
+    const state = makeState({
+      tileResource: 'sheep', tileImprovement: 'pasture',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'plains',
+      completed: ['animal-husbandry'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.production).toBe(1);
+    expect(bonus.food).toBe(0);
+    expect(bonus.gold).toBe(0);
+  });
+
+  it('test 5: cattle → { food: 1, ... }', () => {
+    const state = makeState({
+      tileResource: 'cattle', tileImprovement: 'pasture',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'plains',
+      completed: ['domestication'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.food).toBe(1);
+    expect(bonus.gold).toBe(0);
+  });
+
+  it('test 6: salt → { gold: 1, ... }', () => {
+    const state = makeState({
+      tileResource: 'salt', tileImprovement: 'mine',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'hills',
+      completed: ['pottery'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(1);
+  });
+
+  it('test 9: gems AND silver → { gold: 2, ... } (different resources accumulate)', () => {
+    const state = makeMultiResourceState([
+      { resource: 'gems',   improvement: 'mine', tech: 'mining-tech', terrain: 'hills' },
+      { resource: 'silver', improvement: 'mine', tech: 'mining-tech', terrain: 'hills' },
+    ]);
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(2);
+  });
+
+  it('test 10: civ with no resources → all zeros', () => {
+    const state = makeState({ tileResource: null });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.food).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.gold).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+
+  it('test 11: copper/iron/horses/stone (null effect) → all zeros', () => {
+    for (const resourceId of ['copper', 'iron', 'horses', 'stone']) {
+      const def = RESOURCE_DEFINITIONS.find(d => d.id === resourceId)!;
+      const terrain = Array.isArray(def.terrain) ? def.terrain[0] : def.terrain;
+      const state = makeState({
+        tileResource: resourceId,
+        tileImprovement: def.requiredImprovement,
+        tileImprovementTurnsLeft: 0,
+        tileTerrain: terrain,
+        completed: [def.tech],
+      });
+      const bonus = getCivResourceYieldBonus(state, 'player');
+      expect(bonus.gold, `${resourceId} should give 0 gold`).toBe(0);
+      expect(bonus.production, `${resourceId} should give 0 production`).toBe(0);
+      expect(bonus.food, `${resourceId} should give 0 food`).toBe(0);
+    }
+  });
+
+  it('test 12: happiness resources excluded from yield bonus (silk gives 0 gold/prod/food)', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0, completed: ['irrigation'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.food).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+});
+
+// ── Save compatibility ────────────────────────────────────────────────────────
+
+describe('save compatibility', () => {
+  it('test 30: effect is static data on RESOURCE_DEFINITIONS, not stored in GameState', () => {
+    // Confirm calling helpers on a state with no special fields doesn't crash
+    const state = makeState({ tileResource: null });
+    expect(() => getCivHappinessFromResources(state, 'player')).not.toThrow();
+    expect(() => getCivResourceYieldBonus(state, 'player')).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/resource-effects.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `getCivResourceYieldBonus is not a function` / `getCivHappinessFromResources is not a function`.
+
+- [ ] **Step 3: Implement the two helpers in `resource-acquisition-system.ts`**
+
+Add these two exports (after the existing `getCivAvailableResources` function):
+
+```typescript
+import type { GameState, ResourceType, ResourceYield } from '@/core/types';
+import { hexKey } from './hex-utils';
+import { RESOURCE_DEFINITIONS } from './trade-system';
+
+// ... existing getCivAvailableResources unchanged ...
+
+/**
+ * Returns the aggregate per-city yield bonus from all owned resources whose
+ * effect type is NOT 'happiness'. Non-stacking per resource: owning multiple
+ * tiles of the same resource counts once. Different resources with the same
+ * effect type DO accumulate (gems + silver → +2 gold/turn).
+ */
+export function getCivResourceYieldBonus(
+  state: GameState,
+  civId: string,
+): ResourceYield {
+  const bonus: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
+  const owned = getCivAvailableResources(state, civId);
+
+  for (const def of RESOURCE_DEFINITIONS) {
+    if (!def.effect || def.effect.type === 'happiness') continue;
+    if (!owned.has(def.id as ResourceType)) continue;
+
+    switch (def.effect.type) {
+      case 'gold':       bonus.gold       += def.effect.amount; break;
+      case 'production': bonus.production += def.effect.amount; break;
+      case 'food':       bonus.food       += def.effect.amount; break;
+    }
+  }
+
+  return bonus;
+}
+
+/**
+ * Returns the count of distinct happiness-type luxuries owned by the civ.
+ * Empire-wide, non-stacking: owning three silk tiles counts as 1, not 3.
+ * Different resources accumulate: silk + wine = 2.
+ */
+export function getCivHappinessFromResources(
+  state: GameState,
+  civId: string,
+): number {
+  const owned = getCivAvailableResources(state, civId);
+  let count = 0;
+
+  for (const def of RESOURCE_DEFINITIONS) {
+    if (!def.effect || def.effect.type !== 'happiness') continue;
+    if (owned.has(def.id as ResourceType)) count++;
+  }
+
+  return count;
+}
+```
+
+Note: `ResourceYield` must be imported in `resource-acquisition-system.ts`. The existing import line is:
+```typescript
+import type { GameState, ResourceType } from '@/core/types';
+```
+Change it to:
+```typescript
+import type { GameState, ResourceType, ResourceYield } from '@/core/types';
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/resource-effects.test.ts 2>&1 | tail -20
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/resource-acquisition-system.ts tests/systems/resource-effects.test.ts
+git commit -m "feat(s4a): add getCivResourceYieldBonus and getCivHappinessFromResources helpers"
+```
+
+---
+
+## Task 3: Wire yield bonus in `turn-manager.ts`
+
+**Files:**
+- Modify: `src/core/turn-manager.ts`
+- Create test coverage for arch regression and AI parity in existing `tests/systems/resource-effects.test.ts`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add this block to the end of `tests/systems/resource-effects.test.ts`:
+
+```typescript
+// ── Turn processing integration ───────────────────────────────────────────────
+
+import { processTurn } from '@/core/turn-manager';
+import { EventBus } from '@/core/event-bus';
+
+/**
+ * Build a minimal GameState suitable for a single processTurn call.
+ * The civ has `cityCount` cities, each owning a gems tile (hills, mine complete).
+ */
+function makeTurnState(civId: string, cityCount: number): GameState {
+  const bus = new EventBus();
+  const cities: Record<string, unknown> = {};
+  const cityIds: string[] = [];
+
+  for (let i = 0; i < cityCount; i++) {
+    const cityPos = { q: i * 5, r: 0 };
+    const tilePos = { q: i * 5 + 1, r: 0 };
+    const cityId = `city-${i}`;
+    cityIds.push(cityId);
+
+    // Add city tile and gems tile to map
+    cities[cityId] = {
+      id: cityId, name: `City${i}`, owner: civId,
+      position: cityPos,
+      ownedTiles: [cityPos, tilePos],
+      population: 1, food: 0, foodNeeded: 20,
+      production: 0, productionProgress: 0, gold: 0,
+      buildings: [], productionQueue: [], workedTiles: [cityPos],
+      focus: 'balanced', maturity: 'outpost',
+      unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      grid: [[null]], gridSize: 3, hp: 100, maxHp: 100,
+      garrisonUnitId: null, specialistSlots: [],
+    };
+  }
+
+  // Build tiles map
+  const tiles: Record<string, unknown> = {};
+  for (let i = 0; i < cityCount; i++) {
+    const cityPos = { q: i * 5, r: 0 };
+    const tilePos = { q: i * 5 + 1, r: 0 };
+    tiles[`${cityPos.q},${cityPos.r}`] = {
+      coord: cityPos, terrain: 'grassland', elevation: 'lowland',
+      resource: null, improvement: 'none', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: civId,
+    };
+    tiles[`${tilePos.q},${tilePos.r}`] = {
+      coord: tilePos, terrain: 'hills', elevation: 'highland',
+      resource: 'gems', improvement: 'mine', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: civId,
+    };
+  }
+
+  return {
+    turn: 5,
+    era: 2,
+    currentPlayer: civId,
+    map: { width: 50, height: 20, tiles, wrapsHorizontally: false, rivers: [] },
+    cities,
+    civilizations: {
+      [civId]: {
+        id: civId, civType: 'rome', name: 'Rome',
+        cities: cityIds,
+        units: [],
+        gold: 10,
+        techState: { completed: ['mining-tech'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {},
+    barbarianCamps: {},
+    minorCivs: {},
+    marketplace: null,
+  } as unknown as GameState;
+}
+
+describe('turn processing — resource yield bonus integration', () => {
+  it('test 14: 3-city civ owning gems — all 3 cities receive +1 gold from resource bonus', () => {
+    const state = makeTurnState('rome', 3);
+    const goldBefore = Object.values(state.cities).reduce((sum, c: unknown) => sum + (c as never as { gold: number }).gold, 0);
+    const bus = new EventBus();
+    const next = processTurn(state, bus);
+    // Each city should have gained at least 1 gold from gems bonus
+    for (const cityId of Object.keys(next.cities)) {
+      const city = next.cities[cityId];
+      expect(city.gold, `${cityId} should have gained food/prod/gold from turn`).toBeGreaterThan(0);
+    }
+  });
+
+  it('test 15: AI civ owning spices accrues +1 gold/turn per city (same code path)', () => {
+    // Uses same makeTurnState logic but with spices (jungle, plantation)
+    const cityPos = { q: 0, r: 0 };
+    const tilePos = { q: 1, r: 0 };
+    const state: GameState = {
+      turn: 5, era: 2, currentPlayer: 'ai-civ',
+      map: {
+        width: 20, height: 20, wrapsHorizontally: false, rivers: [],
+        tiles: {
+          '0,0': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'ai-civ' },
+          '1,0': { coord: tilePos, terrain: 'jungle', elevation: 'lowland', resource: 'spices', improvement: 'plantation', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'ai-civ' },
+        },
+      },
+      cities: {
+        'ai-city': {
+          id: 'ai-city', name: 'AICity', owner: 'ai-civ',
+          position: cityPos,
+          ownedTiles: [cityPos, tilePos],
+          population: 1, food: 0, foodNeeded: 20,
+          production: 0, productionProgress: 0, gold: 0,
+          buildings: [], productionQueue: [], workedTiles: [cityPos],
+          focus: 'balanced', maturity: 'outpost',
+          unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+          grid: [[null]], gridSize: 3, hp: 100, maxHp: 100,
+          garrisonUnitId: null, specialistSlots: [],
+        },
+      },
+      civilizations: {
+        'ai-civ': {
+          id: 'ai-civ', civType: 'rome', name: 'Rome', cities: ['ai-city'],
+          units: [], gold: 0,
+          techState: { completed: ['cartography'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+          diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+          visibility: { tiles: {} },
+        },
+      },
+      units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+    } as unknown as GameState;
+
+    const bus = new EventBus();
+    // Should not throw and gold should increase (gold from spices + base gold yield)
+    expect(() => processTurn(state, bus)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify integration tests fail as expected**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/resource-effects.test.ts 2>&1 | grep -E "FAIL|PASS|getCivResource"
+```
+
+Expected: Tests 14 and 15 may already pass if the turn-manager picks up the bonus, or fail if not wired yet. The arch-regression test (test 16) cannot be auto-checked in a unit test — it is a code-review concern and is confirmed by reading the diff.
+
+- [ ] **Step 3: Wire `getCivResourceYieldBonus` in `turn-manager.ts`**
+
+In `src/core/turn-manager.ts`:
+
+**Add import** (near the other resource-system imports, after line 14 `import { calculateCityYields }`):
+```typescript
+import { getCivResourceYieldBonus } from '@/systems/resource-acquisition-system';
+```
+
+**Locate the per-civ city loop** (around line 82). Before the `for (const cityId of civ.cities)` loop, add one line:
+
+```typescript
+    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
+```
+
+**Update the yields object** inside the city loop (currently lines 96-101):
+
+Replace:
+```typescript
+      const yields = {
+        food: Math.floor((baseYields.food + (wonderCityBonuses.food ?? 0)) * unrestMultiplier),
+        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0)) * unrestMultiplier),
+        gold: Math.floor((baseYields.gold + (wonderCityBonuses.gold ?? 0)) * unrestMultiplier),
+        science: Math.floor((baseYields.science + (wonderCityBonuses.science ?? 0)) * unrestMultiplier),
+      };
+```
+
+With:
+```typescript
+      const yields = {
+        food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food)       * unrestMultiplier),
+        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production) * unrestMultiplier),
+        gold:       Math.floor((baseYields.gold       + (wonderCityBonuses.gold       ?? 0) + resourceYieldBonus.gold)       * unrestMultiplier),
+        science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0))                                 * unrestMultiplier),
+      };
+```
+
+Note: `science` intentionally does NOT include `resourceYieldBonus.science` because no resource has a science effect in S4a (and `ResourceYield` is `{ food, production, gold, science }` but the helper always returns science=0).
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/turn-manager.ts tests/systems/resource-effects.test.ts
+git commit -m "feat(s4a): wire getCivResourceYieldBonus into turn-manager once per civ"
+```
+
+---
+
+## Task 4: Wire happiness into `faction-system.ts`
+
+**Files:**
+- Modify: `src/systems/faction-system.ts`
+- Create: `tests/systems/faction-happiness.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/systems/faction-happiness.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import type { GameState, City, HexCoord } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import {
+  computeUnrestPressure,
+  processFactionTurn,
+} from '@/systems/faction-system';
+
+function makeCity(id: string, owner: string, position: HexCoord, overrides: Partial<City> = {}): City {
+  return {
+    id, name: id, owner, position,
+    population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost',
+    grid: [[null]], gridSize: 3,
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+function makeState({
+  cityCount = 1,
+  cityPosition = { q: 0, r: 0 } as HexCoord,
+  atWarCount = 0,
+  era = 2,
+  silkOwned = false,
+}: {
+  cityCount?: number;
+  cityPosition?: HexCoord;
+  atWarCount?: number;
+  era?: number;
+  silkOwned?: boolean;
+} = {}): GameState {
+  const civId = 'player';
+  const cities: Record<string, City> = {};
+  const cityIds: string[] = [];
+
+  // Capital at (0,0)
+  const capital = makeCity('capital', civId, { q: 0, r: 0 });
+  cities['capital'] = capital;
+  cityIds.push('capital');
+
+  for (let i = 1; i <= cityCount; i++) {
+    const city = makeCity(`city-${i}`, civId, cityPosition);
+    cities[`city-${i}`] = city;
+    cityIds.push(`city-${i}`);
+  }
+
+  const atWarWith: string[] = [];
+  for (let i = 0; i < atWarCount; i++) atWarWith.push(`enemy-${i}`);
+
+  // Build silk tile if needed
+  const tiles: Record<string, unknown> = {
+    '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: civId },
+  };
+  let ownedTiles = [{ q: 0, r: 0 }];
+
+  if (silkOwned) {
+    tiles['1,0'] = { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: 'silk', improvement: 'plantation', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: civId };
+    ownedTiles = [...ownedTiles, { q: 1, r: 0 }];
+    cities['capital'] = { ...capital, ownedTiles };
+  }
+
+  return {
+    turn: 10, era,
+    currentPlayer: civId,
+    map: { width: 20, height: 20, tiles, wrapsHorizontally: false, rivers: [] },
+    cities,
+    civilizations: {
+      [civId]: {
+        id: civId, civType: 'rome', name: 'Rome',
+        cities: cityIds, units: [], gold: 50,
+        techState: { completed: silkOwned ? ['irrigation'] : [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { ...createDiplomacyState(civId), atWarWith },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+  } as unknown as GameState;
+}
+
+describe('computeUnrestPressure with happiness', () => {
+  it('test 17: ownerHappiness=3 reduces pressure by 6', () => {
+    // 1 city, no wars, no conquest — base pressure is 0
+    // With ownerHappiness=3 → -6, clamped to 0
+    const state = makeState();
+    const pressureWithout = computeUnrestPressure('city-1', state, 0);
+    const pressureWith = computeUnrestPressure('city-1', state, 3);
+    expect(pressureWith).toBe(Math.max(0, pressureWithout - 6));
+  });
+
+  it('test 18: base pressure 45 with 3 happiness luxuries → pressure 39 → no unrest fires', () => {
+    // 2 wars × 8 = 16 + 6 cities × 3 = 18 → pressure = 34, but let's create exactly 45:
+    // Use 9 cities (9-5)*3=12 + 3 wars*8=24 + distance pressure from cityPosition far from capital
+    const state = makeState({ cityCount: 8, cityPosition: { q: 20, r: 0 }, atWarCount: 3, era: 2 });
+    // Check raw pressure is above 40 without happiness
+    const pressureBase = computeUnrestPressure('city-1', state, 0);
+    expect(pressureBase).toBeGreaterThan(40); // should trigger unrest without happiness
+
+    // With 3 happiness points → -6 pressure
+    const pressureHappy = computeUnrestPressure('city-1', state, 3);
+    // Pressure should be 6 less
+    expect(pressureHappy).toBe(Math.max(0, pressureBase - 6));
+  });
+
+  it('test 19: same pressure with 0 happiness → unrest fires; with happiness may not', () => {
+    // Use a lot of cities to push pressure over 40
+    const state = makeState({ cityCount: 10, atWarCount: 2, era: 2 });
+    const pressureZeroHappy = computeUnrestPressure('city-1', state, 0);
+    const pressureThreeHappy = computeUnrestPressure('city-1', state, 3);
+    // 3 happiness should reduce by 6
+    expect(pressureZeroHappy - pressureThreeHappy).toBe(6);
+  });
+
+  it('test 20: computeUnrestPressure called without ownerHappiness → defaults to 0, no crash', () => {
+    const state = makeState();
+    // This must not throw — optional param defaults to 0
+    expect(() => computeUnrestPressure('city-1', state)).not.toThrow();
+  });
+});
+
+describe('processFactionTurn with happiness', () => {
+  it('silk owned: unrest pressure reduced for all cities', () => {
+    const state = makeState({ cityCount: 8, atWarCount: 2, era: 2, silkOwned: true });
+    const bus = new EventBus();
+    // Should not throw
+    expect(() => processFactionTurn(state, bus)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/faction-happiness.test.ts 2>&1 | tail -20
+```
+
+Expected: Tests for `ownerHappiness` parameter fail because `computeUnrestPressure` doesn't accept it yet.
+
+- [ ] **Step 3: Update `computeUnrestPressure` in `faction-system.ts`**
+
+Add import at top of `src/systems/faction-system.ts`:
+```typescript
+import { getCivHappinessFromResources } from './resource-acquisition-system';
+```
+
+Update the function signature from:
+```typescript
+export function computeUnrestPressure(cityId: string, state: GameState): number {
+```
+To:
+```typescript
+export function computeUnrestPressure(cityId: string, state: GameState, ownerHappiness = 0): number {
+```
+
+Add happiness reduction inside `computeUnrestPressure`, immediately before the final `return` statement:
+```typescript
+  // Happiness from luxury resources reduces unrest pressure
+  pressure -= ownerHappiness * 2; // up to −10 from 5 happiness luxuries
+
+  return Math.min(100, Math.max(0, pressure));
+```
+
+The existing final line `return Math.min(100, pressure);` must be changed to `return Math.min(100, Math.max(0, pressure));` (add `Math.max(0, ...)` to prevent negative pressure).
+
+- [ ] **Step 4: Add civHappiness map to `processFactionTurn`**
+
+In `processFactionTurn`, immediately after:
+```typescript
+  let nextState = state;
+```
+
+Add:
+```typescript
+  // Pre-compute happiness per civ to avoid O(cities²) tile scans inside the city loop
+  const civHappiness: Record<string, number> = {};
+  for (const civId of Object.keys(nextState.civilizations)) {
+    civHappiness[civId] = getCivHappinessFromResources(nextState, civId);
+  }
+```
+
+Then update the **1 internal call site** of `computeUnrestPressure` (currently around line 179):
+
+```typescript
+    const pressure = computeUnrestPressure(cityId, nextState);
+```
+
+To:
+```typescript
+    const pressure = computeUnrestPressure(cityId, nextState, civHappiness[city.owner] ?? 0);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/faction-happiness.test.ts 2>&1 | tail -20
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/faction-system.ts tests/systems/faction-happiness.test.ts
+git commit -m "feat(s4a): happiness from luxury resources reduces unrest pressure by 2 per point"
+```
+
+---
+
+## Task 5: City panel — resource bonus section
+
+**Files:**
+- Modify: `src/ui/city-panel.ts`
+- Create: `tests/ui/city-panel-resources.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/city-panel-resources.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { GameState } from '@/core/types';
+import { createCityPanel } from '@/ui/city-panel';
+
+// Minimal DOM setup
+beforeEach(() => {
+  document.body.innerHTML = '<div id="panel-root"></div>';
+});
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const noopCallbacks = {
+  onBuild: () => {},
+  onOpenWonderPanel: () => {},
+  onClose: () => {},
+};
+
+function makeMinimalState(overrides: {
+  silkOwned?: boolean;
+  gemsOwned?: boolean;
+  goldResourceOwned?: boolean;
+  noResources?: boolean;
+} = {}): GameState {
+  const cityPos = { q: 0, r: 0 };
+  const tiles: Record<string, unknown> = {
+    '0,0': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' },
+  };
+  const ownedTiles = [cityPos];
+  const completed: string[] = [];
+
+  if (overrides.silkOwned) {
+    tiles['1,0'] = { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: 'silk', improvement: 'plantation', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' };
+    ownedTiles.push({ q: 1, r: 0 });
+    completed.push('irrigation');
+  }
+  if (overrides.gemsOwned) {
+    tiles['2,0'] = { coord: { q: 2, r: 0 }, terrain: 'hills', elevation: 'highland', resource: 'gems', improvement: 'mine', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' };
+    ownedTiles.push({ q: 2, r: 0 });
+    completed.push('mining-tech');
+  }
+  if (overrides.goldResourceOwned) {
+    tiles['3,0'] = { coord: { q: 3, r: 0 }, terrain: 'hills', elevation: 'highland', resource: 'gold', improvement: 'mine', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' };
+    ownedTiles.push({ q: 3, r: 0 });
+    if (!completed.includes('currency')) completed.push('currency');
+  }
+
+  return {
+    turn: 1, era: 1, currentPlayer: 'player',
+    map: { width: 20, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'Rome', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 2, food: 0, foodNeeded: 20,
+        production: 0, productionProgress: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [cityPos],
+        focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+        grid: [[null, null, null], [null, null, null], [null, null, null]], gridSize: 3,
+        hp: 100, maxHp: 100, garrisonUnitId: null, specialistSlots: [],
+      },
+    },
+    civilizations: {
+      'player': {
+        id: 'player', civType: 'rome', name: 'Rome',
+        cities: ['city-1'], units: [], gold: 50,
+        techState: { completed, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+    economyStatusByCiv: {},
+  } as unknown as GameState;
+}
+
+describe('city panel resource bonus section', () => {
+  it('test 21: silk owned → "Empire bonuses" header and "Silk" text present', () => {
+    const container = document.getElementById('panel-root')!;
+    const state = makeMinimalState({ silkOwned: true });
+    createCityPanel(container, 'city-1', state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Empire bonuses');
+    expect(text).toContain('Silk');
+    expect(text).toContain('+1 happiness');
+  });
+
+  it('test 22: gems owned → "City bonuses" header and "Gems" with "+1 gold/turn"', () => {
+    const container = document.getElementById('panel-root')!;
+    const state = makeMinimalState({ gemsOwned: true });
+    createCityPanel(container, 'city-1', state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('City bonuses');
+    expect(text).toContain('Gems');
+    expect(text).toContain('+1 gold/turn');
+  });
+
+  it('test 23: gold resource shows "Gold deposits" not bare "Gold"', () => {
+    const container = document.getElementById('panel-root')!;
+    const state = makeMinimalState({ goldResourceOwned: true });
+    createCityPanel(container, 'city-1', state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Gold deposits');
+    expect(text).not.toMatch(/(?<!\w)Gold(?!\s+deposits).*\+1 gold/); // no bare "Gold → +1 gold"
+  });
+
+  it('test 24: only yield resources (gems, no silk) → "Empire bonuses" header absent', () => {
+    const container = document.getElementById('panel-root')!;
+    const state = makeMinimalState({ gemsOwned: true });
+    createCityPanel(container, 'city-1', state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Empire bonuses');
+    expect(text).toContain('City bonuses');
+  });
+
+  it('test 25: no resources → entire Resources section absent', () => {
+    const container = document.getElementById('panel-root')!;
+    const state = makeMinimalState({ noResources: true });
+    createCityPanel(container, 'city-1', state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Empire bonuses');
+    expect(text).not.toContain('City bonuses');
+    expect(text).not.toContain('happiness');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/city-panel-resources.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — resource bonus section doesn't exist yet.
+
+- [ ] **Step 3: Add imports to `city-panel.ts`**
+
+At the top of `src/ui/city-panel.ts`, add:
+```typescript
+import { getCivAvailableResources, getCivHappinessFromResources, getCivResourceYieldBonus } from '@/systems/resource-acquisition-system';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+```
+
+(Note: `getCivHappinessFromResources` and `getCivResourceYieldBonus` are not strictly needed here since we only need `getCivAvailableResources` + `RESOURCE_DEFINITIONS` to build the display. But import all three for completeness — they're used to determine which section to show.)
+
+Actually, the city panel only needs:
+```typescript
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+```
+
+- [ ] **Step 4: Build the resource bonus HTML fragment in `city-panel.ts`**
+
+After the line that computes `const yields = {...}` (around line 97-102), add this block:
+
+```typescript
+  // Build resource bonus sections for Empire (happiness) and City (yield) bonuses
+  const playerResources = getCivAvailableResources(state, state.currentPlayer);
+  const happinessResources = RESOURCE_DEFINITIONS.filter(
+    d => d.effect?.type === 'happiness' && playerResources.has(d.id as never),
+  );
+  const yieldResources = RESOURCE_DEFINITIONS.filter(
+    d => d.effect && d.effect.type !== 'happiness' && playerResources.has(d.id as never),
+  );
+
+  function resourceDisplayName(defId: string, defName: string): string {
+    // Special case: the "gold" resource collides with the currency name.
+    return defId === 'gold' ? 'Gold deposits' : defName;
+  }
+
+  function yieldLabel(effectType: string): string {
+    switch (effectType) {
+      case 'gold': return '+1 gold/turn';
+      case 'production': return '+1 production/turn';
+      case 'food': return '+1 food/turn';
+      default: return '';
+    }
+  }
+
+  let resourceBonusSectionHtml = '';
+  if (happinessResources.length > 0 || yieldResources.length > 0) {
+    let empireBonusHtml = '';
+    if (happinessResources.length > 0) {
+      let rows = '';
+      for (const def of happinessResources) {
+        rows += `<div style="font-size:12px;opacity:0.85;" data-res-happiness="${def.id}"></div>`;
+      }
+      empireBonusHtml = `<div style="font-weight:bold;font-size:12px;color:#d4af70;margin-bottom:4px;">Empire bonuses</div>${rows}`;
+    }
+
+    let cityBonusHtml = '';
+    if (yieldResources.length > 0) {
+      let rows = '';
+      for (const def of yieldResources) {
+        rows += `<div style="font-size:12px;opacity:0.85;" data-res-yield="${def.id}"></div>`;
+      }
+      cityBonusHtml = `<div style="font-weight:bold;font-size:12px;color:#d4af70;margin-bottom:4px;${happinessResources.length > 0 ? 'margin-top:8px;' : ''}">City bonuses</div>${rows}`;
+    }
+
+    resourceBonusSectionHtml = `
+      <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px 12px;margin-bottom:16px;">
+        <div style="font-size:13px;font-weight:bold;color:#e8c170;margin-bottom:6px;">Resources</div>
+        ${empireBonusHtml}${cityBonusHtml}
+      </div>
+    `;
+  }
+```
+
+- [ ] **Step 5: Insert resource bonus section into the panel HTML**
+
+In the `const html = \`...\`` template string, after the yield summary row and before the maintenance row, add `${resourceBonusSectionHtml}`:
+
+The yield summary div ends at the `</div>` after the science span (currently around line 333). Insert after that closing `</div>`:
+```
+    ${resourceBonusSectionHtml}
+```
+
+So the section becomes:
+```html
+    <div style="display:flex;gap:16px;margin-bottom:16px;font-size:13px;">
+      <span>🌾 +<span data-text="yield-food"></span></span>
+      <span>⚒️ +<span data-text="yield-prod"></span></span>
+      <span>💰 +<span data-text="yield-gold"></span></span>
+      <span>🔬 +<span data-text="yield-science"></span></span>
+    </div>
+    ${resourceBonusSectionHtml}
+    <div style="display:flex;gap:10px;...">
+```
+
+- [ ] **Step 6: Populate the resource bonus rows via `textContent` (after `panel.innerHTML = html`)**
+
+After the existing `setText` calls (around line 380), add:
+
+```typescript
+  // Populate resource bonus rows (textContent only — no innerHTML with game strings)
+  for (const def of happinessResources) {
+    const el = panel.querySelector(`[data-res-happiness="${def.id}"]`);
+    if (el) el.textContent = `${def.icon} ${resourceDisplayName(def.id, def.name)} → +1 happiness`;
+  }
+  for (const def of yieldResources) {
+    const el = panel.querySelector(`[data-res-yield="${def.id}"]`);
+    if (el) el.textContent = `${def.icon} ${resourceDisplayName(def.id, def.name)} → ${yieldLabel(def.effect!.type)}`;
+  }
+```
+
+Note: `resourceDisplayName` and `yieldLabel` are defined in step 4 above; they are in scope because they're defined in the same `createCityPanel` function.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/city-panel-resources.test.ts 2>&1 | tail -20
+```
+
+Expected: All 5 tests PASS.
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel-resources.test.ts
+git commit -m "feat(s4a): add resource bonus section to city panel (Empire/City bonuses split)"
+```
+
+---
+
+## Task 6: HUD happiness chip
+
+**Files:**
+- Modify: `src/main.ts`
+- Create: `tests/ui/hud-happiness.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/hud-happiness.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
+import type { GameState } from '@/core/types';
+
+// We test the happiness helper directly (HUD rendering is in main.ts, not easily unit-testable)
+// These tests document the HUD chip contract.
+
+function makeStateWithHappiness(happinessCount: number): GameState {
+  const cityPos = { q: 0, r: 0 };
+  const tiles: Record<string, unknown> = {
+    '0,0': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' },
+  };
+  const ownedTiles = [cityPos];
+  const completed: string[] = [];
+
+  // Each happiness luxury uses a different resource
+  const happinessSources = [
+    { id: 'silk', tech: 'irrigation', terrain: 'grassland', improvement: 'plantation' },
+    { id: 'wine', tech: 'pottery', terrain: 'plains', improvement: 'plantation' },
+    { id: 'ivory', tech: 'foraging', terrain: 'forest', improvement: 'camp' },
+    { id: 'furs', tech: 'foraging', terrain: 'forest', improvement: 'camp' },
+    { id: 'incense', tech: 'currency', terrain: 'desert', improvement: 'plantation' },
+  ];
+
+  for (let i = 0; i < happinessCount && i < happinessSources.length; i++) {
+    const src = happinessSources[i];
+    const coord = { q: i + 1, r: 0 };
+    tiles[`${coord.q},0`] = { coord, terrain: src.terrain, elevation: 'lowland', resource: src.id, improvement: src.improvement, improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' };
+    ownedTiles.push(coord);
+    if (!completed.includes(src.tech)) completed.push(src.tech);
+  }
+
+  return {
+    turn: 1, era: 1, currentPlayer: 'player',
+    map: { width: 20, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'Rome', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, foodNeeded: 20,
+        production: 0, productionProgress: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [cityPos],
+        focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+        grid: [[null]], gridSize: 3, hp: 100, maxHp: 100,
+        garrisonUnitId: null, specialistSlots: [],
+      },
+    },
+    civilizations: {
+      'player': {
+        id: 'player', civType: 'rome', name: 'Rome',
+        cities: ['city-1'], units: [], gold: 0,
+        techState: { completed, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+  } as unknown as GameState;
+}
+
+describe('HUD happiness chip contract', () => {
+  it('test 26: civ with 2 happiness luxuries → getCivHappinessFromResources returns 2', () => {
+    const state = makeStateWithHappiness(2);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(2);
+  });
+
+  it('test 27: civ with 0 happiness luxuries → getCivHappinessFromResources returns 0 (chip should be hidden)', () => {
+    const state = makeStateWithHappiness(0);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests pass (they test the helper, not the DOM)**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/hud-happiness.test.ts 2>&1 | tail -10
+```
+
+Expected: PASS (the helper is already implemented in Task 2).
+
+- [ ] **Step 3: Add happiness chip to `updateHUD()` in `src/main.ts`**
+
+Add import near the top of `src/main.ts` (with other system imports):
+```typescript
+import { getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
+```
+
+Inside `updateHUD()`, after the `sciSpan` is appended to `yieldsRow` (currently around line 350), add:
+
+```typescript
+  const happiness = getCivHappinessFromResources(gameState, civ.id);
+  if (happiness > 0) {
+    const happySpan = document.createElement('span');
+    happySpan.title = 'Happiness from luxury resources — each point reduces city unrest pressure by 2';
+    happySpan.textContent = `☺ ${happiness} (stability)`;
+    yieldsRow.appendChild(happySpan);
+  }
+```
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.ts tests/ui/hud-happiness.test.ts
+git commit -m "feat(s4a): add happiness chip to HUD (hidden when 0, shows stability label)"
+```
+
+---
+
+## Task 7: Marketplace panel — effect badges
+
+**Files:**
+- Modify: `src/ui/marketplace-panel.ts`
+- Create: `tests/ui/marketplace-panel-effects.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/marketplace-panel-effects.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { GameState } from '@/core/types';
+import { createMarketplacePanel } from '@/ui/marketplace-panel';
+
+beforeEach(() => { document.body.innerHTML = '<div id="mp-root"></div>'; });
+afterEach(() => { document.body.innerHTML = ''; });
+
+function makeMarketState(options: { knowsSilk?: boolean; knowsIron?: boolean } = {}): GameState {
+  const completed: string[] = [];
+  if (options.knowsSilk) completed.push('irrigation');
+  if (options.knowsIron) completed.push('bronze-working');
+
+  return {
+    turn: 1, era: 2, currentPlayer: 'player',
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    cities: {},
+    civilizations: {
+      'player': {
+        id: 'player', civType: 'rome', name: 'Rome',
+        cities: [], units: [], gold: 0,
+        techState: { completed, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {},
+    marketplace: {
+      prices: { silk: 8, iron: 8 },
+      priceHistory: { silk: [8], iron: [8] },
+      fashionable: null,
+      fashionTurnsLeft: 0,
+      tradeRoutes: [],
+    },
+  } as unknown as GameState;
+}
+
+describe('marketplace panel effect badges', () => {
+  it('test 28: silk row contains "+1 happiness" badge', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState({ knowsSilk: true });
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    const text = container.textContent ?? '';
+    expect(text).toContain('+1 happiness');
+  });
+
+  it('test 29: iron row contains "unlocks advanced units" hint, not "null"', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState({ knowsIron: true });
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    const text = container.textContent ?? '';
+    expect(text).toContain('unlocks advanced units');
+    expect(text).not.toContain('null');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/marketplace-panel-effects.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — effect badges not yet added.
+
+- [ ] **Step 3: Add effect badge to each resource row in `marketplace-panel.ts`**
+
+The resource row HTML is built in the `resourceRowsHtml` map (around lines 57-78). The row currently has:
+```html
+<div style="font-size:11px;opacity:0.6;" data-text="res-owned-${idx}"></div>
+```
+
+Add a placeholder for the effect badge below the owned status:
+```html
+<div style="font-size:10px;opacity:0.65;" data-text="res-effect-${idx}"></div>
+```
+
+So the inner `flex:1` div becomes:
+```html
+        <div style="flex:1;">
+          <div style="font-size:13px;font-weight:bold;"><span data-text="res-name-${idx}"></span> <span style="font-size:10px;color:${typeColor};" data-text="res-type-${idx}"></span></div>
+          <div style="font-size:11px;opacity:0.6;" data-text="res-owned-${idx}"></div>
+          <div style="font-size:10px;opacity:0.65;" data-text="res-effect-${idx}"></div>
+        </div>
+```
+
+Then in the `setText` loop (around line 111-118), add the effect text:
+
+```typescript
+  knownDefs.forEach((def, idx) => {
+    const price = marketplace.prices[def.id] ?? def.basePrice;
+    const isOwned = ownedResources.has(def.id as ResourceType);
+    setText(`res-name-${idx}`, def.name);
+    setText(`res-type-${idx}`, def.type.charAt(0).toUpperCase() + def.type.slice(1));
+    setText(`res-owned-${idx}`, isOwned ? '✓ Owned' : '✗ Not in inventory');
+    setText(`res-price-${idx}`, String(price));
+
+    // Effect badge (added in S4a)
+    let effectText = '';
+    if (def.effect) {
+      switch (def.effect.type) {
+        case 'happiness':   effectText = '★ +1 happiness'; break;
+        case 'gold':        effectText = '$ +1 gold/turn'; break;
+        case 'production':  effectText = '⚙ +1 production/turn'; break;
+        case 'food':        effectText = '🌾 +1 food/turn'; break;
+      }
+    } else {
+      effectText = '(unlocks advanced units & buildings)';
+    }
+    setText(`res-effect-${idx}`, effectText);
+  });
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/ui/marketplace-panel-effects.test.ts 2>&1 | tail -10
+```
+
+Expected: All 2 tests PASS.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/marketplace-panel.ts tests/ui/marketplace-panel-effects.test.ts
+git commit -m "feat(s4a): add effect badge per resource row in marketplace panel"
+```
+
+---
+
+## Task 8: Earth map — RESOURCE_ZONES additions and stone fallback fix
+
+**Files:**
+- Modify: `scripts/generate-earth-maps.ts`
+- Create: `tests/systems/earth-map-geo.test.ts`
+
+- [ ] **Step 1: Write the failing geo-coverage test**
+
+Create `tests/systems/earth-map-geo.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// We test the RESOURCE_ZONES array directly by importing the generate script module.
+// The script is not designed for direct import, so we read the bounding boxes
+// from the spec and verify them against the RESOURCE_ZONES array.
+
+// The expected bounding boxes for new resources, per spec §Earth map.
+// Each entry is: { resource, lonMin, lonMax, latMin, latMax }
+const EXPECTED_NEW_ZONE_BOXES = [
+  // Gold
+  { resource: 'gold', lonMin: 25,   lonMax: 32,   latMin: -30, latMax: -22 }, // S. Africa
+  { resource: 'gold', lonMin: -122, lonMax: -114, latMin: 36,  latMax: 42  }, // California
+  { resource: 'gold', lonMin: 120,  lonMax: 150,  latMin: 55,  latMax: 65  }, // Siberia
+  // Silver
+  { resource: 'silver', lonMin: -107, lonMax: -98, latMin: 20,  latMax: 30  }, // Mexico
+  { resource: 'silver', lonMin: -70,  lonMax: -63, latMin: -24, latMax: -14 }, // Bolivia/Peru
+  // Furs
+  { resource: 'furs', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia
+  { resource: 'furs', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada
+  // Sheep
+  { resource: 'sheep', lonMin: -10, lonMax: 2,   latMin: 50, latMax: 60 }, // British Isles
+  { resource: 'sheep', lonMin: 80,  lonMax: 120, latMin: 40, latMax: 52 }, // C. Asia
+  // Cattle
+  { resource: 'cattle', lonMin: -105, lonMax: -95, latMin: 35, latMax: 50 }, // Great Plains
+  { resource: 'cattle', lonMin: -65,  lonMax: -57, latMin: -40, latMax: -28 }, // Pampas
+  // Salt
+  { resource: 'salt', lonMin: 12,  lonMax: 25,  latMin: 47, latMax: 55 }, // C. Europe
+  { resource: 'salt', lonMin: 44,  lonMax: 58,  latMin: 30, latMax: 38 }, // Iran
+];
+
+// Read RESOURCE_ZONES from the generate script using fs
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+function parseResourceZonesFromScript(): Array<{ resource: string; terrain: string; lonMin: number; lonMax: number; latMin: number; latMax: number }> {
+  const scriptPath = resolve(__dirname, '../../scripts/generate-earth-maps.ts');
+  const content = readFileSync(scriptPath, 'utf-8');
+
+  const zonesMatch = content.match(/const RESOURCE_ZONES[^=]*=\s*\[([\s\S]*?)\];/);
+  if (!zonesMatch) throw new Error('Could not find RESOURCE_ZONES in script');
+
+  const zonesText = zonesMatch[1];
+  const entries: Array<{ resource: string; terrain: string; lonMin: number; lonMax: number; latMin: number; latMax: number }> = [];
+
+  const entryRegex = /\{\s*resource:\s*'([^']+)',\s*terrain:\s*'[^']+',\s*lonMin:\s*(-?[\d.]+),\s*lonMax:\s*(-?[\d.]+),\s*latMin:\s*(-?[\d.]+),\s*latMax:\s*(-?[\d.]+)/g;
+  let match;
+  while ((match = entryRegex.exec(zonesText)) !== null) {
+    entries.push({
+      resource: match[1],
+      terrain: '',
+      lonMin: parseFloat(match[2]),
+      lonMax: parseFloat(match[3]),
+      latMin: parseFloat(match[4]),
+      latMax: parseFloat(match[5]),
+    });
+  }
+
+  return entries;
+}
+
+describe('earth map RESOURCE_ZONES geo-coverage', () => {
+  it('test 31: each new resource has at least one zone entry in the script', () => {
+    const zones = parseResourceZonesFromScript();
+    const newResources = ['gold', 'silver', 'furs', 'sheep', 'cattle', 'salt'];
+
+    for (const resource of newResources) {
+      const found = zones.some(z => z.resource === resource);
+      expect(found, `${resource} has no RESOURCE_ZONES entry`).toBe(true);
+    }
+  });
+
+  it('test 31b: key bounding boxes from spec are present in RESOURCE_ZONES', () => {
+    const zones = parseResourceZonesFromScript();
+
+    for (const expected of EXPECTED_NEW_ZONE_BOXES) {
+      const found = zones.some(z =>
+        z.resource === expected.resource &&
+        z.lonMin === expected.lonMin &&
+        z.lonMax === expected.lonMax &&
+        z.latMin === expected.latMin &&
+        z.latMax === expected.latMax,
+      );
+      expect(found, `Missing zone: ${expected.resource} [${expected.lonMin},${expected.lonMax}]x[${expected.latMin},${expected.latMax}]`).toBe(true);
+    }
+  });
+
+  it('test 31c: stone fallback uses mountain, not hills', () => {
+    const scriptPath = resolve(__dirname, '../../scripts/generate-earth-maps.ts');
+    const content = readFileSync(scriptPath, 'utf-8');
+    // Should NOT contain the old hills fallback for stone
+    expect(content).not.toContain("terrain === 'hills' && r < 0.08");
+    // Should contain the new mountain fallback
+    expect(content).toContain("terrain === 'mountain' && r < 0.15");
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/earth-map-geo.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — zones don't exist yet, stone fallback uses old code.
+
+- [ ] **Step 3: Update `generate-earth-maps.ts` — fix stone fallback**
+
+In `scripts/generate-earth-maps.ts`, find the stone fallback (currently around line 216):
+```typescript
+  if (terrain === 'hills' && r < 0.08) {
+    return 'stone';
+  }
+```
+
+Replace with:
+```typescript
+  if (terrain === 'mountain' && r < 0.15) {
+    return 'stone';
+  }
+```
+
+- [ ] **Step 4: Update `generate-earth-maps.ts` — add missing zones and patch existing zones**
+
+Find the `const RESOURCE_ZONES: ResourceZone[] = [` array and replace it entirely with the zones from the spec. Here is the complete array:
+
+```typescript
+const RESOURCE_ZONES: ResourceZone[] = [
+  // Horses
+  { resource: 'horses', terrain: 'plains', lonMin: 50,   lonMax: 100,  latMin: 40, latMax: 55 }, // Central Asian steppe
+  { resource: 'horses', terrain: 'plains', lonMin: -110, lonMax: -95,  latMin: 30, latMax: 50 }, // Great Plains (Americas)
+  { resource: 'horses', terrain: 'plains', lonMin: 35,   lonMax: 55,   latMin: 15, latMax: 30 }, // PATCH: Arabian Peninsula
+
+  // Iron
+  { resource: 'iron', terrain: 'hills', lonMin: 5,   lonMax: 30,   latMin: 50, latMax: 65 }, // N. Europe/Scandinavia
+  { resource: 'iron', terrain: 'hills', lonMin: 105, lonMax: 120,  latMin: 30, latMax: 45 }, // China
+  { resource: 'iron', terrain: 'hills', lonMin: -95, lonMax: -75,  latMin: 40, latMax: 50 }, // Great Lakes (US)
+  { resource: 'iron', terrain: 'hills', lonMin: -50, lonMax: -40,  latMin: -22, latMax: -10 }, // PATCH: Brazil/Minas Gerais
+  { resource: 'iron', terrain: 'hills', lonMin: 83,  lonMax: 88,   latMin: 21, latMax: 25 }, // PATCH: India/Jharkhand
+
+  // Silk
+  { resource: 'silk', terrain: 'grassland', lonMin: 95, lonMax: 115, latMin: 30, latMax: 40 }, // China
+
+  // Spices
+  { resource: 'spices', terrain: 'jungle', lonMin: 95,  lonMax: 140, latMin: -10, latMax: 20 }, // SE Asia
+  { resource: 'spices', terrain: 'jungle', lonMin: 70,  lonMax: 85,  latMin: 8,   latMax: 20 }, // S. India
+  { resource: 'spices', terrain: 'jungle', lonMin: 38,  lonMax: 42,  latMin: -8,  latMax: 0  }, // PATCH: Zanzibar/E. Africa
+
+  // Incense
+  { resource: 'incense', terrain: 'desert', lonMin: 40, lonMax: 60, latMin: 15, latMax: 30 }, // Arabian Peninsula
+  { resource: 'incense', terrain: 'desert', lonMin: 10, lonMax: 40, latMin: 15, latMax: 30 }, // N. Africa / Horn
+
+  // Gems — terrain MUST be 'hills' (mine required; plantation cannot be built on jungle)
+  { resource: 'gems', terrain: 'hills', lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5  }, // S. Africa
+  { resource: 'gems', terrain: 'hills', lonMin: 75,   lonMax: 85,   latMin: 10,  latMax: 25 }, // India
+  { resource: 'gems', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5  }, // S. America (Andes/Colombia — hills not jungle)
+  { resource: 'gems', terrain: 'hills', lonMin: 95,   lonMax: 103,  latMin: 17,  latMax: 27 }, // PATCH: Myanmar
+  { resource: 'gems', terrain: 'hills', lonMin: 135,  lonMax: 145,  latMin: -32, latMax: -25 }, // PATCH: Australia
+
+  // Ivory
+  { resource: 'ivory', terrain: 'forest', lonMin: 10,  lonMax: 40,   latMin: -15, latMax: 10 }, // Central/West Africa
+  { resource: 'ivory', terrain: 'forest', lonMin: 33,  lonMax: 42,   latMin: -10, latMax: 5  }, // PATCH: East Africa
+  { resource: 'ivory', terrain: 'forest', lonMin: 75,  lonMax: 105,  latMin: 8,   latMax: 22 }, // PATCH: South Asia
+
+  // Wine — terrain MUST be 'plains' (wine's RESOURCE_DEFINITION terrain)
+  { resource: 'wine', terrain: 'plains', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 }, // Mediterranean/France/Iberia
+  { resource: 'wine', terrain: 'plains', lonMin: -123, lonMax: -119, latMin: 37, latMax: 39 }, // PATCH: California (Napa)
+  { resource: 'wine', terrain: 'plains', lonMin: 18,   lonMax: 22,   latMin: -34, latMax: -32 }, // PATCH: S. Africa (Cape)
+  { resource: 'wine', terrain: 'plains', lonMin: -72,  lonMax: -68,  latMin: -37, latMax: -30 }, // PATCH: Chile/Mendoza
+
+  // Copper
+  { resource: 'copper', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -35, latMax: 10 }, // S. America (Andes)
+  { resource: 'copper', terrain: 'hills', lonMin: -9,   lonMax: -5,   latMin: 37,  latMax: 43 }, // Iberian Peninsula
+  { resource: 'copper', terrain: 'hills', lonMin: 25,   lonMax: 30,   latMin: -15, latMax: -8 }, // PATCH: Zambia/DRC
+  { resource: 'copper', terrain: 'hills', lonMin: -115, lonMax: -108, latMin: 32,  latMax: 48 }, // PATCH: Arizona/Montana
+
+  // Gold (NEW)
+  { resource: 'gold', terrain: 'hills', lonMin: 25,   lonMax: 32,   latMin: -30, latMax: -22 }, // S. Africa (Witwatersrand)
+  { resource: 'gold', terrain: 'hills', lonMin: -122, lonMax: -114, latMin: 36,  latMax: 42  }, // California/Sierra Nevada
+  { resource: 'gold', terrain: 'hills', lonMin: 120,  lonMax: 150,  latMin: 55,  latMax: 65  }, // Siberia
+  { resource: 'gold', terrain: 'hills', lonMin: -3,   lonMax: 2,    latMin: 5,   latMax: 10  }, // W. Africa (Ghana)
+
+  // Silver (NEW)
+  { resource: 'silver', terrain: 'hills', lonMin: -107, lonMax: -98, latMin: 20, latMax: 30 }, // Mexico (Zacatecas)
+  { resource: 'silver', terrain: 'hills', lonMin: -70,  lonMax: -63, latMin: -24, latMax: -14 }, // Bolivia/Peru (Potosí)
+  { resource: 'silver', terrain: 'hills', lonMin: 12,   lonMax: 20,  latMin: 49, latMax: 53 }, // C. Europe (Saxony)
+
+  // Furs (NEW — forest and tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia (forest)
+  { resource: 'furs', terrain: 'tundra', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia (tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada (forest)
+  { resource: 'furs', terrain: 'tundra', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada (tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: 15,   lonMax: 30,   latMin: 60, latMax: 70 }, // Scandinavia
+
+  // Sheep (NEW — hills and plains)
+  { resource: 'sheep', terrain: 'hills',  lonMin: -10, lonMax: 2,   latMin: 50, latMax: 60 }, // British Isles
+  { resource: 'sheep', terrain: 'plains', lonMin: 80,  lonMax: 120, latMin: 40, latMax: 52 }, // C. Asia/Mongolia
+  { resource: 'sheep', terrain: 'plains', lonMin: -73, lonMax: -60, latMin: -52, latMax: -37 }, // Patagonia
+  { resource: 'sheep', terrain: 'hills',  lonMin: -8,  lonMax: 2,   latMin: 38, latMax: 43 }, // Iberia (merino)
+
+  // Cattle (NEW — grassland and plains)
+  { resource: 'cattle', terrain: 'plains',    lonMin: -105, lonMax: -95, latMin: 35, latMax: 50 }, // Great Plains
+  { resource: 'cattle', terrain: 'grassland', lonMin: -65,  lonMax: -57, latMin: -40, latMax: -28 }, // Argentine Pampas
+  { resource: 'cattle', terrain: 'grassland', lonMin: 32,   lonMax: 42,  latMin: -5,  latMax: 10 }, // East Africa
+
+  // Salt (NEW — hills)
+  { resource: 'salt', terrain: 'hills', lonMin: 12,  lonMax: 25,  latMin: 47, latMax: 55 }, // C. Europe (Wieliczka)
+  { resource: 'salt', terrain: 'hills', lonMin: 44,  lonMax: 58,  latMin: 30, latMax: 38 }, // Zagros/Iran
+  { resource: 'salt', terrain: 'hills', lonMin: -70, lonMax: -65, latMin: -25, latMax: -16 }, // Andes (Atacama)
+  { resource: 'salt', terrain: 'hills', lonMin: -5,  lonMax: 10,  latMin: 30, latMax: 37 }, // N. Africa/Atlas
+];
+```
+
+- [ ] **Step 5: Run geo tests to verify they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/earth-map-geo.test.ts 2>&1 | tail -20
+```
+
+Expected: All 3 sub-tests PASS.
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit the script changes**
+
+```bash
+git add scripts/generate-earth-maps.ts tests/systems/earth-map-geo.test.ts
+git commit -m "feat(s4a): add RESOURCE_ZONES for 6 new resources, patch existing zones, fix stone fallback to mountain"
+```
+
+---
+
+## Task 9: Regenerate earth-map data
+
+**Files:**
+- Regenerate: `src/systems/earth-map-data.ts`, `src/systems/old-world-map-data.ts`, `src/systems/new-world-map-data.ts`
+
+- [ ] **Step 1: Run the map generator**
+
+```bash
+bash scripts/run-with-mise.sh yarn generate-maps 2>&1
+```
+
+Expected: Exits 0. `src/systems/earth-map-data.ts` (and old/new world variants) are regenerated.
+
+- [ ] **Step 2: Verify the regenerated data has the new resources**
+
+```bash
+grep -c "gold\|silver\|furs\|sheep\|cattle\|salt" src/systems/earth-map-data.ts
+```
+
+Expected: Non-zero count (at least some of the new resources appear in tiles).
+
+Also verify stone now appears on mountain tiles (not hills):
+```bash
+grep "stone" src/systems/earth-map-data.ts | head -5
+```
+
+Expected output contains `terrain:'mountain'` with resource `'stone'` (or vice versa in the tile structure).
+
+- [ ] **Step 3: Run full test suite one more time**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 4: Build to verify TypeScript**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -10
+```
+
+Expected: Exits 0, no TypeScript errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/earth-map-data.ts src/systems/old-world-map-data.ts src/systems/new-world-map-data.ts
+git commit -m "chore(s4a): regenerate earth-map-data with new resource zones and stone-on-mountain fix"
+```
+
+---
+
+## Task 10: Final verification and PR
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: All tests PASS. Count total PASS lines — should include the 31 new tests across the 5 test files.
+
+- [ ] **Step 2: Run TypeScript build**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -10
+```
+
+Expected: Exits 0.
+
+- [ ] **Step 3: Verify git log shows all commits on the branch**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: 9 commits (Tasks 1–9 each produced one commit).
+
+- [ ] **Step 4: Open PR**
+
+```bash
+gh pr create \
+  --title "feat(marketplace): S4a — per-resource yield & happiness effects" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `ResourceEffect` type and `effect` field to all 16 `RESOURCE_DEFINITIONS` (static data, no GameState migration needed)
+- Adds `getCivResourceYieldBonus` and `getCivHappinessFromResources` pure helpers in `resource-acquisition-system.ts`
+- Wires yield bonuses into `turn-manager.ts` (once per civ before city loop — architecture regression covered)
+- Wires happiness reduction into `faction-system.ts` (`computeUnrestPressure` optional param + per-civ pre-computation in `processFactionTurn`)
+- Surfaces bonuses in city panel (Empire bonuses / City bonuses split), HUD (☺ N (stability) chip when > 0), and marketplace panel (effect badge per row)
+- Fixes earth map: adds RESOURCE_ZONES for 6 new S2a resources (gold, silver, furs, sheep, cattle, salt), patches missing zones for 7 existing resources, and corrects the stone terrain fallback from `hills` to `mountain`
+- 31 new tests across 5 test files
+
+## Test plan
+
+- [ ] `yarn test` exits 0 — 31 new tests all pass
+- [ ] `yarn build` exits 0 — no TypeScript errors
+- [ ] Start dev server (`yarn dev`) and verify: own a silk tile → HUD shows "☺ 1 (stability)"; own gems → city panel shows "City bonuses — Gems → +1 gold/turn"; open marketplace → iron row shows "unlocks advanced units & buildings"
+- [ ] Start new earth map game — verify salt, cattle, furs, sheep, silver, gold tiles appear on the map within expected geographic regions
+
+## Out of scope
+
+- S4b: strategic resource prerequisites for units/buildings (copper/iron/horses/stone effects)
+- Era/tech scaling of bonus amounts (flat +1 in this slice)
+- Old-world and new-world map data geographic review (follow-up)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Covered in plan? |
+|---|---|
+| Effect table (all 16 resources) | ✓ Task 1 — all 16 updated |
+| Non-stacking per resource, accumulation across different resources | ✓ Tests 7, 8, 9 |
+| Loss timing: computed fresh each turn | ✓ No persistent copy — pure helpers only |
+| `ResourceEffect` type in `trade-system.ts` | ✓ Task 1 |
+| `getCivResourceYieldBonus` (excludes happiness) | ✓ Task 2, test 12 |
+| `getCivHappinessFromResources` | ✓ Task 2 |
+| `turn-manager.ts` once per civ (not per city) | ✓ Task 3, arch regression confirmed in diff |
+| Science not boosted by resources | ✓ Task 3 code explicitly omits science |
+| `computeUnrestPressure` optional `ownerHappiness = 0` | ✓ Task 4, test 20 |
+| civHappiness map in `processFactionTurn` (O(cities²) prevention) | ✓ Task 4 |
+| −2 pressure per happiness point | ✓ Task 4, tests 17-19 |
+| City panel Empire/City split; sub-headers omitted when empty | ✓ Task 5, tests 21-25 |
+| "Gold deposits" naming for gold resource | ✓ Task 5, test 23 |
+| HUD chip hidden when 0, self-explanatory "(stability)" label | ✓ Task 6, tests 26-27 |
+| Marketplace effect badge; null resources say "unlocks advanced units & buildings" | ✓ Task 7, tests 28-29 |
+| Save compatibility (effect is static, no migration) | ✓ Test 30 |
+| Stone fallback: hills → mountain at 15% | ✓ Task 8, test 31c |
+| 6 new resource zones | ✓ Task 8, test 31 |
+| Patch zones for existing resources (iron+3, horses+1, spices+1, gems+2, ivory+2, wine+3, copper+2) | ✓ Task 8 zone array |
+| Regenerate earth-map-data | ✓ Task 9 |
+
+**Placeholder scan:** No "TBD", "TODO", "implement later", or similar. All code steps show exact implementation.
+
+**Type consistency check:**
+- `ResourceEffect.type` = `'happiness' | 'gold' | 'production' | 'food'` — consistent throughout
+- `getCivResourceYieldBonus` returns `ResourceYield` — consistent with turn-manager usage
+- `computeUnrestPressure(cityId, state, ownerHappiness = 0)` — consistent between Task 4 implementation and all test call sites
+- `createCityPanel` — function exists in `city-panel.ts` at the expected export path
+- `RESOURCE_DEFINITIONS` imported from `@/systems/trade-system` everywhere — consistent

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -22,7 +22,7 @@ This file is the **index** and is intentionally deliverable #1 so the high-level
 
 | Area | Status | Location / detail |
 |---|---|---|
-| Resource types (10 luxury, 6 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert), gold(hills), silver(hills), furs(forest/tundra), sheep(hills/plains). Strategic: copper(hills), iron(hills), horses(plains), stone(**hills** — S2a moved from mountain), cattle(grassland/plains), salt(hills). |
+| Resource types (10 luxury, 6 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert), gold(hills), silver(hills), furs(forest/tundra), sheep(hills/plains). Strategic: copper(hills), iron(hills), horses(plains), stone(**mountain** — S2a moved from hills; earth-map generator stone fallback still uses hills incorrectly — fixed in S4a), cattle(grassland/plains), salt(hills). |
 | Resources placed on map tiles (`tile.resource`) | ✅ exists | `map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`; geo maps via `geo-map-loader.ts`. |
 | Per-turn price engine (supply/demand) + history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388. Note: `updatePrices` hardcodes `isMonopoly=false` (S12). |
 | Marketplace **building** | ✅ exists | `city-system.ts` L59 `marketplace` (gold +3, cost 50, `techRequired: 'currency'`, icon 🏪). |

--- a/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
+++ b/docs/superpowers/specs/2026-05-20-marketplace-trade-roadmap.md
@@ -22,7 +22,7 @@ This file is the **index** and is intentionally deliverable #1 so the high-level
 
 | Area | Status | Location / detail |
 |---|---|---|
-| Resource types (6 luxury, 4 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert). Strategic: copper(hills), iron(hills), horses(plains), stone(mountain). |
+| Resource types (10 luxury, 6 strategic) + base prices | ✅ exists | `trade-system.ts` `RESOURCE_DEFINITIONS`. Luxury: silk(grassland), wine(plains), spices(jungle), gems(hills), ivory(forest), incense(desert), gold(hills), silver(hills), furs(forest/tundra), sheep(hills/plains). Strategic: copper(hills), iron(hills), horses(plains), stone(**hills** — S2a moved from mountain), cattle(grassland/plains), salt(hills). |
 | Resources placed on map tiles (`tile.resource`) | ✅ exists | `map-generator.ts`, `balanced-map-generator.ts`, `continent-map-generator.ts`; geo maps via `geo-map-loader.ts`. |
 | Per-turn price engine (supply/demand) + history + fashion cycle | ✅ exists | `trade-system.ts` (`calculatePrice`, `updatePrices`, `processFashionCycle`); driven in `turn-manager.ts` ~L388. Note: `updatePrices` hardcodes `isMonopoly=false` (S12). |
 | Marketplace **building** | ✅ exists | `city-system.ts` L59 `marketplace` (gold +3, cost 50, `techRequired: 'currency'`, icon 🏪). |
@@ -39,6 +39,11 @@ This file is the **index** and is intentionally deliverable #1 so the high-level
 | Relationship gating on trade | ❌ MISSING | must be implemented as score thresholds (D-Q8). |
 | Actual buy / sell / barter | ❌ MISSING | panel has no transaction actions. |
 | Gameplay effect of owning a resource | ❌ NONE today | `tile.resource` only read by marketplace supply, map-gen balancing, wonder diversity counts, espionage intel. Owning a resource confers no benefit → S4 adds effects (D-Q1). |
+| S1 resources on map | ✅ merged | tech-gated icon render, legend, inspection panel |
+| S2a resource-specific improvements | ✅ merged | plantation, pasture, camp, quarry end-to-end; expanded catalog to 16 resources |
+| S2b acquisition model + inventory UI | ✅ merged | `getCivAvailableResources`; "Your Resources" panel; territory inspection |
+| S3 marketplace tells the truth | ✅ merged | tech-filtered display, fashion banner gate, `getCivAvailableResources` counts |
+| S4a per-resource yield & happiness effects | 🔄 in progress | spec: `docs/superpowers/specs/2026-05-23-marketplace-s4a-resource-effects-design.md` |
 
 **Gotcha:** `src/systems/resource-system.ts` is misnamed — it computes **city tile yields**, not resources. Trade/resource logic lives in `trade-system.ts`. Put the new acquisition system in a clearly named new file (e.g. `resource-acquisition-system.ts`).
 
@@ -189,7 +194,7 @@ Linear; each phase gates the next.
 - **D-Q8 — Thresholds.** Foreign trade establishes at relationship ≥ 0; terminates when < −25 or at war. → S5/S6.
 
 ### Open at slice level (resolve in each slice's brainstorm)
-Exact happiness/yield magnitudes per resource; the resource→improvement and resource→effect tables; which units/buildings require which strategic resource; naval-trader tech gate and overseas-route rules; route-capacity formula constants; barter UI (propose/accept vs. instant).
+~~Exact happiness/yield magnitudes per resource; the resource→improvement and resource→effect tables~~ — **resolved in S4a brainstorm (2026-05-23):** flat +1 per resource, empire-wide non-stacking for happiness, per-city for yield bonuses; full 16-resource effect table in S4a spec. Which units/buildings require which strategic resource (S4b); naval-trader tech gate and overseas-route rules (S7); route-capacity formula constants (S5); barter UI (propose/accept vs. instant) (S10).
 
 ## Rejected items
 

--- a/docs/superpowers/specs/2026-05-23-marketplace-s4a-resource-effects-design.md
+++ b/docs/superpowers/specs/2026-05-23-marketplace-s4a-resource-effects-design.md
@@ -6,12 +6,12 @@
 
 ## Goal
 
-Owning a resource (as determined by `getCivAvailableResources`) now confers a passive empire-wide effect: luxury resources grant happiness or per-city yield bonuses; two strategic resources (cattle, salt) get small passive bonuses. The bonus is visible in the city panel and HUD. Losing a resource removes the bonus immediately (same turn).
+Owning a resource (as determined by `getCivAvailableResources`) now confers a passive empire-wide effect: luxury resources grant happiness or per-city yield bonuses; two strategic resources (cattle, salt) get small passive bonuses. The bonus is visible in the city panel and HUD. Effects are recomputed fresh each turn from current ownership — no stale copy is stored.
 
 This slice also patches two companion issues introduced by prior work:
 - Six new resources added in S2a (gold, silver, furs, sheep, cattle, salt) have no placement zones in `generate-earth-maps.ts` and therefore never appear on earth maps.
 - Several existing resources have missing geographic zones (iron, horses, spices, gems, ivory, wine, copper — see §Earth map).
-- The roadmap "Current state" table incorrectly lists stone's terrain as `mountain`; S2a moved it to `hills`.
+- The earth map generator's stone fallback incorrectly uses `hills` terrain, but S2a moved stone to `mountain` terrain. The fallback must be updated to `mountain`.
 
 ## Effect table (all 16 resources)
 
@@ -44,9 +44,9 @@ This slice also patches two companion issues introduced by prior work:
 
 **Magnitude:** flat +1 in S4a. Era/tech scaling deferred to a future slice.
 
-**Scope:** empire-wide, non-stacking. Owning three silk tiles still gives +1 happiness, not +3. Duplicates are for selling (S8+).
+**Scope:** empire-wide, non-stacking **per resource**. Owning three silk tiles gives +1 happiness, not +3 — duplicates are for selling (S8+). However, owning silk **and** wine gives +2 happiness (two distinct resources, each contributes once). Same rule applies to yield resources: gems + silver both contribute +1 gold/turn each, so a civ owning both gets +2 gold/turn per city.
 
-**Loss timing:** immediate (same turn). The effect is derived fresh from `getCivAvailableResources` each turn; no persistent copy to go stale.
+**Loss timing:** computed fresh each turn from the current resource ownership state at the point each subsystem runs. Yield bonuses (gold, production, food) are applied in the per-civ city loop; happiness reduction is applied during `processFactionTurn` at the top of the turn. In practice: an improvement destroyed by combat mid-turn drops the yield bonus on the following turn's city processing and drops the happiness pressure reduction on the following turn's faction pass. No persistent copy of effects is stored, so nothing can go stale.
 
 ## Data model
 
@@ -79,9 +79,11 @@ export interface ResourceDefinition {
 
 ```typescript
 /**
- * Returns the aggregate per-city yield bonus from all owned non-happiness
- * resources. Empire-wide, non-stacking: owning any amount of a resource
- * counts once.
+ * Returns the aggregate per-city yield bonus from all owned resources whose
+ * effect type is NOT 'happiness' (i.e. gold, production, food effects only).
+ * Non-stacking per resource: owning any number of the same resource counts once.
+ * Different resources with the same effect type DO accumulate
+ * (gems + silver → +2 gold/turn).
  */
 export function getCivResourceYieldBonus(
   state: GameState,
@@ -118,16 +120,41 @@ const yields = {
 
 ### `faction-system.ts` — happiness reduces unrest pressure
 
-`computeUnrestPressure` gains a happiness offset (capped so pressure cannot go below 0):
+**Performance constraint:** `computeUnrestPressure` is called once per city, not once per civ. Calling `getCivHappinessFromResources` (which itself calls `getCivAvailableResources`) inside it would scan all owned tiles once per city per turn — O(cities²) per civ. Instead, `processFactionTurn` computes happiness once per civ and passes it down.
 
 ```typescript
+// In processFactionTurn, build a happiness map before the city loop:
 import { getCivHappinessFromResources } from './resource-acquisition-system';
 
-// At the end of computeUnrestPressure, before the final cap:
-const happiness = getCivHappinessFromResources(state, owner);
-pressure -= happiness * 2; // up to −10 from 5 happiness luxuries
-return Math.min(100, Math.max(0, pressure));
+// Before the per-city loop in processFactionTurn:
+const civHappiness: Record<string, number> = {};
+for (const civId of Object.keys(nextState.civilizations)) {
+  civHappiness[civId] = getCivHappinessFromResources(nextState, civId);
+}
+
+// computeUnrestPressure gains a happiness parameter:
+export function computeUnrestPressure(
+  cityId: string,
+  state: GameState,
+  ownerHappiness: number,  // pre-computed, passed from processFactionTurn
+): number {
+  // ...existing pressure logic...
+  pressure -= ownerHappiness * 2; // up to −10 from 5 happiness luxuries
+  return Math.min(100, Math.max(0, pressure));
+}
 ```
+
+There is **1 internal call site** of `computeUnrestPressure` in `faction-system.ts` (line ~179 in `processFactionTurn`). Because the function is `export`ed, add `ownerHappiness` as an **optional parameter with default 0** to avoid breaking any future external callers:
+
+```typescript
+export function computeUnrestPressure(
+  cityId: string,
+  state: GameState,
+  ownerHappiness = 0,
+): number
+```
+
+The internal call site passes `civHappiness[city.owner] ?? 0`; any external call site that omits the argument defaults to 0 (no happiness benefit), which is safe.
 
 Effect in context: each luxury happiness resource offsets 2 pressure. Five luxuries (−10) meaningfully counteracts two wars' worth of war-weariness (2 × 8 = +16) or two-and-a-half cities of overextension.
 
@@ -137,22 +164,45 @@ No new `GameState` fields are added. Happiness is fully computed each turn from 
 
 ### City panel — resource bonus subsection
 
-A new "Resources" row group is inserted below the yield summary in the city panel. One line per owned resource that has an effect, using `createTextNode` / `textContent` only:
+A new "Resources" row group is inserted below the yield summary. It is split into two labelled sub-rows to avoid confusing empire-wide bonuses with per-city yields:
 
 ```
-Silk      → +1 happiness
-Ivory     → +1 happiness
-Gems      → +1 gold/turn
-Sheep     → +1 production/turn
+Empire bonuses
+  Silk    → +1 happiness
+  Ivory   → +1 happiness
+
+City bonuses
+  Gems    → +1 gold/turn
+  Sheep   → +1 production/turn
 ```
 
-- Happiness lines are identical across all city panels (empire-wide effect, not city-specific).
-- Only resources with a non-null effect are shown; the section is omitted entirely if the civ owns no effect-bearing resources.
+Rules:
+- "Empire bonuses" shows only happiness-type resources; each line represents a unique owned resource (non-stacking). The label makes clear the bonus is not specific to this city.
+- "City bonuses" shows yield-type resources (gold, production, food). These apply equally to every city, but showing them here gives per-city context.
+- A sub-row header that has no resources beneath it is omitted entirely (e.g., if the civ owns only yield resources, only "City bonuses" appears; the "Empire bonuses" header is omitted).
+- The entire "Resources" section is omitted if no effect-bearing resources are owned.
 - Uses `state.currentPlayer` (never hardcoded `'player'`).
+- `createTextNode` / `textContent` only — no `innerHTML` with game strings.
+- **Naming**: the gold (resource) displays as "Gold deposits → +1 gold/turn" to avoid the confusing "Gold → +1 gold" collision between resource name and currency name.
 
 ### HUD — happiness chip
 
 A `☺ N` chip is added alongside the existing per-turn yield chips (food, production, gold, science). Computes `getCivHappinessFromResources(state, state.currentPlayer)`. The chip is omitted when the value is 0 (no clutter when no luxuries are owned).
+
+The chip must be **self-explanatory**: players have never seen a happiness number in this game before. Use a tooltip or inline label that makes the effect clear. Recommended display: `☺ 3 — reduces unrest risk`. If the HUD layout cannot support a tooltip, add a parenthetical: `☺ 3 (stability)`. The raw number alone is not enough.
+
+### Marketplace panel — effect annotation
+
+Each resource row in the marketplace panel (already filtered by tech in S3) gains a small effect badge:
+
+```
+🧵 Silk    luxury   ★ +1 happiness
+💎 Gems    luxury   $ +1 gold/turn
+🐑 Sheep   luxury   ⚙ +1 production/turn
+⚙️ Iron    strategic  (unit prerequisite — S4b)
+```
+
+Resources with `effect: null` (copper, iron, horses, stone) show `(unlocks advanced units & buildings)` as a player-readable hint that their value comes later. Do not use internal slice names like "S4b". Uses `textContent` only.
 
 ## Earth map — geographic zones
 
@@ -189,23 +239,23 @@ The full intended `RESOURCE_ZONES` table after this slice (new entries marked **
 { resource: 'incense', terrain: 'desert', lonMin: 40, lonMax: 60, latMin: 15, latMax: 30 }, // Arabian Peninsula
 { resource: 'incense', terrain: 'desert', lonMin: 10, lonMax: 40, latMin: 15, latMax: 30 }, // N. Africa / Horn
 
-// Gems
-{ resource: 'gems', terrain: 'hills',  lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5  }, // S. Africa (diamonds)
-{ resource: 'gems', terrain: 'hills',  lonMin: 75,   lonMax: 85,   latMin: 10,  latMax: 25 }, // India (diamonds)
-{ resource: 'gems', terrain: 'jungle', lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5  }, // S. America
-{ resource: 'gems', terrain: 'hills',  lonMin: 95,   lonMax: 103,  latMin: 17,  latMax: 27 }, // PATCH: Myanmar (rubies/jade)
-{ resource: 'gems', terrain: 'hills',  lonMin: 135,  lonMax: 145,  latMin: -32, latMax: -25 }, // PATCH: Australia (opals)
+// Gems — terrain MUST be 'hills' (gems requires a mine; mines can't be built on jungle)
+{ resource: 'gems', terrain: 'hills', lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5  }, // S. Africa (diamonds, Kimberlite pipes)
+{ resource: 'gems', terrain: 'hills', lonMin: 75,   lonMax: 85,   latMin: 10,  latMax: 25 }, // India (diamonds, Golconda)
+{ resource: 'gems', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5  }, // S. America (emeralds, Andes/Colombia — hills, not jungle)
+{ resource: 'gems', terrain: 'hills', lonMin: 95,   lonMax: 103,  latMin: 17,  latMax: 27 }, // PATCH: Myanmar (rubies/jade)
+{ resource: 'gems', terrain: 'hills', lonMin: 135,  lonMax: 145,  latMin: -32, latMax: -25 }, // PATCH: Australia (opals)
 
 // Ivory
 { resource: 'ivory', terrain: 'forest', lonMin: 10,  lonMax: 40,   latMin: -15, latMax: 10 }, // Central/West Africa
 { resource: 'ivory', terrain: 'forest', lonMin: 33,  lonMax: 42,   latMin: -10, latMax: 5  }, // PATCH: East Africa
 { resource: 'ivory', terrain: 'forest', lonMin: 75,  lonMax: 105,  latMin: 8,   latMax: 22 }, // PATCH: South Asia (Indian elephant)
 
-// Wine
-{ resource: 'wine', terrain: 'grassland', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 }, // Mediterranean/France
-{ resource: 'wine', terrain: 'grassland', lonMin: -123, lonMax: -119, latMin: 37, latMax: 39 }, // PATCH: California (Napa)
-{ resource: 'wine', terrain: 'grassland', lonMin: 18,   lonMax: 22,   latMin: -34, latMax: -32 }, // PATCH: S. Africa (Cape)
-{ resource: 'wine', terrain: 'grassland', lonMin: -72,  lonMax: -68,  latMin: -37, latMax: -30 }, // PATCH: Chile/Mendoza
+// Wine — terrain MUST be 'plains' (wine's RESOURCE_DEFINITION terrain; plantation is buildable on plains)
+{ resource: 'wine', terrain: 'plains', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 }, // Mediterranean/France/Iberia
+{ resource: 'wine', terrain: 'plains', lonMin: -123, lonMax: -119, latMin: 37, latMax: 39 }, // PATCH: California (Napa)
+{ resource: 'wine', terrain: 'plains', lonMin: 18,   lonMax: 22,   latMin: -34, latMax: -32 }, // PATCH: S. Africa (Cape)
+{ resource: 'wine', terrain: 'plains', lonMin: -72,  lonMax: -68,  latMin: -37, latMax: -30 }, // PATCH: Chile/Mendoza
 
 // Copper
 { resource: 'copper', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -35, latMax: 10 }, // S. America (Andes)
@@ -249,7 +299,11 @@ The full intended `RESOURCE_ZONES` table after this slice (new entries marked **
 { resource: 'salt', terrain: 'hills', lonMin: -5,  lonMax: 10,  latMin: 30, latMax: 37 }, // N. Africa/Atlas
 ```
 
-Stone keeps its existing global fallback (8% of hills tiles — stone is geographically ubiquitous).
+**Stone fallback fix:** The existing generator fallback `if (terrain === 'hills' && r < 0.08) return 'stone'` is wrong — S2a moved stone to `mountain` terrain (requiring a quarry, which is buildable only on mountains). Update the fallback to:
+```typescript
+if (terrain === 'mountain' && r < 0.15) return 'stone';
+```
+Threshold raised from 8% to 15% because mountains are rarer than hills on the map, preserving roughly the same total stone tile count. Stone is geographically ubiquitous so a global mountain fallback is appropriate.
 
 ### Regeneration
 
@@ -261,6 +315,8 @@ This overwrites `src/systems/earth-map-data.ts`, `old-world-map-data.ts`, and `n
 
 ## Tests
 
+**Helpers (unit)**
+
 | # | Test | Type |
 |---|---|---|
 | 1 | Every entry in `RESOURCE_DEFINITIONS` has `effect` defined (non-undefined — may be `null`) | catalog |
@@ -269,23 +325,68 @@ This overwrites `src/systems/earth-map-data.ts`, `old-world-map-data.ts`, and `n
 | 4 | `getCivResourceYieldBonus` returns `{ production: 1, ... }` for a civ owning sheep | positive |
 | 5 | `getCivResourceYieldBonus` returns `{ food: 1, ... }` for a civ owning cattle | positive |
 | 6 | `getCivResourceYieldBonus` returns `{ gold: 1, ... }` for a civ owning salt | positive |
-| 7 | Civ owning 3 silk tiles (3 different cities) → happiness still 1 (non-stacking) | non-stacking |
-| 8 | Civ with no owned resources → happiness 0, all yield bonuses 0 | negative |
-| 9 | Copper/iron/horses/stone produce no S4a effect (`getCivResourceYieldBonus` returns zeros, `getCivHappinessFromResources` returns 0 for a civ owning only those) | negative |
-| 10 | Silk improvement destroyed (`improvementTurnsLeft > 0`) → `getCivHappinessFromResources` returns 0 same turn | loss |
-| 11 | Civ with 3 cities owning gems → all 3 cities receive +1 gold in turn processing | all-cities |
-| 12 | AI civ owning spices accrues gold/turn via the same turn-manager code path | AI parity |
-| 13 | City with pressure 45, civ owns 3 happiness luxuries → pressure reduced by 6 → 39 → no unrest | unrest |
-| 14 | `computeUnrestPressure` with happiness = 5 → pressure reduced by 10 | unrest magnitude |
-| 15 | Old-save load: `GameState` with no `effect` on RESOURCE_DEFINITIONS initialises without crash (static data, no migration) | save-compat |
-| 16 | Earth map (small): each resource in RESOURCE_ZONES appears within at least one of its declared lon/lat bounding boxes | geo-coverage |
+| 7 | Civ owning 3 silk tiles (3 different cities) → `getCivHappinessFromResources` returns 1, not 3 (same-resource non-stacking) | non-stacking |
+| 8 | Civ owning silk AND wine → `getCivHappinessFromResources` returns 2 (different resources accumulate) | accumulation |
+| 9 | Civ owning gems AND silver → `getCivResourceYieldBonus` returns `{ gold: 2, ... }` (different resources accumulate) | accumulation |
+| 10 | Civ with no owned resources → happiness 0, all yield bonuses 0 | negative |
+| 11 | Copper/iron/horses/stone → `getCivResourceYieldBonus` returns all zeros; `getCivHappinessFromResources` returns 0 | negative |
+| 12 | `getCivResourceYieldBonus` returns 0 happiness contribution (happiness resources excluded from yield bonus) | negative |
+| 13 | Silk improvement destroyed (`improvementTurnsLeft > 0`) → `getCivHappinessFromResources` returns 0 | loss |
+
+**Turn processing (integration)**
+
+| # | Test | Type |
+|---|---|---|
+| 14 | Civ with 3 cities owning gems → all 3 cities receive +1 gold in turn processing (not cities[0] only) | all-cities |
+| 15 | AI civ owning spices accrues +1 gold/turn per city via same turn-manager code path as human civ | AI parity |
+| 16 | `getCivResourceYieldBonus` called exactly once per civ per turn-manager pass, not once per city | arch regression |
+
+**Faction / unrest**
+
+| # | Test | Type |
+|---|---|---|
+| 17 | `computeUnrestPressure` with `ownerHappiness=3` → pressure reduced by 6 | unrest magnitude |
+| 18 | City at base pressure 45 with 3 happiness luxuries → pressure 39 → no unrest fires | unrest positive |
+| 19 | City at base pressure 45 with 0 happiness luxuries → pressure 45 → unrest fires (without happiness, same pressure triggers) | unrest negative |
+| 20 | `computeUnrestPressure` called with no `ownerHappiness` arg (omitted) → defaults to 0, no crash | API safety |
+
+**UI — city panel**
+
+| # | Test | Type |
+|---|---|---|
+| 21 | Civ owning silk: city panel DOM contains "Empire bonuses" header and "Silk" text in happiness sub-section | DOM |
+| 22 | Civ owning gems: city panel DOM contains "City bonuses" header and "Gems" text with "+1 gold/turn" | DOM |
+| 23 | "Gold deposits" (not "Gold") appears for the gold resource to avoid currency name collision | naming |
+| 24 | Civ owning only yield resources (gems, no silk): "Empire bonuses" header absent from DOM | DOM negative |
+| 25 | Civ owning no resources: entire "Resources" section absent from city panel DOM | DOM negative |
+
+**UI — HUD**
+
+| # | Test | Type |
+|---|---|---|
+| 26 | Civ with 2 happiness luxuries: HUD contains "☺" chip with value 2 | HUD |
+| 27 | Civ with 0 happiness luxuries: HUD does not contain "☺" chip | HUD negative |
+
+**UI — marketplace panel**
+
+| # | Test | Type |
+|---|---|---|
+| 28 | Silk row in marketplace panel contains "+1 happiness" badge text | DOM |
+| 29 | Iron row in marketplace panel contains "unlocks advanced units" hint text (not raw "null") | DOM |
+
+**Save compatibility & map**
+
+| # | Test | Type |
+|---|---|---|
+| 30 | Old `GameState` save (pre-S4a) loads without crash — `effect` is static data, no migration needed | save-compat |
+| 31 | Earth map (small): each of the 16 resources appears at least once; gold/furs/sheep/cattle/salt/silver each appear in at least one tile within their declared lon/lat bounding boxes | geo-coverage |
 
 ## Roadmap updates required
 
 Update `2026-05-20-marketplace-trade-roadmap.md`:
-- Current-state table: stone terrain `mountain` → `hills`
-- Record S4a locked decisions (this spec path, effect magnitudes, happiness→pressure wiring)
-- Mark S4a as "In progress"
+- Current-state table: stone terrain entry should read `stone(mountain)` — S2a moved stone FROM hills TO mountain; earth-map generator stone fallback also needs updating from `hills` to `mountain` (captured in §Earth map above).
+- Record S4a locked decisions (this spec path, effect magnitudes, non-stacking rule, happiness→pressure wiring, happiness magnitude = 2 pressure per point).
+- Mark S4a as "In progress".
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-05-23-marketplace-s4a-resource-effects-design.md
+++ b/docs/superpowers/specs/2026-05-23-marketplace-s4a-resource-effects-design.md
@@ -1,0 +1,296 @@
+# Marketplace S4a — Per-Resource Yield & Happiness Effects
+
+**Slice:** S4a in the [Marketplace & Trade Roadmap](../specs/2026-05-20-marketplace-trade-roadmap.md)
+**Depends on:** S2b (`getCivAvailableResources` — already merged)
+**Blocks:** S4b (strategic resource prerequisites for units/buildings)
+
+## Goal
+
+Owning a resource (as determined by `getCivAvailableResources`) now confers a passive empire-wide effect: luxury resources grant happiness or per-city yield bonuses; two strategic resources (cattle, salt) get small passive bonuses. The bonus is visible in the city panel and HUD. Losing a resource removes the bonus immediately (same turn).
+
+This slice also patches two companion issues introduced by prior work:
+- Six new resources added in S2a (gold, silver, furs, sheep, cattle, salt) have no placement zones in `generate-earth-maps.ts` and therefore never appear on earth maps.
+- Several existing resources have missing geographic zones (iron, horses, spices, gems, ivory, wine, copper — see §Earth map).
+- The roadmap "Current state" table incorrectly lists stone's terrain as `mountain`; S2a moved it to `hills`.
+
+## Effect table (all 16 resources)
+
+| Resource | Type | Effect in S4a |
+|---|---|---|
+| silk | luxury | happiness +1 (empire-wide, non-stacking) |
+| wine | luxury | happiness +1 |
+| ivory | luxury | happiness +1 |
+| furs | luxury | happiness +1 |
+| incense | luxury | happiness +1 |
+| gems | luxury | gold +1/turn (all cities) |
+| gold | luxury | gold +1/turn (all cities) |
+| silver | luxury | gold +1/turn (all cities) |
+| spices | luxury | gold +1/turn (all cities) |
+| sheep | luxury | production +1/turn (all cities) |
+| cattle | strategic | food +1/turn (all cities) |
+| salt | strategic | gold +1/turn (all cities) |
+| copper | strategic | null — waits for S4b gating |
+| iron | strategic | null — waits for S4b gating |
+| horses | strategic | null — waits for S4b gating |
+| stone | strategic | null — waits for S4b gating |
+
+**Thematic rationale:**
+- Silk, wine, ivory, furs, incense → comfort and prestige → happiness
+- Gems, gold, silver, spices → high monetary/trade value → gold/turn
+- Sheep → wool (textiles) → production/turn
+- Cattle → livestock sustenance → food/turn
+- Salt → preservation and trade → gold/turn
+- Copper/iron/horses/stone → their value is unlocking units and buildings (S4b)
+
+**Magnitude:** flat +1 in S4a. Era/tech scaling deferred to a future slice.
+
+**Scope:** empire-wide, non-stacking. Owning three silk tiles still gives +1 happiness, not +3. Duplicates are for selling (S8+).
+
+**Loss timing:** immediate (same turn). The effect is derived fresh from `getCivAvailableResources` each turn; no persistent copy to go stale.
+
+## Data model
+
+### `ResourceEffect` and `effect` field in `trade-system.ts`
+
+```typescript
+export interface ResourceEffect {
+  type: 'happiness' | 'gold' | 'production' | 'food';
+  amount: number; // always 1 in S4a
+}
+
+export interface ResourceDefinition {
+  id: ResourceType;
+  name: string;
+  type: 'luxury' | 'strategic';
+  terrain: string | string[];
+  basePrice: number;
+  tech: string;
+  icon: string;
+  requiredImprovement: BuildableImprovementType;
+  effect: ResourceEffect | null; // null = no S4a passive
+}
+```
+
+**Save compatibility:** `effect` is a field on `RESOURCE_DEFINITIONS` (static data, not saved `GameState`). Old saves load without migration.
+
+## Architecture
+
+### New pure helpers in `resource-acquisition-system.ts`
+
+```typescript
+/**
+ * Returns the aggregate per-city yield bonus from all owned non-happiness
+ * resources. Empire-wide, non-stacking: owning any amount of a resource
+ * counts once.
+ */
+export function getCivResourceYieldBonus(
+  state: GameState,
+  civId: string,
+): ResourceYield
+
+/**
+ * Returns the count of distinct happiness-type luxuries owned by the civ.
+ * Empire-wide, non-stacking.
+ */
+export function getCivHappinessFromResources(
+  state: GameState,
+  civId: string,
+): number
+```
+
+Both call `getCivAvailableResources(state, civId)` internally, then loop over `RESOURCE_DEFINITIONS` filtering by owned resource and effect type.
+
+### `turn-manager.ts` — yield bonus wiring
+
+`getCivResourceYieldBonus` is called **once per civ** (not per city) before the city loop. The result is added alongside wonder city bonuses when computing each city's final yields:
+
+```typescript
+const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
+
+// Per city:
+const yields = {
+  food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food)       * unrestMultiplier),
+  production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production) * unrestMultiplier),
+  gold:       Math.floor((baseYields.gold       + (wonderCityBonuses.gold       ?? 0) + resourceYieldBonus.gold)       * unrestMultiplier),
+  science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0))                                 * unrestMultiplier),
+};
+```
+
+### `faction-system.ts` — happiness reduces unrest pressure
+
+`computeUnrestPressure` gains a happiness offset (capped so pressure cannot go below 0):
+
+```typescript
+import { getCivHappinessFromResources } from './resource-acquisition-system';
+
+// At the end of computeUnrestPressure, before the final cap:
+const happiness = getCivHappinessFromResources(state, owner);
+pressure -= happiness * 2; // up to −10 from 5 happiness luxuries
+return Math.min(100, Math.max(0, pressure));
+```
+
+Effect in context: each luxury happiness resource offsets 2 pressure. Five luxuries (−10) meaningfully counteracts two wars' worth of war-weariness (2 × 8 = +16) or two-and-a-half cities of overextension.
+
+No new `GameState` fields are added. Happiness is fully computed each turn from live resource ownership.
+
+## UI surface
+
+### City panel — resource bonus subsection
+
+A new "Resources" row group is inserted below the yield summary in the city panel. One line per owned resource that has an effect, using `createTextNode` / `textContent` only:
+
+```
+Silk      → +1 happiness
+Ivory     → +1 happiness
+Gems      → +1 gold/turn
+Sheep     → +1 production/turn
+```
+
+- Happiness lines are identical across all city panels (empire-wide effect, not city-specific).
+- Only resources with a non-null effect are shown; the section is omitted entirely if the civ owns no effect-bearing resources.
+- Uses `state.currentPlayer` (never hardcoded `'player'`).
+
+### HUD — happiness chip
+
+A `☺ N` chip is added alongside the existing per-turn yield chips (food, production, gold, science). Computes `getCivHappinessFromResources(state, state.currentPlayer)`. The chip is omitted when the value is 0 (no clutter when no luxuries are owned).
+
+## Earth map — geographic zones
+
+### Problem
+
+`generate-earth-maps.ts` places resources via a `RESOURCE_ZONES` array. Six new S2a resources have no zones and cannot appear on earth maps. Several existing resources have notable geographic gaps.
+
+### Zone additions and patches
+
+The full intended `RESOURCE_ZONES` table after this slice (new entries marked **NEW**, missing-zone patches marked **PATCH**):
+
+```typescript
+// Horses
+{ resource: 'horses', terrain: 'plains', lonMin: 50,   lonMax: 100,  latMin: 40, latMax: 55 }, // Central Asian steppe
+{ resource: 'horses', terrain: 'plains', lonMin: -110, lonMax: -95,  latMin: 30, latMax: 50 }, // Great Plains (Americas)
+{ resource: 'horses', terrain: 'plains', lonMin: 35,   lonMax: 55,   latMin: 15, latMax: 30 }, // PATCH: Arabian Peninsula
+
+// Iron
+{ resource: 'iron', terrain: 'hills', lonMin: 5,   lonMax: 30,   latMin: 50, latMax: 65 }, // N. Europe/Scandinavia
+{ resource: 'iron', terrain: 'hills', lonMin: 105, lonMax: 120,  latMin: 30, latMax: 45 }, // China
+{ resource: 'iron', terrain: 'hills', lonMin: -95, lonMax: -75,  latMin: 40, latMax: 50 }, // Great Lakes (US)
+{ resource: 'iron', terrain: 'hills', lonMin: -50, lonMax: -40,  latMin: -22, latMax: -10 }, // PATCH: Brazil/Minas Gerais
+{ resource: 'iron', terrain: 'hills', lonMin: 83,  lonMax: 88,   latMin: 21, latMax: 25 }, // PATCH: India/Jharkhand
+
+// Silk
+{ resource: 'silk', terrain: 'grassland', lonMin: 95, lonMax: 115, latMin: 30, latMax: 40 }, // China
+
+// Spices
+{ resource: 'spices', terrain: 'jungle', lonMin: 95,  lonMax: 140, latMin: -10, latMax: 20 }, // SE Asia
+{ resource: 'spices', terrain: 'jungle', lonMin: 70,  lonMax: 85,  latMin: 8,   latMax: 20 }, // S. India
+{ resource: 'spices', terrain: 'jungle', lonMin: 38,  lonMax: 42,  latMin: -8,  latMax: 0  }, // PATCH: Zanzibar/E. Africa
+
+// Incense
+{ resource: 'incense', terrain: 'desert', lonMin: 40, lonMax: 60, latMin: 15, latMax: 30 }, // Arabian Peninsula
+{ resource: 'incense', terrain: 'desert', lonMin: 10, lonMax: 40, latMin: 15, latMax: 30 }, // N. Africa / Horn
+
+// Gems
+{ resource: 'gems', terrain: 'hills',  lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5  }, // S. Africa (diamonds)
+{ resource: 'gems', terrain: 'hills',  lonMin: 75,   lonMax: 85,   latMin: 10,  latMax: 25 }, // India (diamonds)
+{ resource: 'gems', terrain: 'jungle', lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5  }, // S. America
+{ resource: 'gems', terrain: 'hills',  lonMin: 95,   lonMax: 103,  latMin: 17,  latMax: 27 }, // PATCH: Myanmar (rubies/jade)
+{ resource: 'gems', terrain: 'hills',  lonMin: 135,  lonMax: 145,  latMin: -32, latMax: -25 }, // PATCH: Australia (opals)
+
+// Ivory
+{ resource: 'ivory', terrain: 'forest', lonMin: 10,  lonMax: 40,   latMin: -15, latMax: 10 }, // Central/West Africa
+{ resource: 'ivory', terrain: 'forest', lonMin: 33,  lonMax: 42,   latMin: -10, latMax: 5  }, // PATCH: East Africa
+{ resource: 'ivory', terrain: 'forest', lonMin: 75,  lonMax: 105,  latMin: 8,   latMax: 22 }, // PATCH: South Asia (Indian elephant)
+
+// Wine
+{ resource: 'wine', terrain: 'grassland', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 }, // Mediterranean/France
+{ resource: 'wine', terrain: 'grassland', lonMin: -123, lonMax: -119, latMin: 37, latMax: 39 }, // PATCH: California (Napa)
+{ resource: 'wine', terrain: 'grassland', lonMin: 18,   lonMax: 22,   latMin: -34, latMax: -32 }, // PATCH: S. Africa (Cape)
+{ resource: 'wine', terrain: 'grassland', lonMin: -72,  lonMax: -68,  latMin: -37, latMax: -30 }, // PATCH: Chile/Mendoza
+
+// Copper
+{ resource: 'copper', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -35, latMax: 10 }, // S. America (Andes)
+{ resource: 'copper', terrain: 'hills', lonMin: -9,   lonMax: -5,   latMin: 37,  latMax: 43 }, // Iberian Peninsula
+{ resource: 'copper', terrain: 'hills', lonMin: 25,   lonMax: 30,   latMin: -15, latMax: -8 }, // PATCH: Zambia/DRC Copper Belt
+{ resource: 'copper', terrain: 'hills', lonMin: -115, lonMax: -108, latMin: 32,  latMax: 48 }, // PATCH: Arizona/Montana (US)
+
+// Gold (NEW)
+{ resource: 'gold', terrain: 'hills', lonMin: 25,   lonMax: 32,   latMin: -30, latMax: -22 }, // S. Africa (Witwatersrand)
+{ resource: 'gold', terrain: 'hills', lonMin: -122, lonMax: -114, latMin: 36,  latMax: 42  }, // California/Sierra Nevada
+{ resource: 'gold', terrain: 'hills', lonMin: 120,  lonMax: 150,  latMin: 55,  latMax: 65  }, // Siberia (Lena/Kolyma)
+{ resource: 'gold', terrain: 'hills', lonMin: -3,   lonMax: 2,    latMin: 5,   latMax: 10  }, // W. Africa (Ghana/Gold Coast)
+
+// Silver (NEW)
+{ resource: 'silver', terrain: 'hills', lonMin: -107, lonMax: -98, latMin: 20, latMax: 30 }, // Mexico (Zacatecas)
+{ resource: 'silver', terrain: 'hills', lonMin: -70,  lonMax: -63, latMin: -24, latMax: -14 }, // Bolivia/Peru (Potosí)
+{ resource: 'silver', terrain: 'hills', lonMin: 12,   lonMax: 20,  latMin: 49, latMax: 53 }, // C. Europe (Saxony/Bohemia)
+
+// Furs (NEW — forest and tundra)
+{ resource: 'furs', terrain: 'forest', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia
+{ resource: 'furs', terrain: 'tundra', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia (tundra belt)
+{ resource: 'furs', terrain: 'forest', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada
+{ resource: 'furs', terrain: 'tundra', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada (tundra)
+{ resource: 'furs', terrain: 'forest', lonMin: 15,   lonMax: 30,   latMin: 60, latMax: 70 }, // Scandinavia
+
+// Sheep (NEW — hills and plains)
+{ resource: 'sheep', terrain: 'hills',  lonMin: -10, lonMax: 2,   latMin: 50, latMax: 60 }, // British Isles
+{ resource: 'sheep', terrain: 'plains', lonMin: 80,  lonMax: 120, latMin: 40, latMax: 52 }, // C. Asia/Mongolia
+{ resource: 'sheep', terrain: 'plains', lonMin: -73, lonMax: -60, latMin: -52, latMax: -37 }, // Patagonia/Argentina
+{ resource: 'sheep', terrain: 'hills',  lonMin: -8,  lonMax: 2,   latMin: 38, latMax: 43 }, // Iberia/Castile (merino)
+
+// Cattle (NEW — grassland and plains)
+{ resource: 'cattle', terrain: 'plains',    lonMin: -105, lonMax: -95, latMin: 35, latMax: 50 }, // Great Plains (N. America)
+{ resource: 'cattle', terrain: 'grassland', lonMin: -65,  lonMax: -57, latMin: -40, latMax: -28 }, // Argentine Pampas
+{ resource: 'cattle', terrain: 'grassland', lonMin: 32,   lonMax: 42,  latMin: -5,  latMax: 10 }, // East Africa (Maasai)
+
+// Salt (NEW — hills)
+{ resource: 'salt', terrain: 'hills', lonMin: 12,  lonMax: 25,  latMin: 47, latMax: 55 }, // C. Europe (Wieliczka/Austria)
+{ resource: 'salt', terrain: 'hills', lonMin: 44,  lonMax: 58,  latMin: 30, latMax: 38 }, // Zagros/Iran
+{ resource: 'salt', terrain: 'hills', lonMin: -70, lonMax: -65, latMin: -25, latMax: -16 }, // Andes (Atacama)
+{ resource: 'salt', terrain: 'hills', lonMin: -5,  lonMax: 10,  latMin: 30, latMax: 37 }, // N. Africa/Atlas
+```
+
+Stone keeps its existing global fallback (8% of hills tiles — stone is geographically ubiquitous).
+
+### Regeneration
+
+After updating `generate-earth-maps.ts`, run:
+```
+bash scripts/run-with-mise.sh yarn generate-maps
+```
+This overwrites `src/systems/earth-map-data.ts`, `old-world-map-data.ts`, and `new-world-map-data.ts`.
+
+## Tests
+
+| # | Test | Type |
+|---|---|---|
+| 1 | Every entry in `RESOURCE_DEFINITIONS` has `effect` defined (non-undefined — may be `null`) | catalog |
+| 2 | `getCivHappinessFromResources` returns 1 for a civ owning silk | positive |
+| 3 | `getCivResourceYieldBonus` returns `{ gold: 1, ... }` for a civ owning gems | positive |
+| 4 | `getCivResourceYieldBonus` returns `{ production: 1, ... }` for a civ owning sheep | positive |
+| 5 | `getCivResourceYieldBonus` returns `{ food: 1, ... }` for a civ owning cattle | positive |
+| 6 | `getCivResourceYieldBonus` returns `{ gold: 1, ... }` for a civ owning salt | positive |
+| 7 | Civ owning 3 silk tiles (3 different cities) → happiness still 1 (non-stacking) | non-stacking |
+| 8 | Civ with no owned resources → happiness 0, all yield bonuses 0 | negative |
+| 9 | Copper/iron/horses/stone produce no S4a effect (`getCivResourceYieldBonus` returns zeros, `getCivHappinessFromResources` returns 0 for a civ owning only those) | negative |
+| 10 | Silk improvement destroyed (`improvementTurnsLeft > 0`) → `getCivHappinessFromResources` returns 0 same turn | loss |
+| 11 | Civ with 3 cities owning gems → all 3 cities receive +1 gold in turn processing | all-cities |
+| 12 | AI civ owning spices accrues gold/turn via the same turn-manager code path | AI parity |
+| 13 | City with pressure 45, civ owns 3 happiness luxuries → pressure reduced by 6 → 39 → no unrest | unrest |
+| 14 | `computeUnrestPressure` with happiness = 5 → pressure reduced by 10 | unrest magnitude |
+| 15 | Old-save load: `GameState` with no `effect` on RESOURCE_DEFINITIONS initialises without crash (static data, no migration) | save-compat |
+| 16 | Earth map (small): each resource in RESOURCE_ZONES appears within at least one of its declared lon/lat bounding boxes | geo-coverage |
+
+## Roadmap updates required
+
+Update `2026-05-20-marketplace-trade-roadmap.md`:
+- Current-state table: stone terrain `mountain` → `hills`
+- Record S4a locked decisions (this spec path, effect magnitudes, happiness→pressure wiring)
+- Mark S4a as "In progress"
+
+## Out of scope
+
+- Era/tech scaling of bonuses (deferred)
+- Happiness affecting anything beyond unrest pressure (golden age mechanic, etc.) — deferred
+- S4b strategic resource prerequisites for units/buildings
+- Monopoly price detection using resource counts (S12)
+- Old-world and new-world map data geographic review (can be a follow-up; earth map is the primary)

--- a/scripts/generate-earth-maps.ts
+++ b/scripts/generate-earth-maps.ts
@@ -185,23 +185,88 @@ type ResourceZone = {
 };
 
 const RESOURCE_ZONES: ResourceZone[] = [
-  { resource: 'horses',  terrain: 'plains',    lonMin: 50,   lonMax: 100,  latMin: 40, latMax: 55 },
-  { resource: 'horses',  terrain: 'plains',    lonMin: -110, lonMax: -95,  latMin: 30, latMax: 50 },
-  { resource: 'iron',    terrain: 'hills',     lonMin: 5,    lonMax: 30,   latMin: 50, latMax: 65 },
-  { resource: 'iron',    terrain: 'hills',     lonMin: 105,  lonMax: 120,  latMin: 30, latMax: 45 },
-  { resource: 'iron',    terrain: 'hills',     lonMin: -95,  lonMax: -75,  latMin: 40, latMax: 50 },
-  { resource: 'silk',    terrain: 'grassland', lonMin: 95,   lonMax: 115,  latMin: 30, latMax: 40 },
-  { resource: 'spices',  terrain: 'jungle',    lonMin: 95,   lonMax: 140,  latMin: -10, latMax: 20 },
-  { resource: 'spices',  terrain: 'jungle',    lonMin: 70,   lonMax: 85,   latMin: 8,  latMax: 20 },
-  { resource: 'incense', terrain: 'desert',    lonMin: 40,   lonMax: 60,   latMin: 15, latMax: 30 },
-  { resource: 'incense', terrain: 'desert',    lonMin: 10,   lonMax: 40,   latMin: 15, latMax: 30 },
-  { resource: 'gems',    terrain: 'hills',     lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5 },
-  { resource: 'gems',    terrain: 'hills',     lonMin: 75,   lonMax: 85,   latMin: 10, latMax: 25 },
-  { resource: 'gems',    terrain: 'jungle',    lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5 },
-  { resource: 'ivory',   terrain: 'forest',    lonMin: 10,   lonMax: 40,   latMin: -15, latMax: 10 },
-  { resource: 'wine',    terrain: 'grassland', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 },
-  { resource: 'copper',  terrain: 'hills',     lonMin: -80,  lonMax: -65,  latMin: -35, latMax: 10 },
-  { resource: 'copper',  terrain: 'hills',     lonMin: -9,   lonMax: -5,   latMin: 37, latMax: 43 },
+  // Horses
+  { resource: 'horses', terrain: 'plains', lonMin: 50,   lonMax: 100,  latMin: 40, latMax: 55 }, // Central Asian steppe
+  { resource: 'horses', terrain: 'plains', lonMin: -110, lonMax: -95,  latMin: 30, latMax: 50 }, // Great Plains (Americas)
+  { resource: 'horses', terrain: 'plains', lonMin: 35,   lonMax: 55,   latMin: 15, latMax: 30 }, // PATCH: Arabian Peninsula
+
+  // Iron
+  { resource: 'iron', terrain: 'hills', lonMin: 5,   lonMax: 30,   latMin: 50, latMax: 65 }, // N. Europe/Scandinavia
+  { resource: 'iron', terrain: 'hills', lonMin: 105, lonMax: 120,  latMin: 30, latMax: 45 }, // China
+  { resource: 'iron', terrain: 'hills', lonMin: -95, lonMax: -75,  latMin: 40, latMax: 50 }, // Great Lakes (US)
+  { resource: 'iron', terrain: 'hills', lonMin: -50, lonMax: -40,  latMin: -22, latMax: -10 }, // PATCH: Brazil/Minas Gerais
+  { resource: 'iron', terrain: 'hills', lonMin: 83,  lonMax: 88,   latMin: 21, latMax: 25 }, // PATCH: India/Jharkhand
+
+  // Silk
+  { resource: 'silk', terrain: 'grassland', lonMin: 95, lonMax: 115, latMin: 30, latMax: 40 }, // China
+
+  // Spices
+  { resource: 'spices', terrain: 'jungle', lonMin: 95,  lonMax: 140, latMin: -10, latMax: 20 }, // SE Asia
+  { resource: 'spices', terrain: 'jungle', lonMin: 70,  lonMax: 85,  latMin: 8,   latMax: 20 }, // S. India
+  { resource: 'spices', terrain: 'jungle', lonMin: 38,  lonMax: 42,  latMin: -8,  latMax: 0  }, // PATCH: Zanzibar/E. Africa
+
+  // Incense
+  { resource: 'incense', terrain: 'desert', lonMin: 40, lonMax: 60, latMin: 15, latMax: 30 }, // Arabian Peninsula
+  { resource: 'incense', terrain: 'desert', lonMin: 10, lonMax: 40, latMin: 15, latMax: 30 }, // N. Africa / Horn
+
+  // Gems — terrain MUST be 'hills' (mine required; plantation cannot be built on jungle)
+  { resource: 'gems', terrain: 'hills', lonMin: 20,   lonMax: 40,   latMin: -30, latMax: 5  }, // S. Africa
+  { resource: 'gems', terrain: 'hills', lonMin: 75,   lonMax: 85,   latMin: 10,  latMax: 25 }, // India
+  { resource: 'gems', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -20, latMax: 5  }, // S. America (Andes/Colombia — hills not jungle)
+  { resource: 'gems', terrain: 'hills', lonMin: 95,   lonMax: 103,  latMin: 17,  latMax: 27 }, // PATCH: Myanmar
+  { resource: 'gems', terrain: 'hills', lonMin: 135,  lonMax: 145,  latMin: -32, latMax: -25 }, // PATCH: Australia
+
+  // Ivory
+  { resource: 'ivory', terrain: 'forest', lonMin: 10,  lonMax: 40,   latMin: -15, latMax: 10 }, // Central/West Africa
+  { resource: 'ivory', terrain: 'forest', lonMin: 33,  lonMax: 42,   latMin: -10, latMax: 5  }, // PATCH: East Africa
+  { resource: 'ivory', terrain: 'forest', lonMin: 75,  lonMax: 105,  latMin: 8,   latMax: 22 }, // PATCH: South Asia
+
+  // Wine — terrain MUST be 'plains' (wine's RESOURCE_DEFINITION terrain)
+  { resource: 'wine', terrain: 'plains', lonMin: -5,   lonMax: 30,   latMin: 35, latMax: 47 }, // Mediterranean/France/Iberia
+  { resource: 'wine', terrain: 'plains', lonMin: -123, lonMax: -119, latMin: 37, latMax: 39 }, // PATCH: California (Napa)
+  { resource: 'wine', terrain: 'plains', lonMin: 18,   lonMax: 22,   latMin: -34, latMax: -32 }, // PATCH: S. Africa (Cape)
+  { resource: 'wine', terrain: 'plains', lonMin: -72,  lonMax: -68,  latMin: -37, latMax: -30 }, // PATCH: Chile/Mendoza
+
+  // Copper
+  { resource: 'copper', terrain: 'hills', lonMin: -80,  lonMax: -65,  latMin: -35, latMax: 10 }, // S. America (Andes)
+  { resource: 'copper', terrain: 'hills', lonMin: -9,   lonMax: -5,   latMin: 37,  latMax: 43 }, // Iberian Peninsula
+  { resource: 'copper', terrain: 'hills', lonMin: 25,   lonMax: 30,   latMin: -15, latMax: -8 }, // PATCH: Zambia/DRC
+  { resource: 'copper', terrain: 'hills', lonMin: -115, lonMax: -108, latMin: 32,  latMax: 48 }, // PATCH: Arizona/Montana
+
+  // Gold (NEW)
+  { resource: 'gold', terrain: 'hills', lonMin: 25,   lonMax: 32,   latMin: -30, latMax: -22 }, // S. Africa (Witwatersrand)
+  { resource: 'gold', terrain: 'hills', lonMin: -122, lonMax: -114, latMin: 36,  latMax: 42  }, // California/Sierra Nevada
+  { resource: 'gold', terrain: 'hills', lonMin: 120,  lonMax: 150,  latMin: 55,  latMax: 65  }, // Siberia
+  { resource: 'gold', terrain: 'hills', lonMin: -3,   lonMax: 2,    latMin: 5,   latMax: 10  }, // W. Africa (Ghana)
+
+  // Silver (NEW)
+  { resource: 'silver', terrain: 'hills', lonMin: -107, lonMax: -98, latMin: 20, latMax: 30 }, // Mexico (Zacatecas)
+  { resource: 'silver', terrain: 'hills', lonMin: -70,  lonMax: -63, latMin: -24, latMax: -14 }, // Bolivia/Peru (Potosí)
+  { resource: 'silver', terrain: 'hills', lonMin: 12,   lonMax: 20,  latMin: 49, latMax: 53 }, // C. Europe (Saxony)
+
+  // Furs (NEW — forest and tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia (forest)
+  { resource: 'furs', terrain: 'tundra', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia (tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada (forest)
+  { resource: 'furs', terrain: 'tundra', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada (tundra)
+  { resource: 'furs', terrain: 'forest', lonMin: 15,   lonMax: 30,   latMin: 60, latMax: 70 }, // Scandinavia
+
+  // Sheep (NEW — hills and plains)
+  { resource: 'sheep', terrain: 'hills',  lonMin: -10, lonMax: 2,   latMin: 50, latMax: 60 }, // British Isles
+  { resource: 'sheep', terrain: 'plains', lonMin: 80,  lonMax: 120, latMin: 40, latMax: 52 }, // C. Asia/Mongolia
+  { resource: 'sheep', terrain: 'plains', lonMin: -73, lonMax: -60, latMin: -52, latMax: -37 }, // Patagonia
+  { resource: 'sheep', terrain: 'hills',  lonMin: -8,  lonMax: 2,   latMin: 38, latMax: 43 }, // Iberia (merino)
+
+  // Cattle (NEW — grassland and plains)
+  { resource: 'cattle', terrain: 'plains',    lonMin: -105, lonMax: -95, latMin: 35, latMax: 50 }, // Great Plains
+  { resource: 'cattle', terrain: 'grassland', lonMin: -65,  lonMax: -57, latMin: -40, latMax: -28 }, // Argentine Pampas
+  { resource: 'cattle', terrain: 'grassland', lonMin: 32,   lonMax: 42,  latMin: -5,  latMax: 10 }, // East Africa
+
+  // Salt (NEW — hills)
+  { resource: 'salt', terrain: 'hills', lonMin: 12,  lonMax: 25,  latMin: 47, latMax: 55 }, // C. Europe (Wieliczka)
+  { resource: 'salt', terrain: 'hills', lonMin: 44,  lonMax: 58,  latMin: 30, latMax: 38 }, // Zagros/Iran
+  { resource: 'salt', terrain: 'hills', lonMin: -70, lonMax: -65, latMin: -25, latMax: -16 }, // Andes (Atacama)
+  { resource: 'salt', terrain: 'hills', lonMin: -5,  lonMax: 10,  latMin: 30, latMax: 37 }, // N. Africa/Atlas
 ];
 
 function placeResourceForTile(
@@ -213,7 +278,7 @@ function placeResourceForTile(
   const hash = ((lon * 1000 + lat * 997) | 0) ^ seed;
   const r = (Math.abs(hash) % 1000) / 1000;
 
-  if (terrain === 'hills' && r < 0.08) {
+  if (terrain === 'mountain' && r < 0.15) {
     return 'stone';
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -12,6 +12,7 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { calculateCityYields } from '@/systems/resource-system';
+import { getCivResourceYieldBonus } from '@/systems/resource-acquisition-system';
 import type { HexCoord } from './types';
 import { updateVisibility, revealMinorCivCities, applySharedVision, applySatelliteSurveillance } from '@/systems/fog-of-war';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
@@ -79,6 +80,8 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     let totalScience = 0;
     let totalGold = 0;
 
+    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
+
     for (const cityId of civ.cities) {
       let city = newState.cities[cityId];
       if (!city) continue;
@@ -94,10 +97,10 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       const wonderCityBonuses = getLegendaryWonderCityYieldBonus(newState, civId, cityId);
       const unrestMultiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city));
       const yields = {
-        food: Math.floor((baseYields.food + (wonderCityBonuses.food ?? 0)) * unrestMultiplier),
-        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0)) * unrestMultiplier),
-        gold: Math.floor((baseYields.gold + (wonderCityBonuses.gold ?? 0)) * unrestMultiplier),
-        science: Math.floor((baseYields.science + (wonderCityBonuses.science ?? 0)) * unrestMultiplier),
+        food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food)       * unrestMultiplier),
+        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production) * unrestMultiplier),
+        gold:       Math.floor((baseYields.gold       + (wonderCityBonuses.gold       ?? 0) + resourceYieldBonus.gold)       * unrestMultiplier),
+        science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0))                                 * unrestMultiplier),
       };
       totalScience += yields.science;
       totalGold += yields.gold;

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,6 +149,7 @@ import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecyc
 import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { calculateCivEconomy, formatGoldHudText, formatMaintenanceTooltip, rushBuyActiveProduction } from '@/systems/economy-system';
+import { getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
 import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
 import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
 import { createLegendaryWonderCompletionQueue } from '@/ui/legendary-wonder-completion-queue';
@@ -348,6 +349,14 @@ function updateHUD(): void {
   const sciSpan = document.createElement('span');
   sciSpan.textContent = `🔬 ${techName !== 'None' ? techName : 'None'} (+${totalScience})`;
   yieldsRow.appendChild(sciSpan);
+
+  const happiness = getCivHappinessFromResources(gameState, civ.id);
+  if (happiness > 0) {
+    const happySpan = document.createElement('span');
+    happySpan.title = 'Happiness from luxury resources — each point reduces city unrest pressure by 2';
+    happySpan.textContent = `☺ ${happiness} (stability)`;
+    yieldsRow.appendChild(happySpan);
+  }
 
   const infoRow = document.createElement('div');
   if (gameState.hotSeat && civ.name) {

--- a/src/systems/earth-map-data.ts
+++ b/src/systems/earth-map-data.ts
@@ -503,13 +503,13 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 22,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 23,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 24,
@@ -761,7 +761,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 5,
       "r": 4,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 6,
@@ -1307,7 +1307,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 6,
       "r": 7,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 7,
@@ -6649,7 +6649,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 6,
       "r": 4,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 7,
@@ -6871,7 +6871,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 43,
       "r": 4,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 44,
@@ -7117,7 +7117,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 34,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 35,
@@ -7861,1695 +7861,1695 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 8,
       "r": 8,
       "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 8,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 8,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 8,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 36,
-      "r": 8,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 8,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 8,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 39,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 8,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 9,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 9,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 9,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 9,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 9,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 37,
-      "r": 9,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 9,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": "wine"
-    },
-    {
-      "q": 29,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 10,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 38,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 10,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 10,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 11,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 11,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 11,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 37,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 11,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 11,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 11,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 12,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 12,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 35,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 12,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 38,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 12,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 12,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 13,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 13,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 13,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 13,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 13,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 13,
-      "terrain": "hills",
       "resource": "stone"
     },
     {
+      "q": 9,
+      "r": 8,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 8,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 8,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 12,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 8,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 8,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 8,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 8,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 36,
+      "r": 8,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 8,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 8,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 39,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 8,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 9,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 9,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 9,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 9,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 9,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 37,
+      "r": 9,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 9,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 27,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 10,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 37,
+      "r": 10,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 38,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 10,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 10,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 42,
+      "r": 10,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 11,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 11,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 11,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 37,
+      "r": 11,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 38,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 11,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 11,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 11,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 12,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 12,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 35,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 12,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 38,
+      "r": 12,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 39,
+      "r": 12,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 40,
+      "r": 12,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 12,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 13,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 13,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 13,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 13,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 13,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 35,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
       "q": 40,
       "r": 13,
       "terrain": "plains",
@@ -9763,7 +9763,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 14,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,
@@ -9823,7 +9823,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 35,
       "r": 14,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 36,
@@ -10099,7 +10099,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 31,
       "r": 15,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 32,
@@ -10435,7 +10435,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 37,
       "r": 16,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 38,
@@ -23697,7 +23697,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 67,
       "r": 6,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -23709,7 +23709,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 69,
       "r": 6,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -23889,7 +23889,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 19,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 20,
@@ -24117,7 +24117,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 57,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
@@ -24129,7 +24129,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 59,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 60,
@@ -24153,7 +24153,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 63,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 64,
@@ -24165,7 +24165,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 65,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 66,
@@ -24177,7 +24177,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 67,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -24345,7 +24345,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 15,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 16,
@@ -24357,7 +24357,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 17,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 18,
@@ -24609,7 +24609,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 59,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 60,
@@ -24621,7 +24621,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 61,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 62,
@@ -24801,7 +24801,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 11,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 12,
@@ -25065,7 +25065,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 55,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 56,
@@ -25137,7 +25137,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 67,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -25629,7 +25629,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 69,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -26025,7 +26025,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 55,
       "r": 11,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 56,
@@ -26037,7 +26037,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 57,
       "r": 11,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
@@ -26049,7 +26049,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 59,
       "r": 11,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 60,
@@ -26085,7 +26085,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 65,
       "r": 11,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 66,
@@ -26109,7 +26109,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 69,
       "r": 11,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -27483,7 +27483,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 14,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 59,
@@ -27495,7 +27495,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 60,
       "r": 14,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 61,
@@ -28347,7 +28347,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 42,
       "r": 16,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 43,
@@ -28443,7 +28443,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 16,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 59,
@@ -28455,7 +28455,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 60,
       "r": 16,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 61,
@@ -28827,7 +28827,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 42,
       "r": 17,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 43,
@@ -28923,7 +28923,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 17,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 59,
@@ -29403,7 +29403,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 18,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 59,
@@ -29415,7 +29415,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 60,
       "r": 18,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 61,
@@ -29883,7 +29883,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 19,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 59,
@@ -30819,7 +30819,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 54,
       "r": 21,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 55,
@@ -31299,7 +31299,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 54,
       "r": 22,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 55,
@@ -31335,7 +31335,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 60,
       "r": 22,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 61,
@@ -31779,7 +31779,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 54,
       "r": 23,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 55,
@@ -31803,7 +31803,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 23,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -32283,7 +32283,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 24,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -32307,7 +32307,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 62,
       "r": 24,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 63,
@@ -32751,7 +32751,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 56,
       "r": 25,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 57,
@@ -32763,7 +32763,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 58,
       "r": 25,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -32787,7 +32787,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 62,
       "r": 25,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 63,
@@ -33231,7 +33231,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 56,
       "r": 26,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 57,
@@ -33267,7 +33267,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 62,
       "r": 26,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 63,
@@ -44565,7 +44565,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 50,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,
@@ -45525,7 +45525,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 52,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,
@@ -47445,13 +47445,13 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 56,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,
       "r": 56,
       "terrain": "grassland",
-      "resource": null
+      "resource": "cattle"
     },
     {
       "q": 27,
@@ -47925,7 +47925,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 57,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,
@@ -48405,7 +48405,7 @@ export const EARTH_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = {
       "q": 25,
       "r": 58,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 26,

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -6,6 +6,7 @@ import { createUnit } from './unit-system';
 import { hexDistance } from './hex-utils';
 import { createBreakawayFromCity } from './breakaway-system';
 import { getEconomyStatusForCiv } from './economy-system';
+import { getCivHappinessFromResources } from './resource-acquisition-system';
 
 // --- Thresholds ---
 const UNREST_TRIGGER_PRESSURE = 40;
@@ -21,7 +22,7 @@ const MAX_PRESSURE_ECONOMY = 20;
 
 // --- Pressure computation ---
 
-export function computeUnrestPressure(cityId: string, state: GameState): number {
+export function computeUnrestPressure(cityId: string, state: GameState, ownerHappiness = 0): number {
   const city = state.cities[cityId];
   if (!city) return 0;
   const owner = city.owner;
@@ -64,7 +65,10 @@ export function computeUnrestPressure(cityId: string, state: GameState): number 
     }
   }
 
-  return Math.min(100, pressure);
+  // Happiness from luxury resources reduces unrest pressure (2 pressure per happiness point)
+  pressure -= ownerHappiness * 2;
+
+  return Math.min(100, Math.max(0, pressure));
 }
 
 // --- Resolution helpers ---
@@ -153,6 +157,12 @@ export function processFactionTurn(state: GameState, bus: EventBus): GameState {
 
   let nextState = state;
 
+  // Pre-compute happiness per civ to avoid O(cities²) tile scans inside the city loop
+  const civHappiness: Record<string, number> = {};
+  for (const civId of Object.keys(nextState.civilizations)) {
+    civHappiness[civId] = getCivHappinessFromResources(nextState, civId);
+  }
+
   for (const cityId of Object.keys(nextState.cities)) {
     const city = nextState.cities[cityId];
     if (!city) continue;
@@ -176,7 +186,7 @@ export function processFactionTurn(state: GameState, bus: EventBus): GameState {
       : currentCity.unrestLevel === 2
         ? 'revolt'
         : null;
-    const pressure = computeUnrestPressure(cityId, nextState);
+    const pressure = computeUnrestPressure(cityId, nextState, civHappiness[city.owner] ?? 0);
     let updated = { ...currentCity };
 
     if (updated.unrestLevel === 0) {

--- a/src/systems/new-world-map-data.ts
+++ b/src/systems/new-world-map-data.ts
@@ -413,7 +413,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 7,
       "r": 2,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 8,
@@ -803,7 +803,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 12,
       "r": 4,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 13,
@@ -1163,7 +1163,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 12,
       "r": 6,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 13,
@@ -1523,7 +1523,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 12,
       "r": 8,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 13,
@@ -3191,7 +3191,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 20,
       "r": 17,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 21,
@@ -3203,7 +3203,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 22,
       "r": 17,
       "terrain": "hills",
-      "resource": null
+      "resource": "gems"
     },
     {
       "q": 23,
@@ -3563,7 +3563,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 22,
       "r": 19,
       "terrain": "hills",
-      "resource": null
+      "resource": "gems"
     },
     {
       "q": 23,
@@ -6409,7 +6409,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 16,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 17,
@@ -6697,7 +6697,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 14,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 15,
@@ -7015,940 +7015,940 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 17,
       "r": 5,
       "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 5,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 5,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 26,
+      "r": 5,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 5,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 5,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 5,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 5,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 6,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 6,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 20,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 6,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 25,
+      "r": 6,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 26,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 6,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 6,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 6,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 21,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 7,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 7,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 7,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 7,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 8,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 8,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 8,
+      "terrain": "mountain",
       "resource": "stone"
     },
     {
       "q": 18,
-      "r": 5,
-      "terrain": "hills",
+      "r": 8,
+      "terrain": "mountain",
       "resource": null
     },
     {
       "q": 19,
-      "r": 5,
-      "terrain": "hills",
+      "r": 8,
+      "terrain": "mountain",
       "resource": null
     },
     {
       "q": 20,
-      "r": 5,
-      "terrain": "hills",
+      "r": 8,
+      "terrain": "mountain",
       "resource": null
     },
     {
       "q": 21,
-      "r": 5,
-      "terrain": "hills",
+      "r": 8,
+      "terrain": "mountain",
       "resource": null
     },
     {
       "q": 22,
-      "r": 5,
-      "terrain": "hills",
+      "r": 8,
+      "terrain": "mountain",
       "resource": "stone"
     },
     {
       "q": 23,
-      "r": 5,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 5,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 5,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 5,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 5,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 5,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 5,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 5,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 6,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 6,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 6,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 6,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 6,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 6,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 6,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 7,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 7,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 7,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 7,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 8,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 8,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 8,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 23,
       "r": 8,
       "terrain": "mountain",
       "resource": null
@@ -8221,7 +8221,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 18,
       "r": 9,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 19,
@@ -8251,7 +8251,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 23,
       "r": 9,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 24,
@@ -8533,7 +8533,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 20,
       "r": 10,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 21,
@@ -8815,7 +8815,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 17,
       "r": 11,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 18,
@@ -9121,7 +9121,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 18,
       "r": 12,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 19,
@@ -9151,7 +9151,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 23,
       "r": 12,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 24,
@@ -9433,7 +9433,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 20,
       "r": 13,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 21,
@@ -9469,7 +9469,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 26,
       "r": 13,
       "terrain": "plains",
-      "resource": null
+      "resource": "cattle"
     },
     {
       "q": 27,
@@ -9739,7 +9739,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 21,
       "r": 14,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 22,
@@ -13729,1215 +13729,1215 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 36,
       "r": 27,
       "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 27,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 28,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 30,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 31,
-      "terrain": "hills",
       "resource": "stone"
     },
     {
+      "q": 37,
+      "r": 27,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 28,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 35,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 37,
+      "r": 30,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 31,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
       "q": 38,
       "r": 31,
       "terrain": "desert",
@@ -15217,7 +15217,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 32,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 35,
@@ -15235,7 +15235,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 32,
       "terrain": "hills",
-      "resource": null
+      "resource": "gems"
     },
     {
       "q": 38,
@@ -15535,7 +15535,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 33,
       "terrain": "hills",
-      "resource": null
+      "resource": "gems"
     },
     {
       "q": 38,
@@ -15835,7 +15835,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 34,
       "terrain": "hills",
-      "resource": null
+      "resource": "silver"
     },
     {
       "q": 38,
@@ -16135,7 +16135,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 35,
       "terrain": "hills",
-      "resource": null
+      "resource": "silver"
     },
     {
       "q": 38,
@@ -17629,7 +17629,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 36,
       "r": 40,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 37,
@@ -18529,7 +18529,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 36,
       "r": 43,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 37,
@@ -22473,7 +22473,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 23,
       "r": 4,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 24,
@@ -22491,13 +22491,13 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 26,
       "r": 4,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 27,
       "r": 4,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 28,
@@ -22959,7 +22959,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 24,
       "r": 5,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 25,
@@ -23025,7 +23025,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 5,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 36,
@@ -23079,7 +23079,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 44,
       "r": 5,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 45,
@@ -23517,7 +23517,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 38,
@@ -23907,13 +23907,13 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 22,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 23,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 24,
@@ -23961,7 +23961,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 31,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 32,
@@ -23979,13 +23979,13 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 35,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 36,
@@ -24003,7 +24003,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 38,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 39,
@@ -24393,7 +24393,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 23,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 24,
@@ -24495,7 +24495,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 40,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 41,
@@ -24861,7 +24861,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 21,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 22,
@@ -24897,20367 +24897,20367 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 27,
       "r": 9,
       "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 9,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 9,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 9,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 9,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 9,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 10,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 10,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 10,
-      "terrain": "hills",
       "resource": "stone"
     },
     {
-      "q": 41,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 10,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 10,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 10,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 11,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
       "q": 28,
-      "r": 11,
+      "r": 9,
       "terrain": "mountain",
       "resource": null
     },
     {
       "q": 29,
-      "r": 11,
+      "r": 9,
       "terrain": "mountain",
       "resource": null
     },
     {
       "q": 30,
-      "r": 11,
+      "r": 9,
       "terrain": "mountain",
       "resource": null
     },
     {
       "q": 31,
-      "r": 11,
+      "r": 9,
       "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 11,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 11,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 11,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 11,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 11,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 12,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 12,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 12,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 12,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 12,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 12,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 13,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 13,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 13,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 13,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 13,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 14,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 14,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 14,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 14,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 14,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 15,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 15,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 16,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 16,
-      "terrain": "forest",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 17,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 17,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 17,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 43,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 17,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 17,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 17,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 17,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 18,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 18,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 18,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 42,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 19,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 19,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 43,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 20,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 21,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 21,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 22,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 22,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 22,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 42,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 23,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 24,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 40,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 24,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 42,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 25,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 37,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 25,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 43,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 27,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 28,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 39,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 39,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 39,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 39,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 39,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 40,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 41,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 42,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 43,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 44,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 45,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 46,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 47,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 47,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 48,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 48,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 49,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 49,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 50,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 50,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 51,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 51,
-      "terrain": "hills",
       "resource": "stone"
     },
     {
+      "q": 32,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 36,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 9,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 40,
+      "r": 9,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 9,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 55,
+      "r": 9,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 9,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 9,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 10,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 23,
+      "r": 10,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 10,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 10,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 33,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 10,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 10,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 10,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 10,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 10,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 56,
+      "r": 10,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 10,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 10,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 11,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 11,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 11,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 11,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 56,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 11,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 11,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 11,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 12,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 28,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 36,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 12,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 12,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 12,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 12,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 12,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 29,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 33,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 37,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 13,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 13,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 13,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 13,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 13,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 30,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 14,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 14,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 14,
+      "terrain": "forest",
+      "resource": "furs"
+    },
+    {
+      "q": 49,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 14,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 14,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 14,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 36,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 15,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 15,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 33,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 37,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 16,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 16,
+      "terrain": "forest",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 30,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 38,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 17,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 17,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 17,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 43,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 17,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 17,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 17,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 17,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 18,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 18,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 42,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 33,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 19,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 43,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 30,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 38,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 20,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 31,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 39,
+      "r": 21,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 21,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 22,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 22,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 22,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 42,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 23,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 24,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 40,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 24,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 42,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 25,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 37,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 25,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 43,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 27,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 28,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 39,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 39,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 39,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 58,
+      "r": 39,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 39,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 55,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 40,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 57,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 41,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 58,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 42,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 55,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 59,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 43,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 56,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 44,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 58,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 45,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 55,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 59,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 46,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 47,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 47,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 48,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 48,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 55,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 59,
+      "r": 49,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 49,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 56,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 50,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 60,
+      "r": 50,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 51,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 51,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
       "q": 61,
       "r": 51,
       "terrain": "desert",
@@ -46215,7 +46215,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 60,
       "r": 53,
       "terrain": "hills",
-      "resource": null
+      "resource": "silver"
     },
     {
       "q": 61,
@@ -50523,7 +50523,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 58,
       "r": 62,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -50559,7 +50559,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 64,
       "r": 62,
       "terrain": "grassland",
-      "resource": null
+      "resource": "cattle"
     },
     {
       "q": 65,
@@ -51477,7 +51477,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 57,
       "r": 64,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 58,
@@ -51507,7 +51507,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 62,
       "r": 64,
       "terrain": "grassland",
-      "resource": null
+      "resource": "cattle"
     },
     {
       "q": 63,
@@ -51963,7 +51963,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 58,
       "r": 65,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -52449,7 +52449,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 59,
       "r": 66,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 60,
@@ -53403,7 +53403,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 58,
       "r": 68,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 59,
@@ -54351,7 +54351,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 56,
       "r": 70,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 57,
@@ -55305,7 +55305,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 55,
       "r": 72,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 56,
@@ -55791,7 +55791,7 @@ export const NEW_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 56,
       "r": 73,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 57,
@@ -58843,8 +58843,8 @@ export const NEW_WORLD_START_POSITIONS: Record<'small' | 'medium' | 'large', Rec
       "r": 10
     },
     "spain": {
-      "q": 26,
-      "r": 21
+      "q": 25,
+      "r": 20
     },
     "aztec": {
       "q": 25,
@@ -58862,7 +58862,7 @@ export const NEW_WORLD_START_POSITIONS: Record<'small' | 'medium' | 'large', Rec
     },
     "spain": {
       "q": 41,
-      "r": 33
+      "r": 32
     },
     "viking": {
       "q": 66,

--- a/src/systems/old-world-map-data.ts
+++ b/src/systems/old-world-map-data.ts
@@ -305,7 +305,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 19,
       "r": 1,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 20,
@@ -353,7 +353,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 27,
       "r": 1,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 28,
@@ -635,7 +635,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 14,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 15,
@@ -647,7 +647,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 16,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 17,
@@ -1025,7 +1025,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 19,
       "r": 5,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 20,
@@ -1127,7 +1127,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 6,
       "r": 6,
       "terrain": "grassland",
-      "resource": "wine"
+      "resource": null
     },
     {
       "q": 7,
@@ -1379,7 +1379,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 18,
       "r": 7,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 19,
@@ -2057,7 +2057,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 11,
       "r": 11,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 12,
@@ -2081,7 +2081,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 15,
       "r": 11,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 16,
@@ -2093,7 +2093,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 17,
       "r": 11,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 18,
@@ -3125,7 +3125,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 9,
       "r": 17,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 10,
@@ -5923,7 +5923,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 36,
@@ -5941,7 +5941,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 38,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 39,
@@ -5983,7 +5983,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 45,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 46,
@@ -6205,7 +6205,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 32,
       "r": 2,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 33,
@@ -6223,7 +6223,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 2,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 36,
@@ -6283,7 +6283,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 45,
       "r": 2,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 46,
@@ -6487,7 +6487,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 29,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 30,
@@ -6511,7 +6511,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 33,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 34,
@@ -6547,7 +6547,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 39,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 40,
@@ -6571,7 +6571,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 43,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 44,
@@ -6589,7 +6589,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 46,
       "r": 3,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 47,
@@ -6769,13 +6769,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 26,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 27,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 28,
@@ -6811,7 +6811,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 33,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 34,
@@ -6835,7 +6835,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 38,
@@ -7063,7 +7063,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 25,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 26,
@@ -7075,7 +7075,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 27,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 28,
@@ -7093,7 +7093,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 30,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 31,
@@ -7117,7 +7117,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 35,
@@ -7135,7 +7135,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 37,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 38,
@@ -7177,7 +7177,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 44,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 45,
@@ -7423,7 +7423,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 36,
@@ -8317,7 +8317,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 9,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 35,
@@ -8605,7 +8605,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 32,
       "r": 10,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 33,
@@ -8647,7 +8647,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 39,
       "r": 10,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 40,
@@ -8953,7 +8953,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 40,
       "r": 11,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 41,
@@ -9193,7 +9193,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 30,
       "r": 12,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 31,
@@ -9499,7 +9499,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 31,
       "r": 13,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 32,
@@ -9517,7 +9517,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 13,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 35,
@@ -10087,351 +10087,351 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 29,
       "r": 15,
       "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 15,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 15,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 15,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 15,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 15,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 15,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 16,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 16,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 16,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 16,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 16,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 16,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 16,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 16,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 16,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 16,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 16,
-      "terrain": "hills",
       "resource": "stone"
     },
     {
+      "q": 30,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 33,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 15,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 15,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 15,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 15,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 15,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 15,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 7,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 16,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 16,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 16,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 16,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 16,
+      "terrain": "hills",
+      "resource": "salt"
+    },
+    {
+      "q": 21,
+      "r": 16,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 16,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 16,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 16,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 27,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 34,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 16,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 16,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
       "q": 37,
       "r": 16,
       "terrain": "plains",
@@ -10693,7 +10693,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 30,
       "r": 17,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 31,
@@ -10975,7 +10975,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 27,
       "r": 18,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 28,
@@ -11017,7 +11017,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 34,
       "r": 18,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 35,
@@ -11281,7 +11281,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 28,
       "r": 19,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 29,
@@ -11299,7 +11299,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 31,
       "r": 19,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 32,
@@ -21171,13 +21171,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 46,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 47,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 48,
@@ -21243,13 +21243,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 58,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 59,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 60,
@@ -21261,13 +21261,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 61,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 62,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 63,
@@ -21285,7 +21285,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 65,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 66,
@@ -21339,7 +21339,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 74,
       "r": 1,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 75,
@@ -21603,7 +21603,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 38,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 39,
@@ -21669,13 +21669,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 49,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 50,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 51,
@@ -21693,13 +21693,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 53,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 54,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 55,
@@ -21759,13 +21759,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 64,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 65,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 66,
@@ -21783,13 +21783,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 68,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 69,
       "r": 2,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -22119,7 +22119,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 44,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 45,
@@ -22173,7 +22173,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 53,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 54,
@@ -22191,13 +22191,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 56,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 57,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
@@ -22215,7 +22215,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 60,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 61,
@@ -22269,25 +22269,25 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 69,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 71,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 72,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 73,
@@ -22299,7 +22299,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 74,
       "r": 3,
       "terrain": "tundra",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 75,
@@ -22599,7 +22599,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 44,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 45,
@@ -22623,13 +22623,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 48,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 49,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 50,
@@ -22641,7 +22641,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 51,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 52,
@@ -22695,13 +22695,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 60,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 61,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 62,
@@ -22719,13 +22719,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 64,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 65,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 66,
@@ -22737,7 +22737,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 67,
       "r": 4,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -22941,7 +22941,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 21,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 22,
@@ -23049,13 +23049,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 39,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 40,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 41,
@@ -23121,7 +23121,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 51,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 52,
@@ -23145,13 +23145,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 55,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 56,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 57,
@@ -23211,13 +23211,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 66,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 67,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -23235,13 +23235,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 70,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 71,
       "r": 5,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 72,
@@ -23505,7 +23505,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 6,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 36,
@@ -23529,7 +23529,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 39,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 40,
@@ -23553,13 +23553,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 43,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 44,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 45,
@@ -23571,7 +23571,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 46,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 47,
@@ -23625,19 +23625,19 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 55,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 56,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 57,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
@@ -23649,25 +23649,25 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 59,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 60,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 61,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 62,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 63,
@@ -23721,7 +23721,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 71,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 72,
@@ -23739,7 +23739,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 74,
       "r": 6,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 75,
@@ -24051,7 +24051,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 46,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 47,
@@ -24075,13 +24075,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 50,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 51,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 52,
@@ -24147,13 +24147,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 62,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 63,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 64,
@@ -24171,13 +24171,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 66,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 67,
       "r": 7,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 68,
@@ -24501,13 +24501,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 41,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 42,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 43,
@@ -24561,7 +24561,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 51,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 52,
@@ -24585,7 +24585,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 55,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 56,
@@ -24597,13 +24597,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 57,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 59,
@@ -24651,7 +24651,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 66,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 67,
@@ -24669,7 +24669,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 69,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -24687,13 +24687,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 72,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 73,
       "r": 8,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 74,
@@ -24951,7 +24951,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 36,
       "r": 9,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 37,
@@ -25005,13 +25005,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 45,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 46,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 47,
@@ -25077,7 +25077,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 57,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 58,
@@ -25101,7 +25101,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 61,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 62,
@@ -25113,13 +25113,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 63,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 64,
       "r": 9,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 65,
@@ -25527,13 +25527,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 52,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 53,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 54,
@@ -25599,7 +25599,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 64,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 65,
@@ -25623,13 +25623,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 68,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 69,
       "r": 10,
       "terrain": "forest",
-      "resource": null
+      "resource": "furs"
     },
     {
       "q": 70,
@@ -27345,7 +27345,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 35,
       "r": 14,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 36,
@@ -27417,7 +27417,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 47,
       "r": 14,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 48,
@@ -27429,13 +27429,13 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 49,
       "r": 14,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 50,
       "r": 14,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 51,
@@ -28179,7 +28179,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 14,
       "r": 16,
       "terrain": "mountain",
-      "resource": null
+      "resource": "stone"
     },
     {
       "q": 15,
@@ -28869,7 +28869,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 49,
       "r": 17,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 50,
@@ -28881,7 +28881,7 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 51,
       "r": 17,
       "terrain": "plains",
-      "resource": null
+      "resource": "sheep"
     },
     {
       "q": 52,
@@ -29151,26893 +29151,26893 @@ export const OLD_WORLD_TILES: Record<'small' | 'medium' | 'large', GeoTile[]> = 
       "q": 16,
       "r": 18,
       "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 18,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 18,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 38,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 39,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 52,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 54,
+      "r": 18,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 55,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 18,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 18,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 18,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 18,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 19,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 47,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 49,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 52,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 53,
+      "r": 19,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 54,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 19,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 19,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 19,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 19,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 20,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 42,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 44,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 50,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 51,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 52,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 53,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 54,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 55,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 20,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 58,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 20,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 20,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 20,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 20,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 21,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 21,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 38,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 40,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "horses"
+    },
+    {
+      "q": 41,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 47,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 50,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 56,
+      "r": 21,
+      "terrain": "plains",
+      "resource": "sheep"
+    },
+    {
+      "q": 57,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 21,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 21,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 21,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 21,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 22,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 22,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 22,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 22,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 23,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 23,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 40,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 41,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 23,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": "silk"
+    },
+    {
+      "q": 60,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 23,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 23,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 23,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 23,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 24,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 30,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 24,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 24,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 24,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": "silk"
+    },
+    {
+      "q": 61,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 24,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 24,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 24,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 24,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 25,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 25,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 51,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 52,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 53,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 25,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 25,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 25,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 25,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 25,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 25,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 9,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 10,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 11,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 26,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 26,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 42,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 57,
+      "r": 26,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 58,
+      "r": 26,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 26,
+      "terrain": "grassland",
+      "resource": "silk"
+    },
+    {
+      "q": 63,
+      "r": 26,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 26,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 26,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 32,
+      "r": 27,
+      "terrain": "hills",
+      "resource": "salt"
+    },
+    {
+      "q": 33,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 27,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 27,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 48,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 27,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 27,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": "silk"
+    },
+    {
+      "q": 60,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 27,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 27,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 27,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 27,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 6,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 28,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 28,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 54,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 55,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 28,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 28,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 28,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 28,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 28,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 28,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 29,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 25,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 44,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 29,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 29,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 29,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 29,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 29,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 30,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 13,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 30,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 15,
+      "r": 30,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 16,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 30,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 36,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 50,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 30,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 30,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 30,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 30,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 30,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 31,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 27,
+      "r": 31,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 28,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 31,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 56,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 31,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 31,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 31,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 31,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 31,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 32,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 18,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 32,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 27,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 32,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 32,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 32,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 32,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 33,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 15,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 33,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 18,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 33,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 33,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 33,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 34,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 14,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 34,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 29,
+      "r": 34,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 30,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 34,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 34,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 34,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 35,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 18,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 35,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 28,
+      "r": 35,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 29,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 35,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 35,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 35,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 36,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 17,
+      "r": 36,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 18,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 36,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 20,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 36,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 36,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 36,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 37,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 15,
+      "r": 37,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 16,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 37,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 31,
+      "r": 37,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 32,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 37,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 37,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 37,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 38,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 20,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 38,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 30,
+      "r": 38,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 31,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 38,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 38,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 38,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 39,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 19,
+      "r": 39,
+      "terrain": "desert",
+      "resource": "incense"
+    },
+    {
+      "q": 20,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 39,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 39,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 39,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 39,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 40,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 40,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 40,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 40,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 41,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 41,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 41,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 41,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 25,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 26,
+      "r": 42,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 42,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 42,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 42,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 43,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 43,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 43,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 43,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 44,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 44,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 44,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 44,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 26,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 27,
+      "r": 45,
+      "terrain": "mountain",
+      "resource": "stone"
+    },
+    {
+      "q": 28,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 45,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 45,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 45,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 46,
+      "terrain": "mountain",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 46,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 46,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 46,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 47,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 47,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 47,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 47,
+      "terrain": "hills",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 47,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 47,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 47,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 48,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 48,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 48,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 49,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 49,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 49,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 50,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 50,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 50,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 51,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 51,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 51,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 52,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 52,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 52,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 53,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 53,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 53,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 54,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 54,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 54,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 55,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 55,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 55,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 56,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 56,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 56,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 57,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 57,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 57,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 57,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 57,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 57,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 58,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 58,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 58,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 58,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 58,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 59,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 59,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 59,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 59,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 59,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 60,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 60,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 60,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 61,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 61,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 61,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 62,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 62,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 62,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 63,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 63,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 63,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 64,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 64,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 64,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 65,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 65,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 65,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 66,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 66,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 66,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 67,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 67,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 67,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 68,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 68,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 68,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 69,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 69,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 69,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 69,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 69,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 69,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 70,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 70,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 70,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 70,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 70,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 70,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 70,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 71,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 71,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 71,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 71,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 71,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 71,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 72,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 72,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 72,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 72,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 72,
+      "terrain": "desert",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 72,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 18,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 19,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 20,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 21,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 22,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 23,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 24,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 25,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 26,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 27,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 28,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 29,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 30,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 31,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 32,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 33,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 34,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 35,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 36,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 37,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 38,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 39,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 40,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 41,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 42,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 43,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 44,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 45,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 46,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 47,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 48,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 49,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 50,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 51,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 52,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 53,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 54,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 55,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 56,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 57,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 58,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 59,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 60,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 61,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 62,
+      "r": 73,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 63,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 64,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 65,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 66,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 67,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 68,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 69,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 70,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 71,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 72,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 73,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 74,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 75,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 76,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 77,
+      "r": 73,
+      "terrain": "grassland",
+      "resource": null
+    },
+    {
+      "q": 78,
+      "r": 73,
+      "terrain": "plains",
+      "resource": null
+    },
+    {
+      "q": 79,
+      "r": 73,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 0,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 1,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 2,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 3,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 4,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 5,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 6,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 7,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 8,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 9,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 10,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 11,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 12,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 13,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 14,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 15,
+      "r": 74,
+      "terrain": "ocean",
+      "resource": null
+    },
+    {
+      "q": 16,
+      "r": 74,
+      "terrain": "coast",
+      "resource": null
+    },
+    {
+      "q": 17,
+      "r": 74,
+      "terrain": "plains",
       "resource": "wine"
-    },
-    {
-      "q": 17,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 18,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 18,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 18,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 38,
-      "r": 18,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 39,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 18,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 52,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 18,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 54,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 18,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 18,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 18,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 18,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 19,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 19,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 52,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 19,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 54,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 19,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 19,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 19,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 19,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 20,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 42,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 44,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 50,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 51,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 52,
-      "r": 20,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 53,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 20,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 20,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 20,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 20,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 21,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 21,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 21,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 38,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 21,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 40,
-      "r": 21,
-      "terrain": "plains",
-      "resource": "horses"
-    },
-    {
-      "q": 41,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 21,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 21,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 21,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 21,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": "wine"
-    },
-    {
-      "q": 6,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 22,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 22,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 22,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 22,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 23,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 23,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 39,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 23,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": "silk"
-    },
-    {
-      "q": 60,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 23,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 23,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 23,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 23,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 24,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 24,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 24,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 24,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 45,
-      "r": 24,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 46,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 24,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": "silk"
-    },
-    {
-      "q": 61,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 24,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 24,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 24,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 24,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 25,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 25,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 25,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 25,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 25,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 25,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 25,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 25,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 26,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 26,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 26,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 26,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 59,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 26,
-      "terrain": "grassland",
-      "resource": "silk"
-    },
-    {
-      "q": 63,
-      "r": 26,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 26,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 26,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 27,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 27,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 27,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 27,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 27,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": "silk"
-    },
-    {
-      "q": 60,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 27,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 27,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 27,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 27,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 28,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 28,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 28,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 28,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 28,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 28,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 28,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 28,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 29,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 12,
-      "r": 29,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 29,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 25,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 29,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 29,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 59,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 29,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 29,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 29,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 30,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 13,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 30,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 15,
-      "r": 30,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 16,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 30,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 36,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 30,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 30,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 30,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 30,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 30,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 31,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 27,
-      "r": 31,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 28,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 31,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 31,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 31,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 31,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 31,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 31,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 32,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 18,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 32,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 27,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 32,
-      "terrain": "hills",
-      "resource": "stone"
-    },
-    {
-      "q": 45,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 32,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 32,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 32,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 32,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 33,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 15,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 33,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 18,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 33,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 33,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 33,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 34,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 14,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 34,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 29,
-      "r": 34,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 30,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 34,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 34,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 34,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 35,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 18,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 35,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 28,
-      "r": 35,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 29,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 35,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 35,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 35,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 36,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 17,
-      "r": 36,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 18,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 36,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 20,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 36,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 36,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 36,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 37,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 15,
-      "r": 37,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 16,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 37,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 31,
-      "r": 37,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 32,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 37,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 37,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 37,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 38,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 20,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 38,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 30,
-      "r": 38,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 31,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 38,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 38,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 38,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 39,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 19,
-      "r": 39,
-      "terrain": "desert",
-      "resource": "incense"
-    },
-    {
-      "q": 20,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 39,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 39,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 39,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 39,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 40,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 40,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 40,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 40,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 41,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 41,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 41,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 41,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 42,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 42,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 42,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 42,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 43,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 43,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 43,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 43,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 44,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 44,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 44,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 44,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 45,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 45,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 45,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 45,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 46,
-      "terrain": "mountain",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 46,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 46,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 46,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 47,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 47,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 47,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 47,
-      "terrain": "hills",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 47,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 47,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 47,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 48,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 48,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 48,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 49,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 49,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 49,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 50,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 50,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 50,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 51,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 51,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 51,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 52,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 52,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 52,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 53,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 53,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 53,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 54,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 54,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 54,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 55,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 55,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 55,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 56,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 56,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 56,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 57,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 57,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 57,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 57,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 57,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 57,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 58,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 58,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 58,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 58,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 58,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 59,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 59,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 59,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 59,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 59,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 60,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 60,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 60,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 61,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 61,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 61,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 62,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 62,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 62,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 63,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 63,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 63,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 64,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 64,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 64,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 65,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 65,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 65,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 66,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 66,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 66,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 67,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 67,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 67,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 68,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 68,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 68,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 69,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 69,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 69,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 69,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 69,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 69,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 70,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 70,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 70,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 70,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 70,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 70,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 70,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 71,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 71,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 71,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 71,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 71,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 71,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 72,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 72,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 72,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 72,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 72,
-      "terrain": "desert",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 72,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 18,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 19,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 20,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 21,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 22,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 23,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 24,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 25,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 26,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 27,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 28,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 29,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 30,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 31,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 32,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 33,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 34,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 35,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 36,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 37,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 38,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 39,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 40,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 41,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 42,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 43,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 44,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 45,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 46,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 47,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 48,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 49,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 50,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 51,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 52,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 53,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 54,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 55,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 56,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 57,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 58,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 59,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 60,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 61,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 62,
-      "r": 73,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 63,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 64,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 65,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 66,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 67,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 68,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 69,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 70,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 71,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 72,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 73,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 74,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 75,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 76,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 77,
-      "r": 73,
-      "terrain": "grassland",
-      "resource": null
-    },
-    {
-      "q": 78,
-      "r": 73,
-      "terrain": "plains",
-      "resource": null
-    },
-    {
-      "q": 79,
-      "r": 73,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 0,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 1,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 2,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 3,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 4,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 5,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 6,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 7,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 8,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 9,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 10,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 11,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 12,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 13,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 14,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 15,
-      "r": 74,
-      "terrain": "ocean",
-      "resource": null
-    },
-    {
-      "q": 16,
-      "r": 74,
-      "terrain": "coast",
-      "resource": null
-    },
-    {
-      "q": 17,
-      "r": 74,
-      "terrain": "plains",
-      "resource": null
     },
     {
       "q": 18,

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -1,4 +1,4 @@
-import type { GameState, ResourceType } from '@/core/types';
+import type { GameState, ResourceType, ResourceYield } from '@/core/types';
 import { hexKey } from './hex-utils';
 import { RESOURCE_DEFINITIONS } from './trade-system';
 
@@ -58,4 +58,52 @@ export function getCivAvailableResources(state: GameState, civId: string): Set<R
   }
 
   return result;
+}
+
+/**
+ * Returns the aggregate per-city yield bonus from all owned resources whose
+ * effect type is NOT 'happiness' (i.e. gold, production, food effects only).
+ * Non-stacking per resource: owning any number of the same resource counts once.
+ * Different resources with the same effect type DO accumulate
+ * (gems + silver → +2 gold/turn).
+ */
+export function getCivResourceYieldBonus(
+  state: GameState,
+  civId: string,
+): ResourceYield {
+  const bonus: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
+  const owned = getCivAvailableResources(state, civId);
+
+  for (const def of RESOURCE_DEFINITIONS) {
+    if (!def.effect || def.effect.type === 'happiness') continue;
+    if (!owned.has(def.id as ResourceType)) continue;
+
+    switch (def.effect.type) {
+      case 'gold':       bonus.gold       += def.effect.amount; break;
+      case 'production': bonus.production += def.effect.amount; break;
+      case 'food':       bonus.food       += def.effect.amount; break;
+    }
+  }
+
+  return bonus;
+}
+
+/**
+ * Returns the count of distinct happiness-type luxuries owned by the civ.
+ * Empire-wide, non-stacking: owning three silk tiles counts as 1, not 3.
+ * Different resources accumulate: silk + wine = 2.
+ */
+export function getCivHappinessFromResources(
+  state: GameState,
+  civId: string,
+): number {
+  const owned = getCivAvailableResources(state, civId);
+  let count = 0;
+
+  for (const def of RESOURCE_DEFINITIONS) {
+    if (!def.effect || def.effect.type !== 'happiness') continue;
+    if (owned.has(def.id as ResourceType)) count++;
+  }
+
+  return count;
 }

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -1,5 +1,10 @@
 import type { BuildableImprovementType, MarketplaceState, ResourceType, TradeRoute } from '@/core/types';
 
+export interface ResourceEffect {
+  type: 'happiness' | 'gold' | 'production' | 'food';
+  amount: number; // always 1 in S4a
+}
+
 export interface ResourceDefinition {
   id: ResourceType;
   name: string;
@@ -9,27 +14,32 @@ export interface ResourceDefinition {
   tech: string;
   icon: string;
   requiredImprovement: BuildableImprovementType;
+  effect: ResourceEffect | null; // null = no S4a passive (copper/iron/horses/stone)
 }
 
 export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
-  // Luxury
-  { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland',            basePrice: 8,  tech: 'irrigation',       icon: '🧵', requiredImprovement: 'plantation' },
-  { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',               basePrice: 7,  tech: 'pottery',           icon: '🍇', requiredImprovement: 'plantation' },
-  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',               basePrice: 10, tech: 'cartography',       icon: '🌶️', requiredImprovement: 'plantation' },
-  { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',                basePrice: 12, tech: 'mining-tech',       icon: '💎', requiredImprovement: 'mine' },
-  { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',               basePrice: 9,  tech: 'foraging',          icon: '🐘', requiredImprovement: 'camp' },
-  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',               basePrice: 6,  tech: 'currency',          icon: '🕯️', requiredImprovement: 'plantation' },
-  { id: 'gold',    name: 'Gold',    type: 'luxury',    terrain: 'hills',                basePrice: 15, tech: 'currency',          icon: '⭐', requiredImprovement: 'mine' },
-  { id: 'silver',  name: 'Silver',  type: 'luxury',    terrain: 'hills',                basePrice: 11, tech: 'mining-tech',       icon: '🥈', requiredImprovement: 'mine' },
-  { id: 'furs',    name: 'Furs',    type: 'luxury',    terrain: ['forest', 'tundra'],   basePrice: 9,  tech: 'foraging',          icon: '🦊', requiredImprovement: 'camp' },
-  { id: 'sheep',   name: 'Sheep',   type: 'luxury',    terrain: ['hills', 'plains'],    basePrice: 7,  tech: 'animal-husbandry',  icon: '🐑', requiredImprovement: 'pasture' },
-  // Strategic
-  { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',                basePrice: 5,  tech: 'stone-weapons',     icon: '🪙', requiredImprovement: 'mine' },
-  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',                basePrice: 8,  tech: 'bronze-working',    icon: '⚙️', requiredImprovement: 'mine' },
-  { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',               basePrice: 7,  tech: 'animal-husbandry',  icon: '🐎', requiredImprovement: 'pasture' },
-  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',             basePrice: 4,  tech: 'gathering',         icon: '🪨', requiredImprovement: 'quarry' },
-  { id: 'cattle',  name: 'Cattle',  type: 'strategic', terrain: ['grassland', 'plains'],basePrice: 5,  tech: 'domestication',     icon: '🐄', requiredImprovement: 'pasture' },
-  { id: 'salt',    name: 'Salt',    type: 'strategic', terrain: 'hills',                basePrice: 5,  tech: 'pottery',           icon: '🧂', requiredImprovement: 'mine' },
+  // Luxury — happiness
+  { id: 'silk',    name: 'Silk',    type: 'luxury',    terrain: 'grassland',             basePrice: 8,  tech: 'irrigation',       icon: '🧵', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  { id: 'wine',    name: 'Wine',    type: 'luxury',    terrain: 'plains',                basePrice: 7,  tech: 'pottery',           icon: '🍇', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  { id: 'ivory',   name: 'Ivory',   type: 'luxury',    terrain: 'forest',                basePrice: 9,  tech: 'foraging',          icon: '🐘', requiredImprovement: 'camp',       effect: { type: 'happiness', amount: 1 } },
+  { id: 'furs',    name: 'Furs',    type: 'luxury',    terrain: ['forest', 'tundra'],    basePrice: 9,  tech: 'foraging',          icon: '🦊', requiredImprovement: 'camp',       effect: { type: 'happiness', amount: 1 } },
+  { id: 'incense', name: 'Incense', type: 'luxury',    terrain: 'desert',                basePrice: 6,  tech: 'currency',          icon: '🕯️', requiredImprovement: 'plantation', effect: { type: 'happiness', amount: 1 } },
+  // Luxury — gold/turn
+  { id: 'gems',    name: 'Gems',    type: 'luxury',    terrain: 'hills',                 basePrice: 12, tech: 'mining-tech',       icon: '💎', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'gold',    name: 'Gold',    type: 'luxury',    terrain: 'hills',                 basePrice: 15, tech: 'currency',          icon: '⭐', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'silver',  name: 'Silver',  type: 'luxury',    terrain: 'hills',                 basePrice: 11, tech: 'mining-tech',       icon: '🥈', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  { id: 'spices',  name: 'Spices',  type: 'luxury',    terrain: 'jungle',                basePrice: 10, tech: 'cartography',       icon: '🌶️', requiredImprovement: 'plantation', effect: { type: 'gold', amount: 1 } },
+  // Luxury — production/turn
+  { id: 'sheep',   name: 'Sheep',   type: 'luxury',    terrain: ['hills', 'plains'],     basePrice: 7,  tech: 'animal-husbandry',  icon: '🐑', requiredImprovement: 'pasture',    effect: { type: 'production', amount: 1 } },
+  // Strategic — food/turn
+  { id: 'cattle',  name: 'Cattle',  type: 'strategic', terrain: ['grassland', 'plains'], basePrice: 5,  tech: 'domestication',     icon: '🐄', requiredImprovement: 'pasture',    effect: { type: 'food', amount: 1 } },
+  // Strategic — gold/turn
+  { id: 'salt',    name: 'Salt',    type: 'strategic', terrain: 'hills',                 basePrice: 5,  tech: 'pottery',           icon: '🧂', requiredImprovement: 'mine',       effect: { type: 'gold', amount: 1 } },
+  // Strategic — null (S4b gating)
+  { id: 'copper',  name: 'Copper',  type: 'strategic', terrain: 'hills',                 basePrice: 5,  tech: 'stone-weapons',     icon: '🪙', requiredImprovement: 'mine',       effect: null },
+  { id: 'iron',    name: 'Iron',    type: 'strategic', terrain: 'hills',                 basePrice: 8,  tech: 'bronze-working',    icon: '⚙️', requiredImprovement: 'mine',       effect: null },
+  { id: 'horses',  name: 'Horses',  type: 'strategic', terrain: 'plains',                basePrice: 7,  tech: 'animal-husbandry',  icon: '🐎', requiredImprovement: 'pasture',    effect: null },
+  { id: 'stone',   name: 'Stone',   type: 'strategic', terrain: 'mountain',              basePrice: 4,  tech: 'gathering',         icon: '🪨', requiredImprovement: 'quarry',     effect: null },
 ];
 
 export const BASE_PRICES: Record<string, number> = {};

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -8,6 +8,8 @@ import {
   getProductionDisplayName,
   getProductionIconForItem,
 } from '@/systems/city-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
 import {
   getCompactLegendaryWonderEntriesForCity,
   getLegendaryWonderPresentationForCity,
@@ -103,6 +105,59 @@ export function createCityPanel(
   const occupiedMood = getOccupiedCityMood(city);
   const occupiedStatus = city.occupation ? `Occupied: ${city.occupation.turnsRemaining} turns to integrate` : '';
   const occupiedMoodText = occupiedMood === 2 ? 'Very Unhappy' : occupiedMood === 1 ? 'Unhappy' : '';
+
+  // Resource bonus sections: happiness (empire-wide) and yield (per-city)
+  const playerResources = getCivAvailableResources(state, state.currentPlayer);
+  const happinessResources = RESOURCE_DEFINITIONS.filter(
+    d => d.effect?.type === 'happiness' && playerResources.has(d.id as never),
+  );
+  const yieldResources = RESOURCE_DEFINITIONS.filter(
+    d => d.effect && d.effect.type !== 'happiness' && playerResources.has(d.id as never),
+  );
+
+  function resourceDisplayName(defId: string, defName: string): string {
+    // The "gold" resource name collides with the currency name in context like "+1 gold/turn"
+    return defId === 'gold' ? 'Gold deposits' : defName;
+  }
+
+  function yieldLabel(effectType: string): string {
+    switch (effectType) {
+      case 'gold': return '+1 gold/turn';
+      case 'production': return '+1 production/turn';
+      case 'food': return '+1 food/turn';
+      default: return '';
+    }
+  }
+
+  let resourceBonusSectionHtml = '';
+  if (happinessResources.length > 0 || yieldResources.length > 0) {
+    let empireBonusHtml = '';
+    if (happinessResources.length > 0) {
+      let rows = '';
+      for (const def of happinessResources) {
+        rows += `<div style="font-size:12px;opacity:0.85;" data-res-happiness="${def.id}"></div>`;
+      }
+      empireBonusHtml = `<div style="font-weight:bold;font-size:12px;color:#d4af70;margin-bottom:4px;">Empire bonuses</div>${rows}`;
+    }
+
+    let cityBonusHtml = '';
+    if (yieldResources.length > 0) {
+      let rows = '';
+      for (const def of yieldResources) {
+        rows += `<div style="font-size:12px;opacity:0.85;" data-res-yield="${def.id}"></div>`;
+      }
+      const topMargin = happinessResources.length > 0 ? 'margin-top:8px;' : '';
+      cityBonusHtml = `<div style="font-weight:bold;font-size:12px;color:#d4af70;margin-bottom:4px;${topMargin}">City bonuses</div>${rows}`;
+    }
+
+    resourceBonusSectionHtml = `
+      <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px 12px;margin-bottom:16px;">
+        <div style="font-size:13px;font-weight:bold;color:#e8c170;margin-bottom:6px;">Resources</div>
+        ${empireBonusHtml}${cityBonusHtml}
+      </div>
+    `;
+  }
+
   const currentCiv = state.civilizations[state.currentPlayer];
   const civDef = resolveCivDefinition(state, currentCiv.civType);
   const getDisplayedCost = (itemId: string): number => getProductionCostForItem(itemId, {
@@ -331,6 +386,7 @@ export function createCityPanel(
       <span>💰 +<span data-text="yield-gold"></span></span>
       <span>🔬 +<span data-text="yield-science"></span></span>
     </div>
+    ${resourceBonusSectionHtml}
     <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:16px;font-size:12px;color:#d9d3c0;">
       <span title="" data-maintenance-summary>Free support: ${cityFreeBuildings} buildings, ${economyStatus.breakdown.freeUnits} units</span>
       <span title="" data-maintenance-summary>Paid upkeep: -${cityMaintenance.upkeep} city / -${economyStatus.unitMaintenance} empire</span>
@@ -379,6 +435,16 @@ export function createCityPanel(
   setText('yield-prod', String(yields.production));
   setText('yield-gold', String(yields.gold));
   setText('yield-science', String(yields.science));
+
+  // Populate resource bonus rows via textContent (XSS-safe)
+  for (const def of happinessResources) {
+    const el = panel.querySelector(`[data-res-happiness="${def.id}"]`);
+    if (el) el.textContent = `${def.icon} ${resourceDisplayName(def.id, def.name)} → +1 happiness`;
+  }
+  for (const def of yieldResources) {
+    const el = panel.querySelector(`[data-res-yield="${def.id}"]`);
+    if (el) el.textContent = `${def.icon} ${resourceDisplayName(def.id, def.name)} → ${yieldLabel(def.effect!.type)}`;
+  }
 
   if (city.productionQueue.length > 0) {
     const currentItem = city.productionQueue[0];

--- a/src/ui/marketplace-panel.ts
+++ b/src/ui/marketplace-panel.ts
@@ -68,6 +68,7 @@ export function createMarketplacePanel(
         <div style="flex:1;">
           <div style="font-size:13px;font-weight:bold;"><span data-text="res-name-${idx}"></span> <span style="font-size:10px;color:${typeColor};" data-text="res-type-${idx}"></span></div>
           <div style="font-size:11px;opacity:0.6;" data-text="res-owned-${idx}"></div>
+          <div style="font-size:10px;opacity:0.65;" data-text="res-effect-${idx}"></div>
         </div>
         <div style="text-align:right;">
           <div style="font-size:14px;color:#e8c170;">💰 <span data-text="res-price-${idx}"></span> ${trendIcon}</div>
@@ -115,6 +116,21 @@ export function createMarketplacePanel(
     setText(`res-type-${idx}`, def.type.charAt(0).toUpperCase() + def.type.slice(1));
     setText(`res-owned-${idx}`, isOwned ? '✓ Owned' : '✗ Not in inventory');
     setText(`res-price-${idx}`, String(price));
+
+    // Effect badge — set via textContent, never innerHTML
+    let effectText: string;
+    if (!def.effect) {
+      effectText = '(unlocks advanced units & buildings)';
+    } else {
+      switch (def.effect.type) {
+        case 'happiness':   effectText = '★ +1 happiness'; break;
+        case 'gold':        effectText = '$ +1 gold/turn'; break;
+        case 'production':  effectText = '⚙ +1 production/turn'; break;
+        case 'food':        effectText = '🌾 +1 food/turn'; break;
+        default:            effectText = '';
+      }
+    }
+    setText(`res-effect-${idx}`, effectText);
   });
 
   // Populate Your Resources section

--- a/tests/systems/earth-map-geo.test.ts
+++ b/tests/systems/earth-map-geo.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// We test the RESOURCE_ZONES array directly by reading the generate script source.
+// The script is not designed for direct import, so we parse the bounding boxes
+// from the source text and verify them against the spec.
+
+// The expected bounding boxes for new resources, per spec §Earth map.
+// Each entry is: { resource, lonMin, lonMax, latMin, latMax }
+const EXPECTED_NEW_ZONE_BOXES = [
+  // Gold
+  { resource: 'gold', lonMin: 25,   lonMax: 32,   latMin: -30, latMax: -22 }, // S. Africa
+  { resource: 'gold', lonMin: -122, lonMax: -114, latMin: 36,  latMax: 42  }, // California
+  { resource: 'gold', lonMin: 120,  lonMax: 150,  latMin: 55,  latMax: 65  }, // Siberia
+  // Silver
+  { resource: 'silver', lonMin: -107, lonMax: -98, latMin: 20,  latMax: 30  }, // Mexico
+  { resource: 'silver', lonMin: -70,  lonMax: -63, latMin: -24, latMax: -14 }, // Bolivia/Peru
+  // Furs
+  { resource: 'furs', lonMin: 60,   lonMax: 140,  latMin: 55, latMax: 70 }, // Siberia
+  { resource: 'furs', lonMin: -135, lonMax: -70,  latMin: 50, latMax: 70 }, // Canada
+  // Sheep
+  { resource: 'sheep', lonMin: -10, lonMax: 2,   latMin: 50, latMax: 60 }, // British Isles
+  { resource: 'sheep', lonMin: 80,  lonMax: 120, latMin: 40, latMax: 52 }, // C. Asia
+  // Cattle
+  { resource: 'cattle', lonMin: -105, lonMax: -95, latMin: 35, latMax: 50 }, // Great Plains
+  { resource: 'cattle', lonMin: -65,  lonMax: -57, latMin: -40, latMax: -28 }, // Pampas
+  // Salt
+  { resource: 'salt', lonMin: 12,  lonMax: 25,  latMin: 47, latMax: 55 }, // C. Europe
+  { resource: 'salt', lonMin: 44,  lonMax: 58,  latMin: 30, latMax: 38 }, // Iran
+];
+
+function parseResourceZonesFromScript(): Array<{ resource: string; lonMin: number; lonMax: number; latMin: number; latMax: number }> {
+  const scriptPath = resolve(process.cwd(), 'scripts/generate-earth-maps.ts');
+  const content = readFileSync(scriptPath, 'utf-8');
+
+  const zonesMatch = content.match(/const RESOURCE_ZONES[^=]*=\s*\[([\s\S]*?)\];/);
+  if (!zonesMatch) throw new Error('Could not find RESOURCE_ZONES in script');
+
+  const zonesText = zonesMatch[1];
+  const entries: Array<{ resource: string; lonMin: number; lonMax: number; latMin: number; latMax: number }> = [];
+
+  const entryRegex = /\{\s*resource:\s*'([^']+)',\s*terrain:\s*'[^']+',\s*lonMin:\s*(-?[\d.]+),\s*lonMax:\s*(-?[\d.]+),\s*latMin:\s*(-?[\d.]+),\s*latMax:\s*(-?[\d.]+)/g;
+  let match;
+  while ((match = entryRegex.exec(zonesText)) !== null) {
+    entries.push({
+      resource: match[1],
+      lonMin: parseFloat(match[2]),
+      lonMax: parseFloat(match[3]),
+      latMin: parseFloat(match[4]),
+      latMax: parseFloat(match[5]),
+    });
+  }
+
+  return entries;
+}
+
+describe('earth map RESOURCE_ZONES geo-coverage', () => {
+  it('test 31: each new resource has at least one zone entry in the script', () => {
+    const zones = parseResourceZonesFromScript();
+    const newResources = ['gold', 'silver', 'furs', 'sheep', 'cattle', 'salt'];
+
+    for (const resource of newResources) {
+      const found = zones.some(z => z.resource === resource);
+      expect(found, `${resource} has no RESOURCE_ZONES entry`).toBe(true);
+    }
+  });
+
+  it('test 31b: key bounding boxes from spec are present in RESOURCE_ZONES', () => {
+    const zones = parseResourceZonesFromScript();
+
+    for (const expected of EXPECTED_NEW_ZONE_BOXES) {
+      const found = zones.some(z =>
+        z.resource === expected.resource &&
+        z.lonMin === expected.lonMin &&
+        z.lonMax === expected.lonMax &&
+        z.latMin === expected.latMin &&
+        z.latMax === expected.latMax,
+      );
+      expect(
+        found,
+        `Missing zone: ${expected.resource} [${expected.lonMin},${expected.lonMax}]x[${expected.latMin},${expected.latMax}]`,
+      ).toBe(true);
+    }
+  });
+
+  it('test 31c: stone fallback uses mountain, not hills', () => {
+    const scriptPath = resolve(process.cwd(), 'scripts/generate-earth-maps.ts');
+    const content = readFileSync(scriptPath, 'utf-8');
+    // Should NOT contain the old hills fallback for stone
+    expect(content).not.toContain("terrain === 'hills' && r < 0.08");
+    // Should contain the new mountain fallback
+    expect(content).toContain("terrain === 'mountain' && r < 0.15");
+  });
+});

--- a/tests/systems/faction-happiness.test.ts
+++ b/tests/systems/faction-happiness.test.ts
@@ -62,7 +62,7 @@ function makeMinimalState({
     cities['capital'] = { ...capital, ownedTiles: capitalOwnedTiles };
   }
 
-  const dipState = createDiplomacyState(civId);
+  const dipState = createDiplomacyState([civId], civId);
 
   return {
     turn: 10, era,

--- a/tests/systems/faction-happiness.test.ts
+++ b/tests/systems/faction-happiness.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState, City, HexCoord } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import {
+  computeUnrestPressure,
+  processFactionTurn,
+} from '@/systems/faction-system';
+
+function makeCity(id: string, owner: string, position: HexCoord, overrides: Partial<City> = {}): City {
+  return {
+    id, name: id, owner, position,
+    population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost',
+    grid: [[null]], gridSize: 3,
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  } as City;
+}
+
+function makeMinimalState({
+  cityCount = 1,
+  cityPosition = { q: 0, r: 0 } as HexCoord,
+  atWarCount = 0,
+  era = 2,
+  silkOwned = false,
+}: {
+  cityCount?: number;
+  cityPosition?: HexCoord;
+  atWarCount?: number;
+  era?: number;
+  silkOwned?: boolean;
+} = {}): GameState {
+  const civId = 'player';
+  const cities: Record<string, City> = {};
+  const cityIds: string[] = [];
+
+  // Capital at (0,0) — must be first in cities array (cities[0] = capital by convention)
+  const capital = makeCity('capital', civId, { q: 0, r: 0 });
+  cities['capital'] = capital;
+  cityIds.push('capital');
+
+  for (let i = 1; i <= cityCount; i++) {
+    const city = makeCity(`city-${i}`, civId, cityPosition);
+    cities[`city-${i}`] = city;
+    cityIds.push(`city-${i}`);
+  }
+
+  const atWarWith: string[] = [];
+  for (let i = 0; i < atWarCount; i++) atWarWith.push(`enemy-${i}`);
+
+  const tiles: Record<string, unknown> = {
+    '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: civId },
+  };
+  let capitalOwnedTiles: HexCoord[] = [{ q: 0, r: 0 }];
+
+  if (silkOwned) {
+    tiles['1,0'] = { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: 'silk', improvement: 'plantation', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: civId };
+    capitalOwnedTiles = [...capitalOwnedTiles, { q: 1, r: 0 }];
+    cities['capital'] = { ...capital, ownedTiles: capitalOwnedTiles };
+  }
+
+  const dipState = createDiplomacyState(civId);
+
+  return {
+    turn: 10, era,
+    currentPlayer: civId,
+    map: { width: 20, height: 20, tiles, wrapsHorizontally: false, rivers: [] },
+    cities,
+    civilizations: {
+      [civId]: {
+        id: civId, civType: 'rome', name: 'Rome',
+        cities: cityIds, units: [], gold: 50,
+        techState: { completed: silkOwned ? ['irrigation'] : [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { ...dipState, atWarWith },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+  } as unknown as GameState;
+}
+
+describe('computeUnrestPressure with happiness', () => {
+  it('test 17: ownerHappiness=3 reduces pressure by 6', () => {
+    const state = makeMinimalState({ cityCount: 1 });
+    const pressureWithout = computeUnrestPressure('city-1', state, 0);
+    const pressureWith = computeUnrestPressure('city-1', state, 3);
+    // Pressure reduced by 6, floored at 0
+    expect(pressureWith).toBe(Math.max(0, pressureWithout - 6));
+  });
+
+  it('test 18: high-pressure city with 3 happiness luxuries has pressure reduced by 6', () => {
+    // Many cities + wars = high pressure
+    const state = makeMinimalState({ cityCount: 8, cityPosition: { q: 20, r: 0 }, atWarCount: 3, era: 2 });
+    const pressureBase = computeUnrestPressure('city-1', state, 0);
+    const pressureHappy = computeUnrestPressure('city-1', state, 3);
+    expect(pressureBase).toBeGreaterThan(0);
+    expect(pressureHappy).toBe(Math.max(0, pressureBase - 6));
+  });
+
+  it('test 19: pressure with 0 happiness vs 3 happiness differs by 6', () => {
+    const state = makeMinimalState({ cityCount: 10, atWarCount: 2, era: 2 });
+    const pressureZeroHappy = computeUnrestPressure('city-1', state, 0);
+    const pressureThreeHappy = computeUnrestPressure('city-1', state, 3);
+    expect(pressureZeroHappy - pressureThreeHappy).toBe(6);
+  });
+
+  it('test 20: omitting ownerHappiness arg defaults to 0 — no crash', () => {
+    const state = makeMinimalState();
+    expect(() => computeUnrestPressure('city-1', state)).not.toThrow();
+  });
+
+  it('pressure cannot go negative (clamped to 0)', () => {
+    const state = makeMinimalState({ cityCount: 1 });
+    // With 50 happiness → -100 pressure reduction; should be clamped to 0
+    const pressure = computeUnrestPressure('city-1', state, 50);
+    expect(pressure).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('processFactionTurn with happiness', () => {
+  it('silk owned: processFactionTurn does not crash and applies happiness', () => {
+    const state = makeMinimalState({ cityCount: 8, atWarCount: 2, era: 2, silkOwned: true });
+    const bus = new EventBus();
+    expect(() => processFactionTurn(state, bus)).not.toThrow();
+  });
+});

--- a/tests/systems/resource-effects.test.ts
+++ b/tests/systems/resource-effects.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from 'vitest';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+import {
+  getCivAvailableResources,
+  getCivResourceYieldBonus,
+  getCivHappinessFromResources,
+} from '@/systems/resource-acquisition-system';
+import type { GameState } from '@/core/types';
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+function makeTechState(completed: string[] = []) {
+  return {
+    completed,
+    currentResearch: null,
+    researchQueue: [],
+    researchProgress: 0,
+    trackPriorities: {} as never,
+  };
+}
+
+/**
+ * Builds a minimal GameState where 'player' owns a single city at (3,3) and
+ * one additional resource tile at (4,3) (unless tileIsCity=true).
+ */
+function makeState(overrides: {
+  tileResource?: string | null;
+  tileImprovement?: string;
+  tileImprovementTurnsLeft?: number;
+  tileTerrain?: string;
+  tileIsCity?: boolean;
+  completed?: string[];
+}): GameState {
+  const {
+    tileResource = null,
+    tileImprovement = 'none',
+    tileImprovementTurnsLeft = 0,
+    tileTerrain = 'grassland',
+    tileIsCity = false,
+    completed = [],
+  } = overrides;
+
+  const cityPos = { q: 3, r: 3 };
+  const tileCoord = tileIsCity ? cityPos : { q: 4, r: 3 };
+
+  const tiles: Record<string, unknown> = {
+    '3,3': {
+      coord: cityPos, terrain: 'grassland', elevation: 'lowland',
+      resource: tileIsCity ? tileResource : null,
+      improvement: tileIsCity ? tileImprovement : 'none',
+      improvementTurnsLeft: tileIsCity ? tileImprovementTurnsLeft : 0,
+      hasRiver: false, wonder: null, owner: null,
+    },
+  };
+
+  if (!tileIsCity) {
+    tiles['4,3'] = {
+      coord: tileCoord, terrain: tileTerrain, elevation: 'lowland',
+      resource: tileResource, improvement: tileImprovement,
+      improvementTurnsLeft: tileImprovementTurnsLeft,
+      hasRiver: false, wonder: null, owner: null,
+    };
+  }
+
+  const ownedTiles = tileIsCity ? [cityPos] : [cityPos, tileCoord];
+
+  return {
+    map: { width: 10, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'TestCity', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, production: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [],
+        specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+      } as unknown as never,
+    },
+    civilizations: {
+      'player': {
+        id: 'player',
+        cities: ['city-1'],
+        techState: makeTechState(completed),
+      } as unknown as never,
+    },
+  } as unknown as GameState;
+}
+
+/** State with two off-center tiles having different resources */
+function makeMultiResourceState(resources: Array<{
+  resource: string;
+  improvement: string;
+  tech: string;
+  terrain: string;
+}>): GameState {
+  const cityPos = { q: 3, r: 3 };
+  const tiles: Record<string, unknown> = {
+    '3,3': {
+      coord: cityPos, terrain: 'grassland', elevation: 'lowland',
+      resource: null, improvement: 'none', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: null,
+    },
+  };
+  const ownedTiles = [cityPos];
+  const completed: string[] = [];
+
+  resources.forEach((r, i) => {
+    const coord = { q: 4 + i, r: 3 };
+    tiles[`${coord.q},${coord.r}`] = {
+      coord, terrain: r.terrain, elevation: 'lowland',
+      resource: r.resource, improvement: r.improvement,
+      improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: null,
+    };
+    ownedTiles.push(coord);
+    if (!completed.includes(r.tech)) completed.push(r.tech);
+  });
+
+  return {
+    map: { width: 10, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'TestCity', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, production: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [],
+        specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+      } as unknown as never,
+    },
+    civilizations: {
+      'player': {
+        id: 'player',
+        cities: ['city-1'],
+        techState: makeTechState(completed),
+      } as unknown as never,
+    },
+  } as unknown as GameState;
+}
+
+// ── Catalog test ─────────────────────────────────────────────────────────────
+
+describe('RESOURCE_DEFINITIONS catalog', () => {
+  it('test 1: every entry has effect defined (not undefined — may be null)', () => {
+    for (const def of RESOURCE_DEFINITIONS) {
+      expect(def.effect, `${def.id} is missing effect field`).not.toBeUndefined();
+    }
+  });
+});
+
+// ── getCivHappinessFromResources ──────────────────────────────────────────────
+
+describe('getCivHappinessFromResources', () => {
+  it('test 2: returns 1 for a civ owning silk (plantation complete, irrigation known)', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0, completed: ['irrigation'],
+    });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(1);
+  });
+
+  it('test 7: three silk tiles → returns 1 (same-resource non-stacking)', () => {
+    const cityPos = { q: 3, r: 3 };
+    const silkTile = (q: number) => ({
+      coord: { q, r: 3 }, terrain: 'grassland', elevation: 'lowland',
+      resource: 'silk', improvement: 'plantation', improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, owner: null,
+    });
+    const state: GameState = {
+      map: {
+        width: 10, height: 10, wrapsHorizontally: false, rivers: [],
+        tiles: {
+          '3,3': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: null },
+          '4,3': silkTile(4),
+          '5,3': silkTile(5),
+          '6,3': silkTile(6),
+        },
+      } as unknown as never,
+      cities: {
+        'city-1': {
+          id: 'city-1', name: 'TestCity', owner: 'player',
+          position: cityPos,
+          ownedTiles: [cityPos, { q: 4, r: 3 }, { q: 5, r: 3 }, { q: 6, r: 3 }],
+          population: 1, food: 0, production: 0, gold: 0,
+          buildings: [], productionQueue: [], workedTiles: [],
+          specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+        } as unknown as never,
+      },
+      civilizations: {
+        'player': {
+          id: 'player', cities: ['city-1'],
+          techState: makeTechState(['irrigation']),
+        } as unknown as never,
+      },
+    } as unknown as GameState;
+
+    expect(getCivHappinessFromResources(state, 'player')).toBe(1);
+  });
+
+  it('test 8: silk AND wine → returns 2 (different resources accumulate)', () => {
+    const state = makeMultiResourceState([
+      { resource: 'silk',  improvement: 'plantation', tech: 'irrigation', terrain: 'grassland' },
+      { resource: 'wine',  improvement: 'plantation', tech: 'pottery',    terrain: 'plains'    },
+    ]);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(2);
+  });
+
+  it('test 10a: civ with no owned resources → returns 0', () => {
+    const state = makeState({ tileResource: null });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+
+  it('test 11a: copper/iron/horses/stone (null effect) → returns 0', () => {
+    for (const resourceId of ['copper', 'iron', 'horses', 'stone'] as const) {
+      const def = RESOURCE_DEFINITIONS.find(d => d.id === resourceId)!;
+      const terrain = Array.isArray(def.terrain) ? def.terrain[0] : def.terrain;
+      const state = makeState({
+        tileResource: resourceId,
+        tileImprovement: def.requiredImprovement,
+        tileImprovementTurnsLeft: 0,
+        tileTerrain: terrain,
+        completed: [def.tech],
+      });
+      expect(getCivHappinessFromResources(state, 'player'), `${resourceId} should give 0 happiness`).toBe(0);
+    }
+  });
+
+  it('test 13: improvement destroyed (improvementTurnsLeft > 0) → returns 0', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 2, completed: ['irrigation'],
+    });
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+});
+
+// ── getCivResourceYieldBonus ──────────────────────────────────────────────────
+
+describe('getCivResourceYieldBonus', () => {
+  it('test 3: gems → { gold: 1, food: 0, production: 0, science: 0 }', () => {
+    const state = makeState({
+      tileResource: 'gems', tileImprovement: 'mine',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'hills',
+      completed: ['mining-tech'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(1);
+    expect(bonus.food).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+
+  it('test 4: sheep → { production: 1, food: 0, gold: 0 }', () => {
+    const state = makeState({
+      tileResource: 'sheep', tileImprovement: 'pasture',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'plains',
+      completed: ['animal-husbandry'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.production).toBe(1);
+    expect(bonus.food).toBe(0);
+    expect(bonus.gold).toBe(0);
+  });
+
+  it('test 5: cattle → { food: 1, gold: 0, production: 0 }', () => {
+    const state = makeState({
+      tileResource: 'cattle', tileImprovement: 'pasture',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'plains',
+      completed: ['domestication'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.food).toBe(1);
+    expect(bonus.gold).toBe(0);
+  });
+
+  it('test 6: salt → { gold: 1 }', () => {
+    const state = makeState({
+      tileResource: 'salt', tileImprovement: 'mine',
+      tileImprovementTurnsLeft: 0, tileTerrain: 'hills',
+      completed: ['pottery'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(1);
+  });
+
+  it('test 9: gems AND silver → { gold: 2 } (different resources accumulate)', () => {
+    const state = makeMultiResourceState([
+      { resource: 'gems',   improvement: 'mine', tech: 'mining-tech', terrain: 'hills' },
+      { resource: 'silver', improvement: 'mine', tech: 'mining-tech', terrain: 'hills' },
+    ]);
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(2);
+  });
+
+  it('test 10b: civ with no resources → all zeros', () => {
+    const state = makeState({ tileResource: null });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.food).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.gold).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+
+  it('test 11b: copper/iron/horses/stone (null effect) → all zeros', () => {
+    for (const resourceId of ['copper', 'iron', 'horses', 'stone'] as const) {
+      const def = RESOURCE_DEFINITIONS.find(d => d.id === resourceId)!;
+      const terrain = Array.isArray(def.terrain) ? def.terrain[0] : def.terrain;
+      const state = makeState({
+        tileResource: resourceId,
+        tileImprovement: def.requiredImprovement,
+        tileImprovementTurnsLeft: 0,
+        tileTerrain: terrain,
+        completed: [def.tech],
+      });
+      const bonus = getCivResourceYieldBonus(state, 'player');
+      expect(bonus.gold, `${resourceId} should give 0 gold`).toBe(0);
+      expect(bonus.production, `${resourceId} should give 0 production`).toBe(0);
+      expect(bonus.food, `${resourceId} should give 0 food`).toBe(0);
+    }
+  });
+
+  it('test 12: happiness resources excluded from yield bonus (silk gives 0 gold/prod/food)', () => {
+    const state = makeState({
+      tileResource: 'silk', tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0, completed: ['irrigation'],
+    });
+    const bonus = getCivResourceYieldBonus(state, 'player');
+    expect(bonus.gold).toBe(0);
+    expect(bonus.production).toBe(0);
+    expect(bonus.food).toBe(0);
+    expect(bonus.science).toBe(0);
+  });
+});
+
+// ── Save compatibility ────────────────────────────────────────────────────────
+
+describe('save compatibility', () => {
+  it('test 30: effect is static data on RESOURCE_DEFINITIONS, not stored in GameState', () => {
+    const state = makeState({ tileResource: null });
+    expect(() => getCivHappinessFromResources(state, 'player')).not.toThrow();
+    expect(() => getCivResourceYieldBonus(state, 'player')).not.toThrow();
+  });
+});

--- a/tests/ui/city-panel-resources.test.ts
+++ b/tests/ui/city-panel-resources.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createCityPanel } from '@/ui/city-panel';
+import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
+import type { GameState } from '@/core/types';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="panel-root"></div>';
+});
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const noopCallbacks = {
+  onBuild: () => {},
+  onOpenWonderPanel: () => {},
+  onClose: () => {},
+};
+
+/**
+ * Returns a state with a silk tile (happiness luxury) owned by player.
+ * Silk requires 'irrigation' tech + 'plantation' improvement.
+ */
+function makeStateWithSilk(): GameState {
+  const state = makeLegendaryWonderFixture({ completedTechs: ['irrigation', 'philosophy', 'pilgrimages'] });
+  // city-river city owns tiles at (2,2) and (2,3). Add silk at (2,3).
+  state.map.tiles['2,3'] = {
+    coord: { q: 2, r: 3 },
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: 'silk' as never,
+    improvement: 'plantation' as never,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    owner: 'player',
+  };
+  return state;
+}
+
+/**
+ * Returns a state with a gems tile (gold/turn yield luxury) owned by player.
+ * Gems requires 'mining-tech' tech + 'mine' improvement.
+ */
+function makeStateWithGems(): GameState {
+  const state = makeLegendaryWonderFixture({ completedTechs: ['mining-tech', 'philosophy', 'pilgrimages'] });
+  state.map.tiles['2,3'] = {
+    coord: { q: 2, r: 3 },
+    terrain: 'hills',
+    elevation: 'highland',
+    resource: 'gems' as never,
+    improvement: 'mine' as never,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    owner: 'player',
+  };
+  return state;
+}
+
+/**
+ * Returns a state with a gold resource tile owned by player.
+ * Gold requires 'currency' tech + 'mine' improvement.
+ */
+function makeStateWithGoldResource(): GameState {
+  const state = makeLegendaryWonderFixture({ completedTechs: ['currency', 'philosophy', 'pilgrimages'] });
+  state.map.tiles['2,3'] = {
+    coord: { q: 2, r: 3 },
+    terrain: 'hills',
+    elevation: 'highland',
+    resource: 'gold' as never,
+    improvement: 'mine' as never,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    owner: 'player',
+  };
+  return state;
+}
+
+/**
+ * Returns a state with no resources on player tiles.
+ */
+function makeStateNoResources(): GameState {
+  return makeLegendaryWonderFixture({ completedTechs: ['philosophy', 'pilgrimages'] });
+}
+
+describe('city panel resource bonus section', () => {
+  it('test 21: silk owned → "Empire bonuses" header and "Silk" text with "+1 happiness"', () => {
+    const state = makeStateWithSilk();
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Empire bonuses');
+    expect(text).toContain('Silk');
+    expect(text).toContain('+1 happiness');
+  });
+
+  it('test 22: gems owned → "City bonuses" header and "Gems" with "+1 gold/turn"', () => {
+    const state = makeStateWithGems();
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('City bonuses');
+    expect(text).toContain('Gems');
+    expect(text).toContain('+1 gold/turn');
+  });
+
+  it('test 23: gold resource shows "Gold deposits" not bare "Gold"', () => {
+    const state = makeStateWithGoldResource();
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Gold deposits');
+    expect(text).toContain('+1 gold/turn');
+  });
+
+  it('test 24: only yield resources (gems, no silk) → "Empire bonuses" header absent', () => {
+    const state = makeStateWithGems();
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Empire bonuses');
+    expect(text).toContain('City bonuses');
+  });
+
+  it('test 25: no resources → entire "Resources" section absent', () => {
+    const state = makeStateNoResources();
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('Empire bonuses');
+    expect(text).not.toContain('City bonuses');
+    expect(text).not.toContain('+1 happiness');
+  });
+});

--- a/tests/ui/hud-happiness.test.ts
+++ b/tests/ui/hud-happiness.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
+import type { GameState } from '@/core/types';
+
+// The HUD chip contract: getCivHappinessFromResources drives whether the chip shows.
+// We test the helper directly since updateHUD() lives in main.ts and is not unit-testable.
+
+const happinessSources = [
+  { id: 'silk',    tech: 'irrigation', terrain: 'grassland', improvement: 'plantation' },
+  { id: 'wine',    tech: 'pottery',    terrain: 'plains',    improvement: 'plantation' },
+  { id: 'ivory',   tech: 'foraging',   terrain: 'forest',    improvement: 'camp'       },
+  { id: 'furs',    tech: 'foraging',   terrain: 'forest',    improvement: 'camp'       },
+  { id: 'incense', tech: 'currency',   terrain: 'desert',    improvement: 'plantation' },
+] as const;
+
+function makeStateWithHappiness(count: number): GameState {
+  const cityPos = { q: 0, r: 0 };
+  const tiles: Record<string, unknown> = {
+    '0,0': { coord: cityPos, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' },
+  };
+  const ownedTiles: Array<{ q: number; r: number }> = [cityPos];
+  const completed: string[] = [];
+
+  for (let i = 0; i < count && i < happinessSources.length; i++) {
+    const src = happinessSources[i];
+    const coord = { q: i + 1, r: 0 };
+    tiles[`${coord.q},0`] = { coord, terrain: src.terrain, elevation: 'lowland', resource: src.id, improvement: src.improvement, improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'player' };
+    ownedTiles.push(coord);
+    if (!completed.includes(src.tech)) completed.push(src.tech);
+  }
+
+  return {
+    turn: 1, era: 1, currentPlayer: 'player',
+    map: { width: 20, height: 10, tiles, wrapsHorizontally: false, rivers: [] },
+    cities: {
+      'city-1': {
+        id: 'city-1', name: 'Rome', owner: 'player',
+        position: cityPos, ownedTiles,
+        population: 1, food: 0, foodNeeded: 20,
+        production: 0, productionProgress: 0, gold: 0,
+        buildings: [], productionQueue: [], workedTiles: [cityPos],
+        focus: 'balanced', maturity: 'outpost',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+        grid: [[null]], gridSize: 3, hp: 100, maxHp: 100,
+        garrisonUnitId: null, specialistSlots: [],
+      },
+    },
+    civilizations: {
+      'player': {
+        id: 'player', civType: 'rome', name: 'Rome',
+        cities: ['city-1'], units: [], gold: 0,
+        techState: { completed, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {}, marketplace: null,
+  } as unknown as GameState;
+}
+
+describe('HUD happiness chip contract', () => {
+  it('test 26: 2 happiness luxuries → getCivHappinessFromResources returns 2 (chip shown)', () => {
+    const state = makeStateWithHappiness(2);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(2);
+  });
+
+  it('test 27: 0 happiness luxuries → getCivHappinessFromResources returns 0 (chip hidden)', () => {
+    const state = makeStateWithHappiness(0);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(0);
+  });
+
+  it('all 5 happiness luxuries → returns 5 (max in S4a)', () => {
+    const state = makeStateWithHappiness(5);
+    expect(getCivHappinessFromResources(state, 'player')).toBe(5);
+  });
+});

--- a/tests/ui/marketplace-panel-effects.test.ts
+++ b/tests/ui/marketplace-panel-effects.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { GameState } from '@/core/types';
+import { createMarketplacePanel } from '@/ui/marketplace-panel';
+
+beforeEach(() => { document.body.innerHTML = '<div id="mp-root"></div>'; });
+afterEach(() => { document.body.innerHTML = ''; });
+
+function makeMarketState(options: { knowsSilk?: boolean; knowsIron?: boolean } = {}): GameState {
+  const completed: string[] = [];
+  if (options.knowsSilk) completed.push('irrigation');
+  if (options.knowsIron) completed.push('bronze-working');
+
+  return {
+    turn: 1, era: 2, currentPlayer: 'player',
+    map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    cities: {},
+    civilizations: {
+      'player': {
+        id: 'player', civType: 'rome', name: 'Rome',
+        cities: [], units: [], gold: 0,
+        techState: { completed, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        diplomacy: { relationships: {}, atWarWith: [], treaties: [], events: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, tributeAmount: 0, peakCities: 1, peakMilitary: 0 } },
+        visibility: { tiles: {} },
+      },
+    },
+    units: {}, barbarianCamps: {}, minorCivs: {},
+    marketplace: {
+      prices: { silk: 8, iron: 8 },
+      priceHistory: { silk: [8], iron: [8] },
+      fashionable: null,
+      fashionTurnsLeft: 0,
+      tradeRoutes: [],
+    },
+  } as unknown as GameState;
+}
+
+describe('marketplace panel effect badges', () => {
+  it('test 28: silk row contains "+1 happiness" badge', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState({ knowsSilk: true });
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    expect(container.textContent).toContain('+1 happiness');
+  });
+
+  it('test 29: iron row contains "unlocks advanced units" hint, not literal "null"', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState({ knowsIron: true });
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    const text = container.textContent ?? '';
+    expect(text).toContain('unlocks advanced units');
+    expect(text).not.toContain('null');
+  });
+
+  it('gems row contains "+1 gold/turn" badge when gems tech known', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState();
+    // Inject mining-tech so gems row appears
+    (state.civilizations['player'].techState.completed as string[]).push('mining-tech');
+    (state.marketplace!.prices as Record<string, number>)['gems'] = 12;
+    (state.marketplace!.priceHistory as Record<string, number[]>)['gems'] = [12];
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    expect(container.textContent).toContain('+1 gold/turn');
+  });
+
+  it('cattle row contains "+1 food/turn" badge when domestication known', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState();
+    (state.civilizations['player'].techState.completed as string[]).push('domestication');
+    (state.marketplace!.prices as Record<string, number>)['cattle'] = 5;
+    (state.marketplace!.priceHistory as Record<string, number[]>)['cattle'] = [5];
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    expect(container.textContent).toContain('+1 food/turn');
+  });
+});


### PR DESCRIPTION
## Summary

- **ResourceEffect static type** on all 16 `RESOURCE_DEFINITIONS` in `trade-system.ts`: 5 happiness luxuries, 4 gold/turn luxuries, 1 production luxury, 1 food strategic, 1 gold strategic, 4 null-effect strategics
- **`getCivResourceYieldBonus`** pure helper: accumulates food/production/gold across distinct owned resources (non-stacking per resource, excludes happiness)
- **`getCivHappinessFromResources`** pure helper: counts distinct owned happiness-type luxuries empire-wide
- **Turn-manager** wires `getCivResourceYieldBonus` once per-civ before the city loop (avoids O(cities²) tile scans); yield bonus applied to all cities for food/production/gold (science deliberately excluded)
- **Faction system** `computeUnrestPressure` now takes optional `ownerHappiness = 0`; subtracts `ownerHappiness * 2` from pressure; `processFactionTurn` pre-computes `civHappiness` map before city loop
- **HUD** shows `☺ N (stability)` chip when happiness > 0, hidden when 0, with tooltip explaining the mechanic
- **City panel** shows "Empire bonuses" section (happiness luxuries → +1 happiness each) and "City bonuses" section (yield resources → +1 gold/food/production/turn); entire section absent when no resources; "Gold deposits" label to avoid collision with gold currency
- **Marketplace panel** shows effect badge per resource row (`★ +1 happiness`, `$ +1 gold/turn`, etc.); null-effect strategics show `(unlocks advanced units & buildings)`
- **Earth map generator** RESOURCE_ZONES expanded from 17 → 52 entries covering all 16 resources with geographically correct placements and patches; stone fallback fixed from `hills @ r<0.08` to `mountain @ r<0.15`; earth-map-data.ts regenerated
- **31 new tests** across 5 test files covering: catalog completeness, non-stacking, accumulation, null exclusion, improvement gates, happiness pressure reduction, DOM badge rendering, geo-coverage

## Test plan

- [ ] `bash scripts/run-with-mise.sh yarn test` → 2403 tests pass (verified locally)
- [ ] `bash scripts/run-with-mise.sh yarn build` → clean TypeScript build (verified locally)
- [ ] In-game: research Irrigation, build plantation on silk → HUD shows ☺ 1 (stability); city panel shows "Empire bonuses" → Silk → +1 happiness
- [ ] In-game: research Mining Tech, build mine on gems → city panel shows "City bonuses" → Gems → +1 gold/turn; gold income increases by 1
- [ ] In-game: open Marketplace panel → each resource row shows its effect badge
- [ ] Cities with happiness luxuries should trigger unrest at higher pressure (40 → 40+N×2 effective threshold shift)

## FF merge note

Branch rebased onto `origin/main` before all S4a commits; 0 commits behind main at PR creation time. Safe for `--ff-only` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)