### PR TITLE
fix: unit targeting bugs — hasActed attack guard and post-move city assault (#264, #266)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1455,6 +1455,7 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
     );
     if (cityAtDest) {
       beginPlayerCityAssault(unitId, cityAtDest.id);
+      SFX.tap(); // match audio feedback of the tap-path assault (line ~2094)
       renderLoop.setGameState(gameState);
       updateHUD();
       // beginPlayerCityAssault handles its own selectNextUnit call via finalizePendingCityCaptureChoice.
@@ -1726,7 +1727,10 @@ function executeAttack(attackerId: string, targetKey: string): void {
   const attacker = gameState.units[attackerId];
   const targetCoord = parseHexKey(targetKey);
   const legality = canUnitAttackTarget(gameState, attacker, targetCoord, { viewerId: gameState.currentPlayer });
-  if (!attacker || !legality.ok || legality.targetType !== 'unit') {
+  // hasActed guard: enforce "no action remaining" at the execution layer, not just
+  // the highlight layer (getAttackTargets). Prevents double-action if executeAttack
+  // is ever called outside the normal tap → highlight → confirm flow.
+  if (!attacker || attacker.hasActed || !legality.ok || legality.targetType !== 'unit') {
     showNotification('That target is no longer attackable.', 'warning');
     if (selectedUnitId) selectUnit(selectedUnitId);
     return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1440,6 +1440,27 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
     wonderDiscoveryQueue?.notifyActionSettled();
     const unit = gameState.units[unitId];
     if (!unit || unit.owner !== gameState.currentPlayer) return;
+
+    // Post-move: check if the unit has landed on a hostile major-civ city tile.
+    // This handles the case where canReachCityAssault returned false because the unit
+    // was beyond attack range before moving (e.g., melee at distance 2 from city).
+    // Minor civ cities (owner starts with 'mc-') are excluded — they use the
+    // assault-minor-civ intent path. Allied cities are excluded by the atWarWith check.
+    const destKey = hexKey(unit.position);
+    const cityAtDest = Object.values(gameState.cities).find(c =>
+      hexKey(c.position) === destKey
+      && c.owner !== gameState.currentPlayer
+      && !c.owner.startsWith('mc-')
+      && (gameState.civilizations[gameState.currentPlayer]?.diplomacy?.atWarWith?.includes(c.owner) ?? false),
+    );
+    if (cityAtDest) {
+      beginPlayerCityAssault(unitId, cityAtDest.id);
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      // beginPlayerCityAssault handles its own selectNextUnit call via finalizePendingCityCaptureChoice.
+      return;
+    }
+
     if ((unit.movementPointsLeft ?? 0) <= 0) {
       selectNextUnit();
     } else if (selectedUnitId === unitId) {

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -125,6 +125,9 @@ export function getAttackTargets(
   attacker: Unit,
   options: AttackTargetOptions = {},
 ): AttackTarget[] {
+  // A unit that has already acted cannot attack again this turn.
+  if (attacker.hasActed) return [];
+
   const profile = getUnitAttackProfile(attacker.type);
   const candidates = state.map.wrapsHorizontally
     ? getWrappedHexesInRange(attacker.position, profile.range, state.map.width)

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -162,15 +162,17 @@ export function renderSelectedUnitInfo(
   actionsDiv.style.cssText = 'margin-top:8px;display:flex;gap:8px;flex-wrap:wrap;';
 
   if (def.canFoundCity && callbacks.onFoundCity) {
-    if (canFoundCityAt(state, unit.position)) {
+    if (unit.movementPointsLeft > 0 && canFoundCityAt(state, unit.position)) {
       actionsDiv.appendChild(makeButton('Found City', '#e8c170', callbacks.onFoundCity));
     } else {
-      const blockers = getCityFoundingBlockers(state, unit.position);
+      const blockerTitle = unit.movementPointsLeft <= 0
+        ? 'No movement remaining'
+        : formatCityFoundingBlockerMessage(getCityFoundingBlockers(state, unit.position));
       const btn = makeButton('Found City', '#e8c170');
       btn.disabled = true;
       btn.style.opacity = '0.5';
       btn.style.cursor = 'not-allowed';
-      btn.title = formatCityFoundingBlockerMessage(blockers);
+      btn.title = blockerTitle;
       actionsDiv.appendChild(btn);
     }
   }

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import type { NotificationEntry } from '@/ui/notification-log';
 import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
+import { hexKey } from '@/systems/hex-utils';
+import type { HexCoord } from '@/core/types';
 
 function makeSink() {
   const calls: Array<{ civId: string; message: string; type: string }> = [];
@@ -41,5 +43,52 @@ describe('era:advanced notification', () => {
     expect(toastCalls).toHaveLength(1);
     expect(toastCalls[0]!.message).toContain('Era 3');
     expect(factionCalls).toHaveLength(0);
+  });
+});
+
+// ─── Post-move hostile city detection (#264) ─────────────────────────────────
+// Tests the detection logic added inside animateMovedUnit in main.ts.
+// Mirrors the city-hex-tap.test.ts pattern: inline the pure detection helper
+// so there's no DOM or module-mocking overhead, but the conditions are proven.
+
+type SlimCity = { id: string; owner: string; position: HexCoord };
+type SlimCivs = Record<string, { diplomacy?: { atWarWith?: string[] } }>;
+
+function findHostileWarCity(
+  cities: Record<string, SlimCity>,
+  civilizations: SlimCivs,
+  position: HexCoord,
+  ownerCivId: string,
+): string | null {
+  const key = hexKey(position);
+  const entry = Object.entries(cities).find(([, city]) =>
+    hexKey(city.position) === key
+    && city.owner !== ownerCivId
+    && !city.owner.startsWith('mc-')
+    && (civilizations[ownerCivId]?.diplomacy?.atWarWith?.includes(city.owner) ?? false),
+  );
+  return entry ? entry[0] : null;
+}
+
+describe('post-move hostile city detection', () => {
+  it('detects a hostile at-war major-civ city at the unit landing position', () => {
+    const cities = { 'city-1': { id: 'city-1', owner: 'ai-1', position: { q: 3, r: 2 } } };
+    const civs: SlimCivs = { player: { diplomacy: { atWarWith: ['ai-1'] } } };
+
+    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBe('city-1');
+  });
+
+  it('does not trigger for a city the player is not at war with (allied / neutral)', () => {
+    const cities = { 'city-1': { id: 'city-1', owner: 'ai-1', position: { q: 3, r: 2 } } };
+    const civs: SlimCivs = { player: { diplomacy: { atWarWith: [] } } };
+
+    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
+  });
+
+  it('does not trigger for a minor civ city (owner starts with mc-)', () => {
+    const cities = { 'mc-abc': { id: 'mc-abc', owner: 'mc-abc', position: { q: 3, r: 2 } } };
+    const civs: SlimCivs = { player: { diplomacy: { atWarWith: ['mc-abc'] } } };
+
+    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -48,8 +48,11 @@ describe('era:advanced notification', () => {
 
 // ─── Post-move hostile city detection (#264) ─────────────────────────────────
 // Tests the detection logic added inside animateMovedUnit in main.ts.
-// Mirrors the city-hex-tap.test.ts pattern: inline the pure detection helper
-// so there's no DOM or module-mocking overhead, but the conditions are proven.
+// Follows the pattern in tests/integration/city-hex-tap.test.ts: inline the
+// pure detection helper so there's no DOM or module-mocking overhead, but the
+// conditions are proven. If the production logic in animateMovedUnit diverges,
+// these tests will still pass — they prove correctness of the algorithm, not
+// of the wiring. The wiring is covered by the tap-intent regression tests.
 
 type SlimCity = { id: string; owner: string; position: HexCoord };
 type SlimCivs = Record<string, { diplomacy?: { atWarWith?: string[] } }>;
@@ -88,6 +91,15 @@ describe('post-move hostile city detection', () => {
   it('does not trigger for a minor civ city (owner starts with mc-)', () => {
     const cities = { 'mc-abc': { id: 'mc-abc', owner: 'mc-abc', position: { q: 3, r: 2 } } };
     const civs: SlimCivs = { player: { diplomacy: { atWarWith: ['mc-abc'] } } };
+
+    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
+  });
+
+  it('does not trigger when the mover owns the city (own-city landing)', () => {
+    // The animateMovedUnit guard `c.owner !== gameState.currentPlayer` prevents
+    // a player from assaulting their own city. Verify the algorithm excludes it.
+    const cities = { 'city-1': { id: 'city-1', owner: 'player', position: { q: 3, r: 2 } } };
+    const civs: SlimCivs = { player: { diplomacy: { atWarWith: [] } } };
 
     expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
   });

--- a/tests/systems/attack-targeting.test.ts
+++ b/tests/systems/attack-targeting.test.ts
@@ -149,4 +149,32 @@ describe('attack-targeting', () => {
 
     expect(getAttackTargets(state, attacker, { viewerId: 'player' }).map(target => hexKey(target.coord))).toEqual(['2,0']);
   });
+
+  it('returns empty array when attacker.hasActed is true even if targets are in range', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '1,0': 'visible' });
+    state.units['attacker'] = { ...attacker, hasActed: true };
+
+    expect(getAttackTargets(state, state.units['attacker'], { viewerId: 'player' })).toEqual([]);
+  });
+
+  it('returns targets normally when attacker.hasActed is false (no regression)', () => {
+    const attacker = unit('attacker', 'warrior', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 1, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '1,0': 'visible' });
+    state.units['attacker'] = { ...attacker, hasActed: false };
+
+    expect(getAttackTargets(state, state.units['attacker'], { viewerId: 'player' })).toHaveLength(1);
+  });
+
+  it('returns targets for a ranged unit with movementPointsLeft=0 but hasActed=false', () => {
+    // ranged units can attack without moving — movementPointsLeft alone must not block
+    const attacker = unit('attacker', 'archer', 'player', { q: 0, r: 0 });
+    const defender = unit('defender', 'warrior', 'ai-1', { q: 2, r: 0 });
+    const state = stateWithUnits({ attacker, defender }, { '2,0': 'visible' });
+    state.units['attacker'] = { ...attacker, movementPointsLeft: 0, hasActed: false };
+
+    expect(getAttackTargets(state, state.units['attacker'], { viewerId: 'player' })).toHaveLength(1);
+  });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -6,9 +6,11 @@ import type { GameState } from '@/core/types';
 class MockElement {
   tagName: string;
   children: MockElement[] = [];
-  style = { cssText: '', display: '' };
+  style = { cssText: '', display: '', opacity: '', cursor: '' };
   textContent = '';
   type = '';
+  disabled = false;
+  title = '';
   listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
 
   get childElementCount(): number {
@@ -715,6 +717,39 @@ describe('renderSelectedUnitInfo - found city button', () => {
     expect(btn).toBeDefined();
     btn!.click();
     expect(called).toBe(false);
+  });
+
+  it('renders Found City as disabled when settler has no movement points remaining', () => {
+    const state = makeSettlerState();
+    state.units['settler-1'] = { ...state.units['settler-1'], movementPointsLeft: 0 };
+    const container = new MockElement('div');
+    let called = false;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'settler-1', {
+      onFoundCity: () => { called = true; },
+    });
+
+    const btn = findButtons(container).find(b => b.textContent === 'Found City');
+    expect(btn).toBeDefined();
+    expect(btn!.disabled).toBe(true);
+    btn!.click();
+    expect(called).toBe(false);
+  });
+
+  it('renders Found City as enabled when settler has movement points on a valid tile', () => {
+    const state = makeSettlerState(); // movementPointsLeft: 2 by default
+    const container = new MockElement('div');
+    let called = false;
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'settler-1', {
+      onFoundCity: () => { called = true; },
+    });
+
+    const btn = findButtons(container).find(b => b.textContent === 'Found City');
+    expect(btn).toBeDefined();
+    expect(btn!.disabled).toBeFalsy();
+    btn!.click();
+    expect(called).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- **#266 — `getAttackTargets` `hasActed` guard:** Units that have already acted this turn (`hasActed: true`) now return `[]` from `getAttackTargets`, eliminating phantom attack highlights. Uses `hasActed` (not `movementPointsLeft`) so ranged units that spent their movement but haven't acted can still attack.
- **#266 — Found City MP guard:** Settler's \"Found City\" button is now disabled with tooltip \"No movement remaining\" when `movementPointsLeft <= 0`, preventing a clickable-but-broken button when the settler has exhausted its movement.
- **#264 — Post-move city assault:** `animateMovedUnit` now checks if the unit landed on a hostile at-war major-civ city tile after the animation completes and fires `beginPlayerCityAssault`. This handles the common case where `canReachCityAssault` returned `move` before the unit stepped forward (e.g. melee at distance 2). Minor civ cities and non-war cities are explicitly excluded.

## Files changed

| File | Change |
|------|--------|
| `src/systems/attack-targeting.ts` | Early-return `[]` when `attacker.hasActed` |
| `src/ui/selected-unit-info.ts` | Found City button guards `movementPointsLeft > 0` |
| `src/main.ts` | Post-move hostile city check in `animateMovedUnit` callback |
| `tests/systems/attack-targeting.test.ts` | 3 new tests (hasActed blocks, hasActed=false passes, ranged 0-MP passes) |
| `tests/ui/selected-unit-info.test.ts` | 2 new tests (0-MP disabled, MP>0 enabled); MockElement gains `disabled`/`title`/`style.opacity`/`style.cursor` |
| `tests/main.integration.test.ts` | 3 pure detection tests proving at-war/allied/minor-civ cases |

## Test plan
- [x] `yarn test` — 2657/2657 pass
- [x] `yarn build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)