### PR TITLE
fix(animation): hex-by-hex movement with ease-in-out and AI replay

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1121,7 +1121,7 @@ export interface GameSettings {
 export interface GameEvents {
   'turn:start': { turn: number; playerId: string };
   'turn:end': { turn: number; playerId: string };
-  'unit:move': { unitId: string; from: HexCoord; to: HexCoord };
+  'unit:move': { unitId: string; from: HexCoord; to: HexCoord; path: HexCoord[] };
   'unit:created': { unit: Unit };
   'unit:destroyed': { unitId: string; position: HexCoord };
   'city:founded': { city: City; founderId: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1504,13 +1504,13 @@ function isUnitAnimationLocked(unitId: string | null): boolean {
   return Boolean(unitId && renderLoop.hasMovingUnit(unitId));
 }
 
-function animateMovedUnit(unitId: string, from: HexCoord, to: HexCoord): void {
+function animateMovedUnit(unitId: string, path: HexCoord[]): void {
   const movedUnit = gameState.units[unitId];
-  if (!movedUnit) return;
+  if (!movedUnit || path.length < 2) return;
   movementRange = [];
   attackRange = [];
   renderLoop.clearHighlights();
-  renderLoop.animateUnitMove({ ...movedUnit, position: from }, from, to, () => {
+  renderLoop.animateUnitMove({ ...movedUnit, position: path[0]! }, path, () => {
     renderLoop.setGameState(gameState);
     updateHUD();
     deferWonderDiscoveryRevealUntilMoveSettles = false;
@@ -1560,7 +1560,7 @@ function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResu
   deferWonderDiscoveryRevealUntilMoveSettles = true;
   try {
     const moveResult = move();
-    animateMovedUnit(unitId, moveResult.from, moveResult.to);
+    animateMovedUnit(unitId, moveResult.path);
     return moveResult;
   } catch (error) {
     deferWonderDiscoveryRevealUntilMoveSettles = false;
@@ -2428,6 +2428,32 @@ function handleVictoryIfNeeded(): boolean {
   return true;
 }
 
+type AIMoveRecord = { unit: Unit; path: HexCoord[] };
+
+function captureAIMoves(fn: () => void): AIMoveRecord[] {
+  const moves: AIMoveRecord[] = [];
+  const unsub = bus.on('unit:move', ({ unitId, from, path }) => {
+    const unit = gameState.units[unitId];
+    if (unit) moves.push({ unit: { ...unit, position: from }, path });
+  });
+  fn();
+  unsub();
+  return moves;
+}
+
+async function replayAIMoves(moves: AIMoveRecord[]): Promise<void> {
+  const playerVis = gameState.civilizations[gameState.currentPlayer]?.visibility;
+  const visibleMoves = moves
+    .filter(({ path }) => {
+      const dest = path[path.length - 1];
+      return dest && playerVis && getVisibility(playerVis, dest) !== 'unexplored';
+    })
+    .slice(0, 6);
+  for (const { unit, path } of visibleMoves) {
+    await new Promise<void>(resolve => renderLoop.animateUnitMove(unit, path, resolve));
+  }
+}
+
 async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<void> {
   if (gameState.gameOver) return;
   try {
@@ -2451,13 +2477,19 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
         // Last human player finished — process improvements, AI, and round end
         processImprovements();
 
+        const hotSeatAIMoves: AIMoveRecord[] = [];
         for (const ai of getAIPlayers(hotSeat)) {
-          gameState = processAITurn(gameState, ai.slotId, bus);
+          hotSeatAIMoves.push(...captureAIMoves(() => {
+            gameState = processAITurn(gameState, ai.slotId, bus);
+          }));
         }
 
         gameState = processTurn(gameState, bus);
 
         if (handleVictoryIfNeeded()) return;
+
+        renderLoop.setGameState(gameState);
+        await replayAIMoves(hotSeatAIMoves);
 
       }
 
@@ -2483,12 +2515,15 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       // --- Solo Mode ---
       processImprovements();
 
-      gameState = processAITurn(gameState, 'ai-1', bus);
+      const soloAIMoves = captureAIMoves(() => {
+        gameState = processAITurn(gameState, 'ai-1', bus);
+      });
       gameState = processTurn(gameState, bus);
 
       if (handleVictoryIfNeeded()) return;
 
       renderLoop.setGameState(gameState);
+      await replayAIMoves(soloAIMoves);
       updateHUD();
 
       showNotification(`Turn ${gameState.turn}`, 'info');

--- a/src/main.ts
+++ b/src/main.ts
@@ -2433,6 +2433,8 @@ type AIMoveRecord = { unit: Unit; path: HexCoord[] };
 function captureAIMoves(fn: () => void): AIMoveRecord[] {
   const moves: AIMoveRecord[] = [];
   const unsub = bus.on('unit:move', ({ unitId, from, path }) => {
+    // executeUnitMove mutates state.units before emitting, so the unit is already
+    // at `to` when this fires. Override position: from so animation starts correctly.
     const unit = gameState.units[unitId];
     if (unit) moves.push({ unit: { ...unit, position: from }, path });
   });

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -82,10 +82,13 @@ export class RenderLoop {
     );
   }
 
-  animateUnitMove(unit: Unit, from: HexCoord, to: HexCoord, onComplete?: () => void): void {
-    if (!this.state) return;
+  animateUnitMove(unit: Unit, path: HexCoord[], onComplete?: () => void): void {
+    if (!this.state || path.length < 2) {
+      onComplete?.();
+      return;
+    }
     this.unitMovementAnimations.push({
-      ...createMovementAnimation(unit, from, to, this.state.map),
+      ...createMovementAnimation(unit, path, this.state.map),
       startTime: performance.now(),
       onComplete,
     });

--- a/src/renderer/unit-movement-animation.ts
+++ b/src/renderer/unit-movement-animation.ts
@@ -1,12 +1,15 @@
 import type { GameMap, HexCoord, Unit } from '@/core/types';
 import type { UnitMotionState } from '@/renderer/unit-visual-resolver';
 
+export const MOVEMENT_MS_PER_HEX = 220;
+export const MOVEMENT_MAX_MS = 800;
+
 export interface UnitMovementAnimation {
   unit: Unit;
+  path: HexCoord[];
+  renderPath: HexCoord[];
   from: HexCoord;
   to: HexCoord;
-  renderFrom: HexCoord;
-  renderTo: HexCoord;
   duration: number;
 }
 
@@ -15,39 +18,64 @@ export interface UnitMovementFrame {
   motion: UnitMotionState;
 }
 
-export function getMovementDurationMs(path: HexCoord[]): number {
-  const steps = Math.max(1, path.length - 1);
-  return Math.min(600, 250 + Math.max(0, steps - 1) * 120);
+function easeInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
 }
 
-function wrappedRenderDestination(from: HexCoord, to: HexCoord, map: GameMap): HexCoord {
+export function getMovementDurationMs(stepCount: number): number {
+  return Math.min(MOVEMENT_MAX_MS, stepCount * MOVEMENT_MS_PER_HEX);
+}
+
+function wrappedRenderStep(from: HexCoord, to: HexCoord, map: GameMap): HexCoord {
   if (!map.wrapsHorizontally) return to;
   const directDelta = to.q - from.q;
   const westDelta = to.q - map.width - from.q;
   const eastDelta = to.q + map.width - from.q;
-  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0];
+  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0]!;
   return { q: from.q + bestDelta, r: to.r };
 }
 
-export function createMovementAnimation(unit: Unit, from: HexCoord, to: HexCoord, map: GameMap): UnitMovementAnimation {
+export function createMovementAnimation(unit: Unit, path: HexCoord[], map: GameMap): UnitMovementAnimation {
+  if (path.length < 2) {
+    const coord = path[0] ?? unit.position;
+    return { unit, path: [coord], renderPath: [coord], from: coord, to: coord, duration: 0 };
+  }
+  const renderPath: HexCoord[] = [path[0]!];
+  for (let i = 1; i < path.length; i++) {
+    renderPath.push(wrappedRenderStep(renderPath[i - 1]!, path[i]!, map));
+  }
+  const steps = path.length - 1;
   return {
     unit,
-    from,
-    to,
-    renderFrom: from,
-    renderTo: wrappedRenderDestination(from, to, map),
-    duration: getMovementDurationMs([from, to]),
+    path,
+    renderPath,
+    from: path[0]!,
+    to: path[path.length - 1]!,
+    duration: getMovementDurationMs(steps),
   };
 }
 
 export function getMovementAnimationPosition(animation: UnitMovementAnimation, progress: number): UnitMovementFrame {
   const clamped = Math.max(0, Math.min(1, progress));
+  const steps = Math.max(1, animation.renderPath.length - 1);
+
+  // Map overall progress to a step index + intra-step fraction
+  const rawStepProgress = clamped * steps;
+  const stepIndex = Math.min(steps - 1, Math.floor(rawStepProgress));
+  const stepFraction = rawStepProgress - stepIndex;
+
+  // Ease-in-out applied per segment so each hex traversal feels weighted
+  const segEased = easeInOut(stepFraction);
+
+  const segFrom = animation.renderPath[stepIndex]!;
+  const segTo = animation.renderPath[stepIndex + 1]!;
+
   return {
     coord: {
-      q: animation.renderFrom.q + (animation.renderTo.q - animation.renderFrom.q) * clamped,
-      r: animation.renderFrom.r + (animation.renderTo.r - animation.renderFrom.r) * clamped,
+      q: segFrom.q + (segTo.q - segFrom.q) * segEased,
+      r: segFrom.r + (segTo.r - segFrom.r) * segEased,
     },
-    motion: Math.floor(clamped * 6) % 2 === 0 ? 'move-a' : 'move-b',
+    motion: Math.floor(rawStepProgress * 6) % 2 === 0 ? 'move-a' : 'move-b',
   };
 }
 

--- a/src/renderer/unit-movement-animation.ts
+++ b/src/renderer/unit-movement-animation.ts
@@ -56,8 +56,13 @@ export function createMovementAnimation(unit: Unit, path: HexCoord[], map: GameM
 }
 
 export function getMovementAnimationPosition(animation: UnitMovementAnimation, progress: number): UnitMovementFrame {
+  // Degenerate: nothing to interpolate
+  if (animation.renderPath.length < 2) {
+    return { coord: animation.renderPath[0] ?? animation.from, motion: 'idle' };
+  }
+
   const clamped = Math.max(0, Math.min(1, progress));
-  const steps = Math.max(1, animation.renderPath.length - 1);
+  const steps = animation.renderPath.length - 1;
 
   // Map overall progress to a step index + intra-step fraction
   const rawStepProgress = clamped * steps;

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -25,6 +25,7 @@ export interface WonderDiscoveryResult {
 export interface ExecuteUnitMoveResult {
   from: HexCoord;
   to: HexCoord;
+  path: HexCoord[];
   revealedTiles: HexCoord[];
   discoveredWonders: WonderDiscoveryResult[];
   villageOutcome?: {
@@ -82,6 +83,7 @@ export function executeUnitMove(
     return {
       from: to,
       to,
+      path: [to],
       revealedTiles: [],
       discoveredWonders: [],
     };
@@ -107,7 +109,8 @@ export function executeUnitMove(
     ...state.units,
     [unitId]: moveUnit(unit, to, cost),
   };
-  options.bus?.emit('unit:move', { unitId, from, to });
+  const movePath = path ?? [from, to];
+  options.bus?.emit('unit:move', { unitId, from, to, path: movePath });
 
   let villageOutcome: ExecuteUnitMoveResult['villageOutcome'];
   const villageAtDestination = Object.values(state.tribalVillages).find(village => hexKey(village.position) === hexKey(to));
@@ -170,6 +173,7 @@ export function executeUnitMove(
   return {
     from,
     to,
+    path: movePath,
     revealedTiles,
     discoveredWonders,
     villageOutcome,
@@ -268,7 +272,7 @@ export function advanceRouteRunners(state: GameState, bus?: EventBus): GameState
         [caravan.id]: { ...newState.units[caravan.id]!, position: nextStep },
       },
     };
-    bus?.emit('unit:move', { unitId: caravan.id, from, to: nextStep });
+    bus?.emit('unit:move', { unitId: caravan.id, from, to: nextStep, path: [from, nextStep] });
 
     if (nextStep.q === targetCity.position.q && nextStep.r === targetCity.position.r) {
       const movedCaravan = newState.units[caravan.id];

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -158,7 +158,7 @@ describe('render-loop wrap parity', () => {
 
     loop.setGameState(state);
     loop.camera.isHexVisible = () => true;
-    loop.animateUnitMove(unit as Unit, { q: 0, r: 0 }, { q: 1, r: 0 }, () => {
+    loop.animateUnitMove(unit as Unit, [{ q: 0, r: 0 }, { q: 1, r: 0 }], () => {
       callbackSawMoving = loop.hasMovingUnit('u1');
     });
     nowSpy.mockReturnValue(1000);

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -2,34 +2,44 @@ import { describe, it, expect } from 'vitest';
 import { UNIT_SPRITE_CATALOG, BUILDING_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
 import { derivePalette } from '@/renderer/sprites/sprite-system';
 import { BUILDINGS } from '@/systems/city-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 
-const ALL_UNIT_TYPES = [
-  'settler', 'worker', 'scout', 'warrior', 'archer',
-  'swordsman', 'pikeman', 'musketeer', 'galley', 'trireme',
-  'spy_scout', 'spy_informant', 'spy_agent', 'spy_operative', 'spy_hacker',
-  'scout_hound', 'shadow_warden', 'war_hound',
-] as const;
+// Derive the authoritative unit-type list from UNIT_DEFINITIONS so this test
+// automatically catches any new UnitType added to types.ts without a matching
+// sprite or motion wiring.
+const ALL_UNIT_TYPES = Object.keys(UNIT_DEFINITIONS) as Array<keyof typeof UNIT_DEFINITIONS>;
 
 describe('sprite-catalog coverage', () => {
   describe('UNIT_SPRITE_CATALOG', () => {
-    for (const unitType of ALL_UNIT_TYPES) {
-      it(`has a component for unit type: ${unitType}`, () => {
-        expect(UNIT_SPRITE_CATALOG[unitType]).toBeDefined();
-        expect(typeof UNIT_SPRITE_CATALOG[unitType]).toBe('function');
-      });
-    }
+    it('has an entry for every UnitType in UNIT_DEFINITIONS', () => {
+      for (const unitType of ALL_UNIT_TYPES) {
+        expect(UNIT_SPRITE_CATALOG[unitType], `missing sprite for unit type: ${unitType}`).toBeDefined();
+        expect(typeof UNIT_SPRITE_CATALOG[unitType], `sprite for ${unitType} must be a function`).toBe('function');
+      }
+    });
 
-    it('every unit sprite returns distinct moving output', () => {
+    it('UNIT_SPRITE_CATALOG has no entries for unknown types', () => {
+      for (const unitType of Object.keys(UNIT_SPRITE_CATALOG)) {
+        expect(UNIT_DEFINITIONS[unitType as keyof typeof UNIT_DEFINITIONS], `${unitType} in sprite catalog but not in UNIT_DEFINITIONS`).toBeDefined();
+      }
+    });
+
+    it('every unit sprite responds to all three motion states', () => {
       const palette = derivePalette('#4a90d9');
-      for (const [type, render] of Object.entries(UNIT_SPRITE_CATALOG)) {
-        const idle = render({ palette, svgOnly: true, motion: 'idle' });
+      for (const unitType of ALL_UNIT_TYPES) {
+        const render = UNIT_SPRITE_CATALOG[unitType];
+        if (!render) continue; // caught by entry test above
+
+        const idle    = render({ palette, svgOnly: true, motion: 'idle' });
         const movingA = render({ palette, svgOnly: true, motion: 'move-a' });
         const movingB = render({ palette, svgOnly: true, motion: 'move-b' });
-        expect(idle, `${type} idle sprite`).toContain('data-motion="idle"');
-        expect(movingA, `${type} move-a sprite`).toContain('data-motion="move-a"');
-        expect(movingB, `${type} move-b sprite`).toContain('data-motion="move-b"');
-        expect(movingA, `${type} move-a differs from idle`).not.toBe(idle);
-        expect(movingB, `${type} move-b differs from move-a`).not.toBe(movingA);
+
+        expect(idle,    `${unitType} idle`).toContain('data-motion="idle"');
+        expect(movingA, `${unitType} move-a`).toContain('data-motion="move-a"');
+        expect(movingB, `${unitType} move-b`).toContain('data-motion="move-b"');
+
+        expect(movingA, `${unitType} move-a must differ from idle`).not.toBe(idle);
+        expect(movingB, `${unitType} move-b must differ from move-a`).not.toBe(movingA);
       }
     });
   });

--- a/tests/renderer/unit-movement-animation.test.ts
+++ b/tests/renderer/unit-movement-animation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { GameMap, Unit } from '@/core/types';
-import { createMovementAnimation, getMovementAnimationPosition, getMovementDurationMs, getMovingUnitIds } from '@/renderer/unit-movement-animation';
+import { createMovementAnimation, getMovementAnimationPosition, getMovementDurationMs, getMovingUnitIds, MOVEMENT_MS_PER_HEX, MOVEMENT_MAX_MS } from '@/renderer/unit-movement-animation';
 import { createUnit } from '@/systems/unit-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
@@ -12,29 +12,123 @@ function unit(id: string): Unit {
 }
 
 describe('unit-movement-animation', () => {
-  it('uses a short wrapped route across the horizontal edge', () => {
-    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 5, r: 1 }, map);
+  describe('getMovementDurationMs', () => {
+    it('uses 220 ms per step for a single-hex move', () => {
+      expect(getMovementDurationMs(1)).toBe(MOVEMENT_MS_PER_HEX);
+    });
 
-    expect(animation.renderFrom.q).toBe(0);
-    expect(animation.renderTo.q).toBe(-1);
+    it('scales linearly up to the cap', () => {
+      expect(getMovementDurationMs(2)).toBe(MOVEMENT_MS_PER_HEX * 2);
+      expect(getMovementDurationMs(3)).toBe(MOVEMENT_MS_PER_HEX * 3);
+    });
+
+    it('caps at MOVEMENT_MAX_MS for long paths', () => {
+      expect(getMovementDurationMs(100)).toBe(MOVEMENT_MAX_MS);
+    });
+
+    it('exports named constants so callers can reason about timing', () => {
+      expect(MOVEMENT_MS_PER_HEX).toBe(220);
+      expect(MOVEMENT_MAX_MS).toBe(800);
+    });
   });
 
-  it('clamps normal movement duration to a responsive range', () => {
-    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }])).toBe(250);
-    expect(getMovementDurationMs([{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 }, { q: 3, r: 0 }])).toBeLessThanOrEqual(600);
+  describe('createMovementAnimation (path-based)', () => {
+    it('accepts a path array and derives from/to from its endpoints', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 1, r: 1 }], map);
+      expect(anim.from).toEqual({ q: 0, r: 1 });
+      expect(anim.to).toEqual({ q: 1, r: 1 });
+    });
+
+    it('stores the full path', () => {
+      const path = [{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 }];
+      const anim = createMovementAnimation(unit('u1'), path, map);
+      expect(anim.path).toEqual(path);
+      expect(anim.renderPath).toHaveLength(3);
+    });
+
+    it('uses a short wrapped route across the horizontal edge', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 5, r: 1 }], map);
+      expect(anim.renderPath[0].q).toBe(0);
+      expect(anim.renderPath[1].q).toBe(-1); // wraps westward (shorter route on width-6 map)
+    });
+
+    it('wraps each step relative to the previous render position for multi-step paths', () => {
+      // On a width-6 map, going 0→5→4 should wrap consistently
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 0 }, { q: 5, r: 0 }, { q: 4, r: 0 }], map);
+      // First step wraps to -1 (westward)
+      expect(anim.renderPath[1].q).toBe(-1);
+      // Second step continues in the same direction
+      expect(anim.renderPath[2].q).toBe(-2);
+    });
+
+    it('sets duration using 220 ms per step', () => {
+      const oneStep = createMovementAnimation(unit('u1'), [{ q: 0, r: 0 }, { q: 1, r: 0 }], map);
+      expect(oneStep.duration).toBe(220);
+
+      const threeStep = createMovementAnimation(unit('u1'), [
+        { q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 }, { q: 3, r: 0 },
+      ], map);
+      expect(threeStep.duration).toBe(660);
+    });
   });
 
-  it('interpolates position and alternates moving frames', () => {
-    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
-    const halfway = getMovementAnimationPosition(animation, 0.5);
+  describe('getMovementAnimationPosition', () => {
+    it('starts at the first path coordinate at progress 0', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 2, r: 1 }], map);
+      const frame = getMovementAnimationPosition(anim, 0);
+      expect(frame.coord.q).toBeCloseTo(0);
+    });
 
-    expect(halfway.coord.q).toBeCloseTo(0.5);
-    expect(halfway.motion).toBe('move-b');
+    it('reaches the final path coordinate at progress 1', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 2, r: 1 }], map);
+      const frame = getMovementAnimationPosition(anim, 1);
+      expect(frame.coord.q).toBeCloseTo(2);
+    });
+
+    it('applies ease-in-out so mid-segment position is at 0.5 eased fraction', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 1, r: 1 }], map);
+      const halfway = getMovementAnimationPosition(anim, 0.5);
+      // ease-in-out(0.5) = 0.5 exactly
+      expect(halfway.coord.q).toBeCloseTo(0.5);
+    });
+
+    it('is slower at start and end than in the middle (ease-in-out shape)', () => {
+      // Use a non-wrapping map so coords aren't adjusted
+      const bigMap = { width: 100, height: 100, wrapsHorizontally: false, tiles: {}, rivers: [] } as GameMap;
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 0 }, { q: 10, r: 0 }], bigMap);
+      const at10 = getMovementAnimationPosition(anim, 0.1).coord.q;
+      const at40 = getMovementAnimationPosition(anim, 0.4).coord.q;
+      const at60 = getMovementAnimationPosition(anim, 0.6).coord.q;
+      const at90 = getMovementAnimationPosition(anim, 0.9).coord.q;
+      // Middle spans (40→60) cover more distance than edge spans (0→10 and 90→100)
+      const midSpan = at60 - at40;
+      const startSpan = at10 - 0;
+      const endSpan = 10 - at90;
+      expect(midSpan).toBeGreaterThan(startSpan);
+      expect(midSpan).toBeGreaterThan(endSpan);
+    });
+
+    it('alternates move-a / move-b motion states throughout', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 1, r: 1 }], map);
+      const motions = [0, 0.2, 0.4, 0.6, 0.8].map(p => getMovementAnimationPosition(anim, p).motion);
+      expect(motions).toContain('move-a');
+      expect(motions).toContain('move-b');
+    });
+
+    it('for a 3-step path, mid-path at progress 0.5 is near the second waypoint', () => {
+      const anim = createMovementAnimation(unit('u1'), [
+        { q: 0, r: 0 }, { q: 1, r: 0 }, { q: 2, r: 0 },
+      ], map);
+      // Progress 0.5 = end of step 1 (half the 2-step path)
+      const midFrame = getMovementAnimationPosition(anim, 0.5);
+      expect(midFrame.coord.q).toBeCloseTo(1, 0);
+    });
   });
 
-  it('tracks moving unit ids for stationary renderer hiding', () => {
-    const animation = createMovementAnimation(unit('u1'), { q: 0, r: 1 }, { q: 1, r: 1 }, map);
-
-    expect(getMovingUnitIds([animation])).toEqual(new Set(['u1']));
+  describe('getMovingUnitIds', () => {
+    it('tracks moving unit ids for stationary renderer hiding', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 0, r: 1 }, { q: 1, r: 1 }], map);
+      expect(getMovingUnitIds([anim])).toEqual(new Set(['u1']));
+    });
   });
 });

--- a/tests/renderer/unit-movement-animation.test.ts
+++ b/tests/renderer/unit-movement-animation.test.ts
@@ -131,4 +131,27 @@ describe('unit-movement-animation', () => {
       expect(getMovingUnitIds([anim])).toEqual(new Set(['u1']));
     });
   });
+
+  describe('degenerate / edge-case paths', () => {
+    it('createMovementAnimation handles empty path without crashing', () => {
+      const anim = createMovementAnimation(unit('u1'), [], map);
+      expect(anim.duration).toBe(0);
+      expect(anim.from).toEqual(unit('u1').position);
+    });
+
+    it('createMovementAnimation handles single-coord path without crashing', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 3, r: 3 }], map);
+      expect(anim.duration).toBe(0);
+      expect(anim.from).toEqual({ q: 3, r: 3 });
+    });
+
+    it('getMovementAnimationPosition on a degenerate animation returns the only coord', () => {
+      const anim = createMovementAnimation(unit('u1'), [{ q: 3, r: 3 }], map);
+      // Must not throw
+      const frame0 = getMovementAnimationPosition(anim, 0);
+      const frame1 = getMovementAnimationPosition(anim, 1);
+      expect(frame0.coord).toEqual({ q: 3, r: 3 });
+      expect(frame1.coord).toEqual({ q: 3, r: 3 });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **220 ms per hex** (capped at 800 ms) replaces the flat 250 ms — single-step moves are visibly animated, multi-step moves scale naturally
- **Per-segment ease-in-out** — each hex traversal starts slow, peaks in the middle, and decelerates at arrival, giving units perceptible weight
- **Hex-by-hex path animation** — units now step through every intermediate hex instead of jumping directly from start to final destination
- **`unit:move` event carries the full path** — audio, replay, and any future subscribers don't need to re-run pathfinding
- **AI move replay** — moves made by AI units that are visible to the current player are animated sequentially (capped at 6 per turn) after `processAITurn` completes, before the HUD refreshes

## Why this was a teleportation

The animation infrastructure (`animateUnitMove`, `drawUnitMovementAnimations`) was fully built but had two problems: 250 ms was imperceptible at normal play speed, and multi-step moves interpolated from A to the final destination in a single arc rather than visiting each waypoint. The result felt instant.

## Test plan

- [x] `yarn build` exits 0
- [x] `yarn test` exits 0 (2867 tests)
- [ ] Play a game: move infantry 1 hex — should see a ~220 ms walk with ease-in-out
- [ ] Move cavalry 4 hexes — should see smooth step-by-step traversal (~880 ms total, capped)
- [ ] End turn against an AI opponent — visible AI units animate before your turn resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)