### PR TITLE
Stage 2J legendary landmark intel visibility

### DIFF
--- a/docs/superpowers/plans/2026-06-04-stage-2j-legendary-landmark-intel-visibility.md
+++ b/docs/superpowers/plans/2026-06-04-stage-2j-legendary-landmark-intel-visibility.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. For this repo and user, execute inline with `superpowers:executing-plans`; do not dispatch subagents unless the user explicitly authorizes them.
 
-**Goal:** Add explicit host/location rival intel for legendary landmarks so known-rival landmark previews and map markers render only from earned viewer-scoped records.
+**Goal:** Add explicit host/location rival intel so known-rival landmark previews and map markers render only from paired viewer-scoped location and completion records.
 
-**Architecture:** Keep privacy rules in system and presentation helpers. Add one new discriminated intel union member, mint it only in the canonical stationed-spy start-build path, then route safe views through Codex, inspection, map presentation, and the existing city landmark renderer. The UI and renderer consume safe view models and never inspect hidden rival projects, hidden completions, or rival city objects to enrich missing intel.
+**Architecture:** Keep privacy rules in system and presentation helpers. Add one new discriminated intel union member, mint it only in the canonical stationed-spy start-build path, then pair it with existing completed intel before producing finished landmark previews or map entries. The UI and renderer consume safe view models and never inspect hidden rival projects, hidden completions, or rival city objects to enrich missing intel.
 
 **Tech Stack:** TypeScript, Vitest, Canvas 2D city render passes, DOM UI helpers, existing legendary wonder metadata/rendering catalog, repo verification scripts.
 
@@ -39,18 +39,18 @@
 - Modify: `src/systems/legendary-wonder-intel-presentation.ts`
   - Add safe host-location event and summary support without city action IDs.
 - Modify: `src/systems/legendary-wonder-landmark-presentation.ts`
-  - Add known-rival landmark preview views sourced from host-location records and static metadata.
+  - Add known-rival landmark preview views sourced from paired host-location plus completed records and static metadata.
 - Modify: `src/systems/wonder-codex/presentation.ts`
   - Add `knownRivalLandmarkPreview` to legendary Codex pages.
   - Keep owned `landmarkPreview` primary.
 - Modify: `tests/systems/wonder-codex/presentation.test.ts`
-  - Cover completed-only, started-only, host-location, hot-seat, and no hidden live enrichment cases.
+  - Cover completed-only, started-only, host-location-only, paired host-location plus completed, hot-seat, and no hidden live enrichment cases.
 - Modify: `src/ui/wonder-codex-page.ts`
   - Render compact `Known rival landmark` preview from the new page view model only.
 - Modify: `tests/ui/wonder-codex-page.test.ts`
   - Cover visible copy and absence of rival actions.
 - Modify: `src/systems/legendary-wonder-map-presentation.ts`
-  - Add known-rival map entries from explicit stored coordinates and viewer visibility.
+  - Add known-rival map entries from paired completed-plus-location intel, explicit stored coordinates, and viewer visibility.
 - Modify: `tests/systems/legendary-wonder-map-presentation.test.ts`
   - Cover host-location, fog, unexplored, and partial intel negatives.
 - Modify: `src/renderer/city-renderer.ts`
@@ -62,7 +62,7 @@
 - Modify: `src/ui/territory-inspection-panel.ts`
   - Render known-rival landmark copy for the inspected coordinate from safe presentation data only.
 - Modify: `tests/ui/territory-inspection-panel.test.ts`
-  - Cover matching coordinate, viewer scoping, and started/completed-only negatives.
+  - Cover matching coordinate, viewer scoping, and started/completed/host-location-only negatives.
 
 ## Player Truth Table
 
@@ -70,23 +70,26 @@
 |---|---|---|---|---|
 | Codex shows completed rival intel only | Open legendary page | `completed` intel record only | `Known rival completed` text row | host city, coordinate, map marker, preview, reward, progress, city action |
 | Codex shows started rival intel only | Open legendary page | `started` intel record only | event row names stored city as historical text | coordinate, preview, map marker, live city lookup, city action |
-| Codex has host-location rival intel | Open legendary page | `host-location-known` record and metadata catalog | `Known rival landmark` preview with stored city name and learned turn | reward, quest steps, production, progress, rival `cityId` action target |
-| Map has host-location rival intel at visible coordinate | Pan camera over coordinate | map entry from stored coordinate | medallion landmark glyph renders below labels/badges | active construction ghost, live production badge, hidden rival project data |
-| Map has host-location rival intel at fog coordinate | Pan camera over coordinate | stored coordinate and viewer fog knowledge | landmark glyph renders as remembered location intel | live rival city population, current production, current status |
+| Codex has host-location rival intel only | Open legendary page | `host-location-known` record and metadata catalog | known-host event/copy with stored city name and learned turn | landmark preview, reward, quest steps, production, progress, rival `cityId` action target |
+| Codex has host-location plus completed rival intel | Open legendary page | paired `host-location-known` and `completed` records | `Known rival landmark` preview with stored city name and learned turn | reward, quest steps, production, progress, rival `cityId` action target |
+| Map has paired completed-plus-location intel at visible coordinate | Pan camera over coordinate | map entry from paired records and stored coordinate | medallion landmark glyph renders below labels/badges | active construction ghost, live production badge, hidden rival project data |
+| Map has paired completed-plus-location intel at fog coordinate | Pan camera over coordinate | stored coordinate and viewer fog knowledge | landmark glyph renders as remembered completed landmark intel | live rival city population, current production, current status |
 | Map has host-location rival intel at unexplored coordinate | Pan camera over coordinate | sanitized intel plus viewer visibility | no marker | all host/location visual output |
 | Hot-seat viewer changes | Open Codex or render map as another player | `state.legendaryWonderIntel[viewerId]` only | previous viewer's rows and markers disappear | previous viewer's host city and map marker |
 
 ## Misleading UI Risks
 
-- `Known rival landmark` must mean a `host-location-known` record exists for the current viewer.
+- `Known rival landmark` must mean both `host-location-known` and `completed` records exist for the same viewer, wonder, and rival.
+- Host-location-only intel must remain known-host text, not a finished landmark promise.
 - `Spotted rival project` must not imply map location; only the event text may name the stored city.
 - `Known rival completed` must not imply host city or reward visibility.
 - Owned preview and owned actions must remain primary when owned state and rival location intel coexist.
-- Negative tests must prove completed-only and started-only records cannot produce `knownRivalLandmarkPreview` or known-rival map entries.
+- Negative tests must prove completed-only, started-only, and host-location-only records cannot produce `knownRivalLandmarkPreview` or known-rival map entries.
 
 ## Interaction Replay Checklist
 
-- Open a Codex page with started-only rival intel, then reopen it with host-location intel and verify the preview appears from the new view model.
+- Open a Codex page with started-plus-location rival intel and verify only known-host copy appears.
+- Reopen the page after adding completed intel and verify the completed landmark preview appears from the new view model.
 - Open a Codex page with host-location intel as viewer A, then rerender as viewer B and verify host/location copy disappears.
 - Inspect a tile with matching host-location intel, then inspect a neighboring tile and verify the known-rival line disappears.
 - Render the city pass with known-rival map entries twice and verify landmark operations are stable and do not create production or status badge operations.
@@ -607,7 +610,7 @@ git commit -m "feat(wonders): record legendary host location intel"
 Add these tests to `tests/systems/wonder-codex/presentation.test.ts`:
 
 ```ts
-  it('adds known-rival landmark preview only from host-location intel', () => {
+  it('keeps host-location-only rival intel as known-host text without landmark preview', () => {
     const state = makeState();
     state.legendaryWonderIntel = {
       player: [{
@@ -627,7 +630,46 @@ Add these tests to `tests/systems/wonder-codex/presentation.test.ts`:
     const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
     const serialized = JSON.stringify(model.selectedPage);
 
-    expect(model.selectedPage?.stateLabel).toBe('Known rival landmark');
+    expect(model.selectedPage?.stateLabel).toBe('Known rival host');
+    expect(model.selectedPage?.knownRivalLandmarkPreview).toBeUndefined();
+    expect(model.selectedPage?.rivalIntel?.summaryLine).toContain('Known host: Rival Harbor');
+    expect(serialized).not.toContain('"cityId":"rival-city"');
+    expect(serialized).not.toContain('Reward:');
+    expect(model.selectedPage?.actions).toEqual([]);
+  });
+
+  it('adds known-rival landmark preview only from paired host-location and completed intel', () => {
+    const state = makeState();
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord: { q: 4, r: 2 },
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const serialized = JSON.stringify(model.selectedPage);
+
+    expect(model.selectedPage?.stateLabel).toBe('Known rival completed');
     expect(model.selectedPage?.knownRivalLandmarkPreview).toMatchObject({
       cityName: 'Rival Harbor',
       learnedTurn: 62,
@@ -698,7 +740,8 @@ Add these tests to `tests/systems/wonder-codex/presentation.test.ts`:
     const viewerA = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
     const viewerB = getWonderCodexViewModel(state, 'player-2', { initialWonderId: 'oracle-of-delphi' });
 
-    expect(viewerA.selectedPage?.knownRivalLandmarkPreview?.cityName).toBe('Rival Harbor');
+    expect(viewerA.selectedPage?.rivalIntel?.summaryLine).toContain('Known host: Rival Harbor');
+    expect(viewerA.selectedPage?.knownRivalLandmarkPreview).toBeUndefined();
     expect(viewerB.catalogEntries.some(entry => entry.id === 'oracle-of-delphi')).toBe(false);
     expect(viewerB.selectedPage).toBeNull();
   });
@@ -712,7 +755,7 @@ Run:
 ./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-codex/presentation.test.ts
 ```
 
-Expected: FAIL because `knownRivalLandmarkPreview` and `Known rival landmark` do not exist.
+Expected: FAIL because host-location presentation and `knownRivalLandmarkPreview` do not exist.
 
 - [ ] **Step 3: Add safe host-location presentation types**
 
@@ -722,7 +765,7 @@ In `src/systems/legendary-wonder-intel-presentation.ts`, update the label and ev
 export type LegendaryWonderRivalIntelStateLabel =
   | 'Known rival completed'
   | 'Spotted rival project'
-  | 'Known rival landmark';
+  | 'Known rival host';
 
 export interface LegendaryWonderRivalIntelEventView {
   id: string;
@@ -745,7 +788,7 @@ export interface LegendaryWonderRivalHostLocationView {
 }
 ```
 
-Import `HexCoord` from `@/core/types`. Update `eventView`, `bestState`, and `summaryLine` so a host-location record renders:
+Import `HexCoord` from `@/core/types`. Update `eventView`, `bestState`, and `summaryLine` so a host-location record renders without implying completion:
 
 ```ts
   if (entry.kind === 'host-location-known') {
@@ -755,8 +798,8 @@ Import `HexCoord` from `@/core/types`. Update `eventView`, `bestState`, and `sum
       civId: entry.civId,
       civName: entry.civName,
       turn: entry.learnedTurn,
-      title: 'Known rival landmark',
-      text: `${entry.civName} hosts ${name} in ${entry.cityName}. Location learned on turn ${entry.learnedTurn}.`,
+      title: 'Known rival host',
+      text: `${entry.civName} location for ${name}: ${entry.cityName}. Location learned on turn ${entry.learnedTurn}.`,
     };
   }
 ```
@@ -766,9 +809,32 @@ Use this priority:
 ```ts
 function bestState(events: LegendaryWonderRivalIntelEventView[]): LegendaryWonderRivalIntelStateLabel {
   if (events.some(event => event.kind === 'completed')) return 'Known rival completed';
-  if (events.some(event => event.kind === 'host-location-known')) return 'Known rival landmark';
+  if (events.some(event => event.kind === 'started')) return 'Spotted rival project';
+  if (events.some(event => event.kind === 'host-location-known')) return 'Known rival host';
   return 'Spotted rival project';
 }
+```
+
+Update `summaryLine` so completed status remains primary, started status remains a construction clue, and host-only intel is useful but not celebratory:
+
+```ts
+  const location = [...events].reverse().find(event => event.kind === 'host-location-known');
+  if (completed) {
+    return location
+      ? `Known rival completed: ${completed.text} Known host: ${location.text}`
+      : `Known rival completed: ${completed.text}`;
+  }
+
+  const started = [...events].reverse().find(event => event.kind === 'started');
+  if (started) {
+    return location
+      ? `Last known: under construction. ${started.text} Known host: ${location.text}`
+      : `Last known: under construction. ${started.text}`;
+  }
+
+  if (location) {
+    return `Known host: ${location.text}`;
+  }
 ```
 
 Add a safe location selector:
@@ -802,6 +868,7 @@ In `src/systems/legendary-wonder-landmark-presentation.ts`, add:
 
 ```ts
 import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 ```
 
 Add these interfaces and function:
@@ -823,7 +890,11 @@ export function getKnownRivalLegendaryLandmarkPreviewForWonder(
   viewerId: string,
   wonderId: string,
 ): KnownRivalLegendaryLandmarkPreviewView | null {
-  const [location] = getLegendaryWonderHostLocationIntelForViewer(state, viewerId, wonderId);
+  const completion = getLegendaryWonderIntelForViewer(state, viewerId)
+    .find(entry => entry.kind === 'completed' && entry.wonderId === wonderId);
+  if (!completion) return null;
+  const [location] = getLegendaryWonderHostLocationIntelForViewer(state, viewerId, wonderId)
+    .filter(candidate => candidate.civId === completion.civId);
   if (!location) return null;
   return {
     cityName: location.cityName,
@@ -938,23 +1009,34 @@ Add this test to `tests/ui/wonder-codex-page.test.ts`:
 Add these tests to `tests/ui/territory-inspection-panel.test.ts`:
 
 ```ts
-  it('mentions known-rival legendary landmarks only on the matching known coordinate', () => {
+  it('mentions known-rival legendary landmarks only on the matching completed known coordinate', () => {
     const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
     const rivalCoord = state.cities['city-rival'].position;
     state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
     state.legendaryWonderIntel = {
-      player: [{
-        kind: 'host-location-known',
-        eventId: 'location:oracle-of-delphi:rival:city-rival:62',
-        wonderId: 'oracle-of-delphi',
-        civId: 'rival',
-        civName: 'Rival',
-        cityId: 'city-rival',
-        cityName: 'Rival Harbor',
-        coord: rivalCoord,
-        learnedTurn: 62,
-        source: 'spy-location',
-      }],
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: rivalCoord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
     };
 
     const matching = createTerritoryInspectionPanel(state, rivalCoord, 'player');
@@ -966,7 +1048,7 @@ Add these tests to `tests/ui/territory-inspection-panel.test.ts`:
     expect(nearby.textContent).not.toContain('Known rival legendary landmark');
   });
 
-  it('does not mention known-rival landmarks from started or completed intel alone', () => {
+  it('does not mention known-rival landmarks from started, completed, or host-location intel alone', () => {
     const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
     const rivalCoord = state.cities['city-rival'].position;
     state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
@@ -982,6 +1064,18 @@ Add these tests to `tests/ui/territory-inspection-panel.test.ts`:
           cityId: 'city-rival',
           cityName: 'Rival Harbor',
           revealedTurn: 41,
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: rivalCoord,
+          learnedTurn: 62,
+          source: 'spy-location',
         },
         {
           kind: 'completed',
@@ -1046,13 +1140,20 @@ In `src/ui/territory-inspection-panel.ts`, import:
 
 ```ts
 import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 ```
 
 After the owned completed legendary wonder line, add:
 
 ```ts
+  const completedRivalKeys = new Set(
+    getLegendaryWonderIntelForViewer(state, viewerId)
+      .filter(entry => entry.kind === 'completed')
+      .map(entry => `${entry.wonderId}:${entry.civId}`),
+  );
   const knownRivalAtCoord = getLegendaryWonderHostLocationIntelForViewer(state, viewerId)
+    .filter(entry => completedRivalKeys.has(`${entry.wonderId}:${entry.civId}`))
     .filter(entry => hexKey(entry.coord) === key)
     .map(entry => {
       const definition = getLegendaryWonderDefinition(entry.wonderId);
@@ -1126,23 +1227,34 @@ git commit -m "feat(wonders): show known rival landmark previews"
 Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
 
 ```ts
-  it('returns known-rival map entries from host-location intel at visible or fog coordinates', () => {
+  it('returns known-rival map entries from paired completed and host-location intel at visible or fog coordinates', () => {
     const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
     const coord = state.cities['city-rival'].position;
     state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
     state.legendaryWonderIntel = {
-      player: [{
-        kind: 'host-location-known',
-        eventId: 'location:oracle-of-delphi:rival:city-rival:62',
-        wonderId: 'oracle-of-delphi',
-        civId: 'rival',
-        civName: 'Rival',
-        cityId: 'city-rival',
-        cityName: 'Rival Harbor',
-        coord,
-        learnedTurn: 62,
-        source: 'spy-location',
-      }],
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
     };
 
     expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
@@ -1162,10 +1274,10 @@ Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
     }));
   });
 
-  it('does not return known-rival map entries for unexplored or partial rival intel', () => {
+  it('does not return known-rival map entries for unexplored, host-location-only, or completed-only intel', () => {
     const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
     const coord = state.cities['city-rival'].position;
-    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'unexplored';
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
     state.legendaryWonderIntel = {
       player: [
         {
@@ -1181,8 +1293,8 @@ Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
         },
         {
           kind: 'host-location-known',
-          eventId: 'location:grand-canal:rival:city-rival:62',
-          wonderId: 'grand-canal',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
           civId: 'rival',
           civName: 'Rival',
           cityId: 'city-rival',
@@ -1191,9 +1303,30 @@ Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
           learnedTurn: 62,
           source: 'spy-location',
         },
+        {
+          kind: 'completed',
+          eventId: 'completed:grand-canal:rival:70',
+          wonderId: 'grand-canal',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
       ],
     };
 
+    expect(getLegendaryWonderMapEntries(state, 'player').some(entry => entry.relationship === 'known-rival')).toBe(false);
+
+    state.legendaryWonderIntel.player.push({
+      kind: 'completed',
+      eventId: 'completed:oracle-of-delphi:rival:70',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      completionTurn: 70,
+      learnedTurn: 70,
+    });
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'unexplored';
     expect(getLegendaryWonderMapEntries(state, 'player').some(entry => entry.relationship === 'known-rival')).toBe(false);
   });
 ```
@@ -1203,23 +1336,34 @@ Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
 Add these tests to `tests/renderer/city-renderer.test.ts` near the rival intel renderer tests:
 
 ```ts
-  it('draws known-rival landmark entries from host-location intel without live rival badges', () => {
+  it('draws known-rival landmark entries from paired intel without live rival labels or badges', () => {
     const state = createNewGame(undefined, 'known-rival-landmark-render', 'small');
     const coord = { q: 4, r: 2 };
     state.civilizations.player.visibility.tiles[hexKey(coord)] = 'fog';
     state.legendaryWonderIntel = {
-      player: [{
-        kind: 'host-location-known',
-        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
-        wonderId: 'oracle-of-delphi',
-        civId: 'ai-1',
-        civName: 'Rival',
-        cityId: 'rival-city',
-        cityName: 'Rival Harbor',
-        coord,
-        learnedTurn: 62,
-        source: 'spy-location',
-      }],
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
     };
 
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
@@ -1227,8 +1371,10 @@ Add these tests to `tests/renderer/city-renderer.test.ts` near the rival intel r
 
     expect((ctx as unknown as MockCanvasContext).operations).toContain('legendary-landmarks:start');
     expect((ctx as unknown as MockCanvasContext).operations).toContain('city-pass:landmarks');
-    expect((ctx as unknown as MockCanvasContext).operations).not.toContain('city-pass:production');
-    expect((ctx as unknown as MockCanvasContext).operations).not.toContain('city-pass:status');
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
+    expect(texts).not.toContain('Rival Harbor (0)');
+    expect(texts).not.toContain('🏗️');
+    expect(texts).not.toContain('⚡');
   });
 
   it('does not draw construction ghosts for known-rival location intel', () => {
@@ -1236,18 +1382,29 @@ Add these tests to `tests/renderer/city-renderer.test.ts` near the rival intel r
     const coord = { q: 4, r: 2 };
     state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
     state.legendaryWonderIntel = {
-      player: [{
-        kind: 'host-location-known',
-        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
-        wonderId: 'oracle-of-delphi',
-        civId: 'ai-1',
-        civName: 'Rival',
-        cityId: 'rival-city',
-        cityName: 'Rival Harbor',
-        coord,
-        learnedTurn: 62,
-        source: 'spy-location',
-      }],
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
     };
 
     const entries = getLegendaryWonderMapEntries(state, 'player');
@@ -1278,6 +1435,7 @@ In `src/systems/legendary-wonder-map-presentation.ts`:
 import { hexKey } from '@/systems/hex-utils';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 ```
 
 Update `LegendaryWonderMapEntry`:
@@ -1299,11 +1457,17 @@ export interface LegendaryWonderMapEntry {
 }
 ```
 
-After owned city scanning, append known-rival entries:
+After owned city scanning, append known-rival entries only for paired completed-plus-location records:
 
 ```ts
+  const completedRivalKeys = new Set(
+    getLegendaryWonderIntelForViewer(state, viewerId)
+      .filter(entry => entry.kind === 'completed')
+      .map(entry => `${entry.wonderId}:${entry.civId}`),
+  );
   const seenKnownRival = new Set<string>();
   for (const location of getLegendaryWonderHostLocationIntelForViewer(state, viewerId)) {
+    if (!completedRivalKeys.has(`${location.wonderId}:${location.civId}`)) continue;
     const tileVisibility = getVisibility(visibility, location.coord);
     if (tileVisibility === 'unexplored') continue;
     const key = `${location.wonderId}:${location.civId}:${hexKey(location.coord)}`;
@@ -1571,7 +1735,7 @@ Run:
 ```bash
 gh pr create --draft --base main --head codex/stage-2j-legendary-landmark-intel --title "Stage 2J legendary landmark intel visibility" --body "## Summary
 - add explicit host/location legendary wonder intel records
-- show known-rival landmark previews and map markers only from earned location intel
+- show known-rival landmark previews and map markers only from paired location and completion intel
 - preserve started/completed rival privacy and hot-seat viewer scoping
 
 ## Tests

--- a/docs/superpowers/plans/2026-06-04-stage-2j-legendary-landmark-intel-visibility.md
+++ b/docs/superpowers/plans/2026-06-04-stage-2j-legendary-landmark-intel-visibility.md
@@ -1,0 +1,1594 @@
+# Stage 2J Legendary Landmark Intel Visibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. For this repo and user, execute inline with `superpowers:executing-plans`; do not dispatch subagents unless the user explicitly authorizes them.
+
+**Goal:** Add explicit host/location rival intel for legendary landmarks so known-rival landmark previews and map markers render only from earned viewer-scoped records.
+
+**Architecture:** Keep privacy rules in system and presentation helpers. Add one new discriminated intel union member, mint it only in the canonical stationed-spy start-build path, then route safe views through Codex, inspection, map presentation, and the existing city landmark renderer. The UI and renderer consume safe view models and never inspect hidden rival projects, hidden completions, or rival city objects to enrich missing intel.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D city render passes, DOM UI helpers, existing legendary wonder metadata/rendering catalog, repo verification scripts.
+
+---
+
+## Source Contract
+
+- Design spec: `docs/superpowers/specs/2026-06-04-stage-2j-legendary-landmark-intel-visibility-design.md`
+- Existing architecture to preserve:
+  - `src/systems/legendary-wonder-intel.ts` owns normalization, sanitization, construction, and dedupe.
+  - `src/systems/legendary-wonder-intel-presentation.ts` owns rival summary copy and safe event views.
+  - `src/systems/legendary-wonder-landmark-presentation.ts` owns landmark preview conversion.
+  - `src/systems/legendary-wonder-map-presentation.ts` owns map-safe landmark entries.
+  - `src/renderer/city-renderer.ts` and `src/renderer/city-render-passes.ts` own layer placement, not intel decisions.
+  - `src/ui/wonder-codex-page.ts` and `src/ui/territory-inspection-panel.ts` render prepared view models.
+
+## File Structure
+
+- Modify: `src/core/types.ts`
+  - Add `LegendaryWonderHostLocationIntelEntry`.
+  - Extend `LegendaryWonderIntelKind`, `LegendaryWonderIntelEntry`, and `NormalizedLegendaryWonderIntelEntry`.
+- Modify: `src/systems/legendary-wonder-intel.ts`
+  - Normalize and sanitize host-location records.
+  - Reject malformed coordinates, unknown wonders, missing snapshot labels, and self-rival records.
+  - Add `createHostLocationLegendaryWonderIntelEntry`.
+- Create: `tests/systems/legendary-wonder-intel.test.ts`
+  - Move focused intel coverage out of the large legendary wonder system test surface.
+- Modify: `src/systems/legendary-wonder-system.ts`
+  - Record host-location intel beside existing started intel when a stationed spy observes a rival legendary start.
+- Modify: `tests/systems/legendary-wonder-system.test.ts`
+  - Prove the stationed-spy source creates both records and never grants self or missing-host records.
+- Modify: `src/systems/legendary-wonder-intel-presentation.ts`
+  - Add safe host-location event and summary support without city action IDs.
+- Modify: `src/systems/legendary-wonder-landmark-presentation.ts`
+  - Add known-rival landmark preview views sourced from host-location records and static metadata.
+- Modify: `src/systems/wonder-codex/presentation.ts`
+  - Add `knownRivalLandmarkPreview` to legendary Codex pages.
+  - Keep owned `landmarkPreview` primary.
+- Modify: `tests/systems/wonder-codex/presentation.test.ts`
+  - Cover completed-only, started-only, host-location, hot-seat, and no hidden live enrichment cases.
+- Modify: `src/ui/wonder-codex-page.ts`
+  - Render compact `Known rival landmark` preview from the new page view model only.
+- Modify: `tests/ui/wonder-codex-page.test.ts`
+  - Cover visible copy and absence of rival actions.
+- Modify: `src/systems/legendary-wonder-map-presentation.ts`
+  - Add known-rival map entries from explicit stored coordinates and viewer visibility.
+- Modify: `tests/systems/legendary-wonder-map-presentation.test.ts`
+  - Cover host-location, fog, unexplored, and partial intel negatives.
+- Modify: `src/renderer/city-renderer.ts`
+  - Group legendary entries by coordinate, support landmark-only projections for known rival locations without live city state, and preserve pass ordering.
+- Modify: `src/renderer/city-render-passes.ts`
+  - Allow a `landmark-only` projection mode where only the landmark pass draws.
+- Modify: `tests/renderer/city-renderer.test.ts`
+  - Cover known-rival landmark drawing and no ghost/status/production leakage.
+- Modify: `src/ui/territory-inspection-panel.ts`
+  - Render known-rival landmark copy for the inspected coordinate from safe presentation data only.
+- Modify: `tests/ui/territory-inspection-panel.test.ts`
+  - Cover matching coordinate, viewer scoping, and started/completed-only negatives.
+
+## Player Truth Table
+
+| Before | Player action | Internal state used | Immediate visible result | Must remain hidden |
+|---|---|---|---|---|
+| Codex shows completed rival intel only | Open legendary page | `completed` intel record only | `Known rival completed` text row | host city, coordinate, map marker, preview, reward, progress, city action |
+| Codex shows started rival intel only | Open legendary page | `started` intel record only | event row names stored city as historical text | coordinate, preview, map marker, live city lookup, city action |
+| Codex has host-location rival intel | Open legendary page | `host-location-known` record and metadata catalog | `Known rival landmark` preview with stored city name and learned turn | reward, quest steps, production, progress, rival `cityId` action target |
+| Map has host-location rival intel at visible coordinate | Pan camera over coordinate | map entry from stored coordinate | medallion landmark glyph renders below labels/badges | active construction ghost, live production badge, hidden rival project data |
+| Map has host-location rival intel at fog coordinate | Pan camera over coordinate | stored coordinate and viewer fog knowledge | landmark glyph renders as remembered location intel | live rival city population, current production, current status |
+| Map has host-location rival intel at unexplored coordinate | Pan camera over coordinate | sanitized intel plus viewer visibility | no marker | all host/location visual output |
+| Hot-seat viewer changes | Open Codex or render map as another player | `state.legendaryWonderIntel[viewerId]` only | previous viewer's rows and markers disappear | previous viewer's host city and map marker |
+
+## Misleading UI Risks
+
+- `Known rival landmark` must mean a `host-location-known` record exists for the current viewer.
+- `Spotted rival project` must not imply map location; only the event text may name the stored city.
+- `Known rival completed` must not imply host city or reward visibility.
+- Owned preview and owned actions must remain primary when owned state and rival location intel coexist.
+- Negative tests must prove completed-only and started-only records cannot produce `knownRivalLandmarkPreview` or known-rival map entries.
+
+## Interaction Replay Checklist
+
+- Open a Codex page with started-only rival intel, then reopen it with host-location intel and verify the preview appears from the new view model.
+- Open a Codex page with host-location intel as viewer A, then rerender as viewer B and verify host/location copy disappears.
+- Inspect a tile with matching host-location intel, then inspect a neighboring tile and verify the known-rival line disappears.
+- Render the city pass with known-rival map entries twice and verify landmark operations are stable and do not create production or status badge operations.
+- No queue, ETA, reorder, remove, or repeat-click workflows are introduced in this slice.
+
+## Audio, SFX, PWA, And Attribution Guardrail
+
+This slice does not add or modify audio files, SFX triggers, source media, service workers, web manifest files, platform code, or Tauri configuration. Code review must still confirm no changed file enters `src/audio/**`, `public/audio/**`, `public/manifest*`, `src/platform/**`, `src-tauri/**`, or source-attribution catalogs.
+
+## Task 1: Typed Host-Location Intel
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/legendary-wonder-intel.ts`
+- Create: `tests/systems/legendary-wonder-intel.test.ts`
+
+- [ ] **Step 1: Write failing intel normalization tests**
+
+Create `tests/systems/legendary-wonder-intel.test.ts` with these tests:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import {
+  createHostLocationLegendaryWonderIntelEntry,
+  getLegendaryWonderIntelForViewer,
+  recordLegendaryWonderIntel,
+  sanitizeLegendaryWonderIntel,
+} from '@/systems/legendary-wonder-intel';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-intel host-location records', () => {
+  it('normalizes host-location records with stored coordinate snapshots', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:41',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 41,
+        source: 'spy-location',
+      }],
+    };
+
+    expect(getLegendaryWonderIntelForViewer(state, 'player')).toEqual([
+      expect.objectContaining({
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:41',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+      }),
+    ]);
+  });
+
+  it('sanitizes malformed host-location records and self-rival records', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:unknown:rival:city-rival:41',
+          wonderId: 'unknown',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: { q: 4, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:player:city-river:41',
+          wonderId: 'oracle-of-delphi',
+          civId: 'player',
+          civName: 'Player',
+          cityId: 'city-river',
+          cityName: 'River City',
+          coord: { q: 2, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:bad-city:41',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'bad-city',
+          cityName: '',
+          coord: { q: Number.NaN, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+      ],
+    };
+
+    expect(sanitizeLegendaryWonderIntel(state)).toEqual({});
+  });
+
+  it('dedupes exact host-location event IDs while preserving distinct intel tiers', () => {
+    const state = makeLegendaryWonderFixture();
+    const started = {
+      kind: 'started' as const,
+      eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+      projectKey: 'oracle-of-delphi:rival:city-rival',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      cityId: 'city-rival',
+      cityName: 'Rival Harbor',
+      revealedTurn: 41,
+    };
+    const location = createHostLocationLegendaryWonderIntelEntry({
+      projectKey: 'oracle-of-delphi:rival:city-rival',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      cityId: 'city-rival',
+      cityName: 'Rival Harbor',
+      coord: { q: 4, r: 2 },
+      learnedTurn: 41,
+      source: 'spy-location',
+    });
+    const first = recordLegendaryWonderIntel(state, 'player', started);
+    const second = recordLegendaryWonderIntel({ ...state, legendaryWonderIntel: first }, 'player', location);
+    const third = recordLegendaryWonderIntel({ ...state, legendaryWonderIntel: second }, 'player', location);
+
+    expect(third.player.map(entry => entry.kind)).toEqual(['started', 'host-location-known']);
+  });
+
+  it('keeps legacy started records text-only and distinct from host-location records', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [{
+        projectKey: 'oracle-of-delphi:rival:city-rival',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        revealedTurn: 41,
+        intelLevel: 'started',
+      }],
+    };
+
+    expect(getLegendaryWonderIntelForViewer(state, 'player')[0]).toMatchObject({
+      kind: 'started',
+      cityName: 'Rival Harbor',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing intel tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-intel.test.ts
+```
+
+Expected: FAIL because `createHostLocationLegendaryWonderIntelEntry` and the `host-location-known` union member do not exist.
+
+- [ ] **Step 3: Add host-location types**
+
+In `src/core/types.ts`, replace the current intel type block with:
+
+```ts
+export type LegendaryWonderIntelKind = 'started' | 'completed' | 'host-location-known';
+
+export interface LegacyLegendaryWonderStartedIntelEntry {
+  projectKey: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  revealedTurn: number;
+  intelLevel: 'started';
+  kind?: undefined;
+  eventId?: undefined;
+}
+
+export interface LegendaryWonderStartedIntelEntry {
+  kind: 'started';
+  eventId: string;
+  projectKey: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  revealedTurn: number;
+  intelLevel?: 'started';
+}
+
+export interface LegendaryWonderCompletedIntelEntry {
+  kind: 'completed';
+  eventId: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  completionTurn: number;
+  learnedTurn: number;
+}
+
+export interface LegendaryWonderHostLocationIntelEntry {
+  kind: 'host-location-known';
+  eventId: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+  source: 'spy-location' | 'map-intel' | 'debug-grant';
+}
+
+export type LegendaryWonderIntelEntry =
+  | LegacyLegendaryWonderStartedIntelEntry
+  | LegendaryWonderStartedIntelEntry
+  | LegendaryWonderCompletedIntelEntry
+  | LegendaryWonderHostLocationIntelEntry;
+
+export type NormalizedLegendaryWonderIntelEntry =
+  | LegendaryWonderStartedIntelEntry
+  | LegendaryWonderCompletedIntelEntry
+  | LegendaryWonderHostLocationIntelEntry;
+```
+
+- [ ] **Step 4: Add normalization, sanitization, and construction helpers**
+
+In `src/systems/legendary-wonder-intel.ts`:
+
+```ts
+import type {
+  GameState,
+  HexCoord,
+  LegendaryWonderCompletedIntelEntry,
+  LegendaryWonderHostLocationIntelEntry,
+  LegendaryWonderIntelEntry,
+  LegendaryWonderStartedIntelEntry,
+  NormalizedLegendaryWonderIntelEntry,
+} from '@/core/types';
+```
+
+Add helpers near the existing event ID helpers:
+
+```ts
+function hostLocationEventId(projectKey: string, learnedTurn: number): string {
+  return `location:${projectKey}:${learnedTurn}`;
+}
+
+function isValidCoord(coord: HexCoord | undefined): coord is HexCoord {
+  return !!coord && Number.isFinite(coord.q) && Number.isFinite(coord.r);
+}
+```
+
+Add this branch to `normalizeLegendaryWonderIntelEntry` before the legacy `intelLevel` branch:
+
+```ts
+  if (entry.kind === 'host-location-known') {
+    if (!getLegendaryWonderDefinition(entry.wonderId)) return null;
+    if (!entry.eventId || !entry.civId || !entry.civName || !entry.cityId || !entry.cityName) return null;
+    if (!isValidCoord(entry.coord)) return null;
+    if (entry.source !== 'spy-location' && entry.source !== 'map-intel' && entry.source !== 'debug-grant') return null;
+    return {
+      ...entry,
+      coord: { ...entry.coord },
+    };
+  }
+```
+
+Update `sanitizeLegendaryWonderIntel` so it rejects self-rival records while iterating each viewer:
+
+```ts
+          const safeEntry = normalizeLegendaryWonderIntelEntry(entry);
+          if (!safeEntry || safeEntry.civId === viewerId || seen.has(safeEntry.eventId)) continue;
+```
+
+Add the constructor after `createCompletedLegendaryWonderIntelEntry`:
+
+```ts
+export function createHostLocationLegendaryWonderIntelEntry(input: {
+  projectKey: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+  source: LegendaryWonderHostLocationIntelEntry['source'];
+}): LegendaryWonderHostLocationIntelEntry {
+  return {
+    kind: 'host-location-known',
+    eventId: hostLocationEventId(input.projectKey, input.learnedTurn),
+    wonderId: input.wonderId,
+    civId: input.civId,
+    civName: input.civName,
+    cityId: input.cityId,
+    cityName: input.cityName,
+    coord: { ...input.coord },
+    learnedTurn: input.learnedTurn,
+    source: input.source,
+  };
+}
+```
+
+- [ ] **Step 5: Run intel tests until they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-intel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit typed intel work**
+
+Run:
+
+```bash
+git add src/core/types.ts src/systems/legendary-wonder-intel.ts tests/systems/legendary-wonder-intel.test.ts
+git commit -m "feat(wonders): add host location landmark intel"
+```
+
+## Task 2: Stationed-Spy Grant Path
+
+**Files:**
+- Modify: `src/systems/legendary-wonder-system.ts`
+- Modify: `tests/systems/legendary-wonder-system.test.ts`
+
+- [ ] **Step 1: Write failing grant-path tests**
+
+Append these tests near the existing stationed-spy start intel tests in `tests/systems/legendary-wonder-system.test.ts`:
+
+```ts
+  it('records host-location intel when a stationed spy observes a rival legendary start', () => {
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
+    state.turn = 41;
+    state.civilizations.player.knownCivilizations = ['rival'];
+    state.civilizations.rival.knownCivilizations = ['player'];
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:rival:city-rival': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'rival',
+        cityId: 'city-rival',
+        phase: 'ready_to_build',
+        investedProduction: 0,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+    state.cities['city-rival'] = {
+      ...state.cities['city-rival'],
+      name: 'Rival Harbor',
+      productionQueue: [],
+      productionProgress: 12,
+    };
+    state.espionage = {
+      player: {
+        spies: {
+          spy1: {
+            id: 'spy1',
+            name: 'Watcher',
+            owner: 'player',
+            unitType: 'spy_scout',
+            status: 'stationed',
+            targetCivId: 'rival',
+            targetCityId: 'city-rival',
+            position: state.cities['city-rival'].position,
+            experience: 0,
+            currentMission: null,
+            cooldownTurns: 0,
+            promotionAvailable: false,
+          },
+        },
+        maxSpies: 1,
+        counterIntelligence: {},
+      },
+    };
+
+    const result = startLegendaryWonderBuild(state, 'rival', 'city-rival', 'oracle-of-delphi');
+
+    expect(result.legendaryWonderIntel?.player).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'started', cityName: 'Rival Harbor' }),
+      expect.objectContaining({
+        kind: 'host-location-known',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        cityName: 'Rival Harbor',
+        coord: state.cities['city-rival'].position,
+        learnedTurn: 41,
+        source: 'spy-location',
+      }),
+    ]));
+  });
+
+  it('does not record host-location intel for the builder or when the host city is missing', () => {
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
+    state.turn = 41;
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:rival:missing-city': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'rival',
+        cityId: 'missing-city',
+        phase: 'ready_to_build',
+        investedProduction: 0,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+    state.espionage = {
+      rival: {
+        spies: {
+          selfSpy: {
+            id: 'selfSpy',
+            name: 'Self',
+            owner: 'rival',
+            unitType: 'spy_scout',
+            status: 'stationed',
+            targetCivId: 'rival',
+            targetCityId: 'missing-city',
+            position: { q: 0, r: 0 },
+            experience: 0,
+            currentMission: null,
+            cooldownTurns: 0,
+            promotionAvailable: false,
+          },
+        },
+        maxSpies: 1,
+        counterIntelligence: {},
+      },
+    };
+
+    const result = startLegendaryWonderBuild(state, 'rival', 'missing-city', 'oracle-of-delphi');
+
+    expect(result.legendaryWonderIntel?.rival).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: Run the failing system test file**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts
+```
+
+Expected: FAIL because start build records only `started` intel.
+
+- [ ] **Step 3: Record host-location intel in the canonical start path**
+
+In `src/systems/legendary-wonder-system.ts`, add `createHostLocationLegendaryWonderIntelEntry` to the import from `legendary-wonder-intel`.
+
+Inside the stationed-spy observer block in `startLegendaryWonderBuild`, immediately after recording `createStartedLegendaryWonderIntelEntry`, add:
+
+```ts
+    if (city) {
+      legendaryWonderIntel = recordLegendaryWonderIntel(
+        {
+          ...seededState,
+          legendaryWonderIntel,
+        },
+        observerId,
+        createHostLocationLegendaryWonderIntelEntry({
+          projectKey,
+          wonderId: project.wonderId,
+          civId,
+          civName: civilization ? civilization.name : civId,
+          cityId,
+          cityName: city.name,
+          coord: city.position,
+          learnedTurn: state.turn,
+          source: 'spy-location',
+        }),
+      );
+    }
+```
+
+- [ ] **Step 4: Run system tests until they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-intel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the grant path**
+
+Run:
+
+```bash
+git add src/systems/legendary-wonder-system.ts tests/systems/legendary-wonder-system.test.ts
+git commit -m "feat(wonders): record legendary host location intel"
+```
+
+## Task 3: Safe Rival Location Presentation And Codex Model
+
+**Files:**
+- Modify: `src/systems/legendary-wonder-intel-presentation.ts`
+- Modify: `src/systems/legendary-wonder-landmark-presentation.ts`
+- Modify: `src/systems/wonder-codex/presentation.ts`
+- Modify: `tests/systems/wonder-codex/presentation.test.ts`
+
+- [ ] **Step 1: Write failing presentation tests**
+
+Add these tests to `tests/systems/wonder-codex/presentation.test.ts`:
+
+```ts
+  it('adds known-rival landmark preview only from host-location intel', () => {
+    const state = makeState();
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const serialized = JSON.stringify(model.selectedPage);
+
+    expect(model.selectedPage?.stateLabel).toBe('Known rival landmark');
+    expect(model.selectedPage?.knownRivalLandmarkPreview).toMatchObject({
+      cityName: 'Rival Harbor',
+      learnedTurn: 62,
+      items: [{ wonderId: 'oracle-of-delphi', label: 'Oracle of Delphi', state: 'completed' }],
+    });
+    expect(serialized).not.toContain('"cityId":"rival-city"');
+    expect(serialized).not.toContain('Reward:');
+    expect(model.selectedPage?.actions).toEqual([]);
+  });
+
+  it('does not enrich completed-only rival intel from hidden rival city state', () => {
+    const state = makeState();
+    state.cities['hidden-city'] = {
+      ...state.cities[Object.keys(state.cities)[0]],
+      id: 'hidden-city',
+      name: 'Hidden Harbor',
+      owner: 'ai-1',
+      position: { q: 4, r: 2 },
+    };
+    state.completedLegendaryWonders = {
+      'oracle-of-delphi': { ownerId: 'ai-1', cityId: 'hidden-city', turnCompleted: 58 },
+    };
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'completed',
+        eventId: 'completed:oracle-of-delphi:ai-1:58',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        completionTurn: 58,
+        learnedTurn: 58,
+      }],
+    };
+
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const serialized = JSON.stringify(model.selectedPage);
+
+    expect(model.selectedPage?.knownRivalLandmarkPreview).toBeUndefined();
+    expect(serialized).not.toContain('Hidden Harbor');
+    expect(serialized).not.toContain('"cityId":"hidden-city"');
+  });
+
+  it('keeps host-location intel scoped to the current hot-seat viewer', () => {
+    const state = makeState();
+    state.civilizations['player-2'] = {
+      ...state.civilizations.player,
+      id: 'player-2',
+      name: 'Second Player',
+      isHuman: true,
+      cities: [],
+      units: [],
+    };
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const viewerA = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const viewerB = getWonderCodexViewModel(state, 'player-2', { initialWonderId: 'oracle-of-delphi' });
+
+    expect(viewerA.selectedPage?.knownRivalLandmarkPreview?.cityName).toBe('Rival Harbor');
+    expect(viewerB.catalogEntries.some(entry => entry.id === 'oracle-of-delphi')).toBe(false);
+    expect(viewerB.selectedPage).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Run failing Codex presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-codex/presentation.test.ts
+```
+
+Expected: FAIL because `knownRivalLandmarkPreview` and `Known rival landmark` do not exist.
+
+- [ ] **Step 3: Add safe host-location presentation types**
+
+In `src/systems/legendary-wonder-intel-presentation.ts`, update the label and event types:
+
+```ts
+export type LegendaryWonderRivalIntelStateLabel =
+  | 'Known rival completed'
+  | 'Spotted rival project'
+  | 'Known rival landmark';
+
+export interface LegendaryWonderRivalIntelEventView {
+  id: string;
+  kind: 'started' | 'completed' | 'host-location-known';
+  civId: string;
+  civName: string;
+  turn: number;
+  title: string;
+  text: string;
+}
+
+export interface LegendaryWonderRivalHostLocationView {
+  id: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+}
+```
+
+Import `HexCoord` from `@/core/types`. Update `eventView`, `bestState`, and `summaryLine` so a host-location record renders:
+
+```ts
+  if (entry.kind === 'host-location-known') {
+    return {
+      id: entry.eventId,
+      kind: 'host-location-known',
+      civId: entry.civId,
+      civName: entry.civName,
+      turn: entry.learnedTurn,
+      title: 'Known rival landmark',
+      text: `${entry.civName} hosts ${name} in ${entry.cityName}. Location learned on turn ${entry.learnedTurn}.`,
+    };
+  }
+```
+
+Use this priority:
+
+```ts
+function bestState(events: LegendaryWonderRivalIntelEventView[]): LegendaryWonderRivalIntelStateLabel {
+  if (events.some(event => event.kind === 'completed')) return 'Known rival completed';
+  if (events.some(event => event.kind === 'host-location-known')) return 'Known rival landmark';
+  return 'Spotted rival project';
+}
+```
+
+Add a safe location selector:
+
+```ts
+export function getLegendaryWonderHostLocationIntelForViewer(
+  state: GameState,
+  viewerId: string,
+  wonderId: string,
+): LegendaryWonderRivalHostLocationView[] {
+  return getLegendaryWonderIntelForViewer(state, viewerId)
+    .filter((entry): entry is Extract<NormalizedLegendaryWonderIntelEntry, { kind: 'host-location-known' }> =>
+      entry.kind === 'host-location-known' && entry.wonderId === wonderId,
+    )
+    .map(entry => ({
+      id: entry.eventId,
+      wonderId: entry.wonderId,
+      civId: entry.civId,
+      civName: entry.civName,
+      cityName: entry.cityName,
+      coord: { ...entry.coord },
+      learnedTurn: entry.learnedTurn,
+    }))
+    .sort((a, b) => b.learnedTurn - a.learnedTurn || a.civName.localeCompare(b.civName) || a.id.localeCompare(b.id));
+}
+```
+
+- [ ] **Step 4: Add known-rival landmark preview helper**
+
+In `src/systems/legendary-wonder-landmark-presentation.ts`, add:
+
+```ts
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+```
+
+Add these interfaces and function:
+
+```ts
+export interface KnownRivalLegendaryLandmarkPreviewView {
+  cityName: string;
+  civName: string;
+  learnedTurn: number;
+  items: Array<{
+    wonderId: string;
+    label: string;
+    state: 'completed';
+  }>;
+}
+
+export function getKnownRivalLegendaryLandmarkPreviewForWonder(
+  state: GameState,
+  viewerId: string,
+  wonderId: string,
+): KnownRivalLegendaryLandmarkPreviewView | null {
+  const [location] = getLegendaryWonderHostLocationIntelForViewer(state, viewerId, wonderId);
+  if (!location) return null;
+  return {
+    cityName: location.cityName,
+    civName: location.civName,
+    learnedTurn: location.learnedTurn,
+    items: [{
+      wonderId,
+      label: getLegendaryWonderDefinition(wonderId) ? getLegendaryWonderDefinition(wonderId)!.name : 'Legendary wonder',
+      state: 'completed',
+    }],
+  };
+}
+```
+
+- [ ] **Step 5: Wire Codex page model**
+
+In `src/systems/wonder-codex/presentation.ts`, import the new type and helper:
+
+```ts
+import {
+  getKnownRivalLegendaryLandmarkPreviewForWonder,
+  getLegendaryLandmarkPreviewViewForCity,
+  type KnownRivalLegendaryLandmarkPreviewView,
+  type LegendaryWonderLandmarkPreviewView,
+} from '@/systems/legendary-wonder-landmark-presentation';
+```
+
+Add a field to `WonderCodexPageViewModel`:
+
+```ts
+  knownRivalLandmarkPreview?: KnownRivalLegendaryLandmarkPreviewView;
+```
+
+In `buildPage`, after computing `landmarkPreview`, compute:
+
+```ts
+  const knownRivalLandmarkPreview = entry.kind === 'legendary'
+    ? getKnownRivalLegendaryLandmarkPreviewForWonder(state, viewerId, entry.id)
+    : null;
+```
+
+In the returned object, add:
+
+```ts
+    ...(knownRivalLandmarkPreview ? { knownRivalLandmarkPreview } : {}),
+```
+
+- [ ] **Step 6: Run Codex presentation tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/wonder-codex/presentation.test.ts tests/systems/legendary-wonder-intel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit safe presentation work**
+
+Run:
+
+```bash
+git add src/systems/legendary-wonder-intel-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/systems/wonder-codex/presentation.ts tests/systems/wonder-codex/presentation.test.ts
+git commit -m "feat(wonders): present known rival landmark intel"
+```
+
+## Task 4: Codex And Inspection UI
+
+**Files:**
+- Modify: `src/ui/wonder-codex-page.ts`
+- Modify: `tests/ui/wonder-codex-page.test.ts`
+- Modify: `src/ui/territory-inspection-panel.ts`
+- Modify: `tests/ui/territory-inspection-panel.test.ts`
+
+- [ ] **Step 1: Write failing Codex UI test**
+
+Add this test to `tests/ui/wonder-codex-page.test.ts`:
+
+```ts
+  it('renders known-rival landmark preview without rival actions', () => {
+    const root = createWonderCodexPage(page({
+      id: 'oracle-of-delphi',
+      kind: 'legendary',
+      title: 'Oracle of Delphi',
+      subtitle: 'A sanctuary of prophecy.',
+      stateLabel: 'Known rival landmark',
+      visual: getWonderVisualDefinition('oracle-of-delphi'),
+      actions: [],
+      landmarkPreview: undefined,
+      knownRivalLandmarkPreview: {
+        cityName: 'Rival Harbor',
+        civName: 'Rival',
+        learnedTurn: 62,
+        items: [{
+          wonderId: 'oracle-of-delphi',
+          label: 'Oracle of Delphi',
+          state: 'completed',
+        }],
+      },
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    expect(root.querySelector('[data-section="known-rival-landmark-preview"]')?.textContent).toContain('Known rival landmark');
+    expect(root.textContent).toContain('Rival Harbor');
+    expect(root.textContent).toContain('Location learned on turn 62');
+    expect(root.querySelector('[data-codex-action="open-city"]')).toBeNull();
+    expect(root.querySelector('[data-codex-action="view-map"]')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Write failing inspection UI tests**
+
+Add these tests to `tests/ui/territory-inspection-panel.test.ts`:
+
+```ts
+  it('mentions known-rival legendary landmarks only on the matching known coordinate', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const rivalCoord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        coord: rivalCoord,
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const matching = createTerritoryInspectionPanel(state, rivalCoord, 'player');
+    const nearby = createTerritoryInspectionPanel(state, { q: rivalCoord.q + 1, r: rivalCoord.r }, 'player');
+
+    expect(matching.textContent).toContain('Known rival legendary landmark');
+    expect(matching.textContent).toContain('Oracle of Delphi');
+    expect(matching.textContent).toContain('Rival Harbor');
+    expect(nearby.textContent).not.toContain('Known rival legendary landmark');
+  });
+
+  it('does not mention known-rival landmarks from started or completed intel alone', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const rivalCoord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'started',
+          eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+          projectKey: 'oracle-of-delphi:rival:city-rival',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          revealedTurn: 41,
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:58',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 58,
+          learnedTurn: 58,
+        },
+      ],
+    };
+
+    const panel = createTerritoryInspectionPanel(state, rivalCoord, 'player');
+
+    expect(panel.textContent).not.toContain('Known rival legendary landmark');
+  });
+```
+
+- [ ] **Step 3: Run failing UI tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-codex-page.test.ts tests/ui/territory-inspection-panel.test.ts
+```
+
+Expected: FAIL because the DOM sections do not exist.
+
+- [ ] **Step 4: Render known-rival Codex section**
+
+In `src/ui/wonder-codex-page.ts`, after the owned `page.landmarkPreview` section and before rival activity, add:
+
+```ts
+  if (page.knownRivalLandmarkPreview) {
+    const preview = document.createElement('section');
+    preview.dataset.section = 'known-rival-landmark-preview';
+    preview.style.cssText = 'border:1px solid rgba(232,193,112,0.24);border-radius:8px;padding:10px;background:rgba(232,193,112,0.07);display:grid;gap:6px;';
+    appendText(preview, 'h4', 'Known rival landmark', 'margin:0;font-size:13px;color:#f4d188;');
+    appendText(
+      preview,
+      'p',
+      `${page.knownRivalLandmarkPreview.civName} host: ${page.knownRivalLandmarkPreview.cityName}. Location learned on turn ${page.knownRivalLandmarkPreview.learnedTurn}.`,
+      'margin:0;font-size:12px;color:rgba(248,241,223,0.74);',
+    );
+    const list = document.createElement('ul');
+    list.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;color:rgba(248,241,223,0.74);';
+    for (const item of page.knownRivalLandmarkPreview.items) {
+      const li = document.createElement('li');
+      li.dataset.knownRivalLandmarkPreview = item.wonderId;
+      li.textContent = `${item.label} — Completed`;
+      list.appendChild(li);
+    }
+    preview.appendChild(list);
+    root.appendChild(preview);
+  }
+```
+
+- [ ] **Step 5: Render inspection known-rival copy from safe helper**
+
+In `src/ui/territory-inspection-panel.ts`, import:
+
+```ts
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+```
+
+After the owned completed legendary wonder line, add:
+
+```ts
+  const knownRivalAtCoord = getLegendaryWonderHostLocationIntelForViewer(state, viewerId)
+    .filter(entry => hexKey(entry.coord) === key)
+    .map(entry => {
+      const definition = getLegendaryWonderDefinition(entry.wonderId);
+      return `${definition ? definition.name : entry.wonderId} in ${entry.cityName}`;
+    });
+```
+
+Adjust the helper from Task 3 before using this code so `wonderId` is optional:
+
+```ts
+export function getLegendaryWonderHostLocationIntelForViewer(
+  state: GameState,
+  viewerId: string,
+  wonderId?: string,
+): LegendaryWonderRivalHostLocationView[] {
+  return getLegendaryWonderIntelForViewer(state, viewerId)
+    .filter((entry): entry is Extract<NormalizedLegendaryWonderIntelEntry, { kind: 'host-location-known' }> =>
+      entry.kind === 'host-location-known' && (!wonderId || entry.wonderId === wonderId),
+    )
+    .map(entry => ({
+      id: entry.eventId,
+      wonderId: entry.wonderId,
+      civId: entry.civId,
+      civName: entry.civName,
+      cityName: entry.cityName,
+      coord: { ...entry.coord },
+      learnedTurn: entry.learnedTurn,
+    }))
+    .sort((a, b) => b.learnedTurn - a.learnedTurn || a.civName.localeCompare(b.civName) || a.id.localeCompare(b.id));
+}
+```
+
+Then in `src/ui/territory-inspection-panel.ts` render:
+
+```ts
+  if (knownRivalAtCoord.length > 0) {
+    addLine(panel, 'Known rival legendary landmark', knownRivalAtCoord.join(', '));
+  }
+```
+
+- [ ] **Step 6: Run UI tests until they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/wonder-codex-page.test.ts tests/ui/territory-inspection-panel.test.ts tests/systems/wonder-codex/presentation.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit UI work**
+
+Run:
+
+```bash
+git add src/ui/wonder-codex-page.ts tests/ui/wonder-codex-page.test.ts src/ui/territory-inspection-panel.ts tests/ui/territory-inspection-panel.test.ts src/systems/legendary-wonder-intel-presentation.ts
+git commit -m "feat(wonders): show known rival landmark previews"
+```
+
+## Task 5: Map Entries And City Renderer
+
+**Files:**
+- Modify: `src/systems/legendary-wonder-map-presentation.ts`
+- Modify: `tests/systems/legendary-wonder-map-presentation.test.ts`
+- Modify: `src/renderer/city-renderer.ts`
+- Modify: `src/renderer/city-render-passes.ts`
+- Modify: `tests/renderer/city-renderer.test.ts`
+
+- [ ] **Step 1: Write failing map presentation tests**
+
+Add these tests to `tests/systems/legendary-wonder-map-presentation.test.ts`:
+
+```ts
+  it('returns known-rival map entries from host-location intel at visible or fog coordinates', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const coord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        coord,
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      relationship: 'known-rival',
+      state: 'completed',
+      coord,
+      label: 'Oracle of Delphi',
+      progressRatio: undefined,
+    }));
+
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'fog';
+    expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      relationship: 'known-rival',
+      coord,
+    }));
+  });
+
+  it('does not return known-rival map entries for unexplored or partial rival intel', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const coord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'unexplored';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'started',
+          eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+          projectKey: 'oracle-of-delphi:rival:city-rival',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          revealedTurn: 41,
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:grand-canal:rival:city-rival:62',
+          wonderId: 'grand-canal',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+      ],
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player').some(entry => entry.relationship === 'known-rival')).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Write failing renderer tests**
+
+Add these tests to `tests/renderer/city-renderer.test.ts` near the rival intel renderer tests:
+
+```ts
+  it('draws known-rival landmark entries from host-location intel without live rival badges', () => {
+    const state = createNewGame(undefined, 'known-rival-landmark-render', 'small');
+    const coord = { q: 4, r: 2 };
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'fog';
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord,
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player', { nowMs: 1000 });
+
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('legendary-landmarks:start');
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('city-pass:landmarks');
+    expect((ctx as unknown as MockCanvasContext).operations).not.toContain('city-pass:production');
+    expect((ctx as unknown as MockCanvasContext).operations).not.toContain('city-pass:status');
+  });
+
+  it('does not draw construction ghosts for known-rival location intel', () => {
+    const state = createNewGame(undefined, 'known-rival-no-ghost', 'small');
+    const coord = { q: 4, r: 2 };
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord,
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const entries = getLegendaryWonderMapEntries(state, 'player');
+
+    expect(entries).toContainEqual(expect.objectContaining({
+      relationship: 'known-rival',
+      state: 'completed',
+      progressRatio: undefined,
+    }));
+  });
+```
+
+- [ ] **Step 3: Run failing map and renderer tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: FAIL because known-rival map entries and landmark-only projections do not exist.
+
+- [ ] **Step 4: Add known-rival map entries**
+
+In `src/systems/legendary-wonder-map-presentation.ts`:
+
+```ts
+import { hexKey } from '@/systems/hex-utils';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+```
+
+Update `LegendaryWonderMapEntry`:
+
+```ts
+export interface LegendaryWonderMapEntry {
+  wonderId: string;
+  cityId?: string;
+  cityName?: string;
+  coord: HexCoord;
+  ownerId: string;
+  relationship: 'owned' | 'known-rival';
+  state: LegendaryWonderLandmarkState;
+  turnCompleted: number;
+  label: string;
+  visual: WonderVisualDefinition;
+  metadata: LegendaryWonderLandmarkMetadata;
+  progressRatio?: number;
+}
+```
+
+After owned city scanning, append known-rival entries:
+
+```ts
+  const seenKnownRival = new Set<string>();
+  for (const location of getLegendaryWonderHostLocationIntelForViewer(state, viewerId)) {
+    const tileVisibility = getVisibility(visibility, location.coord);
+    if (tileVisibility === 'unexplored') continue;
+    const key = `${location.wonderId}:${location.civId}:${hexKey(location.coord)}`;
+    if (seenKnownRival.has(key)) continue;
+    seenKnownRival.add(key);
+    entries.push({
+      wonderId: location.wonderId,
+      cityName: location.cityName,
+      coord: { ...location.coord },
+      ownerId: location.civId,
+      relationship: 'known-rival',
+      state: 'completed',
+      turnCompleted: location.learnedTurn,
+      label: getLegendaryWonderDefinition(location.wonderId)
+        ? getLegendaryWonderDefinition(location.wonderId)!.name
+        : 'Legendary wonder',
+      visual: getWonderVisualDefinition(location.wonderId),
+      metadata: getLegendaryWonderLandmarkMetadata(location.wonderId),
+    });
+  }
+```
+
+- [ ] **Step 5: Support landmark-only render items without hidden city data**
+
+In `src/renderer/city-render-passes.ts`, update `CityRenderProjection`:
+
+```ts
+export interface CityRenderProjection {
+  name: string;
+  position: HexCoord;
+  population: number;
+  owner: string;
+  isLive: boolean;
+  liveCityId?: string;
+  renderMode?: 'city' | 'landmark-only';
+}
+```
+
+At the top of each non-landmark pass, before `markPass`, skip landmark-only projections:
+
+```ts
+  if (item.projection.renderMode === 'landmark-only') return;
+```
+
+Apply that skip in `drawCityBasePass`, `drawCityIconPass`, `drawCityLabelPass`, `drawCityStatusBadgePass`, `drawCityProductionBadgePass`, and `drawCityIdleBadgePass`. Do not add the skip to `drawCityLandmarkPass`.
+
+In `src/renderer/city-renderer.ts`, replace `landmarksByCity` grouping with coordinate grouping:
+
+```ts
+  const landmarksByCoord = new Map<string, LegendaryWonderMapEntry[]>();
+  for (const entry of getLegendaryWonderMapEntries(state, playerCivId)) {
+    const key = `${entry.coord.q},${entry.coord.r}`;
+    landmarksByCoord.set(key, [...(landmarksByCoord.get(key) || []), entry]);
+  }
+```
+
+When assigning `landmarkEntries` inside the projection loop:
+
+```ts
+      const landmarkEntries = landmarksByCoord.get(`${projection.position.q},${projection.position.r}`) || [];
+```
+
+Before iterating projections, store projections in a local variable and create a set of projection coordinate keys:
+
+```ts
+  const projections = getCityRenderProjection(state, playerCivId);
+  const projectedKeys = new Set(projections.map(projection => `${projection.position.q},${projection.position.r}`));
+```
+
+After the normal projection loop:
+
+```ts
+  for (const [coordKey, landmarkEntries] of landmarksByCoord.entries()) {
+    if (projectedKeys.has(coordKey)) continue;
+    const [q, r] = coordKey.split(',').map(Number);
+    const coord = { q, r };
+    if (!camera.isHexVisible(coord)) continue;
+    const pixel = hexToPixel(coord, camera.hexSize);
+    const screen = camera.worldToScreen(pixel.x, pixel.y);
+    items.push({
+      projection: {
+        name: landmarkEntries[0].cityName !== undefined ? landmarkEntries[0].cityName : landmarkEntries[0].label,
+        position: coord,
+        population: 0,
+        owner: landmarkEntries[0].ownerId,
+        isLive: false,
+        renderMode: 'landmark-only',
+      },
+      screen,
+      size: camera.hexSize * camera.zoom,
+      ownerColor: state.civilizations[landmarkEntries[0].ownerId]
+        ? state.civilizations[landmarkEntries[0].ownerId].color
+        : OWNER_COLORS[landmarkEntries[0].ownerId] || '#888',
+      playerCivId,
+      isMinorCiv: false,
+      landmarkEntries,
+      lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+      reducedMotion,
+      nowMs,
+      turn: state.turn,
+    });
+  }
+```
+
+- [ ] **Step 6: Run map and renderer tests until they pass**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-map-presentation.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit map and renderer work**
+
+Run:
+
+```bash
+git add src/systems/legendary-wonder-map-presentation.ts tests/systems/legendary-wonder-map-presentation.test.ts src/renderer/city-renderer.ts src/renderer/city-render-passes.ts tests/renderer/city-renderer.test.ts
+git commit -m "feat(wonders): render known rival landmark intel"
+```
+
+## Task 6: Review, Rule Checks, And Full Verification
+
+**Files:**
+- Review all changed files from Tasks 1-5.
+
+- [ ] **Step 1: Run targeted test set**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-intel.test.ts tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts tests/ui/territory-inspection-panel.test.ts tests/renderer/city-renderer.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run source rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/legendary-wonder-intel.ts src/systems/legendary-wonder-system.ts src/systems/legendary-wonder-intel-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts src/ui/territory-inspection-panel.ts src/systems/legendary-wonder-map-presentation.ts src/renderer/city-renderer.ts src/renderer/city-render-passes.ts
+```
+
+Expected: PASS with no rule violations.
+
+- [ ] **Step 3: Run wonder regressions**
+
+Run:
+
+```bash
+./scripts/run-wonder-regressions.sh
+```
+
+Expected: PASS. A sandbox-only mise cache warning is acceptable only when the script exits 0.
+
+- [ ] **Step 4: Run build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS. Existing Vite chunk-size warnings are acceptable when the command exits 0.
+
+- [ ] **Step 5: Run full test suite**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Inspect branch and working-tree diffs**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD
+git diff
+```
+
+Expected:
+- Branch diff contains only Stage 2J spec, plan, implementation, and tests.
+- Working-tree diff is empty before final PR work.
+- No files under `src/audio/**`, `public/audio/**`, `src/platform/**`, `src-tauri/**`, PWA manifest, or service worker paths changed.
+- No serialized view model exposes rival `cityId`, rival production, rival quest steps, rival reward, or hidden completion city.
+
+- [ ] **Step 7: Commit verification fixes if review finds issues**
+
+If Step 6 reveals a concrete issue, write the smallest regression test that fails for that issue, implement the fix, rerun the relevant targeted command, and commit:
+
+```bash
+git add <changed-files>
+git commit -m "fix(wonders): harden known rival landmark intel"
+```
+
+## Task 7: Rebase, Fast-Forward Check, Push, And PR
+
+**Files:**
+- No source edits unless rebase conflict resolution requires them.
+
+- [ ] **Step 1: Fetch latest main**
+
+Run:
+
+```bash
+git fetch origin main
+```
+
+Expected: fetch succeeds.
+
+- [ ] **Step 2: Rebase onto latest `origin/main`**
+
+Run:
+
+```bash
+git rebase origin/main
+```
+
+Expected: rebase succeeds. On conflict, resolve by preserving Stage 2J privacy contracts, rerun affected targeted tests, then continue with `git -c core.editor=true rebase --continue`.
+
+- [ ] **Step 3: Verify fast-forward eligibility**
+
+Run:
+
+```bash
+git merge-base --is-ancestor origin/main HEAD
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Re-run final verification after rebase**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Push branch**
+
+Run:
+
+```bash
+git push -u origin codex/stage-2j-legendary-landmark-intel
+```
+
+Expected: push succeeds.
+
+- [ ] **Step 6: Create draft PR**
+
+Run:
+
+```bash
+gh pr create --draft --base main --head codex/stage-2j-legendary-landmark-intel --title "Stage 2J legendary landmark intel visibility" --body "## Summary
+- add explicit host/location legendary wonder intel records
+- show known-rival landmark previews and map markers only from earned location intel
+- preserve started/completed rival privacy and hot-seat viewer scoping
+
+## Tests
+- ./scripts/run-with-mise.sh yarn test --run tests/systems/legendary-wonder-intel.test.ts tests/systems/legendary-wonder-system.test.ts tests/systems/legendary-wonder-map-presentation.test.ts tests/systems/wonder-codex/presentation.test.ts tests/ui/wonder-codex-page.test.ts tests/ui/territory-inspection-panel.test.ts tests/renderer/city-renderer.test.ts
+- scripts/check-src-rule-violations.sh src/core/types.ts src/systems/legendary-wonder-intel.ts src/systems/legendary-wonder-system.ts src/systems/legendary-wonder-intel-presentation.ts src/systems/legendary-wonder-landmark-presentation.ts src/systems/wonder-codex/presentation.ts src/ui/wonder-codex-page.ts src/ui/territory-inspection-panel.ts src/systems/legendary-wonder-map-presentation.ts src/renderer/city-renderer.ts src/renderer/city-render-passes.ts
+- ./scripts/run-wonder-regressions.sh
+- ./scripts/run-with-mise.sh yarn build
+- ./scripts/run-with-mise.sh yarn test"
+```
+
+Expected: PR URL is printed.
+
+## Plan Self-Review
+
+- Spec coverage: The plan maps the new union tier, existing started/completed privacy, canonical stationed-spy source, safe Codex/inspection/map views, hot-seat scoping, renderer layer preservation, and verification requirements to Tasks 1-7.
+- Architecture check: Privacy decisions stay in `src/systems/**`; DOM and Canvas code receive safe view objects and map entries. The renderer gains a landmark-only projection mode so known-rival markers can render from stored coordinates without reading live rival city state.
+- Testing check: Every behavior change starts with a failing Vitest test. Negative tests cover completed-only, started-only, unexplored location, hidden live enrichment, self-rival sanitization, and hot-seat leakage.
+- UI/UX check: The Codex adds compact passive copy, not new actions. Inspection adds informational text only at the matching known coordinate. No queue or repeat-click workflow is introduced.
+- Audio/SFX check: The plan changes no audio files, SFX triggers, media attribution, PWA files, service worker code, platform code, or Tauri code.
+- Regression check: Targeted tests, source rule checks, wonder regressions, build, full test suite, branch diff, and working-tree diff are required before PR creation.

--- a/docs/superpowers/specs/2026-06-04-stage-2j-legendary-landmark-intel-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-04-stage-2j-legendary-landmark-intel-visibility-design.md
@@ -1,0 +1,199 @@
+# Stage 2J Legendary Landmark Intel Visibility Design
+
+**Date:** 2026-06-04
+**Status:** Draft for review
+**Related roadmap:** `docs/superpowers/specs/2026-05-21-wonder-atlas-and-map-identity-design.md`
+**Builds on:** Stage 2F Atlas Intel Records, Stage 2G Legendary City Landmarks, Stage 2I Bespoke Legendary Landmarks, Stage 2K City Renderer Layer Architecture
+
+## Purpose
+
+Stage 2J lets the player see rival legendary landmarks only when the player has explicitly earned host/location intel. Earlier stages deliberately kept rival legendary completions as safe journal knowledge: the player could know that a rival completed a wonder without knowing where it was built. This stage adds the missing middle tier without weakening those privacy promises.
+
+The selected design is conservative for map and preview visibility. Existing `started` intel may continue to show a rival host city name as plain text because that snapshot already exists. Existing `completed` intel remains completion-only. Neither existing tier can create a rival map landmark, host-city action, or landmark preview. A new explicit `host-location-known` intel tier is required before known-rival landmarks can render on map, inspection, or Codex preview surfaces.
+
+## Goals
+
+- Add a new viewer-scoped `host-location-known` legendary wonder intel tier.
+- Render known-rival legendary landmarks only from `host-location-known` records.
+- Keep existing `started` intel as text-only host-name knowledge.
+- Keep existing `completed` intel from revealing host city, map coordinate, landmark preview, reward, progress, or action targets.
+- Preserve hot-seat privacy by reading only `state.legendaryWonderIntel[viewerId]`.
+- Extend existing Stage 2G landmark metadata and Stage 2I bespoke rendering rather than creating a rival-only art path.
+- Make the map renderer consume the same viewer-safe `LegendaryWonderMapEntry` shape for owned and known-rival landmarks.
+- Add negative tests proving partial knowledge is insufficient.
+
+## Non-Goals
+
+- No retroactive migration of old `started` records into map-capable location intel.
+- No rival city opening action.
+- No rival reward, quest, progress, production, active construction ghost, or project phase detail.
+- No new spy mission UI, espionage mission design, or AI strategy.
+- No new art assets, audio/SFX, video, service-worker, PWA, Tauri, storage, or platform behavior.
+- No change to natural-wonder audio, natural-wonder Atlas behavior, or owned legendary wonder presentation.
+- No location inference from live rival city objects, hidden `completedLegendaryWonders`, or hidden `legendaryWonderProjects` during rendering.
+
+## Product Behavior
+
+The player experience has three clear knowledge levels.
+
+`completed` rival intel says only that a rival completed a legendary wonder. The Codex may show `Known rival completed` and a journal row naming the rival and turn. It must not show a host city, coordinate, map button, landmark preview, or reward line.
+
+`started` rival intel says a rival project was spotted. The Codex may show the stored rival city name as text, for example `Rival began Oracle of Delphi in Rival Harbor on turn 41`. This remains a historical spy snapshot. It does not become a map target or landmark preview.
+
+`host-location-known` rival intel says the viewer has explicitly learned the host city/location for a rival legendary wonder. This tier may show a compact known-rival landmark preview in the Codex and may create a known-rival map landmark entry if the stored coordinate is currently visible or fogged as an already-known map area for the viewer. The map marker is informational and decorative. It does not add an action target beyond existing tile/city inspection behavior.
+
+## Player Truth Table
+
+| Situation | Visible behavior | Must not happen |
+|---|---|---|
+| Viewer has completed rival intel only | Codex shows known-rival completion text | No host city, map marker, landmark preview, reward, progress, or city action |
+| Viewer has started rival intel only | Codex event row may name the stored host city as text | No map marker, map action, preview, live city lookup, or coordinate |
+| Viewer has host-location-known intel only | Codex can show known host/location and compact landmark preview | No reward, progress, active ghost, quest text, production, or rival city action |
+| Viewer has completed plus host-location-known intel | Summary prefers completed status and adds host/location preview as earned location knowledge | Do not infer missing fields from completion record |
+| Viewer has own state and rival location intel for same wonder | Owned label and owned actions remain primary; rival location appears as secondary intel | Do not replace owned status or owned city preview |
+| Hot-seat current player changes | Rival location marker/preview swaps to new viewer's records only | Do not retain previous viewer's DOM rows or map entries |
+
+## Data Model
+
+Extend `LegendaryWonderIntelKind` with:
+
+```ts
+export type LegendaryWonderIntelKind = 'started' | 'completed' | 'host-location-known';
+```
+
+Add a new union member:
+
+```ts
+export interface LegendaryWonderHostLocationIntelEntry {
+  kind: 'host-location-known';
+  eventId: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+  source: 'spy-location' | 'map-intel' | 'debug-grant';
+}
+```
+
+`cityId` is a snapshot identity for deduplication and text only. It must not be emitted as a Codex action target or used to open a rival city. `coord` is the only field that can support map placement, and it is allowed only because this tier explicitly stores location knowledge.
+
+Existing `started` and legacy `intelLevel: 'started'` records remain valid and normalize as they do today. They are not upgraded to `host-location-known` unless a new explicit record exists. Exact duplicate host-location records dedupe by stable `eventId`; distinct started, completed, and host-location records for the same wonder/rival/city may coexist.
+
+## Intel Creation Rules
+
+Stage 2J should add helper functions for constructing and recording host-location intel, and the first implementation should keep earning rules narrow.
+
+Create `host-location-known` intel only in a canonical system path when all of these are true:
+
+- the viewer has earned the location tier through the event source being implemented
+- the target wonder ID is a real legendary wonder
+- the rival civ is not the viewer
+- the host city snapshot includes a city ID, city name, and axial coordinate
+- the coordinate is stored as snapshot data on the intel record at creation time
+
+The first implementation grants the location tier from the existing stationed-spy rival-start observation path. That path already identifies the observer, rival civ, target city ID, target city name, and legendary wonder at the canonical moment the start intel is earned. Stage 2J records a separate `host-location-known` event there by snapshotting the host city's current axial coordinate. Existing saves and pre-2J `started` records are not upgraded.
+
+Do not create host-location records from rendering, Codex opening, map scanning, or hidden completed-wonder state. UI may display and route records; it must not mint them.
+
+## Presentation Architecture
+
+Add or extend system presentation helpers rather than duplicating privacy logic in UI.
+
+`src/systems/legendary-wonder-intel.ts` owns normalization, sanitization, dedupe, and construction helpers for the new union member.
+
+`src/systems/legendary-wonder-intel-presentation.ts` owns rival intel summaries. It may expose a safe location view containing `wonderId`, `civName`, `cityName`, `coord`, `learnedTurn`, and copy labels. It must not expose rival `cityId` in page actions.
+
+`src/systems/legendary-wonder-landmark-presentation.ts` should add a known-rival helper that converts host-location intel into `LegendaryWonderLandmarkView` or a sibling safe view. It must draw from intel records and static landmark metadata only.
+
+`src/systems/legendary-wonder-map-presentation.ts` should add known-rival map entries by reading explicit host-location records, not live rival city data. Known-rival map entries should use `relationship: 'known-rival'`, the stored coordinate, the stored city name for labels, and completed landmark metadata. They must not produce under-construction ghosts.
+
+`src/systems/wonder-codex/presentation.ts` should add known-rival landmark preview data only when the selected page has host-location intel. Owned previews stay primary and unchanged.
+
+UI modules render the resulting view models. They should not inspect raw rival projects, completed city IDs, or rival city objects.
+
+## Map And Visibility Contract
+
+Map placement requires an explicit stored coordinate and viewer map knowledge of that coordinate. A known-rival landmark may render when:
+
+- the viewer has a `host-location-known` record for that wonder/rival/city
+- the coordinate in the record is at least known to the viewer as `visible` or `fog`
+- the coordinate is within the camera's visible screen area
+
+The map renderer must still be passive. It consumes safe entries from `getLegendaryWonderMapEntries(state, viewerId)` and draws the existing landmark medallion path. It must not decide whether the player earned intel.
+
+If a coordinate is currently `unexplored` for the viewer, no map marker renders even if a malformed record exists. If the coordinate is fogged, the marker may render as remembered intel because the record itself is location knowledge, but it must not read live rival city state.
+
+## UI And UX
+
+Catalog entries keep one row per legendary wonder. A wonder with rival host/location intel may reuse the existing rival activity badge/count; it should not create a separate map-oriented catalog item.
+
+Codex pages should show:
+
+- owned state and owned landmark preview first, when present
+- rival summary and event log next
+- a compact `Known rival landmark` preview only when host-location intel exists
+- copy such as `Known host: Rival Harbor` and `Location learned on turn 62`
+
+Codex pages must not show rival `Open City`, `View on Map`, or reward actions in this slice. Any separate design that adds a rival map action must define an explicit action contract with tests.
+
+Territory or tile inspection may list a known-rival legendary landmark when the inspected coordinate matches a host-location intel record for the current viewer. It should render as informational text and compact preview only.
+
+## Privacy And Failure Modes
+
+- Completed intel alone is insufficient.
+- Started intel alone is insufficient for map/preview surfaces.
+- Hidden live rival city data is never used to fill missing intel fields.
+- Viewer A's host-location record never appears for viewer B.
+- Malformed records with unknown wonder IDs, missing city names, invalid coordinates, or self-rival civ IDs are sanitized away.
+- Unsupported or missing landmark metadata falls back through existing defensive landmark metadata paths, but catalog tests should keep authored definitions valid.
+
+## Testing Requirements
+
+System and intel tests:
+
+- new `host-location-known` entries normalize and sanitize.
+- malformed host-location records are removed.
+- duplicate host-location event IDs dedupe.
+- started and completed records for the same wonder/rival remain distinct from host-location records.
+- existing legacy started records do not become map-capable.
+- self-rival host-location records are rejected.
+
+Presentation tests:
+
+- completed-only rival intel does not produce host/location landmark preview or map entries.
+- started-only rival intel may render city name text but does not produce preview or map entries.
+- host-location-known intel produces safe Codex preview data without rival city action targets.
+- host-location-known intel produces known-rival map entries only from stored coordinates.
+- hidden `completedLegendaryWonders` and rival city objects do not enrich missing host-location records.
+- hot-seat viewer switching swaps known-rival previews and map entries by viewer.
+- serialized view models do not contain rival `cityId` action targets, progress, quest steps, reward summaries, production, or live project fields.
+
+Renderer and UI tests:
+
+- known-rival map entries draw through the same landmark renderer path as owned completed landmarks.
+- known-rival entries do not draw construction ghosts.
+- city label, production badge, status badge, and owned landmarks remain ordered according to Stage 2K pass tests.
+- Codex/Atlas UI renders the known-rival preview only when the view model contains it.
+- inspection text appears only for matching current-viewer location intel.
+
+Verification:
+
+- targeted legendary-wonder intel, map presentation, Codex presentation, renderer, and UI/inspection tests
+- `scripts/check-src-rule-violations.sh` for changed `src/` files
+- `./scripts/run-wonder-regressions.sh`
+- `./scripts/run-with-mise.sh yarn build`
+- `./scripts/run-with-mise.sh yarn test`
+
+## Acceptance Criteria
+
+- New host/location intel is represented as an explicit discriminated union member.
+- Existing completed intel alone still reveals no host, location, preview, or map marker.
+- Existing started intel remains text-only unless a separate host-location record exists.
+- Known-rival landmark previews and map entries render only from `host-location-known` records.
+- Map entries use stored coordinates and viewer visibility, never hidden live rival city/completion state.
+- Owned wonder state stays primary when owned and rival intel coexist.
+- Hot-seat privacy tests prove viewer-scoped records do not leak.
+- Wonder regressions, build, and full tests pass before merge.

--- a/docs/superpowers/specs/2026-06-04-stage-2j-legendary-landmark-intel-visibility-design.md
+++ b/docs/superpowers/specs/2026-06-04-stage-2j-legendary-landmark-intel-visibility-design.md
@@ -9,12 +9,12 @@
 
 Stage 2J lets the player see rival legendary landmarks only when the player has explicitly earned host/location intel. Earlier stages deliberately kept rival legendary completions as safe journal knowledge: the player could know that a rival completed a wonder without knowing where it was built. This stage adds the missing middle tier without weakening those privacy promises.
 
-The selected design is conservative for map and preview visibility. Existing `started` intel may continue to show a rival host city name as plain text because that snapshot already exists. Existing `completed` intel remains completion-only. Neither existing tier can create a rival map landmark, host-city action, or landmark preview. A new explicit `host-location-known` intel tier is required before known-rival landmarks can render on map, inspection, or Codex preview surfaces.
+The selected design is conservative for map and preview visibility. Existing `started` intel may continue to show a rival host city name as plain text because that snapshot already exists. Existing `completed` intel remains completion-only. Neither existing tier can create a rival map landmark, host-city action, or landmark preview by itself. A new explicit `host-location-known` intel tier is required before known-rival landmark surfaces can know where a rival wonder belongs, but completed landmark preview/map rendering also requires completed rival intel for the same wonder and rival. This avoids the misleading and less fun outcome where spying on a started rival project immediately paints it as a finished landmark.
 
 ## Goals
 
 - Add a new viewer-scoped `host-location-known` legendary wonder intel tier.
-- Render known-rival legendary landmarks only from `host-location-known` records.
+- Render known-rival legendary landmarks only from paired `host-location-known` and `completed` rival records.
 - Keep existing `started` intel as text-only host-name knowledge.
 - Keep existing `completed` intel from revealing host city, map coordinate, landmark preview, reward, progress, or action targets.
 - Preserve hot-seat privacy by reading only `state.legendaryWonderIntel[viewerId]`.
@@ -40,7 +40,7 @@ The player experience has three clear knowledge levels.
 
 `started` rival intel says a rival project was spotted. The Codex may show the stored rival city name as text, for example `Rival began Oracle of Delphi in Rival Harbor on turn 41`. This remains a historical spy snapshot. It does not become a map target or landmark preview.
 
-`host-location-known` rival intel says the viewer has explicitly learned the host city/location for a rival legendary wonder. This tier may show a compact known-rival landmark preview in the Codex and may create a known-rival map landmark entry if the stored coordinate is currently visible or fogged as an already-known map area for the viewer. The map marker is informational and decorative. It does not add an action target beyond existing tile/city inspection behavior.
+`host-location-known` rival intel says the viewer has explicitly learned the host city/location for a rival legendary wonder. By itself, this tier is host/location knowledge, not completion knowledge. The Codex may show a passive known-host line or event copy, but a compact known-rival landmark preview and known-rival map landmark entry appear only when a completed rival intel record also exists for the same viewer, wonder, and rival. The map marker is informational and decorative. It does not add an action target beyond existing tile/city inspection behavior.
 
 ## Player Truth Table
 
@@ -48,7 +48,7 @@ The player experience has three clear knowledge levels.
 |---|---|---|
 | Viewer has completed rival intel only | Codex shows known-rival completion text | No host city, map marker, landmark preview, reward, progress, or city action |
 | Viewer has started rival intel only | Codex event row may name the stored host city as text | No map marker, map action, preview, live city lookup, or coordinate |
-| Viewer has host-location-known intel only | Codex can show known host/location and compact landmark preview | No reward, progress, active ghost, quest text, production, or rival city action |
+| Viewer has host-location-known intel only | Codex can show known host/location as intel text | No landmark preview, map marker, reward, progress, active ghost, quest text, production, or rival city action |
 | Viewer has completed plus host-location-known intel | Summary prefers completed status and adds host/location preview as earned location knowledge | Do not infer missing fields from completion record |
 | Viewer has own state and rival location intel for same wonder | Owned label and owned actions remain primary; rival location appears as secondary intel | Do not replace owned status or owned city preview |
 | Hot-seat current player changes | Rival location marker/preview swaps to new viewer's records only | Do not retain previous viewer's DOM rows or map entries |
@@ -106,11 +106,11 @@ Add or extend system presentation helpers rather than duplicating privacy logic 
 
 `src/systems/legendary-wonder-intel-presentation.ts` owns rival intel summaries. It may expose a safe location view containing `wonderId`, `civName`, `cityName`, `coord`, `learnedTurn`, and copy labels. It must not expose rival `cityId` in page actions.
 
-`src/systems/legendary-wonder-landmark-presentation.ts` should add a known-rival helper that converts host-location intel into `LegendaryWonderLandmarkView` or a sibling safe view. It must draw from intel records and static landmark metadata only.
+`src/systems/legendary-wonder-landmark-presentation.ts` should add a known-rival helper that converts paired completion-plus-host-location intel into `LegendaryWonderLandmarkView` or a sibling safe view. It must draw from intel records and static landmark metadata only.
 
-`src/systems/legendary-wonder-map-presentation.ts` should add known-rival map entries by reading explicit host-location records, not live rival city data. Known-rival map entries should use `relationship: 'known-rival'`, the stored coordinate, the stored city name for labels, and completed landmark metadata. They must not produce under-construction ghosts.
+`src/systems/legendary-wonder-map-presentation.ts` should add known-rival map entries by reading explicit host-location records paired with completed rival records, not live rival city data. Known-rival map entries should use `relationship: 'known-rival'`, the stored coordinate, the stored city name for labels, and completed landmark metadata. They must not produce under-construction ghosts.
 
-`src/systems/wonder-codex/presentation.ts` should add known-rival landmark preview data only when the selected page has host-location intel. Owned previews stay primary and unchanged.
+`src/systems/wonder-codex/presentation.ts` should add known-rival landmark preview data only when the selected page has paired completion-plus-host-location intel. Owned previews stay primary and unchanged.
 
 UI modules render the resulting view models. They should not inspect raw rival projects, completed city IDs, or rival city objects.
 
@@ -119,12 +119,13 @@ UI modules render the resulting view models. They should not inspect raw rival p
 Map placement requires an explicit stored coordinate and viewer map knowledge of that coordinate. A known-rival landmark may render when:
 
 - the viewer has a `host-location-known` record for that wonder/rival/city
+- the viewer also has a `completed` rival intel record for the same wonder and rival
 - the coordinate in the record is at least known to the viewer as `visible` or `fog`
 - the coordinate is within the camera's visible screen area
 
 The map renderer must still be passive. It consumes safe entries from `getLegendaryWonderMapEntries(state, viewerId)` and draws the existing landmark medallion path. It must not decide whether the player earned intel.
 
-If a coordinate is currently `unexplored` for the viewer, no map marker renders even if a malformed record exists. If the coordinate is fogged, the marker may render as remembered intel because the record itself is location knowledge, but it must not read live rival city state.
+If a coordinate is currently `unexplored` for the viewer, no map marker renders even if a malformed record exists. If the coordinate is fogged, the marker may render as remembered intel because paired completion-plus-location records are already earned knowledge, but it must not read live rival city state.
 
 ## UI And UX
 
@@ -134,17 +135,19 @@ Codex pages should show:
 
 - owned state and owned landmark preview first, when present
 - rival summary and event log next
-- a compact `Known rival landmark` preview only when host-location intel exists
+- a passive known-host line when host-location intel exists before completion
+- a compact `Known rival landmark` preview only when paired completion-plus-host-location intel exists
 - copy such as `Known host: Rival Harbor` and `Location learned on turn 62`
 
 Codex pages must not show rival `Open City`, `View on Map`, or reward actions in this slice. Any separate design that adds a rival map action must define an explicit action contract with tests.
 
-Territory or tile inspection may list a known-rival legendary landmark when the inspected coordinate matches a host-location intel record for the current viewer. It should render as informational text and compact preview only.
+Territory or tile inspection may list a known-rival legendary landmark when the inspected coordinate matches paired completion-plus-host-location intel for the current viewer. It should render as informational text and compact preview only.
 
 ## Privacy And Failure Modes
 
 - Completed intel alone is insufficient.
 - Started intel alone is insufficient for map/preview surfaces.
+- Host-location intel alone is insufficient for completed landmark preview/map surfaces.
 - Hidden live rival city data is never used to fill missing intel fields.
 - Viewer A's host-location record never appears for viewer B.
 - Malformed records with unknown wonder IDs, missing city names, invalid coordinates, or self-rival civ IDs are sanitized away.
@@ -165,8 +168,9 @@ Presentation tests:
 
 - completed-only rival intel does not produce host/location landmark preview or map entries.
 - started-only rival intel may render city name text but does not produce preview or map entries.
-- host-location-known intel produces safe Codex preview data without rival city action targets.
-- host-location-known intel produces known-rival map entries only from stored coordinates.
+- host-location-known intel alone produces safe known-host text without rival city action targets.
+- paired host-location-known plus completed intel produces safe Codex preview data without rival city action targets.
+- paired host-location-known plus completed intel produces known-rival map entries only from stored coordinates.
 - hidden `completedLegendaryWonders` and rival city objects do not enrich missing host-location records.
 - hot-seat viewer switching swaps known-rival previews and map entries by viewer.
 - serialized view models do not contain rival `cityId` action targets, progress, quest steps, reward summaries, production, or live project fields.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -139,7 +139,7 @@ export interface LegendaryWonderHistory {
   discoveredSites: LegendaryWonderDiscoveredSiteRecord[];
 }
 
-export type LegendaryWonderIntelKind = 'started' | 'completed';
+export type LegendaryWonderIntelKind = 'started' | 'completed' | 'host-location-known';
 
 export interface LegacyLegendaryWonderStartedIntelEntry {
   projectKey: string;
@@ -177,14 +177,29 @@ export interface LegendaryWonderCompletedIntelEntry {
   learnedTurn: number;
 }
 
+export interface LegendaryWonderHostLocationIntelEntry {
+  kind: 'host-location-known';
+  eventId: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+  source: 'spy-location' | 'map-intel' | 'debug-grant';
+}
+
 export type LegendaryWonderIntelEntry =
   | LegacyLegendaryWonderStartedIntelEntry
   | LegendaryWonderStartedIntelEntry
-  | LegendaryWonderCompletedIntelEntry;
+  | LegendaryWonderCompletedIntelEntry
+  | LegendaryWonderHostLocationIntelEntry;
 
 export type NormalizedLegendaryWonderIntelEntry =
   | LegendaryWonderStartedIntelEntry
-  | LegendaryWonderCompletedIntelEntry;
+  | LegendaryWonderCompletedIntelEntry
+  | LegendaryWonderHostLocationIntelEntry;
 
 // --- Tribal Villages ---
 

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -14,6 +14,7 @@ export interface CityRenderProjection {
   owner: string;
   isLive: boolean;
   liveCityId?: string;
+  renderMode?: 'city' | 'landmark-only';
 }
 
 export interface CityRenderItem {
@@ -67,6 +68,7 @@ function markPass(ctx: CanvasRenderingContext2D, passName: CityRenderPassName): 
 }
 
 export function drawCityBasePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'base');
   ctx.beginPath();
   ctx.arc(item.screen.x, item.screen.y, item.size * 0.45, 0, Math.PI * 2);
@@ -78,6 +80,7 @@ export function drawCityBasePass(ctx: CanvasRenderingContext2D, item: CityRender
 }
 
 export function drawCityIconPass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'icon');
   ctx.font = `${item.size * 0.45}px system-ui`;
   ctx.textAlign = 'center';
@@ -106,6 +109,7 @@ export function drawCityLandmarkPass(ctx: CanvasRenderingContext2D, item: CityRe
 }
 
 export function drawCityLabelPass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'label');
   ctx.font = `bold ${Math.max(9, item.size * 0.22)}px system-ui`;
   ctx.fillStyle = '#fff';
@@ -119,6 +123,7 @@ export function drawCityLabelPass(ctx: CanvasRenderingContext2D, item: CityRende
 }
 
 export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'status');
   if (!item.projection.isLive || !item.city) return;
 
@@ -139,6 +144,7 @@ export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: Cit
 }
 
 export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'production');
   if (!item.projection.isLive || !item.city || item.city.owner !== item.playerCivId) return;
 
@@ -165,6 +171,7 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
 }
 
 export function drawCityIdleBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
+  if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'idle');
   if (
     !item.projection.isLive ||

--- a/src/renderer/city-renderer.ts
+++ b/src/renderer/city-renderer.ts
@@ -80,13 +80,16 @@ function createCityRenderItems(
   const vis = state.civilizations[playerCivId]?.visibility;
   if (!vis) return [];
 
-  const landmarksByCity = new Map<string, LegendaryWonderMapEntry[]>();
+  const landmarksByCoord = new Map<string, LegendaryWonderMapEntry[]>();
   for (const entry of getLegendaryWonderMapEntries(state, playerCivId)) {
-    landmarksByCity.set(entry.cityId, [...(landmarksByCity.get(entry.cityId) ?? []), entry]);
+    const key = `${entry.coord.q},${entry.coord.r}`;
+    landmarksByCoord.set(key, [...(landmarksByCoord.get(key) ?? []), entry]);
   }
 
   const items: CityRenderItem[] = [];
-  for (const projection of getCityRenderProjection(state, playerCivId)) {
+  const projections = getCityRenderProjection(state, playerCivId);
+  const projectedKeys = new Set(projections.map(projection => `${projection.position.q},${projection.position.r}`));
+  for (const projection of projections) {
     const city = projection.liveCityId ? state.cities[projection.liveCityId] : undefined;
     const mcState = projection.isLive && projection.owner.startsWith('mc-') ? state.minorCivs?.[projection.owner] : null;
     const mcDef = mcState ? MINOR_CIV_DEFINITIONS.find(definition => definition.id === mcState.definitionId) : null;
@@ -111,9 +114,7 @@ function createCityRenderItems(
       const pixel = hexToPixel(renderCoord, camera.hexSize);
       const screen = camera.worldToScreen(pixel.x, pixel.y);
       const size = camera.hexSize * camera.zoom;
-      const landmarkEntries = projection.liveCityId
-        ? landmarksByCity.get(projection.liveCityId) ?? []
-        : [];
+      const landmarkEntries = landmarksByCoord.get(`${projection.position.q},${projection.position.r}`) ?? [];
 
       items.push({
         projection,
@@ -125,6 +126,44 @@ function createCityRenderItems(
         isMinorCiv: projection.isLive && projection.owner.startsWith('mc-'),
         minorCivIcon,
         breakaway: breakaway ? { status: breakaway.status } : undefined,
+        landmarkEntries,
+        lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
+        reducedMotion,
+        nowMs,
+        turn: state.turn,
+      });
+    }
+  }
+
+  for (const [coordKey, landmarkEntries] of landmarksByCoord.entries()) {
+    if (projectedKeys.has(coordKey)) continue;
+    const [q, r] = coordKey.split(',').map(Number);
+    const coord = { q, r };
+    const renderCoords = state.map.wrapsHorizontally
+      ? getHorizontalWrapRenderCoords(coord, state.map.width, camera)
+      : [coord];
+    for (const renderCoord of renderCoords) {
+      if (!camera.isHexVisible(renderCoord)) continue;
+      const pixel = hexToPixel(renderCoord, camera.hexSize);
+      const screen = camera.worldToScreen(pixel.x, pixel.y);
+      const size = camera.hexSize * camera.zoom;
+      const firstEntry = landmarkEntries[0];
+      items.push({
+        projection: {
+          name: firstEntry.cityName ?? firstEntry.label,
+          position: coord,
+          population: 0,
+          owner: firstEntry.ownerId,
+          isLive: false,
+          renderMode: 'landmark-only',
+        },
+        screen,
+        size,
+        ownerColor: state.civilizations[firstEntry.ownerId]?.color
+          ?? OWNER_COLORS[firstEntry.ownerId]
+          ?? '#888',
+        playerCivId,
+        isMinorCiv: false,
         landmarkEntries,
         lowZoom: camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD,
         reducedMotion,

--- a/src/systems/legendary-wonder-intel-presentation.ts
+++ b/src/systems/legendary-wonder-intel-presentation.ts
@@ -1,12 +1,15 @@
-import type { GameState, NormalizedLegendaryWonderIntelEntry } from '@/core/types';
+import type { GameState, HexCoord, NormalizedLegendaryWonderIntelEntry } from '@/core/types';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
 import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 
-export type LegendaryWonderRivalIntelStateLabel = 'Known rival completed' | 'Spotted rival project';
+export type LegendaryWonderRivalIntelStateLabel =
+  | 'Known rival completed'
+  | 'Spotted rival project'
+  | 'Known rival host';
 
 export interface LegendaryWonderRivalIntelEventView {
   id: string;
-  kind: 'started' | 'completed';
+  kind: 'started' | 'completed' | 'host-location-known';
   civId: string;
   civName: string;
   turn: number;
@@ -21,6 +24,16 @@ export interface LegendaryWonderRivalIntelSummary {
   stateLabel: LegendaryWonderRivalIntelStateLabel;
   summaryLine: string;
   events: LegendaryWonderRivalIntelEventView[];
+}
+
+export interface LegendaryWonderRivalHostLocationView {
+  id: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
 }
 
 function wonderName(wonderId: string): string {
@@ -41,6 +54,18 @@ function eventView(entry: NormalizedLegendaryWonderIntelEntry): LegendaryWonderR
     };
   }
 
+  if (entry.kind === 'host-location-known') {
+    return {
+      id: entry.eventId,
+      kind: 'host-location-known',
+      civId: entry.civId,
+      civName: entry.civName,
+      turn: entry.learnedTurn,
+      title: 'Known rival host',
+      text: `${entry.cityName} for ${name}. Location learned on turn ${entry.learnedTurn}.`,
+    };
+  }
+
   return {
     id: entry.eventId,
     kind: 'started',
@@ -53,20 +78,30 @@ function eventView(entry: NormalizedLegendaryWonderIntelEntry): LegendaryWonderR
 }
 
 function bestState(events: LegendaryWonderRivalIntelEventView[]): LegendaryWonderRivalIntelStateLabel {
-  return events.some(event => event.kind === 'completed')
-    ? 'Known rival completed'
-    : 'Spotted rival project';
+  if (events.some(event => event.kind === 'completed')) return 'Known rival completed';
+  if (events.some(event => event.kind === 'started')) return 'Spotted rival project';
+  if (events.some(event => event.kind === 'host-location-known')) return 'Known rival host';
+  return 'Spotted rival project';
 }
 
 function summaryLine(wonderId: string, events: LegendaryWonderRivalIntelEventView[]): string {
   const completed = [...events].reverse().find(event => event.kind === 'completed');
+  const location = [...events].reverse().find(event => event.kind === 'host-location-known');
   if (completed) {
-    return `Known rival completed: ${completed.text}`;
+    return location
+      ? `Known rival completed: ${completed.text} Known host: ${location.text}`
+      : `Known rival completed: ${completed.text}`;
   }
 
   const started = [...events].reverse().find(event => event.kind === 'started');
   if (started) {
-    return `Last known: under construction. ${started.text}`;
+    return location
+      ? `Last known: under construction. ${started.text} Known host: ${location.text}`
+      : `Last known: under construction. ${started.text}`;
+  }
+
+  if (location) {
+    return `Known host: ${location.text}`;
   }
 
   return `No known rival activity for ${wonderName(wonderId)}.`;
@@ -114,4 +149,25 @@ export function isLegendaryWonderVisibleToPlayer(
   if (owned && owned.phase !== 'locked') return true;
   const summaries = precomputedRivalIntel ?? getLegendaryWonderRivalIntelSummariesForViewer(state, viewerId);
   return summaries.has(wonderId);
+}
+
+export function getLegendaryWonderHostLocationIntelForViewer(
+  state: GameState,
+  viewerId: string,
+  wonderId?: string,
+): LegendaryWonderRivalHostLocationView[] {
+  return getLegendaryWonderIntelForViewer(state, viewerId)
+    .filter((entry): entry is Extract<NormalizedLegendaryWonderIntelEntry, { kind: 'host-location-known' }> =>
+      entry.kind === 'host-location-known' && (!wonderId || entry.wonderId === wonderId),
+    )
+    .map(entry => ({
+      id: entry.eventId,
+      wonderId: entry.wonderId,
+      civId: entry.civId,
+      civName: entry.civName,
+      cityName: entry.cityName,
+      coord: { ...entry.coord },
+      learnedTurn: entry.learnedTurn,
+    }))
+    .sort((a, b) => b.learnedTurn - a.learnedTurn || a.civName.localeCompare(b.civName) || a.id.localeCompare(b.id));
 }

--- a/src/systems/legendary-wonder-intel.ts
+++ b/src/systems/legendary-wonder-intel.ts
@@ -1,6 +1,8 @@
 import type {
   GameState,
+  HexCoord,
   LegendaryWonderCompletedIntelEntry,
+  LegendaryWonderHostLocationIntelEntry,
   LegendaryWonderIntelEntry,
   LegendaryWonderStartedIntelEntry,
   NormalizedLegendaryWonderIntelEntry,
@@ -14,6 +16,14 @@ function startedEventId(projectKey: string, revealedTurn: number): string {
 
 function completedEventId(wonderId: string, civId: string, completionTurn: number): string {
   return `completed:${wonderId}:${civId}:${completionTurn}`;
+}
+
+function hostLocationEventId(projectKey: string, learnedTurn: number): string {
+  return `location:${projectKey}:${learnedTurn}`;
+}
+
+function isValidCoord(coord: HexCoord | undefined): coord is HexCoord {
+  return !!coord && Number.isFinite(coord.q) && Number.isFinite(coord.r);
 }
 
 export function normalizeLegendaryWonderIntelEntry(
@@ -32,6 +42,17 @@ export function normalizeLegendaryWonderIntelEntry(
       ...entry,
       eventId: entry.eventId || startedEventId(entry.projectKey, entry.revealedTurn),
       intelLevel: entry.intelLevel,
+    };
+  }
+
+  if (entry.kind === 'host-location-known') {
+    if (!getLegendaryWonderDefinition(entry.wonderId)) return null;
+    if (!entry.eventId || !entry.civId || !entry.civName || !entry.cityId || !entry.cityName) return null;
+    if (!isValidCoord(entry.coord)) return null;
+    if (entry.source !== 'spy-location' && entry.source !== 'map-intel' && entry.source !== 'debug-grant') return null;
+    return {
+      ...entry,
+      coord: { ...entry.coord },
     };
   }
 
@@ -64,7 +85,7 @@ export function sanitizeLegendaryWonderIntel(
         const seen = new Set<string>();
         for (const entry of entries) {
           const safeEntry = normalizeLegendaryWonderIntelEntry(entry);
-          if (!safeEntry || seen.has(safeEntry.eventId)) continue;
+          if (!safeEntry || safeEntry.civId === viewerId || seen.has(safeEntry.eventId)) continue;
           seen.add(safeEntry.eventId);
           normalized.push(safeEntry);
         }
@@ -132,6 +153,31 @@ export function createCompletedLegendaryWonderIntelEntry(input: {
     kind: 'completed',
     eventId: completedEventId(input.wonderId, input.civId, input.completionTurn),
     ...input,
+  };
+}
+
+export function createHostLocationLegendaryWonderIntelEntry(input: {
+  projectKey: string;
+  wonderId: string;
+  civId: string;
+  civName: string;
+  cityId: string;
+  cityName: string;
+  coord: HexCoord;
+  learnedTurn: number;
+  source: LegendaryWonderHostLocationIntelEntry['source'];
+}): LegendaryWonderHostLocationIntelEntry {
+  return {
+    kind: 'host-location-known',
+    eventId: hostLocationEventId(input.projectKey, input.learnedTurn),
+    wonderId: input.wonderId,
+    civId: input.civId,
+    civName: input.civName,
+    cityId: input.cityId,
+    cityName: input.cityName,
+    coord: { ...input.coord },
+    learnedTurn: input.learnedTurn,
+    source: input.source,
   };
 }
 

--- a/src/systems/legendary-wonder-landmark-presentation.ts
+++ b/src/systems/legendary-wonder-landmark-presentation.ts
@@ -1,6 +1,8 @@
 import type { City, GameState } from '@/core/types';
 import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
 import type { LegendaryWonderLandmarkView } from '@/systems/legendary-wonder-landmark-types';
 
 export const LEGENDARY_CONSTRUCTION_GHOST_MAP_THRESHOLD = 0.6;
@@ -89,4 +91,38 @@ export function getLegendaryLandmarkPreviewViewForCity(
     .map(item => ({ wonderId: item.wonderId, label: item.label, state: item.state }));
   if (items.length === 0) return null;
   return { cityId, cityName: city.name, items };
+}
+
+export interface KnownRivalLegendaryLandmarkPreviewView {
+  cityName: string;
+  civName: string;
+  learnedTurn: number;
+  items: Array<{
+    wonderId: string;
+    label: string;
+    state: 'completed';
+  }>;
+}
+
+export function getKnownRivalLegendaryLandmarkPreviewForWonder(
+  state: GameState,
+  viewerId: string,
+  wonderId: string,
+): KnownRivalLegendaryLandmarkPreviewView | null {
+  const completion = getLegendaryWonderIntelForViewer(state, viewerId)
+    .find(entry => entry.kind === 'completed' && entry.wonderId === wonderId);
+  if (!completion) return null;
+  const [location] = getLegendaryWonderHostLocationIntelForViewer(state, viewerId, wonderId)
+    .filter(candidate => candidate.civId === completion.civId);
+  if (!location) return null;
+  return {
+    cityName: location.cityName,
+    civName: location.civName,
+    learnedTurn: location.learnedTurn,
+    items: [{
+      wonderId,
+      label: getLegendaryWonderDefinition(wonderId)?.name ?? 'Legendary wonder',
+      state: 'completed',
+    }],
+  };
 }

--- a/src/systems/legendary-wonder-map-presentation.ts
+++ b/src/systems/legendary-wonder-map-presentation.ts
@@ -1,5 +1,10 @@
 import type { GameState, HexCoord } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey } from '@/systems/hex-utils';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
 import {
   getActiveLegendaryConstructionGhostForCity,
   getCompletedLegendaryLandmarksForCity,
@@ -9,7 +14,8 @@ import { getWonderVisualDefinition, type WonderVisualDefinition } from '@/system
 
 export interface LegendaryWonderMapEntry {
   wonderId: string;
-  cityId: string;
+  cityId?: string;
+  cityName?: string;
   coord: HexCoord;
   ownerId: string;
   relationship: 'owned' | 'known-rival';
@@ -59,6 +65,34 @@ export function getLegendaryWonderMapEntries(state: GameState, viewerId: string)
         progressRatio: ghost.progressRatio,
       });
     }
+  }
+
+  const completedRivalKeys = new Set(
+    getLegendaryWonderIntelForViewer(state, viewerId)
+      .filter(entry => entry.kind === 'completed')
+      .map(entry => `${entry.wonderId}:${entry.civId}`),
+  );
+  const seenKnownRival = new Set<string>();
+  for (const location of getLegendaryWonderHostLocationIntelForViewer(state, viewerId)) {
+    if (!completedRivalKeys.has(`${location.wonderId}:${location.civId}`)) continue;
+    const tileVisibility = getVisibility(visibility, location.coord);
+    if (tileVisibility === 'unexplored') continue;
+    const key = `${location.wonderId}:${location.civId}:${hexKey(location.coord)}`;
+    if (seenKnownRival.has(key)) continue;
+    seenKnownRival.add(key);
+    entries.push({
+      wonderId: location.wonderId,
+      cityName: location.cityName,
+      coord: { ...location.coord },
+      ownerId: location.civId,
+      relationship: 'known-rival',
+      state: 'completed',
+      turnCompleted: location.learnedTurn,
+      label: getLegendaryWonderDefinition(location.wonderId)?.name ?? 'Legendary wonder',
+      visual: getWonderVisualDefinition(location.wonderId),
+      metadata: getLegendaryWonderLandmarkMetadata(location.wonderId),
+      progressRatio: undefined,
+    });
   }
   return entries;
 }

--- a/src/systems/legendary-wonder-system.ts
+++ b/src/systems/legendary-wonder-system.ts
@@ -5,6 +5,7 @@ import { getTechById } from '@/systems/tech-system';
 import { hexDistance } from '@/systems/hex-utils';
 import { routeMatchesLegendaryWonderRequirement } from '@/systems/trade-route-classification';
 import {
+  createHostLocationLegendaryWonderIntelEntry,
   createStartedLegendaryWonderIntelEntry,
   recordKnownHumanLegendaryWonderCompletionIntel,
   recordLegendaryWonderIntel,
@@ -655,6 +656,26 @@ export function startLegendaryWonderBuild(
         revealedTurn: state.turn,
       }),
     );
+    if (city) {
+      legendaryWonderIntel = recordLegendaryWonderIntel(
+        {
+          ...seededState,
+          legendaryWonderIntel,
+        },
+        observerId,
+        createHostLocationLegendaryWonderIntelEntry({
+          projectKey,
+          wonderId: project.wonderId,
+          civId,
+          civName: civilization?.name ?? civId,
+          cityId,
+          cityName: city.name,
+          coord: city.position,
+          learnedTurn: state.turn,
+          source: 'spy-location',
+        }),
+      );
+    }
     bus?.emit('wonder:legendary-race-revealed', {
       observerId,
       civId,

--- a/src/systems/wonder-atlas-presentation.ts
+++ b/src/systems/wonder-atlas-presentation.ts
@@ -31,7 +31,7 @@ export interface LegendaryWonderAtlasEntry {
   visibility: 'masked';
   name: string;
   maskedLabel: string;
-  stateLabel: 'Available' | 'Under construction' | 'Completed' | 'Recovered' | 'Known rival completed' | 'Spotted rival project' | 'Legendary wonder';
+  stateLabel: 'Available' | 'Under construction' | 'Completed' | 'Recovered' | 'Known rival completed' | 'Known rival host' | 'Spotted rival project' | 'Legendary wonder';
   canViewOnMap: false;
   visual: WonderVisualDefinition;
   rivalIntelCount: number;

--- a/src/systems/wonder-codex/presentation.ts
+++ b/src/systems/wonder-codex/presentation.ts
@@ -14,7 +14,9 @@ import {
   type LegendaryWonderRivalIntelSummary,
 } from '@/systems/legendary-wonder-intel-presentation';
 import {
+  getKnownRivalLegendaryLandmarkPreviewForWonder,
   getLegendaryLandmarkPreviewViewForCity,
+  type KnownRivalLegendaryLandmarkPreviewView,
   type LegendaryWonderLandmarkPreviewView,
 } from '@/systems/legendary-wonder-landmark-presentation';
 
@@ -52,6 +54,7 @@ export interface WonderCodexPageViewModel extends WonderCodexCatalogEntry {
   statusLines: string[];
   rivalIntel?: LegendaryWonderRivalIntelSummary;
   landmarkPreview?: LegendaryWonderLandmarkPreviewView;
+  knownRivalLandmarkPreview?: KnownRivalLegendaryLandmarkPreviewView;
   canStartBuild?: boolean;
   questSteps?: Array<{ id: string; description: string; completed: boolean }>;
   sections: WonderCodexSection[];
@@ -189,6 +192,7 @@ function buildLegendaryStatus(
   const statusLines = [`Status: ${label}`];
   const ownsKnownState = label !== 'Legendary wonder'
     && label !== 'Known rival completed'
+    && label !== 'Known rival host'
     && label !== 'Spotted rival project';
   if (definition && ownsKnownState) statusLines.push(`Reward: ${definition.reward.summary}`);
 
@@ -233,6 +237,9 @@ function buildPage(
   const landmarkPreview = cityIdForPreview
     ? getLegendaryLandmarkPreviewViewForCity(state, viewerId, cityIdForPreview)
     : null;
+  const knownRivalLandmarkPreview = entry.kind === 'legendary'
+    ? getKnownRivalLegendaryLandmarkPreviewForWonder(state, viewerId, entry.id)
+    : null;
 
   return {
     ...entry,
@@ -248,6 +255,7 @@ function buildPage(
     statusLines: status.statusLines,
     ...(rivalIntel ? { rivalIntel } : {}),
     ...(landmarkPreview ? { landmarkPreview } : {}),
+    ...(knownRivalLandmarkPreview ? { knownRivalLandmarkPreview } : {}),
     canStartBuild: status.canStartBuild,
     ...(status.questSteps ? { questSteps: status.questSteps } : {}),
     sections: content.sections.map(section => ({ ...section })),

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -4,7 +4,10 @@ import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { TERRITORY_PRESSURE_BALANCE } from '@/systems/city-territory-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
+import { getLegendaryWonderDefinition } from '@/systems/legendary-wonder-definitions';
+import { getLegendaryWonderIntelForViewer } from '@/systems/legendary-wonder-intel';
 import { getCompletedLegendaryLandmarksForCity } from '@/systems/legendary-wonder-landmark-presentation';
+import { getLegendaryWonderHostLocationIntelForViewer } from '@/systems/legendary-wonder-intel-presentation';
 import { renderTerritoryFrontierInfo } from '@/ui/territory-frontier-info';
 import { createGameButton } from '@/ui/ui-kit';
 import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
@@ -31,6 +34,22 @@ function addLine(parent: HTMLElement, label: string, value: string): void {
   line.appendChild(labelNode);
   line.appendChild(valueNode);
   parent.appendChild(line);
+}
+
+function getKnownRivalLegendaryLandmarkLines(state: GameState, coord: HexCoord, viewerId: string): string[] {
+  const key = hexKey(coord);
+  const completedRivalKeys = new Set(
+    getLegendaryWonderIntelForViewer(state, viewerId)
+      .filter(entry => entry.kind === 'completed')
+      .map(entry => `${entry.wonderId}:${entry.civId}`),
+  );
+  return getLegendaryWonderHostLocationIntelForViewer(state, viewerId)
+    .filter(entry => completedRivalKeys.has(`${entry.wonderId}:${entry.civId}`))
+    .filter(entry => hexKey(entry.coord) === key)
+    .map(entry => {
+      const definition = getLegendaryWonderDefinition(entry.wonderId);
+      return `${definition?.name ?? entry.wonderId} in ${entry.cityName}`;
+    });
 }
 
 export function createTerritoryInspectionPanel(
@@ -134,6 +153,11 @@ export function createTerritoryInspectionPanel(
   if (tile.wonder) addLine(panel, 'Wonder', getWonderDefinition(tile.wonder)?.name ?? tile.wonder);
 
   if (visibility === 'fog') {
+    const knownRivalAtCoord = getKnownRivalLegendaryLandmarkLines(state, coord, viewerId);
+    if (knownRivalAtCoord.length > 0) {
+      addLine(panel, 'Known rival legendary landmark', knownRivalAtCoord.join(', '));
+    }
+
     const fogNotice = document.createElement('p');
     fogNotice.style.cssText = 'margin:12px 0 0;color:rgba(244,241,232,0.7);font-size:13px;line-height:1.35;';
     fogNotice.textContent = 'Last seen information only. Current border pressure is unknown.';
@@ -150,6 +174,11 @@ export function createTerritoryInspectionPanel(
     : [];
   if (completedInCity.length > 0) {
     addLine(panel, 'Completed legendary wonders', completedInCity.join(', '));
+  }
+
+  const knownRivalAtCoord = getKnownRivalLegendaryLandmarkLines(state, coord, viewerId);
+  if (knownRivalAtCoord.length > 0) {
+    addLine(panel, 'Known rival legendary landmark', knownRivalAtCoord.join(', '));
   }
 
   const frontier = state.territoryFrontiers?.[key];

--- a/src/ui/wonder-codex-page.ts
+++ b/src/ui/wonder-codex-page.ts
@@ -211,6 +211,29 @@ export function createWonderCodexPage(
     root.appendChild(preview);
   }
 
+  if (page.knownRivalLandmarkPreview) {
+    const preview = document.createElement('section');
+    preview.dataset.section = 'known-rival-landmark-preview';
+    preview.style.cssText = 'border:1px solid rgba(232,193,112,0.24);border-radius:8px;padding:10px;background:rgba(232,193,112,0.07);display:grid;gap:6px;';
+    appendText(preview, 'h4', 'Known rival landmark', 'margin:0;font-size:13px;color:#f4d188;');
+    appendText(
+      preview,
+      'p',
+      `${page.knownRivalLandmarkPreview.civName} host: ${page.knownRivalLandmarkPreview.cityName}. Location learned on turn ${page.knownRivalLandmarkPreview.learnedTurn}.`,
+      'margin:0;font-size:12px;color:rgba(248,241,223,0.74);',
+    );
+    const list = document.createElement('ul');
+    list.style.cssText = 'margin:0;padding-left:18px;display:grid;gap:4px;font-size:12px;color:rgba(248,241,223,0.74);';
+    for (const item of page.knownRivalLandmarkPreview.items) {
+      const li = document.createElement('li');
+      li.dataset.knownRivalLandmarkPreview = item.wonderId;
+      li.textContent = `${item.label} - Completed`;
+      list.appendChild(li);
+    }
+    preview.appendChild(list);
+    root.appendChild(preview);
+  }
+
   if (page.rivalIntel) {
     const rivalIntel = document.createElement('section');
     rivalIntel.dataset.rivalIntelSection = 'true';

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -4,6 +4,7 @@ import { drawCities, getCityRenderData, getProductionBadgeIcon } from '@/rendere
 import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
+import { getLegendaryWonderMapEntries } from '@/systems/legendary-wonder-map-presentation';
 import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
@@ -514,6 +515,86 @@ describe('drawCities — explicit city render pass contract', () => {
     drawCities(ctx, state, makeCamera(), 'player', { nowMs: 1000 });
 
     expect((ctx as unknown as MockCanvasContext).operations).not.toContain('legendary-landmarks:start');
+  });
+
+  it('draws known-rival landmark entries from paired intel without live rival labels or badges', () => {
+    const state = createNewGame(undefined, 'known-rival-landmark-render', 'small');
+    const coord = { q: 4, r: 2 };
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'fog';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawCities(ctx, state, makeCamera(), 'player', { nowMs: 1000 });
+
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('legendary-landmarks:start');
+    expect((ctx as unknown as MockCanvasContext).operations).toContain('city-pass:landmarks');
+    const texts = (ctx as unknown as MockCanvasContext).fillTextCalls.map(call => call.text);
+    expect(texts).not.toContain('Rival Harbor (0)');
+    expect(texts).not.toContain('🏗️');
+    expect(texts).not.toContain('⚡');
+  });
+
+  it('does not draw construction ghosts for known-rival location intel', () => {
+    const state = createNewGame(undefined, 'known-rival-no-ghost', 'small');
+    const coord = { q: 4, r: 2 };
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const entries = getLegendaryWonderMapEntries(state, 'player');
+
+    expect(entries).toContainEqual(expect.objectContaining({
+      relationship: 'known-rival',
+      state: 'completed',
+      progressRatio: undefined,
+    }));
   });
 });
 

--- a/tests/systems/legendary-wonder-intel.test.ts
+++ b/tests/systems/legendary-wonder-intel.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createHostLocationLegendaryWonderIntelEntry,
+  getLegendaryWonderIntelForViewer,
+  recordLegendaryWonderIntel,
+  sanitizeLegendaryWonderIntel,
+} from '@/systems/legendary-wonder-intel';
+import { makeLegendaryWonderFixture } from './helpers/legendary-wonder-fixture';
+
+describe('legendary-wonder-intel host-location records', () => {
+  it('normalizes host-location records with stored coordinate snapshots', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:41',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 41,
+        source: 'spy-location',
+      }],
+    };
+
+    expect(getLegendaryWonderIntelForViewer(state, 'player')).toEqual([
+      expect.objectContaining({
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:rival:city-rival:41',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+      }),
+    ]);
+  });
+
+  it('sanitizes malformed host-location records and self-rival records', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:unknown:rival:city-rival:41',
+          wonderId: 'unknown',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: { q: 4, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:player:city-river:41',
+          wonderId: 'oracle-of-delphi',
+          civId: 'player',
+          civName: 'Player',
+          cityId: 'city-river',
+          cityName: 'River City',
+          coord: { q: 2, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:bad-city:41',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'bad-city',
+          cityName: '',
+          coord: { q: Number.NaN, r: 2 },
+          learnedTurn: 41,
+          source: 'spy-location',
+        },
+      ],
+    };
+
+    expect(sanitizeLegendaryWonderIntel(state)).toEqual({});
+  });
+
+  it('dedupes exact host-location event IDs while preserving distinct intel tiers', () => {
+    const state = makeLegendaryWonderFixture();
+    const started = {
+      kind: 'started' as const,
+      eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+      projectKey: 'oracle-of-delphi:rival:city-rival',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      cityId: 'city-rival',
+      cityName: 'Rival Harbor',
+      revealedTurn: 41,
+    };
+    const location = createHostLocationLegendaryWonderIntelEntry({
+      projectKey: 'oracle-of-delphi:rival:city-rival',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      cityId: 'city-rival',
+      cityName: 'Rival Harbor',
+      coord: { q: 4, r: 2 },
+      learnedTurn: 41,
+      source: 'spy-location',
+    });
+    const first = recordLegendaryWonderIntel(state, 'player', started);
+    const second = recordLegendaryWonderIntel({ ...state, legendaryWonderIntel: first }, 'player', location);
+    const third = recordLegendaryWonderIntel({ ...state, legendaryWonderIntel: second }, 'player', location);
+
+    expect(third.player.map(entry => entry.kind)).toEqual(['started', 'host-location-known']);
+  });
+
+  it('keeps legacy started records text-only and distinct from host-location records', () => {
+    const state = makeLegendaryWonderFixture();
+    state.legendaryWonderIntel = {
+      player: [{
+        projectKey: 'oracle-of-delphi:rival:city-rival',
+        wonderId: 'oracle-of-delphi',
+        civId: 'rival',
+        civName: 'Rival',
+        cityId: 'city-rival',
+        cityName: 'Rival Harbor',
+        revealedTurn: 41,
+        intelLevel: 'started',
+      }],
+    };
+
+    expect(getLegendaryWonderIntelForViewer(state, 'player')[0]).toMatchObject({
+      kind: 'started',
+      cityName: 'Rival Harbor',
+    });
+  });
+});

--- a/tests/systems/legendary-wonder-map-presentation.test.ts
+++ b/tests/systems/legendary-wonder-map-presentation.test.ts
@@ -126,4 +126,107 @@ describe('legendary-wonder-map-presentation', () => {
 
     expect(getLegendaryWonderMapEntries(state, 'player')).toEqual([]);
   });
+
+  it('returns known-rival map entries from paired completed and host-location intel at visible or fog coordinates', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const coord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      relationship: 'known-rival',
+      state: 'completed',
+      coord,
+      label: 'Oracle of Delphi',
+      progressRatio: undefined,
+    }));
+
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'fog';
+    expect(getLegendaryWonderMapEntries(state, 'player')).toContainEqual(expect.objectContaining({
+      wonderId: 'oracle-of-delphi',
+      relationship: 'known-rival',
+      coord,
+    }));
+  });
+
+  it('does not return known-rival map entries for unexplored, host-location-only, or completed-only intel', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const coord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'started',
+          eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+          projectKey: 'oracle-of-delphi:rival:city-rival',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          revealedTurn: 41,
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:grand-canal:rival:70',
+          wonderId: 'grand-canal',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    expect(getLegendaryWonderMapEntries(state, 'player').some(entry => entry.relationship === 'known-rival')).toBe(false);
+
+    state.legendaryWonderIntel.player.push({
+      kind: 'completed',
+      eventId: 'completed:oracle-of-delphi:rival:70',
+      wonderId: 'oracle-of-delphi',
+      civId: 'rival',
+      civName: 'Rival',
+      completionTurn: 70,
+      learnedTurn: 70,
+    });
+    state.civilizations.player.visibility.tiles[hexKey(coord)] = 'unexplored';
+    expect(getLegendaryWonderMapEntries(state, 'player').some(entry => entry.relationship === 'known-rival')).toBe(false);
+  });
 });

--- a/tests/systems/legendary-wonder-system.test.ts
+++ b/tests/systems/legendary-wonder-system.test.ts
@@ -559,10 +559,62 @@ describe('legendary-wonder-system', () => {
         cityId: 'city-river',
         intelLevel: 'started',
       }),
+      expect.objectContaining({
+        kind: 'host-location-known',
+        wonderId: 'oracle-of-delphi',
+        civId: 'player',
+        cityId: 'city-river',
+        cityName: state.cities['city-river'].name,
+        coord: state.cities['city-river'].position,
+        learnedTurn: state.turn,
+        source: 'spy-location',
+      }),
     ]));
     expect(revealedEvents).toEqual([
       { observerId: 'observer', civId: 'player', cityId: 'city-river', wonderId: 'oracle-of-delphi' },
     ]);
+  });
+
+  it('does not record host-location intel for the builder or when the host city is missing', () => {
+    const state = makeLegendaryWonderFixture({ oracleStepsCompleted: 2, resources: ['stone'] });
+    state.turn = 41;
+    state.legendaryWonderProjects = {
+      'oracle-of-delphi:rival:missing-city': {
+        wonderId: 'oracle-of-delphi',
+        ownerId: 'rival',
+        cityId: 'missing-city',
+        phase: 'ready_to_build',
+        investedProduction: 0,
+        transferableProduction: 0,
+        questSteps: [],
+      },
+    };
+    state.espionage = {
+      rival: {
+        spies: {
+          selfSpy: {
+            id: 'selfSpy',
+            name: 'Self',
+            owner: 'rival',
+            unitType: 'spy_scout',
+            status: 'stationed',
+            targetCivId: 'rival',
+            targetCityId: 'missing-city',
+            position: { q: 0, r: 0 },
+            experience: 0,
+            currentMission: null,
+            cooldownTurns: 0,
+            promotionAvailable: false,
+          },
+        },
+        maxSpies: 1,
+        counterIntelligence: {},
+      },
+    };
+
+    const result = startLegendaryWonderBuild(state, 'rival', 'missing-city', 'oracle-of-delphi');
+
+    expect(result.legendaryWonderIntel?.rival).toBeUndefined();
   });
 
   it('preserves every queued city item when a legendary wonder starts, even from a full queue', () => {

--- a/tests/systems/wonder-atlas-presentation.test.ts
+++ b/tests/systems/wonder-atlas-presentation.test.ts
@@ -222,4 +222,38 @@ describe('wonder-atlas-presentation', () => {
       rivalIntelCount: 0,
     });
   });
+
+  it('surfaces host-location rival intel without exposing map targeting data', () => {
+    const state = makeAtlasState();
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord: { q: 4, r: 2 },
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+      ],
+    };
+
+    const oracle = getWonderAtlasEntries(state, 'player')
+      .find(entry => entry.kind === 'legendary' && entry.wonderId === 'oracle-of-delphi');
+
+    expect(oracle).toMatchObject({
+      kind: 'legendary',
+      stateLabel: 'Known rival host',
+      rivalIntelCount: 1,
+      rivalIntelBadgeLabel: 'Known rival activity',
+      canViewOnMap: false,
+    });
+    expect(JSON.stringify(oracle)).not.toContain('rival-city');
+    expect(JSON.stringify(oracle)).not.toContain('Rival Harbor');
+    expect(JSON.stringify(oracle)).not.toContain('"q":4');
+  });
 });

--- a/tests/systems/wonder-codex/presentation.test.ts
+++ b/tests/systems/wonder-codex/presentation.test.ts
@@ -189,6 +189,110 @@ describe('wonder-codex presentation', () => {
     expect(model.selectedPage?.actions).toEqual([]);
   });
 
+  it('keeps host-location-only rival intel as known-host text without landmark preview', () => {
+    const state = makeState();
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const serialized = JSON.stringify(model.selectedPage);
+
+    expect(model.selectedPage?.stateLabel).toBe('Known rival host');
+    expect(model.selectedPage?.knownRivalLandmarkPreview).toBeUndefined();
+    expect(model.selectedPage?.rivalIntel?.summaryLine).toContain('Known host: Rival Harbor');
+    expect(serialized).not.toContain('"cityId":"rival-city"');
+    expect(serialized).not.toContain('Reward:');
+    expect(model.selectedPage?.actions).toEqual([]);
+  });
+
+  it('adds known-rival landmark preview only from paired host-location and completed intel', () => {
+    const state = makeState();
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          cityId: 'rival-city',
+          cityName: 'Rival Harbor',
+          coord: { q: 4, r: 2 },
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:ai-1:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'ai-1',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const model = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const serialized = JSON.stringify(model.selectedPage);
+
+    expect(model.selectedPage?.stateLabel).toBe('Known rival completed');
+    expect(model.selectedPage?.knownRivalLandmarkPreview).toMatchObject({
+      cityName: 'Rival Harbor',
+      learnedTurn: 62,
+      items: [{ wonderId: 'oracle-of-delphi', label: 'Oracle of Delphi', state: 'completed' }],
+    });
+    expect(serialized).not.toContain('"cityId":"rival-city"');
+    expect(serialized).not.toContain('Reward:');
+    expect(model.selectedPage?.actions).toEqual([]);
+  });
+
+  it('keeps host-location intel scoped to the current hot-seat viewer', () => {
+    const state = makeState();
+    state.civilizations['player-2'] = {
+      ...state.civilizations.player,
+      id: 'player-2',
+      name: 'Second Player',
+      isHuman: true,
+      cities: [],
+      units: [],
+    };
+    state.legendaryWonderIntel = {
+      player: [{
+        kind: 'host-location-known',
+        eventId: 'location:oracle-of-delphi:ai-1:rival-city:62',
+        wonderId: 'oracle-of-delphi',
+        civId: 'ai-1',
+        civName: 'Rival',
+        cityId: 'rival-city',
+        cityName: 'Rival Harbor',
+        coord: { q: 4, r: 2 },
+        learnedTurn: 62,
+        source: 'spy-location',
+      }],
+    };
+
+    const viewerA = getWonderCodexViewModel(state, 'player', { initialWonderId: 'oracle-of-delphi' });
+    const viewerB = getWonderCodexViewModel(state, 'player-2', { initialWonderId: 'oracle-of-delphi' });
+
+    expect(viewerA.selectedPage?.rivalIntel?.summaryLine).toContain('Known host: Rival Harbor');
+    expect(viewerA.selectedPage?.knownRivalLandmarkPreview).toBeUndefined();
+    expect(viewerB.catalogEntries.some(entry => entry.id === 'oracle-of-delphi')).toBe(false);
+    expect(viewerB.selectedPage).toBeNull();
+  });
+
   it('keeps owned state primary when owned state and rival intel both exist', () => {
     const state = makeState();
     state.legendaryWonderProjects = {

--- a/tests/ui/territory-inspection-panel.test.ts
+++ b/tests/ui/territory-inspection-panel.test.ts
@@ -204,6 +204,129 @@ describe('createTerritoryInspectionPanel', () => {
     expect(panel.textContent).toContain('Grand Canal');
     expect(panel.textContent).toContain('Tidecaller Bastion');
   });
+
+  it('mentions known-rival legendary landmarks only on the matching completed known coordinate', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const rivalCoord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: rivalCoord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const matching = createTerritoryInspectionPanel(state, rivalCoord, 'player');
+    const nearby = createTerritoryInspectionPanel(state, { q: rivalCoord.q + 1, r: rivalCoord.r }, 'player');
+
+    expect(matching.textContent).toContain('Known rival legendary landmark');
+    expect(matching.textContent).toContain('Oracle of Delphi');
+    expect(matching.textContent).toContain('Rival Harbor');
+    expect(nearby.textContent).not.toContain('Known rival legendary landmark');
+  });
+
+  it('mentions remembered known-rival legendary landmarks on fogged matching coordinates', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const rivalCoord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'fog';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: rivalCoord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:oracle-of-delphi:rival:70',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 70,
+          learnedTurn: 70,
+        },
+      ],
+    };
+
+    const panel = createTerritoryInspectionPanel(state, rivalCoord, 'player');
+
+    expect(panel.textContent).toContain('Known rival legendary landmark');
+    expect(panel.textContent).toContain('Oracle of Delphi');
+    expect(panel.textContent).toContain('Rival Harbor');
+    expect(panel.textContent).toContain('Last seen information only');
+  });
+
+  it('does not mention known-rival landmarks from started, completed, or host-location intel alone', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: [], resources: [] });
+    const rivalCoord = state.cities['city-rival'].position;
+    state.civilizations.player.visibility.tiles[hexKey(rivalCoord)] = 'visible';
+    state.legendaryWonderIntel = {
+      player: [
+        {
+          kind: 'started',
+          eventId: 'started:oracle-of-delphi:rival:city-rival:41',
+          projectKey: 'oracle-of-delphi:rival:city-rival',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          revealedTurn: 41,
+        },
+        {
+          kind: 'host-location-known',
+          eventId: 'location:oracle-of-delphi:rival:city-rival:62',
+          wonderId: 'oracle-of-delphi',
+          civId: 'rival',
+          civName: 'Rival',
+          cityId: 'city-rival',
+          cityName: 'Rival Harbor',
+          coord: rivalCoord,
+          learnedTurn: 62,
+          source: 'spy-location',
+        },
+        {
+          kind: 'completed',
+          eventId: 'completed:grand-canal:rival:58',
+          wonderId: 'grand-canal',
+          civId: 'rival',
+          civName: 'Rival',
+          completionTurn: 58,
+          learnedTurn: 58,
+        },
+      ],
+    };
+
+    const panel = createTerritoryInspectionPanel(state, rivalCoord, 'player');
+
+    expect(panel.textContent).not.toContain('Known rival legendary landmark');
+  });
 });
 
 describe('createTerritoryInspectionPanel — S2b acquisition status', () => {

--- a/tests/ui/wonder-codex-page.test.ts
+++ b/tests/ui/wonder-codex-page.test.ts
@@ -150,6 +150,35 @@ describe('wonder-codex-page', () => {
     expect(root.querySelector('[data-codex-action="open-city"]')).toBeNull();
   });
 
+  it('renders known-rival landmark preview without rival actions', () => {
+    const root = createWonderCodexPage(page({
+      id: 'oracle-of-delphi',
+      kind: 'legendary',
+      title: 'Oracle of Delphi',
+      subtitle: 'A sanctuary of prophecy.',
+      stateLabel: 'Known rival completed',
+      visual: getWonderVisualDefinition('oracle-of-delphi'),
+      actions: [],
+      landmarkPreview: undefined,
+      knownRivalLandmarkPreview: {
+        cityName: 'Rival Harbor',
+        civName: 'Rival',
+        learnedTurn: 62,
+        items: [{
+          wonderId: 'oracle-of-delphi',
+          label: 'Oracle of Delphi',
+          state: 'completed',
+        }],
+      },
+    }), { onAction: vi.fn(), onSelectRelated: vi.fn() });
+
+    expect(root.querySelector('[data-section="known-rival-landmark-preview"]')?.textContent).toContain('Known rival landmark');
+    expect(root.textContent).toContain('Rival Harbor');
+    expect(root.textContent).toContain('Location learned on turn 62');
+    expect(root.querySelector('[data-codex-action="open-city"]')).toBeNull();
+    expect(root.querySelector('[data-codex-action="view-map"]')).toBeNull();
+  });
+
   it('keeps reduced-motion Codex spectacle static', () => {
     const onReplayNaturalWonder = vi.fn();
     const root = createWonderCodexPage(page(), {


### PR DESCRIPTION
## Summary
- add explicit viewer-scoped host-location-known legendary wonder intel and record it from stationed-spy rival start observations
- render known-rival landmark previews, inspection text, Atlas state, and map markers only from paired host-location plus completed rival intel
- route known-rival map markers through the existing city landmark render pass without live rival city/project enrichment

## Verification
- scripts/check-src-rule-violations.sh src/core/types.ts src/renderer/city-render-passes.ts src/renderer/city-renderer.ts src/systems/legendary-wonder-intel-presentation.ts src/systems/legendary-wonder-intel.ts src/systems/legendary-wonder-landmark-presentation.ts src/systems/legendary-wonder-map-presentation.ts src/systems/legendary-wonder-system.ts src/systems/wonder-atlas-presentation.ts src/systems/wonder-codex/presentation.ts src/ui/territory-inspection-panel.ts src/ui/wonder-codex-page.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-wonder-regressions.sh
- ./scripts/run-with-mise.sh yarn test

Notes: build still emits the existing Vite chunk-size warning; wonder regressions still emit the sandbox-only mise cache warning, but both commands exit 0.