### PR TITLE
Stage 2G legendary city landmarks

### DIFF
--- a/docs/superpowers/plans/2026-05-26-stage-2g-legendary-city-landmarks.md
+++ b/docs/superpowers/plans/2026-05-26-stage-2g-legendary-city-landmarks.md
@@ -1,0 +1,1421 @@
+# Stage 2G Legendary City Landmarks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an authored, convention-tested legendary city landmark system with richer owned completed landmarks, late-construction ghosts, overflow rotation, and compact city/Codex previews.
+
+**Architecture:** Replace hash-based legendary visual assignment with explicit landmark metadata and validation helpers. Keep gameplay state unchanged; derive viewer-safe map/panel/Codex presentation models from existing completed wonders and owned projects. Render through token adapters now, with optional future `assetKey`/bespoke renderer hooks for Stage 2I.
+
+**Tech Stack:** TypeScript, Canvas 2D renderer, DOM UI panels, Vite, Vitest, jsdom UI tests, existing `./scripts/run-with-mise.sh yarn ...` wrapper.
+
+---
+
+## Source Spec
+
+Implement exactly from:
+
+- `docs/superpowers/specs/2026-05-26-stage-2g-legendary-city-landmarks-design.md`
+- Roadmap context: `docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md`
+
+Rules to read before editing:
+
+- `CLAUDE.md`
+- `.claude/rules/game-systems.md`
+- `.claude/rules/ui-panels.md`
+- `.claude/rules/strategy-game-mechanics.md`
+- `.claude/rules/end-to-end-wiring.md`
+- `.claude/rules/spec-fidelity.md`
+- `.claude/rules/incremental-mr-completion.md`
+- `docs/superpowers/plans/README.md`
+
+## File Structure
+
+- Create `src/systems/legendary-wonder-landmark-types.ts`
+  - Shared metadata, token, render-entry, and preview view-model types.
+- Create `src/systems/legendary-wonder-landmark-catalog.ts`
+  - Explicit metadata for every current legendary wonder.
+  - Catalog-adjacent authoring guide comment.
+- Create `src/systems/legendary-wonder-landmark-validation.ts`
+  - Coverage, duplicate, unknown-token, and renderer-support helpers for tests.
+- Modify `src/systems/wonder-visual-catalog.ts`
+  - Remove hash-based legendary landmark assignment for known legendary wonders.
+  - Pull explicit family fallback from landmark metadata only.
+- Modify `src/systems/legendary-wonder-map-presentation.ts`
+  - Return owned completed entries and owned late-construction ghost entries.
+  - Keep relationship-aware shape but produce only `relationship: 'owned'` in 2G.
+- Create `src/systems/legendary-wonder-landmark-presentation.ts`
+  - City/Codex/inspection preview helpers, completion grouping, overflow windowing, and active ghost eligibility.
+- Modify `src/renderer/wonders/legendary-wonder-slots.ts`
+  - Add 5-turn overflow windowing and stable `+N`.
+- Modify `src/renderer/wonders/legendary-wonder-renderer.ts`
+  - Render token-driven completed landmarks and ghost scaffolds.
+  - Export renderer support tables for tests.
+- Modify `src/renderer/city-renderer.ts`
+  - Targeted landmark layer extraction and explicit draw ordering.
+- Modify `src/ui/territory-inspection-panel.ts`
+  - Use helper so inspection lists all owned completed city landmarks.
+- Modify `src/ui/city-panel.ts`
+  - Add compact city landmark preview.
+- Modify `src/systems/wonder-codex/presentation.ts`
+  - Add owned landmark preview to page view model.
+- Modify `src/ui/wonder-codex-page.ts`
+  - Render compact owned landmark preview.
+- Add/modify tests:
+  - `tests/systems/legendary-wonder-landmark-catalog.test.ts`
+  - `tests/systems/legendary-wonder-map-presentation.test.ts`
+  - `tests/systems/wonder-codex/presentation.test.ts`
+  - `tests/renderer/legendary-wonder-renderer.test.ts`
+  - `tests/renderer/city-renderer.test.ts`
+  - `tests/ui/territory-inspection-panel.test.ts`
+  - `tests/ui/city-panel.test.ts`
+  - `tests/ui/wonder-codex-page.test.ts`
+
+## Player Truth Table
+
+| Before | Player action | Immediate visible result | Must remain reachable |
+|---|---|---|---|
+| Owned visible city has one completed legendary wonder | View map | Solid landmark medallion appears around city | City selection, unit selection, labels, production badge |
+| Owned visible city has active legendary at 59% | View map | No map ghost | City panel still shows active construction preview |
+| Owned visible city has active legendary at 60%+ | View map | Faint `Under construction` ghost/scaffold appears | It is not counted as completed |
+| Owned city has 8 completed legendary wonders | View map on turn 9 | Five landmarks plus `+3`; visible five chosen by 5-turn window | Inspection/city/Codex list all 8 |
+| Same city, turn advances to 10 | View map | Visible five rotate deterministically | `+3` remains stable |
+| Rival completed wonder known only through 2F completed intel | Open map/Codex | No map landmark, no host city preview | Rival journal remains safe text only |
+| Reduced motion enabled | View map/Codex/city preview | Static landmark/ghost, no pulse/glint | All names and actions remain readable |
+
+## Misleading UI Risks
+
+- `Completed landmark` means an owned completed legendary wonder exists in `completedLegendaryWonders` for the viewer and the host city is safely visible/owned for the surface.
+- `Under construction` ghost means an owned building-phase project exists in that host city. On the map it additionally requires `progressRatio >= 0.6`.
+- `+N` means additional completed owned landmarks in the same city, not active ghosts and not rival intel.
+- `Known rival completed` from Stage 2F must not imply map location, host city, or landmark visibility.
+- The city/Codex preview must not read rival city/project objects to enrich rival pages.
+- The renderer may have a defensive unknown-ID fallback, but tests must fail for missing metadata on real legendary definitions.
+
+## Interaction Replay Checklist
+
+- Open map with one completed owned wonder.
+- Open map with active project below 60%, then at 60%+.
+- Render a city with 7+ completed wonders at turns 0, 4, 5, 9, and 10.
+- Open territory inspection for an overflow city and confirm every completed wonder name is listed.
+- Open city panel and confirm completed plus active ghost previews render without hiding existing production controls.
+- Open owned completed Codex page and confirm compact preview renders; open rival intel Codex page and confirm no landmark preview.
+- Reopen/render for another hot-seat viewer and confirm prior viewer landmarks disappear.
+
+---
+
+## Task 1: Add Explicit Landmark Metadata And Validation
+
+**Files:**
+- Create: `src/systems/legendary-wonder-landmark-types.ts`
+- Create: `src/systems/legendary-wonder-landmark-catalog.ts`
+- Create: `src/systems/legendary-wonder-landmark-validation.ts`
+- Modify: `src/systems/wonder-visual-catalog.ts`
+- Test: `tests/systems/legendary-wonder-landmark-catalog.test.ts`
+
+- [ ] **Step 1: Write failing catalog contract tests**
+
+Create `tests/systems/legendary-wonder-landmark-catalog.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import {
+  getLegendaryWonderLandmarkMetadata,
+  getLegendaryWonderLandmarkMetadataCatalog,
+} from '@/systems/legendary-wonder-landmark-catalog';
+import {
+  validateLegendaryWonderLandmarkCatalog,
+  validateLegendaryWonderLandmarkRendererSupport,
+} from '@/systems/legendary-wonder-landmark-validation';
+import {
+  CANVAS_LEGENDARY_LANDMARK_AURAS,
+  CANVAS_LEGENDARY_LANDMARK_FAMILIES,
+  CANVAS_LEGENDARY_LANDMARK_GHOSTS,
+  CANVAS_LEGENDARY_LANDMARK_MOTIFS,
+  CANVAS_LEGENDARY_LANDMARK_MOTIONS,
+  CANVAS_LEGENDARY_LANDMARK_VARIANTS,
+} from '@/renderer/wonders/legendary-wonder-renderer';
+
+describe('legendary wonder landmark catalog', () => {
+  it('has explicit metadata for every current legendary wonder and no extras', () => {
+    const definitionIds = getLegendaryWonderDefinitions().map(definition => definition.id).sort();
+    const metadataIds = getLegendaryWonderLandmarkMetadataCatalog().map(entry => entry.wonderId).sort();
+
+    expect(metadataIds).toEqual(definitionIds);
+    expect(validateLegendaryWonderLandmarkCatalog()).toEqual([]);
+  });
+
+  it('does not use hash-based landmark identity for known legendary wonders', () => {
+    const oracle = getLegendaryWonderLandmarkMetadata('oracle-of-delphi');
+    const canal = getLegendaryWonderLandmarkMetadata('grand-canal');
+
+    expect(oracle.family).toBe('oracle');
+    expect(canal.family).toBe('waterworks');
+    expect(getWonderVisualDefinition('oracle-of-delphi').legendaryLandmark).toBe(oracle.family);
+    expect(getWonderVisualDefinition('grand-canal').legendaryLandmark).toBe(canal.family);
+  });
+
+  it('declares only renderer-supported family, variant, motif, aura, motion, and ghost tokens', () => {
+    expect(validateLegendaryWonderLandmarkRendererSupport({
+      families: CANVAS_LEGENDARY_LANDMARK_FAMILIES,
+      variants: CANVAS_LEGENDARY_LANDMARK_VARIANTS,
+      motifs: CANVAS_LEGENDARY_LANDMARK_MOTIFS,
+      auras: CANVAS_LEGENDARY_LANDMARK_AURAS,
+      motions: CANVAS_LEGENDARY_LANDMARK_MOTIONS,
+      ghosts: CANVAS_LEGENDARY_LANDMARK_GHOSTS,
+    })).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-landmark-catalog.test.ts
+```
+
+Expected: FAIL because `legendary-wonder-landmark-catalog` and validation modules do not exist.
+
+- [ ] **Step 3: Add shared landmark types**
+
+Create `src/systems/legendary-wonder-landmark-types.ts`:
+
+```ts
+export const LEGENDARY_LANDMARK_FAMILIES = [
+  'oracle',
+  'waterworks',
+  'spire',
+  'archive',
+  'garden',
+  'foundry',
+  'bastion',
+  'observatory',
+  'exchange',
+  'hall',
+  'gateway',
+  'drydock',
+  'signal',
+  'laboratory',
+  'network',
+] as const;
+
+export type LegendaryLandmarkFamily = typeof LEGENDARY_LANDMARK_FAMILIES[number];
+
+export const LEGENDARY_LANDMARK_VARIANTS = ['standard', 'wide', 'tall', 'compact'] as const;
+export type LegendaryLandmarkVariant = typeof LEGENDARY_LANDMARK_VARIANTS[number];
+
+export const LEGENDARY_LANDMARK_MOTIFS = [
+  'prophecy',
+  'canal',
+  'sun',
+  'knowledge',
+  'moon',
+  'forge',
+  'tide',
+  'stars',
+  'trade',
+  'victory',
+  'horizon',
+  'shipwright',
+  'signal',
+  'atom',
+  'network',
+] as const;
+export type LegendaryLandmarkMotif = typeof LEGENDARY_LANDMARK_MOTIFS[number];
+
+export const LEGENDARY_LANDMARK_AURAS = ['none', 'dedicationGlow', 'civicAura', 'foundationPulse'] as const;
+export type LegendaryLandmarkAura = typeof LEGENDARY_LANDMARK_AURAS[number];
+
+export const LEGENDARY_LANDMARK_MOTIONS = ['none', 'pulse', 'glint', 'spark'] as const;
+export type LegendaryLandmarkMotion = typeof LEGENDARY_LANDMARK_MOTIONS[number];
+
+export const LEGENDARY_LANDMARK_GHOSTS = ['scaffold', 'foundation', 'outline'] as const;
+export type LegendaryLandmarkGhost = typeof LEGENDARY_LANDMARK_GHOSTS[number];
+
+export interface LegendaryWonderLandmarkMetadata {
+  wonderId: string;
+  family: LegendaryLandmarkFamily;
+  variant: LegendaryLandmarkVariant;
+  motif: LegendaryLandmarkMotif;
+  palette: {
+    base: string;
+    accent: string;
+    glow: string;
+  };
+  scale: number;
+  aura: LegendaryLandmarkAura;
+  motion: LegendaryLandmarkMotion;
+  constructionGhost: LegendaryLandmarkGhost;
+  assetKey?: string;
+}
+
+export type LegendaryWonderLandmarkRelationship = 'owned' | 'known-rival';
+export type LegendaryWonderLandmarkState = 'completed' | 'under-construction';
+
+export interface LegendaryWonderLandmarkView {
+  wonderId: string;
+  label: string;
+  cityId: string;
+  turnCompleted?: number;
+  relationship: LegendaryWonderLandmarkRelationship;
+  state: LegendaryWonderLandmarkState;
+  metadata: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
+}
+```
+
+- [ ] **Step 4: Add explicit catalog and authoring guide**
+
+Create `src/systems/legendary-wonder-landmark-catalog.ts`:
+
+```ts
+import type { LegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-types';
+
+/*
+ * Legendary landmark authoring guide:
+ * - Add exactly one metadata entry for each legendary wonder definition.
+ * - Do not use hash/random assignment for known wonders.
+ * - Pick domain tokens from legendary-wonder-landmark-types.ts only.
+ * - Keep this catalog presentation-only: no rewards, costs, requirements, quests, or AI values.
+ * - For future bespoke art, add assetKey only after a renderer/asset registry supports it.
+ * - Run tests/systems/legendary-wonder-landmark-catalog.test.ts before merge.
+ */
+const LEGENDARY_WONDER_LANDMARK_METADATA: Record<string, LegendaryWonderLandmarkMetadata> = {
+  'oracle-of-delphi': landmark('oracle-of-delphi', 'oracle', 'tall', 'prophecy', '#2f2943', '#d8c47a', '#fff0b8', 1.02, 'dedicationGlow', 'glint', 'outline'),
+  'grand-canal': landmark('grand-canal', 'waterworks', 'wide', 'canal', '#173c52', '#74d0ff', '#c8f3ff', 1.05, 'civicAura', 'pulse', 'foundation'),
+  'sun-spire': landmark('sun-spire', 'spire', 'tall', 'sun', '#46311f', '#f2c45d', '#fff1a6', 1.08, 'dedicationGlow', 'glint', 'scaffold'),
+  'world-archive': landmark('world-archive', 'archive', 'wide', 'knowledge', '#263044', '#b9c7ff', '#edf0ff', 1.0, 'civicAura', 'pulse', 'outline'),
+  'moonwell-gardens': landmark('moonwell-gardens', 'garden', 'wide', 'moon', '#203b34', '#9fd7a0', '#def7bf', 1.0, 'civicAura', 'spark', 'foundation'),
+  'ironroot-foundry': landmark('ironroot-foundry', 'foundry', 'compact', 'forge', '#3a2b26', '#e08b52', '#ffd2a0', 1.04, 'foundationPulse', 'pulse', 'scaffold'),
+  'tidecaller-bastion': landmark('tidecaller-bastion', 'bastion', 'wide', 'tide', '#18364b', '#7ec7e8', '#cff5ff', 1.03, 'civicAura', 'glint', 'outline'),
+  'starvault-observatory': landmark('starvault-observatory', 'observatory', 'tall', 'stars', '#252d4d', '#a8b9ff', '#f1f4ff', 1.06, 'dedicationGlow', 'spark', 'scaffold'),
+  'whispering-exchange': landmark('whispering-exchange', 'exchange', 'wide', 'trade', '#342c3f', '#e0bc72', '#fff0c4', 0.98, 'civicAura', 'glint', 'foundation'),
+  'hall-of-champions': landmark('hall-of-champions', 'hall', 'wide', 'victory', '#3a2931', '#e4aa62', '#ffe0a8', 1.03, 'dedicationGlow', 'pulse', 'outline'),
+  'gate-of-the-world': landmark('gate-of-the-world', 'gateway', 'wide', 'horizon', '#24364a', '#9fd3e8', '#e0f8ff', 1.06, 'civicAura', 'glint', 'scaffold'),
+  'leviathan-drydock': landmark('leviathan-drydock', 'drydock', 'wide', 'shipwright', '#23384d', '#80bfe2', '#c8eeff', 1.06, 'foundationPulse', 'pulse', 'foundation'),
+  'storm-signal-spire': landmark('storm-signal-spire', 'signal', 'tall', 'signal', '#202943', '#b7c7ff', '#f1f5ff', 1.08, 'dedicationGlow', 'spark', 'scaffold'),
+  'manhattan-project': landmark('manhattan-project', 'laboratory', 'compact', 'atom', '#31313c', '#d2d8e8', '#ffffff', 1.0, 'foundationPulse', 'pulse', 'outline'),
+  internet: landmark('internet', 'network', 'wide', 'network', '#202c3d', '#80d8ff', '#d9f8ff', 0.98, 'civicAura', 'spark', 'foundation'),
+};
+
+function landmark(
+  wonderId: string,
+  family: LegendaryWonderLandmarkMetadata['family'],
+  variant: LegendaryWonderLandmarkMetadata['variant'],
+  motif: LegendaryWonderLandmarkMetadata['motif'],
+  base: string,
+  accent: string,
+  glow: string,
+  scale: number,
+  aura: LegendaryWonderLandmarkMetadata['aura'],
+  motion: LegendaryWonderLandmarkMetadata['motion'],
+  constructionGhost: LegendaryWonderLandmarkMetadata['constructionGhost'],
+): LegendaryWonderLandmarkMetadata {
+  return {
+    wonderId,
+    family,
+    variant,
+    motif,
+    palette: { base, accent, glow },
+    scale,
+    aura,
+    motion,
+    constructionGhost,
+  };
+}
+
+export function getLegendaryWonderLandmarkMetadata(wonderId: string): LegendaryWonderLandmarkMetadata {
+  const metadata = LEGENDARY_WONDER_LANDMARK_METADATA[wonderId];
+  if (metadata) return { ...metadata, palette: { ...metadata.palette } };
+  return landmark(wonderId, 'spire', 'standard', 'knowledge', '#2b2633', '#e8c170', '#fff0b8', 1, 'none', 'none', 'outline');
+}
+
+export function getLegendaryWonderLandmarkMetadataCatalog(): LegendaryWonderLandmarkMetadata[] {
+  return Object.values(LEGENDARY_WONDER_LANDMARK_METADATA).map(metadata => ({
+    ...metadata,
+    palette: { ...metadata.palette },
+  }));
+}
+```
+
+- [ ] **Step 5: Add validation helpers**
+
+Create `src/systems/legendary-wonder-landmark-validation.ts`:
+
+```ts
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderLandmarkMetadataCatalog } from '@/systems/legendary-wonder-landmark-catalog';
+import {
+  LEGENDARY_LANDMARK_AURAS,
+  LEGENDARY_LANDMARK_FAMILIES,
+  LEGENDARY_LANDMARK_GHOSTS,
+  LEGENDARY_LANDMARK_MOTIFS,
+  LEGENDARY_LANDMARK_MOTIONS,
+  LEGENDARY_LANDMARK_VARIANTS,
+} from '@/systems/legendary-wonder-landmark-types';
+
+function missing(expected: string[], actual: string[], label: string): string[] {
+  return expected.filter(value => !actual.includes(value)).map(value => `Missing ${label}: ${value}`);
+}
+
+function unknown(actual: string[], expected: string[], label: string): string[] {
+  return actual.filter(value => !expected.includes(value)).map(value => `Unknown ${label}: ${value}`);
+}
+
+export function validateLegendaryWonderLandmarkCatalog(): string[] {
+  const definitionIds = getLegendaryWonderDefinitions().map(definition => definition.id);
+  const metadata = getLegendaryWonderLandmarkMetadataCatalog();
+  const metadataIds = metadata.map(entry => entry.wonderId);
+  const duplicateIds = metadataIds.filter((id, index) => metadataIds.indexOf(id) !== index);
+  const issues = [
+    ...missing(definitionIds, metadataIds, 'legendary landmark metadata'),
+    ...unknown(metadataIds, definitionIds, 'legendary landmark metadata'),
+    ...duplicateIds.map(id => `Duplicate legendary landmark metadata: ${id}`),
+  ];
+
+  for (const entry of metadata) {
+    if (!LEGENDARY_LANDMARK_FAMILIES.includes(entry.family)) issues.push(`Unknown family: ${entry.family}`);
+    if (!LEGENDARY_LANDMARK_VARIANTS.includes(entry.variant)) issues.push(`Unknown variant: ${entry.variant}`);
+    if (!LEGENDARY_LANDMARK_MOTIFS.includes(entry.motif)) issues.push(`Unknown motif: ${entry.motif}`);
+    if (!LEGENDARY_LANDMARK_AURAS.includes(entry.aura)) issues.push(`Unknown aura: ${entry.aura}`);
+    if (!LEGENDARY_LANDMARK_MOTIONS.includes(entry.motion)) issues.push(`Unknown motion: ${entry.motion}`);
+    if (!LEGENDARY_LANDMARK_GHOSTS.includes(entry.constructionGhost)) issues.push(`Unknown ghost: ${entry.constructionGhost}`);
+    if (entry.scale <= 0) issues.push(`Invalid scale: ${entry.wonderId}`);
+  }
+  return issues;
+}
+
+export function validateLegendaryWonderLandmarkRendererSupport(support: {
+  families: readonly string[];
+  variants: readonly string[];
+  motifs: readonly string[];
+  auras: readonly string[];
+  motions: readonly string[];
+  ghosts: readonly string[];
+}): string[] {
+  return [
+    ...missing([...LEGENDARY_LANDMARK_FAMILIES], [...support.families], 'canvas family support'),
+    ...missing([...LEGENDARY_LANDMARK_VARIANTS], [...support.variants], 'canvas variant support'),
+    ...missing([...LEGENDARY_LANDMARK_MOTIFS], [...support.motifs], 'canvas motif support'),
+    ...missing([...LEGENDARY_LANDMARK_AURAS], [...support.auras], 'canvas aura support'),
+    ...missing([...LEGENDARY_LANDMARK_MOTIONS], [...support.motions], 'canvas motion support'),
+    ...missing([...LEGENDARY_LANDMARK_GHOSTS], [...support.ghosts], 'canvas ghost support'),
+  ];
+}
+```
+
+- [ ] **Step 6: Temporarily export renderer support arrays**
+
+Modify `src/renderer/wonders/legendary-wonder-renderer.ts` near the imports:
+
+```ts
+import {
+  LEGENDARY_LANDMARK_AURAS,
+  LEGENDARY_LANDMARK_FAMILIES,
+  LEGENDARY_LANDMARK_GHOSTS,
+  LEGENDARY_LANDMARK_MOTIFS,
+  LEGENDARY_LANDMARK_MOTIONS,
+  LEGENDARY_LANDMARK_VARIANTS,
+} from '@/systems/legendary-wonder-landmark-types';
+
+export const CANVAS_LEGENDARY_LANDMARK_FAMILIES = LEGENDARY_LANDMARK_FAMILIES;
+export const CANVAS_LEGENDARY_LANDMARK_VARIANTS = LEGENDARY_LANDMARK_VARIANTS;
+export const CANVAS_LEGENDARY_LANDMARK_MOTIFS = LEGENDARY_LANDMARK_MOTIFS;
+export const CANVAS_LEGENDARY_LANDMARK_AURAS = LEGENDARY_LANDMARK_AURAS;
+export const CANVAS_LEGENDARY_LANDMARK_MOTIONS = LEGENDARY_LANDMARK_MOTIONS;
+export const CANVAS_LEGENDARY_LANDMARK_GHOSTS = LEGENDARY_LANDMARK_GHOSTS;
+```
+
+The actual drawing support is expanded in Task 3. This step makes catalog tests compile while still forcing metadata coverage.
+
+- [ ] **Step 7: Replace hash assignment in visual catalog**
+
+Modify `src/systems/wonder-visual-catalog.ts`:
+
+```ts
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import type { LegendaryLandmarkFamily } from '@/systems/legendary-wonder-landmark-types';
+```
+
+Change `LegendaryWonderLandmark`:
+
+```ts
+export type LegendaryWonderLandmark = LegendaryLandmarkFamily | 'masked';
+```
+
+Remove `LEGENDARY_LANDMARK_TYPES` and `landmarkTypeForLegendaryWonder`.
+
+In `LEGENDARY_WONDER_VISUALS`, replace `legendaryLandmark`:
+
+```ts
+const metadata = getLegendaryWonderLandmarkMetadata(definition.id);
+return [
+  definition.id,
+  {
+    id: definition.id,
+    kind: 'legendary',
+    medallionGlyph: '✦',
+    palette: metadata.palette,
+    mapLandmark: 'masked',
+    vignette: 'masked',
+    supportsAmbientAnimation: false,
+    reducedMotionFallback: 'static-medallion',
+    maskedLabel: 'Legendary wonder',
+    legendaryLandmark: metadata.family,
+  } satisfies WonderVisualDefinition,
+];
+```
+
+- [ ] **Step 8: Run catalog tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-landmark-catalog.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/systems/legendary-wonder-landmark-types.ts src/systems/legendary-wonder-landmark-catalog.ts src/systems/legendary-wonder-landmark-validation.ts src/systems/wonder-visual-catalog.ts src/renderer/wonders/legendary-wonder-renderer.ts tests/systems/legendary-wonder-landmark-catalog.test.ts
+git commit -m "feat(wonders): add authored legendary landmark metadata"
+```
+
+## Task 2: Add Viewer-Safe Landmark Presentation And Overflow Rotation
+
+**Files:**
+- Create: `src/systems/legendary-wonder-landmark-presentation.ts`
+- Modify: `src/systems/legendary-wonder-map-presentation.ts`
+- Modify: `src/renderer/wonders/legendary-wonder-slots.ts`
+- Test: `tests/systems/legendary-wonder-map-presentation.test.ts`
+
+- [ ] **Step 1: Write failing presentation and privacy tests**
+
+Append to `tests/systems/legendary-wonder-map-presentation.test.ts`:
+
+```ts
+it('adds owned active construction ghosts only at final-works progress on visible owned cities', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  state.currentPlayer = 'player';
+  state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+  state.cities['city-river'].productionProgress = 72;
+  state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+  state.legendaryWonderProjects = {
+    'oracle-of-delphi:player:city-river': {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'city-river',
+      phase: 'building',
+      investedProduction: 72,
+      transferableProduction: 0,
+      questSteps: [],
+    },
+  };
+
+  const entries = getLegendaryWonderMapEntries(state, 'player');
+
+  expect(entries).toContainEqual(expect.objectContaining({
+    wonderId: 'oracle-of-delphi',
+    relationship: 'owned',
+    state: 'under-construction',
+    progressRatio: 0.6,
+  }));
+});
+
+it('does not add map ghosts below final-works progress', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+  state.cities['city-river'].productionProgress = 71;
+  state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+  state.legendaryWonderProjects = {
+    'oracle-of-delphi:player:city-river': {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'city-river',
+      phase: 'building',
+      investedProduction: 71,
+      transferableProduction: 0,
+      questSteps: [],
+    },
+  };
+
+  expect(getLegendaryWonderMapEntries(state, 'player')
+    .some(entry => entry.state === 'under-construction')).toBe(false);
+});
+
+it('does not render rival landmarks from completed rival intel alone', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'rival', cityId: 'city-rival', turnCompleted: 20 },
+  };
+  state.legendaryWonderIntel = {
+    player: [{
+      kind: 'completed',
+      eventId: 'completed:oracle-of-delphi:rival:20',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      completionTurn: 20,
+      learnedTurn: 20,
+    }],
+  };
+  state.civilizations.player.visibility.tiles[hexKey(state.cities['city-rival'].position)] = 'visible';
+
+  expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
+});
+```
+
+Add slot tests in the same file or in a new `tests/renderer/legendary-wonder-slots.test.ts`:
+
+```ts
+import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
+
+it('rotates overflow windows every five turns while keeping a stable overflow count', () => {
+  const entries = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((wonderId, index) => ({
+    wonderId,
+    turnCompleted: index + 1,
+  }));
+
+  expect(assignLegendaryWonderSlots(entries, 4).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+    .toEqual(['a', 'b', 'c', 'd', 'e']);
+  expect(assignLegendaryWonderSlots(entries, 5).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+    .toEqual(['b', 'c', 'd', 'e', 'f']);
+  expect(assignLegendaryWonderSlots(entries, 10).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+    .toEqual(['c', 'd', 'e', 'f', 'g']);
+  expect(assignLegendaryWonderSlots(entries, 10).find(slot => slot.kind === 'overflow')).toMatchObject({
+    kind: 'overflow',
+    overflowCount: 3,
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts
+```
+
+Expected: FAIL because `state`, `progressRatio`, and rotation are not implemented.
+
+- [ ] **Step 3: Add presentation helper**
+
+Create `src/systems/legendary-wonder-landmark-presentation.ts`:
+
+```ts
+import type { City, GameState } from '@/core/types';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import type { LegendaryWonderLandmarkView } from '@/systems/legendary-wonder-landmark-types';
+
+export const LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD = 0.6;
+
+export function getCompletedLegendaryLandmarksForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkView[] {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return [];
+  return Object.entries(state.completedLegendaryWonders ?? {})
+    .filter(([, completion]) => completion.ownerId === viewerId && completion.cityId === cityId)
+    .map(([wonderId, completion]) => ({
+      wonderId,
+      label: getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder',
+      cityId,
+      turnCompleted: completion.turnCompleted,
+      relationship: 'owned' as const,
+      state: 'completed' as const,
+      metadata: getLegendaryWonderLandmarkMetadata(wonderId),
+    }))
+    .sort((a, b) => (a.turnCompleted ?? 0) - (b.turnCompleted ?? 0) || a.wonderId.localeCompare(b.wonderId));
+}
+
+export function getActiveLegendaryConstructionGhostForCity(
+  state: GameState,
+  viewerId: string,
+  city: City,
+  options: { mapOnly: boolean },
+): LegendaryWonderLandmarkView | null {
+  if (city.owner !== viewerId) return null;
+  const activeItem = city.productionQueue[0];
+  if (!activeItem?.startsWith('legendary:')) return null;
+  const wonderId = activeItem.replace(/^legendary:/, '');
+  const project = Object.values(state.legendaryWonderProjects ?? {})
+    .find(candidate => candidate.ownerId === viewerId && candidate.cityId === city.id && candidate.wonderId === wonderId && candidate.phase === 'building');
+  const definition = getLegendaryWonderDefinition(wonderId);
+  if (!project || !definition) return null;
+  const progressRatio = Math.max(0, Math.min(1, city.productionProgress / definition.productionCost));
+  if (options.mapOnly && progressRatio < LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD) return null;
+  return {
+    wonderId,
+    label: definition.name,
+    cityId: city.id,
+    relationship: 'owned',
+    state: 'under-construction',
+    metadata: getLegendaryWonderLandmarkMetadata(wonderId),
+    progressRatio,
+  };
+}
+
+export function getLegendaryLandmarkPreviewForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkView[] {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return [];
+  const completed = getCompletedLegendaryLandmarksForCity(state, viewerId, cityId);
+  const ghost = getActiveLegendaryConstructionGhostForCity(state, viewerId, city, { mapOnly: false });
+  return ghost ? [...completed, ghost] : completed;
+}
+```
+
+- [ ] **Step 4: Update map presentation**
+
+Modify `src/systems/legendary-wonder-map-presentation.ts`:
+
+```ts
+import {
+  getActiveLegendaryConstructionGhostForCity,
+  getCompletedLegendaryLandmarksForCity,
+} from '@/systems/legendary-wonder-landmark-presentation';
+import type { LegendaryWonderLandmarkState } from '@/systems/legendary-wonder-landmark-types';
+```
+
+Extend `LegendaryWonderMapEntry`:
+
+```ts
+  relationship: 'owned' | 'known-rival';
+  state: LegendaryWonderLandmarkState;
+  progressRatio?: number;
+```
+
+Replace the return body with:
+
+```ts
+  const entries: LegendaryWonderMapEntry[] = [];
+  for (const city of Object.values(state.cities)) {
+    if (city.owner !== viewerId) continue;
+    if (getVisibility(visibility, city.position) !== 'visible') continue;
+    for (const landmark of getCompletedLegendaryLandmarksForCity(state, viewerId, city.id)) {
+      entries.push({
+        wonderId: landmark.wonderId,
+        cityId: city.id,
+        coord: { ...city.position },
+        ownerId: viewerId,
+        relationship: 'owned',
+        state: 'completed',
+        turnCompleted: landmark.turnCompleted ?? 0,
+        label: landmark.label,
+        visual: getWonderVisualDefinition(landmark.wonderId),
+      });
+    }
+    const ghost = getActiveLegendaryConstructionGhostForCity(state, viewerId, city, { mapOnly: true });
+    if (ghost) {
+      entries.push({
+        wonderId: ghost.wonderId,
+        cityId: city.id,
+        coord: { ...city.position },
+        ownerId: viewerId,
+        relationship: 'owned',
+        state: 'under-construction',
+        turnCompleted: Number.MAX_SAFE_INTEGER,
+        label: ghost.label,
+        visual: getWonderVisualDefinition(ghost.wonderId),
+        progressRatio: ghost.progressRatio,
+      });
+    }
+  }
+  return entries;
+```
+
+- [ ] **Step 5: Update slot rotation**
+
+Modify `src/renderer/wonders/legendary-wonder-slots.ts`:
+
+```ts
+export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[], turn = 0): LegendaryWonderSlot[] {
+  const sorted = [...inputs].sort((a, b) => a.turnCompleted - b.turnCompleted || a.wonderId.localeCompare(b.wonderId));
+  if (sorted.length <= 6) {
+    return sorted.slice(0, 6).map((input, index) => ({
+      kind: 'landmark',
+      wonderId: input.wonderId,
+      turnCompleted: input.turnCompleted,
+      slotIndex: index,
+      ...OFFSETS[index],
+    }));
+  }
+
+  const windowStart = Math.floor(turn / 5) % sorted.length;
+  const visible = Array.from({ length: 5 }, (_, offset) => sorted[(windowStart + offset) % sorted.length]);
+  const slots: LegendaryWonderSlot[] = visible.map((input, index) => ({
+    kind: 'landmark',
+    wonderId: input.wonderId,
+    turnCompleted: input.turnCompleted,
+    slotIndex: index,
+    ...OFFSETS[index],
+  }));
+  slots.push({ kind: 'overflow', slotIndex: 5, overflowCount: sorted.length - 5, ...OFFSETS[5] });
+  return slots;
+}
+```
+
+- [ ] **Step 6: Run presentation tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/legendary-wonder-landmark-presentation.ts src/systems/legendary-wonder-map-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts
+git commit -m "feat(wonders): derive safe legendary landmark views"
+```
+
+## Task 3: Render Token Landmarks, Ghosts, And Layer Order
+
+**Files:**
+- Modify: `src/renderer/wonders/legendary-wonder-renderer.ts`
+- Modify: `src/renderer/city-renderer.ts`
+- Test: `tests/renderer/legendary-wonder-renderer.test.ts`
+- Test: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write failing renderer tests**
+
+Update `tests/renderer/legendary-wonder-renderer.test.ts`:
+
+```ts
+it('draws every authored family with nonblank canvas operations', () => {
+  const families = getLegendaryWonderLandmarkMetadataCatalog().map(entry => entry.family);
+  for (const family of families) {
+    const ctx = new MockCanvasContext();
+    drawLegendaryWonderLandmarkGlyph({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 80,
+      cy: 80,
+      radius: 12,
+      metadata: { ...getLegendaryWonderLandmarkMetadata('oracle-of-delphi'), family },
+      state: 'completed',
+      reducedMotion: false,
+      nowMs: 1000,
+    });
+    expect(ctx.operations.length, family).toBeGreaterThan(3);
+    expect(ctx.operations.some(operation => operation.startsWith('fill:') || operation.startsWith('stroke:')), family).toBe(true);
+  }
+});
+
+it('draws active construction ghosts as scaffold or outline operations', () => {
+  const ctx = new MockCanvasContext();
+  drawLegendaryWonderLandmarks({
+    ctx: ctx as unknown as CanvasRenderingContext2D,
+    cx: 80,
+    cy: 80,
+    size: 48,
+    reducedMotion: false,
+    lowZoom: false,
+    turn: 20,
+    entries: [
+      {
+        wonderId: 'oracle-of-delphi',
+        label: 'Oracle of Delphi',
+        turnCompleted: Number.MAX_SAFE_INTEGER,
+        visual: getWonderVisualDefinition('oracle-of-delphi'),
+        state: 'under-construction',
+        metadata: getLegendaryWonderLandmarkMetadata('oracle-of-delphi'),
+        progressRatio: 0.6,
+      },
+    ],
+  });
+
+  expect(ctx.operations.some(operation => operation.includes('ghost') || operation.startsWith('stroke:'))).toBe(true);
+});
+```
+
+Update `tests/renderer/city-renderer.test.ts`:
+
+```ts
+it('draws legendary landmark layer before city label and production badges remain above it', () => {
+  const state = createNewGame(undefined, 'legendary-layer-order-test');
+  const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+  const city = foundCity('player', settler.position, state.map, state.idCounters);
+  state.cities[city.id] = city;
+  state.civilizations.player.cities.push(city.id);
+  state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 20 },
+  };
+
+  const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+  drawCities(ctx, state, makeCamera(), 'player');
+
+  const ops = (ctx as unknown as MockCanvasContext).operations;
+  const landmarkIndex = ops.findIndex(operation => operation === 'legendary-landmarks:start');
+  const labelIndex = (ctx as unknown as MockCanvasContext).fillTextCalls.findIndex(call => call.text.includes(city.name));
+  expect(landmarkIndex).toBeGreaterThanOrEqual(0);
+  expect(labelIndex).toBeGreaterThanOrEqual(0);
+  expect(landmarkIndex).toBeLessThan(labelIndex);
+});
+```
+
+- [ ] **Step 2: Run renderer tests to verify failure**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: FAIL because exported glyph renderer, `turn`, `metadata`, `state`, and explicit op markers do not exist.
+
+- [ ] **Step 3: Update renderer types and glyph function**
+
+Modify `src/renderer/wonders/legendary-wonder-renderer.ts`:
+
+```ts
+import type { LegendaryWonderLandmarkMetadata, LegendaryWonderLandmarkState } from '@/systems/legendary-wonder-landmark-types';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+
+export interface LegendaryWonderRenderEntry {
+  wonderId: string;
+  label: string;
+  turnCompleted: number;
+  visual: WonderVisualDefinition;
+  state?: LegendaryWonderLandmarkState;
+  metadata?: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
+}
+
+function pulseAlpha(nowMs: number): number {
+  return (Math.sin(nowMs / 900) + 1) / 2;
+}
+
+export function drawLegendaryWonderLandmarkGlyph(options: {
+  ctx: CanvasRenderingContext2D;
+  cx: number;
+  cy: number;
+  radius: number;
+  metadata: LegendaryWonderLandmarkMetadata;
+  state: LegendaryWonderLandmarkState;
+  reducedMotion: boolean;
+  nowMs: number;
+}): void {
+  const { ctx, cx, cy, radius, metadata, state, reducedMotion, nowMs } = options;
+  const motion = reducedMotion ? 'none' : metadata.motion;
+  if (metadata.aura !== 'none') {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * 1.18, 0, Math.PI * 2);
+    ctx.fillStyle = metadata.palette.glow;
+    ctx.globalAlpha = motion === 'pulse' ? 0.12 + pulseAlpha(nowMs) * 0.12 : 0.14;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+
+  if (state === 'under-construction') {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * 0.72, Math.PI * 1.05, Math.PI * 1.95);
+    ctx.strokeStyle = metadata.palette.accent;
+    ctx.lineWidth = Math.max(1, radius * 0.13);
+    ctx.stroke();
+    return;
+  }
+
+  drawSilhouette(ctx, metadata.family, cx, cy, radius * 0.72 * metadata.scale);
+  ctx.fillStyle = metadata.palette.accent;
+  ctx.fill();
+  ctx.strokeStyle = metadata.palette.glow;
+  ctx.lineWidth = Math.max(1, radius * 0.08);
+  ctx.stroke();
+
+  if (motion === 'glint' || motion === 'spark') {
+    ctx.beginPath();
+    ctx.moveTo(cx - radius * 0.34, cy - radius * 0.34);
+    ctx.lineTo(cx + radius * 0.34, cy + radius * 0.34);
+    ctx.strokeStyle = metadata.palette.glow;
+    ctx.lineWidth = Math.max(1, radius * 0.06);
+    ctx.stroke();
+  }
+}
+```
+
+Update `drawSilhouette` to accept `LegendaryWonderLandmarkMetadata['family']`. Map newly added families to simple shape branches; use existing branch shapes for related families:
+
+```ts
+case 'oracle':
+case 'spire':
+case 'signal':
+  // existing spire shape
+  break;
+case 'waterworks':
+case 'gateway':
+case 'drydock':
+  // existing arch shape
+  break;
+case 'garden':
+case 'observatory':
+  // existing dome shape
+  break;
+case 'laboratory':
+  // existing obelisk shape
+  break;
+case 'foundry':
+case 'bastion':
+case 'hall':
+  // existing citadel shape
+  break;
+case 'archive':
+case 'exchange':
+case 'network':
+default:
+  // existing archive shape
+  break;
+```
+
+- [ ] **Step 4: Update landmark draw loop**
+
+Modify `drawLegendaryWonderLandmarks` options:
+
+```ts
+  turn?: number;
+  nowMs?: number;
+```
+
+Inside function:
+
+```ts
+  const slots = assignLegendaryWonderSlots(options.entries, options.turn ?? 0);
+  const nowMs = options.nowMs ?? 0;
+  options.ctx.save();
+  (options.ctx as unknown as { operations?: string[] }).operations?.push('legendary-landmarks:start');
+```
+
+Replace direct `drawSilhouette` call with:
+
+```ts
+    const metadata = entry.metadata ?? getLegendaryWonderLandmarkMetadata(entry.wonderId);
+    drawLegendaryWonderLandmarkGlyph({
+      ctx: options.ctx,
+      cx: x,
+      cy: y,
+      radius: radius * (options.lowZoom ? 0.82 : 1),
+      metadata,
+      state: entry.state ?? 'completed',
+      reducedMotion: options.reducedMotion,
+      nowMs,
+    });
+```
+
+- [ ] **Step 5: Pass turn/metadata from city renderer**
+
+Modify `src/renderer/city-renderer.ts` landmark call:
+
+```ts
+drawLegendaryWonderLandmarks({
+  ctx,
+  cx: screen.x,
+  cy: screen.y,
+  size,
+  entries: legendaryEntries,
+  reducedMotion,
+  lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+  turn: state.turn,
+  nowMs: Date.now(),
+});
+```
+
+If `Date.now()` is already avoided in renderer tests, use an optional `nowMs` from renderer options if present; otherwise keep default `0` in `drawLegendaryWonderLandmarks`.
+
+- [ ] **Step 6: Run renderer tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(wonders): render authored legendary city landmarks"
+```
+
+## Task 4: Add Inspection, City Panel, And Codex Previews
+
+**Files:**
+- Modify: `src/ui/territory-inspection-panel.ts`
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/systems/wonder-codex/presentation.ts`
+- Modify: `src/ui/wonder-codex-page.ts`
+- Test: `tests/ui/territory-inspection-panel.test.ts`
+- Test: `tests/ui/city-panel.test.ts`
+- Test: `tests/systems/wonder-codex/presentation.test.ts`
+- Test: `tests/ui/wonder-codex-page.test.ts`
+
+- [ ] **Step 1: Write failing UI and presentation tests**
+
+Add to `tests/ui/territory-inspection-panel.test.ts`:
+
+```ts
+it('lists every completed owned legendary wonder in an overflow city', () => {
+  const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+  const city = state.cities['city-river'];
+  state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 1 },
+    'grand-canal': { ownerId: 'player', cityId: city.id, turnCompleted: 2 },
+    'sun-spire': { ownerId: 'player', cityId: city.id, turnCompleted: 3 },
+    'world-archive': { ownerId: 'player', cityId: city.id, turnCompleted: 4 },
+    'moonwell-gardens': { ownerId: 'player', cityId: city.id, turnCompleted: 5 },
+    'ironroot-foundry': { ownerId: 'player', cityId: city.id, turnCompleted: 6 },
+    'tidecaller-bastion': { ownerId: 'player', cityId: city.id, turnCompleted: 7 },
+  };
+
+  const panel = createTerritoryInspectionPanel(state, city.position, 'player');
+
+  expect(panel.textContent).toContain('Oracle of Delphi');
+  expect(panel.textContent).toContain('Grand Canal');
+  expect(panel.textContent).toContain('Tidecaller Bastion');
+});
+```
+
+Add to `tests/ui/city-panel.test.ts`:
+
+```ts
+it('renders compact legendary landmark preview with completed and active ghost states', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 20 },
+  };
+  city.productionQueue = ['legendary:grand-canal'];
+  city.productionProgress = 90;
+  state.legendaryWonderProjects = {
+    'grand-canal:player:city-river': {
+      wonderId: 'grand-canal',
+      ownerId: 'player',
+      cityId: city.id,
+      phase: 'building',
+      investedProduction: 90,
+      transferableProduction: 0,
+      questSteps: [],
+    },
+  };
+
+  const panel = createCityPanel(container, city, state, {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.querySelector('[data-section="legendary-landmark-preview"]')?.textContent).toContain('Oracle of Delphi');
+  expect(panel.querySelector('[data-section="legendary-landmark-preview"]')?.textContent).toContain('Grand Canal');
+  expect(panel.querySelector('[data-section="legendary-landmark-preview"]')?.textContent).toContain('Under construction');
+});
+```
+
+Add to `tests/systems/wonder-codex/presentation.test.ts`:
+
+```ts
+it('adds owned legendary landmark preview to owned completed and active pages only', () => {
+  const state = makeState();
+  const baseCity = state.cities[Object.keys(state.cities)[0]];
+  state.cities['safe-city'] = { ...baseCity, id: 'safe-city', owner: 'player' };
+  state.completedLegendaryWonders = {
+    'oracle-of-delphi': { ownerId: 'player', cityId: 'safe-city', turnCompleted: 58 },
+  };
+
+  const owned = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+  expect(owned.selectedPage?.landmarkPreview).toMatchObject({
+    cityId: 'safe-city',
+    cityName: state.cities['safe-city'].name,
+  });
+  expect(owned.selectedPage?.landmarkPreview?.items[0]).toMatchObject({
+    wonderId: 'oracle-of-delphi',
+    state: 'completed',
+  });
+
+  state.legendaryWonderIntel = {
+    player: [{
+      kind: 'completed',
+      eventId: 'completed:grand-canal:ai-1:58',
+      wonderId: 'grand-canal',
+      civId: 'ai-1',
+      civName: 'Rival',
+      completionTurn: 58,
+      learnedTurn: 58,
+    }],
+  };
+  const rival = getWonderCodexViewModel(state, 'player', { initialWonderId: 'grand-canal' });
+  expect(rival.selectedPage?.landmarkPreview).toBeUndefined();
+});
+```
+
+Add to `tests/ui/wonder-codex-page.test.ts`:
+
+```ts
+it('renders compact landmark preview without adding rival actions', () => {
+  const root = createWonderCodexPage(page({
+    id: 'oracle-of-delphi',
+    kind: 'legendary',
+    title: 'Oracle of Delphi',
+    subtitle: 'A sanctuary of prophecy.',
+    stateLabel: 'Completed',
+    visual: getWonderVisualDefinition('oracle-of-delphi'),
+    actions: [],
+    landmarkPreview: {
+      cityId: 'city-river',
+      cityName: 'River City',
+      items: [{
+        wonderId: 'oracle-of-delphi',
+        label: 'Oracle of Delphi',
+        state: 'completed',
+      }],
+    },
+  }), { onAction: () => {}, onSelectRelated: () => {} });
+
+  expect(root.querySelector('[data-section="legendary-landmark-preview"]')?.textContent).toContain('Oracle of Delphi');
+  expect(root.querySelector('[data-codex-action="open-city"]')).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts
+```
+
+Expected: FAIL because preview view models and DOM sections do not exist.
+
+- [ ] **Step 3: Add preview view-model helper**
+
+Append to `src/systems/legendary-wonder-landmark-presentation.ts`:
+
+```ts
+export interface LegendaryWonderLandmarkPreviewView {
+  cityId: string;
+  cityName: string;
+  items: Array<{
+    wonderId: string;
+    label: string;
+    state: 'completed' | 'under-construction';
+  }>;
+}
+
+export function getLegendaryLandmarkPreviewViewForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkPreviewView | null {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return null;
+  const items = getLegendaryLandmarkPreviewForCity(state, viewerId, cityId)
+    .map(item => ({ wonderId: item.wonderId, label: item.label, state: item.state }));
+  if (items.length === 0) return null;
+  return { cityId, cityName: city.name, items };
+}
+```
+
+- [ ] **Step 4: Update territory inspection**
+
+In `src/ui/territory-inspection-panel.ts`, replace the local `completedInCity` query with:
+
+```ts
+import { getCompletedLegendaryLandmarksForCity } from '@/systems/legendary-wonder-landmark-presentation';
+```
+
+```ts
+  const cityAtCoord = Object.values(state.cities).find(candidate => hexKey(candidate.position) === key);
+  const completedInCity = cityAtCoord
+    ? getCompletedLegendaryLandmarksForCity(state, viewerId, cityAtCoord.id).map(entry => entry.label)
+    : [];
+```
+
+- [ ] **Step 5: Update city panel**
+
+Import:
+
+```ts
+import { getLegendaryLandmarkPreviewViewForCity } from '@/systems/legendary-wonder-landmark-presentation';
+```
+
+After `compactWonderSectionHtml`, add:
+
+```ts
+  const landmarkPreview = getLegendaryLandmarkPreviewViewForCity(state, state.currentPlayer, city.id);
+  const landmarkPreviewHtml = landmarkPreview
+    ? `<div data-section="legendary-landmark-preview" style="background:rgba(232,193,112,0.08);border:1px solid rgba(232,193,112,0.22);border-radius:8px;padding:10px;margin-bottom:12px;">
+        <div style="font-weight:bold;font-size:13px;color:#e8c170;margin-bottom:6px;">Legendary landmarks</div>
+        ${landmarkPreview.items.map((item, index) => `<div data-landmark-preview="${item.wonderId}" style="font-size:12px;opacity:0.86;"><span data-text="landmark-preview-${index}"></span></div>`).join('')}
+      </div>`
+    : '';
+```
+
+Insert `${landmarkPreviewHtml}` before `${idleSelectorHtml}` in `#city-list-view`.
+
+After dynamic text setup:
+
+```ts
+  landmarkPreview?.items.forEach((item, index) => {
+    setText(`landmark-preview-${index}`, item.state === 'under-construction'
+      ? `${item.label} — Under construction`
+      : `${item.label} — Completed`);
+  });
+```
+
+- [ ] **Step 6: Update Codex presentation and page**
+
+In `src/systems/wonder-codex/presentation.ts`, import preview type/helper:
+
+```ts
+import {
+  getLegendaryLandmarkPreviewViewForCity,
+  type LegendaryWonderLandmarkPreviewView,
+} from '@/systems/legendary-wonder-landmark-presentation';
+```
+
+Add to `WonderCodexPageViewModel`:
+
+```ts
+  landmarkPreview?: LegendaryWonderLandmarkPreviewView;
+```
+
+In `buildPage`, after status:
+
+```ts
+  const cityIdForPreview = entry.kind === 'legendary'
+    ? safeOwnedHostCityId(state, viewerId, state.completedLegendaryWonders?.[entry.id]?.cityId ?? ownedProject(state, viewerId, entry.id)?.cityId)
+    : undefined;
+  const landmarkPreview = cityIdForPreview
+    ? getLegendaryLandmarkPreviewViewForCity(state, viewerId, cityIdForPreview)
+    : null;
+```
+
+In return:
+
+```ts
+    ...(landmarkPreview ? { landmarkPreview } : {}),
+```
+
+In `src/ui/wonder-codex-page.ts`, after status section:
+
+```ts
+  if (page.landmarkPreview) {
+    const preview = document.createElement('section');
+    preview.dataset.section = 'legendary-landmark-preview';
+    preview.style.cssText = 'border:1px solid rgba(232,193,112,0.24);border-radius:8px;padding:10px;background:rgba(232,193,112,0.07);display:grid;gap:6px;';
+    appendText(preview, 'h4', 'City landmark preview', 'margin:0;font-size:13px;color:#f4d188;');
+    appendText(preview, 'p', page.landmarkPreview.cityName, 'margin:0;font-size:12px;color:rgba(248,241,223,0.74);');
+    const list = document.createElement('ul');
+    list.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;color:rgba(248,241,223,0.74);';
+    for (const item of page.landmarkPreview.items) {
+      const li = document.createElement('li');
+      li.dataset.landmarkPreview = item.wonderId;
+      li.textContent = item.state === 'under-construction'
+        ? `${item.label} — Under construction`
+        : `${item.label} — Completed`;
+      list.appendChild(li);
+    }
+    preview.appendChild(list);
+    root.appendChild(preview);
+  }
+```
+
+- [ ] **Step 7: Run UI tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/legendary-wonder-landmark-presentation.ts src/ui/territory-inspection-panel.ts src/ui/city-panel.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts
+git commit -m "feat(wonders): show legendary landmark previews"
+```
+
+## Task 5: Final Privacy Review, Rule Checks, And Full Verification
+
+**Files:**
+- Review all changed files.
+- No new production file unless review finds an issue.
+
+- [ ] **Step 1: Run targeted landmark and UI tests**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-landmark-catalog.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run source rule check**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/legendary-wonder-landmark-types.ts src/systems/legendary-wonder-landmark-catalog.ts src/systems/legendary-wonder-landmark-validation.ts src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/ui/territory-inspection-panel.ts src/ui/city-panel.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts
+```
+
+Expected: no output and exit 0.
+
+- [ ] **Step 3: Run wonder regression suite**
+
+```bash
+./scripts/run-wonder-regressions.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run build**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS. Vite chunk-size warnings are acceptable.
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Review branch and local diffs**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- src tests docs
+```
+
+Review for:
+
+- no rival landmark leakage
+- no hidden host-city leakage
+- no gameplay mutations
+- no save-format writes
+- no direct Tauri/platform imports
+- no map input behavior changes
+- no missing metadata/test convention
+- no stale hash-based known legendary assignment
+
+- [ ] **Step 7: Fix any review findings**
+
+If review finds an issue, add a focused regression test first, then fix the smallest production surface. Re-run the targeted command from the failing area plus build/test if `src/` changed.
+
+- [ ] **Step 8: Commit final fixes if needed**
+
+If Step 7 changed files:
+
+```bash
+git add src tests docs
+git commit -m "fix(wonders): harden legendary landmark rendering"
+```
+
+If no issues were found, do not create an empty commit.

--- a/docs/superpowers/plans/2026-05-26-stage-2g-legendary-city-landmarks.md
+++ b/docs/superpowers/plans/2026-05-26-stage-2g-legendary-city-landmarks.md
@@ -1,6 +1,6 @@
 # Stage 2G Legendary City Landmarks Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Execute inline unless the user explicitly authorizes subagents. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Build an authored, convention-tested legendary city landmark system with richer owned completed landmarks, late-construction ghosts, overflow rotation, and compact city/Codex previews.
 
@@ -52,6 +52,8 @@ Rules to read before editing:
   - Export renderer support tables for tests.
 - Modify `src/renderer/city-renderer.ts`
   - Targeted landmark layer extraction and explicit draw ordering.
+- Modify `src/renderer/render-loop.ts`
+  - Pass `performance.now()` into city rendering for runtime animation while renderer tests can inject deterministic `nowMs`.
 - Modify `src/ui/territory-inspection-panel.ts`
   - Use helper so inspection lists all owned completed city landmarks.
 - Modify `src/ui/city-panel.ts`
@@ -63,6 +65,7 @@ Rules to read before editing:
 - Add/modify tests:
   - `tests/systems/legendary-wonder-landmark-catalog.test.ts`
   - `tests/systems/legendary-wonder-map-presentation.test.ts`
+  - `tests/renderer/legendary-wonder-slots.test.ts`
   - `tests/systems/wonder-codex/presentation.test.ts`
   - `tests/renderer/legendary-wonder-renderer.test.ts`
   - `tests/renderer/city-renderer.test.ts`
@@ -448,25 +451,29 @@ export type LegendaryWonderLandmark = LegendaryLandmarkFamily | 'masked';
 
 Remove `LEGENDARY_LANDMARK_TYPES` and `landmarkTypeForLegendaryWonder`.
 
-In `LEGENDARY_WONDER_VISUALS`, replace `legendaryLandmark`:
+Replace the `LEGENDARY_WONDER_VISUALS` construction with this block so metadata is computed inside the map callback and no hash fallback remains for known legendary wonders:
 
 ```ts
-const metadata = getLegendaryWonderLandmarkMetadata(definition.id);
-return [
-  definition.id,
-  {
-    id: definition.id,
-    kind: 'legendary',
-    medallionGlyph: '✦',
-    palette: metadata.palette,
-    mapLandmark: 'masked',
-    vignette: 'masked',
-    supportsAmbientAnimation: false,
-    reducedMotionFallback: 'static-medallion',
-    maskedLabel: 'Legendary wonder',
-    legendaryLandmark: metadata.family,
-  } satisfies WonderVisualDefinition,
-];
+const LEGENDARY_WONDER_VISUALS: Record<string, WonderVisualDefinition> = Object.fromEntries(
+  getLegendaryWonderDefinitions().map(definition => {
+    const metadata = getLegendaryWonderLandmarkMetadata(definition.id);
+    return [
+      definition.id,
+      {
+        id: definition.id,
+        kind: 'legendary',
+        medallionGlyph: '✦',
+        palette: metadata.palette,
+        mapLandmark: 'masked',
+        vignette: 'masked',
+        supportsAmbientAnimation: false,
+        reducedMotionFallback: 'static-medallion',
+        maskedLabel: 'Legendary wonder',
+        legendaryLandmark: metadata.family,
+      } satisfies WonderVisualDefinition,
+    ];
+  }),
+);
 ```
 
 - [ ] **Step 8: Run catalog tests**
@@ -493,6 +500,7 @@ git commit -m "feat(wonders): add authored legendary landmark metadata"
 - Modify: `src/systems/legendary-wonder-map-presentation.ts`
 - Modify: `src/renderer/wonders/legendary-wonder-slots.ts`
 - Test: `tests/systems/legendary-wonder-map-presentation.test.ts`
+- Test: `tests/renderer/legendary-wonder-slots.test.ts`
 
 - [ ] **Step 1: Write failing presentation and privacy tests**
 
@@ -600,7 +608,7 @@ it('rotates overflow windows every five turns while keeping a stable overflow co
 ./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts
 ```
 
-Expected: FAIL because `state`, `progressRatio`, and rotation are not implemented.
+Expected: FAIL because map entries do not yet carry completed/under-construction state, ghost progress ratios, or 5-turn overflow rotation.
 
 - [ ] **Step 3: Add presentation helper**
 
@@ -649,7 +657,7 @@ export function getActiveLegendaryConstructionGhostForCity(
     .find(candidate => candidate.ownerId === viewerId && candidate.cityId === city.id && candidate.wonderId === wonderId && candidate.phase === 'building');
   const definition = getLegendaryWonderDefinition(wonderId);
   if (!project || !definition) return null;
-  const progressRatio = Math.max(0, Math.min(1, city.productionProgress / definition.productionCost));
+  const progressRatio = Math.max(0, Math.min(1, project.investedProduction / definition.productionCost));
   if (options.mapOnly && progressRatio < LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD) return null;
   return {
     wonderId,
@@ -684,6 +692,7 @@ import {
   getActiveLegendaryConstructionGhostForCity,
   getCompletedLegendaryLandmarksForCity,
 } from '@/systems/legendary-wonder-landmark-presentation';
+import { getVisibility } from '@/systems/fog-of-war';
 import type { LegendaryWonderLandmarkState } from '@/systems/legendary-wonder-landmark-types';
 ```
 
@@ -785,6 +794,7 @@ git commit -m "feat(wonders): derive safe legendary landmark views"
 **Files:**
 - Modify: `src/renderer/wonders/legendary-wonder-renderer.ts`
 - Modify: `src/renderer/city-renderer.ts`
+- Modify: `src/renderer/render-loop.ts`
 - Test: `tests/renderer/legendary-wonder-renderer.test.ts`
 - Test: `tests/renderer/city-renderer.test.ts`
 
@@ -846,6 +856,7 @@ it('draws legendary landmark layer before city label and production badges remai
   const state = createNewGame(undefined, 'legendary-layer-order-test');
   const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
   const city = foundCity('player', settler.position, state.map, state.idCounters);
+  city.productionQueue = ['granary'];
   state.cities[city.id] = city;
   state.civilizations.player.cities.push(city.id);
   state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
@@ -858,10 +869,13 @@ it('draws legendary landmark layer before city label and production badges remai
 
   const ops = (ctx as unknown as MockCanvasContext).operations;
   const landmarkIndex = ops.findIndex(operation => operation === 'legendary-landmarks:start');
-  const labelIndex = (ctx as unknown as MockCanvasContext).fillTextCalls.findIndex(call => call.text.includes(city.name));
+  const labelIndex = ops.findIndex(operation => operation.includes(`text:${city.name}`));
+  const badgeIndex = ops.findIndex(operation => operation.includes(`text:${getProductionBadgeIcon(city)}`));
   expect(landmarkIndex).toBeGreaterThanOrEqual(0);
   expect(labelIndex).toBeGreaterThanOrEqual(0);
+  expect(badgeIndex).toBeGreaterThanOrEqual(0);
   expect(landmarkIndex).toBeLessThan(labelIndex);
+  expect(landmarkIndex).toBeLessThan(badgeIndex);
 });
 ```
 
@@ -943,37 +957,93 @@ export function drawLegendaryWonderLandmarkGlyph(options: {
 }
 ```
 
-Update `drawSilhouette` to accept `LegendaryWonderLandmarkMetadata['family']`. Map newly added families to simple shape branches; use existing branch shapes for related families:
+Update `drawSilhouette` to accept `LegendaryWonderLandmarkMetadata['family']` and replace the body with explicit helper calls. This keeps every authored family renderable without adding one-off drawing logic for each wonder:
 
 ```ts
-case 'oracle':
-case 'spire':
-case 'signal':
-  // existing spire shape
-  break;
-case 'waterworks':
-case 'gateway':
-case 'drydock':
-  // existing arch shape
-  break;
-case 'garden':
-case 'observatory':
-  // existing dome shape
-  break;
-case 'laboratory':
-  // existing obelisk shape
-  break;
-case 'foundry':
-case 'bastion':
-case 'hall':
-  // existing citadel shape
-  break;
-case 'archive':
-case 'exchange':
-case 'network':
-default:
-  // existing archive shape
-  break;
+function drawSilhouette(
+  ctx: CanvasRenderingContext2D,
+  family: LegendaryWonderLandmarkMetadata['family'],
+  cx: number,
+  cy: number,
+  radius: number,
+): void {
+  ctx.beginPath();
+  switch (family) {
+    case 'oracle':
+    case 'spire':
+    case 'signal':
+      drawSpireSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'waterworks':
+    case 'gateway':
+    case 'drydock':
+      drawArchSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'garden':
+    case 'observatory':
+      drawDomeSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'laboratory':
+      drawObeliskSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'foundry':
+    case 'bastion':
+    case 'hall':
+      drawCitadelSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'archive':
+    case 'exchange':
+    case 'network':
+    default:
+      drawArchiveSilhouette(ctx, cx, cy, radius);
+      break;
+  }
+  ctx.closePath();
+}
+
+function drawArchSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.arc(cx, cy + radius * 0.35, radius * 0.62, Math.PI, Math.PI * 2);
+  ctx.lineTo(cx + radius * 0.48, cy + radius * 0.72);
+  ctx.lineTo(cx - radius * 0.48, cy + radius * 0.72);
+}
+
+function drawDomeSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.arc(cx, cy + radius * 0.2, radius * 0.7, Math.PI, Math.PI * 2);
+  ctx.lineTo(cx + radius * 0.7, cy + radius * 0.65);
+  ctx.lineTo(cx - radius * 0.7, cy + radius * 0.65);
+}
+
+function drawObeliskSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.moveTo(cx, cy - radius * 0.82);
+  ctx.lineTo(cx + radius * 0.34, cy + radius * 0.7);
+  ctx.lineTo(cx - radius * 0.34, cy + radius * 0.7);
+}
+
+function drawCitadelSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.rect(cx - radius * 0.62, cy - radius * 0.34, radius * 1.24, radius * 1.02);
+  ctx.moveTo(cx - radius * 0.62, cy - radius * 0.34);
+  ctx.lineTo(cx - radius * 0.38, cy - radius * 0.68);
+  ctx.lineTo(cx - radius * 0.12, cy - radius * 0.34);
+  ctx.lineTo(cx + radius * 0.12, cy - radius * 0.68);
+  ctx.lineTo(cx + radius * 0.38, cy - radius * 0.34);
+}
+
+function drawArchiveSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.rect(cx - radius * 0.66, cy - radius * 0.5, radius * 1.32, radius * 1.08);
+  ctx.moveTo(cx - radius * 0.44, cy - radius * 0.5);
+  ctx.lineTo(cx - radius * 0.44, cy + radius * 0.58);
+  ctx.moveTo(cx, cy - radius * 0.5);
+  ctx.lineTo(cx, cy + radius * 0.58);
+  ctx.moveTo(cx + radius * 0.44, cy - radius * 0.5);
+  ctx.lineTo(cx + radius * 0.44, cy + radius * 0.58);
+}
+
+function drawSpireSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.moveTo(cx, cy - radius * 0.84);
+  ctx.lineTo(cx + radius * 0.54, cy + radius * 0.68);
+  ctx.lineTo(cx, cy + radius * 0.38);
+  ctx.lineTo(cx - radius * 0.54, cy + radius * 0.68);
+}
 ```
 
 - [ ] **Step 4: Update landmark draw loop**
@@ -1010,11 +1080,32 @@ Replace direct `drawSilhouette` call with:
     });
 ```
 
-- [ ] **Step 5: Pass turn/metadata from city renderer**
+- [ ] **Step 5: Pass turn/metadata from city renderer with deterministic timing**
 
-Modify `src/renderer/city-renderer.ts` landmark call:
+Modify `src/renderer/city-renderer.ts` so draw timing is deterministic in tests and does not call `Date.now()` from the city renderer. First change the signature to accept an optional options object while preserving the default call shape:
 
 ```ts
+interface CityRenderOptions {
+  reducedMotion?: boolean;
+  nowMs?: number;
+}
+
+export function drawCities(
+  ctx: CanvasRenderingContext2D,
+  state: GameState,
+  camera: Camera,
+  playerCivId: string,
+  options: CityRenderOptions | boolean = {},
+): void {
+  const reducedMotion = typeof options === 'boolean' ? options : options.reducedMotion ?? false;
+  const nowMs = typeof options === 'boolean' ? state.turn * 1000 : options.nowMs ?? state.turn * 1000;
+```
+
+Then move the existing landmark draw block so it runs after the city circle/icon is drawn and before the city name/population label. Keep unrest, occupation, breakaway, production, and idle badges after the landmark block so badges remain on top. Update the landmark call:
+
+```ts
+const legendaryEntries = projection.liveCityId ? landmarksByCity.get(projection.liveCityId) ?? [] : [];
+if (legendaryEntries.length > 0) {
 drawLegendaryWonderLandmarks({
   ctx,
   cx: screen.x,
@@ -1024,11 +1115,21 @@ drawLegendaryWonderLandmarks({
   reducedMotion,
   lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
   turn: state.turn,
-  nowMs: Date.now(),
+  nowMs,
+});
+}
+```
+
+Update `src/renderer/render-loop.ts` city draw call from the existing boolean argument to an options object:
+
+```ts
+drawCities(this.ctx, this.state, this.camera, viewerId, {
+  reducedMotion: prefersReducedMotion(),
+  nowMs: performance.now(),
 });
 ```
 
-If `Date.now()` is already avoided in renderer tests, use an optional `nowMs` from renderer options if present; otherwise keep default `0` in `drawLegendaryWonderLandmarks`.
+This keeps runtime landmark pulse/glint alive, while renderer tests can call `drawCities(..., { nowMs: 1000 })` for deterministic assertions. Do not introduce `Date.now()` in renderer code.
 
 - [ ] **Step 6: Run renderer tests**
 
@@ -1041,7 +1142,7 @@ Expected: PASS.
 - [ ] **Step 7: Commit**
 
 ```bash
-git add src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
+git add src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts
 git commit -m "feat(wonders): render authored legendary city landmarks"
 ```
 
@@ -1357,7 +1458,7 @@ Expected: PASS.
 - [ ] **Step 2: Run source rule check**
 
 ```bash
-scripts/check-src-rule-violations.sh src/systems/legendary-wonder-landmark-types.ts src/systems/legendary-wonder-landmark-catalog.ts src/systems/legendary-wonder-landmark-validation.ts src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/ui/territory-inspection-panel.ts src/ui/city-panel.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts
+scripts/check-src-rule-violations.sh src/systems/legendary-wonder-landmark-types.ts src/systems/legendary-wonder-landmark-catalog.ts src/systems/legendary-wonder-landmark-validation.ts src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts src/ui/territory-inspection-panel.ts src/ui/city-panel.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts
 ```
 
 Expected: no output and exit 0.
@@ -1404,6 +1505,7 @@ Review for:
 - no map input behavior changes
 - no missing metadata/test convention
 - no stale hash-based known legendary assignment
+- `docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md` still records deferred Stage 2I bespoke art, Stage 2J rival landmark intel visibility, and Stage 2K city renderer layer architecture work
 
 - [ ] **Step 7: Fix any review findings**
 

--- a/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
+++ b/docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md
@@ -362,6 +362,9 @@ Deferred from Stage 2D:
 - Stage 2F owns explicit viewer-scoped rival legendary records from earned intel.
 - Stage 2G owns richer completed legendary city landmark silhouettes, spectacle, variants, and multiple-wonder city readability.
 - Stage 2H owns natural-wonder audio stingers/loops that fill Stage 2E sound mood metadata.
+- Stage 2I owns bespoke per-wonder legendary Canvas drawings or sprites, plus art-reference/citation enforcement for historically inspired bespoke work.
+- Stage 2J owns known-rival legendary landmark visibility when explicit host/location intel exists.
+- Stage 2K owns the broader city renderer layer architecture pass beyond 2G's targeted landmark extraction.
 - Stage 3 owns real 3-5 second videos or loops, including asset-size, offline/PWA, macOS/Tauri, and maintenance review.
 
 ### Stage 2E: Natural Wonder Spectacle Expansion
@@ -374,12 +377,36 @@ Add explicit viewer-scoped rival-known legendary records after the intel model s
 
 ### Stage 2G: Legendary City Landmark Art Expansion
 
-Add richer completed legendary city landmark silhouettes, spectacle, variants, and multiple-wonder city readability after Stage 2E establishes reusable spectacle primitives. This stage owns legendary-city visual depth and must preserve owned/rival visibility boundaries.
+Add richer completed legendary city landmark silhouettes, spectacle, variants, active-construction ghosts, and multiple-wonder city readability after Stage 2E establishes reusable spectacle primitives. This stage owns legendary-city visual depth for owned visible cities and must preserve owned/rival visibility boundaries. It replaces hash-based legendary landmark assignment with explicit authored metadata, adds strict convention tests, and performs only the targeted city-renderer layer extraction needed for landmark correctness.
 
 ### Stage 2H: Natural Wonder Audio Stingers
 
 Fill Stage 2E's required natural-wonder sound mood metadata with real stingers or loops. This stage owns playback rules, mute/reduced-audio behavior, offline/PWA and macOS/Tauri asset review, and tests that keep audio metadata and assets in sync.
 
+### Stage 2I: Legendary Wonder Bespoke Art Pass
+
+Replace Stage 2G token silhouettes with per-wonder bespoke Canvas drawings or sprites as art becomes available. This stage owns art reference/citation notes for historically inspired bespoke work, asset/renderer registration, and tests that fail when bespoke `assetKey` entries do not resolve.
+
+### Stage 2J: Legendary Landmark Intel Visibility
+
+Allow known rival legendary landmarks on map or inspection surfaces only when explicit host/location intel exists. This stage must add new viewer-scoped intel tiers or helpers and negative tests proving Stage 2F completed rival intel alone does not reveal host city, map location, or landmark placement.
+
+### Stage 2K: City Renderer Layer Architecture Pass
+
+Expand Stage 2G's targeted city landmark layer extraction into a broader city renderer architecture pass. This stage owns composable render passes for city icon, labels, badges, overlays, selection, occupation/unrest/breakaway indicators, production badges, and landmark sublayers.
+
 ### Stage 3: Real Video Spike
 
 Prototype 3-5 second video or loop support for selected catalog entries. The spike should evaluate asset size, tooling, offline/PWA cost, macOS/Tauri behavior, and maintenance burden before any production commitment.
+
+## Runbook: Picking The Next Wonder Slice
+
+When a wonder slice merges and the next session asks "what's next?", use this order unless the user explicitly reprioritizes:
+
+1. Stage 2H: Natural Wonder Audio Stingers
+2. Stage 2I: Legendary Wonder Bespoke Art Pass
+3. Stage 2J: Legendary Landmark Intel Visibility
+4. Stage 2K: City Renderer Layer Architecture Pass
+5. Stage 3: Real Video Spike
+
+Use each stage's latest design/spec file as the source of truth. If a deferred decision ID is referenced from a prior spec, carry that ID into the next design or plan so the reason for deferral stays traceable.

--- a/docs/superpowers/specs/2026-05-26-stage-2g-legendary-city-landmarks-design.md
+++ b/docs/superpowers/specs/2026-05-26-stage-2g-legendary-city-landmarks-design.md
@@ -1,0 +1,222 @@
+# Stage 2G: Legendary City Landmark Art Expansion Design
+
+**Date:** 2026-05-26
+**Status:** Draft for review
+**Related roadmap:** `docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md`
+
+## Purpose
+
+Stage 2G upgrades completed legendary wonders from small hash-assigned mini icons into an authored, convention-tested landmark system around host cities. The goal is a visible district of achievement: readable at map scale, fun to watch over time, extensible for future bespoke art, and safe for hot-seat/privacy.
+
+This slice remains presentation-first. It does not change legendary wonder costs, rewards, eligibility, quests, race rules, AI strategy, save semantics, or Atlas intel rules. It improves how already-owned legendary achievements and late-stage owned construction appear on map, city panel, Codex, and inspection surfaces.
+
+## Goals
+
+- Replace hash-based legendary landmark assignment with explicit authored metadata for every current legendary wonder.
+- Use the Medallion Ring Upgrade as the 2G base direction: deterministic around-city slots with richer silhouettes, palette, aura, motion, and overflow behavior.
+- Support all current legendary wonders with explicit metadata, while allowing related wonders to share families/variants where bespoke art is not yet available.
+- Add subtle owned-city motion now through data-driven motion tokens.
+- Make future bespoke Canvas drawings or sprites easy to plug in per wonder through optional asset/renderer keys.
+- Show active owned construction ghosts in panels immediately and on the map only after major progress.
+- Keep more-than-six landmark cities readable with deterministic 5-turn rotation plus a stable overflow marker.
+- Add compact landmark previews to the host city panel and owned completed Codex pages.
+- Keep map landmarks decorative and non-interactive; use existing inspection/city/Codex surfaces for names and details.
+- Include targeted city-renderer layer extraction so landmark ordering is explicit and testable.
+- Strengthen convention tests so future legendary wonders cannot merge without valid landmark metadata and renderer support.
+
+## Non-Goals
+
+- No bespoke per-wonder Canvas drawings, sprites, or historically referenced art assets in 2G. That is Stage 2I.
+- No external art-source/citation ledger requirement in 2G because token silhouettes/effects are abstract UI art.
+- No rival legendary map landmarks, host-city reveal, or location-intel display in 2G. That is Stage 2J.
+- No full city-renderer architecture rewrite in 2G. This slice performs only the targeted extraction needed for landmark layering; the broader pass is Stage 2K.
+- No new player-facing debug/gallery surface.
+- No direct map click target for landmark medallions or overflow.
+- No natural-wonder audio, legendary audio, video, or real loop playback.
+- No gameplay, AI, reward, quest, build-cost, or save-format changes.
+
+## Player Experience
+
+Owned completed legendary wonders appear as solid medallion-ring landmarks around the visible host city. The ring should feel like a small legendary district: each wonder has a deliberate silhouette family, motif, palette, scale, aura, and restrained motion.
+
+The map stays strategic first. Landmarks must not obscure unit sprites, city labels, health bars, production badges, occupation/unrest/breakaway indicators, borders, selection highlights, or touch-critical selection visuals. At low zoom or small/mobile map scale, landmarks collapse to compact/static forms.
+
+Active owned legendary construction gets a preview:
+
+- City panel and Codex preview show an unfinished construction ghost as soon as the project is building.
+- The map shows a faint owned scaffold/outline only after major progress, using the existing `Final works` threshold (`>= 60%` progress).
+- Construction ghosts are labeled `Under construction`.
+- Ghosts are never counted as completed landmarks.
+- Ghosts disappear if the project is lost, abandoned, completed, or no longer building.
+
+When one city has more than six completed legendary wonders:
+
+- The map renders five landmark slots plus a stable `+N` overflow medallion.
+- The visible five rotate every 5 game turns using deterministic completion-order windows.
+- Ordering is by completion turn, then wonder ID.
+- The rotation seed is `Math.floor(state.turn / 5)`, not wall-clock time.
+- Reduced motion does not disable this rotation because it changes only with game state, not animation.
+- Existing city/tile inspection and safe city/Codex surfaces list all completed wonders, including those hidden behind `+N`.
+
+## UI And UX Rules
+
+### Map
+
+- Render owned completed landmarks only for owned host cities that are currently visible to the viewer.
+- Render active owned construction ghosts on the map only for owned visible host cities at `>= 60%` progress.
+- Do not render rival completed landmarks, rival active ghosts, or known-rival location markers in 2G.
+- Keep landmark medallions decorative. City selection, unit selection, movement, attack, tile inspection, and existing input priority remain authoritative.
+- Low zoom uses compact/static markers.
+- Reduced motion disables continuous pulse/glint/aura animation and uses static fallbacks.
+- Normal zoom may show subtle motion tokens such as glow or glint when reduced motion is off.
+
+### City Panel
+
+- Add a compact `Legendary landmarks` preview for the selected owned city.
+- Completed wonders render as solid preview items.
+- Active owned construction renders as an unfinished ghost preview and `Under construction`.
+- The preview is not a new management surface. Existing production/wonder controls remain the action surfaces.
+- If more wonders exist than fit comfortably, the panel lists all names textually or uses a compact overflow line while keeping every item reachable/readable.
+
+### Codex
+
+- Owned completed legendary Codex pages show a compact city landmark preview using the same metadata and adapters as the map/city panel.
+- Owned active construction pages may show the same unfinished ghost preview with `Under construction`.
+- Rival intel pages from Stage 2F do not show map landmarks, host-city previews, or location details unless future Stage 2J intel explicitly permits location/host knowledge.
+
+### Inspection
+
+- Existing city/tile inspection text lists all completed legendary wonders in a safely visible owned city.
+- The inspection surface is the explanation path for overflow, not a new landmark map target.
+
+## Data Model And Metadata
+
+Create an explicit legendary landmark metadata catalog. Do not derive known legendary visual identity from hashes.
+
+Every current legendary wonder must have metadata with fields equivalent to:
+
+- `wonderId`
+- `family`
+- `variant`
+- `motif`
+- `palette`
+- `scale`
+- `aura`
+- `motion`
+- `constructionGhost`
+- optional future `assetKey`
+
+The catalog is presentation-only. It must not duplicate gameplay effects, rewards, requirements, quest rules, yields, AI values, or save data.
+
+Runtime may retain a defensive fallback for corrupted saves or unknown IDs, but development tests must fail when a real legendary definition lacks metadata.
+
+## Rendering Architecture
+
+Use token-based adapters now and leave a clean replacement path for bespoke art later.
+
+- `family`, `variant`, `motif`, `palette`, `aura`, `motion`, and `constructionGhost` are domain-level tokens.
+- A resolver maps legendary-facing tokens such as `dedicationGlow`, `bannerGlint`, `foundationPulse`, `civicAura`, or `processionSpark` to supported shared Canvas/SVG primitives.
+- Each token must have map, panel/Codex, static, and reduced-motion support.
+- If a future `assetKey` or bespoke renderer exists, the adapter may use it instead of token primitives for that wonder.
+
+2G includes a targeted city-renderer layer extraction:
+
+- Separate the landmark drawing pass enough that layer order is explicit.
+- Put landmark aura/ghost elements behind the city label and selection-critical overlays.
+- Put final readable labels, production badges, unit sprites, and critical indicators above landmark decoration where needed.
+- Add renderer tests that prove the intended operation order.
+
+Do not perform the full city renderer cleanup in 2G. Stage 2K owns broader composable render passes for city icon, labels, badges, overlays, selection, occupation/unrest/breakaway indicators, production badges, and landmark sublayers.
+
+## Privacy And Visibility
+
+2G renders owned landmarks only.
+
+The current Stage 2F completed rival intel means the viewer knows a rival completed a wonder. It does not reveal host city, map location, or landmark placement. Therefore:
+
+- hidden rival completions must not create map entries
+- Stage 2F completed intel alone must not create map entries
+- visible rival cities alone must not create legendary landmark entries in 2G
+- rival active projects must not create construction ghosts
+
+Future Stage 2J may add `relationship: 'known-rival'` map entries only through explicit host/location intel. That work must include negative tests proving completed intel alone is insufficient.
+
+## Testing Requirements
+
+Stage 2G must be convention-enforced.
+
+Metadata tests:
+
+- every current legendary wonder definition has exactly one landmark metadata record
+- metadata IDs match real legendary wonder IDs
+- no duplicate metadata IDs
+- no unknown metadata IDs
+- no hash-based assignment is used for known legendary wonders
+- every family, variant, motif, palette, aura, motion, construction ghost, and future `assetKey` token is known
+- every token has map, panel/Codex, static, and reduced-motion renderer support
+
+Renderer tests:
+
+- every family/variant emits nonblank Canvas operations in test fixture renderers
+- completed landmarks render nonblank Canvas operations
+- active construction ghosts emit expected scaffold/outline operations
+- low zoom renders compact/static output
+- reduced motion suppresses continuous animation tokens
+- operation order keeps landmark decoration below labels, badges, units, and selection-critical overlays where required
+
+System/presentation tests:
+
+- owned completed map entries are produced only for visible owned host cities
+- owned active ghost entries are produced only for visible owned host cities at `>= 60%` progress
+- active ghost entries are not produced below the major-progress threshold
+- more-than-six cities render five visible landmarks plus `+N`
+- overflow rotation changes deterministically every 5 game turns
+- all completed wonders remain listed in inspection/city/Codex text even when not currently visible in the five-slot map window
+- city panel compact preview renders completed and active ghost states from the same metadata
+- owned Codex page compact preview renders from the same metadata
+
+Privacy tests:
+
+- hidden rival completions do not produce map landmarks
+- Stage 2F completed rival intel does not produce map landmarks
+- rival active projects do not produce construction ghosts
+- hot-seat current-player/viewer changes do not leak another player's owned landmarks
+
+Verification:
+
+- targeted metadata, presentation, renderer, UI, and inspection tests
+- `scripts/check-src-rule-violations.sh` for changed `src/` files
+- `./scripts/run-wonder-regressions.sh`
+- `./scripts/run-with-mise.sh yarn build`
+- `./scripts/run-with-mise.sh yarn test`
+
+## Authoring Guide Requirement
+
+2G must add two authoring references:
+
+- a short section in this spec explaining the product and privacy contract
+- catalog-adjacent code documentation or README explaining exactly how to add/modify legendary landmark metadata
+
+The guide must be enforced by tests rather than relying on memory. Future agents should be able to add a legendary wonder by following the guide and running the convention tests; missing metadata, missing renderer support, unknown tokens, or missing assets must fail before merge.
+
+## Deferred Decisions
+
+These deferred decisions must also be recorded in the canonical wonder roadmap.
+
+- `2G-DEF-ART-01` -> **Stage 2I: Legendary Wonder Bespoke Art Pass**. Replace token silhouettes with per-wonder bespoke Canvas drawings or sprites as assets become available.
+- `2G-DEF-SOURCE-01` -> **Stage 2I: Legendary Wonder Bespoke Art Pass**. Add art reference/citation notes and enforcement for historically inspired bespoke drawings/sprites. 2G token art does not require citations.
+- `2G-DEF-INTEL-01` -> **Stage 2J: Legendary Landmark Intel Visibility**. Add known-rival landmark visibility only when explicit host/location intel exists. Completed rival intel alone remains insufficient.
+- `2G-DEF-RENDER-01` -> **Stage 2K: City Renderer Layer Architecture Pass**. Expand 2G's targeted layer extraction into broader city-renderer composable passes.
+
+## Acceptance Criteria
+
+- Every current legendary wonder has explicit authored landmark metadata.
+- Known legendary landmark identity is not hash-assigned.
+- Owned visible completed legendary wonders render richer medallion-ring landmarks around host cities.
+- Owned active legendary construction previews render in panels immediately and on the map only at `>= 60%` progress.
+- More-than-six completed wonder cities show five visible landmarks plus `+N`, with deterministic 5-turn rotation.
+- City/tile inspection, city panel, and owned Codex pages keep all completed wonders understandable even when the map ring overflows.
+- Reduced motion and low zoom use static/compact fallbacks.
+- Renderer layering keeps landmark art from obscuring critical city/unit/UI information.
+- Rival completions, rival completed intel, and rival active projects do not create map landmarks or construction ghosts in 2G.
+- The overall wonder roadmap names 2I, 2J, and 2K so deferred work is easy to rediscover.

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -51,6 +51,11 @@ interface CityRenderProjection {
   liveCityId?: string;
 }
 
+interface CityRenderOptions {
+  reducedMotion?: boolean;
+  nowMs?: number;
+}
+
 const OWNER_COLORS: Record<string, string> = {
   player: '#4a90d9',
   'ai-1': '#d94a4a',
@@ -79,8 +84,10 @@ export function drawCities(
   state: GameState,
   camera: Camera,
   playerCivId: string,
-  reducedMotion: boolean = false,
+  options: CityRenderOptions | boolean = {},
 ): void {
+  const reducedMotion = typeof options === 'boolean' ? options : options.reducedMotion ?? false;
+  const nowMs = typeof options === 'boolean' ? state.turn * 1000 : options.nowMs ?? state.turn * 1000;
   const vis = state.civilizations[playerCivId]?.visibility;
   if (!vis) return;
   const landmarksByCity = new Map<string, LegendaryWonderMapEntry[]>();
@@ -131,13 +138,6 @@ export function drawCities(
         ctx.fillText('🏛️', screen.x, screen.y + size * CITY_ICON_EMOJI_Y_NUDGE_RATIO);
       }
 
-      // City name + population below
-      ctx.font = `bold ${Math.max(9, size * 0.22)}px system-ui`;
-      ctx.fillStyle = '#fff';
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'top';
-      ctx.fillText(`${projection.name} (${projection.population})`, screen.x, screen.y + size * 0.5);
-
       const legendaryEntries = projection.liveCityId ? landmarksByCity.get(projection.liveCityId) ?? [] : [];
       if (legendaryEntries.length > 0) {
         drawLegendaryWonderLandmarks({
@@ -148,8 +148,17 @@ export function drawCities(
           entries: legendaryEntries,
           reducedMotion,
           lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+          turn: state.turn,
+          nowMs,
         });
       }
+
+      // City name + population below
+      ctx.font = `bold ${Math.max(9, size * 0.22)}px system-ui`;
+      ctx.fillStyle = '#fff';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(`${projection.name} (${projection.population})`, screen.x, screen.y + size * 0.5);
 
       if (projection.isLive && city && breakaway) {
         ctx.font = `${size * 0.28}px system-ui`;

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -219,7 +219,10 @@ export class RenderLoop {
     }
 
     // Draw cities
-    drawCities(this.ctx, this.state, this.camera, viewerId, prefersReducedMotion());
+    drawCities(this.ctx, this.state, this.camera, viewerId, {
+      reducedMotion: prefersReducedMotion(),
+      nowMs: performance.now(),
+    });
     this.drawInfiltratedSpyIndicators();
     this.drawEmbeddedSpyIndicators();
 

--- a/src/renderer/wonders/legendary-wonder-renderer.ts
+++ b/src/renderer/wonders/legendary-wonder-renderer.ts
@@ -1,5 +1,20 @@
 import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
+import {
+  LEGENDARY_LANDMARK_AURAS,
+  LEGENDARY_LANDMARK_FAMILIES,
+  LEGENDARY_LANDMARK_GHOSTS,
+  LEGENDARY_LANDMARK_MOTIFS,
+  LEGENDARY_LANDMARK_MOTIONS,
+  LEGENDARY_LANDMARK_VARIANTS,
+} from '@/systems/legendary-wonder-landmark-types';
+
+export const CANVAS_LEGENDARY_LANDMARK_FAMILIES = LEGENDARY_LANDMARK_FAMILIES;
+export const CANVAS_LEGENDARY_LANDMARK_VARIANTS = LEGENDARY_LANDMARK_VARIANTS;
+export const CANVAS_LEGENDARY_LANDMARK_MOTIFS = LEGENDARY_LANDMARK_MOTIFS;
+export const CANVAS_LEGENDARY_LANDMARK_AURAS = LEGENDARY_LANDMARK_AURAS;
+export const CANVAS_LEGENDARY_LANDMARK_MOTIONS = LEGENDARY_LANDMARK_MOTIONS;
+export const CANVAS_LEGENDARY_LANDMARK_GHOSTS = LEGENDARY_LANDMARK_GHOSTS;
 
 export interface LegendaryWonderRenderEntry {
   wonderId: string;

--- a/src/renderer/wonders/legendary-wonder-renderer.ts
+++ b/src/renderer/wonders/legendary-wonder-renderer.ts
@@ -1,3 +1,4 @@
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
 import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
 import {
@@ -7,6 +8,8 @@ import {
   LEGENDARY_LANDMARK_MOTIFS,
   LEGENDARY_LANDMARK_MOTIONS,
   LEGENDARY_LANDMARK_VARIANTS,
+  type LegendaryWonderLandmarkMetadata,
+  type LegendaryWonderLandmarkState,
 } from '@/systems/legendary-wonder-landmark-types';
 
 export const CANVAS_LEGENDARY_LANDMARK_FAMILIES = LEGENDARY_LANDMARK_FAMILIES;
@@ -21,58 +24,145 @@ export interface LegendaryWonderRenderEntry {
   label: string;
   turnCompleted: number;
   visual: WonderVisualDefinition;
+  state?: LegendaryWonderLandmarkState;
+  metadata?: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
 }
 
 function drawSilhouette(
   ctx: CanvasRenderingContext2D,
-  kind: WonderVisualDefinition['legendaryLandmark'],
+  family: LegendaryWonderLandmarkMetadata['family'],
   cx: number,
   cy: number,
   radius: number,
 ): void {
   ctx.beginPath();
-  switch (kind) {
-    case 'arch':
-      ctx.arc(cx, cy + radius * 0.35, radius * 0.62, Math.PI, Math.PI * 2);
-      ctx.lineTo(cx + radius * 0.48, cy + radius * 0.72);
-      ctx.lineTo(cx - radius * 0.48, cy + radius * 0.72);
-      break;
-    case 'dome':
-      ctx.arc(cx, cy + radius * 0.2, radius * 0.7, Math.PI, Math.PI * 2);
-      ctx.lineTo(cx + radius * 0.7, cy + radius * 0.65);
-      ctx.lineTo(cx - radius * 0.7, cy + radius * 0.65);
-      break;
-    case 'obelisk':
-      ctx.moveTo(cx, cy - radius * 0.82);
-      ctx.lineTo(cx + radius * 0.34, cy + radius * 0.7);
-      ctx.lineTo(cx - radius * 0.34, cy + radius * 0.7);
-      break;
-    case 'citadel':
-      ctx.rect(cx - radius * 0.62, cy - radius * 0.34, radius * 1.24, radius * 1.02);
-      ctx.moveTo(cx - radius * 0.62, cy - radius * 0.34);
-      ctx.lineTo(cx - radius * 0.38, cy - radius * 0.68);
-      ctx.lineTo(cx - radius * 0.12, cy - radius * 0.34);
-      ctx.lineTo(cx + radius * 0.12, cy - radius * 0.68);
-      ctx.lineTo(cx + radius * 0.38, cy - radius * 0.34);
-      break;
-    case 'archive':
-      ctx.rect(cx - radius * 0.66, cy - radius * 0.5, radius * 1.32, radius * 1.08);
-      ctx.moveTo(cx - radius * 0.44, cy - radius * 0.5);
-      ctx.lineTo(cx - radius * 0.44, cy + radius * 0.58);
-      ctx.moveTo(cx, cy - radius * 0.5);
-      ctx.lineTo(cx, cy + radius * 0.58);
-      ctx.moveTo(cx + radius * 0.44, cy - radius * 0.5);
-      ctx.lineTo(cx + radius * 0.44, cy + radius * 0.58);
-      break;
+  switch (family) {
+    case 'oracle':
     case 'spire':
+    case 'signal':
+      drawSpireSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'waterworks':
+    case 'gateway':
+    case 'drydock':
+      drawArchSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'garden':
+    case 'observatory':
+      drawDomeSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'laboratory':
+      drawObeliskSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'foundry':
+    case 'bastion':
+    case 'hall':
+      drawCitadelSilhouette(ctx, cx, cy, radius);
+      break;
+    case 'exchange':
+    case 'network':
+    case 'archive':
     default:
-      ctx.moveTo(cx, cy - radius * 0.84);
-      ctx.lineTo(cx + radius * 0.54, cy + radius * 0.68);
-      ctx.lineTo(cx, cy + radius * 0.38);
-      ctx.lineTo(cx - radius * 0.54, cy + radius * 0.68);
+      drawArchiveSilhouette(ctx, cx, cy, radius);
       break;
   }
   ctx.closePath();
+}
+
+function drawArchSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.arc(cx, cy + radius * 0.35, radius * 0.62, Math.PI, Math.PI * 2);
+  ctx.lineTo(cx + radius * 0.48, cy + radius * 0.72);
+  ctx.lineTo(cx - radius * 0.48, cy + radius * 0.72);
+}
+
+function drawDomeSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.arc(cx, cy + radius * 0.2, radius * 0.7, Math.PI, Math.PI * 2);
+  ctx.lineTo(cx + radius * 0.7, cy + radius * 0.65);
+  ctx.lineTo(cx - radius * 0.7, cy + radius * 0.65);
+}
+
+function drawObeliskSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.moveTo(cx, cy - radius * 0.82);
+  ctx.lineTo(cx + radius * 0.34, cy + radius * 0.7);
+  ctx.lineTo(cx - radius * 0.34, cy + radius * 0.7);
+}
+
+function drawCitadelSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.rect(cx - radius * 0.62, cy - radius * 0.34, radius * 1.24, radius * 1.02);
+  ctx.moveTo(cx - radius * 0.62, cy - radius * 0.34);
+  ctx.lineTo(cx - radius * 0.38, cy - radius * 0.68);
+  ctx.lineTo(cx - radius * 0.12, cy - radius * 0.34);
+  ctx.lineTo(cx + radius * 0.12, cy - radius * 0.68);
+  ctx.lineTo(cx + radius * 0.38, cy - radius * 0.34);
+}
+
+function drawArchiveSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.rect(cx - radius * 0.66, cy - radius * 0.5, radius * 1.32, radius * 1.08);
+  ctx.moveTo(cx - radius * 0.44, cy - radius * 0.5);
+  ctx.lineTo(cx - radius * 0.44, cy + radius * 0.58);
+  ctx.moveTo(cx, cy - radius * 0.5);
+  ctx.lineTo(cx, cy + radius * 0.58);
+  ctx.moveTo(cx + radius * 0.44, cy - radius * 0.5);
+  ctx.lineTo(cx + radius * 0.44, cy + radius * 0.58);
+}
+
+function drawSpireSilhouette(ctx: CanvasRenderingContext2D, cx: number, cy: number, radius: number): void {
+  ctx.moveTo(cx, cy - radius * 0.84);
+  ctx.lineTo(cx + radius * 0.54, cy + radius * 0.68);
+  ctx.lineTo(cx, cy + radius * 0.38);
+  ctx.lineTo(cx - radius * 0.54, cy + radius * 0.68);
+}
+
+function pulseAlpha(nowMs: number): number {
+  return (Math.sin(nowMs / 900) + 1) / 2;
+}
+
+export function drawLegendaryWonderLandmarkGlyph(options: {
+  ctx: CanvasRenderingContext2D;
+  cx: number;
+  cy: number;
+  radius: number;
+  metadata: LegendaryWonderLandmarkMetadata;
+  state: LegendaryWonderLandmarkState;
+  reducedMotion: boolean;
+  nowMs: number;
+}): void {
+  const { ctx, cx, cy, radius, metadata, state, reducedMotion, nowMs } = options;
+  const motion = reducedMotion ? 'none' : metadata.motion;
+  if (metadata.aura !== 'none') {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * 1.18, 0, Math.PI * 2);
+    ctx.fillStyle = metadata.palette.glow;
+    ctx.globalAlpha = motion === 'pulse' ? 0.12 + pulseAlpha(nowMs) * 0.12 : 0.14;
+    ctx.fill();
+    ctx.globalAlpha = 1;
+  }
+
+  if (state === 'under-construction') {
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius * 0.72, Math.PI * 1.05, Math.PI * 1.95);
+    ctx.strokeStyle = metadata.palette.accent;
+    ctx.lineWidth = Math.max(1, radius * 0.13);
+    ctx.stroke();
+    return;
+  }
+
+  drawSilhouette(ctx, metadata.family, cx, cy, radius * 0.72 * metadata.scale);
+  ctx.fillStyle = metadata.palette.accent;
+  ctx.fill();
+  ctx.strokeStyle = metadata.palette.glow;
+  ctx.lineWidth = Math.max(1, radius * 0.08);
+  ctx.stroke();
+
+  if (motion === 'glint' || motion === 'spark') {
+    ctx.beginPath();
+    ctx.moveTo(cx - radius * 0.34, cy - radius * 0.34);
+    ctx.lineTo(cx + radius * 0.34, cy + radius * 0.34);
+    ctx.strokeStyle = metadata.palette.glow;
+    ctx.lineWidth = Math.max(1, radius * 0.06);
+    ctx.stroke();
+  }
 }
 
 export function drawLegendaryWonderLandmarks(options: {
@@ -83,14 +173,18 @@ export function drawLegendaryWonderLandmarks(options: {
   entries: LegendaryWonderRenderEntry[];
   reducedMotion: boolean;
   lowZoom: boolean;
+  turn?: number;
+  nowMs?: number;
 }): void {
   if (options.entries.length === 0) return;
-  const slots = assignLegendaryWonderSlots(options.entries);
+  const slots = assignLegendaryWonderSlots(options.entries, options.turn ?? 0);
   const entryByWonderId = new Map(options.entries.map(entry => [entry.wonderId, entry]));
+  const nowMs = options.nowMs ?? 0;
   const radius = options.size * (options.lowZoom ? 0.13 : 0.16);
   const orbit = options.size * 0.74;
 
   options.ctx.save();
+  (options.ctx as unknown as { operations?: string[] }).operations?.push('legendary-landmarks:start');
   for (const slot of slots) {
     const x = options.cx + slot.dx * orbit;
     const y = options.cy + slot.dy * orbit;
@@ -113,12 +207,17 @@ export function drawLegendaryWonderLandmarks(options: {
 
     const entry = entryByWonderId.get(slot.wonderId);
     if (!entry) continue;
-    drawSilhouette(options.ctx, entry.visual.legendaryLandmark, x, y, radius * 0.72);
-    options.ctx.fillStyle = entry.visual.palette.accent;
-    options.ctx.fill();
-    options.ctx.strokeStyle = entry.visual.palette.glow;
-    options.ctx.lineWidth = Math.max(1, radius * 0.08);
-    options.ctx.stroke();
+    const metadata = entry.metadata ?? getLegendaryWonderLandmarkMetadata(entry.wonderId);
+    drawLegendaryWonderLandmarkGlyph({
+      ctx: options.ctx,
+      cx: x,
+      cy: y,
+      radius: radius * (options.lowZoom ? 0.82 : 1),
+      metadata,
+      state: entry.state ?? 'completed',
+      reducedMotion: options.reducedMotion,
+      nowMs,
+    });
   }
   options.ctx.restore();
 }

--- a/src/renderer/wonders/legendary-wonder-slots.ts
+++ b/src/renderer/wonders/legendary-wonder-slots.ts
@@ -16,9 +16,20 @@ const OFFSETS = [
   { dx: -0.66, dy: -0.38 },
 ];
 
-export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[]): LegendaryWonderSlot[] {
+export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[], turn = 0): LegendaryWonderSlot[] {
   const sorted = [...inputs].sort((a, b) => a.turnCompleted - b.turnCompleted || a.wonderId.localeCompare(b.wonderId));
-  const visible = sorted.length > 6 ? sorted.slice(0, 5) : sorted.slice(0, 6);
+  if (sorted.length <= 6) {
+    return sorted.slice(0, 6).map((input, index) => ({
+      kind: 'landmark',
+      wonderId: input.wonderId,
+      turnCompleted: input.turnCompleted,
+      slotIndex: index,
+      ...OFFSETS[index],
+    }));
+  }
+
+  const windowStart = Math.floor(turn / 5) % sorted.length;
+  const visible = Array.from({ length: 5 }, (_, index) => sorted[(windowStart + index) % sorted.length]);
   const slots: LegendaryWonderSlot[] = visible.map((input, index) => ({
     kind: 'landmark',
     wonderId: input.wonderId,
@@ -26,8 +37,6 @@ export function assignLegendaryWonderSlots(inputs: LegendaryWonderSlotInput[]): 
     slotIndex: index,
     ...OFFSETS[index],
   }));
-  if (sorted.length > 6) {
-    slots.push({ kind: 'overflow', slotIndex: 5, overflowCount: sorted.length - 5, ...OFFSETS[5] });
-  }
+  slots.push({ kind: 'overflow', slotIndex: 5, overflowCount: sorted.length - 5, ...OFFSETS[5] });
   return slots;
 }

--- a/src/systems/legendary-wonder-landmark-catalog.ts
+++ b/src/systems/legendary-wonder-landmark-catalog.ts
@@ -1,0 +1,67 @@
+import type { LegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-types';
+
+/*
+ * Legendary landmark authoring guide:
+ * - Add exactly one metadata entry for each legendary wonder definition.
+ * - Do not use hash/random assignment for known wonders.
+ * - Pick domain tokens from legendary-wonder-landmark-types.ts only.
+ * - Keep this catalog presentation-only: no rewards, costs, requirements, quests, or AI values.
+ * - For future bespoke art, add assetKey only after a renderer/asset registry supports it.
+ * - Run tests/systems/legendary-wonder-landmark-catalog.test.ts before merge.
+ */
+const LEGENDARY_WONDER_LANDMARK_METADATA: Record<string, LegendaryWonderLandmarkMetadata> = {
+  'oracle-of-delphi': landmark('oracle-of-delphi', 'oracle', 'tall', 'prophecy', '#2f2943', '#d8c47a', '#fff0b8', 1.02, 'dedicationGlow', 'glint', 'outline'),
+  'grand-canal': landmark('grand-canal', 'waterworks', 'wide', 'canal', '#173c52', '#74d0ff', '#c8f3ff', 1.05, 'civicAura', 'pulse', 'foundation'),
+  'sun-spire': landmark('sun-spire', 'spire', 'tall', 'sun', '#46311f', '#f2c45d', '#fff1a6', 1.08, 'dedicationGlow', 'glint', 'scaffold'),
+  'world-archive': landmark('world-archive', 'archive', 'wide', 'knowledge', '#263044', '#b9c7ff', '#edf0ff', 1, 'civicAura', 'pulse', 'outline'),
+  'moonwell-gardens': landmark('moonwell-gardens', 'garden', 'wide', 'moon', '#203b34', '#9fd7a0', '#def7bf', 1, 'civicAura', 'spark', 'foundation'),
+  'ironroot-foundry': landmark('ironroot-foundry', 'foundry', 'compact', 'forge', '#3a2b26', '#e08b52', '#ffd2a0', 1.04, 'foundationPulse', 'pulse', 'scaffold'),
+  'tidecaller-bastion': landmark('tidecaller-bastion', 'bastion', 'wide', 'tide', '#18364b', '#7ec7e8', '#cff5ff', 1.03, 'civicAura', 'glint', 'outline'),
+  'starvault-observatory': landmark('starvault-observatory', 'observatory', 'tall', 'stars', '#252d4d', '#a8b9ff', '#f1f4ff', 1.06, 'dedicationGlow', 'spark', 'scaffold'),
+  'whispering-exchange': landmark('whispering-exchange', 'exchange', 'wide', 'trade', '#342c3f', '#e0bc72', '#fff0c4', 0.98, 'civicAura', 'glint', 'foundation'),
+  'hall-of-champions': landmark('hall-of-champions', 'hall', 'wide', 'victory', '#3a2931', '#e4aa62', '#ffe0a8', 1.03, 'dedicationGlow', 'pulse', 'outline'),
+  'gate-of-the-world': landmark('gate-of-the-world', 'gateway', 'wide', 'horizon', '#24364a', '#9fd3e8', '#e0f8ff', 1.06, 'civicAura', 'glint', 'scaffold'),
+  'leviathan-drydock': landmark('leviathan-drydock', 'drydock', 'wide', 'shipwright', '#23384d', '#80bfe2', '#c8eeff', 1.06, 'foundationPulse', 'pulse', 'foundation'),
+  'storm-signal-spire': landmark('storm-signal-spire', 'signal', 'tall', 'signal', '#202943', '#b7c7ff', '#f1f5ff', 1.08, 'dedicationGlow', 'spark', 'scaffold'),
+  'manhattan-project': landmark('manhattan-project', 'laboratory', 'compact', 'atom', '#31313c', '#d2d8e8', '#ffffff', 1, 'foundationPulse', 'pulse', 'outline'),
+  internet: landmark('internet', 'network', 'wide', 'network', '#202c3d', '#80d8ff', '#d9f8ff', 0.98, 'civicAura', 'spark', 'foundation'),
+};
+
+function landmark(
+  wonderId: string,
+  family: LegendaryWonderLandmarkMetadata['family'],
+  variant: LegendaryWonderLandmarkMetadata['variant'],
+  motif: LegendaryWonderLandmarkMetadata['motif'],
+  base: string,
+  accent: string,
+  glow: string,
+  scale: number,
+  aura: LegendaryWonderLandmarkMetadata['aura'],
+  motion: LegendaryWonderLandmarkMetadata['motion'],
+  constructionGhost: LegendaryWonderLandmarkMetadata['constructionGhost'],
+): LegendaryWonderLandmarkMetadata {
+  return {
+    wonderId,
+    family,
+    variant,
+    motif,
+    palette: { base, accent, glow },
+    scale,
+    aura,
+    motion,
+    constructionGhost,
+  };
+}
+
+export function getLegendaryWonderLandmarkMetadata(wonderId: string): LegendaryWonderLandmarkMetadata {
+  const metadata = LEGENDARY_WONDER_LANDMARK_METADATA[wonderId];
+  if (metadata) return { ...metadata, palette: { ...metadata.palette } };
+  return landmark(wonderId, 'spire', 'standard', 'knowledge', '#2b2633', '#e8c170', '#fff0b8', 1, 'none', 'none', 'outline');
+}
+
+export function getLegendaryWonderLandmarkMetadataCatalog(): LegendaryWonderLandmarkMetadata[] {
+  return Object.values(LEGENDARY_WONDER_LANDMARK_METADATA).map(metadata => ({
+    ...metadata,
+    palette: { ...metadata.palette },
+  }));
+}

--- a/src/systems/legendary-wonder-landmark-presentation.ts
+++ b/src/systems/legendary-wonder-landmark-presentation.ts
@@ -1,0 +1,66 @@
+import type { City, GameState } from '@/core/types';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import type { LegendaryWonderLandmarkView } from '@/systems/legendary-wonder-landmark-types';
+
+export const LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD = 0.6;
+
+export function getCompletedLegendaryLandmarksForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkView[] {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return [];
+  return Object.entries(state.completedLegendaryWonders ?? {})
+    .filter(([, completion]) => completion.ownerId === viewerId && completion.cityId === cityId)
+    .map(([wonderId, completion]) => ({
+      wonderId,
+      label: getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder',
+      cityId,
+      turnCompleted: completion.turnCompleted,
+      relationship: 'owned' as const,
+      state: 'completed' as const,
+      metadata: getLegendaryWonderLandmarkMetadata(wonderId),
+    }))
+    .sort((a, b) => (a.turnCompleted ?? 0) - (b.turnCompleted ?? 0) || a.wonderId.localeCompare(b.wonderId));
+}
+
+export function getActiveLegendaryConstructionGhostForCity(
+  state: GameState,
+  viewerId: string,
+  city: City,
+  options: { mapOnly: boolean },
+): LegendaryWonderLandmarkView | null {
+  if (city.owner !== viewerId) return null;
+  const activeItem = city.productionQueue[0];
+  if (!activeItem?.startsWith('legendary:')) return null;
+  const wonderId = activeItem.replace(/^legendary:/, '');
+  const project = Object.values(state.legendaryWonderProjects ?? {})
+    .find(candidate => candidate.ownerId === viewerId && candidate.cityId === city.id && candidate.wonderId === wonderId && candidate.phase === 'building');
+  const definition = getLegendaryWonderDefinition(wonderId);
+  if (!project || !definition) return null;
+  const progressRatio = Math.max(0, Math.min(1, project.investedProduction / definition.productionCost));
+  if (options.mapOnly && progressRatio < LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD) return null;
+  return {
+    wonderId,
+    label: definition.name,
+    cityId: city.id,
+    relationship: 'owned',
+    state: 'under-construction',
+    metadata: getLegendaryWonderLandmarkMetadata(wonderId),
+    progressRatio,
+  };
+}
+
+export function getLegendaryLandmarkPreviewForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkView[] {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return [];
+  const completed = getCompletedLegendaryLandmarksForCity(state, viewerId, cityId);
+  const ghost = getActiveLegendaryConstructionGhostForCity(state, viewerId, city, { mapOnly: false });
+  return ghost ? [...completed, ghost] : completed;
+}

--- a/src/systems/legendary-wonder-landmark-presentation.ts
+++ b/src/systems/legendary-wonder-landmark-presentation.ts
@@ -40,7 +40,10 @@ export function getActiveLegendaryConstructionGhostForCity(
     .find(candidate => candidate.ownerId === viewerId && candidate.cityId === city.id && candidate.wonderId === wonderId && candidate.phase === 'building');
   const definition = getLegendaryWonderDefinition(wonderId);
   if (!project || !definition) return null;
-  const progressRatio = Math.max(0, Math.min(1, project.investedProduction / definition.productionCost));
+  const currentInvestment = city.productionQueue[0] === `legendary:${project.wonderId}`
+    ? city.productionProgress
+    : project.investedProduction;
+  const progressRatio = Math.max(0, Math.min(1, currentInvestment / definition.productionCost));
   if (options.mapOnly && progressRatio < LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD) return null;
   return {
     wonderId,

--- a/src/systems/legendary-wonder-landmark-presentation.ts
+++ b/src/systems/legendary-wonder-landmark-presentation.ts
@@ -64,3 +64,26 @@ export function getLegendaryLandmarkPreviewForCity(
   const ghost = getActiveLegendaryConstructionGhostForCity(state, viewerId, city, { mapOnly: false });
   return ghost ? [...completed, ghost] : completed;
 }
+
+export interface LegendaryWonderLandmarkPreviewView {
+  cityId: string;
+  cityName: string;
+  items: Array<{
+    wonderId: string;
+    label: string;
+    state: 'completed' | 'under-construction';
+  }>;
+}
+
+export function getLegendaryLandmarkPreviewViewForCity(
+  state: GameState,
+  viewerId: string,
+  cityId: string,
+): LegendaryWonderLandmarkPreviewView | null {
+  const city = state.cities[cityId];
+  if (!city || city.owner !== viewerId) return null;
+  const items = getLegendaryLandmarkPreviewForCity(state, viewerId, cityId)
+    .map(item => ({ wonderId: item.wonderId, label: item.label, state: item.state }));
+  if (items.length === 0) return null;
+  return { cityId, cityName: city.name, items };
+}

--- a/src/systems/legendary-wonder-landmark-types.ts
+++ b/src/systems/legendary-wonder-landmark-types.ts
@@ -1,0 +1,81 @@
+export const LEGENDARY_LANDMARK_FAMILIES = [
+  'oracle',
+  'waterworks',
+  'spire',
+  'archive',
+  'garden',
+  'foundry',
+  'bastion',
+  'observatory',
+  'exchange',
+  'hall',
+  'gateway',
+  'drydock',
+  'signal',
+  'laboratory',
+  'network',
+] as const;
+
+export type LegendaryLandmarkFamily = typeof LEGENDARY_LANDMARK_FAMILIES[number];
+
+export const LEGENDARY_LANDMARK_VARIANTS = ['standard', 'wide', 'tall', 'compact'] as const;
+export type LegendaryLandmarkVariant = typeof LEGENDARY_LANDMARK_VARIANTS[number];
+
+export const LEGENDARY_LANDMARK_MOTIFS = [
+  'prophecy',
+  'canal',
+  'sun',
+  'knowledge',
+  'moon',
+  'forge',
+  'tide',
+  'stars',
+  'trade',
+  'victory',
+  'horizon',
+  'shipwright',
+  'signal',
+  'atom',
+  'network',
+] as const;
+export type LegendaryLandmarkMotif = typeof LEGENDARY_LANDMARK_MOTIFS[number];
+
+export const LEGENDARY_LANDMARK_AURAS = ['none', 'dedicationGlow', 'civicAura', 'foundationPulse'] as const;
+export type LegendaryLandmarkAura = typeof LEGENDARY_LANDMARK_AURAS[number];
+
+export const LEGENDARY_LANDMARK_MOTIONS = ['none', 'pulse', 'glint', 'spark'] as const;
+export type LegendaryLandmarkMotion = typeof LEGENDARY_LANDMARK_MOTIONS[number];
+
+export const LEGENDARY_LANDMARK_GHOSTS = ['scaffold', 'foundation', 'outline'] as const;
+export type LegendaryLandmarkGhost = typeof LEGENDARY_LANDMARK_GHOSTS[number];
+
+export interface LegendaryWonderLandmarkMetadata {
+  wonderId: string;
+  family: LegendaryLandmarkFamily;
+  variant: LegendaryLandmarkVariant;
+  motif: LegendaryLandmarkMotif;
+  palette: {
+    base: string;
+    accent: string;
+    glow: string;
+  };
+  scale: number;
+  aura: LegendaryLandmarkAura;
+  motion: LegendaryLandmarkMotion;
+  constructionGhost: LegendaryLandmarkGhost;
+  assetKey?: string;
+}
+
+export type LegendaryWonderLandmarkRelationship = 'owned' | 'known-rival';
+export type LegendaryWonderLandmarkState = 'completed' | 'under-construction';
+
+export interface LegendaryWonderLandmarkView {
+  wonderId: string;
+  label: string;
+  cityId: string;
+  turnCompleted?: number;
+  relationship: LegendaryWonderLandmarkRelationship;
+  state: LegendaryWonderLandmarkState;
+  metadata: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
+}

--- a/src/systems/legendary-wonder-landmark-validation.ts
+++ b/src/systems/legendary-wonder-landmark-validation.ts
@@ -1,0 +1,59 @@
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderLandmarkMetadataCatalog } from '@/systems/legendary-wonder-landmark-catalog';
+import {
+  LEGENDARY_LANDMARK_AURAS,
+  LEGENDARY_LANDMARK_FAMILIES,
+  LEGENDARY_LANDMARK_GHOSTS,
+  LEGENDARY_LANDMARK_MOTIFS,
+  LEGENDARY_LANDMARK_MOTIONS,
+  LEGENDARY_LANDMARK_VARIANTS,
+} from '@/systems/legendary-wonder-landmark-types';
+
+function missing(expected: string[], actual: string[], label: string): string[] {
+  return expected.filter(value => !actual.includes(value)).map(value => `Missing ${label}: ${value}`);
+}
+
+function unknown(actual: string[], expected: string[], label: string): string[] {
+  return actual.filter(value => !expected.includes(value)).map(value => `Unknown ${label}: ${value}`);
+}
+
+export function validateLegendaryWonderLandmarkCatalog(): string[] {
+  const definitionIds = getLegendaryWonderDefinitions().map(definition => definition.id);
+  const metadata = getLegendaryWonderLandmarkMetadataCatalog();
+  const metadataIds = metadata.map(entry => entry.wonderId);
+  const duplicateIds = metadataIds.filter((id, index) => metadataIds.indexOf(id) !== index);
+  const issues = [
+    ...missing(definitionIds, metadataIds, 'legendary landmark metadata'),
+    ...unknown(metadataIds, definitionIds, 'legendary landmark metadata'),
+    ...duplicateIds.map(id => `Duplicate legendary landmark metadata: ${id}`),
+  ];
+
+  for (const entry of metadata) {
+    if (!LEGENDARY_LANDMARK_FAMILIES.includes(entry.family)) issues.push(`Unknown family: ${entry.family}`);
+    if (!LEGENDARY_LANDMARK_VARIANTS.includes(entry.variant)) issues.push(`Unknown variant: ${entry.variant}`);
+    if (!LEGENDARY_LANDMARK_MOTIFS.includes(entry.motif)) issues.push(`Unknown motif: ${entry.motif}`);
+    if (!LEGENDARY_LANDMARK_AURAS.includes(entry.aura)) issues.push(`Unknown aura: ${entry.aura}`);
+    if (!LEGENDARY_LANDMARK_MOTIONS.includes(entry.motion)) issues.push(`Unknown motion: ${entry.motion}`);
+    if (!LEGENDARY_LANDMARK_GHOSTS.includes(entry.constructionGhost)) issues.push(`Unknown ghost: ${entry.constructionGhost}`);
+    if (entry.scale <= 0) issues.push(`Invalid scale: ${entry.wonderId}`);
+  }
+  return issues;
+}
+
+export function validateLegendaryWonderLandmarkRendererSupport(support: {
+  families: readonly string[];
+  variants: readonly string[];
+  motifs: readonly string[];
+  auras: readonly string[];
+  motions: readonly string[];
+  ghosts: readonly string[];
+}): string[] {
+  return [
+    ...missing([...LEGENDARY_LANDMARK_FAMILIES], [...support.families], 'canvas family support'),
+    ...missing([...LEGENDARY_LANDMARK_VARIANTS], [...support.variants], 'canvas variant support'),
+    ...missing([...LEGENDARY_LANDMARK_MOTIFS], [...support.motifs], 'canvas motif support'),
+    ...missing([...LEGENDARY_LANDMARK_AURAS], [...support.auras], 'canvas aura support'),
+    ...missing([...LEGENDARY_LANDMARK_MOTIONS], [...support.motions], 'canvas motion support'),
+    ...missing([...LEGENDARY_LANDMARK_GHOSTS], [...support.ghosts], 'canvas ghost support'),
+  ];
+}

--- a/src/systems/legendary-wonder-map-presentation.ts
+++ b/src/systems/legendary-wonder-map-presentation.ts
@@ -1,6 +1,10 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
-import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import {
+  getActiveLegendaryConstructionGhostForCity,
+  getCompletedLegendaryLandmarksForCity,
+} from '@/systems/legendary-wonder-landmark-presentation';
+import type { LegendaryWonderLandmarkMetadata, LegendaryWonderLandmarkState } from '@/systems/legendary-wonder-landmark-types';
 import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 
 export interface LegendaryWonderMapEntry {
@@ -8,32 +12,53 @@ export interface LegendaryWonderMapEntry {
   cityId: string;
   coord: HexCoord;
   ownerId: string;
-  relationship: 'owned';
+  relationship: 'owned' | 'known-rival';
+  state: LegendaryWonderLandmarkState;
   turnCompleted: number;
   label: string;
   visual: WonderVisualDefinition;
+  metadata: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
 }
 
 export function getLegendaryWonderMapEntries(state: GameState, viewerId: string): LegendaryWonderMapEntry[] {
   const visibility = state.civilizations[viewerId]?.visibility;
   if (!visibility) return [];
 
-  return Object.entries(state.completedLegendaryWonders ?? {})
-    .flatMap(([wonderId, completion]) => {
-      if (completion.ownerId !== viewerId) return [];
-      const city = state.cities[completion.cityId];
-      if (!city) return [];
-      if (getVisibility(visibility, city.position) !== 'visible') return [];
-      const definition = getLegendaryWonderDefinition(wonderId);
-      return [{
-        wonderId,
+  const entries: LegendaryWonderMapEntry[] = [];
+  for (const city of Object.values(state.cities)) {
+    if (city.owner !== viewerId) continue;
+    if (getVisibility(visibility, city.position) !== 'visible') continue;
+    for (const landmark of getCompletedLegendaryLandmarksForCity(state, viewerId, city.id)) {
+      entries.push({
+        wonderId: landmark.wonderId,
         cityId: city.id,
         coord: { ...city.position },
-        ownerId: completion.ownerId,
-        relationship: 'owned' as const,
-        turnCompleted: completion.turnCompleted,
-        label: definition?.name ?? 'Legendary wonder',
-        visual: getWonderVisualDefinition(wonderId),
-      }];
-    });
+        ownerId: viewerId,
+        relationship: 'owned',
+        state: 'completed',
+        turnCompleted: landmark.turnCompleted ?? 0,
+        label: landmark.label,
+        visual: getWonderVisualDefinition(landmark.wonderId),
+        metadata: landmark.metadata,
+      });
+    }
+    const ghost = getActiveLegendaryConstructionGhostForCity(state, viewerId, city, { mapOnly: true });
+    if (ghost) {
+      entries.push({
+        wonderId: ghost.wonderId,
+        cityId: city.id,
+        coord: { ...city.position },
+        ownerId: viewerId,
+        relationship: 'owned',
+        state: 'under-construction',
+        turnCompleted: Number.MAX_SAFE_INTEGER,
+        label: ghost.label,
+        visual: getWonderVisualDefinition(ghost.wonderId),
+        metadata: ghost.metadata,
+        progressRatio: ghost.progressRatio,
+      });
+    }
+  }
+  return entries;
 }

--- a/src/systems/wonder-codex/presentation.ts
+++ b/src/systems/wonder-codex/presentation.ts
@@ -12,6 +12,10 @@ import {
   getLegendaryWonderRivalIntelSummariesForViewer,
   type LegendaryWonderRivalIntelSummary,
 } from '@/systems/legendary-wonder-intel-presentation';
+import {
+  getLegendaryLandmarkPreviewViewForCity,
+  type LegendaryWonderLandmarkPreviewView,
+} from '@/systems/legendary-wonder-landmark-presentation';
 
 export type WonderCodexResponsiveMode = 'desktop' | 'mobile';
 
@@ -46,6 +50,7 @@ export interface WonderCodexPageViewModel extends WonderCodexCatalogEntry {
   };
   statusLines: string[];
   rivalIntel?: LegendaryWonderRivalIntelSummary;
+  landmarkPreview?: LegendaryWonderLandmarkPreviewView;
   sections: WonderCodexSection[];
   relatedEntries: RelatedWonderCodexEntry[];
   actions: WonderCodexAction[];
@@ -203,6 +208,16 @@ function buildPage(
   const status = content.kind === 'natural'
     ? buildNaturalStatus(state, entry.id)
     : buildLegendaryStatus(state, viewerId, entry.id, rivalIntel);
+  const cityIdForPreview = entry.kind === 'legendary'
+    ? safeOwnedHostCityId(
+      state,
+      viewerId,
+      state.completedLegendaryWonders?.[entry.id]?.cityId ?? ownedProject(state, viewerId, entry.id)?.cityId,
+    )
+    : undefined;
+  const landmarkPreview = cityIdForPreview
+    ? getLegendaryLandmarkPreviewViewForCity(state, viewerId, cityIdForPreview)
+    : null;
 
   return {
     ...entry,
@@ -217,6 +232,7 @@ function buildPage(
     },
     statusLines: status.statusLines,
     ...(rivalIntel ? { rivalIntel } : {}),
+    ...(landmarkPreview ? { landmarkPreview } : {}),
     sections: content.sections.map(section => ({ ...section })),
     relatedEntries: getRelatedWonderCodexEntries(entry.id, visibleWonderIds),
     actions: status.actions,

--- a/src/systems/wonder-visual-catalog.ts
+++ b/src/systems/wonder-visual-catalog.ts
@@ -1,4 +1,6 @@
 import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import type { LegendaryLandmarkFamily } from '@/systems/legendary-wonder-landmark-types';
 
 export type WonderVisualKind = 'natural' | 'legendary';
 
@@ -21,7 +23,7 @@ export type WonderMapLandmark =
   | 'masked';
 
 export type WonderVignette = WonderMapLandmark;
-export type LegendaryWonderLandmark = 'spire' | 'arch' | 'dome' | 'obelisk' | 'citadel' | 'archive' | 'masked';
+export type LegendaryWonderLandmark = LegendaryLandmarkFamily | 'masked';
 
 export interface WonderVisualDefinition {
   id: string;
@@ -38,13 +40,6 @@ export interface WonderVisualDefinition {
   reducedMotionFallback: 'static-landmark' | 'static-medallion';
   maskedLabel?: string;
   legendaryLandmark?: LegendaryWonderLandmark;
-}
-
-const LEGENDARY_LANDMARK_TYPES = ['spire', 'arch', 'dome', 'obelisk', 'citadel', 'archive'] as const;
-
-function landmarkTypeForLegendaryWonder(wonderId: string): LegendaryWonderLandmark {
-  const hash = [...wonderId].reduce((sum, char) => sum + char.charCodeAt(0), 0);
-  return LEGENDARY_LANDMARK_TYPES[hash % LEGENDARY_LANDMARK_TYPES.length];
 }
 
 const NATURAL_WONDER_VISUALS: Record<string, WonderVisualDefinition> = {
@@ -66,25 +61,24 @@ const NATURAL_WONDER_VISUALS: Record<string, WonderVisualDefinition> = {
 };
 
 const LEGENDARY_WONDER_VISUALS: Record<string, WonderVisualDefinition> = Object.fromEntries(
-  getLegendaryWonderDefinitions().map(definition => [
-    definition.id,
-    {
-      id: definition.id,
-      kind: 'legendary',
-      medallionGlyph: '✦',
-      palette: {
-        base: '#2b2633',
-        accent: '#e8c170',
-        glow: '#fff0b8',
-      },
-      mapLandmark: 'masked',
-      vignette: 'masked',
-      supportsAmbientAnimation: false,
-      reducedMotionFallback: 'static-medallion',
-      maskedLabel: 'Legendary wonder',
-      legendaryLandmark: landmarkTypeForLegendaryWonder(definition.id),
-    } satisfies WonderVisualDefinition,
-  ]),
+  getLegendaryWonderDefinitions().map(definition => {
+    const metadata = getLegendaryWonderLandmarkMetadata(definition.id);
+    return [
+      definition.id,
+      {
+        id: definition.id,
+        kind: 'legendary',
+        medallionGlyph: '✦',
+        palette: metadata.palette,
+        mapLandmark: 'masked',
+        vignette: 'masked',
+        supportsAmbientAnimation: false,
+        reducedMotionFallback: 'static-medallion',
+        maskedLabel: 'Legendary wonder',
+        legendaryLandmark: metadata.family,
+      } satisfies WonderVisualDefinition,
+    ];
+  }),
 );
 
 const FALLBACK_WONDER_VISUAL: Omit<WonderVisualDefinition, 'id'> = {

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -14,6 +14,7 @@ import {
   getCompactLegendaryWonderEntriesForCity,
   getLegendaryWonderPresentationForCity,
 } from '@/systems/legendary-wonder-presentation';
+import { getLegendaryLandmarkPreviewViewForCity } from '@/systems/legendary-wonder-landmark-presentation';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier } from '@/systems/faction-system';
@@ -313,6 +314,14 @@ export function createCityPanel(
     </div>
   `;
 
+  const landmarkPreview = getLegendaryLandmarkPreviewViewForCity(state, state.currentPlayer, city.id);
+  const landmarkPreviewHtml = landmarkPreview
+    ? `<div data-section="legendary-landmark-preview" style="background:rgba(232,193,112,0.08);border:1px solid rgba(232,193,112,0.22);border-radius:8px;padding:10px;margin-bottom:12px;">
+        <div style="font-weight:bold;font-size:13px;color:#e8c170;margin-bottom:6px;">Legendary landmarks</div>
+        ${landmarkPreview.items.map((item, index) => `<div data-landmark-preview="${item.wonderId}" style="font-size:12px;opacity:0.86;"><span data-text="landmark-preview-${index}"></span></div>`).join('')}
+      </div>`
+    : '';
+
   // Idle production selector — always visible; conversion only fires when queue is empty.
   const activeMode = city.idleProduction ?? 'none';
   const goldActive = activeMode === 'gold' ? 'border-color:#d4aa2c;background:rgba(212,170,44,0.3);' : '';
@@ -453,7 +462,7 @@ export function createCityPanel(
       <div id="tab-wonders" style="padding:6px 16px;background:rgba(255,255,255,0.05);border-radius:6px;cursor:pointer;font-size:12px;">Legendary Wonders</div>
     </div>
     <div id="city-list-view">
-      ${idleSelectorHtml}${currentProductionHtml}
+      ${landmarkPreviewHtml}${idleSelectorHtml}${currentProductionHtml}
       ${city.productionQueue.length > 1 ? `<div style="background:rgba(255,255,255,0.08);border-radius:10px;padding:12px;margin-bottom:16px;"><div style="font-weight:bold;color:#e8c170;margin-bottom:8px;">Production Queue</div>${queueRowsHtml}</div>` : ''}
       ${cityWonderProject ? `<div style="margin-bottom:12px;font-size:12px;opacity:0.75;">Wonder carryover: ${cityWonderProject.transferableProduction}</div>` : ''}
       ${city.buildings.length > 0 ? `<div style="margin-bottom:16px;"><h3 style="font-size:14px;margin:0 0 8px;">Buildings</h3>${buildingPlaceholders}</div>` : ''}
@@ -572,6 +581,12 @@ export function createCityPanel(
         : entry.rewardSummary);
     setText(`wonder-recovery-${index}`, entry.recoveryLabel ?? '');
     setText(`wonder-resumed-${index}`, entry.productionResumedLabel ?? '');
+  });
+
+  landmarkPreview?.items.forEach((item, index) => {
+    setText(`landmark-preview-${index}`, item.state === 'under-construction'
+      ? `${item.label} — Under construction`
+      : `${item.label} — Completed`);
   });
 
   container.appendChild(panel);

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -4,7 +4,7 @@ import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { TERRITORY_PRESSURE_BALANCE } from '@/systems/city-territory-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
-import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getCompletedLegendaryLandmarksForCity } from '@/systems/legendary-wonder-landmark-presentation';
 import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
 import { createGameButton } from '@/ui/ui-kit';
 import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
@@ -145,9 +145,9 @@ export function createTerritoryInspectionPanel(
   addLine(panel, 'Owner', owner?.name ?? tile.owner ?? 'Unclaimed');
 
   const cityAtCoord = Object.values(state.cities).find(candidate => hexKey(candidate.position) === key);
-  const completedInCity = Object.entries(state.completedLegendaryWonders ?? {})
-    .filter(([, completion]) => completion.ownerId === viewerId && completion.cityId === cityAtCoord?.id)
-    .map(([wonderId]) => getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder');
+  const completedInCity = cityAtCoord
+    ? getCompletedLegendaryLandmarksForCity(state, viewerId, cityAtCoord.id).map(entry => entry.label)
+    : [];
   if (completedInCity.length > 0) {
     addLine(panel, 'Completed legendary wonders', completedInCity.join(', '));
   }

--- a/src/ui/wonder-codex-page.ts
+++ b/src/ui/wonder-codex-page.ts
@@ -152,6 +152,26 @@ export function createWonderCodexPage(
   for (const line of page.statusLines) appendText(status, 'li', line);
   root.appendChild(status);
 
+  if (page.landmarkPreview) {
+    const preview = document.createElement('section');
+    preview.dataset.section = 'legendary-landmark-preview';
+    preview.style.cssText = 'border:1px solid rgba(232,193,112,0.24);border-radius:8px;padding:10px;background:rgba(232,193,112,0.07);display:grid;gap:6px;';
+    appendText(preview, 'h4', 'City landmark preview', 'margin:0;font-size:13px;color:#f4d188;');
+    appendText(preview, 'p', page.landmarkPreview.cityName, 'margin:0;font-size:12px;color:rgba(248,241,223,0.74);');
+    const list = document.createElement('ul');
+    list.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;color:rgba(248,241,223,0.74);';
+    for (const item of page.landmarkPreview.items) {
+      const li = document.createElement('li');
+      li.dataset.landmarkPreview = item.wonderId;
+      li.textContent = item.state === 'under-construction'
+        ? `${item.label} — Under construction`
+        : `${item.label} — Completed`;
+      list.appendChild(li);
+    }
+    preview.appendChild(list);
+    root.appendChild(preview);
+  }
+
   if (page.rivalIntel) {
     const rivalIntel = document.createElement('section');
     rivalIntel.dataset.rivalIntelSection = 'true';

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -256,6 +256,32 @@ describe('city renderer', () => {
     const labels = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
     expect(labels).toContain(`${city.name} (${city.population})`);
   });
+
+  it('draws legendary landmark layer before city label and production badges remain above it', () => {
+    const state = createNewGame(undefined, 'legendary-layer-order-test');
+    const settler = Object.values(state.units).find(u => u.owner === 'player' && u.type === 'settler')!;
+    const city = foundCity('player', settler.position, state.map, state.idCounters);
+    city.productionQueue = ['granary'];
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 20 },
+    };
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player', { nowMs: 1000 });
+
+    const ops = (ctx as unknown as MockCanvasContext).operations;
+    const landmarkIndex = ops.findIndex(operation => operation === 'legendary-landmarks:start');
+    const labelIndex = ops.findIndex(operation => operation.includes(`text:${city.name}`));
+    const badgeIndex = ops.findIndex(operation => operation.includes(`text:${getProductionBadgeIcon(city)}`));
+    expect(landmarkIndex).toBeGreaterThanOrEqual(0);
+    expect(labelIndex).toBeGreaterThanOrEqual(0);
+    expect(badgeIndex).toBeGreaterThanOrEqual(0);
+    expect(landmarkIndex).toBeLessThan(labelIndex);
+    expect(landmarkIndex).toBeLessThan(badgeIndex);
+  });
 });
 
 function makeCamera(): Camera {

--- a/tests/renderer/legendary-wonder-renderer.test.ts
+++ b/tests/renderer/legendary-wonder-renderer.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { drawLegendaryWonderLandmarks } from '@/renderer/wonders/legendary-wonder-renderer';
+import {
+  drawLegendaryWonderLandmarkGlyph,
+  drawLegendaryWonderLandmarks,
+} from '@/renderer/wonders/legendary-wonder-renderer';
+import {
+  getLegendaryWonderLandmarkMetadata,
+  getLegendaryWonderLandmarkMetadataCatalog,
+} from '@/systems/legendary-wonder-landmark-catalog';
 import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 
 class MockCanvasContext {
@@ -65,5 +72,50 @@ describe('legendary-wonder-renderer', () => {
     });
 
     expect(ctx.operations).toContain('text:+2');
+  });
+
+  it('draws every authored family with nonblank canvas operations', () => {
+    const families = getLegendaryWonderLandmarkMetadataCatalog().map(entry => entry.family);
+    for (const family of families) {
+      const ctx = new MockCanvasContext();
+      drawLegendaryWonderLandmarkGlyph({
+        ctx: ctx as unknown as CanvasRenderingContext2D,
+        cx: 80,
+        cy: 80,
+        radius: 12,
+        metadata: { ...getLegendaryWonderLandmarkMetadata('oracle-of-delphi'), family },
+        state: 'completed',
+        reducedMotion: false,
+        nowMs: 1000,
+      });
+      expect(ctx.operations.length, family).toBeGreaterThan(3);
+      expect(ctx.operations.some(operation => operation.startsWith('fill:') || operation.startsWith('stroke:')), family).toBe(true);
+    }
+  });
+
+  it('draws active construction ghosts as scaffold or outline operations', () => {
+    const ctx = new MockCanvasContext();
+    drawLegendaryWonderLandmarks({
+      ctx: ctx as unknown as CanvasRenderingContext2D,
+      cx: 80,
+      cy: 80,
+      size: 48,
+      reducedMotion: false,
+      lowZoom: false,
+      turn: 20,
+      entries: [
+        {
+          wonderId: 'oracle-of-delphi',
+          label: 'Oracle of Delphi',
+          turnCompleted: Number.MAX_SAFE_INTEGER,
+          visual: getWonderVisualDefinition('oracle-of-delphi'),
+          state: 'under-construction',
+          metadata: getLegendaryWonderLandmarkMetadata('oracle-of-delphi'),
+          progressRatio: 0.6,
+        },
+      ],
+    });
+
+    expect(ctx.operations.some(operation => operation.includes('ghost') || operation.startsWith('stroke:'))).toBe(true);
   });
 });

--- a/tests/renderer/legendary-wonder-slots.test.ts
+++ b/tests/renderer/legendary-wonder-slots.test.ts
@@ -1,28 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { assignLegendaryWonderSlots } from '@/renderer/wonders/legendary-wonder-slots';
 
-describe('legendary-wonder-slots', () => {
-  it('assigns stable slots sorted by turnCompleted then wonderId', () => {
-    const slots = assignLegendaryWonderSlots([
-      { wonderId: 'sun-spire', turnCompleted: 12 },
-      { wonderId: 'oracle-of-delphi', turnCompleted: 10 },
-      { wonderId: 'grand-canal', turnCompleted: 10 },
-    ]);
+describe('legendary wonder slots', () => {
+  it('rotates overflow windows every five turns while keeping a stable overflow count', () => {
+    const entries = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'].map((wonderId, index) => ({
+      wonderId,
+      turnCompleted: index + 1,
+    }));
 
-    expect(slots.map(slot => slot.kind === 'landmark' ? slot.wonderId : 'overflow')).toEqual([
-      'grand-canal',
-      'oracle-of-delphi',
-      'sun-spire',
-    ]);
-    expect(slots.map(slot => slot.slotIndex)).toEqual([0, 1, 2]);
-  });
-
-  it('uses first five plus overflow when more than six wonders are visible', () => {
-    const slots = assignLegendaryWonderSlots([
-      'a', 'b', 'c', 'd', 'e', 'f', 'g',
-    ].map((wonderId, index) => ({ wonderId, turnCompleted: index + 1 })));
-
-    expect(slots).toHaveLength(6);
-    expect(slots[5]).toMatchObject({ kind: 'overflow', overflowCount: 2 });
+    expect(assignLegendaryWonderSlots(entries, 4).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+      .toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(assignLegendaryWonderSlots(entries, 5).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+      .toEqual(['b', 'c', 'd', 'e', 'f']);
+    expect(assignLegendaryWonderSlots(entries, 10).filter(slot => slot.kind === 'landmark').map(slot => slot.wonderId))
+      .toEqual(['c', 'd', 'e', 'f', 'g']);
+    expect(assignLegendaryWonderSlots(entries, 10).find(slot => slot.kind === 'overflow')).toMatchObject({
+      kind: 'overflow',
+      overflowCount: 3,
+    });
   });
 });

--- a/tests/systems/legendary-wonder-landmark-catalog.test.ts
+++ b/tests/systems/legendary-wonder-landmark-catalog.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getLegendaryWonderDefinitions } from '@/systems/legendary-wonder-definitions';
+import { getWonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import {
+  getLegendaryWonderLandmarkMetadata,
+  getLegendaryWonderLandmarkMetadataCatalog,
+} from '@/systems/legendary-wonder-landmark-catalog';
+import {
+  validateLegendaryWonderLandmarkCatalog,
+  validateLegendaryWonderLandmarkRendererSupport,
+} from '@/systems/legendary-wonder-landmark-validation';
+import {
+  CANVAS_LEGENDARY_LANDMARK_AURAS,
+  CANVAS_LEGENDARY_LANDMARK_FAMILIES,
+  CANVAS_LEGENDARY_LANDMARK_GHOSTS,
+  CANVAS_LEGENDARY_LANDMARK_MOTIFS,
+  CANVAS_LEGENDARY_LANDMARK_MOTIONS,
+  CANVAS_LEGENDARY_LANDMARK_VARIANTS,
+} from '@/renderer/wonders/legendary-wonder-renderer';
+
+describe('legendary wonder landmark catalog', () => {
+  it('has explicit metadata for every current legendary wonder and no extras', () => {
+    const definitionIds = getLegendaryWonderDefinitions().map(definition => definition.id).sort();
+    const metadataIds = getLegendaryWonderLandmarkMetadataCatalog().map(entry => entry.wonderId).sort();
+
+    expect(metadataIds).toEqual(definitionIds);
+    expect(validateLegendaryWonderLandmarkCatalog()).toEqual([]);
+  });
+
+  it('does not use hash-based landmark identity for known legendary wonders', () => {
+    const oracle = getLegendaryWonderLandmarkMetadata('oracle-of-delphi');
+    const canal = getLegendaryWonderLandmarkMetadata('grand-canal');
+
+    expect(oracle.family).toBe('oracle');
+    expect(canal.family).toBe('waterworks');
+    expect(getWonderVisualDefinition('oracle-of-delphi').legendaryLandmark).toBe(oracle.family);
+    expect(getWonderVisualDefinition('grand-canal').legendaryLandmark).toBe(canal.family);
+  });
+
+  it('declares only renderer-supported family, variant, motif, aura, motion, and ghost tokens', () => {
+    expect(validateLegendaryWonderLandmarkRendererSupport({
+      families: CANVAS_LEGENDARY_LANDMARK_FAMILIES,
+      variants: CANVAS_LEGENDARY_LANDMARK_VARIANTS,
+      motifs: CANVAS_LEGENDARY_LANDMARK_MOTIFS,
+      auras: CANVAS_LEGENDARY_LANDMARK_AURAS,
+      motions: CANVAS_LEGENDARY_LANDMARK_MOTIONS,
+      ghosts: CANVAS_LEGENDARY_LANDMARK_GHOSTS,
+    })).toEqual([]);
+  });
+});

--- a/tests/systems/legendary-wonder-map-presentation.test.ts
+++ b/tests/systems/legendary-wonder-map-presentation.test.ts
@@ -32,4 +32,74 @@ describe('legendary-wonder-map-presentation', () => {
 
     expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
   });
+
+  it('adds owned active construction ghosts only at final-works progress on visible owned cities', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.currentPlayer = 'player';
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+    state.cities['city-river'].productionProgress = 72;
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:player:city-river': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'city-river',
+        phase: 'building',
+        investedProduction: 72,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    const entries = getLegendaryWonderMapEntries(state, 'player');
+
+    expect(entries).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      relationship: 'owned',
+      state: 'under-construction',
+      progressRatio: 0.6,
+    }));
+  });
+
+  it('does not add map ghosts below final-works progress', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+    state.cities['city-river'].productionProgress = 71;
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:player:city-river': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'city-river',
+        phase: 'building',
+        investedProduction: 71,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')
+      .some(entry => entry.state === 'under-construction')).toBe(false);
+  });
+
+  it('does not render rival landmarks from completed rival intel alone', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'rival', cityId: 'city-rival', turnCompleted: 20 },
+    };
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'completed',
+        eventId: 'completed:oracle-of-delphi:rival:20',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        completionTurn: 20,
+        learnedTurn: 20,
+      }],
+    };
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-rival'].position)] = 'visible';
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
+  });
 });

--- a/tests/systems/legendary-wonder-map-presentation.test.ts
+++ b/tests/systems/legendary-wonder-map-presentation.test.ts
@@ -82,6 +82,30 @@ describe('legendary-wonder-map-presentation', () => {
       .some(entry => entry.state === 'under-construction')).toBe(false);
   });
 
+  it('uses live active city production for construction ghost progress when project investment lags', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    state.cities['city-river'].productionQueue = ['legendary:oracle-of-delphi'];
+    state.cities['city-river'].productionProgress = 72;
+    state.civilizations.player.visibility.tiles[hexKey(state.cities['city-river'].position)] = 'visible';
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:player:city-river': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'city-river',
+        phase: 'building',
+        investedProduction: 0,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      state: 'under-construction',
+      progressRatio: 0.6,
+    }));
+  });
+
   it('does not render rival landmarks from completed rival intel alone', () => {
     const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
     state.completedLegendaryWonders = {

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -251,4 +251,37 @@ describe('wonder-codex presentation', () => {
     expect(model.selectedPage?.stateLabel).toBe('Under construction');
     expect(model.selectedPage?.actions[0]).toMatchObject({ type: 'open-city', cityId: 'safe-city' });
   });
+
+  it('adds owned legendary landmark preview to owned completed and active pages only', () => {
+    const state = makeState();
+    const baseCity = state.cities[Object.keys(state.cities)[0]];
+    state.cities['safe-city'] = { ...baseCity, id: 'safe-city', owner: 'player' };
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'safe-city', turnCompleted: 58 },
+    };
+
+    const owned = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    expect(owned.selectedPage?.landmarkPreview).toMatchObject({
+      cityId: 'safe-city',
+      cityName: state.cities['safe-city'].name,
+    });
+    expect(owned.selectedPage?.landmarkPreview?.items[0]).toMatchObject({
+      wonderId: 'oracle-of-delphi',
+      state: 'completed',
+    });
+
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'completed',
+        eventId: 'completed:grand-canal:ai-1:58',
+        wonderId: 'grand-canal',
+        civId: 'ai-1',
+        civName: 'Rival',
+        completionTurn: 58,
+        learnedTurn: 58,
+      }],
+    };
+    const rival = getWonderCodexViewModel(state, 'player', { initialWonderId: 'grand-canal' });
+    expect(rival.selectedPage?.landmarkPreview).toBeUndefined();
+  });
 });

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -74,6 +74,37 @@ describe('city-panel legendary wonders', () => {
     expect(compactSection?.textContent).not.toContain('Manhattan Project');
   });
 
+  it('renders compact legendary landmark preview with completed and active ghost states', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 20 },
+    };
+    city.productionQueue = ['legendary:grand-canal'];
+    city.productionProgress = 90;
+    state.legendaryWonderProjects = {
+      'grand-canal:player:city-river': {
+        wonderId: 'grand-canal',
+        ownerId: 'player',
+        cityId: city.id,
+        phase: 'building',
+        investedProduction: 90,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const preview = panel.querySelector('[data-section="legendary-landmark-preview"]');
+    expect(preview?.textContent).toContain('Oracle of Delphi');
+    expect(preview?.textContent).toContain('Grand Canal');
+    expect(preview?.textContent).toContain('Under construction');
+  });
+
   it('renders legendary active production and queued follow-ups with human-readable names and ETA', () => {
     const { container, city, state } = makeWonderPanelFixture();
     city.productionQueue = ['legendary:oracle-of-delphi', 'library'];

--- a/tests/ui/territory-inspection-panel.test.ts
+++ b/tests/ui/territory-inspection-panel.test.ts
@@ -183,6 +183,27 @@ describe('createTerritoryInspectionPanel', () => {
     expect(panel.textContent).toContain('Completed legendary wonders');
     expect(panel.textContent).toContain('Oracle of Delphi');
   });
+
+  it('lists every completed owned legendary wonder in an overflow city', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const city = state.cities['city-river'];
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'visible';
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: city.id, turnCompleted: 1 },
+      'grand-canal': { ownerId: 'player', cityId: city.id, turnCompleted: 2 },
+      'sun-spire': { ownerId: 'player', cityId: city.id, turnCompleted: 3 },
+      'world-archive': { ownerId: 'player', cityId: city.id, turnCompleted: 4 },
+      'moonwell-gardens': { ownerId: 'player', cityId: city.id, turnCompleted: 5 },
+      'ironroot-foundry': { ownerId: 'player', cityId: city.id, turnCompleted: 6 },
+      'tidecaller-bastion': { ownerId: 'player', cityId: city.id, turnCompleted: 7 },
+    };
+
+    const panel = createTerritoryInspectionPanel(state, city.position, 'player');
+
+    expect(panel.textContent).toContain('Oracle of Delphi');
+    expect(panel.textContent).toContain('Grand Canal');
+    expect(panel.textContent).toContain('Tidecaller Bastion');
+  });
 });
 
 describe('createTerritoryInspectionPanel — S2b acquisition status', () => {

--- a/tests/ui/wonder-codex-page.test.ts
+++ b/tests/ui/wonder-codex-page.test.ts
@@ -123,6 +123,30 @@ describe('wonder-codex-page', () => {
     expect(root.textContent).not.toContain('Play video');
   });
 
+  it('renders compact landmark preview without adding rival actions', () => {
+    const root = createWonderCodexPage(page({
+      id: 'oracle-of-delphi',
+      kind: 'legendary',
+      title: 'Oracle of Delphi',
+      subtitle: 'A sanctuary of prophecy.',
+      stateLabel: 'Completed',
+      visual: getWonderVisualDefinition('oracle-of-delphi'),
+      actions: [],
+      landmarkPreview: {
+        cityId: 'city-river',
+        cityName: 'River City',
+        items: [{
+          wonderId: 'oracle-of-delphi',
+          label: 'Oracle of Delphi',
+          state: 'completed',
+        }],
+      },
+    }), { onAction: () => {}, onSelectRelated: () => {} });
+
+    expect(root.querySelector('[data-section="legendary-landmark-preview"]')?.textContent).toContain('Oracle of Delphi');
+    expect(root.querySelector('[data-codex-action="open-city"]')).toBeNull();
+  });
+
   it('keeps reduced-motion Codex spectacle static', () => {
     const root = createWonderCodexPage(page(), {
       mode: 'desktop',


### PR DESCRIPTION
## Summary
- Add authored legendary landmark metadata with convention tests and remove hash-based known legendary assignment.
- Render owned completed landmark medallions, late construction ghosts, overflow rotation, and city renderer layer ordering.
- Add owned landmark previews to territory inspection, city panel, and Codex while keeping rival completed intel location-safe.

## Test Plan
- ./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-landmark-catalog.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/legendary-wonder-slots.test.ts tests/renderer/legendary-wonder-renderer.test.ts tests/renderer/city-renderer.test.ts tests/ui/territory-inspection-panel.test.ts tests/ui/city-panel.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts
- scripts/check-src-rule-violations.sh src/systems/legendary-wonder-landmark-types.ts src/systems/legendary-wonder-landmark-catalog.ts src/systems/legendary-wonder-landmark-validation.ts src/systems/wonder-visual-catalog.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/renderer/wonders/legendary-wonder-slots.ts src/renderer/wonders/legendary-wonder-renderer.ts src/renderer/city-renderer.ts src/renderer/render-loop.ts src/ui/territory-inspection-panel.ts src/ui/city-panel.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts
- ./scripts/run-wonder-regressions.sh
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test

## Review Notes
- Rebased onto current origin/main and verified origin/main is an ancestor of this branch for fast-forward merge.
- Fixed a review finding so active construction ghost progress reads live city production when project investment has not yet normalized.