### PR TITLE
Resource Accessibility MR 2a — Outpost Foundation

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -211,6 +211,15 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       }
     }
 
+    // Resource outpost upkeep: 2 gold/turn per completed outpost owned by this civ
+    const outpostUpkeep = Object.values(newState.map.tiles).filter(
+      tile =>
+        tile.improvement === 'resource_outpost' &&
+        tile.improvementTurnsLeft === 0 &&
+        tile.owner === civId,
+    ).length * 2;
+    totalGold -= outpostUpkeep;
+
     // Vassalage tribute (25% of gold income flows to overlord)
     if (civ.diplomacy?.vassalage.overlord) {
       const tribute = processVassalageTribute(totalGold);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -200,8 +200,9 @@ export interface TribalVillage {
 export type VisibilityState = 'unexplored' | 'fog' | 'visible';
 
 export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill'
-  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'none';
-export type BuildableImprovementType = Exclude<ImprovementType, 'none'>;
+  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'resource_outpost' | 'none';
+// resource_outpost is excluded: only Expeditions can establish outposts, not Workers
+export type BuildableImprovementType = Exclude<ImprovementType, 'none' | 'resource_outpost'>;
 export type WorkerActionType = BuildableImprovementType | 'drain_swamp';
 
 export interface HexTile {

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -19,6 +19,7 @@ export const IMPROVEMENT_ICONS: Record<string, string> = {
   pasture: '🐂',
   camp: '⛺',
   quarry: '⚒️',
+  resource_outpost: '🚩',  // dedicated SVG sprite TBD via Claude Design
 };
 
 // --- Terrain labels ---

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -153,6 +153,8 @@ export function canBuildImprovement(
   if (!definition) return false;
   if (options.isCityTile) return false;
   if (ownerId && tile.owner !== ownerId) return false;
+  // resource_outpost is established only by Expeditions — Workers can never overwrite it
+  if (tile.improvement === 'resource_outpost') return false;
   if (tile.improvement !== 'none' && (!options.allowReplacement || tile.improvement === type)) return false;
   if (!definition.validTerrains.includes(tile.terrain)) return false;
   if (definition.requiresRiver && !tile.hasRiver) return false;
@@ -199,6 +201,8 @@ export function getWorkerActionBlockerReason(
   if (!tile) return 'invalid-terrain';
   if (ownerId && tile.owner !== ownerId) return 'outside-territory';
   if (options.isCityTile) return 'city-center';
+  // resource_outpost is established only by Expeditions — Workers can never overwrite it
+  if (tile.improvement === 'resource_outpost') return 'already-improved';
   if (tile.improvement !== 'none' && (!options.allowReplacement || tile.improvement === action)) return 'already-improved';
 
   if (action === 'drain_swamp') {

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -136,6 +136,7 @@ export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
   pasture: IMPROVEMENT_DEFINITIONS.pasture.buildTurns,
   camp: IMPROVEMENT_DEFINITIONS.camp.buildTurns,
   quarry: IMPROVEMENT_DEFINITIONS.quarry.buildTurns,
+  resource_outpost: 0,  // set by Expedition unit, not by Worker
   none: 0,
 };
 
@@ -229,17 +230,18 @@ export function formatWorkerActionBlockerReason(reason: WorkerActionBlockerReaso
 }
 
 export function getImprovementYieldBonus(type: ImprovementType): ResourceYield {
-  if (type === 'none') return { ...NO_YIELD };
+  if (type === 'none' || type === 'resource_outpost') return { ...NO_YIELD };
   return { ...IMPROVEMENT_DEFINITIONS[type].yieldBonus };
 }
 
 export function getImprovementDisplayName(type: ImprovementType): string {
   if (type === 'none') return 'None';
+  if (type === 'resource_outpost') return 'Resource Outpost';
   return IMPROVEMENT_DEFINITIONS[type].name;
 }
 
 export function formatImprovementYieldLabel(type: ImprovementType): string {
-  if (type === 'none') return '';
+  if (type === 'none' || type === 'resource_outpost') return '';
   const bonus = IMPROVEMENT_DEFINITIONS[type as BuildableImprovementType].yieldBonus;
   const parts: string[] = [];
   if (bonus.food) parts.push(`+${bonus.food} Food`);

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -57,6 +57,23 @@ export function getCivAvailableResources(state: GameState, civId: string): Set<R
     }
   }
 
+  // Pass 2 — resource outpost tiles owned by this civ (outside city territory)
+  // Linear scan over all tiles: 60×40 = 2,400 tiles maximum.
+  for (const tile of Object.values(state.map.tiles)) {
+    if (
+      tile.improvement !== 'resource_outpost' ||
+      tile.improvementTurnsLeft !== 0 ||
+      tile.owner !== civId ||
+      !tile.resource
+    ) continue;
+
+    const def = resourceDefMap.get(tile.resource as ResourceType);
+    if (!def) continue;
+    if (!completedTechs.has(def.tech)) continue;
+
+    result.add(tile.resource as ResourceType);
+  }
+
   return result;
 }
 

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -829,6 +829,40 @@ describe('processTurn', () => {
     const afterCi = result.espionage!['player']!.counterIntelligence[cityId] ?? 0;
     expect(afterCi).toBe(startCi + 2); // perTurnBonus = 2 + floor(0 * 0.1) = 2
   });
+
+  it('deducts 2 gold per completed outpost from the owning civ each turn', () => {
+    const state = createNewGame(undefined, 'outpost-upkeep-test', 'small');
+    const bus = new EventBus();
+    const civId = 'player';
+
+    // Zero out income/maintenance for the player so gold change is purely upkeep
+    state.civilizations[civId].cities = [];
+    state.civilizations[civId].units = [];
+    state.civilizations[civId].gold = 100;
+
+    // 2 completed outposts owned by player
+    state.map.tiles['20,20'] = {
+      coord: { q: 20, r: 20 }, terrain: 'hills', elevation: 'lowland',
+      resource: 'iron', improvement: 'resource_outpost', improvementTurnsLeft: 0,
+      owner: civId, hasRiver: false, wonder: null,
+    };
+    state.map.tiles['21,21'] = {
+      coord: { q: 21, r: 21 }, terrain: 'hills', elevation: 'lowland',
+      resource: 'iron', improvement: 'resource_outpost', improvementTurnsLeft: 0,
+      owner: civId, hasRiver: false, wonder: null,
+    };
+    // In-progress outpost — must NOT charge upkeep
+    state.map.tiles['22,22'] = {
+      coord: { q: 22, r: 22 }, terrain: 'hills', elevation: 'lowland',
+      resource: 'iron', improvement: 'resource_outpost', improvementTurnsLeft: 1,
+      owner: civId, hasRiver: false, wonder: null,
+    };
+
+    const result = processTurn(state, bus);
+
+    // 2 completed outposts × 2 gold = 4 deducted; no income/maintenance → 100 - 4 = 96
+    expect(result.civilizations[civId].gold).toBe(96);
+  });
 });
 
 describe('espionage post-loop snapshot', () => {

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -508,4 +508,36 @@ describe('formatImprovementYieldLabel', () => {
   it('formats farm yield', () => {
     expect(formatImprovementYieldLabel('farm')).toBe('(+2 Food)');
   });
+
+  it('returns empty string for resource_outpost (no yield bonus)', () => {
+    expect(formatImprovementYieldLabel('resource_outpost')).toBe('');
+  });
+});
+
+describe('resource_outpost immutability — workers cannot overwrite it', () => {
+  const outpostTile: HexTile = {
+    coord: { q: 0, r: 0 }, terrain: 'hills', elevation: 'highland',
+    resource: 'iron', improvement: 'resource_outpost', owner: 'p1',
+    improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+  };
+
+  it('canBuildImprovement returns false even with allowReplacement: true', () => {
+    expect(canBuildImprovement(outpostTile, 'mine', ['bronze-working'], 'p1', { allowReplacement: true })).toBe(false);
+  });
+
+  it('getWorkerActionBlockerReason returns already-improved even with allowReplacement: true', () => {
+    expect(getWorkerActionBlockerReason(outpostTile, 'mine', ['bronze-working'], 'p1', { allowReplacement: true })).toBe('already-improved');
+  });
+
+  it('getAvailableWorkerActions returns empty array on an outpost tile', () => {
+    expect(getAvailableWorkerActions(outpostTile, ['bronze-working'], 'p1', { allowReplacement: true })).toEqual([]);
+  });
+
+  it('getImprovementDisplayName returns "Resource Outpost"', () => {
+    expect(getImprovementDisplayName('resource_outpost')).toBe('Resource Outpost');
+  });
+
+  it('getImprovementYieldBonus returns all-zero yield', () => {
+    expect(getImprovementYieldBonus('resource_outpost')).toEqual({ food: 0, production: 0, gold: 0, science: 0 });
+  });
 });

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -320,3 +320,112 @@ describe('stone on mountain resource accessibility (issue #280)', () => {
     expect(result.has('stone')).toBe(true);
   });
 });
+
+describe('outpost pass (Pillar 2)', () => {
+  function makeStateWithOutpost(opts: {
+    outpostOwner: string;
+    resourceId: string;
+    improvementTurnsLeft: number;
+    playerTech: string[];
+    outpostImprovement?: string;
+  }): GameState {
+    const outpostTile = {
+      coord: { q: 10, r: 10 },
+      terrain: 'hills',
+      elevation: 'flat',
+      resource: opts.resourceId,
+      improvement: opts.outpostImprovement ?? 'resource_outpost',
+      improvementTurnsLeft: opts.improvementTurnsLeft,
+      owner: opts.outpostOwner,
+      hasRiver: false,
+      wonder: null,
+    };
+
+    return {
+      map: {
+        width: 20, height: 20,
+        wrapsHorizontally: false,
+        rivers: [],
+        tiles: {
+          '3,3': { coord: { q: 3, r: 3 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', improvementTurnsLeft: 0, owner: null, hasRiver: false, wonder: null },
+          '10,10': outpostTile,
+        },
+      },
+      cities: {
+        'city-player': {
+          id: 'city-player', name: 'PlayerCity', owner: 'player',
+          position: { q: 3, r: 3 },
+          ownedTiles: [{ q: 3, r: 3 }],
+          population: 1, food: 0, production: 0, gold: 0,
+          buildings: [], productionQueue: [], workedTiles: [], specialistSlots: [],
+          garrisonUnitId: null, hp: 100, maxHp: 100,
+        },
+        'city-ai1': {
+          id: 'city-ai1', name: 'AI1City', owner: 'ai-1',
+          position: { q: 5, r: 5 },
+          ownedTiles: [{ q: 5, r: 5 }],
+          population: 1, food: 0, production: 0, gold: 0,
+          buildings: [], productionQueue: [], workedTiles: [], specialistSlots: [],
+          garrisonUnitId: null, hp: 100, maxHp: 100,
+        },
+      },
+      civilizations: {
+        'player': {
+          id: 'player',
+          cities: ['city-player'],
+          techState: { completed: opts.playerTech, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        },
+        'ai-1': {
+          id: 'ai-1',
+          cities: ['city-ai1'],
+          techState: { completed: opts.playerTech, currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+        },
+      },
+    } as unknown as GameState;
+  }
+
+  it('grants the resource when outpost is complete (improvementTurnsLeft === 0)', () => {
+    const state = makeStateWithOutpost({
+      outpostOwner: 'player',
+      resourceId: 'iron',
+      improvementTurnsLeft: 0,
+      playerTech: ['bronze-working'],
+    });
+    const result = getCivAvailableResources(state, 'player');
+    expect(result.has('iron')).toBe(true);
+  });
+
+  it('does NOT grant the resource when outpost is still in progress (improvementTurnsLeft > 0)', () => {
+    const state = makeStateWithOutpost({
+      outpostOwner: 'player',
+      resourceId: 'iron',
+      improvementTurnsLeft: 1,
+      playerTech: ['bronze-working'],
+    });
+    const result = getCivAvailableResources(state, 'player');
+    expect(result.has('iron')).toBe(false);
+  });
+
+  it('does NOT grant the resource when outpost is pillaged (improvement = none)', () => {
+    const state = makeStateWithOutpost({
+      outpostOwner: 'player',
+      resourceId: 'iron',
+      improvementTurnsLeft: 0,
+      playerTech: ['bronze-working'],
+      outpostImprovement: 'none',
+    });
+    const result = getCivAvailableResources(state, 'player');
+    expect(result.has('iron')).toBe(false);
+  });
+
+  it('does NOT grant the resource to a different civ', () => {
+    const state = makeStateWithOutpost({
+      outpostOwner: 'player',
+      resourceId: 'iron',
+      improvementTurnsLeft: 0,
+      playerTech: ['bronze-working'],
+    });
+    const result = getCivAvailableResources(state, 'ai-1');
+    expect(result.has('iron')).toBe(false);
+  });
+});

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -332,7 +332,7 @@ describe('outpost pass (Pillar 2)', () => {
     const outpostTile = {
       coord: { q: 10, r: 10 },
       terrain: 'hills',
-      elevation: 'flat',
+      elevation: 'lowland',
       resource: opts.resourceId,
       improvement: opts.outpostImprovement ?? 'resource_outpost',
       improvementTurnsLeft: opts.improvementTurnsLeft,
@@ -428,4 +428,16 @@ describe('outpost pass (Pillar 2)', () => {
     const result = getCivAvailableResources(state, 'ai-1');
     expect(result.has('iron')).toBe(false);
   });
+
+  it('does NOT grant the resource when the owning civ lacks the required tech', () => {
+    const state = makeStateWithOutpost({
+      outpostOwner: 'player',
+      resourceId: 'iron',
+      improvementTurnsLeft: 0,
+      playerTech: [], // no bronze-working
+    });
+    const result = getCivAvailableResources(state, 'player');
+    expect(result.has('iron')).toBe(false);
+  });
+
 });


### PR DESCRIPTION
## Summary

- Adds `'resource_outpost'` to `ImprovementType`, excluded from `BuildableImprovementType` (Workers can never build one)
- Extends `getCivAvailableResources` with a Pass 2 that scans all map tiles for completed outposts owned by the civ, respecting the tech gate
- Deducts 2 gold/turn upkeep per completed outpost in `processTurn` (from `totalGold` before `grossGoldByCiv` accumulation)
- Adds 🚩 emoji icon to `IMPROVEMENT_ICONS`; handles `resource_outpost` gracefully in `getImprovementYieldBonus`, `getImprovementDisplayName`, `formatImprovementYieldLabel`, and `IMPROVEMENT_BUILD_TURNS`
- Guards `canBuildImprovement` and `getWorkerActionBlockerReason` so Workers cannot overwrite outpost tiles even with `allowReplacement: true`

## Why this is safe to merge partial

No player-visible surface is introduced. Players cannot create `resource_outpost` tiles — the Expedition unit (MR 2b) is required. All new code paths are inert until MR 2b ships. The 🚩 icon and upkeep logic are wired but unreachable through normal gameplay.

## Test plan

- [ ] 5 new outpost acquisition tests (grants, in-progress, pillaged, wrong civ, missing tech)
- [ ] 1 new upkeep test (2 completed × 2 gold = 4 deducted; in-progress not charged)
- [ ] 6 new improvement-system tests covering outpost immutability, display name, yield, and `formatImprovementYieldLabel`
- [ ] `yarn build` exits 0
- [ ] `yarn test` 2855 passing, 0 failing

## Out of scope

- Expedition unit that establishes outposts (MR 2b)
- Dedicated SVG sprite for the outpost icon (Phase 2, after MR 2b)
- Outpost upkeep line in the economy status panel (deferred to MR 2b UI work — no outposts can exist yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)