### PR TITLE
feat(wonders): resolve #278 #281 — visibility gate, navigable notification, codex UI redesign

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -504,6 +504,11 @@ function toggleNotificationLog(): void {
   const panel = createNotificationLogPanel(entries, {
     onClose: () => panel.remove(),
     onFocusTarget: focusNotificationTarget,
+    onOpenCity: (cityId) => {
+      panel.remove();
+      const city = gameState?.cities[cityId];
+      if (city) openCityPanelForCity(city);
+    },
   });
 
   ul.appendChild(panel);

--- a/src/systems/legendary-wonder-intel-presentation.ts
+++ b/src/systems/legendary-wonder-intel-presentation.ts
@@ -101,3 +101,16 @@ export function getLegendaryWonderRivalIntelSummariesForViewer(
 
   return summaries;
 }
+
+export function isLegendaryWonderVisibleToPlayer(
+  state: GameState,
+  viewerId: string,
+  wonderId: string,
+  precomputedRivalIntel?: Map<string, LegendaryWonderRivalIntelSummary>,
+): boolean {
+  const owned = Object.values(state.legendaryWonderProjects ?? {})
+    .find(p => p.ownerId === viewerId && p.wonderId === wonderId);
+  if (owned && owned.phase !== 'locked') return true;
+  const summaries = precomputedRivalIntel ?? getLegendaryWonderRivalIntelSummariesForViewer(state, viewerId);
+  return summaries.has(wonderId);
+}

--- a/src/systems/legendary-wonder-intel-presentation.ts
+++ b/src/systems/legendary-wonder-intel-presentation.ts
@@ -108,6 +108,7 @@ export function isLegendaryWonderVisibleToPlayer(
   wonderId: string,
   precomputedRivalIntel?: Map<string, LegendaryWonderRivalIntelSummary>,
 ): boolean {
+  if (state.completedLegendaryWonders?.[wonderId]?.ownerId === viewerId) return true;
   const owned = Object.values(state.legendaryWonderProjects ?? {})
     .find(p => p.ownerId === viewerId && p.wonderId === wonderId);
   if (owned && owned.phase !== 'locked') return true;

--- a/src/systems/wonder-codex/presentation.ts
+++ b/src/systems/wonder-codex/presentation.ts
@@ -10,6 +10,7 @@ import { getImageSource } from '@/systems/wonder-codex/sources';
 import type { WonderCodexContent, WonderCodexSection } from '@/systems/wonder-codex/types';
 import {
   getLegendaryWonderRivalIntelSummariesForViewer,
+  isLegendaryWonderVisibleToPlayer,
   type LegendaryWonderRivalIntelSummary,
 } from '@/systems/legendary-wonder-intel-presentation';
 import {
@@ -130,20 +131,22 @@ function visibleCatalogEntries(state: GameState, viewerId: string): WonderCodexC
     });
 
   const rivalIntelSummaries = getLegendaryWonderRivalIntelSummariesForViewer(state, viewerId);
-  const legendaryEntries = getLegendaryWonderDefinitions().map(definition => {
-    const content = getWonderCodexContent(definition.id);
-    const rivalIntel = rivalIntelSummaries.get(definition.id);
-    return {
-      id: definition.id,
-      kind: 'legendary' as const,
-      title: content?.title ?? definition.name,
-      subtitle: content?.subtitle ?? 'Legendary wonder',
-      stateLabel: legendaryStateLabel(state, viewerId, definition.id, rivalIntel),
-      visual: getWonderVisualDefinition(definition.id),
-      rivalIntelCount: rivalIntel?.activityCount ?? 0,
-      rivalIntelBadgeLabel: rivalIntel?.badgeLabel,
-    };
-  });
+  const legendaryEntries = getLegendaryWonderDefinitions()
+    .filter(definition => isLegendaryWonderVisibleToPlayer(state, viewerId, definition.id, rivalIntelSummaries))
+    .map(definition => {
+      const content = getWonderCodexContent(definition.id);
+      const rivalIntel = rivalIntelSummaries.get(definition.id);
+      return {
+        id: definition.id,
+        kind: 'legendary' as const,
+        title: content?.title ?? definition.name,
+        subtitle: content?.subtitle ?? 'Legendary wonder',
+        stateLabel: legendaryStateLabel(state, viewerId, definition.id, rivalIntel),
+        visual: getWonderVisualDefinition(definition.id),
+        rivalIntelCount: rivalIntel?.activityCount ?? 0,
+        rivalIntelBadgeLabel: rivalIntel?.badgeLabel,
+      };
+    });
 
   return [...naturalEntries, ...legendaryEntries];
 }

--- a/src/systems/wonder-codex/presentation.ts
+++ b/src/systems/wonder-codex/presentation.ts
@@ -52,6 +52,8 @@ export interface WonderCodexPageViewModel extends WonderCodexCatalogEntry {
   statusLines: string[];
   rivalIntel?: LegendaryWonderRivalIntelSummary;
   landmarkPreview?: LegendaryWonderLandmarkPreviewView;
+  canStartBuild?: boolean;
+  questSteps?: Array<{ id: string; description: string; completed: boolean }>;
   sections: WonderCodexSection[];
   relatedEntries: RelatedWonderCodexEntry[];
   actions: WonderCodexAction[];
@@ -151,7 +153,14 @@ function visibleCatalogEntries(state: GameState, viewerId: string): WonderCodexC
   return [...naturalEntries, ...legendaryEntries];
 }
 
-function buildNaturalStatus(state: GameState, wonderId: string): { statusLines: string[]; actions: WonderCodexAction[] } {
+type StatusResult = {
+  statusLines: string[];
+  actions: WonderCodexAction[];
+  canStartBuild: boolean;
+  questSteps?: Array<{ id: string; description: string; completed: boolean }>;
+};
+
+function buildNaturalStatus(state: GameState, wonderId: string): StatusResult {
   const coord = findWonderCoord(state, wonderId);
   const statusLines = [
     formatNaturalWonderEffectSummary(wonderId),
@@ -160,7 +169,7 @@ function buildNaturalStatus(state: GameState, wonderId: string): { statusLines: 
   const actions: WonderCodexAction[] = coord
     ? [{ type: 'view-map', label: 'View on Map', wonderId, coord }]
     : [];
-  return { statusLines, actions };
+  return { statusLines, actions, canStartBuild: false };
 }
 
 function publicAssetUrl(localPath: string): string {
@@ -174,7 +183,7 @@ function buildLegendaryStatus(
   viewerId: string,
   wonderId: string,
   rivalIntel: LegendaryWonderRivalIntelSummary | undefined,
-): { statusLines: string[]; actions: WonderCodexAction[] } {
+): StatusResult {
   const definition = getLegendaryWonderDefinition(wonderId);
   const label = legendaryStateLabel(state, viewerId, wonderId, rivalIntel);
   const statusLines = [`Status: ${label}`];
@@ -188,12 +197,15 @@ function buildLegendaryStatus(
     statusLines.push(`Progress recorded in your city: ${project.investedProduction} production invested.`);
   }
 
+  const canStartBuild = label === 'Available';
+  const questSteps = project?.questSteps;
+
   const completion = state.completedLegendaryWonders?.[wonderId];
   const cityId = safeOwnedHostCityId(state, viewerId, completion?.cityId ?? project?.cityId);
   const actions: WonderCodexAction[] = cityId
     ? [{ type: 'open-city', label: 'Open City', wonderId, cityId }]
     : [];
-  return { statusLines, actions };
+  return { statusLines, actions, canStartBuild, questSteps };
 }
 
 function buildPage(
@@ -236,6 +248,8 @@ function buildPage(
     statusLines: status.statusLines,
     ...(rivalIntel ? { rivalIntel } : {}),
     ...(landmarkPreview ? { landmarkPreview } : {}),
+    canStartBuild: status.canStartBuild,
+    ...(status.questSteps ? { questSteps: status.questSteps } : {}),
     sections: content.sections.map(section => ({ ...section })),
     relatedEntries: getRelatedWonderCodexEntries(entry.id, visibleWonderIds),
     actions: status.actions,

--- a/src/ui/legendary-wonder-notifications.ts
+++ b/src/ui/legendary-wonder-notifications.ts
@@ -52,9 +52,10 @@ export function getLegendaryWonderNotification(
 
   if (event.type === 'wonder:legendary-ready') {
     return {
-      message: `${city.name} can start ${wonder?.name ?? event.wonderId}. Open the city Build list, choose its Wonder Ambitions card, then Start Construction.`,
+      message: `${city.name} can start ${wonder?.name ?? event.wonderId}. Tap to open that city.`,
       type: 'info',
       turn: state.turn,
+      linkedCityId: event.cityId,
     };
   }
 

--- a/src/ui/notification-log-panel.ts
+++ b/src/ui/notification-log-panel.ts
@@ -3,6 +3,7 @@ import type { NotificationEntry, NotificationMapTarget } from '@/ui/notification
 interface NotificationLogPanelOptions {
   onClose: () => void;
   onFocusTarget: (target: NotificationMapTarget) => void;
+  onOpenCity?: (cityId: string) => void;
 }
 
 const colors: Record<NotificationEntry['type'], string> = {
@@ -59,6 +60,15 @@ function createNotificationRow(
     row.addEventListener('click', event => {
       event.stopPropagation();
       options.onFocusTarget(entry.target!);
+    });
+  }
+  if (entry.linkedCityId) {
+    row.dataset.notificationCity = entry.linkedCityId;
+    row.style.cursor = 'pointer';
+    row.title = 'Open city panel';
+    row.addEventListener('click', event => {
+      event.stopPropagation();
+      options.onOpenCity?.(entry.linkedCityId!);
     });
   }
 

--- a/src/ui/notification-log.ts
+++ b/src/ui/notification-log.ts
@@ -11,6 +11,7 @@ export interface NotificationEntry {
   type: 'info' | 'success' | 'warning';
   turn: number;
   target?: NotificationMapTarget;
+  linkedCityId?: string;
 }
 
 export type NotificationLog = Record<string, NotificationEntry[]>;

--- a/src/ui/wonder-codex-page.ts
+++ b/src/ui/wonder-codex-page.ts
@@ -110,7 +110,21 @@ export function createWonderCodexPage(
   hero.appendChild(vignetteHost);
   const copy = document.createElement('div');
   copy.style.cssText = 'min-width:0;flex:1;';
-  appendText(copy, 'p', page.stateLabel, 'margin:0 0 3px;font-size:12px;color:#e8c170;');
+  if (page.kind === 'legendary') {
+    const badge = document.createElement('span');
+    badge.dataset.codexStatusBadge = 'true';
+    badge.textContent = page.stateLabel;
+    const badgeColor = page.stateLabel === 'Available' ? '#d9a441'
+      : page.stateLabel === 'Under construction' ? '#4a90d9'
+      : page.stateLabel === 'Completed' ? '#4a9b6b'
+      : page.stateLabel === 'Recovered' ? 'rgba(248,241,223,0.28)'
+      : '#e8c170';
+    const badgeTextColor = page.stateLabel === 'Recovered' ? 'rgba(248,241,223,0.55)' : '#0a0d12';
+    badge.style.cssText = `display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:600;background:${badgeColor};color:${badgeTextColor};margin-bottom:6px;`;
+    copy.appendChild(badge);
+  } else {
+    appendText(copy, 'p', page.stateLabel, 'margin:0 0 3px;font-size:12px;color:#e8c170;');
+  }
   appendText(copy, 'h3', page.title, 'margin:0;font-size:24px;letter-spacing:0;');
   appendText(copy, 'p', page.subtitle, 'margin:5px 0 0;font-size:13px;line-height:1.45;color:rgba(248,241,223,0.74);');
   if (page.kind === 'natural') {
@@ -151,6 +165,29 @@ export function createWonderCodexPage(
   status.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;color:rgba(248,241,223,0.76);';
   for (const line of page.statusLines) appendText(status, 'li', line);
   root.appendChild(status);
+
+  if (page.questSteps && page.questSteps.length > 0) {
+    const questSection = document.createElement('section');
+    questSection.style.cssText = 'margin-top:4px;';
+    const questLabel = document.createElement('p');
+    questLabel.style.cssText = 'margin:0 0 5px;font-size:11px;color:rgba(248,241,223,0.55);text-transform:uppercase;letter-spacing:0.05em;';
+    questLabel.textContent = 'Quest steps';
+    questSection.appendChild(questLabel);
+    const list = document.createElement('ul');
+    list.dataset.codexQuestSteps = 'true';
+    list.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;';
+    for (const step of page.questSteps) {
+      const item = document.createElement('li');
+      item.dataset.completed = String(step.completed);
+      item.style.cssText = step.completed
+        ? 'color:rgba(248,241,223,0.42);text-decoration:line-through;'
+        : 'color:rgba(248,241,223,0.78);';
+      item.textContent = step.description;
+      list.appendChild(item);
+    }
+    questSection.appendChild(list);
+    root.appendChild(questSection);
+  }
 
   if (page.landmarkPreview) {
     const preview = document.createElement('section');
@@ -194,10 +231,17 @@ export function createWonderCodexPage(
     const actions = document.createElement('div');
     actions.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;';
     for (const action of page.actions) {
-      const button = createGameButton(action.label, 'secondary');
-      button.dataset.codexAction = action.type === 'view-map' ? 'view-map' : 'open-city';
-      button.addEventListener('click', () => options.onAction(action));
-      actions.appendChild(button);
+      if (page.canStartBuild && action.type === 'open-city') {
+        const btn = createGameButton('Start Construction', 'primary');
+        btn.dataset.codexAction = 'start-construction';
+        btn.addEventListener('click', () => options.onAction(action));
+        actions.appendChild(btn);
+      } else {
+        const button = createGameButton(action.label, 'secondary');
+        button.dataset.codexAction = action.type === 'view-map' ? 'view-map' : 'open-city';
+        button.addEventListener('click', () => options.onAction(action));
+        actions.appendChild(button);
+      }
     }
     root.appendChild(actions);
   }

--- a/src/ui/wonder-codex-panel.ts
+++ b/src/ui/wonder-codex-panel.ts
@@ -87,7 +87,12 @@ export function createWonderCodexPanel(
     catalog.dataset.codexCatalog = 'true';
     catalog.style.cssText = 'min-width:0;overflow:auto;padding:12px;display:flex;flex-direction:column;gap:8px;border-right:1px solid rgba(255,255,255,0.08);';
     if (entries.length === 0) {
-      appendText(catalog, 'p', 'No wonders recorded yet.', 'margin:0;font-size:13px;opacity:0.74;');
+      appendText(
+        catalog,
+        'p',
+        'No legendary wonders discovered yet — complete quests and explore to uncover them.',
+        'margin:0;font-size:12px;opacity:0.5;padding:8px;',
+      );
       return catalog;
     }
     for (const entry of entries) {
@@ -131,7 +136,7 @@ export function createWonderCodexPanel(
       reader.appendChild(back);
     }
     if (!page) {
-      appendText(reader, 'p', 'No wonders recorded yet.', 'margin:0;opacity:0.74;');
+      appendText(reader, 'p', 'No legendary wonders discovered yet — complete quests and explore to uncover them.', 'margin:0;font-size:12px;opacity:0.5;');
       return reader;
     }
     reader.appendChild(createWonderCodexPage(page, {

--- a/src/ui/wonder-codex-panel.ts
+++ b/src/ui/wonder-codex-panel.ts
@@ -37,6 +37,9 @@ function styleCatalogButton(button: HTMLButtonElement, selected: boolean): void 
   button.style.gridTemplateColumns = '34px 1fr';
   button.style.gap = '8px';
   button.style.alignItems = 'center';
+  button.style.background = 'rgba(255,255,255,0.05)';
+  button.style.borderRadius = '6px';
+  button.style.padding = '8px';
   if (selected) {
     button.style.boxShadow = '0 0 0 2px rgba(232,193,112,0.34) inset';
   }

--- a/src/ui/wonder-codex-panel.ts
+++ b/src/ui/wonder-codex-panel.ts
@@ -139,7 +139,6 @@ export function createWonderCodexPanel(
       reader.appendChild(back);
     }
     if (!page) {
-      appendText(reader, 'p', 'No legendary wonders discovered yet — complete quests and explore to uncover them.', 'margin:0;font-size:12px;opacity:0.5;');
       return reader;
     }
     reader.appendChild(createWonderCodexPage(page, {

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -395,3 +395,30 @@ describe('legendary wonder catalog gating', () => {
     expect(model.selectedPage).toBeNull();
   });
 });
+
+describe('legendary page view-model fields', () => {
+  it('canStartBuild is true when project is ready_to_build and city requirements are met', () => {
+    const state = makeLegendaryWonderFixture({
+      completedTechs: ['philosophy', 'pilgrimages'],
+      resources: ['stone'],
+      hasRiver: true,
+    });
+    state.legendaryWonderProjects!['oracle-of-delphi'].phase = 'ready_to_build';
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    expect(model.selectedPage?.canStartBuild).toBe(true);
+  });
+
+  it('canStartBuild is false when project is still questing', () => {
+    const state = makeLegendaryWonderFixture();
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    expect(model.selectedPage?.canStartBuild).toBe(false);
+  });
+
+  it('questSteps are populated from the project when available', () => {
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 1 });
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    expect(Array.isArray(model.selectedPage?.questSteps)).toBe(true);
+    expect(model.selectedPage?.questSteps?.length).toBeGreaterThan(0);
+    expect(model.selectedPage?.questSteps?.[0]?.completed).toBe(true);
+  });
+});

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -16,11 +16,11 @@ function makeState(): GameState {
 }
 
 describe('wonder-codex presentation', () => {
-  it('hides undiscovered natural wonders without hiding the legendary catalog', () => {
+  it('hides undiscovered natural wonders and gates legendaries without a project or intel', () => {
     const model = getWonderCodexViewModel(makeState(), 'player');
 
     expect(model.catalogEntries.some(entry => entry.id === 'great_volcano')).toBe(false);
-    expect(model.catalogEntries.some(entry => entry.id === 'oracle-of-delphi')).toBe(true);
+    expect(model.catalogEntries.filter(entry => entry.kind === 'legendary')).toHaveLength(0);
   });
 
   it('shows discovered natural pages with source image and safe map action', () => {
@@ -42,13 +42,13 @@ describe('wonder-codex presentation', () => {
     });
   });
 
-  it('falls back to the first visible entry when a deep link is not viewer-safe', () => {
+  it('does not load a page for a wonder the player cannot see', () => {
     const state = makeState();
 
     const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'great_volcano' });
 
     expect(model.selectedPage?.id).not.toBe('great_volcano');
-    expect(model.selectedPage?.kind).toBe('legendary');
+    expect(model.selectedPage).toBeNull();
   });
 
   it('does not expose rival legendary project or completion details', () => {
@@ -71,8 +71,9 @@ describe('wonder-codex presentation', () => {
     const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
     const serialized = JSON.stringify(model);
 
-    expect(model.selectedPage?.stateLabel).toBe('Legendary wonder');
-    expect(model.selectedPage?.statusLines.join(' ')).not.toContain('Reward:');
+    // Rival-owned projects and completions do not grant visibility to viewer
+    expect(model.catalogEntries.some(e => e.id === 'oracle-of-delphi')).toBe(false);
+    expect(model.catalogEntries.some(e => e.id === 'grand-canal')).toBe(false);
     expect(serialized).not.toContain('rival-city');
     expect(serialized).not.toContain('rival-canal-city');
     expect(serialized).not.toContain('90');
@@ -344,5 +345,53 @@ describe('isLegendaryWonderVisibleToPlayer', () => {
     };
     expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'grand-canal')).toBe(true);
     expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(false);
+  });
+
+  it('returns true when the player owns a completed legendary wonder', () => {
+    const state = baseState();
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'player', cityId: 'c1', turnCompleted: 50 },
+    };
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(true);
+    expect(isLegendaryWonderVisibleToPlayer(state, 'other-player', 'oracle-of-delphi')).toBe(false);
+  });
+});
+
+describe('legendary wonder catalog gating', () => {
+  it('excludes legendary wonders the player has no project or rival intel for', () => {
+    const state = createNewGame(undefined, 'gate-test');
+    state.legendaryWonderProjects = {};
+    const model = getWonderCodexViewModel(state, 'player');
+    const legendaryIds = model.catalogEntries
+      .filter(e => e.kind === 'legendary')
+      .map(e => e.id);
+    expect(legendaryIds).toHaveLength(0);
+  });
+
+  it('includes a legendary wonder once the player project phase is questing', () => {
+    const state = createNewGame(undefined, 'gate-questing-test');
+    state.legendaryWonderProjects = {
+      p1: {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'player',
+        cityId: 'c1',
+        phase: 'questing',
+        investedProduction: 0,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+    const model = getWonderCodexViewModel(state, 'player');
+    expect(model.catalogEntries.some(e => e.id === 'oracle-of-delphi')).toBe(true);
+  });
+
+  it('selectedPage is null when no legendary wonders are visible and no naturals are known', () => {
+    const state = createNewGame(undefined, 'gate-null-test');
+    state.legendaryWonderProjects = {};
+    state.wonderDiscoverers = {};
+    for (const tile of Object.values(state.map.tiles)) tile.wonder = null;
+    const model = getWonderCodexViewModel(state, 'player');
+    expect(model.catalogEntries).toHaveLength(0);
+    expect(model.selectedPage).toBeNull();
   });
 });

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -51,7 +51,7 @@ describe('wonder-codex presentation', () => {
     expect(model.selectedPage).toBeNull();
   });
 
-  it('does not expose rival legendary project or completion details', () => {
+  it('rival-owned project and completion do not appear in player catalog and no private data leaks', () => {
     const state = makeState();
     state.legendaryWonderProjects = {
       rival: {
@@ -354,6 +354,20 @@ describe('isLegendaryWonderVisibleToPlayer', () => {
     };
     expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(true);
     expect(isLegendaryWonderVisibleToPlayer(state, 'other-player', 'oracle-of-delphi')).toBe(false);
+  });
+
+  it('returns true when the player project phase is lost_race', () => {
+    const state = baseState();
+    state.legendaryWonderProjects!['p1'] = {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'c1',
+      phase: 'lost_race',
+      investedProduction: 0,
+      transferableProduction: 0,
+      questSteps: [],
+    };
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(true);
   });
 });
 

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -3,6 +3,7 @@ import { createNewGame } from '@/core/game-state';
 import type { GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { getWonderCodexViewModel } from '@/systems/wonder-codex/presentation';
+import { isLegendaryWonderVisibleToPlayer } from '@/systems/legendary-wonder-intel-presentation';
 import { makeLegendaryWonderFixture } from '../helpers/legendary-wonder-fixture';
 
 function makeState(): GameState {
@@ -283,5 +284,65 @@ describe('wonder-codex presentation', () => {
     };
     const rival = getWonderCodexViewModel(state, 'player', { initialWonderId: 'grand-canal' });
     expect(rival.selectedPage?.landmarkPreview).toBeUndefined();
+  });
+});
+
+describe('isLegendaryWonderVisibleToPlayer', () => {
+  function baseState(): GameState {
+    const s = createNewGame(undefined, 'vis-gate-test');
+    s.legendaryWonderProjects = {};
+    return s;
+  }
+
+  it('returns false when the player has no project and no rival intel', () => {
+    const state = baseState();
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(false);
+  });
+
+  it('returns false when the player project phase is locked', () => {
+    const state = baseState();
+    state.legendaryWonderProjects!['p1'] = {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'c1',
+      phase: 'locked',
+      investedProduction: 0,
+      transferableProduction: 0,
+      questSteps: [],
+    };
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(false);
+  });
+
+  it('returns true when the player project phase is questing', () => {
+    const state = baseState();
+    state.legendaryWonderProjects!['p1'] = {
+      wonderId: 'oracle-of-delphi',
+      ownerId: 'player',
+      cityId: 'c1',
+      phase: 'questing',
+      investedProduction: 0,
+      transferableProduction: 0,
+      questSteps: [],
+    };
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(true);
+  });
+
+  it('returns true when rival intel exists for the wonder (no owned project needed)', () => {
+    const state = baseState();
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'started',
+        eventId: 'started:grand-canal:rival:5',
+        projectKey: 'grand-canal:rival',
+        wonderId: 'grand-canal',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival City',
+        revealedTurn: 5,
+      }],
+    };
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'grand-canal')).toBe(true);
+    expect(isLegendaryWonderVisibleToPlayer(state, 'player', 'oracle-of-delphi')).toBe(false);
   });
 });

--- a/tests/ui/legendary-wonder-notifications.test.ts
+++ b/tests/ui/legendary-wonder-notifications.test.ts
@@ -3,7 +3,7 @@ import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notificati
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 
 describe('legendary-wonder-notifications', () => {
-  it('points ready wonders back to the city Build list and journal action', () => {
+  it('points ready wonders to the city via tap-to-open notification', () => {
     const state = makeLegendaryWonderFixture();
 
     const visible = getLegendaryWonderNotification(state, 'player', {
@@ -13,9 +13,9 @@ describe('legendary-wonder-notifications', () => {
       wonderId: 'oracle-of-delphi',
     });
 
-    expect(visible?.message).toContain('city-river');
-    expect(visible?.message).toContain('Build list');
-    expect(visible?.message).toContain('Start Construction');
+    expect(visible?.message).toContain('can start');
+    expect(visible?.message).toContain('Tap to open');
+    expect(visible?.linkedCityId).toBe('city-river');
   });
 
   it('only shows race-revealed notifications to the observing current player', () => {
@@ -79,5 +79,28 @@ describe('legendary-wonder-notifications', () => {
     // Observer has not met the builder in the fixture — name is redacted.
     expect(observerView?.message).toMatch(/A rival civilization completed/);
     expect(observerView?.type).toBe('info');
+  });
+
+  it('wonder:legendary-ready notification includes linkedCityId pointing to the build city', () => {
+    const state = makeLegendaryWonderFixture();
+    const entry = getLegendaryWonderNotification(state, 'player', {
+      type: 'wonder:legendary-ready',
+      civId: 'player',
+      cityId: 'city-river',
+      wonderId: 'oracle-of-delphi',
+    });
+    expect(entry?.linkedCityId).toBe('city-river');
+  });
+
+  it('wonder:legendary-completed notification does not include linkedCityId for the rival observer', () => {
+    const state = makeLegendaryWonderFixture();
+    const entry = getLegendaryWonderNotification(state, 'player', {
+      type: 'wonder:legendary-completed',
+      civId: 'rival',
+      cityId: 'city-rival',
+      wonderId: 'grand-canal',
+      turnCompleted: 10,
+    });
+    expect(entry?.linkedCityId).toBeUndefined();
   });
 });

--- a/tests/ui/notification-log-panel.test.ts
+++ b/tests/ui/notification-log-panel.test.ts
@@ -26,4 +26,22 @@ describe('notification log panel', () => {
     row?.click();
     expect(onFocusTarget).toHaveBeenCalledWith(target);
   });
+
+  it('renders city-linked entries as clickable and fires onOpenCity on click', () => {
+    const onOpenCity = vi.fn();
+    const entries: NotificationEntry[] = [
+      { message: 'Carthage can start Oracle of Delphi. Tap to open that city.', type: 'info', turn: 5, linkedCityId: 'city-1' },
+    ];
+
+    const panel = createNotificationLogPanel(entries, {
+      onClose: vi.fn(),
+      onFocusTarget: vi.fn(),
+      onOpenCity,
+    });
+
+    const row = panel.querySelector('[data-notification-city]') as HTMLElement | null;
+    expect(row).not.toBeNull();
+    row?.click();
+    expect(onOpenCity).toHaveBeenCalledWith('city-1');
+  });
 });

--- a/tests/ui/wonder-atlas-panel.test.ts
+++ b/tests/ui/wonder-atlas-panel.test.ts
@@ -59,7 +59,6 @@ describe('wonder-atlas-panel', () => {
     expect(panel.textContent).not.toContain('The Great Volcano');
     expect(panel.textContent).not.toContain('Replay animation');
     expect(panel.textContent).not.toContain('volcanic-breath');
-    expect(panel.textContent).toContain('Legendary wonder');
   });
 
   it('selects a discovered natural wonder and renders sourced codex detail', () => {

--- a/tests/ui/wonder-codex-page.test.ts
+++ b/tests/ui/wonder-codex-page.test.ts
@@ -182,3 +182,80 @@ describe('wonder-codex-page', () => {
     expect(root.querySelector('[data-wonder-spectacle-mode="codex-ambient"]')).toBeTruthy();
   });
 });
+
+function legendaryPage(overrides: Partial<WonderCodexPageViewModel> = {}): WonderCodexPageViewModel {
+  return page({
+    id: 'oracle-of-delphi',
+    kind: 'legendary',
+    title: 'Oracle of Delphi',
+    subtitle: 'A sanctuary of prophecy.',
+    stateLabel: 'Quest in progress',
+    actions: [],
+    sections: [],
+    relatedEntries: [],
+    ...overrides,
+  });
+}
+
+describe('wonder-codex-page — legendary UI redesign', () => {
+  it('renders a status badge element for legendary wonders', () => {
+    const root = createWonderCodexPage(legendaryPage({ stateLabel: 'Quest in progress' }), {
+      onAction: vi.fn(),
+      onSelectRelated: vi.fn(),
+    });
+    const badge = root.querySelector('[data-codex-status-badge]');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toContain('Quest in progress');
+  });
+
+  it('renders a primary Start Construction button when canStartBuild is true', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      canStartBuild: true,
+      stateLabel: 'Available',
+      actions: [{ type: 'open-city', label: 'Open City', wonderId: 'oracle-of-delphi', cityId: 'c1' }],
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    const primaryBtn = root.querySelector('[data-codex-action="start-construction"]') as HTMLButtonElement | null;
+    expect(primaryBtn).not.toBeNull();
+    expect(root.querySelectorAll('[data-codex-action="open-city"]')).toHaveLength(0);
+  });
+
+  it('does not render a primary Start Construction button when canStartBuild is false', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      canStartBuild: false,
+      actions: [{ type: 'open-city', label: 'Open City', wonderId: 'oracle-of-delphi', cityId: 'c1' }],
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    expect(root.querySelector('[data-codex-action="start-construction"]')).toBeNull();
+    expect(root.querySelector('[data-codex-action="open-city"]')).not.toBeNull();
+  });
+
+  it('renders quest steps as a checklist when questSteps is present', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      questSteps: [
+        { id: 'q1', description: 'Discover a natural wonder', completed: true },
+        { id: 'q2', description: 'Establish a trade route', completed: false },
+      ],
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    const checklist = root.querySelector('[data-codex-quest-steps]');
+    expect(checklist).not.toBeNull();
+    const items = checklist?.querySelectorAll('li');
+    expect(items).toHaveLength(2);
+    expect(items?.[0]?.dataset.completed).toBe('true');
+    expect(items?.[1]?.dataset.completed).toBe('false');
+    expect(items?.[0]?.textContent).toContain('Discover a natural wonder');
+  });
+
+  it('fires onAction with the open-city action when Start Construction is clicked', () => {
+    const onAction = vi.fn();
+    const cityAction = { type: 'open-city' as const, label: 'Open City', wonderId: 'oracle-of-delphi', cityId: 'c1' };
+    const root = createWonderCodexPage(legendaryPage({
+      canStartBuild: true,
+      actions: [cityAction],
+    }), { onAction, onSelectRelated: vi.fn() });
+
+    root.querySelector<HTMLElement>('[data-codex-action="start-construction"]')?.click();
+    expect(onAction).toHaveBeenCalledWith(cityAction);
+  });
+});

--- a/tests/ui/wonder-codex-panel.test.ts
+++ b/tests/ui/wonder-codex-panel.test.ts
@@ -5,6 +5,7 @@ import { createNewGame } from '@/core/game-state';
 import type { GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { createWonderCodexPanel } from '@/ui/wonder-codex-panel';
+import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 
 function click(element: Element | null | undefined): void {
   expect(element).toBeTruthy();
@@ -98,5 +99,23 @@ describe('wonder-codex-panel', () => {
     click(panel.querySelector('[data-codex-close]'));
     expect(onClose).toHaveBeenCalled();
     expect(document.querySelector('#wonder-codex-panel')).toBeNull();
+  });
+
+  it('catalog entry buttons have card-style background', () => {
+    const state = makeLegendaryWonderFixture();
+    state.currentPlayer = 'player';
+
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    createWonderCodexPanel(container, state, {
+      onViewOnMap: vi.fn(),
+      onOpenCity: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    const entryBtn = container.querySelector('[data-codex-entry-id="oracle-of-delphi"]') as HTMLElement | null;
+    expect(entryBtn).not.toBeNull();
+    expect(entryBtn?.style.background).toBeTruthy();
+    container.remove();
   });
 });


### PR DESCRIPTION
## Summary

- **#281 — Visibility gate:** Legendary wonders are now hidden from the Wonder Codex until the player has a non-locked project, has received rival intel, or owns a completed legendary wonder. New `isLegendaryWonderVisibleToPlayer` helper in `legendary-wonder-intel-presentation.ts`. Empty-state copy updated to "No legendary wonders discovered yet — complete quests and explore to uncover them."
- **#281 — Navigable notification:** `wonder:legendary-ready` notifications now carry `linkedCityId`. Clicking the linked row in the notification log closes the log and opens the correct city panel directly. Message simplified to "Tap to open that city."
- **#278 — Codex page redesign:** Status badge (color-coded chip) replaces plain state label for legendary wonders. `canStartBuild` and `questSteps` threaded into `WonderCodexPageViewModel`. Quest steps render as a compact checklist (completed steps struck through). When `canStartBuild` is true, the open-city action is promoted to a primary "Start Construction" CTA. Catalog sidebar entry buttons get consistent card background and padding.

## Test plan

- [ ] Visibility gate: locked-phase project hides wonder; questing/ready_to_build/building/completed shows it; rival intel shows it; rival-owned project/completion does not grant viewer visibility
- [ ] Catalog filtered view: fresh game shows no legendary wonders; empty-state message appears
- [ ] Notification `linkedCityId` set on `wonder:legendary-ready`, not on other events
- [ ] Notification log panel: city-linked row fires `onOpenCity`
- [ ] Codex page: primary CTA only when `canStartBuild`; quest checklist items render with correct completed state; status badge renders for legendary
- [ ] `yarn test` — all pass (2777 tests)
- [ ] `yarn build` — TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)