### PR TITLE
feat(polish): resolve #276 #279 — city icon centering, hotkeys, multi-turn journey

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -1,7 +1,7 @@
 import type { AdvisorType, GameState } from './types';
 import { EventBus } from './event-bus';
 import { checkDominationVictory } from '@/systems/victory-system';
-import { resetUnitTurn, createUnit, healUnit, moveUnit } from '@/systems/unit-system';
+import { resetUnitTurn, createUnit, healUnit, moveUnit, findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { processCity, TRAINABLE_UNITS } from '@/systems/city-system';
 import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
 import { applyCityMaturity } from '@/systems/city-maturity-system';
@@ -12,6 +12,8 @@ import { resolveCombat } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
+import { hexKey } from '@/systems/hex-utils';
+import { executeUnitMove } from '@/systems/unit-movement-system';
 import { calculateCityYields } from '@/systems/resource-system';
 import { getCivResourceYieldBonus } from '@/systems/resource-acquisition-system';
 import type { HexCoord } from './types';
@@ -266,6 +268,23 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       const unit = newState.units[unitId];
       if (unit?.automation?.mode === 'auto-explore') {
         applyAutoExploreOrder(newState, unitId, { bus });
+      } else if (unit?.automation?.mode === 'journey') {
+        const destination = unit.automation.destination;
+        const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+        const path = findPath(unit.position, destination, newState.map, domain);
+        if (!path || path.length < 2) {
+          newState.units[unitId] = { ...unit, automation: undefined };
+          bus.emit('unit:journey-blocked', { unitId, position: { ...unit.position } });
+        } else {
+          const nextStep = path[1];
+          executeUnitMove(newState, unitId, nextStep, { actor: 'automation', civId, bus });
+          if (hexKey(nextStep) === hexKey(destination)) {
+            const movedUnit = newState.units[unitId];
+            if (movedUnit) {
+              newState.units[unitId] = { ...movedUnit, automation: undefined };
+            }
+          }
+        }
       }
     }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -315,11 +315,9 @@ export interface Unit {
   isResting: boolean;        // player explicitly chose to rest/heal this turn
   skippedTurn?: boolean;     // player chose to hold this unit out of unit cycling this turn
   isFortified?: boolean;    // unit is in defensive stance; excluded from unmoved-unit cycling, +25% defense
-  automation?: {
-    mode: 'auto-explore';
-    lastTargets: string[];
-    startedTurn: number;
-  };
+  automation?:
+    | { mode: 'auto-explore'; lastTargets: string[]; startedTurn: number }
+    | { mode: 'journey'; destination: HexCoord };
   committedToRouteId?: string;   // set on establish; blocks movement while set
   tripsRemaining?: number;       // S5 sets it; S6b decrements on each completed round trip
   routeDirection?: 'outbound' | 'inbound';  // S6b uses; S5 leaves undefined
@@ -1231,4 +1229,5 @@ export interface GameEvents {
   'espionage:intel-extracted': { captorId: string; intel: InterrogationIntel[] };
   'unit:obsolete': { civId: string; unitId: string; unitType: UnitType };
   'espionage:spy-expired': { civId: string; spyId: string; spyName: string; unitType: UnitType };
+  'unit:journey-blocked': { unitId: string; position: HexCoord };
 }

--- a/src/input/keyboard-shortcuts.ts
+++ b/src/input/keyboard-shortcuts.ts
@@ -2,6 +2,12 @@ export interface KeyboardShortcutCallbacks {
   onOpenCouncil: () => void;
   onOpenTech: () => void;
   onEndTurn: () => void;
+  onCenterUnit?: () => void;
+  onFortify?: () => void;
+  onSettle?: () => void;
+  onNextUnit?: () => void;
+  onStartJourney?: () => void;
+  getSelectedUnitId?: () => string | null;
 }
 
 export interface KeyboardShortcutOptions {
@@ -29,15 +35,33 @@ export function installKeyboardShortcuts(
     }
 
     const key = event.key.toLowerCase();
+    const hasUnit = callbacks.getSelectedUnitId ? callbacks.getSelectedUnitId() !== null : false;
+
     if (key === 'c') {
       event.preventDefault();
-      callbacks.onOpenCouncil();
+      if (hasUnit && callbacks.onCenterUnit) {
+        callbacks.onCenterUnit();
+      } else {
+        callbacks.onOpenCouncil();
+      }
     } else if (key === 't') {
       event.preventDefault();
       callbacks.onOpenTech();
     } else if (key === 'e') {
       event.preventDefault();
       callbacks.onEndTurn();
+    } else if (key === 'n') {
+      event.preventDefault();
+      callbacks.onNextUnit?.();
+    } else if (key === 'f' && hasUnit) {
+      event.preventDefault();
+      callbacks.onFortify?.();
+    } else if (key === 'b' && hasUnit) {
+      event.preventDefault();
+      callbacks.onSettle?.();
+    } else if (key === 'g' && hasUnit) {
+      event.preventDefault();
+      callbacks.onStartJourney?.();
     }
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
 import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
-import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason } from '@/systems/unit-system';
+import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason, findPath } from '@/systems/unit-system';
 import { scanIdCounters } from '@/core/id-counters';
 import { foundCity, BUILDINGS, getProductionDisplayName, getUnplacedBuildings, placeBuilding } from '@/systems/city-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
@@ -168,6 +168,7 @@ let councilPanelOpen = false;
 let persistedSettings: GameState['settings'] | undefined;
 let pacingDebugOpen = false;
 let pendingCityCaptureChoice: PendingCityCaptureChoice | null = null;
+let pendingJourneyUnitId: string | null = null;
 let deferWonderDiscoveryRevealUntilMoveSettles = false;
 
 function mergePersistedSettings(loadedSettings?: GameState['settings']): GameState['settings'] {
@@ -244,6 +245,11 @@ legendaryCompletionQueue = createLegendaryWonderCompletionQueue({
 // --- Resize ---
 window.addEventListener('resize', () => renderLoop.resizeCanvas());
 window.addEventListener('keydown', event => {
+  if (event.key === 'Escape' && pendingJourneyUnitId) {
+    pendingJourneyUnitId = null;
+    showNotification('Journey cancelled.', 'info');
+    return;
+  }
   if (event.key !== '`') {
     return;
   }
@@ -1233,6 +1239,15 @@ function selectUnit(unitId: string): void {
   }
   renderLoop.setHighlights(highlightResult.highlights);
 
+  // Update journey path overlay
+  if (unit.automation?.mode === 'journey') {
+    const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+    const path = findPath(unit.position, unit.automation.destination, gameState.map, domain);
+    renderLoop.setJourneyPath(path);
+  } else {
+    renderLoop.setJourneyPath(null);
+  }
+
   // Show unit info panel
   const panel = document.getElementById('info-panel');
   if (panel) {
@@ -1452,6 +1467,7 @@ function deselectUnit(): void {
   movementRange = [];
   attackRange = [];
   renderLoop.clearHighlights();
+  renderLoop.setJourneyPath(null);
   const panel = document.getElementById('info-panel');
   if (panel) {
     panel.style.display = 'none';
@@ -1507,6 +1523,15 @@ function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
 }
 
 function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResult): ExecuteUnitMoveResult {
+  // Clear journey automation when the player manually moves a unit
+  const movingUnit = gameState.units[unitId];
+  if (movingUnit?.automation?.mode === 'journey') {
+    gameState = {
+      ...gameState,
+      units: { ...gameState.units, [unitId]: { ...movingUnit, automation: undefined } },
+    };
+    renderLoop.setJourneyPath(null);
+  }
   deferWonderDiscoveryRevealUntilMoveSettles = true;
   try {
     const moveResult = move();
@@ -1527,7 +1552,7 @@ function startAutoExplore(unitId: string): void {
     automation: {
       mode: 'auto-explore',
       startedTurn: gameState.turn,
-      lastTargets: unit.automation?.lastTargets ?? [],
+      lastTargets: unit.automation?.mode === 'auto-explore' ? unit.automation.lastTargets : [],
     },
   };
 
@@ -1902,6 +1927,30 @@ function handleHexTap(rawCoord: HexCoord): void {
   const coord = gameState.map.wrapsHorizontally
     ? wrapHexCoord(rawCoord, gameState.map.width)
     : rawCoord;
+
+  if (pendingJourneyUnitId) {
+    const unit = gameState.units[pendingJourneyUnitId];
+    if (unit) {
+      const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+      const path = findPath(unit.position, coord, gameState.map, domain);
+      if (!path || path.length < 2) {
+        showNotification('No path to that destination.', 'warning');
+      } else {
+        gameState = {
+          ...gameState,
+          units: {
+            ...gameState.units,
+            [pendingJourneyUnitId]: { ...unit, automation: { mode: 'journey', destination: coord } },
+          },
+        };
+        renderLoop.setGameState(gameState);
+        selectUnit(pendingJourneyUnitId);
+        showNotification('Journey set. Your unit will advance each turn.', 'info');
+      }
+    }
+    pendingJourneyUnitId = null;
+    return;
+  }
   const key = hexKey(coord);
 
   if (isUnitAnimationLocked(selectedUnitId)) {
@@ -2879,6 +2928,12 @@ bus.on('unit:obsolete', ({ civId, unitType }) => {
   appendToCivLog(civId, `Your ${name} is now obsolete — upgrade it in your home city.`, 'info');
 });
 
+bus.on('unit:journey-blocked', ({ unitId, position }) => {
+  const unit = gameState.units[unitId];
+  const type = unit ? UNIT_DEFINITIONS[unit.type]?.name ?? unit.type : 'Unit';
+  appendToCivLog(unit?.owner ?? gameState.currentPlayer, `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`, 'warning');
+});
+
 bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
   appendToCivLog(civId, `${spyName}'s network dissolved — ${unitType} era ended. No diplomatic penalty.`, 'info');
 });
@@ -3172,8 +3227,34 @@ function startGame(): void {
     installKeyboardShortcuts(document, {
       onOpenCouncil: () => togglePanel('council'),
       onOpenTech: () => togglePanel('tech'),
-      onEndTurn: () => {
-        void endTurn();
+      onEndTurn: () => { void endTurn(); },
+      getSelectedUnitId: () => selectedUnitId,
+      onCenterUnit: () => {
+        if (!selectedUnitId) return;
+        const unit = gameState.units[selectedUnitId];
+        if (unit) renderLoop.camera.centerOn(unit.position);
+      },
+      onFortify: () => {
+        if (!selectedUnitId) return;
+        const unit = gameState.units[selectedUnitId];
+        if (!unit || unit.hasActed || unit.owner !== gameState.currentPlayer) return;
+        gameState = fortifyUnitInState(gameState, gameState.currentPlayer, selectedUnitId);
+        showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        selectUnit(selectedUnitId);
+      },
+      onSettle: () => {
+        if (!selectedUnitId) return;
+        const unit = gameState.units[selectedUnitId];
+        if (!unit || unit.type !== 'settler') return;
+        foundCityAction();
+      },
+      onNextUnit: () => selectNextUnit(),
+      onStartJourney: () => {
+        if (!selectedUnitId) return;
+        pendingJourneyUnitId = selectedUnitId;
+        showNotification('Tap a destination for this unit. Press Escape to cancel.', 'info');
       },
     }, {
       canHandle: () => !uiInteractions.isInteractionBlocked(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1273,6 +1273,7 @@ function selectUnit(unitId: string): void {
         selectUnit(uid);
       },
       onCancelAutoExplore: () => cancelAutoExplore(unitId),
+      onCancelJourney: () => cancelJourney(unitId),
       onOpenStack: (coord) => {
         handleFriendlyUnitStackTap(gameState, coord, selectedUnitId, {
           onSelectUnit: selectUnit,
@@ -1466,6 +1467,7 @@ function deselectUnit(): void {
   selectedUnitId = null;
   movementRange = [];
   attackRange = [];
+  pendingJourneyUnitId = null;
   renderLoop.clearHighlights();
   renderLoop.setJourneyPath(null);
   const panel = document.getElementById('info-panel');
@@ -1570,6 +1572,21 @@ function cancelAutoExplore(unitId: string): void {
   if (!unit?.automation) return;
   delete gameState.units[unitId].automation;
   renderLoop.setGameState(gameState);
+  updateHUD();
+  if (selectedUnitId === unitId) {
+    selectUnit(unitId);
+  }
+}
+
+function cancelJourney(unitId: string): void {
+  const unit = gameState.units[unitId];
+  if (!unit?.automation) return;
+  gameState = {
+    ...gameState,
+    units: { ...gameState.units, [unitId]: { ...unit, automation: undefined } },
+  };
+  renderLoop.setGameState(gameState);
+  renderLoop.setJourneyPath(null);
   updateHUD();
   if (selectedUnitId === unitId) {
     selectUnit(unitId);
@@ -2931,7 +2948,9 @@ bus.on('unit:obsolete', ({ civId, unitType }) => {
 bus.on('unit:journey-blocked', ({ unitId, position }) => {
   const unit = gameState.units[unitId];
   const type = unit ? UNIT_DEFINITIONS[unit.type]?.name ?? unit.type : 'Unit';
-  appendToCivLog(unit?.owner ?? gameState.currentPlayer, `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`, 'warning');
+  const msg = `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`;
+  showNotification(msg, 'warning');
+  appendToCivLog(unit?.owner ?? gameState.currentPlayer, msg, 'warning');
 });
 
 bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
@@ -3238,8 +3257,13 @@ function startGame(): void {
         if (!selectedUnitId) return;
         const unit = gameState.units[selectedUnitId];
         if (!unit || unit.hasActed || unit.owner !== gameState.currentPlayer) return;
-        gameState = fortifyUnitInState(gameState, gameState.currentPlayer, selectedUnitId);
-        showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+        if (unit.isFortified) {
+          gameState = unfortifyUnitInState(gameState, gameState.currentPlayer, selectedUnitId);
+          showNotification('Unit unfortified.', 'info');
+        } else {
+          gameState = fortifyUnitInState(gameState, gameState.currentPlayer, selectedUnitId);
+          showNotification('Unit fortified. +25% defense until unfortified or moved.', 'info');
+        }
         renderLoop.setGameState(gameState);
         updateHUD();
         selectUnit(selectedUnitId);

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -1,4 +1,6 @@
 import type { GameState, HexCoord } from '@/core/types';
+
+const CITY_ICON_EMOJI_Y_NUDGE_RATIO = 0.08;
 import { hexToPixel } from '@/systems/hex-utils';
 import { getVisibility } from '@/systems/fog-of-war';
 import { getOccupiedCityMood } from '@/systems/city-occupation-system';
@@ -124,9 +126,9 @@ export function drawCities(
         const icon = def?.archetype === 'militaristic' ? '⚔️'
           : def?.archetype === 'mercantile' ? '🪙'
           : '📜';
-        ctx.fillText(icon, screen.x, screen.y);
+        ctx.fillText(icon, screen.x, screen.y + size * CITY_ICON_EMOJI_Y_NUDGE_RATIO);
       } else {
-        ctx.fillText('🏛️', screen.x, screen.y);
+        ctx.fillText('🏛️', screen.x, screen.y + size * CITY_ICON_EMOJI_Y_NUDGE_RATIO);
       }
 
       // City name + population below

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -45,6 +45,7 @@ export class RenderLoop {
   private running = false;
   private animFrameId = 0;
   private highlights: HexHighlight[] = [];
+  private journeyPath: HexCoord[] | null = null;
   private unitMovementAnimations: Array<UnitMovementAnimation & { startTime: number; onComplete?: () => void }> = [];
 
   setHighlights(highlights: HexHighlight[]): void {
@@ -53,6 +54,10 @@ export class RenderLoop {
 
   clearHighlights(): void {
     this.highlights = [];
+  }
+
+  setJourneyPath(path: HexCoord[] | null): void {
+    this.journeyPath = path;
   }
 
   requestWonderDiscoveryHighlight(
@@ -193,6 +198,24 @@ export class RenderLoop {
         const color = HEX_HIGHLIGHT_COLORS[highlight.type];
         drawHexHighlight(this.ctx, screen.x, screen.y, scaledSize, color);
       }
+    }
+
+    // Draw journey path overlay
+    if (this.journeyPath && this.journeyPath.length >= 2) {
+      this.ctx.save();
+      this.ctx.strokeStyle = 'rgba(255, 200, 50, 0.8)';
+      this.ctx.lineWidth = 3;
+      this.ctx.setLineDash([6, 4]);
+      this.ctx.beginPath();
+      let started = false;
+      for (const coord of this.journeyPath) {
+        const pixel = hexToPixel(coord, this.camera.hexSize);
+        const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+        if (!started) { this.ctx.moveTo(screen.x, screen.y); started = true; }
+        else { this.ctx.lineTo(screen.x, screen.y); }
+      }
+      this.ctx.stroke();
+      this.ctx.restore();
     }
 
     // Draw cities

--- a/src/systems/auto-explore-system.ts
+++ b/src/systems/auto-explore-system.ts
@@ -57,7 +57,7 @@ function rankCandidate(state: GameState, unitId: string, coord: HexCoord): { sco
   const visibility = getVisibility(viewer.visibility, coord);
   const visibilityScore = visibility === 'unexplored' ? 200 : visibility === 'fog' ? 100 : 0;
   const frontierScore = countUnexploredNeighbors(state, unit.owner, coord) * 10;
-  const recencyPenalty = unit.automation?.lastTargets.includes(hexKey(coord)) ? 500 : 0;
+  const recencyPenalty = unit.automation?.mode === 'auto-explore' && unit.automation.lastTargets.includes(hexKey(coord)) ? 500 : 0;
   const tieBreaker = (coord.r * 100) + coord.q;
 
   return {

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -27,6 +27,7 @@ export interface SelectedUnitInfoCallbacks {
   onDeleteUnit?: (unitId: string) => void;
   onFortify?: (unitId: string) => void;
   onCancelAutoExplore?: () => void;
+  onCancelJourney?: () => void;
   onSetDisguise?: (unitId: string, disguise: DisguiseType | null) => void;
   onInfiltrate?: (unitId: string) => void;
   onEmbed?: (unitId: string) => void;
@@ -157,6 +158,19 @@ export function renderSelectedUnitInfo(
     statusRow.appendChild(statusText);
     if (callbacks.onCancelAutoExplore) {
       statusRow.appendChild(makeButton('Cancel auto-explore', '#0f766e', callbacks.onCancelAutoExplore));
+    }
+    wrapper.appendChild(statusRow);
+  }
+
+  if (unit.automation?.mode === 'journey') {
+    const { q, r } = unit.automation.destination;
+    const statusRow = document.createElement('div');
+    statusRow.style.cssText = 'margin-top:8px;font-size:12px;color:#fcd34d;display:flex;justify-content:space-between;align-items:center;gap:8px;';
+    const statusText = document.createElement('span');
+    statusText.textContent = `Journeying to (${q}, ${r})`;
+    statusRow.appendChild(statusText);
+    if (callbacks.onCancelJourney) {
+      statusRow.appendChild(makeButton('Cancel journey', '#b45309', callbacks.onCancelJourney));
     }
     wrapper.appendChild(statusRow);
   }

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1,7 +1,7 @@
 import { processTurn } from '@/core/turn-manager';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
-import type { CustomCivDefinition, GameState, UnitType } from '@/core/types';
+import type { CustomCivDefinition, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { foundCity } from '@/systems/city-system';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
@@ -15,6 +15,7 @@ import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 import { createUnit } from '@/systems/unit-system';
+import { createTechState } from '@/systems/tech-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -912,5 +913,116 @@ describe('espionage post-loop snapshot', () => {
     // The spy city-vision section makes the tile 'visible'; the post-espionage snapshot
     // must have captured its terrain before processTurn returns.
     expect(result.civilizations.player.visibility.lastSeen?.[tileKey]?.terrain).toBe('desert');
+  });
+});
+
+describe('journey automation', () => {
+  function makeJourneyFixture(start: HexCoord, destination: HexCoord): { state: GameState; unitId: string } {
+    const map = createWrappedGrasslandMap(6, 3);
+    map.wrapsHorizontally = false;
+
+    const unit: Unit = {
+      id: 'scout-1',
+      type: 'scout',
+      owner: 'player',
+      position: start,
+      movementPointsLeft: 3,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+      automation: { mode: 'journey', destination },
+    };
+
+    const civ = {
+      id: 'player',
+      name: 'Player',
+      color: '#4a90d9',
+      isHuman: true,
+      civType: 'generic' as const,
+      cities: [],
+      units: ['scout-1'],
+      techState: createTechState(),
+      gold: 0,
+      visibility: {
+        tiles: Object.fromEntries(
+          Object.keys(map.tiles).map(k => [k, 'visible' as const]),
+        ),
+      },
+      knownCivilizations: [],
+      score: 0,
+      diplomacy: createDiplomacyState(['player'], 'player'),
+    };
+
+    const state: GameState = {
+      turn: 1,
+      era: 1,
+      gameId: 'journey-test',
+      gameTitle: 'Journey Test',
+      civilizations: { player: civ },
+      map,
+      units: { 'scout-1': unit },
+      cities: {},
+      barbarianCamps: {},
+      minorCivs: {},
+      tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+      currentPlayer: 'player',
+      gameOver: false,
+      winner: null,
+      settings: {
+        mapSize: 'small', soundEnabled: false, musicEnabled: false,
+        musicVolume: 0, sfxVolume: 0, tutorialEnabled: false,
+        advisorsEnabled: {
+          builder: true, explorer: true, chancellor: true, warchief: true,
+          treasurer: true, scholar: true, spymaster: true, artisan: true,
+        },
+        councilTalkLevel: 'normal',
+      },
+      tribalVillages: {},
+      discoveredWonders: {},
+      wonderDiscoverers: {},
+      embargoes: [],
+      defensiveLeagues: [],
+      idCounters: { nextUnitId: 2, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    };
+
+    return { state, unitId: 'scout-1' };
+  }
+
+  it('advances unit one step toward destination each turn', () => {
+    const { state, unitId } = makeJourneyFixture({ q: 0, r: 1 }, { q: 3, r: 1 });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    const unit = result.units[unitId];
+    expect(unit).toBeDefined();
+    expect(unit!.position.q).toBeGreaterThan(0);
+    expect(unit!.automation).toBeDefined();
+  });
+
+  it('clears automation when destination is reached', () => {
+    const { state, unitId } = makeJourneyFixture({ q: 0, r: 1 }, { q: 1, r: 1 });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    const unit = result.units[unitId];
+    expect(unit!.position).toEqual({ q: 1, r: 1 });
+    expect(unit!.automation).toBeUndefined();
+  });
+
+  it('emits unit:journey-blocked and clears automation when path is unreachable', () => {
+    const { state, unitId } = makeJourneyFixture({ q: 0, r: 1 }, { q: 5, r: 1 });
+    // Block all paths by making intermediate tiles mountains
+    state.map.tiles['1,1'] = { ...state.map.tiles['1,1']!, terrain: 'mountain' };
+    state.map.tiles['1,0'] = { ...state.map.tiles['1,0']!, terrain: 'mountain' };
+    state.map.tiles['1,2'] = { ...state.map.tiles['1,2']!, terrain: 'mountain' };
+
+    const bus = new EventBus();
+    const blockedEvents: { unitId: string }[] = [];
+    bus.on('unit:journey-blocked', (payload) => blockedEvents.push(payload));
+
+    const result = processTurn(state, bus);
+    expect(blockedEvents).toHaveLength(1);
+    expect(blockedEvents[0].unitId).toBe(unitId);
+    expect(result.units[unitId]!.automation).toBeUndefined();
   });
 });

--- a/tests/input/keyboard-shortcuts.test.ts
+++ b/tests/input/keyboard-shortcuts.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { installKeyboardShortcuts, type KeyboardShortcutCallbacks } from '@/input/keyboard-shortcuts';
+
+function fire(key: string) {
+  document.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+}
+
+function makeCallbacks(overrides: Partial<KeyboardShortcutCallbacks> = {}): KeyboardShortcutCallbacks {
+  return {
+    onOpenCouncil: vi.fn(),
+    onOpenTech: vi.fn(),
+    onEndTurn: vi.fn(),
+    onCenterUnit: vi.fn(),
+    onFortify: vi.fn(),
+    onSettle: vi.fn(),
+    onNextUnit: vi.fn(),
+    onStartJourney: vi.fn(),
+    getSelectedUnitId: vi.fn(() => null),
+    ...overrides,
+  };
+}
+
+describe('existing shortcuts', () => {
+  beforeEach(() => {
+    // Remove all keydown listeners by replacing document with a fresh one isn't possible in jsdom.
+    // Instead each test installs its own handler.
+  });
+
+  it('t opens tech panel', () => {
+    const cb = makeCallbacks();
+    installKeyboardShortcuts(document, cb);
+    fire('t');
+    expect(cb.onOpenTech).toHaveBeenCalledOnce();
+  });
+
+  it('e calls onEndTurn', () => {
+    const cb = makeCallbacks();
+    installKeyboardShortcuts(document, cb);
+    fire('e');
+    expect(cb.onEndTurn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('new unit hotkeys', () => {
+  it('n calls onNextUnit regardless of selected unit', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => null) });
+    installKeyboardShortcuts(document, cb);
+    fire('n');
+    expect(cb.onNextUnit).toHaveBeenCalledOnce();
+  });
+
+  it('c calls onCenterUnit when a unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => 'unit-1') });
+    installKeyboardShortcuts(document, cb);
+    fire('c');
+    expect(cb.onCenterUnit).toHaveBeenCalledOnce();
+    expect(cb.onOpenCouncil).not.toHaveBeenCalled();
+  });
+
+  it('c opens council when no unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => null) });
+    installKeyboardShortcuts(document, cb);
+    fire('c');
+    expect(cb.onOpenCouncil).toHaveBeenCalledOnce();
+    expect(cb.onCenterUnit).not.toHaveBeenCalled();
+  });
+
+  it('f calls onFortify when a unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => 'unit-1') });
+    installKeyboardShortcuts(document, cb);
+    fire('f');
+    expect(cb.onFortify).toHaveBeenCalledOnce();
+  });
+
+  it('f does nothing when no unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => null) });
+    installKeyboardShortcuts(document, cb);
+    fire('f');
+    expect(cb.onFortify).not.toHaveBeenCalled();
+  });
+
+  it('b calls onSettle when a unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => 'settler-1') });
+    installKeyboardShortcuts(document, cb);
+    fire('b');
+    expect(cb.onSettle).toHaveBeenCalledOnce();
+  });
+
+  it('b does nothing when no unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => null) });
+    installKeyboardShortcuts(document, cb);
+    fire('b');
+    expect(cb.onSettle).not.toHaveBeenCalled();
+  });
+
+  it('g calls onStartJourney when a unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => 'unit-1') });
+    installKeyboardShortcuts(document, cb);
+    fire('g');
+    expect(cb.onStartJourney).toHaveBeenCalledOnce();
+  });
+
+  it('g does nothing when no unit is selected', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => null) });
+    installKeyboardShortcuts(document, cb);
+    fire('g');
+    expect(cb.onStartJourney).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when typing in an input field', () => {
+    const cb = makeCallbacks({ getSelectedUnitId: vi.fn(() => 'unit-1') });
+    installKeyboardShortcuts(document, cb);
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'n', bubbles: true }));
+    expect(cb.onNextUnit).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -753,6 +753,61 @@ describe('renderSelectedUnitInfo - found city button', () => {
   });
 });
 
+describe('renderSelectedUnitInfo - journey automation', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  function makeScoutState(unitOverrides: Record<string, unknown> = {}): GameState {
+    return {
+      turn: 1, era: 1, currentPlayer: 'player', gameOver: false, winner: null,
+      map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+      units: {
+        'scout-1': { id: 'scout-1', type: 'scout', owner: 'player', position: { q: 0, r: 0 }, health: 100, experience: 0, movementPointsLeft: 3, hasMoved: false, hasActed: false, isResting: false, ...unitOverrides },
+      },
+      cities: {},
+      civilizations: { player: { color: '#fff', techState: { completed: [] } } },
+    } as unknown as GameState;
+  }
+
+  it('shows journey destination text when unit has journey automation', () => {
+    const state = makeScoutState({ automation: { mode: 'journey', destination: { q: 5, r: 3 } } });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'scout-1', {});
+    const texts = collectAllText(container);
+    expect(texts.some(t => t.includes('5') && t.includes('3'))).toBe(true);
+    expect(texts.some(t => t.toLowerCase().includes('journey'))).toBe(true);
+  });
+
+  it('does not show journey status for a unit without automation', () => {
+    const state = makeScoutState();
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'scout-1', {});
+    const texts = collectAllText(container);
+    expect(texts.some(t => t.toLowerCase().includes('journey'))).toBe(false);
+  });
+
+  it('renders Cancel journey button when onCancelJourney is provided', () => {
+    const state = makeScoutState({ automation: { mode: 'journey', destination: { q: 5, r: 3 } } });
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'scout-1', {
+      onCancelJourney: () => {},
+    });
+    const btns = findButtons(container).map(b => b.textContent);
+    expect(btns.some(t => t?.toLowerCase().includes('cancel') && t?.toLowerCase().includes('journey'))).toBe(true);
+  });
+
+  it('fires onCancelJourney when cancel button is clicked', () => {
+    const state = makeScoutState({ automation: { mode: 'journey', destination: { q: 5, r: 3 } } });
+    const container = new MockElement('div');
+    let cancelled = false;
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'scout-1', {
+      onCancelJourney: () => { cancelled = true; },
+    });
+    findButtons(container).find(b => b.textContent?.toLowerCase().includes('cancel') && b.textContent?.toLowerCase().includes('journey'))?.click();
+    expect(cancelled).toBe(true);
+  });
+});
+
 describe('renderSelectedUnitInfo - fortify button', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);


### PR DESCRIPTION
## Summary

- **#276 — City icon centering:** Apply a `CITY_ICON_EMOJI_Y_NUDGE_RATIO = 0.08` vertical offset to the main city icon emoji only. Canvas `textBaseline = 'middle'` aligns to x-height midpoint which creates an upward visual bias for emoji. Corner badges (⛓, 👑, ☹, ⚡, 🔥, production icons) are unaffected.
- **#279 — Keyboard hotkeys:** Context-aware `c` key (center on selected unit if one is selected, otherwise open council). New keys `f` (fortify), `b` (settle), `n` (next unit), `g` (start journey) — `f`/`b`/`g` only fire when a unit is selected.
- **#279 — Multi-turn journey automation:** `g` key enters journey mode; player taps destination hex. Unit advances one step per turn via `findPath`, auto-stops on arrival. Emits `unit:journey-blocked` if path becomes blocked. Dashed yellow overlay shows the current planned path when a journey unit is selected. Manually moving a unit cancels its journey.

## Test plan

- [x] `tests/input/keyboard-shortcuts.test.ts` — all new hotkey behaviors including context-awareness
- [x] `tests/core/turn-manager.test.ts` — journey automation: advances toward destination, clears on arrival, emits blocked event when path obstructed
- [x] `yarn test` — 2740/2740 pass
- [x] `yarn build` — TypeScript clean

## Why this is safe to merge

Every player-visible surface introduced here has complete end-to-end wiring:
- City icon centering is purely visual; no state changes.
- All new hotkeys delegate to existing actions (`onFortify`, `onSettle`, `selectNextUnit`) — no new dead-end UX.
- Journey automation is fully wired: set via `g`→tap, rendered via dashed overlay, processed in turn-manager, cancelled on manual move, notifies player on block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)