### PR TITLE
test(atlas): Stage 2F UI coverage — rival intel catalog badge + page journal section

### DIFF
--- a/tests/ui/wonder-codex-page.test.ts
+++ b/tests/ui/wonder-codex-page.test.ts
@@ -265,3 +265,115 @@ describe('wonder-codex-page — legendary UI redesign', () => {
     expect(onAction).toHaveBeenCalledWith(cityAction);
   });
 });
+
+describe('wonder-codex-page — rival intel journal section', () => {
+  it('renders the rival intel section with summary and event rows when rivalIntel is present', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      stateLabel: 'Spotted rival project',
+      rivalIntel: {
+        wonderId: 'oracle-of-delphi',
+        activityCount: 1,
+        badgeLabel: 'Known rival activity',
+        stateLabel: 'Spotted rival project',
+        summaryLine: 'Last known: under construction. Rival began Oracle of Delphi in Rival Harbor on turn 41.',
+        events: [{
+          id: 'started:oracle-of-delphi:ai-1:rival-city:41',
+          kind: 'started',
+          civId: 'ai-1',
+          civName: 'Rival',
+          turn: 41,
+          title: 'Spotted rival project',
+          text: 'Rival began Oracle of Delphi in Rival Harbor on turn 41.',
+        }],
+      },
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    const section = root.querySelector('[data-rival-intel-section]');
+    expect(section).not.toBeNull();
+    expect(section?.textContent).toContain('Known rival activity');
+    expect(section?.textContent).toContain('Last known: under construction');
+
+    const events = section?.querySelectorAll('[data-rival-intel-event]');
+    expect(events).toHaveLength(1);
+    expect(events?.[0]?.getAttribute('data-rival-intel-event')).toBe('started');
+    expect(events?.[0]?.textContent).toContain('Rival began Oracle of Delphi in Rival Harbor on turn 41');
+  });
+
+  it('renders multiple rival intel events in order', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      stateLabel: 'Known rival completed',
+      rivalIntel: {
+        wonderId: 'oracle-of-delphi',
+        activityCount: 2,
+        badgeLabel: '2 rival records',
+        stateLabel: 'Known rival completed',
+        summaryLine: 'Known rival completed: Rival completed Oracle of Delphi on turn 58.',
+        events: [
+          {
+            id: 'started:oracle-of-delphi:ai-1:41',
+            kind: 'started',
+            civId: 'ai-1',
+            civName: 'Rival',
+            turn: 41,
+            title: 'Spotted rival project',
+            text: 'Rival began Oracle of Delphi in Rival Harbor on turn 41.',
+          },
+          {
+            id: 'completed:oracle-of-delphi:ai-1:58',
+            kind: 'completed',
+            civId: 'ai-1',
+            civName: 'Rival',
+            turn: 58,
+            title: 'Known rival completed',
+            text: 'Rival completed Oracle of Delphi on turn 58.',
+          },
+        ],
+      },
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    const events = root.querySelectorAll('[data-rival-intel-event]');
+    expect(events).toHaveLength(2);
+    expect(events[0]?.getAttribute('data-rival-intel-event')).toBe('started');
+    expect(events[1]?.getAttribute('data-rival-intel-event')).toBe('completed');
+  });
+
+  it('renders no rival action buttons in the rival intel section', () => {
+    const root = createWonderCodexPage(legendaryPage({
+      stateLabel: 'Known rival completed',
+      actions: [],
+      rivalIntel: {
+        wonderId: 'oracle-of-delphi',
+        activityCount: 1,
+        badgeLabel: 'Known rival activity',
+        stateLabel: 'Known rival completed',
+        summaryLine: 'Known rival completed: Rival completed Oracle of Delphi on turn 58.',
+        events: [{
+          id: 'completed:oracle-of-delphi:ai-1:58',
+          kind: 'completed',
+          civId: 'ai-1',
+          civName: 'Rival',
+          turn: 58,
+          title: 'Known rival completed',
+          text: 'Rival completed Oracle of Delphi on turn 58.',
+        }],
+      },
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    const section = root.querySelector('[data-rival-intel-section]');
+    expect(section).not.toBeNull();
+    expect(section?.querySelector('button')).toBeNull();
+    expect(section?.querySelector('[data-codex-action]')).toBeNull();
+    expect(root.textContent).not.toContain('Reward:');
+    expect(root.textContent).not.toContain('Open City');
+    expect(root.textContent).not.toContain('View on Map');
+  });
+
+  it('does not render the rival intel section when rivalIntel is absent', () => {
+    const root = createWonderCodexPage(legendaryPage({ stateLabel: 'Quest in progress' }), {
+      onAction: vi.fn(),
+      onSelectRelated: vi.fn(),
+    });
+
+    expect(root.querySelector('[data-rival-intel-section]')).toBeNull();
+  });
+});

--- a/tests/ui/wonder-codex-panel.test.ts
+++ b/tests/ui/wonder-codex-panel.test.ts
@@ -158,3 +158,80 @@ describe('wonder-codex-panel', () => {
     container.remove();
   });
 });
+
+describe('wonder-codex-panel — rival intel catalog badge', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  function stateWithStartedIntelFor(viewerId: string): GameState {
+    const state = makeLegendaryWonderFixture();
+    state.currentPlayer = viewerId;
+    state.legendaryWonderIntel = {
+      [viewerId]: [{
+        kind: 'started',
+        eventId: 'started:oracle-of-delphi:ai-1:rival-city:12',
+        projectKey: 'oracle-of-delphi:ai-1:rival-city',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rome',
+        cityId: 'rival-city',
+        cityName: 'Rome City',
+        revealedTurn: 12,
+      }],
+    };
+    return state;
+  }
+
+  it('shows rival intel badge on the catalog entry for the current viewer when they have intel', () => {
+    const state = stateWithStartedIntelFor('player');
+    const panel = createWonderCodexPanel(document.body, state, {
+      onViewOnMap: vi.fn(),
+      onOpenCity: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    const entryBtn = panel.querySelector('[data-codex-entry-id="oracle-of-delphi"]');
+    expect(entryBtn).not.toBeNull();
+    expect(entryBtn?.querySelector('[data-rival-intel-badge]')).not.toBeNull();
+    expect(entryBtn?.querySelector('[data-rival-intel-badge]')?.textContent).toContain('Known rival activity');
+  });
+
+  it('does not show rival intel badge when the current viewer has no intel for that wonder', () => {
+    const state = makeLegendaryWonderFixture();
+    state.currentPlayer = 'player';
+    // no legendaryWonderIntel set
+
+    const panel = createWonderCodexPanel(document.body, state, {
+      onViewOnMap: vi.fn(),
+      onOpenCity: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    const entryBtn = panel.querySelector('[data-codex-entry-id="oracle-of-delphi"]');
+    expect(entryBtn?.querySelector('[data-rival-intel-badge]')).toBeNull();
+  });
+
+  it('rival intel badge is keyed to currentPlayer — player-2 sees no badge when only player has intel', () => {
+    const playerState = stateWithStartedIntelFor('player');
+
+    // Same game state but now rendered for player-2 (who has no intel)
+    const player2State = { ...playerState, currentPlayer: 'player-2' };
+
+    const panel = createWonderCodexPanel(document.body, player2State, {
+      onViewOnMap: vi.fn(),
+      onOpenCity: vi.fn(),
+      onClose: vi.fn(),
+    });
+
+    // oracle-of-delphi is not visible to player-2 (they have no project and no intel)
+    // so the entry shouldn't appear in their catalog at all
+    const entryBtn = panel.querySelector('[data-codex-entry-id="oracle-of-delphi"]');
+    if (entryBtn) {
+      // If somehow visible, the badge must not show player's intel
+      expect(entryBtn.querySelector('[data-rival-intel-badge]')).toBeNull();
+    }
+    // Confirm player-2's catalog does not bleed player's intel into any entry
+    expect(panel.querySelectorAll('[data-rival-intel-badge]')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2F (Atlas Intel Records) was already fully implemented — the data model, system helpers, intel creation wiring, presentation layer, and UI rendering were all in place. This PR adds the missing DOM-level UI test coverage that the spec requires.

**New tests in `tests/ui/wonder-codex-page.test.ts`:**
- Rival intel journal section renders `[data-rival-intel-section]` with summary text and `[data-rival-intel-event]` rows keyed by kind
- Multiple events render in order
- No action buttons appear inside the rival intel section (no city open, no map jump, no reward)
- Section is absent when `rivalIntel` is not on the page view model

**New tests in `tests/ui/wonder-codex-panel.test.ts`:**
- Catalog badge `[data-rival-intel-badge]` appears on entries where the current viewer has rival intel
- Badge is absent when the current viewer has no intel for a wonder
- Hot-seat isolation: another player rendered as `currentPlayer` does not see the first player's rival intel badge in their catalog

## Why no code changes

The full Stage 2F implementation was already shipped as part of prior incremental MRs. The spec's test gate required these DOM-level checks; this PR closes that gap.

## Test plan
- [x] `yarn test` — 3082 passing
- [x] `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)