### PR TITLE
docs(sprites): audit S6 delivery — all original defects resolved, 2 remaining

### DIFF
--- a/docs/sprite-defect-prompts-2026-05-30.md
+++ b/docs/sprite-defect-prompts-2026-05-30.md
@@ -1,119 +1,138 @@
-# Sprite Defect Prompts — 2026-05-30 (updated after S6 handoff)
+# Sprite Defect Prompts — 2026-05-30 (final audit after S6 handoff)
 
-## Status summary
+## Status — all original defects resolved
 
-| Defect | Status |
-|--------|--------|
-| Work-state preview button missing (S5) | ✅ Fixed — preview now has Idle / Walk / Work tabs |
-| Wonders not included | ✅ Fixed — S6 delivers 4 legendary + 4 natural wonders |
-| V2 animation rollout (15 units) | ❌ Still outstanding |
-| PikemanV2 forward-thrust keyframe | ❌ Still outstanding |
-| More wonders (beyond S6 4+4) | ❌ Not yet started |
-
-Prompts below are for the three remaining gaps.
+| Original Defect | Status | How |
+|----------------|--------|-----|
+| Work-state preview button (S5) | ✅ Resolved | Preview has Idle/Walk/Work; animations verified |
+| V2 rollout (18 original units) | ✅ Resolved | All 18 in `design/conquestoria-sprites/lib/units-v2.jsx`; serialized to `src/renderer/sprites/v2/` |
+| PikemanV2 forward-thrust keyframe | ✅ Resolved | `cq2-attack-pike-thrust` in game CSS; `variant="pike"` wires it via `data-kind-variant` |
+| Wonder sprites (S6) | ✅ Resolved | 4 legendary + 4 natural integrated in PR #307 |
 
 ---
 
-## DEFECT 1 — V2 animation rollout: 15 units still on V1
+## ACTIVE DEFECT 1 — V2 sprites needed for S4b + S5 units (10 units)
 
-**Status**: Four canary sprites work (SwordsmanV2, WorkerV2, ArcherV2, SpyOperativeV2).
-The remaining 14 (excluding blocked Pikeman) need V2 ports following HANDOFF.md.
+**Background**: The V2 sprite system serializes design-project React components into
+static HTML strings (`src/renderer/sprites/v2/<name>.svg.ts`). The serialize script
+(`scripts/serialize-sprites.mjs`) already handles all 18 original units. The 10 units
+added in S4b and S5 are missing from both the design library and the serialize list.
+
+**How the game wires V2 sprites**: The serialize script reads from
+`design/conquestoria-sprites/lib/units-v2.jsx`, renders each component to static markup,
+and writes `src/renderer/sprites/v2/<name>.svg.ts`. The game then imports these files
+wherever inline animated SVG is needed (unit detail panels, ceremony screens, etc.).
+
+**Critical**: Read the existing PikemanV2Sprite in `design/conquestoria-sprites/lib/units-v2.jsx`
+before writing any new sprites — it uses `variant="pike"` in `SpriteFrameV2` (which generates
+`data-kind-variant="pike"` on the SVG), NOT a `cq-pike` CSS class. Follow that pattern exactly.
+All hooks must follow the wrap rule: no `className="cq-*"` element may also have
+`transform="..."` on the same element. Exception: `.cq-weapon` uses `view-box` pivot vars.
+
+**Reference files** (fetch these before starting):
+```
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/design/conquestoria-sprites/lib/units-v2.jsx
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/design/conquestoria-sprites/lib/sprite-system.jsx
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/assets/sprite-animations-v2.css
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/scripts/serialize-sprites.mjs
+```
 
 **Prompt for Claude Design**:
 
-> Continue the V2 animation rollout following the HANDOFF.md in this project.
-> These units still need porting — group them by which canary they follow:
+> Add V2 sprites for the 10 units that were added in S4b and S5 but are missing
+> from the V2 design library. Paste directly into
+> `design/conquestoria-sprites/lib/units-v2.jsx` after the existing sprites.
+> Read the file at the URL above before starting — follow the exact same patterns
+> (SpriteFrameV2, HumanoidV2, hook wrap rule, `phase` with no default, etc.)
 >
-> **Like Worker (civilian + tool, `arms="free"` + `armRContent`):**
-> - SettlerSprite — ox-cart body art, walking staff in `armRContent`
-> - ScoutSprite — spyglass at brow (`armRContent` at shoulder-level, not hand-level)
+> **S4b — military units (8):**
 >
-> **Like Archer (ranged, `arms="locked"` + external weapon):**
-> - MusketeerSprite — replace bow with musket; add `.cq-muzzle-flash` at muzzle tip
+> | Unit | Kind | Pattern | Notes |
+> |------|------|---------|-------|
+> | AxemanV2Sprite | melee | Like Warrior | axe as .cq-weapon, pivot at shoulder; no shield |
+> | SpearmanV2Sprite | melee | Like Pikeman | long spear, variant="spear"; thrust keyframe already exists (use it) |
+> | HorsemanV2Sprite | hound | Like ScoutHound | light cavalry; rider sits on horse body; variant="scout" tempo |
+> | CavalryV2Sprite | hound | Like WarHound | heavier cavalry; armoured rider; variant="war" tempo |
+> | KnightV2Sprite | hound | Like WarHound | heaviest cavalry; lance as .cq-weapon, full plate rider |
+> | CrossbowmanV2Sprite | ranged | Like Archer | crossbow replaces bow; .cq-muzzle-flash at bolt tip |
+> | CatapultV2Sprite | naval | Like Galley | siege engine; no legs; .cq-weapon throwing arm (pivot at axle) |
+> | BallistaV2Sprite | naval | Like Galley | ballista bolt launcher; operator figure; .cq-muzzle-flash at bolt tip |
 >
-> **Like Swordsman (melee, custom geometry):**
-> - WarriorSprite — HumanoidV2 `arms="free"`, club in `.cq-weapon`, round shield in `armLContent`
+> **S5 — civilian units (2):**
 >
-> **Like SpyOperative (cloak + gadget):**
-> - SpyScoutSprite — monocular gadget
-> - SpyInformantSprite — newspaper/papers gadget
-> - SpyAgentSprite — mini radio gadget
-> - SpyHackerSprite — handheld terminal
-> - ShadowWardenSprite — `arms="free"` + `.cq-cape` + lantern in `armRContent`
+> | Unit | Kind | Pattern | Notes |
+> |------|------|---------|-------|
+> | CaravanV2Sprite | civilian | Like Worker | donkey body (4 legs), merchant humanoid alongside; no .cq-weapon |
+> | ExpeditionV2Sprite | civilian | Like Scout | wide-brim hat, pickaxe as .cq-weapon (NOT combat — kind="civilian") |
 >
-> **Quadrupeds (just wrap existing legs for body-bob, no articulation):**
-> - ScoutHoundSprite — outer translate / inner wrapper (no hook class) per leg
-> - WarHoundSprite — same
+> For mounted units (Horseman, Cavalry, Knight) the body IS the horse; the rider
+> sits on top. Wrap each horse leg in the outer-translate / inner `.cq-leg-*` pattern
+> for the body-bob. The rider bobs with the horse body (no separate leg hooks).
 >
-> **Naval (auto-phase only; `.cq-sail` already animated):**
-> - GalleySprite — confirm no detached parts, add `SpriteFrameV2` wrapper
-> - TriremeSprite — same
+> After writing each sprite, verify in the browser preview that walk loops have no
+> flying parts and that the phase-desync strip shows non-zero `--phase` values.
 >
-> For each sprite: add a V2 row to `anim-compare.jsx`, run the devtools lint
-> snippet from HANDOFF.md, and confirm walk + attack loops have no flying parts.
-> Do NOT port PikemanSprite — it is blocked on DEFECT 2 below.
+> **Deliver**: the complete function bodies to append to `units-v2.jsx`, plus the
+> 10 entries to add to `UNIT_SPRITES` in `scripts/serialize-sprites.mjs`:
+> ```js
+> ['axeman',      'AxemanV2Sprite'],
+> ['spearman',    'SpearmanV2Sprite'],
+> ['horseman',    'HorsemanV2Sprite'],
+> ['cavalry',     'CavalryV2Sprite'],
+> ['knight',      'KnightV2Sprite'],
+> ['crossbowman', 'CrossbowmanV2Sprite'],
+> ['catapult',    'CatapultV2Sprite'],
+> ['ballista',    'BallistaV2Sprite'],
+> ['caravan',     'CaravanV2Sprite'],
+> ['expedition',  'ExpeditionV2Sprite'],
+> ```
 
 ---
 
-## DEFECT 2 — PikemanV2 blocked: needs forward-thrust keyframe
+## ACTIVE DEFECT 2 — More wonders (S7 batch: 4 legendary + 4 natural)
 
-**Status**: HANDOFF.md explicitly says to flag this rather than invent the keyframe alone.
+**Background**: S6 delivered 4 legendary + 4 natural wonders. Additional wonders
+are needed for the remaining natural wonder hex tiles (which currently show the
+procedural canvas landmark) and the remaining legendary wonder IDs in the game.
+
+**Natural wonder game IDs still using canvas fallback** (no SVG tile):
+`crystal_caverns`, `ancient_forest`, `coral_reef`, `grand_canyon`, `aurora_fields`,
+`frozen_falls`, `dragon_bones`, `singing_sands`, `sunken_ruins`, `floating_islands`,
+`bioluminescent_bay`, `bottomless_lake`, `eternal_storm`
+
+**Reference files** (fetch before starting):
+```
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/renderer/terrain/wonder-tiles.ts
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/renderer/terrain/wonder-tile-loader.ts
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/renderer/sprites/wonders.tsx
+https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/systems/wonder-visual-catalog.ts
+```
 
 **Prompt for Claude Design**:
 
-> Add a `cq-pike-thrust` keyframe to `lib/sprite-animations-v2.css` for the Pikeman's
-> attack animation. A pike thrusts linearly — it must NOT use the generic `cq2-swing`
-> rotation (which looks like a sword).
+> Add a second batch of wonder sprites in `sprites-s7/`. Same conventions as S6:
 >
-> Desired motion:
-> - Idle / walk: pike rests diagonally over the shoulder (static geometry).
-> - Attack: the whole pike assembly translates forward ~12px along its shaft axis,
->   with a slight anticipatory pullback (−4px) in the first 15% of the cycle, then
->   snaps forward and returns. Total duration ~1.1s to match other melee units.
->
-> Hook class: `.cq-weapon` on `data-kind="melee"` units. Scope it with a
-> `[data-kind="pikeman"]` attribute (or a dedicated `data-subkind`) so it only
-> fires on Pikeman and doesn't override Swordsman / Warrior.
->
-> After adding the keyframe, port PikemanV2Sprite following HANDOFF.md checklist.
-> The pike shaft is long — confirm the tip doesn't exit the 128×128 viewBox during
-> the thrust frame.
-
----
-
-## DEFECT 3 — Additional wonders (beyond S6 4+4)
-
-**Status**: S6 delivered the minimum four of each category. The note in the S6
-REVIEW.md says "Say the word for the rest of each category."
-
-**Prompt for Claude Design** (additional legendary wonders):
-
-> Add four more legendary wonder sprites to the `sprites-s7/` folder, following
-> the same S6 conventions (`BuildingFrame` · 192×192 · `palette.*` · existing hooks only):
+> **Legendary (192×192, BuildingFrame, faction-tinted, existing CSS hooks only):**
 >
 > | Wonder | Category | Concept |
 > |--------|----------|---------|
-> | Hanging Gardens | food | multi-level terraced garden, waterwheels feeding canals, `.cq-water-stream`, lush `#7ea860` terraces |
-> | Great Wall | military | crenellated wall section in `P.stone.mid`, watchtower at left, `.cq-smoke` beacon fire |
-> | Leviathan Drydock | economy | enormous dry dock, half-built warship hull, `.cq-spark` metalwork, `.cq-smoke` furnace |
-> | Moonwell Gardens | science | moonlit reflecting pool, stone observatory dome, `.cq-glow` pool surface, starfield detail |
+> | Hanging Gardens | food | multi-level terraced gardens, waterwheels, `.cq-water-stream` feeding canals |
+> | Great Wall | military | crenellated wall segment, watchtower, `.cq-smoke` beacon fire, `.cq-crowd-fig` guards |
+> | Leviathan Drydock | economy | enormous dry dock, half-built warship hull, `.cq-spark` forge work, `.cq-smoke` |
+> | Moonwell Gardens | science | moonlit reflecting pool, stone observatory dome, `.cq-glow` pool surface |
 >
-> Deliver: `sprites-s7/wonders-legendary.tsx` (paste-ready into `wonders.tsx`),
-> plus a `REVIEW.md` checklist confirming no new animation keyframes were needed.
-
-**Prompt for Claude Design** (additional natural wonder tiles):
-
-> Add four more natural wonder hex tiles to `sprites-s7/wonders-natural.tsx`,
-> following the S6 hex tile format (`viewBox 0 0 128 111`, unique `clipPath id="hexW-*"`,
-> SMIL only, no faction palette):
+> **Natural (128×111 hex, SMIL, faction-neutral — use the EXACT game wonder IDs as keys):**
 >
 > | Wonder ID | Concept | SMIL |
 > |-----------|---------|------|
-> | `coral_reef` | turquoise water, fan corals, darting fish silhouettes | fish `<animateTransform type="translate">` + gentle wave `<animate>` on water |
-> | `aurora_fields` | dark tundra, sweeping aurora bands in teal/violet | aurora `<animate attributeName="opacity">` + slow colour shift |
-> | `frozen_falls` | icy blue cliff, frozen waterfall curtain, snow dusting | light particle drift matching snow tile pattern |
-> | `grand_canyon` | layered rust-red strata, river glint at base, long shadows | river glint `<animate attributeName="opacity">` shimmer |
+> | `coral_reef` | turquoise water, fan coral fronds, darting fish silhouettes | fish `<animateTransform type="translate">` |
+> | `aurora_fields` | dark tundra, sweeping teal/violet aurora bands | band `<animate attributeName="opacity">` + slow hue suggest |
+> | `frozen_falls` | icy cliff face, frozen waterfall curtain, snow dusting | particle drift like snow tiles |
+> | `grand_canyon` | layered rust-red strata (3 colour bands), narrow river at base | river glint shimmer |
 >
-> Deliver: `sprites-s7/wonders-natural.tsx` with the four new entries in the
-> `NATURAL_WONDER_TILES` record. These will be merged into the game's
-> `src/renderer/terrain/wonder-tiles.ts`.
+> **Important**: Natural wonder tile keys must match the game's wonder IDs exactly
+> (e.g. `coral_reef`, not `Coral Reef`). The wonder-tile-loader.ts alias table maps
+> these directly; no alias is needed if the key matches the game wonder ID.
+>
+> Deliver: `sprites-s7/wonders-legendary.tsx` + `sprites-s7/wonders-natural.tsx`
+> + `sprites-s7/REVIEW.md`.


### PR DESCRIPTION
## Summary

Full audit of the `conquestoria sprites-2` Claude Design delivery against the
game's actual state. Result: all 4 original defects from the sprite integration
work are already resolved in the game.

### Audit findings

| Defect | Claimed fixed? | Verified? | Notes |
|--------|---------------|-----------|-------|
| Work-state preview (S5) | ✅ | ✅ | Idle/Walk/Work toggle exists; dig+dust confirmed |
| V2 rollout (18 units) | ✅ | ✅ | Game's `design/conquestoria-sprites/lib/units-v2.jsx` was already ahead — the downloaded version was actually a regression (missing `variant="pike"` that the game's CSS depends on) |
| PikemanV2 thrust | ✅ | ✅ | `cq2-attack-pike-thrust` + `data-kind-variant="pike"` already in game CSS and serialized `.svg.ts` |
| Wonders (S6) | ✅ | ✅ | Integrated in PR #307 |

**The downloaded sprites-2 was NOT merged** — the game's own design library
is the authoritative version and is more complete.

### What's in this PR

Updated `docs/sprite-defect-prompts-2026-05-30.md` with:
- Accurate status of all resolved defects
- Two actionable defect prompts with full GitHub raw URLs for Claude Design:
  1. V2 sprites for 10 new units (S4b: axeman/spearman/cavalry/etc, S5: caravan/expedition)
  2. S7 wonders (4 legendary + 4 natural using exact game wonder IDs)

## Out of scope
No code changes — the game is already correct. Only the defect tracker doc changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)