### PR TITLE
fix(movement): preserve worker tasks on failed moves

### DIFF
--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -2,7 +2,7 @@ import type { GameState, HexCoord, WorkerActionType } from '@/core/types';
 import type { HexHighlight } from '@/renderer/render-loop';
 import { getAttackTargets, type AttackTarget } from '@/systems/attack-targeting';
 import { getVisibility } from '@/systems/fog-of-war';
-import { hexKey } from '@/systems/hex-utils';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { getAvailableWorkerActions, getKnownTileResourceForWorkerAction } from '@/systems/improvement-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getMovementRange } from '@/systems/unit-system';
@@ -80,6 +80,15 @@ function buildHostileOwners(state: GameState, civId: string): Set<string> {
   return hostile;
 }
 
+function isPreviewableMoveDestination(state: GameState, from: HexCoord, to: HexCoord): boolean {
+  const visibility = state.civilizations[state.currentPlayer]?.visibility;
+  if (!visibility || getVisibility(visibility, to) !== 'unexplored') return true;
+  const distance = state.map.wrapsHorizontally
+    ? wrappedHexDistance(from, to, state.map.width)
+    : hexDistance(from, to);
+  return distance === 1;
+}
+
 export function buildSelectedUnitHighlights(state: GameState, unitId: string): SelectedUnitHighlightResult {
   const unit = state.units[unitId];
   if (!unit || unit.owner !== state.currentPlayer) {
@@ -96,7 +105,7 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
     occupancy.ownersByUnitId,
     hostileOwners,
     { completedTechs },
-  );
+  ).filter(coord => isPreviewableMoveDestination(state, unit.position, coord));
   const attackTargets = getAttackTargets(state, unit, { viewerId: state.currentPlayer })
     .filter(target => target.result.targetType === 'unit');
   const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));

--- a/src/input/worker-movement-flow.ts
+++ b/src/input/worker-movement-flow.ts
@@ -2,6 +2,7 @@ import type { GameState, HexCoord } from '@/core/types';
 import {
   abandonWorkerTask,
   executeUnitMove,
+  validateUnitMove,
   type ExecuteUnitMoveOptions,
   type ExecuteUnitMoveResult,
 } from '@/systems/unit-movement-system';
@@ -12,6 +13,10 @@ export function confirmBusyWorkerMove(
   to: HexCoord,
   options: ExecuteUnitMoveOptions,
 ): ExecuteUnitMoveResult & { state: GameState } {
+  const validation = validateUnitMove(state, unitId, to, options);
+  if (!validation.ok) {
+    return { ...validation, state };
+  }
   abandonWorkerTask(state, unitId);
   const result = executeUnitMove(state, unitId, to, options);
   return { ...result, state };

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -1,6 +1,6 @@
 import type { EventBus } from '@/core/event-bus';
 import type { GameState, HexCoord, VillageOutcomeType } from '@/core/types';
-import { updateVisibility } from '@/systems/fog-of-war';
+import { getVisibility, updateVisibility } from '@/systems/fog-of-war';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import {
@@ -238,7 +238,7 @@ export function validateUnitMove(
   state: GameState,
   unitId: string,
   to: HexCoord,
-  _options: ExecuteUnitMoveOptions,
+  options: ExecuteUnitMoveOptions,
 ): UnitMoveValidationResult {
   const unit = state.units[unitId];
   if (!unit) return movementFailure(to, to, [to], 'missing-unit', 'Unit not found');
@@ -268,6 +268,17 @@ export function validateUnitMove(
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
   const path = findPath(from, target, state.map, domain, { unit, completedTechs });
   if (!path) return movementFailure(from, target, [from], 'unreachable', 'No passable route to that tile.');
+
+  const visibility = state.civilizations[options.civId]?.visibility;
+  const isPlayerControlledMove = options.actor !== 'automation' && options.actor !== 'ai';
+  if (
+    isPlayerControlledMove
+    && visibility
+    && path.length > 2
+    && path.slice(1).some(coord => getVisibility(visibility, coord) === 'unexplored')
+  ) {
+    return movementFailure(from, target, path, 'unexplored', 'Move one step at a time into unexplored territory.');
+  }
 
   let cost = 0;
   for (let i = 1; i < path.length; i++) {

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -143,6 +143,28 @@ describe('selected-unit-highlights', () => {
     expect(result.movementRange.some(c => hexKey(c) === '1,0')).toBe(true);
   });
 
+  it('shows only one-step exploratory movement into unexplored tiles', () => {
+    const state = createNewGame(undefined, 'movement-preview-unexplored-step-limit', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      scout: { ...createUnit('scout', 'player', { q: 0, r: 0 }, mkC()), id: 'scout', movementPointsLeft: 3 },
+    };
+    state.civilizations.player.units = ['scout'];
+    state.civilizations.player.visibility.tiles = {
+      '0,0': 'visible',
+      '1,0': 'unexplored',
+      '2,0': 'unexplored',
+    };
+    state.map.tiles['1,0'] = { coord: { q: 1, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null, owner: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+    state.map.tiles['2,0'] = { coord: { q: 2, r: 0 }, terrain: 'plains', elevation: 'lowland', resource: null, owner: null, improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+
+    const result = buildSelectedUnitHighlights(state, 'scout');
+
+    expect(result.movementRange.map(hexKey)).toContain('1,0');
+    expect(result.movementRange.map(hexKey)).not.toContain('2,0');
+    expect(result.highlights.filter(h => h.type === 'move').map(h => hexKey(h.coord))).not.toContain('2,0');
+  });
+
   it('does not add foreign-blocked worker guidance on unexplored plausible terrain', () => {
     const state = createNewGame(undefined, 'worker-guidance-unexplored-no-leak', 'small');
     state.currentPlayer = 'player';

--- a/tests/input/worker-movement-flow.test.ts
+++ b/tests/input/worker-movement-flow.test.ts
@@ -40,4 +40,38 @@ describe('worker-movement-flow', () => {
     expect(() => confirmBusyWorkerMove(state, unitId, { q: 1, r: 2 }, { actor: 'player', civId: 'player' })).not.toThrow();
     expect(state.map.tiles['0,1']).toMatchObject({ improvement: 'none', improvementTurnsLeft: 0 });
   });
+
+  it('keeps in-progress work when the confirmed move fails validation', () => {
+    const { state, unitId } = makeEdgeMoveState();
+    state.units[unitId] = {
+      ...state.units[unitId],
+      type: 'worker',
+      workerTask: { action: 'farm', coord: { q: 0, r: 1 } },
+    };
+    state.units.blocker = {
+      id: 'blocker',
+      type: 'warrior',
+      owner: 'player',
+      position: { q: 1, r: 1 },
+      movementPointsLeft: 2,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    };
+    state.map.tiles['0,1'].improvement = 'farm';
+    state.map.tiles['0,1'].improvementTurnsLeft = 3;
+    state.civilizations.player.visibility.tiles['1,1'] = 'visible';
+
+    const result = confirmBusyWorkerMove(state, unitId, { q: 1, r: 1 }, {
+      actor: 'player',
+      civId: 'player',
+      bus: new EventBus(),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.state.units[unitId].workerTask).toEqual({ action: 'farm', coord: { q: 0, r: 1 } });
+    expect(result.state.map.tiles['0,1']).toMatchObject({ improvement: 'farm', improvementTurnsLeft: 3 });
+  });
 });

--- a/tests/systems/unit-movement-regression.test.ts
+++ b/tests/systems/unit-movement-regression.test.ts
@@ -31,7 +31,11 @@ describe('Unit Movement Regression', () => {
           isHuman: true,
           score: 0,
           gold: 0,
-          visibility: { tiles: {} },
+          visibility: { tiles: {
+            [hexKey(startPos)]: 'visible',
+            [hexKey(intermediatePos)]: 'visible',
+            [hexKey(destPos)]: 'visible',
+          } },
           techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: { military: 'medium', economy: 'medium', science: 'medium', civics: 'medium', exploration: 'medium', agriculture: 'medium', medicine: 'medium', philosophy: 'medium', arts: 'medium', maritime: 'medium', metallurgy: 'medium', construction: 'medium', communication: 'medium', espionage: 'medium', spirituality: 'medium' } },
           diplomacy: { relationships: {}, atWarWith: [], treaties: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 0, protectionTimers: [], peakCities: 0, peakMilitary: 0 }, events: [] },
         }
@@ -88,7 +92,10 @@ describe('Unit Movement Regression', () => {
           isHuman: true,
           score: 0,
           gold: 0,
-          visibility: { tiles: {} },
+          visibility: { tiles: {
+            [hexKey(startPos)]: 'visible',
+            [hexKey(destPos)]: 'visible',
+          } },
           techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: { military: 'medium', economy: 'medium', science: 'medium', civics: 'medium', exploration: 'medium', agriculture: 'medium', medicine: 'medium', philosophy: 'medium', arts: 'medium', maritime: 'medium', metallurgy: 'medium', construction: 'medium', communication: 'medium', espionage: 'medium', spirituality: 'medium' } },
           diplomacy: { relationships: {}, atWarWith: [], treaties: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 0, protectionTimers: [], peakCities: 0, peakMilitary: 0 }, events: [] },
         }

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -165,6 +165,25 @@ describe('unit-movement-system', () => {
     expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
   });
 
+  it('refuses player movement that paths through unexplored tiles at execution time', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }, 'plains'),
+      tile({ q: 1, r: 0 }, 'plains'),
+      tile({ q: 2, r: 0 }, 'plains'),
+    ]);
+    state.civilizations.player.visibility.tiles['1,0'] = 'unexplored';
+    state.civilizations.player.visibility.tiles['2,0'] = 'unexplored';
+
+    const result = executeUnitMove(state, 'mover', { q: 2, r: 0 }, { actor: 'player', civId: 'player' });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected unexplored path move to fail');
+    expect(result.reason).toBe('unexplored');
+    expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
+  });
+
   it('gates Transport coast and ocean movement by owner tech', () => {
     const transport = createUnit('transport', 'player', { q: 0, r: 0 }, mkC());
     transport.id = 'transport';


### PR DESCRIPTION
## Summary
- Revalidates confirmed busy-worker moves before abandoning in-progress improvement work, so failed moves preserve the worker task and tile progress.
- Blocks multi-step player movement paths through unexplored tiles while still allowing one-step scouting into the unknown.
- Filters movement previews to match that one-step unexplored movement rule.

## Review notes
- Transport SFX/sprite/catalog attribution paths were reviewed; transport death SFX is covered by the Kenney CC0 SFX credit in AUDIO-CREDITS.md, and load/unload tones are synthesized Web Audio.
- No subagents were used.

## Verification
- scripts/check-src-rule-violations.sh src/systems/unit-movement-system.ts src/input/worker-movement-flow.ts src/input/selected-unit-highlights.ts
- git diff --check
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test
- git merge-base --is-ancestor origin/main HEAD