### PR TITLE
feat(mr-d): unrest guidance, era-2 notification, audio stinger restore (#257 #259 #263 #265)

### DIFF
--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -52,11 +52,9 @@ export class AudioSystem {
     if (state.era > 1) {
       this.director.handleEraAdvanced({ era: state.era, civType: this.currentCivType });
     } else {
-      // Era-1 new game: the AudioContext is created before any user gesture and
-      // may be suspended. setSnapshot('peace', 0) is synchronous and ensures gain
-      // nodes are at the correct peace levels as soon as preloadForEra resolves
-      // and setBusSource starts the audio nodes — no stinger needed.
-      this.mixer.setSnapshot('peace', 0);
+      // Era-1 new game: delegate to director so intendedSnapshot stays in sync.
+      // initPeaceSnapshot is synchronous and idempotent — safe before preloadForEra resolves.
+      this.director.initPeaceSnapshot();
     }
   }
 

--- a/src/audio/music-director.ts
+++ b/src/audio/music-director.ts
@@ -42,6 +42,11 @@ export class MusicDirector {
     private readonly loader: AudioLoader,
   ) {}
 
+  initPeaceSnapshot(): void {
+    this.intendedSnapshot = 'peace';
+    this.mixer.setSnapshot('peace', 0);
+  }
+
   handleEraAdvanced(p: EraAdvancedPayload): void {
     const target: SnapshotId = this.intendedSnapshot === 'at-war' ? 'at-war' : 'peace';
     this.intendedSnapshot = target;

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ import {
   routeCombatRewardEarned,
   routeCombatResolved,
   routeEconomyTreasuryStrain,
+  routeEraAdvanced,
   routeFactionTransition,
   queueFirstContactPendingEvents,
   routeFirstContact,
@@ -2689,6 +2690,12 @@ function appendFactionNotice(civId: string, message: string, type: NotificationE
     collectEvent(gameState.pendingEvents, civId, { type: 'faction:critical', message, turn: gameState.turn });
   }
 }
+
+bus.on('era:advanced', ({ era }) => {
+  const civId = gameState.currentPlayer;
+  const civName = gameState.civilizations[civId]?.name ?? 'Your civilization';
+  routeEraAdvanced(era, civId, civName, showNotification, appendFactionNotice);
+});
 
 bus.on('faction:unrest-started', event => {
   routeFactionTransition(gameState, { type: 'faction:unrest-started', ...event }, appendFactionNotice);

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -10,8 +10,9 @@ import { getCivHappinessFromResources } from './resource-acquisition-system';
 
 // --- Thresholds ---
 const UNREST_TRIGGER_PRESSURE = 40;
-const REVOLT_UNREST_TURNS = 5;        // turns at unrest before revolt escalates
-const CONQUEST_UNREST_DURATION = 15;  // turns until conquestTurn is cleared
+export const REVOLT_UNREST_TURNS = 5;        // turns at unrest before revolt escalates
+export const BREAKAWAY_REVOLT_TURNS = 10;    // turns at revolt before breakaway
+const CONQUEST_UNREST_DURATION = 15;         // turns until conquestTurn is cleared
 const GOLD_APPEASE_COST_PER_POP = 15;
 
 // Pressure caps per category
@@ -245,7 +246,7 @@ export function processFactionTurn(state: GameState, bus: EventBus): GameState {
           ...nextState,
           cities: { ...nextState.cities, [cityId]: updated },
         };
-        if (updated.unrestTurns >= 10) {
+        if (updated.unrestTurns >= BREAKAWAY_REVOLT_TURNS) {
           nextState = createBreakawayFromCity(nextState, cityId, bus);
         }
       }

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -3,7 +3,7 @@ import { collectEvent } from '@/core/hotseat-events';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { REVOLT_UNREST_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
+import { REVOLT_UNREST_TURNS, BREAKAWAY_REVOLT_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import type { NotificationEntry } from '@/ui/notification-log';
 
@@ -93,7 +93,7 @@ export function routeFactionTransition(
     if (!city) return;
     sink(
       event.owner,
-      `${city.name} is in open revolt! Rebels have spawned. Defeat them and reduce pressure to restore order. After 10 turns of revolt the city may break away permanently.`,
+      `${city.name} is in open revolt! Rebels have spawned. Defeat them and reduce pressure to restore order. After ${BREAKAWAY_REVOLT_TURNS} turns of revolt the city may break away permanently.`,
       'warning',
     );
     return;

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -322,3 +322,20 @@ export function routeBarbarianSpawned(
     });
   }
 }
+
+export function routeEraAdvanced(
+  era: number,
+  civId: string,
+  civName: string,
+  toastSink: (message: string, type: NotificationEntry['type']) => void,
+  factionSink: NotificationSink,
+): void {
+  toastSink(`${civName} has entered Era ${era}!`, 'success');
+  if (era === 2) {
+    factionSink(
+      civId,
+      `Era 2 begins — cities can now experience unrest. High pressure (overcrowding, distance from capital, unhappiness) will trigger it. Garrison units, spend gold to appease, or build happiness improvements to keep order.`,
+      'info',
+    );
+  }
+}

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -3,6 +3,7 @@ import { collectEvent } from '@/core/hotseat-events';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { REVOLT_UNREST_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import type { NotificationEntry } from '@/ui/notification-log';
 
@@ -77,13 +78,24 @@ export function routeFactionTransition(
 ): void {
   if (event.type === 'faction:unrest-started') {
     const city = state.cities[event.cityId];
-    sink(event.owner, `${city?.name ?? 'A city'} is slipping into unrest. Stabilize it before revolt spreads.`, 'warning');
+    if (!city) return;
+    const appeaseCost = getCityAppeaseCost(city);
+    sink(
+      event.owner,
+      `${city.name} is slipping into unrest. Stabilize within ${REVOLT_UNREST_TURNS} turns or rebels will spawn. Options: garrison a military unit, spend ${appeaseCost}🪙 to appease, or build happiness improvements.`,
+      'warning',
+    );
     return;
   }
 
   if (event.type === 'faction:revolt-started') {
     const city = state.cities[event.cityId];
-    sink(event.owner, `${city?.name ?? 'A city'} is in open revolt. Defeat nearby rebels and reduce pressure.`, 'warning');
+    if (!city) return;
+    sink(
+      event.owner,
+      `${city.name} is in open revolt! Rebels have spawned. Defeat them and reduce pressure to restore order. After 10 turns of revolt the city may break away permanently.`,
+      'warning',
+    );
     return;
   }
 

--- a/tests/audio/music-director.test.ts
+++ b/tests/audio/music-director.test.ts
@@ -160,4 +160,27 @@ describe('MusicDirector', () => {
     expect(snapshotCalls).toContain('at-war');
     expect(snapshotCalls.at(-1)).not.toBe('peace');
   });
+
+  // --- initPeaceSnapshot ---
+
+  it('initPeaceSnapshot sets intendedSnapshot so stinger restore returns to peace', async () => {
+    director.initPeaceSnapshot();
+    director.handleCityFounded({ civType: 'rome' });
+    await flushPromises();
+    const lastSnapshot = vi.mocked(mixer.setSnapshot).mock.calls.at(-1)![0];
+    expect(lastSnapshot).toBe('peace');
+  });
+
+  it('handleCityFounded without initPeaceSnapshot restores to silent (regression guard — confirms bug existed)', async () => {
+    // Default intendedSnapshot is 'silent'. This test proves the pre-fix behavior.
+    director.handleCityFounded({ civType: 'rome' });
+    await flushPromises();
+    const lastSnapshot = vi.mocked(mixer.setSnapshot).mock.calls.at(-1)![0];
+    expect(lastSnapshot).toBe('silent');
+  });
+
+  it('initPeaceSnapshot calls mixer.setSnapshot("peace", 0) immediately', () => {
+    director.initPeaceSnapshot();
+    expect(mixer.setSnapshot).toHaveBeenCalledWith('peace', 0);
+  });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationEntry } from '@/ui/notification-log';
+import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
+
+function makeSink() {
+  const calls: Array<{ civId: string; message: string; type: string }> = [];
+  const sink: NotificationSink = (civId, message, type) => calls.push({ civId, message, type });
+  return { sink, calls };
+}
+
+function makeToastSink() {
+  const calls: Array<{ message: string; type: NotificationEntry['type'] }> = [];
+  const sink = (message: string, type: NotificationEntry['type']) => calls.push({ message, type });
+  return { sink, calls };
+}
+
+describe('era:advanced notification', () => {
+  it('era 2 calls toastSink with Era 2 and factionSink once with Era 2 and unrest', () => {
+    const { sink: toastSink, calls: toastCalls } = makeToastSink();
+    const { sink: factionSink, calls: factionCalls } = makeSink();
+
+    routeEraAdvanced(2, 'p1', 'Alice', toastSink, factionSink);
+
+    expect(toastCalls).toHaveLength(1);
+    expect(toastCalls[0]!.message).toContain('Era 2');
+    expect(toastCalls[0]!.type).toBe('success');
+
+    expect(factionCalls).toHaveLength(1);
+    expect(factionCalls[0]!.civId).toBe('p1');
+    expect(factionCalls[0]!.message).toContain('Era 2');
+    expect(factionCalls[0]!.message).toContain('unrest');
+    expect(factionCalls[0]!.type).toBe('info');
+  });
+
+  it('era 3 calls toastSink with Era 3 but does NOT call factionSink', () => {
+    const { sink: toastSink, calls: toastCalls } = makeToastSink();
+    const { sink: factionSink, calls: factionCalls } = makeSink();
+
+    routeEraAdvanced(3, 'p1', 'Alice', toastSink, factionSink);
+
+    expect(toastCalls).toHaveLength(1);
+    expect(toastCalls[0]!.message).toContain('Era 3');
+    expect(factionCalls).toHaveLength(0);
+  });
+});

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -3,6 +3,8 @@ import type { GameState, City, HexCoord } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
 import {
+  REVOLT_UNREST_TURNS,
+  BREAKAWAY_REVOLT_TURNS,
   canGarrisonCity,
   computeUnrestPressure,
   getCityAppeaseCost,
@@ -508,5 +510,33 @@ describe('faction-system', () => {
     });
 
     expect(canGarrisonCity('city-1', state)).toBe(true);
+  });
+});
+
+describe('faction-system constant exports and era-gating', () => {
+  it('REVOLT_UNREST_TURNS is exported and equals 5', () => {
+    expect(REVOLT_UNREST_TURNS).toBe(5);
+  });
+
+  it('BREAKAWAY_REVOLT_TURNS is exported and equals 10', () => {
+    expect(BREAKAWAY_REVOLT_TURNS).toBe(10);
+  });
+
+  it('processFactionTurn clears unrest in era 1 (era-gating active)', () => {
+    const bus = new EventBus();
+    const state = makeState({ era: 1, unrestLevel: 1, unrestTurns: 3 });
+    const result = processFactionTurn(state, bus);
+    expect(result.cities['city-1']?.unrestLevel).toBe(0);
+    expect(result.cities['city-1']?.unrestTurns).toBe(0);
+  });
+
+  it('processFactionTurn does NOT clear unrest in era 2 (era-gating lifts)', () => {
+    const bus = new EventBus();
+    // cityCount:10 → 11 total cities → empire pressure (11-5)*3=18; 3 wars → 24; total 42 > 40
+    // City starts at unrestLevel 1, era 2 — processFactionTurn should NOT zero it out
+    const state = makeState({ era: 2, unrestLevel: 1, unrestTurns: 1, atWarCount: 3, cityCount: 10 });
+    const result = processFactionTurn(state, bus);
+    // With pressure > 40 and no garrison, city stays in unrest (not cleared by clearEraOneUnrest)
+    expect(result.cities['city-1']?.unrestLevel).not.toBe(0);
   });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { CombatResult, GameState } from '@/core/types';
+import { BREAKAWAY_REVOLT_TURNS } from '@/systems/faction-system';
 import {
   formatEconomyTreasuryStrainMessage,
   getNotificationTargetsForEvent,
@@ -461,7 +462,7 @@ describe('bus listener routing contract', () => {
     const { sink, calls } = makeSink();
     routeFactionTransition(state, { type: 'faction:revolt-started', cityId: 'c1', owner: 'p1' }, sink);
     expect(calls).toHaveLength(1);
-    expect(calls[0]!.message).toContain('10 turns');
+    expect(calls[0]!.message).toContain(`${BREAKAWAY_REVOLT_TURNS} turns`);
     expect(calls[0]!.message).toContain('Thebes');
     expect(calls[0]!.type).toBe('warning');
   });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -424,4 +424,76 @@ describe('bus listener routing contract', () => {
     expect(p1Calls).toHaveLength(3);
     expect(p2Calls).toHaveLength(0);
   });
+
+  // --- faction transition routing ---
+
+  it('faction:unrest-started includes turn countdown, garrison option, and appease cost', () => {
+    const state = makeState({
+      cities: {
+        c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 3, position: { q: 0, r: 0 } },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeFactionTransition(state, { type: 'faction:unrest-started', cityId: 'c1', owner: 'p1' }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.civId).toBe('p1');
+    // 5 = REVOLT_UNREST_TURNS
+    expect(calls[0]!.message).toContain('5');
+    expect(calls[0]!.message).toContain('garrison');
+    // 3 population * 15 gold per pop = 45
+    expect(calls[0]!.message).toContain('45');
+    expect(calls[0]!.type).toBe('warning');
+  });
+
+  it('faction:unrest-started with undefined city calls sink zero times (null guard)', () => {
+    const state = makeState({ cities: {} as any });
+    const { sink, calls } = makeSink();
+    routeFactionTransition(state, { type: 'faction:unrest-started', cityId: 'nonexistent', owner: 'p1' }, sink);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('faction:revolt-started includes 10-turn breakaway warning and city name', () => {
+    const state = makeState({
+      cities: {
+        c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 3, position: { q: 0, r: 0 } },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeFactionTransition(state, { type: 'faction:revolt-started', cityId: 'c1', owner: 'p1' }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.message).toContain('10 turns');
+    expect(calls[0]!.message).toContain('Thebes');
+    expect(calls[0]!.type).toBe('warning');
+  });
+
+  it('faction:revolt-started with undefined city calls sink zero times (null guard)', () => {
+    const state = makeState({ cities: {} as any });
+    const { sink, calls } = makeSink();
+    routeFactionTransition(state, { type: 'faction:revolt-started', cityId: 'nonexistent', owner: 'p1' }, sink);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('faction:critical-status with status=unrest produces a short message and no guidance text (anti-spam regression guard)', () => {
+    const state = makeState({
+      cities: {
+        c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 3, position: { q: 0, r: 0 } },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeFactionTransition(state, { type: 'faction:critical-status', cityId: 'c1', owner: 'p1', status: 'unrest' }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.message.length).toBeLessThan(100);
+    expect(calls[0]!.message).not.toContain('garrison');
+  });
+
+  it('faction:unrest-started where state.civilizations[owner] is undefined does not throw (#263 null guard)', () => {
+    const state = makeState({
+      cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 3, position: { q: 0, r: 0 } } } as any,
+    });
+    delete (state.civilizations as Record<string, unknown>)['p1'];
+    const { sink } = makeSink();
+    expect(() =>
+      routeFactionTransition(state, { type: 'faction:unrest-started', cityId: 'c1', owner: 'p1' }, sink)
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

- **#257 audio fix** — `MusicDirector.initPeaceSnapshot()` keeps `intendedSnapshot` in sync with the era-1 startup path in `audio-system.ts`; city-founding stingers now restore to `'peace'` instead of going silent
- **#259/#263 richer unrest notifications** — `faction:unrest-started` now includes the 5-turn countdown, garrison option, and gold appease cost; `faction:revolt-started` includes the breakaway warning; both handlers null-guard on undefined city; `faction:critical-status` stays brief (anti-spam verified by test)
- **#265 era-2 guidance + constants** — `REVOLT_UNREST_TURNS` and `BREAKAWAY_REVOLT_TURNS` exported from `faction-system.ts`; new `routeEraAdvanced` pure function (testable without bootstrapping `main.ts`) wired into a `bus.on('era:advanced', ...)` handler that shows the era toast and — on era 2 specifically — appends a one-time unrest guidance notification

## Test Plan

- [ ] Start a new era-1 game, found a city — music should continue playing after the stinger (not go silent)
- [ ] Trigger unrest in era 2 — notification log should show the enriched message with turn countdown, garrison option, and gold cost
- [ ] Trigger revolt — notification log should show the breakaway warning with correct turn count
- [ ] Advance to era 2 — toast and notification log should show era-entered message + unrest guidance; no guidance on era 3+
- [ ] Verify `yarn test` (2557 tests) and `yarn build` both exit 0

## New tests

| File | Tests added |
|---|---|
| `tests/audio/music-director.test.ts` | 3 (initPeaceSnapshot behavior + regression guard) |
| `tests/systems/faction-system.test.ts` | 4 (constant exports + era-gating regressions) |
| `tests/ui/notification-routing.test.ts` | 6 (enriched messages, null guards, anti-spam, no-crash) |
| `tests/main.integration.test.ts` | 2 (era:advanced era-2 vs era-3 routing) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)