### PR TITLE
feat(s6a): trade route lifecycle — war, hostile relations, embargo termination

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -723,7 +723,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   // --- S6a: terminate routes to embargoed civs ---
   if (newState.embargoes && newState.marketplace) {
     newState = scrubEmbargoedRoutes(newState, bus);
-    newState.embargoes = cleanupEmbargoes(newState.embargoes);
+    newState = { ...newState, embargoes: cleanupEmbargoes(newState.embargoes) };
   }
 
   if (newState.marketplace) {

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -30,14 +30,13 @@ import {
   endVassalageUnilateral,
   declareWar,
   decayTreachery,
-  enforceEmbargoes,
   joinEmbargo,
   cleanupEmbargoes,
   checkLeagueDissolution,
   triggerLeagueDefense,
   getLeagueForCiv,
 } from '@/systems/diplomacy-system';
-import { processTradeRouteIncome, processFashionCycle, updatePrices, removeRouteForUnit } from '@/systems/trade-system';
+import { processTradeRouteIncome, processFashionCycle, updatePrices, removeRouteForUnit, scrubStaleForeignRoutes, scrubEmbargoedRoutes } from '@/systems/trade-system';
 import { processWonderEffects } from '@/systems/wonder-system';
 import { createRng } from '@/systems/map-generator';
 import { processMinorCivTurn, checkEraAdvancement, processMinorCivEraUpgrade, checkCampEvolution } from '@/systems/minor-civ-system';
@@ -716,15 +715,14 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     }
   }
 
-  // --- Enforce embargoes ---
+  // --- S6a: terminate stale foreign routes (war / hostile relations) ---
+  if (newState.marketplace) {
+    newState = scrubStaleForeignRoutes(newState, bus);
+  }
+
+  // --- S6a: terminate routes to embargoed civs ---
   if (newState.embargoes && newState.marketplace) {
-    const cityOwners: Record<string, string> = {};
-    for (const [cityId, city] of Object.entries(newState.cities)) {
-      cityOwners[cityId] = city.owner;
-    }
-    newState.marketplace.tradeRoutes = enforceEmbargoes(
-      newState.embargoes, newState.marketplace.tradeRoutes, cityOwners,
-    );
+    newState = scrubEmbargoedRoutes(newState, bus);
     newState.embargoes = cleanupEmbargoes(newState.embargoes);
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1145,7 +1145,7 @@ export interface GameEvents {
   'diplomacy:treaty-broken': { breakerId: string; otherCiv: string; treaty: TreatyType };
   'advisor:message': { advisor: AdvisorType; message: string; icon: string; tone?: CouncilCallbackTone; memoryKey?: string };
   'trade:route-created': { route: TradeRoute };
-  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' };
+  'trade:route-ended': { routeId: string; fromCityId: string; toCityId: string; reason: 'unit-died' | 'unit-disbanded' | 'war-declared' | 'hostile-relations' | 'embargo' };
   'trade:price-changed': { resource: ResourceType; oldPrice: number; newPrice: number };
   'wonder:discovered': { civId: string; wonderId: string; position: HexCoord; isFirstDiscoverer: boolean };
   'wonder:eruption': { wonderId: string; position: HexCoord; tilesAffected: HexCoord[] };

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,7 @@ import { getCivHappinessFromResources, getCivAvailableResources } from '@/system
 import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
 import { buildLegendaryWonderCompletionCeremonyItem } from '@/systems/legendary-wonder-completion-presentation';
 import { createLegendaryWonderCompletionQueue } from '@/ui/legendary-wonder-completion-queue';
-import { removeRouteForUnit, createMarketplaceState, establishRoute } from '@/systems/trade-system';
+import { removeRouteForUnit, createMarketplaceState, establishRoute, getEffectiveGoldPerTurn } from '@/systems/trade-system';
 import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
 
 // --- App State ---
@@ -2831,7 +2831,8 @@ bus.on('trade:route-created', ({ route }) => {
   const ownerCity = gameState.cities[route.fromCityId];
   const toCity = gameState.cities[route.toCityId];
   if (!ownerCity) return;
-  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? route.toCityId} established`, 'success');
+  const goldPerTurn = getEffectiveGoldPerTurn(route);
+  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? route.toCityId} established (+${goldPerTurn} gold/turn)`, 'success');
 });
 
 bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2827,6 +2827,27 @@ bus.on('espionage:spy-auto-exfiltrated', ({ civId, cityId }) => {
   appendToCivLog(civId, `Your spy was auto-exfiltrated from ${city?.name ?? 'a city'} after it changed hands.`, 'info');
 });
 
+bus.on('trade:route-created', ({ route }) => {
+  const ownerCity = gameState.cities[route.fromCityId];
+  const toCity = gameState.cities[route.toCityId];
+  if (!ownerCity) return;
+  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? route.toCityId} established`, 'success');
+});
+
+bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {
+  const ownerCity = gameState.cities[fromCityId];
+  const toCity = gameState.cities[toCityId];
+  if (!ownerCity) return;
+  const reasonText: Record<string, string> = {
+    'unit-died': 'caravan destroyed',
+    'unit-disbanded': 'caravan disbanded',
+    'war-declared': 'war declared — caravan is free to redeploy',
+    'hostile-relations': 'hostile relations — caravan is free to redeploy',
+    'embargo': 'embargo enforced — caravan is free to redeploy',
+  };
+  appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? toCityId} ended: ${reasonText[reason] ?? reason}`, 'warning');
+});
+
 // --- Initialization ---
 async function init(): Promise<void> {
   await registerConquestoriaServiceWorker();

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -426,11 +426,10 @@ export function scrubEmbargoedRoutes(state: GameState, bus: EventBus | undefined
     if (!route.foreignCivId) continue;
 
     const fromCity = state.cities[route.fromCityId];
-    const toCity = state.cities[route.toCityId];
-    if (!fromCity || !toCity) continue;
+    if (!fromCity) continue;
 
     const fromOwner = fromCity.owner;
-    const toOwner = toCity.owner;
+    const toOwner = route.foreignCivId; // stored at route creation — avoids missing-city lookup
 
     const embargoed = state.embargoes.some(embargo =>
       (embargo.targetCivId === toOwner && embargo.participants.includes(fromOwner)) ||

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -371,19 +371,20 @@ export function removeRouteById(
   const newRoutes = state.marketplace!.tradeRoutes.filter(r => r.id !== routeId);
   const newMarketplace = { ...state.marketplace!, tradeRoutes: newRoutes };
 
-  bus?.emit('trade:route-ended', {
-    routeId,
-    fromCityId: route.fromCityId,
-    toCityId: route.toCityId,
-    reason,
-  });
-
+  // Clear caravan commitment before emitting so listeners see freed unit state
   const updatedUnits = { ...state.units };
   for (const [unitId, unit] of Object.entries(state.units)) {
     if (unit.committedToRouteId === routeId) {
       updatedUnits[unitId] = { ...unit, committedToRouteId: undefined, tripsRemaining: undefined };
     }
   }
+
+  bus?.emit('trade:route-ended', {
+    routeId,
+    fromCityId: route.fromCityId,
+    toCityId: route.toCityId,
+    reason,
+  });
 
   return { ...state, marketplace: newMarketplace, units: updatedUnits };
 }
@@ -392,14 +393,15 @@ export function scrubStaleForeignRoutes(state: GameState, bus: EventBus | undefi
   if (!state.marketplace) return state;
 
   let newState = state;
-  const routes = state.marketplace.tradeRoutes;
+  const routes = state.marketplace.tradeRoutes; // snapshot — original array never mutated
 
   for (const route of routes) {
     if (!route.foreignCivId) continue;
 
-    const fromCity = state.cities[route.fromCityId];
+    // Read from newState so any same-turn city/civ changes are visible
+    const fromCity = newState.cities[route.fromCityId];
     if (!fromCity) continue;
-    const ownerCiv = state.civilizations[fromCity.owner];
+    const ownerCiv = newState.civilizations[fromCity.owner];
     if (!ownerCiv) continue;
 
     if (isAtWar(ownerCiv.diplomacy, route.foreignCivId)) {
@@ -417,7 +419,7 @@ export function scrubStaleForeignRoutes(state: GameState, bus: EventBus | undefi
 }
 
 export function scrubEmbargoedRoutes(state: GameState, bus: EventBus | undefined): GameState {
-  if (!state.embargoes || !state.marketplace) return state;
+  if (!state.embargoes || state.embargoes.length === 0 || !state.marketplace) return state;
 
   let newState = state;
   const routes = state.marketplace.tradeRoutes;

--- a/src/systems/trade-system.ts
+++ b/src/systems/trade-system.ts
@@ -357,6 +357,94 @@ export function establishRoute(
 
 // --- S5: route removal helper ---
 
+// --- S6a: route lifecycle helpers ---
+
+export function removeRouteById(
+  state: GameState,
+  routeId: string,
+  bus: EventBus | undefined,
+  reason: 'war-declared' | 'hostile-relations' | 'embargo',
+): GameState {
+  const route = state.marketplace?.tradeRoutes.find(r => r.id === routeId);
+  if (!route) return state;
+
+  const newRoutes = state.marketplace!.tradeRoutes.filter(r => r.id !== routeId);
+  const newMarketplace = { ...state.marketplace!, tradeRoutes: newRoutes };
+
+  bus?.emit('trade:route-ended', {
+    routeId,
+    fromCityId: route.fromCityId,
+    toCityId: route.toCityId,
+    reason,
+  });
+
+  const updatedUnits = { ...state.units };
+  for (const [unitId, unit] of Object.entries(state.units)) {
+    if (unit.committedToRouteId === routeId) {
+      updatedUnits[unitId] = { ...unit, committedToRouteId: undefined, tripsRemaining: undefined };
+    }
+  }
+
+  return { ...state, marketplace: newMarketplace, units: updatedUnits };
+}
+
+export function scrubStaleForeignRoutes(state: GameState, bus: EventBus | undefined): GameState {
+  if (!state.marketplace) return state;
+
+  let newState = state;
+  const routes = state.marketplace.tradeRoutes;
+
+  for (const route of routes) {
+    if (!route.foreignCivId) continue;
+
+    const fromCity = state.cities[route.fromCityId];
+    if (!fromCity) continue;
+    const ownerCiv = state.civilizations[fromCity.owner];
+    if (!ownerCiv) continue;
+
+    if (isAtWar(ownerCiv.diplomacy, route.foreignCivId)) {
+      newState = removeRouteById(newState, route.id, bus, 'war-declared');
+      continue;
+    }
+
+    const rel = getRelationship(ownerCiv.diplomacy, route.foreignCivId);
+    if (rel < -25) {
+      newState = removeRouteById(newState, route.id, bus, 'hostile-relations');
+    }
+  }
+
+  return newState;
+}
+
+export function scrubEmbargoedRoutes(state: GameState, bus: EventBus | undefined): GameState {
+  if (!state.embargoes || !state.marketplace) return state;
+
+  let newState = state;
+  const routes = state.marketplace.tradeRoutes;
+
+  for (const route of routes) {
+    if (!route.foreignCivId) continue;
+
+    const fromCity = state.cities[route.fromCityId];
+    const toCity = state.cities[route.toCityId];
+    if (!fromCity || !toCity) continue;
+
+    const fromOwner = fromCity.owner;
+    const toOwner = toCity.owner;
+
+    const embargoed = state.embargoes.some(embargo =>
+      (embargo.targetCivId === toOwner && embargo.participants.includes(fromOwner)) ||
+      (embargo.targetCivId === fromOwner && embargo.participants.includes(toOwner)),
+    );
+
+    if (embargoed) {
+      newState = removeRouteById(newState, route.id, bus, 'embargo');
+    }
+  }
+
+  return newState;
+}
+
 export function removeRouteForUnit(
   state: GameState,
   unitId: string,

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -18,12 +18,79 @@ import {
   establishRoute,
   removeRouteForUnit,
   resolveFromCity,
+  removeRouteById,
+  scrubStaleForeignRoutes,
+  scrubEmbargoedRoutes,
 } from '@/systems/trade-system';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS } from '@/systems/unit-system';
 import { TRAINABLE_UNITS, PRODUCTION_ICONS } from '@/systems/city-system';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import type { GameState } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
+
+// Shared fixture — used by S5 and S6a describe blocks
+function makeTile(q: number, r: number) {
+  return { coord: { q, r }, terrain: 'grassland' as const, rivers: [], improvement: null, owner: null, resource: null, wonder: null };
+}
+
+function makeMinimalState(overrides: Partial<{
+  caravanPos: { q: number; r: number };
+  city1Buildings: string[];
+  city2Buildings: string[];
+  atWarWith: string[];
+  relationship: number;
+  tradeRoutes: any[];
+}> = {}): GameState {
+  const tiles: Record<string, any> = {};
+  for (let q = 0; q < 5; q++) {
+    for (let r = 0; r < 5; r++) {
+      tiles[`${q},${r}`] = makeTile(q, r);
+    }
+  }
+  const caravanPos = overrides.caravanPos ?? { q: 0, r: 0 };
+  const marketplace = createMarketplaceState();
+  if (overrides.tradeRoutes) {
+    marketplace.tradeRoutes = overrides.tradeRoutes;
+  }
+  return {
+    turn: 1,
+    era: 1,
+    currentPlayer: 'player',
+    map: { tiles, width: 5, height: 5, wrapsHorizontally: false },
+    marketplace,
+    idCounters: { nextUnitId: 10, nextCityId: 10, nextCampId: 10, nextQuestId: 10, nextRouteId: 1 },
+    civilizations: {
+      player: {
+        id: 'player', name: 'Player', color: '#00f', civType: 'generic',
+        gold: 100, cities: ['city1', 'city2'], units: ['caravan1'],
+        techState: { completed: ['trade-routes', 'wheel'], currentResearch: null, progress: {}, trackPriorities: {} as any },
+        diplomacy: { relationships: { enemy: overrides.relationship ?? 0 }, treaties: [], events: [], atWarWith: overrides.atWarWith ?? [] },
+        knownCivilizations: ['enemy'],
+        visibility: { tiles: {}, fogMap: {} },
+      },
+      enemy: {
+        id: 'enemy', name: 'Enemy', color: '#f00', civType: 'generic',
+        gold: 100, cities: ['city3'], units: [],
+        techState: { completed: [], currentResearch: null, progress: {}, trackPriorities: {} as any },
+        diplomacy: { relationships: { player: overrides.relationship ?? 0 }, treaties: [], events: [], atWarWith: overrides.atWarWith?.includes('player') ? ['player'] : [] },
+        knownCivilizations: [],
+        visibility: { tiles: {}, fogMap: {} },
+      },
+    },
+    cities: {
+      city1: { id: 'city1', name: 'Alpha', owner: 'player', position: { q: 0, r: 0 }, buildings: overrides.city1Buildings ?? [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
+      city2: { id: 'city2', name: 'Beta', owner: 'player', position: { q: 2, r: 0 }, buildings: overrides.city2Buildings ?? [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
+      city3: { id: 'city3', name: 'Gamma', owner: 'enemy', position: { q: 4, r: 0 }, buildings: [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
+    },
+    units: {
+      caravan1: { id: 'caravan1', type: 'caravan', owner: 'player', position: caravanPos, health: 100, movementPointsLeft: 3, hasActed: false, hasMoved: false, skippedTurn: false, isResting: false } as any,
+    },
+    barbarianCamps: {}, minorCivs: {}, espionage: {}, pendingEvents: {},
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {}, legendaryWonderHistory: { destroyedStrongholds: [], discoveredSites: [] },
+    legendaryWonderIntel: {}, legendaryWonderProjects: {},
+    settings: { mapSize: 'small', opponentCount: 1, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
+  } as any;
+}
 
 describe('trade-system', () => {
   describe('RESOURCE_DEFINITIONS', () => {
@@ -281,69 +348,6 @@ describe('trade-system', () => {
   });
 
   describe('S5 — caravan trade routes', () => {
-    function makeTile(q: number, r: number) {
-      return { coord: { q, r }, terrain: 'grassland' as const, rivers: [], improvement: null, owner: null, resource: null, wonder: null };
-    }
-
-    function makeMinimalState(overrides: Partial<{
-      caravanPos: { q: number; r: number };
-      city1Buildings: string[];
-      city2Buildings: string[];
-      atWarWith: string[];
-      relationship: number;
-      tradeRoutes: any[];
-    }> = {}): GameState {
-      const tiles: Record<string, any> = {};
-      for (let q = 0; q < 5; q++) {
-        for (let r = 0; r < 5; r++) {
-          tiles[`${q},${r}`] = makeTile(q, r);
-        }
-      }
-      const caravanPos = overrides.caravanPos ?? { q: 0, r: 0 };
-      const marketplace = createMarketplaceState();
-      if (overrides.tradeRoutes) {
-        marketplace.tradeRoutes = overrides.tradeRoutes;
-      }
-      return {
-        turn: 1,
-        era: 1,
-        currentPlayer: 'player',
-        map: { tiles, width: 5, height: 5, wrapsHorizontally: false },
-        marketplace,
-        idCounters: { nextUnitId: 10, nextCityId: 10, nextCampId: 10, nextQuestId: 10, nextRouteId: 1 },
-        civilizations: {
-          player: {
-            id: 'player', name: 'Player', color: '#00f', civType: 'generic',
-            gold: 100, cities: ['city1', 'city2'], units: ['caravan1'],
-            techState: { completed: ['trade-routes', 'wheel'], currentResearch: null, progress: {}, trackPriorities: {} as any },
-            diplomacy: { relationships: { enemy: overrides.relationship ?? 0 }, treaties: [], events: [], atWarWith: overrides.atWarWith ?? [] },
-            knownCivilizations: ['enemy'],
-            visibility: { tiles: {}, fogMap: {} },
-          },
-          enemy: {
-            id: 'enemy', name: 'Enemy', color: '#f00', civType: 'generic',
-            gold: 100, cities: ['city3'], units: [],
-            techState: { completed: [], currentResearch: null, progress: {}, trackPriorities: {} as any },
-            diplomacy: { relationships: { player: overrides.relationship ?? 0 }, treaties: [], events: [], atWarWith: overrides.atWarWith?.includes('player') ? ['player'] : [] },
-            knownCivilizations: [],
-            visibility: { tiles: {}, fogMap: {} },
-          },
-        },
-        cities: {
-          city1: { id: 'city1', name: 'Alpha', owner: 'player', position: { q: 0, r: 0 }, buildings: overrides.city1Buildings ?? [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
-          city2: { id: 'city2', name: 'Beta', owner: 'player', position: { q: 2, r: 0 }, buildings: overrides.city2Buildings ?? [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
-          city3: { id: 'city3', name: 'Gamma', owner: 'enemy', position: { q: 4, r: 0 }, buildings: [], productionQueue: [], food: 0, production: 0, population: 1, workedTiles: [], unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0 } as any,
-        },
-        units: {
-          caravan1: { id: 'caravan1', type: 'caravan', owner: 'player', position: caravanPos, health: 100, movementPointsLeft: 3, hasActed: false, hasMoved: false, skippedTurn: false, isResting: false } as any,
-        },
-        barbarianCamps: {}, minorCivs: {}, espionage: {}, pendingEvents: {},
-        tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {}, legendaryWonderHistory: { destroyedStrongholds: [], discoveredSites: [] },
-        legendaryWonderIntel: {}, legendaryWonderProjects: {},
-        settings: { mapSize: 'small', opponentCount: 1, advisorsEnabled: {} as any, councilTalkLevel: 'normal' },
-      } as any;
-    }
-
     it("'caravan' is in UNIT_DEFINITIONS", () => {
       expect(UNIT_DEFINITIONS['caravan']).toBeDefined();
       expect(UNIT_DEFINITIONS['caravan'].strength).toBe(0);
@@ -508,6 +512,214 @@ describe('trade-system', () => {
       bus.on('trade:route-ended', (e) => events.push(e.reason));
       newState = removeRouteForUnit(newState, 'caravan1', bus, 'unit-died');
       expect(events).toEqual(['unit-died']);
+    });
+  });
+
+  describe('S6a — route lifecycle', () => {
+    it('removeRouteById: removes route, clears caravan, emits event with given reason', () => {
+      const state = makeMinimalState();
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0); // foreign route to 'enemy'
+      const routeId = s.marketplace!.tradeRoutes[0].id;
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = removeRouteById(s, routeId, bus, 'war-declared');
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(s.units['caravan1']?.committedToRouteId).toBeUndefined();
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('war-declared');
+    });
+
+    it('removeRouteById: no-op when route does not exist', () => {
+      const state = makeMinimalState();
+      const bus = new EventBus();
+      const events: string[] = [];
+      bus.on('trade:route-ended', () => events.push('fired'));
+      const result = removeRouteById(state, 'no-such-route', bus, 'embargo');
+      expect(result).toBe(state); // same reference — nothing changed
+      expect(events).toHaveLength(0);
+    });
+
+    it('scrubStaleForeignRoutes: war → foreign route terminated', () => {
+      // Establish route while not at war, then simulate war before lifecycle pass
+      const state = makeMinimalState({ atWarWith: [], relationship: 0 });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0); // foreign route to 'enemy'
+      // Simulate war declared (both sides added to atWarWith — bilateral)
+      s = {
+        ...s,
+        civilizations: {
+          ...s.civilizations,
+          player: { ...s.civilizations['player'], diplomacy: { ...s.civilizations['player'].diplomacy, atWarWith: ['enemy'] } },
+        },
+      };
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1);
+
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = scrubStaleForeignRoutes(s, bus);
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(events).toHaveLength(1);
+      expect(events[0].reason).toBe('war-declared');
+    });
+
+    it('scrubStaleForeignRoutes: relations >= 0 + no war → keeps route', () => {
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0); // foreign route
+      s = scrubStaleForeignRoutes(s, bus);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1); // kept
+    });
+
+    it('scrubStaleForeignRoutes: relations drop to −26 → terminated', () => {
+      // Establish at neutral (0), then drop to −26 before the lifecycle pass
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      // Simulate relation drift (relationship system lowered it)
+      s = {
+        ...s,
+        civilizations: {
+          ...s.civilizations,
+          player: {
+            ...s.civilizations['player'],
+            diplomacy: { ...s.civilizations['player'].diplomacy, relationships: { enemy: -26 } },
+          },
+        },
+      };
+
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = scrubStaleForeignRoutes(s, bus);
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(events[0].reason).toBe('hostile-relations');
+    });
+
+    it('scrubStaleForeignRoutes: domestic route unaffected by war', () => {
+      const state = makeMinimalState({ atWarWith: ['enemy'] });
+      const bus = new EventBus();
+      // city2 is owned by 'player' → domestic route (no foreignCivId)
+      let s = establishRoute(state, 'caravan1', 'city2', bus, 0);
+      s = scrubStaleForeignRoutes(s, bus);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1); // domestic always survives
+    });
+
+    it('scrubStaleForeignRoutes: domestic route unaffected by hostile relations', () => {
+      const state = makeMinimalState({ relationship: -80, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city2', bus, 0); // domestic
+      s = scrubStaleForeignRoutes(s, bus);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1);
+    });
+
+    it('scrubStaleForeignRoutes: termination event fires exactly once (idempotent)', () => {
+      const state = makeMinimalState({ atWarWith: ['enemy'] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      const events: string[] = [];
+      bus.on('trade:route-ended', () => events.push('fired'));
+      s = scrubStaleForeignRoutes(s, bus);  // removes route, fires event
+      s = scrubStaleForeignRoutes(s, bus);  // route already gone — no second event
+      expect(events).toHaveLength(1);
+    });
+
+    it('scrubEmbargoedRoutes: participant route to embargoed civ → terminated', () => {
+      // player embargoes enemy; player has a route TO enemy → must die
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0); // player → enemy
+      s = { ...s, embargoes: [{ id: 'emb-1', targetCivId: 'enemy', participants: ['player'], proposedTurn: 1 }] };
+
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = scrubEmbargoedRoutes(s, bus);
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(events[0].reason).toBe('embargo');
+    });
+
+    it('scrubEmbargoedRoutes: embargoed civ route to participant → also terminated', () => {
+      // Embargo targets 'enemy'; enemy has a route TO player → must also die
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      // Manually inject a route owned by 'enemy' (fromCity=city3) to player's city (city1)
+      const marketplace = { ...state.marketplace!, tradeRoutes: [
+        { id: 'route-99', fromCityId: 'city3', toCityId: 'city1', goldPerTrip: 6, turnsPerTrip: 2, foreignCivId: 'player' },
+      ]};
+      let s = { ...state, marketplace };
+      s = { ...s, embargoes: [{ id: 'emb-2', targetCivId: 'enemy', participants: ['player'], proposedTurn: 1 }] };
+
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = scrubEmbargoedRoutes(s, bus);
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(events[0].reason).toBe('embargo');
+    });
+
+    it('scrubEmbargoedRoutes: domestic route unaffected by embargo', () => {
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city2', bus, 0); // domestic
+      s = { ...s, embargoes: [{ id: 'emb-1', targetCivId: 'enemy', participants: ['player'], proposedTurn: 1 }] };
+      s = scrubEmbargoedRoutes(s, bus);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1);
+    });
+
+    it('actor-complete: AI-declared war terminates the human route owner\'s foreign route', () => {
+      // Start: neutral, no war
+      const state = makeMinimalState({ atWarWith: [], relationship: 5 });
+      const bus = new EventBus();
+      // Establish foreign route player→enemy while relations are good
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1);
+
+      // Simulate AI war declaration: both sides get each other in atWarWith
+      s = {
+        ...s,
+        civilizations: {
+          ...s.civilizations,
+          player: {
+            ...s.civilizations['player'],
+            diplomacy: { ...s.civilizations['player'].diplomacy, atWarWith: ['enemy'] },
+          },
+          enemy: {
+            ...s.civilizations['enemy'],
+            diplomacy: { ...s.civilizations['enemy'].diplomacy, atWarWith: ['player'] },
+          },
+        },
+      };
+
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = scrubStaleForeignRoutes(s, bus); // same function called each turn in processTurn
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(events[0].reason).toBe('war-declared');
+    });
+
+    it('unit-loss: removeRouteForUnit unit-died terminates route + caravan cleared', () => {
+      const state = makeMinimalState();
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      const routeId = s.units['caravan1'].committedToRouteId!;
+      const events: Array<{ reason: string }> = [];
+      bus.on('trade:route-ended', e => events.push({ reason: e.reason }));
+
+      s = removeRouteForUnit(s, 'caravan1', bus, 'unit-died', routeId);
+
+      expect(s.marketplace!.tradeRoutes).toHaveLength(0);
+      expect(s.units['caravan1']?.committedToRouteId).toBeUndefined();
+      expect(events[0].reason).toBe('unit-died');
     });
   });
 });

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -601,6 +601,41 @@ describe('trade-system', () => {
       expect(events[0].reason).toBe('hostile-relations');
     });
 
+    it('scrubStaleForeignRoutes: relations at exactly −25 → keeps route', () => {
+      // < -25 terminates; exactly -25 must NOT
+      const state = makeMinimalState({ relationship: 0, atWarWith: [] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      s = {
+        ...s,
+        civilizations: {
+          ...s.civilizations,
+          player: {
+            ...s.civilizations['player'],
+            diplomacy: { ...s.civilizations['player'].diplomacy, relationships: { enemy: -25 } },
+          },
+        },
+      };
+      s = scrubStaleForeignRoutes(s, bus);
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1); // -25 is not < -25 → survives
+    });
+
+    it('scrubStaleForeignRoutes: missing fromCity (razed) → route left untouched', () => {
+      // Guard: if fromCity no longer exists, skip rather than crash or falsely terminate
+      const state = makeMinimalState({ atWarWith: ['enemy'] });
+      const bus = new EventBus();
+      let s = establishRoute(state, 'caravan1', 'city3', bus, 0);
+      // Raze the from-city so it disappears from state.cities
+      const { city1: _removed, ...remainingCities } = s.cities;
+      s = { ...s, cities: remainingCities as typeof s.cities };
+      const events: string[] = [];
+      bus.on('trade:route-ended', () => events.push('fired'));
+      s = scrubStaleForeignRoutes(s, bus);
+      // Route stays (can't determine owner, so skip rather than terminate)
+      expect(s.marketplace!.tradeRoutes).toHaveLength(1);
+      expect(events).toHaveLength(0);
+    });
+
     it('scrubStaleForeignRoutes: domestic route unaffected by war', () => {
       const state = makeMinimalState({ atWarWith: ['enemy'] });
       const bus = new EventBus();


### PR DESCRIPTION
## Summary

- Routes terminate automatically when a caravan's foreign civ enters war, drops below −25 relations, or is under an active embargo — income stops the same turn
- Domestic routes (no `foreignCivId`) are never affected by any of the above
- Actor-complete: the per-turn lifecycle pass in `processTurn` catches both human and AI war declarations before the income block runs
- Player receives a civ-log notification on route creation (+N gold/turn) and termination (reason + "caravan is free to redeploy" hint)

## What changed

| File | Change |
|---|---|
| `src/core/types.ts` | Extended `trade:route-ended` reason union with `war-declared`, `hostile-relations`, `embargo` |
| `src/systems/trade-system.ts` | Added `removeRouteById`, `scrubStaleForeignRoutes`, `scrubEmbargoedRoutes` |
| `src/core/turn-manager.ts` | Replaced legacy `enforceEmbargoes` call with the two new lifecycle passes (run before income) |
| `src/main.ts` | Added `bus.on('trade:route-created')` and `bus.on('trade:route-ended')` notification handlers |
| `tests/systems/trade-system.test.ts` | 15 new S6a tests (war, hostile relations, embargo, domestic exemptions, boundary at −25, idempotency, actor-complete, razed-city guard) |

## Architecture notes

- `scrubStaleForeignRoutes` reads from the accumulating `newState` (not stale input) so same-turn city/civ changes are visible
- `removeRouteById` clears caravan unit commitment before emitting the event so listeners see freed unit state
- `scrubEmbargoedRoutes` uses `route.foreignCivId` (stored at creation) rather than looking up `toCityId` in cities, which is safe when the destination city no longer exists
- `cleanupEmbargoes` result is spread-assigned (`newState = { ...newState, embargoes: ... }`) — no direct mutation

## Test plan

- [x] `yarn test` — 2625 tests pass (15 new S6a tests)
- [x] `yarn build` — TypeScript clean
- [x] Rebased onto latest `origin/main`