### PR TITLE
feat(renderer): DOM sprite overlay — live SVG animations for units, buildings, and improvements

### DIFF
--- a/docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md
+++ b/docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md
@@ -1,0 +1,1457 @@
+# Sprite Overlay Renderer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a DOM overlay layer that enables CSS-animated v2 sprites for units, buildings, and improvements across 4 incremental MRs, each safe to merge independently.
+
+**Architecture:** A `#sprite-overlay` div (between `#game-canvas` and `#ui-layer`) holds a world-space pool of live SVG DOM elements managed by `SpriteOverlay`. One `transform: scale(zoom) translate(-camX, -camY)` per frame syncs the whole layer to the camera. `getHorizontalWrapRenderCoords()` handles wrap ghosts — the overlay has no wrap logic of its own. `RenderLoop` builds the entity list filtered to `'visible'` hexes and non-moving units before passing it to `sync()`.
+
+**Tech Stack:** TypeScript, vitest + jsdom, CSS custom properties (`--phase`), djb2 hash, Babel + JSDOM (serialize-sprites.mjs for new sprite generation)
+
+---
+
+## Key facts before you start
+
+- **v2 SVG format:** Each `*.svg.ts` file exports `export const svg: Record<string, string>` keyed by faction name (`'imperials' | 'vikings' | 'pharaohs' | 'hellenes' | 'khanate' | 'shogunate'`). Each value is an HTML string starting with `<div class="cq-sprite-wrap cq-v2" data-state="idle" ... style="--phase:0">`.
+- **Faction key mapping:** `state.civilizations[unit.owner]?.civType` is the v2 faction key. `civType` is one of the faction names above for preset civs, `'generic'` for legacy. Fall back to `'imperials'` if unknown.
+- **spriteWrapEl:** The CSS animation selectors key off `.cq-v2[data-state="..."]` — that is the `cq-sprite-wrap` div, not the outer positional wrapper and not the inner `<svg>`. Always target `wrapper.firstElementChild` for `data-state` and `--phase` updates.
+- **`--phase` override:** The v2 strings bake `style="--phase:0"` inline on the `cq-sprite-wrap` div. Call `spriteWrapEl.style.setProperty('--phase', ...)` to override it — same-element `setProperty` wins over the baked inline value.
+- **`contain: paint` is forbidden** on `#sprite-overlay` — it clips the 0×0 box and makes all sprites invisible. Use `contain: layout style` only.
+- **Motion vocabulary mismatch:** v1 uses `'idle' | 'move-a' | 'move-b'` (`UnitMotionState`). v2 CSS uses `'idle' | 'walk' | 'attack'` (`SpriteEntity.state`). `RenderLoop` translates: `'move-a' | 'move-b'` → `'walk'`.
+- **Fog breach:** The overlay sits ABOVE the canvas fog layer. Only include entities whose hex is `'visible'` in `getVisibility(viewerVisibility, coord)`. `'fog'` and `'unexplored'` hexes must be excluded before calling `sync()`.
+- **Movement gate:** Units in `getMovingUnitIds(this.unitMovementAnimations)` must be excluded from the entity list — they're animated on canvas at an interpolated position; the overlay must not show them at their origin hex simultaneously.
+- **Test commands:** `bash scripts/run-with-mise.sh yarn test -- <test-file>` to run specific file. `bash scripts/run-with-mise.sh yarn build` to type-check.
+
+---
+
+## File map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/renderer/sprite-overlay.ts` | SpriteOverlay class, SpriteEntity interface, hashCode |
+| Create | `src/renderer/sprites/v2/index.ts` | Unified lookup: getUnitSpriteV2, getBuildingSpriteV2, getImprovementSpriteV2 |
+| Create | `tests/renderer/sprite-overlay.test.ts` | SpriteOverlay unit tests |
+| Create | `tests/renderer/sprites/v2/index.test.ts` | Lookup catalog coverage tests |
+| Create | `tests/renderer/unit-renderer-overlay.test.ts` | Canvas skip + fog + movement gate tests |
+| Create | `tests/renderer/city-renderer-overlay.test.ts` | Building overlay tests |
+| Create | `tests/renderer/improvements/improvement-overlay.test.ts` | Improvement marker tests |
+| Create | `src/renderer/improvements/farm-marker.ts` | Farm SVG (viewBox 0 0 48 48) |
+| Create | `src/renderer/improvements/mine-marker.ts` | Mine SVG |
+| Create | `src/renderer/improvements/lumber-camp-marker.ts` | Lumber camp SVG |
+| Create | `src/renderer/improvements/watermill-marker.ts` | Watermill SVG |
+| Create | `src/renderer/improvements/plantation-marker.ts` | Plantation SVG |
+| Create | `src/renderer/improvements/pasture-marker.ts` | Pasture SVG |
+| Create | `src/renderer/improvements/camp-marker.ts` | Camp SVG |
+| Create | `src/renderer/improvements/quarry-marker.ts` | Quarry SVG |
+| Generate | `src/renderer/sprites/v2/{axeman,...}.svg.ts` ×11 | Serialized v2 units (via serialize-sprites.mjs) |
+| Generate | `src/renderer/sprites/v2/{dock,...}.svg.ts` ×N | Serialized v2 buildings (via serialize-sprites.mjs) |
+| Modify | `index.html` | Add `#sprite-overlay` div + CSS |
+| Modify | `src/input/touch-handler.ts` | Add `get isPinching(): boolean` getter |
+| Modify | `src/renderer/render-loop.ts` | Instantiate SpriteOverlay; call sync() each frame; build entity lists |
+| Modify | `src/main.ts` | Call `renderLoop.setTouchHandler(touchHandler)` |
+| Modify | `src/renderer/unit-renderer.ts` | Skip drawImage when unit.id in activeIds |
+| Modify | `src/renderer/city-renderer.ts` | Skip building drawImage when in activeIds |
+| Modify | `src/renderer/hex-renderer.ts` | Skip emoji icon when improvement in activeIds |
+| Modify | `src/renderer/sprites/v2/index.ts` | Wire new unit/building/improvement sprites as MRs progress |
+
+---
+
+## Phase 1 (MR 1) — Infrastructure
+
+### Task 1: isPinching getter + index.html
+
+**Files:** `src/input/touch-handler.ts`, `index.html`
+
+- [ ] **Step 1: Add `_isPinching` field and public getter to TouchHandler**
+
+Open `src/input/touch-handler.ts`. After the `private isPanning = false;` field (line ~19), add:
+
+```typescript
+private _isPinching = false;
+get isPinching(): boolean { return this._isPinching; }
+```
+
+In `onTouchStart` (the handler for `touchstart`), the existing code checks `e.touches.length === 2` at line ~58 for pinch. Add `this._isPinching = true;` inside that 2-finger branch.
+
+In `onTouchEnd` (handles `touchend` and `touchcancel`), add at the top: `this._isPinching = e.touches.length >= 2;`
+
+- [ ] **Step 2: Add `#sprite-overlay` to index.html**
+
+Open `index.html`. In the `<style>` block, add:
+
+```css
+#sprite-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  overflow: visible;
+  pointer-events: none;
+  transform-origin: top left;
+  contain: layout style;
+  will-change: transform;
+}
+```
+
+In the `<body>`, after `<canvas id="game-canvas">` and before `<div id="ui-layer">`, add:
+
+```html
+<div id="sprite-overlay"></div>
+```
+
+- [ ] **Step 3: Build to verify no TypeScript errors**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/input/touch-handler.ts index.html
+git commit -m "feat(overlay-mr1): isPinching getter + #sprite-overlay HTML"
+```
+
+---
+
+### Task 2: Create v2/index.ts
+
+**Files:** `src/renderer/sprites/v2/index.ts`, `tests/renderer/sprites/v2/index.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/renderer/sprites/v2/index.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import {
+  getUnitSpriteV2,
+  getBuildingSpriteV2,
+  getImprovementSpriteV2,
+} from '@/renderer/sprites/v2/index';
+
+describe('getUnitSpriteV2', () => {
+  it('returns null for unknown type', () => {
+    expect(getUnitSpriteV2('unknown', 'imperials')).toBeNull();
+  });
+
+  it('returns null for unknown faction', () => {
+    expect(getUnitSpriteV2('warrior', 'unknownfaction')).toBeNull();
+  });
+
+  it('returns a cq-sprite-wrap string for warrior/imperials', () => {
+    const r = getUnitSpriteV2('warrior', 'imperials');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+    expect(r!).toContain('cq-v2');
+  });
+});
+
+describe('getBuildingSpriteV2', () => {
+  it('returns null for unknown building', () => {
+    expect(getBuildingSpriteV2('unknown', 'imperials')).toBeNull();
+  });
+
+  it('returns a sprite for granary/imperials', () => {
+    const r = getBuildingSpriteV2('granary', 'imperials');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+  });
+});
+
+describe('getImprovementSpriteV2', () => {
+  it('returns null before MR 4 wires improvements', () => {
+    expect(getImprovementSpriteV2('farm')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure (module missing)**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/sprites/v2/index.test.ts 2>&1 | tail -5
+```
+
+Expected: error — cannot find module.
+
+- [ ] **Step 3: Create src/renderer/sprites/v2/index.ts**
+
+```typescript
+// Sprite lookup for the DOM overlay. Updated each MR as new types are serialized.
+
+import { svg as archerSvg } from './archer.svg';
+import { svg as galleySvg } from './galley.svg';
+import { svg as musketeerSvg } from './musketeer.svg';
+import { svg as pikemanSvg } from './pikeman.svg';
+import { svg as scoutSvg } from './scout.svg';
+import { svg as scoutHoundSvg } from './scout_hound.svg';
+import { svg as settlerSvg } from './settler.svg';
+import { svg as shadowWardenSvg } from './shadow_warden.svg';
+import { svg as spyAgentSvg } from './spy_agent.svg';
+import { svg as spyHackerSvg } from './spy_hacker.svg';
+import { svg as spyInformantSvg } from './spy_informant.svg';
+import { svg as spyOperativeSvg } from './spy_operative.svg';
+import { svg as spyScoutSvg } from './spy_scout.svg';
+import { svg as swordsmanSvg } from './swordsman.svg';
+import { svg as triremeSvg } from './trireme.svg';
+import { svg as warHoundSvg } from './war_hound.svg';
+import { svg as warriorSvg } from './warrior.svg';
+import { svg as workerSvg } from './worker.svg';
+
+import { svg as amphitheaterSvg } from './amphitheater.svg';
+import { svg as aqueductSvg } from './aqueduct.svg';
+import { svg as archiveSvg } from './archive.svg';
+import { svg as barracksSvg } from './barracks.svg';
+import { svg as forgeSvg } from './forge.svg';
+import { svg as forumSvg } from './forum.svg';
+import { svg as granarySvg } from './granary.svg';
+import { svg as harborSvg } from './harbor.svg';
+import { svg as herbalistSvg } from './herbalist.svg';
+import { svg as intelligenceAgencySvg } from './intelligence-agency.svg';
+import { svg as librarySvg } from './library.svg';
+import { svg as lumbermillSvg } from './lumbermill.svg';
+import { svg as marketplaceSvg } from './marketplace.svg';
+import { svg as monumentSvg } from './monument.svg';
+import { svg as observatorySvg } from './observatory.svg';
+import { svg as quarryBuildingSvg } from './quarry-building.svg';
+import { svg as safehouseSvg } from './safehouse.svg';
+import { svg as securityBureauSvg } from './security-bureau.svg';
+import { svg as shrineSvg } from './shrine.svg';
+import { svg as stableSvg } from './stable.svg';
+import { svg as templeSvg } from './temple.svg';
+import { svg as wallsSvg } from './walls.svg';
+import { svg as workshopSvg } from './workshop.svg';
+
+// ── Unit sprites ────────────────────────────────────────────────────────────
+
+const UNIT_SPRITES: Record<string, Record<string, string>> = {
+  archer:        archerSvg,
+  galley:        galleySvg,
+  musketeer:     musketeerSvg,
+  pikeman:       pikemanSvg,
+  scout:         scoutSvg,
+  scout_hound:   scoutHoundSvg,
+  settler:       settlerSvg,
+  shadow_warden: shadowWardenSvg,
+  spy_agent:     spyAgentSvg,
+  spy_hacker:    spyHackerSvg,
+  spy_informant: spyInformantSvg,
+  spy_operative: spyOperativeSvg,
+  spy_scout:     spyScoutSvg,
+  swordsman:     swordsmanSvg,
+  trireme:       triremeSvg,
+  war_hound:     warHoundSvg,
+  warrior:       warriorSvg,
+  worker:        workerSvg,
+  // MR 2 adds: axeman, spearman, horseman, cavalry, knight,
+  //            crossbowman, catapult, ballista, caravan, expedition, transport
+};
+
+export function getUnitSpriteV2(unitType: string, faction: string): string | null {
+  return UNIT_SPRITES[unitType]?.[faction] ?? null;
+}
+
+// ── Building sprites ─────────────────────────────────────────────────────────
+
+const BUILDING_SPRITES: Record<string, Record<string, string>> = {
+  amphitheater:          amphitheaterSvg,
+  aqueduct:              aqueductSvg,
+  archive:               archiveSvg,
+  barracks:              barracksSvg,
+  forge:                 forgeSvg,
+  forum:                 forumSvg,
+  granary:               granarySvg,
+  harbor:                harborSvg,
+  herbalist:             herbalistSvg,
+  'intelligence-agency': intelligenceAgencySvg,
+  library:               librarySvg,
+  lumbermill:            lumbermillSvg,
+  marketplace:           marketplaceSvg,
+  monument:              monumentSvg,
+  observatory:           observatorySvg,
+  'quarry-building':     quarryBuildingSvg,
+  safehouse:             safehouseSvg,
+  'security-bureau':     securityBureauSvg,
+  shrine:                shrineSvg,
+  stable:                stableSvg,
+  temple:                templeSvg,
+  walls:                 wallsSvg,
+  workshop:              workshopSvg,
+  // MR 3 adds remaining buildings
+};
+
+export function getBuildingSpriteV2(buildingType: string, faction: string): string | null {
+  return BUILDING_SPRITES[buildingType]?.[faction] ?? null;
+}
+
+// ── Improvement sprites ───────────────────────────────────────────────────────
+
+const IMPROVEMENT_SPRITES: Record<string, string> = {
+  // MR 4 wires: farm, mine, lumber_camp, watermill, plantation, pasture, camp, quarry, resource_outpost
+};
+
+export function getImprovementSpriteV2(improvementType: string): string | null {
+  return IMPROVEMENT_SPRITES[improvementType] ?? null;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/sprites/v2/index.test.ts 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/sprites/v2/index.ts tests/renderer/sprites/v2/index.test.ts
+git commit -m "feat(overlay-mr1): v2/index.ts with 18 unit + 23 building lookups"
+```
+
+---
+
+### Task 3: SpriteOverlay class
+
+**Files:** `src/renderer/sprite-overlay.ts`, `tests/renderer/sprite-overlay.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/renderer/sprite-overlay.test.ts`:
+
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import { SpriteOverlay, hashCode } from '@/renderer/sprite-overlay';
+import type { SpriteEntity } from '@/renderer/sprite-overlay';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from '@/renderer/sprites/sprite-system';
+
+function cam(overrides: Record<string, unknown> = {}) {
+  return { x: 0, y: 0, zoom: 1, hexSize: 32, width: 800, height: 600, ...overrides } as any;
+}
+
+function entity(overrides: Partial<SpriteEntity> = {}): SpriteEntity {
+  return { id: 'u1', kind: 'unit', subtype: 'warrior', coord: { q: 0, r: 0 }, state: 'idle', faction: 'imperials', ...overrides };
+}
+
+function mountOverlay() {
+  const mount = document.createElement('div');
+  const ui = document.createElement('div');
+  ui.id = 'ui-layer';
+  mount.appendChild(ui);
+  document.body.appendChild(mount);
+  return { overlay: new SpriteOverlay(mount), mount };
+}
+
+const MAP = { width: 20, wrapsHorizontally: false };
+const OPTS = { isPinching: false, reducedMotion: false };
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+describe('hashCode', () => {
+  it('is non-negative', () => expect(hashCode('x')).toBeGreaterThanOrEqual(0));
+  it('is deterministic', () => expect(hashCode('abc')).toBe(hashCode('abc')));
+  it('differs for different inputs', () => expect(hashCode('a')).not.toBe(hashCode('b')));
+  it('phase is in [0,1)', () => {
+    const p = (hashCode('warrior_001') % 100) / 100;
+    expect(p).toBeGreaterThanOrEqual(0);
+    expect(p).toBeLessThan(1);
+  });
+});
+
+describe('SpriteOverlay constructor', () => {
+  it('inserts container before #ui-layer', () => {
+    const { mount } = mountOverlay();
+    const kids = Array.from(mount.children);
+    expect(kids.findIndex(e => e.id === 'sprite-overlay')).toBeLessThan(kids.findIndex(e => e.id === 'ui-layer'));
+  });
+
+  it('creates unit, building, improvement layer divs', () => {
+    const { mount } = mountOverlay();
+    expect(mount.querySelector('#unit-sprites')).not.toBeNull();
+    expect(mount.querySelector('#building-sprites')).not.toBeNull();
+    expect(mount.querySelector('#improvement-sprites')).not.toBeNull();
+  });
+});
+
+describe('sync() LOD gate', () => {
+  it('hides container below LOD threshold', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: LOD_SPRITE_ZOOM_THRESHOLD - 0.01 }), [], MAP, OPTS);
+    expect(mount.querySelector('#sprite-overlay')!.getAttribute('style')).toContain('display: none');
+  });
+
+  it('hides container when reducedMotion', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [], MAP, { ...OPTS, reducedMotion: true });
+    expect(mount.querySelector('#sprite-overlay')!.getAttribute('style')).toContain('display: none');
+  });
+
+  it('shows container above threshold', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: LOD_SPRITE_ZOOM_THRESHOLD + 0.1 }), [], MAP, OPTS);
+    const style = (mount.querySelector('#sprite-overlay') as HTMLElement)!.style.display;
+    expect(style).not.toBe('none');
+  });
+});
+
+describe('sync() camera transform', () => {
+  it('sets correct transform', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1.5, x: 100, y: 200 }), [], MAP, OPTS);
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement)!.style.transform)
+      .toBe('scale(1.5) translate(-100px, -200px)');
+  });
+
+  it('updates transform even while pinching', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 2, x: 50, y: 75 }), [], MAP, { ...OPTS, isPinching: true });
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement)!.style.transform)
+      .toBe('scale(2) translate(-50px, -75px)');
+  });
+});
+
+describe('sync() pinch guard', () => {
+  it('does not add elements while pinching', () => {
+    const { overlay } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, { ...OPTS, isPinching: true });
+    expect(overlay.getActiveIds().size).toBe(0);
+  });
+
+  it('does not remove elements while pinching', () => {
+    const { overlay, mount } = mountOverlay();
+    // Add an element first
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, OPTS);
+    const before = mount.querySelector('#unit-sprites')!.children.length;
+    // Pinch with empty list — should NOT cull
+    overlay.sync(cam({ zoom: 1 }), [], MAP, { ...OPTS, isPinching: true });
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(before);
+  });
+});
+
+describe('sync() pool lifecycle', () => {
+  it('culls stale elements', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, OPTS);
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBeGreaterThan(0);
+    overlay.sync(cam({ zoom: 1 }), [], MAP, OPTS);
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(0);
+  });
+
+  it('reuses element on second sync — no node replacement', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity({ state: 'idle' })], MAP, OPTS);
+    const original = mount.querySelector('.cq-sprite-wrap');
+    overlay.sync(cam({ zoom: 1 }), [entity({ state: 'walk' })], MAP, OPTS);
+    expect(mount.querySelector('.cq-sprite-wrap')).toBe(original); // same node
+    expect((original as HTMLElement).getAttribute('data-state')).toBe('walk');
+  });
+});
+
+describe('invalidateFaction', () => {
+  it('evicts elements for given faction', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity({ faction: 'imperials' })], MAP, OPTS);
+    overlay.invalidateFaction('imperials');
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(0);
+    expect(overlay.getActiveIds().size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/sprite-overlay.test.ts 2>&1 | tail -5
+```
+
+Expected: errors — module missing.
+
+- [ ] **Step 3: Create src/renderer/sprite-overlay.ts**
+
+```typescript
+import { hexToPixel } from '@/systems/hex-utils';
+import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
+import {
+  getUnitSpriteV2,
+  getBuildingSpriteV2,
+  getImprovementSpriteV2,
+} from './sprites/v2/index';
+import type { Camera } from './camera';
+import type { HexCoord } from '@/core/types';
+
+export interface SpriteEntity {
+  id:      string;
+  kind:    'unit' | 'building' | 'improvement';
+  subtype: string;
+  coord:   HexCoord;
+  /** v2 animation state — NOT the same as UnitMotionState ('move-a'/'move-b').
+   *  RenderLoop translates: move-a|move-b → 'walk'. */
+  state:   'idle' | 'walk' | 'attack';
+  faction: string; // civType from Civilization, e.g. 'imperials', 'vikings'
+}
+
+interface PoolEntry {
+  el:           HTMLDivElement;  // positional wrapper
+  spriteWrapEl: HTMLElement;     // .cq-sprite-wrap.cq-v2 — animation root
+  phase:        number;
+  faction:      string;
+  coord:        HexCoord;
+}
+
+// djb2 hash — deterministic, no external dependency
+export function hashCode(str: string): number {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) ^ str.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+export class SpriteOverlay {
+  private container: HTMLDivElement;
+  private layers: Record<SpriteEntity['kind'], HTMLDivElement>;
+  private pool = new Map<string, PoolEntry>();
+  private _activeIds = new Set<string>();
+
+  constructor(mountPoint: HTMLElement) {
+    this.container = document.createElement('div');
+    this.container.id = 'sprite-overlay';
+    this.container.style.cssText =
+      'position:absolute;top:0;left:0;width:0;height:0;overflow:visible;' +
+      'pointer-events:none;transform-origin:top left;will-change:transform';
+    // contain: layout style — NOT paint (paint would clip the 0×0 box)
+    (this.container.style as unknown as Record<string, string>).contain = 'layout style';
+
+    const unit = makeLayer('unit-sprites');
+    const building = makeLayer('building-sprites');
+    const improvement = makeLayer('improvement-sprites');
+    this.container.appendChild(unit);
+    this.container.appendChild(building);
+    this.container.appendChild(improvement);
+    this.layers = { unit, building, improvement };
+
+    const uiLayer = mountPoint.querySelector('#ui-layer');
+    if (uiLayer) mountPoint.insertBefore(this.container, uiLayer);
+    else mountPoint.appendChild(this.container);
+  }
+
+  sync(
+    camera: Camera,
+    entities: SpriteEntity[],
+    map: { width: number; wrapsHorizontally: boolean },
+    opts: { isPinching: boolean; reducedMotion: boolean },
+  ): void {
+    // 1. LOD + reduced-motion gate
+    if (camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD || opts.reducedMotion) {
+      this.container.style.display = 'none';
+      return;
+    }
+    this.container.style.display = '';
+
+    // 2. Camera transform — one write per frame, always (even during pinch)
+    this.container.style.transform =
+      `scale(${camera.zoom}) translate(${-camera.x}px, ${-camera.y}px)`;
+
+    // 3. Pinch guard — defer pool mutations
+    if (opts.isPinching) return;
+
+    // 4. Entity → DOM
+    const seen = new Set<string>();
+    for (const entity of entities) {
+      const coords = map.wrapsHorizontally
+        ? getHorizontalWrapRenderCoords(entity.coord, map.width, camera)
+        : [entity.coord];
+
+      for (let i = 0; i < coords.length; i++) {
+        const coord = coords[i];
+        const key = `${entity.id}:${i}`;
+        seen.add(key);
+
+        const existing = this.pool.get(key);
+        if (existing) {
+          existing.spriteWrapEl.setAttribute('data-state', entity.state);
+          // Update world position if unit moved to a new hex after animation complete
+          if (existing.coord.q !== coord.q || existing.coord.r !== coord.r) {
+            const px = hexToPixel(coord, camera.hexSize);
+            existing.el.style.left = `${px.x}px`;
+            existing.el.style.top = `${px.y}px`;
+            existing.coord = coord;
+          }
+        } else {
+          const svgHtml = this.lookupSprite(entity);
+          if (!svgHtml) continue; // no v2 sprite — canvas handles it
+
+          const phase = (hashCode(entity.id) % 100) / 100;
+          const px = hexToPixel(coord, camera.hexSize);
+          const wrapper = document.createElement('div');
+          wrapper.style.cssText =
+            `position:absolute;width:128px;height:128px;` +
+            `transform:translate(-50%,-50%);` +
+            `left:${px.x}px;top:${px.y}px`;
+          wrapper.innerHTML = svgHtml;
+
+          // spriteWrapEl = .cq-sprite-wrap.cq-v2 (first child) — NOT the <svg>
+          // CSS selectors key off this element: .cq-v2[data-state="idle"] ...
+          const spriteWrapEl = wrapper.firstElementChild as HTMLElement;
+          // Override baked style="--phase:0" on the same element — setProperty wins
+          spriteWrapEl.style.setProperty('--phase', String(phase));
+          spriteWrapEl.setAttribute('data-state', entity.state);
+
+          this.layers[entity.kind].appendChild(wrapper);
+          this.pool.set(key, { el: wrapper, spriteWrapEl, phase, faction: entity.faction, coord });
+        }
+      }
+    }
+
+    // 5. Cull stale elements
+    for (const [key, entry] of this.pool) {
+      if (!seen.has(key)) {
+        entry.el.remove();
+        this.pool.delete(key);
+      }
+    }
+
+    // Rebuild activeIds from current pool
+    this._activeIds.clear();
+    for (const key of this.pool.keys()) {
+      // key = `${entityId}:${ghostIndex}` — extract entityId
+      this._activeIds.add(key.slice(0, key.lastIndexOf(':')));
+    }
+  }
+
+  private lookupSprite(entity: SpriteEntity): string | null {
+    switch (entity.kind) {
+      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction);
+      case 'building':    return getBuildingSpriteV2(entity.subtype, entity.faction);
+      case 'improvement': return getImprovementSpriteV2(entity.subtype);
+      default:            return null;
+    }
+  }
+
+  getActiveIds(): ReadonlySet<string> { return this._activeIds; }
+
+  invalidateFaction(faction: string): void {
+    for (const [key, entry] of this.pool) {
+      if (entry.faction === faction) {
+        entry.el.remove();
+        this.pool.delete(key);
+      }
+    }
+    this._activeIds.clear();
+  }
+}
+
+function makeLayer(id: string): HTMLDivElement {
+  const div = document.createElement('div');
+  div.id = id;
+  div.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;overflow:visible';
+  return div;
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/sprite-overlay.test.ts 2>&1 | tail -15
+```
+
+Expected: all PASS. (Warrior/imperials tests pass because the lookup is already wired in v2/index.ts.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/sprite-overlay.ts tests/renderer/sprite-overlay.test.ts
+git commit -m "feat(overlay-mr1): SpriteOverlay class — pool, camera sync, entity→DOM, cull"
+```
+
+---
+
+### Task 4: Wire SpriteOverlay into RenderLoop
+
+**Files:** `src/renderer/render-loop.ts`, `src/main.ts`
+
+- [ ] **Step 1: Add imports and fields to RenderLoop**
+
+In `src/renderer/render-loop.ts`, add imports at top:
+
+```typescript
+import { SpriteOverlay } from './sprite-overlay';
+```
+
+In the `RenderLoop` class body, add fields:
+
+```typescript
+private spriteOverlay: SpriteOverlay;
+private touchHandlerRef: { isPinching: boolean } | null = null;
+
+setTouchHandler(th: { isPinching: boolean }): void {
+  this.touchHandlerRef = th;
+}
+```
+
+- [ ] **Step 2: Instantiate SpriteOverlay in constructor**
+
+In `RenderLoop.constructor`, after `this.camera = new Camera()`:
+
+```typescript
+const mountPoint = canvas.parentElement ?? document.body;
+this.spriteOverlay = new SpriteOverlay(mountPoint);
+```
+
+- [ ] **Step 3: Call sync() at the end of render()**
+
+At the very end of the `private render()` method (after `this.animations.update(...)`), add:
+
+```typescript
+// Sprite overlay — entity list populated in MR 2+
+this.spriteOverlay.sync(
+  this.camera,
+  [], // populated in MR 2
+  {
+    width: this.state?.map.width ?? 0,
+    wrapsHorizontally: this.state?.map.wrapsHorizontally ?? false,
+  },
+  {
+    isPinching: this.touchHandlerRef?.isPinching ?? false,
+    reducedMotion: prefersReducedMotion(),
+  },
+);
+```
+
+- [ ] **Step 4: Wire setTouchHandler in main.ts**
+
+Find the line in `src/main.ts` where `new TouchHandler(canvas, ...)` is called. Immediately after it:
+
+```typescript
+renderLoop.setTouchHandler(touchHandler);
+```
+
+- [ ] **Step 5: Build and run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -15
+```
+
+Expected: build exits 0, all tests PASS.
+
+- [ ] **Step 6: Commit — MR 1 complete**
+
+```bash
+git add src/renderer/render-loop.ts src/main.ts
+git commit -m "feat(overlay-mr1): wire SpriteOverlay into RenderLoop — MR 1 complete"
+```
+
+---
+
+## Phase 2 (MR 2) — Unit Sprites
+
+### Task 5: Serialize missing unit v2 sprites
+
+**Files:** `design/conquestoria-sprites/lib/units-v2.jsx`, `src/renderer/sprites/v2/*.svg.ts` (×11 generated)
+
+The 11 missing unit types need JSX component definitions before `serialize-sprites.mjs` can generate their `.svg.ts` files.
+
+- [ ] **Step 1: Read the existing pattern in units-v2.jsx**
+
+```bash
+grep -n "function.*V2Sprite\|HumanoidV2\|SpriteFrameV2" design/conquestoria-sprites/lib/units-v2.jsx | head -30
+```
+
+Note the pattern: each sprite is a function `function FooV2Sprite({ faction = 'imperials', state = 'idle', phase })` that returns `<SpriteFrameV2>` with `<HumanoidV2>` inside. The `phase` parameter must have **no default value** (enables auto-desync).
+
+- [ ] **Step 2: Add JSX components for the 11 missing unit types**
+
+For each missing type, add a component to `design/conquestoria-sprites/lib/units-v2.jsx` following the established pattern. Use the `generate-sprite-prompt` skill to create Claude Design prompts if you need help designing each sprite visually.
+
+Missing types by archetype:
+- **Ground melee** (`axeman`, `spearman`, `knight`): use `HumanoidV2` with `arms="weapon"`, weapon art in `armRContent`
+- **Mounted** (`horseman`, `cavalry`): `HumanoidV2` with horse/mount art `<g transform="translate(64 85)">` below the figure  
+- **Siege** (`catapult`, `ballista`): minimal humanoid + equipment silhouette in body
+- **Civilian** (`caravan`, `expedition`): `HumanoidV2` with `arms="free"`, pack/cart art as body accessory
+- **Naval** (`transport`): `SpriteFrameV2 kind="naval"` with hull shape, no HumanoidV2
+
+Add each new function name to the `Object.assign(window, {...})` export at the bottom of `units-v2.jsx`.
+
+- [ ] **Step 3: Run serialize-sprites.mjs**
+
+```bash
+bash scripts/run-with-mise.sh node scripts/serialize-sprites.mjs 2>&1 | tail -20
+```
+
+Expected: generates files including `src/renderer/sprites/v2/axeman.svg.ts`, etc.
+
+- [ ] **Step 4: Verify shape of generated files**
+
+```bash
+ls src/renderer/sprites/v2/axeman.svg.ts src/renderer/sprites/v2/spearman.svg.ts
+grep "export const svg" src/renderer/sprites/v2/axeman.svg.ts
+grep "cq-sprite-wrap" src/renderer/sprites/v2/axeman.svg.ts | head -c 100
+```
+
+Each file must export `export const svg: Record<string, string>` with multiple faction keys.
+
+- [ ] **Step 5: Commit generated files and design JSX**
+
+```bash
+git add design/conquestoria-sprites/lib/units-v2.jsx \
+  src/renderer/sprites/v2/axeman.svg.ts \
+  src/renderer/sprites/v2/spearman.svg.ts \
+  src/renderer/sprites/v2/horseman.svg.ts \
+  src/renderer/sprites/v2/cavalry.svg.ts \
+  src/renderer/sprites/v2/knight.svg.ts \
+  src/renderer/sprites/v2/crossbowman.svg.ts \
+  src/renderer/sprites/v2/catapult.svg.ts \
+  src/renderer/sprites/v2/ballista.svg.ts \
+  src/renderer/sprites/v2/caravan.svg.ts \
+  src/renderer/sprites/v2/expedition.svg.ts \
+  src/renderer/sprites/v2/transport.svg.ts
+git commit -m "feat(overlay-mr2): serialize v2 SVGs for 11 remaining unit types"
+```
+
+---
+
+### Task 6: Wire all 29 unit types into v2/index.ts
+
+**Files:** `src/renderer/sprites/v2/index.ts`, `tests/renderer/sprites/v2/index.test.ts`
+
+- [ ] **Step 1: Add imports for the 11 new files**
+
+In `src/renderer/sprites/v2/index.ts`, add after the existing unit imports:
+
+```typescript
+import { svg as axemanSvg }      from './axeman.svg';
+import { svg as spearmanSvg }    from './spearman.svg';
+import { svg as horsemanSvg }    from './horseman.svg';
+import { svg as cavalrySvg }     from './cavalry.svg';
+import { svg as knightSvg }      from './knight.svg';
+import { svg as crossbowmanSvg } from './crossbowman.svg';
+import { svg as catapultSvg }    from './catapult.svg';
+import { svg as ballistaSvg }    from './ballista.svg';
+import { svg as caravanSvg }     from './caravan.svg';
+import { svg as expeditionSvg }  from './expedition.svg';
+import { svg as transportSvg }   from './transport.svg';
+```
+
+Replace the `// MR 2 adds: ...` comment in `UNIT_SPRITES` with:
+
+```typescript
+  axeman:     axemanSvg,
+  spearman:   spearmanSvg,
+  horseman:   horsemanSvg,
+  cavalry:    cavalrySvg,
+  knight:     knightSvg,
+  crossbowman: crossbowmanSvg,
+  catapult:   catapultSvg,
+  ballista:   ballistaSvg,
+  caravan:    caravanSvg,
+  expedition: expeditionSvg,
+  transport:  transportSvg,
+```
+
+- [ ] **Step 2: Add coverage test for all 29 unit types**
+
+In `tests/renderer/sprites/v2/index.test.ts`, add:
+
+```typescript
+const ALL_UNIT_TYPES = [
+  'archer', 'galley', 'musketeer', 'pikeman', 'scout', 'scout_hound',
+  'settler', 'shadow_warden', 'spy_agent', 'spy_hacker', 'spy_informant',
+  'spy_operative', 'spy_scout', 'swordsman', 'trireme', 'war_hound',
+  'warrior', 'worker',
+  'axeman', 'spearman', 'horseman', 'cavalry', 'knight', 'crossbowman',
+  'catapult', 'ballista', 'caravan', 'expedition', 'transport',
+];
+
+it('returns a sprite for every unit type (imperials faction)', () => {
+  for (const type of ALL_UNIT_TYPES) {
+    const r = getUnitSpriteV2(type, 'imperials');
+    expect(r, `missing v2 sprite for: ${type}`).not.toBeNull();
+  }
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/sprites/v2/index.test.ts 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/sprites/v2/index.ts tests/renderer/sprites/v2/index.test.ts
+git commit -m "feat(overlay-mr2): wire all 29 unit types in v2/index.ts"
+```
+
+---
+
+### Task 7: Build unit entity list + skip canvas drawImage
+
+**Files:** `src/renderer/render-loop.ts`, `src/renderer/unit-renderer.ts`, `tests/renderer/unit-renderer-overlay.test.ts`
+
+- [ ] **Step 1: Write failing tests for fog gate and canvas skip**
+
+Create `tests/renderer/unit-renderer-overlay.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { buildUnitEntities } from '@/renderer/render-loop';
+import type { GameState, Unit, VisibilityMap } from '@/core/types';
+
+function makeState(units: Unit[], visMap: VisibilityMap = {}): GameState {
+  const civs: GameState['civilizations'] = {
+    'player1': { id: 'player1', color: '#b53026', civType: 'imperials', visibility: visMap } as any,
+    'barbarian': { id: 'barbarian', color: '#8b4513', civType: 'generic', visibility: {} } as any,
+  };
+  return {
+    currentPlayer: 'player1',
+    units: Object.fromEntries(units.map(u => [u.id, u])),
+    civilizations: civs,
+    espionage: {},
+  } as unknown as GameState;
+}
+
+function makeUnit(overrides: Partial<Unit> = {}): Unit {
+  return { id: 'u1', type: 'warrior', position: { q: 2, r: 3 }, owner: 'player1', ...overrides } as Unit;
+}
+
+function visMap(coords: Array<{ q: number; r: number }>, status: 'visible' | 'fog' | 'unexplored') {
+  const m: VisibilityMap = {};
+  for (const c of coords) m[`${c.q},${c.r}`] = status;
+  return m;
+}
+
+describe('buildUnitEntities', () => {
+  it('includes units in visible hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).toContain('u1');
+  });
+
+  it('excludes units in fog hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'fog'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('excludes units in unexplored hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'unexplored'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('excludes moving units (movement animation gate)', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']));
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('maps civType to faction', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities[0]?.faction).toBe('imperials');
+  });
+
+  it('falls back to imperials for generic civType', () => {
+    const u = makeUnit({ position: { q: 0, r: 0 }, owner: 'barbarian' });
+    const state = makeState([u], visMap([{ q: 0, r: 0 }], 'visible'));
+    // barbarian has civType 'generic'
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    // barbarians are filtered by getVisibleUnitsForPlayer so won't appear; but faction logic should still default
+    // This test validates the fallback path indirectly via a player-owned unit with unknown civType
+    expect(true).toBe(true); // covered by mapping logic
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/unit-renderer-overlay.test.ts 2>&1 | tail -5
+```
+
+Expected: module error — `buildUnitEntities` not exported yet.
+
+- [ ] **Step 3: Export buildUnitEntities from render-loop.ts**
+
+In `src/renderer/render-loop.ts`, add this exported helper function (outside the class):
+
+```typescript
+import { getVisibility } from '@/systems/fog-of-war';
+import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
+import type { SpriteEntity } from './sprite-overlay';
+
+const KNOWN_FACTIONS = new Set([
+  'imperials', 'vikings', 'pharaohs', 'hellenes', 'khanate', 'shogunate',
+]);
+
+export function buildUnitEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+  movingUnitIds: ReadonlySet<string>,
+): SpriteEntity[] {
+  const visible = getVisibleUnitsForPlayer(state.units, state, viewerId);
+  return visible
+    .filter(u => {
+      if (movingUnitIds.has(u.id)) return false;
+      return getVisibility(viewerVisibility, u.position) === 'visible';
+    })
+    .map(u => {
+      const civType = state.civilizations[u.owner]?.civType ?? 'generic';
+      const faction = KNOWN_FACTIONS.has(civType) ? civType : 'imperials';
+      return {
+        id: u.id,
+        kind: 'unit' as const,
+        subtype: u.type,
+        coord: u.position,
+        state: 'idle' as const, // walk state set during movement in overlay (MR 2 extension)
+        faction,
+      };
+    });
+}
+```
+
+- [ ] **Step 4: Wire buildUnitEntities into sync() call in render()**
+
+In `RenderLoop.render()`, replace `entities: [],` in the `spriteOverlay.sync()` call with:
+
+```typescript
+entities: viewerVisibility
+  ? buildUnitEntities(
+      this.state,
+      viewerId,
+      viewerVisibility,
+      new Set(getMovingUnitIds(this.unitMovementAnimations)),
+    )
+  : [],
+```
+
+- [ ] **Step 5: Skip drawImage in unit-renderer.ts for overlay-managed units**
+
+In `src/renderer/unit-renderer.ts`, `drawUnitGlyph` is called for each unit. Add a parameter to accept the active IDs set:
+
+Find the `export function drawUnits(...)` signature and add `activeOverlayIds: ReadonlySet<string>` as a parameter after the existing params.
+
+Inside the loop that calls `drawUnitGlyph` for each unit, wrap it:
+
+```typescript
+if (activeOverlayIds.has(unit.id)) continue; // overlay renders this unit
+```
+
+Then in `render-loop.ts`, pass `this.spriteOverlay.getActiveIds()` to `drawUnits`:
+
+```typescript
+drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup, {
+  hiddenUnitIds: getMovingUnitIds(this.unitMovementAnimations),
+}, this.spriteOverlay.getActiveIds()); // add this
+```
+
+Update the `drawUnits` function signature accordingly.
+
+- [ ] **Step 6: Run all tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+```
+
+Expected: all PASS, build exits 0.
+
+- [ ] **Step 7: Commit — MR 2 complete**
+
+```bash
+git add src/renderer/render-loop.ts src/renderer/unit-renderer.ts tests/renderer/unit-renderer-overlay.test.ts
+git commit -m "feat(overlay-mr2): unit sprites wired — fog gate, movement gate, canvas skip — MR 2 complete"
+```
+
+---
+
+## Phase 3 (MR 3) — Building Sprites
+
+### Task 8: Serialize missing building v2 sprites
+
+**Files:** `design/conquestoria-sprites/lib/buildings-v2.jsx`, `src/renderer/sprites/v2/*.svg.ts`
+
+- [ ] **Step 1: Identify missing buildings**
+
+```bash
+ls src/renderer/sprites/v2/*.svg.ts | xargs -I{} basename {} .svg.ts | sort > /tmp/v2-files.txt
+grep "Sprite," src/renderer/sprites/sprite-catalog.ts | sed "s/.*import { svg as //;s/Svg.*//" | tr '[:upper:]' '[:lower:]' | sort > /tmp/catalog.txt
+# Compare — any catalog entry without a v2 file needs serialization
+```
+
+Or simply run the script; it will skip types it already has and generate new ones for any added to buildings-v2.jsx.
+
+- [ ] **Step 2: Add JSX components for missing building types**
+
+Open `design/conquestoria-sprites/lib/buildings-v2.jsx`. For each building type missing from v2, add a `FooV2Building({ faction, phase })` function following the `BuildingFrameV2` pattern (auto-phase only, v1 animation CSS carries over). Export each via `Object.assign`.
+
+- [ ] **Step 3: Run serialize-sprites.mjs**
+
+```bash
+bash scripts/run-with-mise.sh node scripts/serialize-sprites.mjs 2>&1 | tail -20
+```
+
+- [ ] **Step 4: Verify generated files and commit**
+
+```bash
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+git add design/conquestoria-sprites/lib/buildings-v2.jsx src/renderer/sprites/v2/
+git commit -m "feat(overlay-mr3): serialize v2 SVGs for remaining building types"
+```
+
+---
+
+### Task 9: Wire buildings into v2/index.ts + RenderLoop
+
+**Files:** `src/renderer/sprites/v2/index.ts`, `src/renderer/render-loop.ts`, `tests/renderer/city-renderer-overlay.test.ts`
+
+- [ ] **Step 1: Add imports for new building files in v2/index.ts**
+
+For each newly generated `.svg.ts` file, add the matching import and entry in `BUILDING_SPRITES`. Follow the same pattern as existing entries. Remove the `// MR 3 adds remaining buildings` comment.
+
+- [ ] **Step 2: Add coverage test for all building types**
+
+In `tests/renderer/sprites/v2/index.test.ts`, add:
+
+```typescript
+import { BUILDINGS } from '@/systems/city-system';
+
+it('returns a sprite for every non-wonder building type (imperials faction)', () => {
+  const wonderIds = new Set(['pyramids', 'colosseum', 'great-library', 'lighthouse']);
+  for (const id of Object.keys(BUILDINGS)) {
+    if (wonderIds.has(id)) continue; // wonders are canvas-only — no v2 expected
+    const r = getBuildingSpriteV2(id, 'imperials');
+    expect(r, `missing v2 sprite for building: ${id}`).not.toBeNull();
+  }
+});
+```
+
+- [ ] **Step 3: Write city-renderer-overlay test**
+
+Create `tests/renderer/city-renderer-overlay.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { buildBuildingEntities } from '@/renderer/render-loop';
+import type { GameState, City } from '@/core/types';
+
+function makeState(city: Partial<City>): GameState {
+  const c = { id: 'c1', position: { q: 3, r: 4 }, owner: 'player1', buildings: ['granary'], ...city } as City;
+  return {
+    currentPlayer: 'player1',
+    cities: { c1: c },
+    civilizations: {
+      'player1': { id: 'player1', civType: 'imperials', visibility: { '3,4': 'visible' } } as any,
+    },
+  } as unknown as GameState;
+}
+
+describe('buildBuildingEntities', () => {
+  it('returns building entities for visible city', () => {
+    const state = makeState({});
+    const entities = buildBuildingEntities(state, 'player1', state.civilizations['player1'].visibility);
+    expect(entities.length).toBeGreaterThan(0);
+    expect(entities[0].kind).toBe('building');
+    expect(entities[0].coord).toEqual({ q: 3, r: 4 });
+  });
+
+  it('excludes buildings in fog cities', () => {
+    const state = makeState({});
+    // Override visibility to fog
+    (state.civilizations['player1'].visibility as any)['3,4'] = 'fog';
+    const entities = buildBuildingEntities(state, 'player1', state.civilizations['player1'].visibility);
+    expect(entities.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 4: Export buildBuildingEntities from render-loop.ts**
+
+```typescript
+export function buildBuildingEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+): SpriteEntity[] {
+  const civType = state.civilizations[viewerId]?.civType ?? 'generic';
+  const faction = KNOWN_FACTIONS.has(civType) ? civType : 'imperials';
+  const entities: SpriteEntity[] = [];
+
+  for (const city of Object.values(state.cities)) {
+    if (getVisibility(viewerVisibility, city.position) !== 'visible') continue;
+    for (const buildingId of city.buildings) {
+      entities.push({
+        id: `${city.id}:${buildingId}`,
+        kind: 'building',
+        subtype: buildingId,
+        coord: city.position,
+        state: 'idle',
+        faction,
+      });
+    }
+  }
+  return entities;
+}
+```
+
+Wire into `spriteOverlay.sync()` by combining unit and building entities:
+
+```typescript
+const unitEntities = viewerVisibility ? buildUnitEntities(...) : [];
+const buildingEntities = viewerVisibility ? buildBuildingEntities(this.state, viewerId, viewerVisibility) : [];
+this.spriteOverlay.sync(this.camera, [...unitEntities, ...buildingEntities], ...);
+```
+
+- [ ] **Step 5: Skip building drawImage in city-renderer.ts**
+
+In `src/renderer/city-renderer.ts`, find the `drawBuilding` call (or wherever `spriteCache.getBuilding` is called with `ctx.drawImage`). Add `activeOverlayIds: ReadonlySet<string>` to the `drawCities` signature and skip draw if `activeOverlayIds.has(buildingEntityId)`.
+
+The building entity ID format is `` `${city.id}:${buildingId}` `` — match this in the skip check.
+
+Pass `this.spriteOverlay.getActiveIds()` from `RenderLoop.render()` to `drawCities`.
+
+- [ ] **Step 6: Run full test suite and build**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+```
+
+- [ ] **Step 7: Commit — MR 3 complete**
+
+```bash
+git add src/renderer/sprites/v2/index.ts src/renderer/render-loop.ts src/renderer/city-renderer.ts \
+  tests/renderer/sprites/v2/index.test.ts tests/renderer/city-renderer-overlay.test.ts
+git commit -m "feat(overlay-mr3): building sprites wired — fog gate, canvas skip — MR 3 complete"
+```
+
+---
+
+## Phase 4 (MR 4) — Improvement Markers
+
+### Task 10: Create 8 SVG improvement marker files
+
+**Files:** `src/renderer/improvements/{farm,mine,lumber-camp,watermill,plantation,pasture,camp,quarry}-marker.ts`
+
+Each marker follows the `resource-outpost-marker.ts` pattern: `viewBox="0 0 48 48"`, no faction color, no animation, earthy palette (`#5e3f24`, `#8a6a3a`, `#d4a13c`, `#7ea860`), `stroke-linecap="round"`.
+
+Use the `generate-sprite-prompt` skill (`.claude/skills/generate-sprite-prompt.md`) to create Claude Design prompts for each if you want visual assistance.
+
+- [ ] **Step 1: Read the existing marker pattern**
+
+```bash
+cat src/renderer/improvements/resource-outpost-marker.ts
+```
+
+Note the structure: exports a `const FOO_IMPROVEMENT_SVG: string` with an SVG string literal.
+
+- [ ] **Step 2: Create farm-marker.ts**
+
+```typescript
+// src/renderer/improvements/farm-marker.ts
+export const FARM_IMPROVEMENT_SVG: string = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <rect x="4" y="28" width="40" height="14" rx="2" fill="#7ea860" stroke="#3a5a28" stroke-width="1.2"/>
+  <line x1="12" y1="28" x2="12" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <line x1="24" y1="28" x2="24" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <line x1="36" y1="28" x2="36" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <path d="M8,28 Q12,18 16,20 Q20,14 24,16 Q28,10 32,14 Q36,10 40,18 L40,28 Z" fill="#a0c86a" stroke="#5a8040" stroke-width="1.2"/>
+  <line x1="24" y1="16" x2="24" y2="28" stroke="#5a8040" stroke-width="0.8"/>
+</svg>`;
+```
+
+- [ ] **Step 3: Create the remaining 7 markers**
+
+Create one file per improvement type with a distinct recognisable SVG icon (48×48 viewBox, earthy palette). Follow the same export pattern: `export const MINE_IMPROVEMENT_SVG`, `export const LUMBER_CAMP_IMPROVEMENT_SVG`, etc.
+
+Suggested visual shapes:
+- `mine`: pickaxe silhouette + rock shape  
+- `lumber_camp`: stacked logs + axe  
+- `watermill`: wheel shape + water line  
+- `plantation`: tree row silhouette  
+- `pasture`: fence posts + animal outline  
+- `camp`: tent triangle + fire dot  
+- `quarry`: stepped stone blocks  
+
+- [ ] **Step 4: Commit marker files**
+
+```bash
+git add src/renderer/improvements/
+git commit -m "feat(overlay-mr4): create 8 SVG improvement marker files"
+```
+
+---
+
+### Task 11: Wire improvements into v2/index.ts + RenderLoop
+
+**Files:** `src/renderer/sprites/v2/index.ts`, `src/renderer/render-loop.ts`, `src/renderer/hex-renderer.ts`, `tests/renderer/improvements/improvement-overlay.test.ts`
+
+- [ ] **Step 1: Add improvement imports to v2/index.ts**
+
+```typescript
+import { FARM_IMPROVEMENT_SVG }         from '../improvements/farm-marker';
+import { MINE_IMPROVEMENT_SVG }         from '../improvements/mine-marker';
+import { LUMBER_CAMP_IMPROVEMENT_SVG }  from '../improvements/lumber-camp-marker';
+import { WATERMILL_IMPROVEMENT_SVG }    from '../improvements/watermill-marker';
+import { PLANTATION_IMPROVEMENT_SVG }   from '../improvements/plantation-marker';
+import { PASTURE_IMPROVEMENT_SVG }      from '../improvements/pasture-marker';
+import { CAMP_IMPROVEMENT_SVG }         from '../improvements/camp-marker';
+import { QUARRY_IMPROVEMENT_SVG }       from '../improvements/quarry-marker';
+import { RESOURCE_OUTPOST_IMPROVEMENT_SVG } from '../improvements/resource-outpost-marker';
+```
+
+Replace the empty `IMPROVEMENT_SPRITES` object with:
+
+```typescript
+const IMPROVEMENT_SPRITES: Record<string, string> = {
+  farm:              FARM_IMPROVEMENT_SVG,
+  mine:              MINE_IMPROVEMENT_SVG,
+  lumber_camp:       LUMBER_CAMP_IMPROVEMENT_SVG,
+  watermill:         WATERMILL_IMPROVEMENT_SVG,
+  plantation:        PLANTATION_IMPROVEMENT_SVG,
+  pasture:           PASTURE_IMPROVEMENT_SVG,
+  camp:              CAMP_IMPROVEMENT_SVG,
+  quarry:            QUARRY_IMPROVEMENT_SVG,
+  resource_outpost:  RESOURCE_OUTPOST_IMPROVEMENT_SVG,
+};
+```
+
+- [ ] **Step 2: Write improvement overlay tests**
+
+Create `tests/renderer/improvements/improvement-overlay.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { getImprovementSpriteV2 } from '@/renderer/sprites/v2/index';
+
+const ALL_IMPROVEMENT_TYPES = [
+  'farm', 'mine', 'lumber_camp', 'watermill', 'plantation',
+  'pasture', 'camp', 'quarry', 'resource_outpost',
+];
+
+describe('getImprovementSpriteV2', () => {
+  it('returns a non-null SVG string for every improvement type', () => {
+    for (const type of ALL_IMPROVEMENT_TYPES) {
+      const r = getImprovementSpriteV2(type);
+      expect(r, `missing improvement SVG for: ${type}`).not.toBeNull();
+      expect(r!).toContain('viewBox');
+    }
+  });
+
+  it('returns null for unknown type', () => {
+    expect(getImprovementSpriteV2('unknown_improvement')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/improvements/improvement-overlay.test.ts 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Export buildImprovementEntities from render-loop.ts**
+
+```typescript
+export function buildImprovementEntities(
+  state: GameState,
+  viewerVisibility: VisibilityMap,
+): SpriteEntity[] {
+  const entities: SpriteEntity[] = [];
+  for (const tile of Object.values(state.map?.tiles ?? {})) {
+    if (!tile.improvement) continue;
+    if (getVisibility(viewerVisibility, tile.coord) !== 'visible') continue;
+    entities.push({
+      id: `${tile.coord.q},${tile.coord.r}:${tile.improvement}`,
+      kind: 'improvement',
+      subtype: tile.improvement,
+      coord: tile.coord,
+      state: 'idle',
+      faction: 'neutral',
+    });
+  }
+  return entities;
+}
+```
+
+Add `buildImprovementEntities(...)` to the combined entity array in `spriteOverlay.sync()`.
+
+- [ ] **Step 5: Skip emoji in hex-renderer.ts**
+
+In `src/renderer/hex-renderer.ts`, find the `IMPROVEMENT_ICONS` usage where emoji glyphs are drawn to canvas. Add `activeOverlayIds: ReadonlySet<string>` to the render function signature. Skip emoji draw when:
+
+```typescript
+const improvementEntityId = `${tile.coord.q},${tile.coord.r}:${tile.improvement}`;
+if (activeOverlayIds.has(improvementEntityId)) continue; // overlay renders this
+```
+
+Pass `this.spriteOverlay.getActiveIds()` from `RenderLoop.render()` through `drawHexMap` to the improvement-drawing code path.
+
+- [ ] **Step 6: Run full test suite and build**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+```
+
+Expected: all PASS, build exits 0.
+
+- [ ] **Step 7: Commit — MR 4 complete**
+
+```bash
+git add src/renderer/sprites/v2/index.ts src/renderer/render-loop.ts \
+  src/renderer/hex-renderer.ts tests/renderer/improvements/improvement-overlay.test.ts
+git commit -m "feat(overlay-mr4): improvement markers wired — emoji replaced with SVG overlay — MR 4 complete"
+```
+
+---
+
+## Self-review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| `#sprite-overlay` CSS with `contain: layout style` (not paint) | Task 1 |
+| `will-change: transform` on container only | Task 1 + Task 3 |
+| `isPinching` getter on TouchHandler | Task 1 |
+| hashCode() defined in sprite-overlay.ts | Task 3 |
+| spriteWrapEl = firstElementChild (.cq-sprite-wrap) | Task 3 |
+| `--phase` set on spriteWrapEl (not outer wrapper) | Task 3 |
+| State via setAttribute only, no node replacement | Task 3 |
+| Camera transform: `scale(zoom) translate(-camX, -camY)` | Task 3 |
+| Pinch guard defers pool mutations | Task 3 |
+| LOD gate hides overlay | Task 3 |
+| reducedMotion hides overlay | Task 3 |
+| Fog-of-war entity filtering | Task 7 |
+| Movement animation gate | Task 7 |
+| v2 faction via `civType`, fallback to imperials | Task 7 |
+| Canvas skips drawImage for activeIds (units) | Task 7 |
+| Canvas skips drawImage for activeIds (buildings) | Task 9 |
+| Canvas skips emoji for activeIds (improvements) | Task 11 |
+| `getHorizontalWrapRenderCoords` — no overlay-owned wrap logic | Task 3 |
+| Pool position update when unit changes hex | Task 3 |
+| `invalidateFaction()` evicts by faction | Task 3 |
+| 29 unit types in v2/index | Task 6 |
+| All building types in v2/index | Task 9 |
+| All 9 improvement types in v2/index | Task 11 |
+
+**Placeholder scan:** No TBDs or "implement later" in tasks with code steps. Task 5 and Task 8 reference creative/design work (JSX sprite components) which genuinely cannot be shown as code — documented as design tasks with pattern references.
+
+**Type consistency:** `SpriteEntity`, `PoolEntry`, `hashCode`, `buildUnitEntities`, `buildBuildingEntities`, `buildImprovementEntities` — all defined once, referenced consistently.

--- a/docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md
+++ b/docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md
@@ -75,9 +75,9 @@ In `onTouchStart` (the handler for `touchstart`), the existing code checks `e.to
 
 In `onTouchEnd` (handles `touchend` and `touchcancel`), add at the top: `this._isPinching = e.touches.length >= 2;`
 
-- [ ] **Step 2: Add `#sprite-overlay` to index.html**
+- [ ] **Step 2: Add `#sprite-overlay` CSS to index.html**
 
-Open `index.html`. In the `<style>` block, add:
+Open `index.html`. In the `<style>` block, add the CSS rule only — **do NOT add an HTML element**. The `SpriteOverlay` constructor creates and inserts the div dynamically. Adding the element in HTML *and* the constructor would produce two `#sprite-overlay` elements.
 
 ```css
 #sprite-overlay {
@@ -94,13 +94,33 @@ Open `index.html`. In the `<style>` block, add:
 }
 ```
 
-In the `<body>`, after `<canvas id="game-canvas">` and before `<div id="ui-layer">`, add:
+- [ ] **Step 3: Add a smoke test for isPinching getter**
 
-```html
-<div id="sprite-overlay"></div>
+Check if `tests/input/touch-handler.test.ts` exists:
+
+```bash
+ls tests/input/touch-handler.test.ts 2>/dev/null || echo "no existing test"
 ```
 
-- [ ] **Step 3: Build to verify no TypeScript errors**
+If no existing test file, create `tests/input/touch-handler.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { TouchHandler } from '@/input/touch-handler';
+
+describe('TouchHandler.isPinching', () => {
+  it('starts false', () => {
+    const canvas = document.createElement('canvas');
+    // TouchHandler attaches listeners; callbacks are no-ops for this test
+    const th = new TouchHandler(canvas, {} as any, {} as any);
+    expect(th.isPinching).toBe(false);
+  });
+});
+```
+
+If an existing test file is present, add the `isPinching` test to it instead.
+
+- [ ] **Step 4: Build to verify no TypeScript errors**
 
 ```bash
 bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
@@ -108,11 +128,11 @@ bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
 
 Expected: exit 0.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/input/touch-handler.ts index.html
-git commit -m "feat(overlay-mr1): isPinching getter + #sprite-overlay HTML"
+git add src/input/touch-handler.ts index.html tests/input/
+git commit -m "feat(overlay-mr1): isPinching getter + #sprite-overlay CSS"
 ```
 
 ---
@@ -381,13 +401,13 @@ describe('sync() LOD gate', () => {
   it('hides container below LOD threshold', () => {
     const { overlay, mount } = mountOverlay();
     overlay.sync(cam({ zoom: LOD_SPRITE_ZOOM_THRESHOLD - 0.01 }), [], MAP, OPTS);
-    expect(mount.querySelector('#sprite-overlay')!.getAttribute('style')).toContain('display: none');
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.display).toBe('none');
   });
 
   it('hides container when reducedMotion', () => {
     const { overlay, mount } = mountOverlay();
     overlay.sync(cam({ zoom: 1 }), [], MAP, { ...OPTS, reducedMotion: true });
-    expect(mount.querySelector('#sprite-overlay')!.getAttribute('style')).toContain('display: none');
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.display).toBe('none');
   });
 
   it('shows container above threshold', () => {
@@ -524,8 +544,8 @@ export class SpriteOverlay {
     this.container.style.cssText =
       'position:absolute;top:0;left:0;width:0;height:0;overflow:visible;' +
       'pointer-events:none;transform-origin:top left;will-change:transform';
-    // contain: layout style — NOT paint (paint would clip the 0×0 box)
-    (this.container.style as unknown as Record<string, string>).contain = 'layout style';
+    // contain: layout style — NOT paint (paint clips the 0×0 box making sprites invisible)
+    this.container.style.setProperty('contain', 'layout style');
 
     const unit = makeLayer('unit-sprites');
     const building = makeLayer('building-sprites');
@@ -902,7 +922,7 @@ git commit -m "feat(overlay-mr2): wire all 29 unit types in v2/index.ts"
 Create `tests/renderer/unit-renderer-overlay.test.ts`:
 
 ```typescript
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { buildUnitEntities } from '@/renderer/render-loop';
 import type { GameState, Unit, VisibilityMap } from '@/core/types';
 
@@ -965,14 +985,18 @@ describe('buildUnitEntities', () => {
     expect(entities[0]?.faction).toBe('imperials');
   });
 
-  it('falls back to imperials for generic civType', () => {
-    const u = makeUnit({ position: { q: 0, r: 0 }, owner: 'barbarian' });
-    const state = makeState([u], visMap([{ q: 0, r: 0 }], 'visible'));
-    // barbarian has civType 'generic'
+  it('falls back to imperials for unknown civType', () => {
+    // Create a player civ with an unrecognised civType
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player2' });
+    const state = makeState([u], visMap([{ q: 2, r: 3 }], 'visible'));
+    // Add player2 with unknown civType
+    (state.civilizations as any)['player2'] = {
+      id: 'player2', civType: 'unknown_faction', visibility: {},
+    };
     const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
-    // barbarians are filtered by getVisibleUnitsForPlayer so won't appear; but faction logic should still default
-    // This test validates the fallback path indirectly via a player-owned unit with unknown civType
-    expect(true).toBe(true); // covered by mapping logic
+    const p2Entity = entities.find(e => e.id === u.id);
+    expect(p2Entity).toBeDefined();
+    expect(p2Entity!.faction).toBe('imperials'); // fallback
   });
 });
 ```
@@ -1042,25 +1066,39 @@ entities: viewerVisibility
 
 - [ ] **Step 5: Skip drawImage in unit-renderer.ts for overlay-managed units**
 
-In `src/renderer/unit-renderer.ts`, `drawUnitGlyph` is called for each unit. Add a parameter to accept the active IDs set:
-
-Find the `export function drawUnits(...)` signature and add `activeOverlayIds: ReadonlySet<string>` as a parameter after the existing params.
-
-Inside the loop that calls `drawUnitGlyph` for each unit, wrap it:
+In `src/renderer/unit-renderer.ts`, add `activeOverlayIds` with a **default value** to the `drawUnits` signature so existing callers are not broken:
 
 ```typescript
-if (activeOverlayIds.has(unit.id)) continue; // overlay renders this unit
+export function drawUnits(
+  ctx: CanvasRenderingContext2D,
+  units: Record<string, Unit>,
+  camera: Camera,
+  playerVisibility: VisibilityMap,
+  state: GameState,
+  currentPlayer: string,
+  colorLookup?: Record<string, string>,
+  options: { hiddenUnitIds?: Set<string> } = {},
+  activeOverlayIds: ReadonlySet<string> = new Set(), // new — defaults to empty
+): void {
 ```
 
-Then in `render-loop.ts`, pass `this.spriteOverlay.getActiveIds()` to `drawUnits`:
+Inside the existing loop where units are drawn (after filtering `visibleUnits`), add the skip check at the top of the per-stack loop:
+
+```typescript
+for (const stack of Object.values(groupUnitsByHex(visibleUnits))) {
+  // Skip entire stack if the top unit is overlay-managed
+  // (overlay renders the animated sprite; canvas only draws glyph fallback if overlay can't)
+  if (stack.every(u => activeOverlayIds.has(u.id))) continue;
+  // ... rest of existing draw logic
+```
+
+Then in `render-loop.ts`, pass the active IDs:
 
 ```typescript
 drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup, {
   hiddenUnitIds: getMovingUnitIds(this.unitMovementAnimations),
-}, this.spriteOverlay.getActiveIds()); // add this
+}, this.spriteOverlay.getActiveIds());
 ```
-
-Update the `drawUnits` function signature accordingly.
 
 - [ ] **Step 6: Run all tests**
 
@@ -1182,18 +1220,20 @@ describe('buildBuildingEntities', () => {
 
 - [ ] **Step 4: Export buildBuildingEntities from render-loop.ts**
 
+Note: faction must use the **city owner's** civType, not the viewer's. Enemy cities must show their owner's faction colors.
+
 ```typescript
 export function buildBuildingEntities(
   state: GameState,
-  viewerId: string,
   viewerVisibility: VisibilityMap,
 ): SpriteEntity[] {
-  const civType = state.civilizations[viewerId]?.civType ?? 'generic';
-  const faction = KNOWN_FACTIONS.has(civType) ? civType : 'imperials';
   const entities: SpriteEntity[] = [];
 
   for (const city of Object.values(state.cities)) {
     if (getVisibility(viewerVisibility, city.position) !== 'visible') continue;
+    // Use the CITY OWNER's civType, not the viewer's
+    const ownerCivType = state.civilizations[city.owner]?.civType ?? 'generic';
+    const faction = KNOWN_FACTIONS.has(ownerCivType) ? ownerCivType : 'imperials';
     for (const buildingId of city.buildings) {
       entities.push({
         id: `${city.id}:${buildingId}`,
@@ -1212,8 +1252,9 @@ export function buildBuildingEntities(
 Wire into `spriteOverlay.sync()` by combining unit and building entities:
 
 ```typescript
-const unitEntities = viewerVisibility ? buildUnitEntities(...) : [];
-const buildingEntities = viewerVisibility ? buildBuildingEntities(this.state, viewerId, viewerVisibility) : [];
+const unitEntities = viewerVisibility ? buildUnitEntities(this.state, viewerId, viewerVisibility,
+    new Set(getMovingUnitIds(this.unitMovementAnimations))) : [];
+const buildingEntities = viewerVisibility ? buildBuildingEntities(this.state, viewerVisibility) : [];
 this.spriteOverlay.sync(this.camera, [...unitEntities, ...buildingEntities], ...);
 ```
 
@@ -1244,180 +1285,215 @@ git commit -m "feat(overlay-mr3): building sprites wired — fog gate, canvas sk
 
 ## Phase 4 (MR 4) — Improvement Markers
 
-### Task 10: Create 8 SVG improvement marker files
+> **Architecture note:** Improvement markers have **no animation**, so they do NOT go through the DOM overlay. The `sprites.md` rule is explicit: *"No animation — improvement markers are drawn on Canvas 2D directly."* Follow the `resource-outpost-marker.ts` pattern: SVG string → blob → `HTMLImageElement` → `ctx.drawImage`. The `getImprovementSpriteV2` function in `v2/index.ts` remains `null`-returning — it is unused for improvements.
+
+### Task 10: Create 8 SVG improvement marker files + preload helpers
 
 **Files:** `src/renderer/improvements/{farm,mine,lumber-camp,watermill,plantation,pasture,camp,quarry}-marker.ts`
 
-Each marker follows the `resource-outpost-marker.ts` pattern: `viewBox="0 0 48 48"`, no faction color, no animation, earthy palette (`#5e3f24`, `#8a6a3a`, `#d4a13c`, `#7ea860`), `stroke-linecap="round"`.
+Each marker: `viewBox="0 0 48 48"`, no faction color, no animation, earthy palette (`#5e3f24`, `#8a6a3a`, `#d4a13c`, `#7ea860`), `stroke-linecap="round"`. Follows the `resource-outpost-marker.ts` pattern exactly (SVG string → cached HTMLImageElement).
 
-Use the `generate-sprite-prompt` skill (`.claude/skills/generate-sprite-prompt.md`) to create Claude Design prompts for each if you want visual assistance.
-
-- [ ] **Step 1: Read the existing marker pattern**
+- [ ] **Step 1: Read the existing pattern**
 
 ```bash
 cat src/renderer/improvements/resource-outpost-marker.ts
 ```
 
-Note the structure: exports a `const FOO_IMPROVEMENT_SVG: string` with an SVG string literal.
+Note: exports `preloadOutpostMarker()` and `getOutpostMarkerImage()`. Each new marker file must export `preload<Name>Marker()` and `get<Name>MarkerImage()`.
 
 - [ ] **Step 2: Create farm-marker.ts**
 
 ```typescript
 // src/renderer/improvements/farm-marker.ts
-export const FARM_IMPROVEMENT_SVG: string = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
   <rect x="4" y="28" width="40" height="14" rx="2" fill="#7ea860" stroke="#3a5a28" stroke-width="1.2"/>
   <line x1="12" y1="28" x2="12" y2="42" stroke="#5a8040" stroke-width="1"/>
   <line x1="24" y1="28" x2="24" y2="42" stroke="#5a8040" stroke-width="1"/>
   <line x1="36" y1="28" x2="36" y2="42" stroke="#5a8040" stroke-width="1"/>
-  <path d="M8,28 Q12,18 16,20 Q20,14 24,16 Q28,10 32,14 Q36,10 40,18 L40,28 Z" fill="#a0c86a" stroke="#5a8040" stroke-width="1.2"/>
-  <line x1="24" y1="16" x2="24" y2="28" stroke="#5a8040" stroke-width="0.8"/>
+  <path d="M8,28 Q12,18 16,20 Q20,14 24,16 Q28,10 32,14 Q36,10 40,18 L40,28 Z"
+        fill="#a0c86a" stroke="#5a8040" stroke-width="1.2"/>
 </svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadFarmMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(); };
+    img.src = url;
+  });
+}
+
+export function getFarmMarkerImage(): HTMLImageElement | null { return cached; }
 ```
 
 - [ ] **Step 3: Create the remaining 7 markers**
 
-Create one file per improvement type with a distinct recognisable SVG icon (48×48 viewBox, earthy palette). Follow the same export pattern: `export const MINE_IMPROVEMENT_SVG`, `export const LUMBER_CAMP_IMPROVEMENT_SVG`, etc.
+Create one file per improvement type (earthy palette, 48×48). Each exports `preload<Name>Marker()` and `get<Name>MarkerImage()`:
 
-Suggested visual shapes:
-- `mine`: pickaxe silhouette + rock shape  
-- `lumber_camp`: stacked logs + axe  
-- `watermill`: wheel shape + water line  
-- `plantation`: tree row silhouette  
-- `pasture`: fence posts + animal outline  
-- `camp`: tent triangle + fire dot  
-- `quarry`: stepped stone blocks  
+- `mine-marker.ts` — pickaxe silhouette + rock
+- `lumber-camp-marker.ts` — stacked logs + axe
+- `watermill-marker.ts` — wheel + water line
+- `plantation-marker.ts` — tree row silhouette
+- `pasture-marker.ts` — fence posts + animal outline
+- `camp-marker.ts` — tent triangle + fire dot
+- `quarry-marker.ts` — stepped stone blocks
 
-- [ ] **Step 4: Commit marker files**
+- [ ] **Step 4: Wire preload calls into game init**
+
+In `src/main.ts`, find where `preloadOutpostMarker()` is called (or `initSprites()`). Add calls to all 8 new `preload*Marker()` functions in the same block:
+
+```typescript
+await Promise.all([
+  preloadOutpostMarker(),
+  preloadFarmMarker(),
+  preloadMineMarker(),
+  preloadLumberCampMarker(),
+  preloadWatermillMarker(),
+  preloadPlantationMarker(),
+  preloadPastureMarker(),
+  preloadCampMarker(),
+  preloadQuarryMarker(),
+]);
+```
+
+- [ ] **Step 5: Commit**
 
 ```bash
-git add src/renderer/improvements/
-git commit -m "feat(overlay-mr4): create 8 SVG improvement marker files"
+git add src/renderer/improvements/ src/main.ts
+git commit -m "feat(overlay-mr4): create 8 SVG improvement marker files with preload helpers"
 ```
 
 ---
 
-### Task 11: Wire improvements into v2/index.ts + RenderLoop
+### Task 11: Replace emoji with ctx.drawImage in hex-renderer
 
-**Files:** `src/renderer/sprites/v2/index.ts`, `src/renderer/render-loop.ts`, `src/renderer/hex-renderer.ts`, `tests/renderer/improvements/improvement-overlay.test.ts`
+**Files:** `src/renderer/hex-renderer.ts`, `tests/renderer/improvements/improvement-markers.test.ts`
 
-- [ ] **Step 1: Add improvement imports to v2/index.ts**
+- [ ] **Step 1: Write a test confirming SVGs are valid and preload correctly**
 
-```typescript
-import { FARM_IMPROVEMENT_SVG }         from '../improvements/farm-marker';
-import { MINE_IMPROVEMENT_SVG }         from '../improvements/mine-marker';
-import { LUMBER_CAMP_IMPROVEMENT_SVG }  from '../improvements/lumber-camp-marker';
-import { WATERMILL_IMPROVEMENT_SVG }    from '../improvements/watermill-marker';
-import { PLANTATION_IMPROVEMENT_SVG }   from '../improvements/plantation-marker';
-import { PASTURE_IMPROVEMENT_SVG }      from '../improvements/pasture-marker';
-import { CAMP_IMPROVEMENT_SVG }         from '../improvements/camp-marker';
-import { QUARRY_IMPROVEMENT_SVG }       from '../improvements/quarry-marker';
-import { RESOURCE_OUTPOST_IMPROVEMENT_SVG } from '../improvements/resource-outpost-marker';
-```
-
-Replace the empty `IMPROVEMENT_SPRITES` object with:
-
-```typescript
-const IMPROVEMENT_SPRITES: Record<string, string> = {
-  farm:              FARM_IMPROVEMENT_SVG,
-  mine:              MINE_IMPROVEMENT_SVG,
-  lumber_camp:       LUMBER_CAMP_IMPROVEMENT_SVG,
-  watermill:         WATERMILL_IMPROVEMENT_SVG,
-  plantation:        PLANTATION_IMPROVEMENT_SVG,
-  pasture:           PASTURE_IMPROVEMENT_SVG,
-  camp:              CAMP_IMPROVEMENT_SVG,
-  quarry:            QUARRY_IMPROVEMENT_SVG,
-  resource_outpost:  RESOURCE_OUTPOST_IMPROVEMENT_SVG,
-};
-```
-
-- [ ] **Step 2: Write improvement overlay tests**
-
-Create `tests/renderer/improvements/improvement-overlay.test.ts`:
+Create `tests/renderer/improvements/improvement-markers.test.ts`:
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import { getImprovementSpriteV2 } from '@/renderer/sprites/v2/index';
 
-const ALL_IMPROVEMENT_TYPES = [
-  'farm', 'mine', 'lumber_camp', 'watermill', 'plantation',
-  'pasture', 'camp', 'quarry', 'resource_outpost',
+// Test the SVG string shapes (preload requires browser Image API not available in vitest)
+// Integration: verify that each marker module exports the required functions
+
+const markerModules = [
+  '@/renderer/improvements/farm-marker',
+  '@/renderer/improvements/mine-marker',
+  '@/renderer/improvements/lumber-camp-marker',
+  '@/renderer/improvements/watermill-marker',
+  '@/renderer/improvements/plantation-marker',
+  '@/renderer/improvements/pasture-marker',
+  '@/renderer/improvements/camp-marker',
+  '@/renderer/improvements/quarry-marker',
 ];
 
-describe('getImprovementSpriteV2', () => {
-  it('returns a non-null SVG string for every improvement type', () => {
-    for (const type of ALL_IMPROVEMENT_TYPES) {
-      const r = getImprovementSpriteV2(type);
-      expect(r, `missing improvement SVG for: ${type}`).not.toBeNull();
-      expect(r!).toContain('viewBox');
+describe('improvement marker modules', () => {
+  it('each module exports preload and getImage functions', async () => {
+    for (const path of markerModules) {
+      const mod = await import(path);
+      const keys = Object.keys(mod);
+      const hasPreload = keys.some(k => k.startsWith('preload'));
+      const hasGet = keys.some(k => k.startsWith('get') && k.endsWith('Image'));
+      expect(hasPreload, `${path} missing preload function`).toBe(true);
+      expect(hasGet, `${path} missing get*Image function`).toBe(true);
     }
-  });
-
-  it('returns null for unknown type', () => {
-    expect(getImprovementSpriteV2('unknown_improvement')).toBeNull();
   });
 });
 ```
 
-- [ ] **Step 3: Run tests**
+- [ ] **Step 2: Run tests**
 
 ```bash
-bash scripts/run-with-mise.sh yarn test -- tests/renderer/improvements/improvement-overlay.test.ts 2>&1 | tail -10
+bash scripts/run-with-mise.sh yarn test -- tests/renderer/improvements/improvement-markers.test.ts 2>&1 | tail -10
 ```
 
 Expected: all PASS.
 
-- [ ] **Step 4: Export buildImprovementEntities from render-loop.ts**
+- [ ] **Step 3: Replace emoji in hex-renderer.ts**
+
+In `src/renderer/hex-renderer.ts`, add imports at the top:
 
 ```typescript
-export function buildImprovementEntities(
-  state: GameState,
-  viewerVisibility: VisibilityMap,
-): SpriteEntity[] {
-  const entities: SpriteEntity[] = [];
-  for (const tile of Object.values(state.map?.tiles ?? {})) {
-    if (!tile.improvement) continue;
-    if (getVisibility(viewerVisibility, tile.coord) !== 'visible') continue;
-    entities.push({
-      id: `${tile.coord.q},${tile.coord.r}:${tile.improvement}`,
-      kind: 'improvement',
-      subtype: tile.improvement,
-      coord: tile.coord,
-      state: 'idle',
-      faction: 'neutral',
-    });
-  }
-  return entities;
+import { getFarmMarkerImage } from './improvements/farm-marker';
+import { getMineMarkerImage } from './improvements/mine-marker';
+import { getLumberCampMarkerImage } from './improvements/lumber-camp-marker';
+import { getWatermillMarkerImage } from './improvements/watermill-marker';
+import { getPlantationMarkerImage } from './improvements/plantation-marker';
+import { getPastureMarkerImage } from './improvements/pasture-marker';
+import { getCampMarkerImage } from './improvements/camp-marker';
+import { getQuarryMarkerImage } from './improvements/quarry-marker';
+```
+
+Add a lookup map alongside `IMPROVEMENT_ICONS`:
+
+```typescript
+const IMPROVEMENT_MARKER_GETTERS: Record<string, () => HTMLImageElement | null> = {
+  farm:        getFarmMarkerImage,
+  mine:        getMineMarkerImage,
+  lumber_camp: getLumberCampMarkerImage,
+  watermill:   getWatermillMarkerImage,
+  plantation:  getPlantationMarkerImage,
+  pasture:     getPastureMarkerImage,
+  camp:        getCampMarkerImage,
+  quarry:      getQuarryMarkerImage,
+};
+```
+
+In `drawHexTile`, find the `else` branch (line ~301) that draws the emoji fallback:
+
+```typescript
+} else {
+  ctx.fillStyle = 'rgba(255,255,255,0.8)';
+  ctx.font = `${size * 0.5}px system-ui`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  const icon = IMPROVEMENT_ICONS[tile.improvement] ?? '◆';
+  ctx.fillText(icon, cx, cy);
 }
 ```
 
-Add `buildImprovementEntities(...)` to the combined entity array in `spriteOverlay.sync()`.
-
-- [ ] **Step 5: Skip emoji in hex-renderer.ts**
-
-In `src/renderer/hex-renderer.ts`, find the `IMPROVEMENT_ICONS` usage where emoji glyphs are drawn to canvas. Add `activeOverlayIds: ReadonlySet<string>` to the render function signature. Skip emoji draw when:
+Replace with:
 
 ```typescript
-const improvementEntityId = `${tile.coord.q},${tile.coord.r}:${tile.improvement}`;
-if (activeOverlayIds.has(improvementEntityId)) continue; // overlay renders this
+} else {
+  const getter = IMPROVEMENT_MARKER_GETTERS[tile.improvement];
+  const img = getter ? getter() : null;
+  if (img) {
+    const s = size * 0.6;
+    ctx.drawImage(img, cx - s / 2, cy - s * 0.7, s, s);
+  } else {
+    // Fallback to emoji while marker loads or for unknown improvement types
+    ctx.fillStyle = 'rgba(255,255,255,0.8)';
+    ctx.font = `${size * 0.5}px system-ui`;
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const icon = IMPROVEMENT_ICONS[tile.improvement] ?? '◆';
+    ctx.fillText(icon, cx, cy);
+  }
+}
 ```
 
-Pass `this.spriteOverlay.getActiveIds()` from `RenderLoop.render()` through `drawHexMap` to the improvement-drawing code path.
-
-- [ ] **Step 6: Run full test suite and build**
+- [ ] **Step 4: Build and run full test suite**
 
 ```bash
-bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
 bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
 ```
 
-Expected: all PASS, build exits 0.
+Expected: build exits 0, all tests PASS.
 
-- [ ] **Step 7: Commit — MR 4 complete**
+- [ ] **Step 5: Commit — MR 4 complete**
 
 ```bash
-git add src/renderer/sprites/v2/index.ts src/renderer/render-loop.ts \
-  src/renderer/hex-renderer.ts tests/renderer/improvements/improvement-overlay.test.ts
-git commit -m "feat(overlay-mr4): improvement markers wired — emoji replaced with SVG overlay — MR 4 complete"
+git add src/renderer/hex-renderer.ts tests/renderer/improvements/improvement-markers.test.ts
+git commit -m "feat(overlay-mr4): replace improvement emoji with SVG canvas drawImage — MR 4 complete"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-06-06-sprite-overlay-renderer-design.md
+++ b/docs/superpowers/specs/2026-06-06-sprite-overlay-renderer-design.md
@@ -1,7 +1,7 @@
 # Sprite Overlay Renderer — Design Spec
 
 **Date:** 2026-06-06  
-**Status:** Approved  
+**Status:** Approved (rev 2 — post code-review)  
 **Scope:** DOM overlay layer for v2 animated sprites (units, buildings, improvements)  
 **Delivery:** 4 independent MRs  
 
@@ -9,7 +9,7 @@
 
 ## Background
 
-The v2 sprite system (`src/renderer/sprites/v2/`) contains pre-serialized SVG strings for **18 of 26 units** and **23 of 33 buildings**, with CSS animation class hooks (`cq-leg-l/r`, `cq-arm-l/r`, `cq-weapon`, `cq-fire`, etc.) driven by `src/assets/sprite-animations-v2.css`. The remaining 8 units (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista, caravan, expedition, transport) and 10 buildings were never serialized and must be generated via `scripts/serialize-sprites.mjs` before they can be wired into the overlay. The 4 legendary wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) have no v2 equivalents and remain on the canvas path indefinitely.
+The v2 sprite system (`src/renderer/sprites/v2/`) contains pre-serialized SVG strings for **18 of 29 units** and **23 of 33 buildings**, with CSS animation class hooks (`cq-leg-l/r`, `cq-arm-l/r`, `cq-weapon`, `cq-fire`, etc.) driven by `src/assets/sprite-animations-v2.css`. The remaining 11 units (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista, caravan, expedition, transport) and 10 buildings were never serialized and must be generated via `scripts/serialize-sprites.mjs` before they can be wired into the overlay. The 4 legendary wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) have no v2 equivalents and remain on the canvas path indefinitely.
 
 These animations require **live DOM SVG elements** — browsers block CSS animations inside SVGs loaded as `<img src="...">`, which is how the current Canvas 2D renderer loads sprites.
 
@@ -53,6 +53,8 @@ This spec defines a DOM overlay layer that sits above the canvas, provides live 
 
 `#sprite-overlay` sits between the canvas and the UI layer. It has `pointer-events: none` so all touch and mouse input continues to reach the canvas unmodified.
 
+**Fog-of-war note:** The overlay sits *above* the canvas fog layer. Sprites must never be added to the overlay for entities in fog or unexplored hexes — this is enforced by entity filtering in `RenderLoop` before `sync()` is called (see [Entity filtering](#entity-filtering)).
+
 ### sprite-overlay CSS
 
 ```css
@@ -62,15 +64,18 @@ This spec defines a DOM overlay layer that sits above the canvas, provides live 
   left: 0;
   width: 0;
   height: 0;
-  overflow: visible;
+  overflow: visible;           /* REQUIRED — sprites are positioned outside the 0×0 box */
   pointer-events: none;
   transform-origin: top left;
-  contain: layout style paint;   /* isolates subtree — pool mutations don't trigger page reflow */
-  will-change: transform;        /* one GPU layer for the whole overlay — NEVER on individual sprites */
+  contain: layout style;       /* isolates subtree layout/style — omit 'paint': paint containment
+                                  clips to the 0×0 border box and makes all sprites invisible */
+  will-change: transform;      /* one GPU layer for the whole overlay — NEVER on individual sprites */
 }
 ```
 
 **`will-change` discipline:** `will-change: transform` goes on `#sprite-overlay` only, promoting the entire overlay to a single GPU texture. It must never be applied to individual sprite wrapper elements — excessive layer promotion exhausts VRAM on mobile devices (confirmed by Chrome hardware acceleration docs and MDN).
+
+**`contain: paint` is explicitly excluded.** The element's layout box is 0×0 with `overflow: visible` — `paint` containment would clip all rendering to that box, making every sprite invisible.
 
 ### Camera synchronization
 
@@ -80,7 +85,7 @@ Each frame, a single style write syncs the overlay to the camera:
 container.style.transform = `scale(${zoom}) translate(${-camX}px, ${-camY}px)`
 ```
 
-Sprites are positioned at **world pixel coordinates** (`left: hexToPixel(coord).x`, `top: hexToPixel(coord).y`). The container transform is applied by the browser compositor — this is mathematically identical to `camera.worldToScreen()`:
+Sprites are positioned at **world pixel coordinates** (`left: hexToPixel(coord, camera.hexSize).x`, `top: hexToPixel(coord, camera.hexSize).y`). The `camera.hexSize` value must always be used — not a hardcoded constant. The container transform is applied by the browser compositor — this is mathematically identical to `camera.worldToScreen()`:
 
 ```
 Canvas:  screenX = (worldX - camX) * zoom
@@ -112,20 +117,51 @@ interface SpriteEntity {
   kind:    'unit' | 'building' | 'improvement';
   subtype: string;                          // UnitType | building key | improvement type
   coord:   HexCoord;
-  state:   'idle' | 'walk' | 'attack';     // drives data-state on inner SVG
+  state:   'idle' | 'walk' | 'attack';     // v2 animation vocabulary — see Motion Vocabulary below
   faction: string;                          // 'imperials' | 'vikings' | … | 'neutral' (improvements)
 }
 ```
+
+### Motion vocabulary — v1 vs v2
+
+Two motion vocabularies coexist in the codebase and must not be conflated:
+
+| System | Type | Values |
+|---|---|---|
+| v1 canvas | `UnitSpriteMotion` | `'idle' \| 'move-a' \| 'move-b'` |
+| v2 CSS | `SpriteEntity.state` | `'idle' \| 'walk' \| 'attack'` |
+
+`RenderLoop` is responsible for translating: when a unit's `UnitSpriteMotion` is `'move-a'` or `'move-b'`, the corresponding `SpriteEntity.state` is `'walk'`. The CSS animation keyframes key off `data-state="walk"` on the `cq-sprite-wrap` element.
 
 ### Pool entry
 
 ```typescript
 interface PoolEntry {
-  el:    HTMLDivElement;   // the 128×128 wrapper div
-  svgEl: Element;          // reference to the inner element with data-state — for O(1) setAttribute
-  phase: number;           // 0–1, set once at creation, never recalculated
+  el:          HTMLDivElement;    // the positional wrapper div (world-space left/top)
+  spriteWrapEl: HTMLElement;      // the inner .cq-sprite-wrap.cq-v2 element — animation root
+  phase:       number;            // 0–1, set once at creation on spriteWrapEl, never recalculated
 }
 ```
+
+`spriteWrapEl` is the element that carries `class="cq-sprite-wrap cq-v2"`, `data-state`, and `--phase`. It is the root the CSS animation selectors key off (`.cq-v2[data-state="idle"]`). It is NOT the outer positional wrapper and NOT the `<svg>` element inside it.
+
+### Phase hash
+
+```typescript
+// djb2 hash — deterministic, no external dependency
+function hashCode(str: string): number {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) ^ str.charCodeAt(i);
+  }
+  return h >>> 0;  // unsigned 32-bit
+}
+
+// Usage: phase ∈ [0, 1), unique per entity.id
+const phase = (hashCode(entity.id) % 100) / 100;
+```
+
+Defined in `src/renderer/sprite-overlay.ts`. Not exposed publicly.
 
 ---
 
@@ -135,7 +171,7 @@ interface PoolEntry {
 
 ```typescript
 class SpriteOverlay {
-  // Mounts #sprite-overlay into mountPoint, inserts layer divs
+  // Mounts container into mountPoint, inserts layer divs
   constructor(mountPoint: HTMLElement)
 
   // Called every rAF from RenderLoop.render()
@@ -154,9 +190,11 @@ class SpriteOverlay {
 }
 ```
 
+**`reducedMotion` in opts:** When `true`, the overlay hides itself (`display: none`) and falls back to the canvas path entirely. CSS `prefers-reduced-motion` already pauses animation keyframes, but hiding the overlay ensures canvas glyphs (which don't animate) render instead of static frozen SVGs.
+
 ### sync() — frame-by-frame steps
 
-1. **LOD gate** — if `camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD`, set `container.style.display = 'none'` and return. Canvas glyph fallbacks take over.
+1. **LOD gate** — if `camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD` or `opts.reducedMotion`, set `container.style.display = 'none'` and return. Canvas glyph fallbacks take over.
 
 2. **Camera transform** — always runs, even during pinch:
    ```
@@ -167,24 +205,81 @@ class SpriteOverlay {
 
 4. **Entity → DOM** — for each entity:
    - Call `getHorizontalWrapRenderCoords()` to get render coords (including ghosts)
-   - For each coord, key = `${entity.id}:ghostIndex`
-   - Pool hit: call `svgEl.setAttribute('data-state', entity.state)` — no node replacement
-   - Pool miss: create element, parse SVG once via `innerHTML`, store `{ el, svgEl, phase }` in pool
+   - For each coord, key = `${entity.id}:${ghostIndex}`
+   - Pool hit: `spriteWrapEl.setAttribute('data-state', entity.state)` — no node replacement
+   - Pool miss: create element, parse SVG once via `innerHTML`, store `{ el, spriteWrapEl, phase }` in pool
 
 5. **Cull stale** — remove from DOM and pool any entry not seen this frame. Update `activeIds`.
 
 ### Element creation
 
 ```typescript
-// Wrapper div — world-space positioned, centered on hex
+// Positional wrapper — world-space coordinates, centered on hex
+const wrapper = document.createElement('div');
 wrapper.style.cssText = 'position:absolute;width:128px;height:128px;transform:translate(-50%,-50%)';
-wrapper.style.setProperty('--phase', String(phase));  // set once, never updated
-wrapper.innerHTML = svgHtml;                           // parse once at creation only
+// NO will-change here — only the container gets it
+
+wrapper.innerHTML = svgHtml;  // parse once at creation only
+// svgHtml is our own generated content — safe; no user-generated strings
+
+// spriteWrapEl is the .cq-sprite-wrap.cq-v2 div inserted by innerHTML
+const spriteWrapEl = wrapper.firstElementChild as HTMLElement;
+
+// Override the baked style="--phase:0" with the entity's deterministic phase
+// setProperty on the same element wins over the baked inline style
+spriteWrapEl.style.setProperty('--phase', String(phase));
+
+pool.set(key, { el: wrapper, spriteWrapEl, phase });
+layerDiv.appendChild(wrapper);
 ```
 
-**Phase desync:** `phase = Math.abs(hashCode(entity.id) % 100) / 100` — deterministic from entity ID, produces different values for every unit even of the same type, set once at element creation.
+**Why `spriteWrapEl`, not `wrapper`:** The v2 SVG strings are serialized as:
+```
+<div class="cq-sprite-wrap cq-v2" data-state="idle" data-kind="..." style="--phase:0">
+  <svg ...>...</svg>
+</div>
+```
+The CSS animation selectors are `.cq-v2[data-state="idle"] .cq-sprite-figure` etc. — they key off the `cq-sprite-wrap` div, not the outer positional wrapper or the `<svg>`. All state updates and phase overrides must target `spriteWrapEl` (the first child of `wrapper`).
 
-**State transitions:** Unit animation state (idle/walk/attack) is updated via `svgEl.setAttribute('data-state', state)` only. The DOM node is never replaced — replacement would reset the CSS animation timer, causing the walking cycle to restart from frame 0.
+**Phase desync:** Set once at element creation by calling `spriteWrapEl.style.setProperty('--phase', ...)` which overrides the baked `style="--phase:0"`. CSS custom properties on the same element: inline `setProperty` wins. Phase is deterministic from entity ID via `hashCode()` — never recalculated, survives pool reuse.
+
+**State transitions:** `spriteWrapEl.setAttribute('data-state', state)` only. Never replace the DOM node — replacement resets the CSS animation timer, causing walking to restart from frame 0.
+
+### Entity filtering (fog-of-war and movement animations) {#entity-filtering}
+
+`RenderLoop` builds `SpriteEntity[]` before calling `sync()`. Two filters are mandatory:
+
+**Fog gate:** Only include entities whose hex is `'visible'` in the viewer's visibility map. `'fog'` and `'unexplored'` hexes must be excluded. The overlay sits above the canvas fog layer — any sprite passed to `sync()` will be visible to the player regardless of fog state.
+
+```typescript
+// In RenderLoop.render(), before building unitEntities:
+const visibleUnits = getVisibleUnitsForPlayer(state.units, state, viewerId)
+  .filter(u => getVisibility(viewerVisibility, u.position) === 'visible');
+```
+
+**Movement animation gate:** Units currently in a canvas movement animation are hidden from the static `drawUnits` call via `hiddenUnitIds`. They must also be excluded from the `SpriteEntity[]` to avoid showing a static overlay sprite at the origin hex while the canvas animation plays the interpolated position.
+
+```typescript
+const movingIds = new Set(getMovingUnitIds(this.unitMovementAnimations));
+const unitEntities = visibleUnits
+  .filter(u => !movingIds.has(u.id))
+  .map(u => toSpriteEntity(u, state, colorLookup));
+```
+
+### isPinching — TouchHandler API
+
+`TouchHandler` must expose a public getter:
+
+```typescript
+class TouchHandler {
+  private _isPinching = false;
+
+  get isPinching(): boolean { return this._isPinching; }
+  // ... existing implementation sets _isPinching in touch event handlers
+}
+```
+
+`RenderLoop` reads `this.touchHandler.isPinching` at the start of each `render()` call and passes it through to `sync()`.
 
 ### Layer structure inside #sprite-overlay
 
@@ -257,44 +352,50 @@ Barbarian and minor civ unit sprites are not preloaded in the v2 system by desig
 
 **Modified files:**
 - `index.html` — add `#sprite-overlay` div with CSS
-- `src/renderer/render-loop.ts` — instantiate SpriteOverlay; call `sync()` with empty entity list
-- `src/input/touch-handler.ts` — expose `isPinching: boolean` flag
+- `src/renderer/render-loop.ts` — instantiate SpriteOverlay; call `sync()` with empty entity list; read `touchHandler.isPinching` each frame
+- `src/input/touch-handler.ts` — add `get isPinching(): boolean` public getter
 
-**Tests:** `tests/renderer/sprite-overlay.test.ts` — camera math, ghost count, pinch guard, pool lifecycle, LOD gate, state transition via setAttribute.
+**Tests:** `tests/renderer/sprite-overlay.test.ts` — camera math, ghost count, pinch guard (no DOM mutations while pinching), pool lifecycle, LOD gate, state transition via setAttribute only (no node replacement), `reducedMotion` hides overlay.
 
 **Safe to merge because:** Overlay is invisible (empty entity list). All existing canvas rendering untouched.
 
 ---
 
-### MR 2 — Unit sprites (18 of 26 animated; remainder serialized in this MR)
+### MR 2 — Unit sprites (29 total; 18 existing + 11 serialized in this MR)
 
-v2 files exist today for 18 units. The remaining 8 (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista) and 3 transport units (caravan, expedition, transport) must be serialized first by running `node scripts/serialize-sprites.mjs` with the missing types added to the design JSX. This serialization is part of MR 2.
+v2 files exist today for 18 units. The remaining 11 (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista, caravan, expedition, transport) must be serialized first by running `node scripts/serialize-sprites.mjs` with the missing types added to the design JSX in `design/conquestoria-sprites/lib/units-v2.jsx`. This serialization step is part of MR 2.
 
 **Modified files:**
-- `src/renderer/render-loop.ts` — build `SpriteEntity[]` from visible units; pass to `sync()`
+- `src/renderer/render-loop.ts` — build `SpriteEntity[]` from visible, non-moving units only; apply fog gate and movement animation gate; pass to `sync()`
 - `src/renderer/unit-renderer.ts` — skip `ctx.drawImage` if `activeIds.has(unit.id)`
 - `src/renderer/sprites/v2/index.ts` — wire `getUnitSpriteV2()`
-- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all remaining unit types
+- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all 11 remaining unit types
 
-**Tests:** `tests/renderer/unit-renderer-overlay.test.ts` — canvas skips drawImage for overlay-managed units; barbarians always canvas; wrap ghost count correct.
+**Tests:** `tests/renderer/unit-renderer-overlay.test.ts`:
+- Canvas skips drawImage for overlay-managed units
+- Barbarians always canvas (never in activeIds)
+- Wrap ghost count correct at seam
+- Unit in fog hex excluded from entity list
+- Moving unit excluded from entity list (no double-render at origin hex)
+- data-state='walk' set during movement animation (while unit is NOT in movingIds — i.e. after animation completes)
 
-**Safe to merge because:** Canvas falls back to drawImage → glyph for barbarians and any type the overlay can't serve. Wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) always stay on canvas — they have no v2 files and are not expected to.
+**Safe to merge because:** Canvas falls back to drawImage → glyph for barbarians and any type the overlay can't serve. Wonder sprites always stay on canvas.
 
 ---
 
-### MR 3 — Building sprites (23 of 33 animated; remainder serialized in this MR)
+### MR 3 — Building sprites (33 total; 23 existing + 10 serialized in this MR)
 
 v2 files exist today for 23 buildings. The remaining 10 must be serialized as part of this MR using `scripts/serialize-sprites.mjs`. The 4 legendary wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) have no v2 equivalents and remain on the canvas path — they are explicitly out of scope.
 
 **Modified files:**
-- `src/renderer/render-loop.ts` — add building entity list from visible cities
+- `src/renderer/render-loop.ts` — add building entity list from visible cities; apply fog gate
 - `src/renderer/city-renderer.ts` — skip building `drawImage` if in `activeIds`
 - `src/renderer/sprites/v2/index.ts` — wire `getBuildingSpriteV2()`
-- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all remaining building types
+- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all 10 remaining building types
 
-**Tests:** Building in overlay at city hex; canvas does not double-draw; wrap ghost correct; buildings not in v2 catalog (including wonders) fall back to canvas.
+**Tests:** Building in overlay at city hex; canvas does not double-draw; wrap ghost correct; buildings not in v2 catalog (including wonders) fall back to canvas; building in fog city excluded.
 
-**Safe to merge because:** Same fallback chain as MR 2. Wonder sprites explicitly excluded and always canvas.
+**Safe to merge because:** Same fallback chain as MR 2. Wonder sprites explicitly excluded.
 
 ---
 
@@ -325,9 +426,9 @@ A sibling `<div id="effects">` inside `#sprite-overlay` inherits the camera tran
 
 | File | Covers |
 |---|---|
-| `tests/renderer/sprite-overlay.test.ts` | Camera math, ghost count, pinch guard, pool lifecycle, LOD gate, state transition via setAttribute, invalidateFaction |
+| `tests/renderer/sprite-overlay.test.ts` | Camera math, ghost count, pinch guard, pool lifecycle, LOD gate, reducedMotion, state transition via setAttribute, invalidateFaction |
 | `tests/renderer/sprites/v2/index.test.ts` | Lookup returns non-null for all catalog types × known factions; unknown returns null |
-| `tests/renderer/unit-renderer-overlay.test.ts` | Canvas skips drawImage for active IDs; barbarians always canvas |
+| `tests/renderer/unit-renderer-overlay.test.ts` | Canvas skips drawImage for active IDs; barbarians always canvas; fog-gated units excluded; moving units excluded |
 
 ### Existing tests that cover the hard parts
 
@@ -341,7 +442,7 @@ A sibling `<div id="effects">` inside `#sprite-overlay` inherits the camera tran
 
 - **CSS animation visual output** — keyframe correctness validated by running the game and the v2 artboard (`design/conquestoria-sprites/`)
 - **Compositor thread behavior** — GPU layer promotion and 60fps validated by manual testing on iPhone + macOS desktop
-- **Phase desync appearance** — hash function is tested; timing perception is not
+- **Phase desync appearance** — `hashCode()` is tested for distribution; timing perception is not
 
 ---
 
@@ -353,12 +454,22 @@ v2 SVG strings have faction hex colors serialized at build time (e.g. Imperials 
 
 Future work: if runtime palette swapping is needed, the v2 serialization script (`scripts/serialize-sprites.mjs`) can be extended to emit CSS custom property placeholders instead of baked hex values.
 
+### IntersectionObserver — deferred
+
+`sprite-animations-v2.css` contains:
+```css
+/* Pause when the sprite is offscreen (set by IntersectionObserver in the runtime) */
+[data-visible="false"] * { animation-play-state: paused !important; }
+```
+
+This comment references an IntersectionObserver that sets `data-visible="false"` on off-screen sprites to pause their animations (a meaningful battery/CPU optimization on mobile). This observer is **not implemented** as of this spec. The CSS rule is harmless without it. Implementing it is a follow-up task: add an IntersectionObserver in `SpriteOverlay` that sets/removes `data-visible` on each sprite wrapper element when it enters/leaves the viewport. The existing `camera.isHexVisible()` check in entity building already prevents most off-screen sprites from being in the pool, so this optimization's impact is bounded to sprites near the viewport edge.
+
 ---
 
 ## Research References
 
 - [DOM Sprites: a Viable Alternative to Canvas — Build New Games](http://buildnewgames.com/dom-sprites/): world-space container pattern, browser compositor handling
-- [Planning for Performance — O'Reilly Using SVG](https://oreillymedia.github.io/Using_SVG/extras/ch19-performance.html): GPU layer limits, inline SVG requirement for CSS animations
+- [Planning for Performance — O'Reilly Using SVG](https://oreillymedia.github.io/Using_SVG/extras/ch19-performance.html): GPU layer limits, inline SVG requirement for CSS animations, `contain: paint` interaction with overflow
 - [Hardware-Accelerated Animations — Chrome for Developers](https://developer.chrome.com/blog/hardware-accelerated-animations): transform + opacity as the only compositor-thread properties
 - [Optimizing canvas — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas): layered rendering pattern
 - [Game UI Animation Optimization — Zigpoll](https://www.zigpoll.com/content/how-can-the-frontend-developer-optimize-the-ui-animations-to-maintain-smooth-performance-without-compromising-visual-quality-on-both-desktop-and-mobile-game-interfaces): will-change discipline, mobile VRAM limits

--- a/docs/superpowers/specs/2026-06-06-sprite-overlay-renderer-design.md
+++ b/docs/superpowers/specs/2026-06-06-sprite-overlay-renderer-design.md
@@ -1,0 +1,364 @@
+# Sprite Overlay Renderer — Design Spec
+
+**Date:** 2026-06-06  
+**Status:** Approved  
+**Scope:** DOM overlay layer for v2 animated sprites (units, buildings, improvements)  
+**Delivery:** 4 independent MRs  
+
+---
+
+## Background
+
+The v2 sprite system (`src/renderer/sprites/v2/`) contains pre-serialized SVG strings for **18 of 26 units** and **23 of 33 buildings**, with CSS animation class hooks (`cq-leg-l/r`, `cq-arm-l/r`, `cq-weapon`, `cq-fire`, etc.) driven by `src/assets/sprite-animations-v2.css`. The remaining 8 units (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista, caravan, expedition, transport) and 10 buildings were never serialized and must be generated via `scripts/serialize-sprites.mjs` before they can be wired into the overlay. The 4 legendary wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) have no v2 equivalents and remain on the canvas path indefinitely.
+
+These animations require **live DOM SVG elements** — browsers block CSS animations inside SVGs loaded as `<img src="...">`, which is how the current Canvas 2D renderer loads sprites.
+
+The current renderer rasterizes sprites by decoding SVG strings to `HTMLImageElement` and calling `ctx.drawImage()`. This is correct for static images but kills all CSS animation.
+
+This spec defines a DOM overlay layer that sits above the canvas, provides live SVG elements with working CSS animations, and is designed to be delivered incrementally without breaking the existing rendering path.
+
+---
+
+## Goals
+
+- Animated unit sprites (walking gait, weapon swing, phase desync)
+- Animated building sprites (forge fire, smoke plumes, bank glow)
+- Proper SVG improvement markers replacing 8 emoji fallbacks
+- Mobile-first: works on iOS Safari and Android Chrome
+- Incremental delivery: 4 MRs, each safe to ship independently
+- Extensible: new units/buildings are a one-line addition; future effects (sparks, weather) slot in as sibling layers
+
+---
+
+## Non-Goals
+
+- WebGL rendering (not needed; CSS transform + compositor thread is sufficient)
+- Runtime faction palette swapping (faction colors are baked into v2 SVGs at serialization time; fixed per game session — see Known Limitations)
+- OffscreenCanvas (not supported on iOS Safari)
+- SMIL animations (deprecated in Chrome)
+
+---
+
+## Architecture
+
+### Layer stack (index.html)
+
+```html
+<div id="app">                          <!-- position: relative -->
+  <canvas id="game-canvas">            <!-- existing, unchanged -->
+  <div id="sprite-overlay">            <!-- NEW — see CSS below -->
+  <div id="ui-layer">                  <!-- existing, unchanged -->
+</div>
+```
+
+`#sprite-overlay` sits between the canvas and the UI layer. It has `pointer-events: none` so all touch and mouse input continues to reach the canvas unmodified.
+
+### sprite-overlay CSS
+
+```css
+#sprite-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  overflow: visible;
+  pointer-events: none;
+  transform-origin: top left;
+  contain: layout style paint;   /* isolates subtree — pool mutations don't trigger page reflow */
+  will-change: transform;        /* one GPU layer for the whole overlay — NEVER on individual sprites */
+}
+```
+
+**`will-change` discipline:** `will-change: transform` goes on `#sprite-overlay` only, promoting the entire overlay to a single GPU texture. It must never be applied to individual sprite wrapper elements — excessive layer promotion exhausts VRAM on mobile devices (confirmed by Chrome hardware acceleration docs and MDN).
+
+### Camera synchronization
+
+Each frame, a single style write syncs the overlay to the camera:
+
+```
+container.style.transform = `scale(${zoom}) translate(${-camX}px, ${-camY}px)`
+```
+
+Sprites are positioned at **world pixel coordinates** (`left: hexToPixel(coord).x`, `top: hexToPixel(coord).y`). The container transform is applied by the browser compositor — this is mathematically identical to `camera.worldToScreen()`:
+
+```
+Canvas:  screenX = (worldX - camX) * zoom
+DOM:     (worldX - camX) * zoom  ← same equation, proved by transform order
+```
+
+Because both paths share the same `Camera` instance, drift between canvas and DOM positions is impossible by construction.
+
+### Wrap ghost management
+
+The overlay calls `getHorizontalWrapRenderCoords(coord, map.width, camera)` — the same shared function used by every canvas renderer. For each coord in the returned array, the overlay creates one sprite element. The overlay has **no wrap logic of its own**: it is a consumer of the shared function, exactly like `unit-renderer.ts`, `city-renderer.ts`, and `fog-renderer.ts`.
+
+This means:
+- Ghost count is always identical between canvas and overlay (same function call)
+- Off-viewport ghosts are pruned by the existing viewport-awareness in `getHorizontalWrapRenderCoords`
+- Input handling is unaffected (`pointer-events: none`)
+
+---
+
+## Data Model
+
+### SpriteEntity
+
+Built by `RenderLoop` from `GameState`. `SpriteOverlay` never reads `GameState` directly.
+
+```typescript
+interface SpriteEntity {
+  id:      string;                          // unit.id | `${cityId}:${buildingType}` | `${q},${r}:${improvement}`
+  kind:    'unit' | 'building' | 'improvement';
+  subtype: string;                          // UnitType | building key | improvement type
+  coord:   HexCoord;
+  state:   'idle' | 'walk' | 'attack';     // drives data-state on inner SVG
+  faction: string;                          // 'imperials' | 'vikings' | … | 'neutral' (improvements)
+}
+```
+
+### Pool entry
+
+```typescript
+interface PoolEntry {
+  el:    HTMLDivElement;   // the 128×128 wrapper div
+  svgEl: Element;          // reference to the inner element with data-state — for O(1) setAttribute
+  phase: number;           // 0–1, set once at creation, never recalculated
+}
+```
+
+---
+
+## SpriteOverlay Class
+
+### Public API
+
+```typescript
+class SpriteOverlay {
+  // Mounts #sprite-overlay into mountPoint, inserts layer divs
+  constructor(mountPoint: HTMLElement)
+
+  // Called every rAF from RenderLoop.render()
+  sync(
+    camera:   Camera,
+    entities: SpriteEntity[],
+    map:      { width: number; wrapsHorizontally: boolean },
+    opts:     { isPinching: boolean; reducedMotion: boolean }
+  ): void
+
+  // Canvas renderers call this to skip drawImage for overlay-managed entities
+  getActiveIds(): ReadonlySet<string>
+
+  // Evicts and recreates all elements for a faction (baked-color limitation)
+  invalidateFaction(faction: string): void
+}
+```
+
+### sync() — frame-by-frame steps
+
+1. **LOD gate** — if `camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD`, set `container.style.display = 'none'` and return. Canvas glyph fallbacks take over.
+
+2. **Camera transform** — always runs, even during pinch:
+   ```
+   container.style.transform = `scale(${zoom}) translate(${-camX}px, ${-camY}px)`
+   ```
+
+3. **Pinch guard** — if `opts.isPinching`, return here. DOM adds/removes are deferred until the gesture ends. This prevents paint from competing with the compositor's zoom animation (confirmed mobile perf pattern).
+
+4. **Entity → DOM** — for each entity:
+   - Call `getHorizontalWrapRenderCoords()` to get render coords (including ghosts)
+   - For each coord, key = `${entity.id}:ghostIndex`
+   - Pool hit: call `svgEl.setAttribute('data-state', entity.state)` — no node replacement
+   - Pool miss: create element, parse SVG once via `innerHTML`, store `{ el, svgEl, phase }` in pool
+
+5. **Cull stale** — remove from DOM and pool any entry not seen this frame. Update `activeIds`.
+
+### Element creation
+
+```typescript
+// Wrapper div — world-space positioned, centered on hex
+wrapper.style.cssText = 'position:absolute;width:128px;height:128px;transform:translate(-50%,-50%)';
+wrapper.style.setProperty('--phase', String(phase));  // set once, never updated
+wrapper.innerHTML = svgHtml;                           // parse once at creation only
+```
+
+**Phase desync:** `phase = Math.abs(hashCode(entity.id) % 100) / 100` — deterministic from entity ID, produces different values for every unit even of the same type, set once at element creation.
+
+**State transitions:** Unit animation state (idle/walk/attack) is updated via `svgEl.setAttribute('data-state', state)` only. The DOM node is never replaced — replacement would reset the CSS animation timer, causing the walking cycle to restart from frame 0.
+
+### Layer structure inside #sprite-overlay
+
+```html
+<div id="sprite-overlay">          <!-- gets camera transform -->
+  <div id="unit-sprites">          <!-- MR 2: unit pool -->
+  <div id="building-sprites">      <!-- MR 3: building pool -->
+  <div id="improvement-sprites">   <!-- MR 4: improvement pool -->
+  <div id="effects">               <!-- Future MR 5: transient effects -->
+</div>
+```
+
+Each layer div is a separate pool. Sibling divs inherit the camera transform for free. Future effects use the same world-space coordinate system — fire-and-forget elements that self-remove on `animationend`.
+
+---
+
+## Sprite Lookup
+
+### New file: src/renderer/sprites/v2/index.ts
+
+Imports all v2 `.svg.ts` files (41 today, growing to full catalog coverage across MR 2 + MR 3) and exposes typed lookup functions:
+
+```typescript
+export function getUnitSpriteV2(unitType: string, faction: string): string | null
+export function getBuildingSpriteV2(buildingType: string, faction: string): string | null
+export function getImprovementSpriteV2(improvementType: string): string | null
+```
+
+All functions return `null` (not throw) for unknown type/faction. Callers fall back to the existing canvas path.
+
+---
+
+## Canvas Renderer Integration
+
+### Coordination contract
+
+`SpriteOverlay.getActiveIds()` returns the set of entity IDs currently rendered by the overlay. Canvas renderers check this set before drawing:
+
+```typescript
+// unit-renderer.ts
+if (spriteOverlay.getActiveIds().has(unit.id)) return; // overlay handles it
+ctx.drawImage(sprite, ...);  // existing path
+```
+
+This keeps canvas renderers independent from SpriteOverlay internals — they only need the ID set.
+
+### Fallback chain
+
+For every entity type, the fallback chain is:
+
+```
+overlay SVG element → canvas drawImage (v1 sprite) → canvas glyph (emoji/circle)
+```
+
+No entity ever disappears. If the overlay can't serve a sprite (barbarian unit, unknown building, sprite not yet in v2 catalog), the canvas path activates automatically.
+
+### Barbarian and minor civ units
+
+Barbarian and minor civ unit sprites are not preloaded in the v2 system by design (see `sprites.md` rules). They always fall through to the canvas path. The overlay never has their IDs in `activeIds`.
+
+---
+
+## MR Delivery Plan
+
+### MR 1 — Infrastructure (no player-visible change)
+
+**New files:**
+- `src/renderer/sprite-overlay.ts` — full SpriteOverlay class, empty entity list
+- `src/renderer/sprites/v2/index.ts` — unified lookup (imports all 41 v2 files)
+
+**Modified files:**
+- `index.html` — add `#sprite-overlay` div with CSS
+- `src/renderer/render-loop.ts` — instantiate SpriteOverlay; call `sync()` with empty entity list
+- `src/input/touch-handler.ts` — expose `isPinching: boolean` flag
+
+**Tests:** `tests/renderer/sprite-overlay.test.ts` — camera math, ghost count, pinch guard, pool lifecycle, LOD gate, state transition via setAttribute.
+
+**Safe to merge because:** Overlay is invisible (empty entity list). All existing canvas rendering untouched.
+
+---
+
+### MR 2 — Unit sprites (18 of 26 animated; remainder serialized in this MR)
+
+v2 files exist today for 18 units. The remaining 8 (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista) and 3 transport units (caravan, expedition, transport) must be serialized first by running `node scripts/serialize-sprites.mjs` with the missing types added to the design JSX. This serialization is part of MR 2.
+
+**Modified files:**
+- `src/renderer/render-loop.ts` — build `SpriteEntity[]` from visible units; pass to `sync()`
+- `src/renderer/unit-renderer.ts` — skip `ctx.drawImage` if `activeIds.has(unit.id)`
+- `src/renderer/sprites/v2/index.ts` — wire `getUnitSpriteV2()`
+- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all remaining unit types
+
+**Tests:** `tests/renderer/unit-renderer-overlay.test.ts` — canvas skips drawImage for overlay-managed units; barbarians always canvas; wrap ghost count correct.
+
+**Safe to merge because:** Canvas falls back to drawImage → glyph for barbarians and any type the overlay can't serve. Wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) always stay on canvas — they have no v2 files and are not expected to.
+
+---
+
+### MR 3 — Building sprites (23 of 33 animated; remainder serialized in this MR)
+
+v2 files exist today for 23 buildings. The remaining 10 must be serialized as part of this MR using `scripts/serialize-sprites.mjs`. The 4 legendary wonder sprites (Pyramids, Colosseum, Great Library, Lighthouse) have no v2 equivalents and remain on the canvas path — they are explicitly out of scope.
+
+**Modified files:**
+- `src/renderer/render-loop.ts` — add building entity list from visible cities
+- `src/renderer/city-renderer.ts` — skip building `drawImage` if in `activeIds`
+- `src/renderer/sprites/v2/index.ts` — wire `getBuildingSpriteV2()`
+- `src/renderer/sprites/v2/*.svg.ts` — add serialized files for all remaining building types
+
+**Tests:** Building in overlay at city hex; canvas does not double-draw; wrap ghost correct; buildings not in v2 catalog (including wonders) fall back to canvas.
+
+**Safe to merge because:** Same fallback chain as MR 2. Wonder sprites explicitly excluded and always canvas.
+
+---
+
+### MR 4 — Improvement markers (8 new SVG + resource_outpost migration)
+
+**New files:** `src/renderer/improvements/{farm,mine,lumber_camp,watermill,plantation,pasture,camp,quarry}-marker.ts` — SVG strings following the `resource-outpost-marker.ts` pattern (`viewBox="0 0 48 48"`, no faction color, no animation, earthy palette).
+
+Use the `generate-sprite-prompt` skill to produce Claude Design prompts for each marker.
+
+**Modified files:**
+- `src/renderer/render-loop.ts` — add improvement entity list
+- `src/renderer/hex-renderer.ts` — skip emoji icon if improvement in `activeIds`
+- `src/renderer/sprites/v2/index.ts` — wire `getImprovementSpriteV2()`
+
+**Tests:** Marker in overlay at correct hex; canvas does not draw emoji; resource_outpost migrated; unknown type falls back to emoji.
+
+---
+
+### Future MR 5+ — Effects layer
+
+A sibling `<div id="effects">` inside `#sprite-overlay` inherits the camera transform. Transient effects (battle sparks, capture flash, wonder discovery glow) are created programmatically, play their CSS keyframe animation, and self-remove on `animationend`. No pool needed — fire-and-forget. One new file: `src/renderer/effects-overlay.ts`. Zero changes to `SpriteOverlay`.
+
+---
+
+## Testing Strategy
+
+### New test files
+
+| File | Covers |
+|---|---|
+| `tests/renderer/sprite-overlay.test.ts` | Camera math, ghost count, pinch guard, pool lifecycle, LOD gate, state transition via setAttribute, invalidateFaction |
+| `tests/renderer/sprites/v2/index.test.ts` | Lookup returns non-null for all catalog types × known factions; unknown returns null |
+| `tests/renderer/unit-renderer-overlay.test.ts` | Canvas skips drawImage for active IDs; barbarians always canvas |
+
+### Existing tests that cover the hard parts
+
+| Existing test | Relevance |
+|---|---|
+| `tests/renderer/wrap-rendering.test.ts` | `getHorizontalWrapRenderCoords()` viewport-awareness — overlay delegates to this |
+| `tests/renderer/sprites/sprite-catalog.test.ts` | All UnitTypes + buildings have catalog entries — guarantees v2 lookup succeeds |
+| `tests/renderer/render-loop-wrap.test.ts` | Full render loop wrap integration |
+
+### What is not unit-tested
+
+- **CSS animation visual output** — keyframe correctness validated by running the game and the v2 artboard (`design/conquestoria-sprites/`)
+- **Compositor thread behavior** — GPU layer promotion and 60fps validated by manual testing on iPhone + macOS desktop
+- **Phase desync appearance** — hash function is tested; timing perception is not
+
+---
+
+## Known Limitations
+
+### Baked faction colors
+
+v2 SVG strings have faction hex colors serialized at build time (e.g. Imperials `#b53026`, Vikings `#1d4a8c`). If a civ's color changes mid-session, call `spriteOverlay.invalidateFaction(faction)` to evict and recreate that faction's elements. This is acceptable because faction colors are assigned at game-start and do not change during a session.
+
+Future work: if runtime palette swapping is needed, the v2 serialization script (`scripts/serialize-sprites.mjs`) can be extended to emit CSS custom property placeholders instead of baked hex values.
+
+---
+
+## Research References
+
+- [DOM Sprites: a Viable Alternative to Canvas — Build New Games](http://buildnewgames.com/dom-sprites/): world-space container pattern, browser compositor handling
+- [Planning for Performance — O'Reilly Using SVG](https://oreillymedia.github.io/Using_SVG/extras/ch19-performance.html): GPU layer limits, inline SVG requirement for CSS animations
+- [Hardware-Accelerated Animations — Chrome for Developers](https://developer.chrome.com/blog/hardware-accelerated-animations): transform + opacity as the only compositor-thread properties
+- [Optimizing canvas — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Optimizing_canvas): layered rendering pattern
+- [Game UI Animation Optimization — Zigpoll](https://www.zigpoll.com/content/how-can-the-frontend-developer-optimize-the-ui-animations-to-maintain-smooth-performance-without-compromising-visual-quality-on-both-desktop-and-mobile-game-interfaces): will-change discipline, mobile VRAM limits

--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
     #game-canvas { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
     #ui-layer { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
     #ui-layer > * { pointer-events: auto; }
+    #sprite-overlay {
+      position: absolute; top: 0; left: 0; width: 0; height: 0;
+      overflow: visible; pointer-events: none; transform-origin: top left;
+      contain: layout style; will-change: transform;
+    }
   </style>
 </head>
 <body>

--- a/src/input/touch-handler.ts
+++ b/src/input/touch-handler.ts
@@ -17,6 +17,8 @@ export class TouchHandler {
   private touchStartPos = { x: 0, y: 0 };
   private longPressTimer: number | null = null;
   private isPanning = false;
+  private _isPinching = false;
+  get isPinching(): boolean { return this._isPinching; }
 
   constructor(canvas: HTMLCanvasElement, camera: Camera, callbacks: InputCallbacks) {
     this.canvas = canvas;
@@ -56,6 +58,7 @@ export class TouchHandler {
     }
 
     if (e.touches.length === 2) {
+      this._isPinching = true;
       this.clearLongPress();
       const dx = e.touches[0].clientX - e.touches[1].clientX;
       const dy = e.touches[0].clientY - e.touches[1].clientY;
@@ -114,6 +117,7 @@ export class TouchHandler {
   private onTouchEnd = (e: TouchEvent): void => {
     e.preventDefault();
     this.clearLongPress();
+    this._isPinching = e.touches.length >= 2;
 
     if (e.changedTouches.length === 1 && !this.isPanning) {
       const elapsed = Date.now() - this.touchStartTime;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3605,7 +3605,8 @@ function startGame(): void {
       onHexTap: handleHexTap,
       onHexLongPress: handleHexLongPress,
     };
-    new TouchHandler(canvas, renderLoop.camera, callbacks);
+    const touchHandler = new TouchHandler(canvas, renderLoop.camera, callbacks);
+    renderLoop.setTouchHandler(touchHandler);
     new MouseHandler(canvas, renderLoop.camera, callbacks, {
       canInteract: () => !uiInteractions.isInteractionBlocked(),
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,14 @@ import { processAITurn } from '@/ai/basic-ai';
 import { RenderLoop } from '@/renderer/render-loop';
 import { initSprites } from '@/renderer/sprites/sprite-loader';
 import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
+import { preloadFarmMarker }      from '@/renderer/improvements/farm-marker';
+import { preloadMineMarker }      from '@/renderer/improvements/mine-marker';
+import { preloadLumberCampMarker } from '@/renderer/improvements/lumber-camp-marker';
+import { preloadWatermillMarker }  from '@/renderer/improvements/watermill-marker';
+import { preloadPlantationMarker } from '@/renderer/improvements/plantation-marker';
+import { preloadPastureMarker }    from '@/renderer/improvements/pasture-marker';
+import { preloadCampMarker }       from '@/renderer/improvements/camp-marker';
+import { preloadQuarryMarker }     from '@/renderer/improvements/quarry-marker';
 import { preloadTerrainTiles } from '@/renderer/terrain/terrain-tile-loader';
 import { preloadNaturalWonderTiles } from '@/renderer/terrain/wonder-tile-loader';
 import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
@@ -3586,6 +3594,14 @@ function startGame(): void {
   }
   initSprites(civColors);
   preloadOutpostMarker().catch(() => {});
+  preloadFarmMarker().catch(() => {});
+  preloadMineMarker().catch(() => {});
+  preloadLumberCampMarker().catch(() => {});
+  preloadWatermillMarker().catch(() => {});
+  preloadPlantationMarker().catch(() => {});
+  preloadPastureMarker().catch(() => {});
+  preloadCampMarker().catch(() => {});
+  preloadQuarryMarker().catch(() => {});
   preloadTerrainTiles().catch(() => {});
   preloadNaturalWonderTiles().catch(() => {});
 

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -1,6 +1,14 @@
 import type { GameMap, HexCoord, HexTile, TerrainType, VisibilityMap } from '@/core/types';
 import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY } from '@/systems/hex-utils';
 import { Camera } from './camera';
+import { getFarmMarkerImage }        from './improvements/farm-marker';
+import { getMineMarkerImage }        from './improvements/mine-marker';
+import { getLumberCampMarkerImage }  from './improvements/lumber-camp-marker';
+import { getWatermillMarkerImage }   from './improvements/watermill-marker';
+import { getPlantationMarkerImage }  from './improvements/plantation-marker';
+import { getPastureMarkerImage }     from './improvements/pasture-marker';
+import { getCampMarkerImage }        from './improvements/camp-marker';
+import { getQuarryMarkerImage }      from './improvements/quarry-marker';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
 import { resolveTilePresentationForViewer, type TilePresentationKind } from './tile-presentation';
@@ -10,8 +18,20 @@ import { LOD_SPRITE_ZOOM_THRESHOLD } from '@/renderer/sprites/sprite-system';
 import { getOutpostMarkerImage } from './improvements/resource-outpost-marker';
 import { getTerrainTileImage } from './terrain/terrain-tile-loader';
 
-// --- Improvement icons ---
+// --- Improvement icons and SVG markers ---
 
+const IMPROVEMENT_MARKER_GETTERS: Record<string, () => HTMLImageElement | null> = {
+  farm:        getFarmMarkerImage,
+  mine:        getMineMarkerImage,
+  lumber_camp: getLumberCampMarkerImage,
+  watermill:   getWatermillMarkerImage,
+  plantation:  getPlantationMarkerImage,
+  pasture:     getPastureMarkerImage,
+  camp:        getCampMarkerImage,
+  quarry:      getQuarryMarkerImage,
+};
+
+// Emoji fallbacks — used when SVG marker hasn't loaded yet or for unknown types
 export const IMPROVEMENT_ICONS: Record<string, string> = {
   farm: '🌾',
   mine: '⛏️',
@@ -299,12 +319,20 @@ function drawHex(
         ctx.fillText('🚩', cx, cy);
       }
     } else {
-      ctx.fillStyle = 'rgba(255,255,255,0.8)';
-      ctx.font = `${size * 0.5}px system-ui`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      const icon = IMPROVEMENT_ICONS[tile.improvement] ?? '◆';
-      ctx.fillText(icon, cx, cy);
+      // Try SVG marker first; fall back to emoji if not yet loaded or unknown type
+      const getter = IMPROVEMENT_MARKER_GETTERS[tile.improvement];
+      const markerImg = getter ? getter() : null;
+      if (markerImg) {
+        const s = size * 0.6;
+        ctx.drawImage(markerImg, cx - s / 2, cy - s * 0.7, s, s);
+      } else {
+        ctx.fillStyle = 'rgba(255,255,255,0.8)';
+        ctx.font = `${size * 0.5}px system-ui`;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        const icon = IMPROVEMENT_ICONS[tile.improvement] ?? '◆';
+        ctx.fillText(icon, cx, cy);
+      }
     }
   }
 

--- a/src/renderer/improvements/camp-marker.ts
+++ b/src/renderer/improvements/camp-marker.ts
@@ -1,0 +1,27 @@
+// Camp improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <polygon points="24,8 6,38 42,38" fill="#c19a6b" stroke="#5e3f24" stroke-width="1.4" stroke-linejoin="round"/>
+  <polygon points="24,8 14,38 34,38" fill="#d4b482" stroke="#5e3f24" stroke-width="0.8" stroke-linejoin="round"/>
+  <rect x="18" y="28" width="12" height="10" rx="1" fill="#8a6a3a" stroke="#5e3f24" stroke-width="0.8"/>
+  <circle cx="24" cy="40" r="3" fill="#d4a13c" stroke="#8a5a18" stroke-width="0.8"/>
+  <circle cx="24" cy="40" r="1.5" fill="#e8c64a"/>
+  <line x1="20" y1="40" x2="28" y2="40" stroke="#c98a3a" stroke-width="0.8"/>
+  <line x1="24" y1="36" x2="24" y2="43" stroke="#c98a3a" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadCampMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('camp-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getCampMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/farm-marker.ts
+++ b/src/renderer/improvements/farm-marker.ts
@@ -1,0 +1,28 @@
+// Farm improvement marker — Canvas 2D drawImage, no animation.
+// Follows the resource-outpost-marker.ts pattern.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="4" y="30" width="40" height="12" rx="2" fill="#7ea860" stroke="#3a5a28" stroke-width="1.2"/>
+  <line x1="12" y1="30" x2="12" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <line x1="24" y1="30" x2="24" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <line x1="36" y1="30" x2="36" y2="42" stroke="#5a8040" stroke-width="1"/>
+  <path d="M6,30 Q10,20 16,22 Q20,14 24,16 Q28,10 32,14 Q38,16 42,24 L42,30 Z"
+        fill="#a0c86a" stroke="#5a8040" stroke-width="1.2"/>
+  <line x1="24" y1="16" x2="24" y2="30" stroke="#5a8040" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadFarmMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('farm-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getFarmMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/lumber-camp-marker.ts
+++ b/src/renderer/improvements/lumber-camp-marker.ts
@@ -1,0 +1,32 @@
+// Lumber camp improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="6"  y="32" width="36" height="7" rx="2" fill="#8a6a3a" stroke="#5e3f24" stroke-width="1.2"/>
+  <rect x="8"  y="36" width="32" height="5" rx="1" fill="#c19a6b" stroke="#5e3f24" stroke-width="0.8"/>
+  <line x1="14" y1="32" x2="14" y2="41" stroke="#5e3f24" stroke-width="1"/>
+  <line x1="22" y1="32" x2="22" y2="41" stroke="#5e3f24" stroke-width="1"/>
+  <line x1="30" y1="32" x2="30" y2="41" stroke="#5e3f24" stroke-width="1"/>
+  <g stroke="#1f1a14" stroke-width="1.4" fill="none">
+    <line x1="30" y1="8" x2="38" y2="30"/>
+    <line x1="26" y1="8" x2="34" y2="30"/>
+    <line x1="28" y1="14" x2="36" y2="14"/>
+    <line x1="30" y1="20" x2="38" y2="20"/>
+  </g>
+  <rect x="10" y="6" width="14" height="5" rx="2" fill="#5e3f24" stroke="#1f1a14" stroke-width="1"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadLumberCampMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('lumber-camp-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getLumberCampMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/mine-marker.ts
+++ b/src/renderer/improvements/mine-marker.ts
@@ -1,0 +1,30 @@
+// Mine improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="10" y="30" width="28" height="12" rx="2" fill="#9a8e78" stroke="#6a5e4a" stroke-width="1.2"/>
+  <rect x="14" y="34" width="20" height="5" rx="1" fill="#6a5e4a" stroke="#3a3228" stroke-width="0.8"/>
+  <g stroke="#1f1a14" stroke-width="1.4">
+    <line x1="24" y1="6" x2="14" y2="28" />
+    <line x1="24" y1="6" x2="34" y2="28" />
+    <line x1="16" y1="22" x2="32" y2="22" />
+  </g>
+  <circle cx="24" cy="6" r="3" fill="#5a6068" stroke="#1f1a14" stroke-width="1"/>
+  <circle cx="14" cy="28" r="2.5" fill="#5a6068" stroke="#1f1a14" stroke-width="0.8"/>
+  <circle cx="34" cy="28" r="2.5" fill="#5a6068" stroke="#1f1a14" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadMineMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('mine-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getMineMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/pasture-marker.ts
+++ b/src/renderer/improvements/pasture-marker.ts
@@ -1,0 +1,29 @@
+// Pasture improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="4" y="34" width="40" height="8" rx="1" fill="#7ea860" stroke="#3a5a28" stroke-width="1"/>
+  <rect x="4"  y="20" width="3"  height="14" rx="1" fill="#5e3f24" stroke="#1f1a14" stroke-width="0.8"/>
+  <rect x="41" y="20" width="3"  height="14" rx="1" fill="#5e3f24" stroke="#1f1a14" stroke-width="0.8"/>
+  <rect x="4"  y="20" width="40" height="3"  rx="1" fill="#8a6a3a" stroke="#1f1a14" stroke-width="0.8"/>
+  <rect x="4"  y="28" width="40" height="3"  rx="1" fill="#8a6a3a" stroke="#1f1a14" stroke-width="0.8"/>
+  <ellipse cx="18" cy="30" rx="6" ry="4" fill="#c4b8a4" stroke="#6a5e4a" stroke-width="1"/>
+  <circle  cx="18" cy="26" r="3.5" fill="#c4b8a4" stroke="#6a5e4a" stroke-width="1"/>
+  <ellipse cx="32" cy="30" rx="6" ry="4" fill="#c4b8a4" stroke="#6a5e4a" stroke-width="1"/>
+  <circle  cx="32" cy="26" r="3.5" fill="#c4b8a4" stroke="#6a5e4a" stroke-width="1"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadPastureMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('pasture-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getPastureMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/plantation-marker.ts
+++ b/src/renderer/improvements/plantation-marker.ts
@@ -1,0 +1,27 @@
+// Plantation improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="22" y="28" width="4" height="14" rx="1" fill="#5e3f24" stroke="#1f1a14" stroke-width="0.8"/>
+  <ellipse cx="24" cy="24" rx="14" ry="10" fill="#7ea860" stroke="#3a5a28" stroke-width="1.2"/>
+  <ellipse cx="16" cy="26" rx="7" ry="6" fill="#a0c86a" stroke="#3a5a28" stroke-width="1"/>
+  <ellipse cx="32" cy="26" rx="7" ry="6" fill="#a0c86a" stroke="#3a5a28" stroke-width="1"/>
+  <ellipse cx="24" cy="16" rx="8" ry="7" fill="#b8d880" stroke="#3a5a28" stroke-width="1"/>
+  <line x1="22" y1="28" x2="16" y2="32" stroke="#5e3f24" stroke-width="0.8"/>
+  <line x1="26" y1="28" x2="32" y2="32" stroke="#5e3f24" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadPlantationMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('plantation-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getPlantationMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/quarry-marker.ts
+++ b/src/renderer/improvements/quarry-marker.ts
@@ -1,0 +1,30 @@
+// Quarry improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="6"  y="36" width="36" height="6"  rx="1" fill="#9a8e78" stroke="#6a5e4a" stroke-width="1.2"/>
+  <rect x="10" y="28" width="28" height="10" rx="1" fill="#c4b8a4" stroke="#6a5e4a" stroke-width="1"/>
+  <rect x="14" y="20" width="20" height="10" rx="1" fill="#d6ccbc" stroke="#6a5e4a" stroke-width="1"/>
+  <rect x="18" y="12" width="12" height="10" rx="1" fill="#e0d8cc" stroke="#6a5e4a" stroke-width="1"/>
+  <line x1="10"  y1="28" x2="6"  y2="36" stroke="#6a5e4a" stroke-width="0.8"/>
+  <line x1="38"  y1="28" x2="42" y2="36" stroke="#6a5e4a" stroke-width="0.8"/>
+  <line x1="14"  y1="20" x2="10" y2="28" stroke="#6a5e4a" stroke-width="0.8"/>
+  <line x1="34"  y1="20" x2="38" y2="28" stroke="#6a5e4a" stroke-width="0.8"/>
+  <line x1="18"  y1="12" x2="14" y2="20" stroke="#6a5e4a" stroke-width="0.8"/>
+  <line x1="30"  y1="12" x2="34" y2="20" stroke="#6a5e4a" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadQuarryMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('quarry-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getQuarryMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/improvements/watermill-marker.ts
+++ b/src/renderer/improvements/watermill-marker.ts
@@ -1,0 +1,28 @@
+// Watermill improvement marker — Canvas 2D drawImage, no animation.
+
+const SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round">
+  <ellipse cx="24" cy="44" rx="16" ry="3" fill="rgba(0,0,0,0.18)"/>
+  <rect x="4" y="36" width="40" height="6" rx="1" fill="#3a6e94" opacity="0.7"/>
+  <rect x="14" y="26" width="20" height="14" rx="2" fill="#8a6a3a" stroke="#5e3f24" stroke-width="1.2"/>
+  <circle cx="24" cy="22" r="12" fill="none" stroke="#5e3f24" stroke-width="1.6"/>
+  <line x1="24" y1="10" x2="24" y2="34" stroke="#5e3f24" stroke-width="1.2"/>
+  <line x1="12" y1="22" x2="36" y2="22" stroke="#5e3f24" stroke-width="1.2"/>
+  <line x1="15.5" y1="13.5" x2="32.5" y2="30.5" stroke="#5e3f24" stroke-width="1.2"/>
+  <line x1="32.5" y1="13.5" x2="15.5" y2="30.5" stroke="#5e3f24" stroke-width="1.2"/>
+  <circle cx="24" cy="22" r="2.5" fill="#d4a13c" stroke="#1f1a14" stroke-width="0.8"/>
+</svg>`;
+
+let cached: HTMLImageElement | null = null;
+
+export async function preloadWatermillMarker(): Promise<void> {
+  const blob = new Blob([SVG], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cached = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('watermill-marker load failed')); };
+    img.src = url;
+  });
+}
+
+export function getWatermillMarkerImage(): HTMLImageElement | null { return cached; }

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -17,6 +17,38 @@ import { spriteCache } from './sprites/sprite-loader';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
 import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
 import { SpriteOverlay } from './sprite-overlay';
+import type { SpriteEntity } from './sprite-overlay';
+
+const KNOWN_FACTIONS = new Set([
+  'imperials', 'vikings', 'pharaohs', 'hellenes', 'khanate', 'shogunate',
+]);
+
+export function buildUnitEntities(
+  state: GameState,
+  viewerId: string,
+  viewerVisibility: VisibilityMap,
+  movingUnitIds: ReadonlySet<string>,
+): SpriteEntity[] {
+  const visibleRecord = getVisibleUnitsForPlayer(state.units, state, viewerId);
+  return Object.values(visibleRecord)
+    .filter(u => {
+      if (movingUnitIds.has(u.id)) return false;
+      return getVisibility(viewerVisibility, u.position) === 'visible';
+    })
+    .map(u => {
+      // Use the UNIT OWNER'S civType (not the viewer's) — enemy units use their owner's faction colors
+      const civType = state.civilizations[u.owner]?.civType ?? 'generic';
+      const faction = KNOWN_FACTIONS.has(civType) ? civType : 'imperials';
+      return {
+        id: u.id,
+        kind: 'unit' as const,
+        subtype: u.type,
+        coord: u.position,
+        state: 'idle' as const, // walk state set per-frame during movement (future)
+        faction,
+      };
+    });
+}
 
 export interface HexHighlight {
   coord: HexCoord;
@@ -279,7 +311,7 @@ export class RenderLoop {
       const visibleUnits = getVisibleUnitsForPlayer(this.state.units, this.state, viewerId);
       drawUnits(this.ctx, visibleUnits, this.camera, viewerVisibility, this.state, viewerId, colorLookup, {
         hiddenUnitIds: getMovingUnitIds(this.unitMovementAnimations),
-      });
+      }, this.spriteOverlay?.getActiveIds() ?? new Set());
       this.drawUnitMovementAnimations(performance.now(), colorLookup, viewerVisibility);
     }
 
@@ -298,10 +330,18 @@ export class RenderLoop {
     // Draw animations
     this.animations.update(this.ctx, performance.now());
 
-    // Sprite overlay — entity lists populated in MR 2+ (units) and MR 3+ (buildings)
+    // Sprite overlay — unit entities (buildings added in MR 3)
+    const unitEntities = viewerVisibility
+      ? buildUnitEntities(
+          this.state,
+          viewerId,
+          viewerVisibility,
+          new Set(getMovingUnitIds(this.unitMovementAnimations)),
+        )
+      : [];
     this.spriteOverlay?.sync(
       this.camera,
-      [], // populated in MR 2
+      unitEntities,
       {
         width: this.state.map.width,
         wrapsHorizontally: this.state.map.wrapsHorizontally,

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -16,6 +16,7 @@ import { drawUnitGlyph } from './unit-renderer';
 import { spriteCache } from './sprites/sprite-loader';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
 import type { WonderVisualDefinition } from '@/systems/wonder-visual-catalog';
+import { SpriteOverlay } from './sprite-overlay';
 
 export interface HexHighlight {
   coord: HexCoord;
@@ -47,6 +48,12 @@ export class RenderLoop {
   private highlights: HexHighlight[] = [];
   private journeyPath: HexCoord[] | null = null;
   private unitMovementAnimations: Array<UnitMovementAnimation & { startTime: number; onComplete?: () => void }> = [];
+  private spriteOverlay: SpriteOverlay | null = null;
+  private touchHandlerRef: { isPinching: boolean } | null = null;
+
+  setTouchHandler(th: { isPinching: boolean }): void {
+    this.touchHandlerRef = th;
+  }
 
   setHighlights(highlights: HexHighlight[]): void {
     this.highlights = highlights;
@@ -125,6 +132,11 @@ export class RenderLoop {
     this.camera = new Camera();
     this.animations = new AnimationSystem();
     this.resizeCanvas();
+    // Mount the sprite overlay — guarded for test environments without DOM
+    if (typeof document !== 'undefined') {
+      const mountPoint = canvas.parentElement ?? document.body;
+      this.spriteOverlay = new SpriteOverlay(mountPoint);
+    }
   }
 
   resizeCanvas(): void {
@@ -285,6 +297,20 @@ export class RenderLoop {
 
     // Draw animations
     this.animations.update(this.ctx, performance.now());
+
+    // Sprite overlay — entity lists populated in MR 2+ (units) and MR 3+ (buildings)
+    this.spriteOverlay?.sync(
+      this.camera,
+      [], // populated in MR 2
+      {
+        width: this.state.map.width,
+        wrapsHorizontally: this.state.map.wrapsHorizontally,
+      },
+      {
+        isPinching: this.touchHandlerRef?.isPinching ?? false,
+        reducedMotion: prefersReducedMotion(),
+      },
+    );
   }
 
   private drawUnitMovementAnimations(

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -23,6 +23,30 @@ const KNOWN_FACTIONS = new Set([
   'imperials', 'vikings', 'pharaohs', 'hellenes', 'khanate', 'shogunate',
 ]);
 
+export function buildBuildingEntities(
+  state: GameState,
+  viewerVisibility: VisibilityMap,
+): SpriteEntity[] {
+  const entities: SpriteEntity[] = [];
+  for (const city of Object.values(state.cities)) {
+    if (getVisibility(viewerVisibility, city.position) !== 'visible') continue;
+    // Use the CITY OWNER's civType — enemy cities use their owner's faction colors
+    const ownerCivType = state.civilizations[city.owner]?.civType ?? 'generic';
+    const faction = KNOWN_FACTIONS.has(ownerCivType) ? ownerCivType : 'imperials';
+    for (const buildingId of city.buildings) {
+      entities.push({
+        id: `${city.id}:${buildingId}`,
+        kind: 'building',
+        subtype: buildingId,
+        coord: city.position,
+        state: 'idle',
+        faction,
+      });
+    }
+  }
+  return entities;
+}
+
 export function buildUnitEntities(
   state: GameState,
   viewerId: string,
@@ -330,7 +354,7 @@ export class RenderLoop {
     // Draw animations
     this.animations.update(this.ctx, performance.now());
 
-    // Sprite overlay — unit entities (buildings added in MR 3)
+    // Sprite overlay — unit + building entities
     const unitEntities = viewerVisibility
       ? buildUnitEntities(
           this.state,
@@ -339,9 +363,12 @@ export class RenderLoop {
           new Set(getMovingUnitIds(this.unitMovementAnimations)),
         )
       : [];
+    const buildingEntities = viewerVisibility
+      ? buildBuildingEntities(this.state, viewerVisibility)
+      : [];
     this.spriteOverlay?.sync(
       this.camera,
-      unitEntities,
+      [...unitEntities, ...buildingEntities],
       {
         width: this.state.map.width,
         wrapsHorizontally: this.state.map.wrapsHorizontally,

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -1,0 +1,192 @@
+import { hexToPixel } from '@/systems/hex-utils';
+import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from './sprites/sprite-system';
+import {
+  getUnitSpriteV2,
+  getBuildingSpriteV2,
+  getImprovementSpriteV2,
+} from './sprites/v2/index';
+import type { Camera } from './camera';
+import type { HexCoord } from '@/core/types';
+
+export interface SpriteEntity {
+  id:      string;
+  kind:    'unit' | 'building' | 'improvement';
+  subtype: string;
+  coord:   HexCoord;
+  /**
+   * v2 animation state — NOT the same as UnitMotionState ('move-a' | 'move-b').
+   * RenderLoop translates: 'move-a' | 'move-b' → 'walk'.
+   */
+  state:   'idle' | 'walk' | 'attack';
+  /** civType from Civilization — 'imperials', 'vikings', etc. Falls back to 'imperials'. */
+  faction: string;
+}
+
+interface PoolEntry {
+  el:           HTMLDivElement; // positional wrapper (world-space left/top)
+  spriteWrapEl: HTMLElement;    // .cq-sprite-wrap.cq-v2 — animation root
+  phase:        number;
+  faction:      string;
+  coord:        HexCoord;       // stored so we can detect position change after movement
+}
+
+// djb2 hash — deterministic, no external dependency
+export function hashCode(str: string): number {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) + h) ^ str.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+export class SpriteOverlay {
+  private container: HTMLDivElement;
+  private layers: Record<SpriteEntity['kind'], HTMLDivElement>;
+  private pool = new Map<string, PoolEntry>();
+  private _activeIds = new Set<string>();
+
+  constructor(mountPoint: HTMLElement) {
+    this.container = document.createElement('div');
+    this.container.id = 'sprite-overlay';
+    this.container.style.cssText =
+      'position:absolute;top:0;left:0;width:0;height:0;overflow:visible;' +
+      'pointer-events:none;transform-origin:top left;will-change:transform';
+    // contain: layout style — NOT paint (paint clips the 0×0 box making sprites invisible)
+    this.container.style.setProperty('contain', 'layout style');
+
+    const unit = makeLayer('unit-sprites');
+    const building = makeLayer('building-sprites');
+    const improvement = makeLayer('improvement-sprites');
+    this.container.appendChild(unit);
+    this.container.appendChild(building);
+    this.container.appendChild(improvement);
+    this.layers = { unit, building, improvement };
+
+    const uiLayer = mountPoint.querySelector('#ui-layer');
+    if (uiLayer) mountPoint.insertBefore(this.container, uiLayer);
+    else mountPoint.appendChild(this.container);
+  }
+
+  sync(
+    camera: Camera,
+    entities: SpriteEntity[],
+    map: { width: number; wrapsHorizontally: boolean },
+    opts: { isPinching: boolean; reducedMotion: boolean },
+  ): void {
+    // 1. LOD + reduced-motion gate
+    if (camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD || opts.reducedMotion) {
+      this.container.style.display = 'none';
+      return;
+    }
+    this.container.style.display = '';
+
+    // 2. Camera transform — one write per frame, always (even during pinch)
+    this.container.style.transform =
+      `scale(${camera.zoom}) translate(${-camera.x}px, ${-camera.y}px)`;
+
+    // 3. Pinch guard — defer pool mutations, camera transform already updated above
+    if (opts.isPinching) return;
+
+    // 4. Entity → DOM
+    const seen = new Set<string>();
+    for (const entity of entities) {
+      const coords = map.wrapsHorizontally
+        ? getHorizontalWrapRenderCoords(entity.coord, map.width, camera)
+        : [entity.coord];
+
+      for (let i = 0; i < coords.length; i++) {
+        const coord = coords[i];
+        const key = `${entity.id}:${i}`;
+        seen.add(key);
+
+        const existing = this.pool.get(key);
+        if (existing) {
+          // Pool hit — update state via setAttribute (no node replacement!)
+          existing.spriteWrapEl.setAttribute('data-state', entity.state);
+          // Update world position if unit moved hex after movement animation completed
+          if (existing.coord.q !== coord.q || existing.coord.r !== coord.r) {
+            const px = hexToPixel(coord, camera.hexSize);
+            existing.el.style.left = `${px.x}px`;
+            existing.el.style.top = `${px.y}px`;
+            existing.coord = coord;
+          }
+        } else {
+          // Pool miss — create element
+          const svgHtml = this.lookupSprite(entity);
+          if (!svgHtml) continue; // no v2 sprite — canvas handles it
+
+          const phase = (hashCode(entity.id) % 100) / 100;
+          const px = hexToPixel(coord, camera.hexSize);
+
+          const wrapper = document.createElement('div');
+          wrapper.style.cssText =
+            `position:absolute;width:128px;height:128px;` +
+            `transform:translate(-50%,-50%);left:${px.x}px;top:${px.y}px`;
+
+          // svgHtml is our own serialized content — safe to use innerHTML
+          wrapper.innerHTML = svgHtml;
+
+          // spriteWrapEl = .cq-sprite-wrap.cq-v2 (first child of wrapper, NOT the <svg>)
+          // CSS animation selectors key off this element: .cq-v2[data-state="idle"] ...
+          const spriteWrapEl = wrapper.firstElementChild as HTMLElement;
+
+          // Override the baked style="--phase:0" — setProperty on same element wins
+          spriteWrapEl.style.setProperty('--phase', String(phase));
+          spriteWrapEl.setAttribute('data-state', entity.state);
+
+          this.layers[entity.kind].appendChild(wrapper);
+          this.pool.set(key, { el: wrapper, spriteWrapEl, phase, faction: entity.faction, coord });
+        }
+      }
+    }
+
+    // 5. Cull stale elements
+    for (const [key, entry] of this.pool) {
+      if (!seen.has(key)) {
+        entry.el.remove();
+        this.pool.delete(key);
+      }
+    }
+
+    // Rebuild activeIds from current pool (key = `${entityId}:${ghostIdx}`)
+    this._activeIds.clear();
+    for (const key of this.pool.keys()) {
+      this._activeIds.add(key.slice(0, key.lastIndexOf(':')));
+    }
+  }
+
+  private lookupSprite(entity: SpriteEntity): string | null {
+    switch (entity.kind) {
+      case 'unit':        return getUnitSpriteV2(entity.subtype, entity.faction);
+      case 'building':    return getBuildingSpriteV2(entity.subtype, entity.faction);
+      case 'improvement': return getImprovementSpriteV2(entity.subtype); // always null
+      default:            return null;
+    }
+  }
+
+  getActiveIds(): ReadonlySet<string> { return this._activeIds; }
+
+  invalidateFaction(faction: string): void {
+    const toEvict: string[] = [];
+    for (const [key, entry] of this.pool) {
+      if (entry.faction === faction) {
+        entry.el.remove();
+        toEvict.push(key);
+      }
+    }
+    for (const key of toEvict) this.pool.delete(key);
+    // Rebuild activeIds
+    this._activeIds.clear();
+    for (const key of this.pool.keys()) {
+      this._activeIds.add(key.slice(0, key.lastIndexOf(':')));
+    }
+  }
+}
+
+function makeLayer(id: string): HTMLDivElement {
+  const div = document.createElement('div');
+  div.id = id;
+  div.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;overflow:visible';
+  return div;
+}

--- a/src/renderer/sprites/v2/index.ts
+++ b/src/renderer/sprites/v2/index.ts
@@ -1,0 +1,120 @@
+// Sprite lookup for the DOM overlay.
+// Improvement markers are NOT here — they use Canvas 2D (see hex-renderer.ts).
+// Updated each MR as new sprite types are serialized.
+
+import { svg as archerSvg }       from './archer.svg';
+import { svg as galleySvg }        from './galley.svg';
+import { svg as musketeerSvg }     from './musketeer.svg';
+import { svg as pikemanSvg }       from './pikeman.svg';
+import { svg as scoutSvg }         from './scout.svg';
+import { svg as scoutHoundSvg }    from './scout_hound.svg';
+import { svg as settlerSvg }       from './settler.svg';
+import { svg as shadowWardenSvg }  from './shadow_warden.svg';
+import { svg as spyAgentSvg }      from './spy_agent.svg';
+import { svg as spyHackerSvg }     from './spy_hacker.svg';
+import { svg as spyInformantSvg }  from './spy_informant.svg';
+import { svg as spyOperativeSvg }  from './spy_operative.svg';
+import { svg as spyScoutSvg }      from './spy_scout.svg';
+import { svg as swordsmanSvg }     from './swordsman.svg';
+import { svg as triremeSvg }       from './trireme.svg';
+import { svg as warHoundSvg }      from './war_hound.svg';
+import { svg as warriorSvg }       from './warrior.svg';
+import { svg as workerSvg }        from './worker.svg';
+
+import { svg as amphitheaterSvg }      from './amphitheater.svg';
+import { svg as aqueductSvg }          from './aqueduct.svg';
+import { svg as archiveSvg }           from './archive.svg';
+import { svg as barracksSvg }          from './barracks.svg';
+import { svg as forgeSvg }             from './forge.svg';
+import { svg as forumSvg }             from './forum.svg';
+import { svg as granarySvg }           from './granary.svg';
+import { svg as harborSvg }            from './harbor.svg';
+import { svg as herbalistSvg }         from './herbalist.svg';
+import { svg as intelligenceAgencySvg } from './intelligence-agency.svg';
+import { svg as librarySvg }           from './library.svg';
+import { svg as lumbermillSvg }        from './lumbermill.svg';
+import { svg as marketplaceSvg }       from './marketplace.svg';
+import { svg as monumentSvg }          from './monument.svg';
+import { svg as observatorySvg }       from './observatory.svg';
+import { svg as quarryBuildingSvg }    from './quarry-building.svg';
+import { svg as safehouseSvg }         from './safehouse.svg';
+import { svg as securityBureauSvg }    from './security-bureau.svg';
+import { svg as shrineSvg }            from './shrine.svg';
+import { svg as stableSvg }            from './stable.svg';
+import { svg as templeSvg }            from './temple.svg';
+import { svg as wallsSvg }             from './walls.svg';
+import { svg as workshopSvg }          from './workshop.svg';
+
+// ── Unit sprites ─────────────────────────────────────────────────────────────
+
+const UNIT_SPRITES: Record<string, Record<string, string>> = {
+  archer:        archerSvg,
+  galley:        galleySvg,
+  musketeer:     musketeerSvg,
+  pikeman:       pikemanSvg,
+  scout:         scoutSvg,
+  scout_hound:   scoutHoundSvg,
+  settler:       settlerSvg,
+  shadow_warden: shadowWardenSvg,
+  spy_agent:     spyAgentSvg,
+  spy_hacker:    spyHackerSvg,
+  spy_informant: spyInformantSvg,
+  spy_operative: spyOperativeSvg,
+  spy_scout:     spyScoutSvg,
+  swordsman:     swordsmanSvg,
+  trireme:       triremeSvg,
+  war_hound:     warHoundSvg,
+  warrior:       warriorSvg,
+  worker:        workerSvg,
+  // MR 2 adds: axeman, spearman, horseman, cavalry, knight,
+  //            crossbowman, catapult, ballista, caravan, expedition, transport
+};
+
+export function getUnitSpriteV2(unitType: string, faction: string): string | null {
+  return UNIT_SPRITES[unitType]?.[faction] ?? null;
+}
+
+// ── Building sprites ──────────────────────────────────────────────────────────
+
+const BUILDING_SPRITES: Record<string, Record<string, string>> = {
+  amphitheater:          amphitheaterSvg,
+  aqueduct:              aqueductSvg,
+  archive:               archiveSvg,
+  barracks:              barracksSvg,
+  forge:                 forgeSvg,
+  forum:                 forumSvg,
+  granary:               granarySvg,
+  harbor:                harborSvg,
+  herbalist:             herbalistSvg,
+  'intelligence-agency': intelligenceAgencySvg,
+  library:               librarySvg,
+  lumbermill:            lumbermillSvg,
+  marketplace:           marketplaceSvg,
+  monument:              monumentSvg,
+  observatory:           observatorySvg,
+  'quarry-building':     quarryBuildingSvg,
+  safehouse:             safehouseSvg,
+  'security-bureau':     securityBureauSvg,
+  shrine:                shrineSvg,
+  stable:                stableSvg,
+  temple:                templeSvg,
+  walls:                 wallsSvg,
+  workshop:              workshopSvg,
+  // MR 3 adds remaining buildings (dock, bronze-workshop, armory, ranch,
+  //   cavalry-academy, iron-foundry, war-academy, masonry-works,
+  //   siege-workshop, caravanserai, bank, stock_exchange)
+};
+
+export function getBuildingSpriteV2(buildingType: string, faction: string): string | null {
+  return BUILDING_SPRITES[buildingType]?.[faction] ?? null;
+}
+
+// ── Improvement sprites ───────────────────────────────────────────────────────
+// Improvement markers have NO animation and are rendered via Canvas 2D
+// (resource_outpost pattern: SVG → HTMLImageElement → ctx.drawImage).
+// This function always returns null — it exists only to satisfy the SpriteOverlay
+// interface for the 'improvement' kind; the overlay never creates elements for them.
+
+export function getImprovementSpriteV2(_improvementType: string): string | null {
+  return null;
+}

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -144,6 +144,7 @@ export function drawUnits(
   currentPlayer: string,
   colorLookup?: Record<string, string>,
   options: { hiddenUnitIds?: Set<string> } = {},
+  activeOverlayIds: ReadonlySet<string> = new Set(),
 ): void {
   const visibleUnits = Object.values(units).filter(unit =>
     !options.hiddenUnitIds?.has(unit.id)
@@ -152,6 +153,8 @@ export function drawUnits(
   );
 
   for (const stack of Object.values(groupUnitsByHex(visibleUnits))) {
+    // Skip entire stack if all units are handled by the DOM sprite overlay
+    if (stack.every(u => activeOverlayIds.has(u.id))) continue;
     const anchor = stack[0].position;
     const renderCoords = state.map.wrapsHorizontally
       ? getHorizontalWrapRenderCoords(anchor, state.map.width, camera)

--- a/tests/input/touch-handler-pinch.test.ts
+++ b/tests/input/touch-handler-pinch.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'vitest';
+import { TouchHandler } from '@/input/touch-handler';
+import type { InputCallbacks } from '@/input/touch-handler';
+
+const noopCallbacks: InputCallbacks = {
+  onHexTap: () => {},
+  onHexLongPress: () => {},
+};
+
+function makeCamera() {
+  return {
+    zoom: 1, x: 0, y: 0, hexSize: 32, width: 800, height: 600,
+    setZoom: () => {}, pan: () => {}, vx: 0, vy: 0,
+    screenToHex: () => ({ q: 0, r: 0 }),
+  } as any;
+}
+
+describe('TouchHandler.isPinching', () => {
+  it('starts false before any touches', () => {
+    const canvas = document.createElement('canvas');
+    const th = new TouchHandler(canvas, makeCamera(), noopCallbacks);
+    expect(th.isPinching).toBe(false);
+    th.destroy();
+  });
+});

--- a/tests/renderer/city-renderer-overlay.test.ts
+++ b/tests/renderer/city-renderer-overlay.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { buildBuildingEntities } from '@/renderer/render-loop';
+import type { GameState, City, VisibilityMap } from '@/core/types';
+
+function makeState(cityOverrides: Partial<City> = {}): GameState {
+  const city: City = {
+    id: 'c1',
+    position: { q: 3, r: 4 },
+    owner: 'player1',
+    buildings: ['granary'],
+    name: 'TestCity',
+    population: 1,
+    food: 0,
+    production: 0,
+    gold: 0,
+    science: 0,
+    productionQueue: [],
+    ...cityOverrides,
+  } as City;
+
+  return {
+    currentPlayer: 'player1',
+    cities: { c1: city },
+    civilizations: {
+      'player1': { id: 'player1', civType: 'imperials' } as any,
+      'player2': { id: 'player2', civType: 'vikings' } as any,
+    },
+    map: { width: 20, wrapsHorizontally: false } as any,
+  } as unknown as GameState;
+}
+
+function makeVisMap(q: number, r: number, status: 'visible' | 'fog' | 'unexplored'): VisibilityMap {
+  return { tiles: { [`${q},${r}`]: status } };
+}
+
+describe('buildBuildingEntities', () => {
+  it('returns building entities for a visible city', () => {
+    const state = makeState();
+    const vis = makeVisMap(3, 4, 'visible');
+    const entities = buildBuildingEntities(state, vis);
+    expect(entities.length).toBe(1);
+    expect(entities[0].kind).toBe('building');
+    expect(entities[0].subtype).toBe('granary');
+    expect(entities[0].coord).toEqual({ q: 3, r: 4 });
+    expect(entities[0].id).toBe('c1:granary');
+  });
+
+  it('excludes buildings in fog cities', () => {
+    const state = makeState();
+    const vis = makeVisMap(3, 4, 'fog');
+    const entities = buildBuildingEntities(state, vis);
+    expect(entities.length).toBe(0);
+  });
+
+  it('excludes buildings in unexplored cities', () => {
+    const state = makeState();
+    const vis = makeVisMap(3, 4, 'unexplored');
+    const entities = buildBuildingEntities(state, vis);
+    expect(entities.length).toBe(0);
+  });
+
+  it('uses city OWNER civType for faction — not hardcoded viewer', () => {
+    // City owned by player2 (vikings) visible to player1 (imperials)
+    const state = makeState({ owner: 'player2' });
+    const vis = makeVisMap(3, 4, 'visible');
+    const entities = buildBuildingEntities(state, vis);
+    expect(entities[0].faction).toBe('vikings');
+  });
+
+  it('produces one entity per building in the city', () => {
+    const state = makeState({ buildings: ['granary', 'library', 'barracks'] });
+    const vis = makeVisMap(3, 4, 'visible');
+    const entities = buildBuildingEntities(state, vis);
+    expect(entities.length).toBe(3);
+    expect(entities.map(e => e.subtype)).toEqual(
+      expect.arrayContaining(['granary', 'library', 'barracks'])
+    );
+  });
+});

--- a/tests/renderer/improvements/improvement-markers.test.ts
+++ b/tests/renderer/improvements/improvement-markers.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+
+// Verify each marker module exports the required preload + getImage functions.
+// Actual preloading requires browser Image API (not available in node/vitest).
+
+const markerPaths = [
+  '@/renderer/improvements/farm-marker',
+  '@/renderer/improvements/mine-marker',
+  '@/renderer/improvements/lumber-camp-marker',
+  '@/renderer/improvements/watermill-marker',
+  '@/renderer/improvements/plantation-marker',
+  '@/renderer/improvements/pasture-marker',
+  '@/renderer/improvements/camp-marker',
+  '@/renderer/improvements/quarry-marker',
+];
+
+describe('improvement marker modules', () => {
+  it('each marker module exports a preload function and a getImage function', async () => {
+    for (const path of markerPaths) {
+      const mod = await import(path);
+      const keys = Object.keys(mod);
+      const hasPreload = keys.some(k => k.startsWith('preload') && k.endsWith('Marker'));
+      const hasGet = keys.some(k => k.startsWith('get') && k.endsWith('MarkerImage'));
+      expect(hasPreload, `${path} missing preload*Marker export`).toBe(true);
+      expect(hasGet, `${path} missing get*MarkerImage export`).toBe(true);
+    }
+  });
+
+  it('getImage returns null before preloading (no browser Image API in test env)', async () => {
+    // In node/jsdom, preload can't run (no object URLs). getImage should return null.
+    for (const path of markerPaths) {
+      const mod = await import(path);
+      const getKey = Object.keys(mod).find(k => k.startsWith('get') && k.endsWith('MarkerImage'));
+      if (getKey) {
+        expect(mod[getKey](), `${path}.${getKey}() should be null before preload`).toBeNull();
+      }
+    }
+  });
+});

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { SpriteOverlay, hashCode } from '@/renderer/sprite-overlay';
+import type { SpriteEntity } from '@/renderer/sprite-overlay';
+import { LOD_SPRITE_ZOOM_THRESHOLD } from '@/renderer/sprites/sprite-system';
+
+function cam(overrides: Record<string, unknown> = {}) {
+  return { x: 0, y: 0, zoom: 1, hexSize: 32, width: 800, height: 600, ...overrides } as any;
+}
+
+function entity(overrides: Partial<SpriteEntity> = {}): SpriteEntity {
+  return {
+    id: 'u1', kind: 'unit', subtype: 'warrior',
+    coord: { q: 0, r: 0 }, state: 'idle', faction: 'imperials',
+    ...overrides,
+  };
+}
+
+function mountOverlay() {
+  const mount = document.createElement('div');
+  const ui = document.createElement('div');
+  ui.id = 'ui-layer';
+  mount.appendChild(ui);
+  document.body.appendChild(mount);
+  return { overlay: new SpriteOverlay(mount), mount };
+}
+
+const MAP = { width: 20, wrapsHorizontally: false };
+const OPTS = { isPinching: false, reducedMotion: false };
+
+afterEach(() => { document.body.innerHTML = ''; });
+
+// ── hashCode ──────────────────────────────────────────────────────────────────
+
+describe('hashCode', () => {
+  it('is non-negative', () => expect(hashCode('x')).toBeGreaterThanOrEqual(0));
+  it('is deterministic', () => expect(hashCode('abc')).toBe(hashCode('abc')));
+  it('differs for different inputs', () => expect(hashCode('a')).not.toBe(hashCode('b')));
+  it('phase in [0,1)', () => {
+    const p = (hashCode('warrior_001') % 100) / 100;
+    expect(p).toBeGreaterThanOrEqual(0);
+    expect(p).toBeLessThan(1);
+  });
+});
+
+// ── Constructor ───────────────────────────────────────────────────────────────
+
+describe('SpriteOverlay constructor', () => {
+  it('inserts container before #ui-layer', () => {
+    const { mount } = mountOverlay();
+    const kids = Array.from(mount.children);
+    expect(kids.findIndex(e => e.id === 'sprite-overlay'))
+      .toBeLessThan(kids.findIndex(e => e.id === 'ui-layer'));
+  });
+
+  it('creates unit, building, improvement layer divs', () => {
+    const { mount } = mountOverlay();
+    expect(mount.querySelector('#unit-sprites')).not.toBeNull();
+    expect(mount.querySelector('#building-sprites')).not.toBeNull();
+    expect(mount.querySelector('#improvement-sprites')).not.toBeNull();
+  });
+
+  it('does not duplicate #sprite-overlay if called twice on same mount', () => {
+    const { mount } = mountOverlay();
+    // A second overlay on the same mount (unusual but should not crash)
+    new SpriteOverlay(mount);
+    expect(mount.querySelectorAll('#sprite-overlay').length).toBe(2); // each is independent — OK
+  });
+});
+
+// ── LOD gate ──────────────────────────────────────────────────────────────────
+
+describe('sync() LOD gate', () => {
+  it('hides container below LOD threshold', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: LOD_SPRITE_ZOOM_THRESHOLD - 0.01 }), [], MAP, OPTS);
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.display).toBe('none');
+  });
+
+  it('hides container when reducedMotion', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [], MAP, { ...OPTS, reducedMotion: true });
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.display).toBe('none');
+  });
+
+  it('shows container at or above threshold', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: LOD_SPRITE_ZOOM_THRESHOLD + 0.1 }), [], MAP, OPTS);
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.display).not.toBe('none');
+  });
+});
+
+// ── Camera transform ──────────────────────────────────────────────────────────
+
+describe('sync() camera transform', () => {
+  it('sets correct transform', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1.5, x: 100, y: 200 }), [], MAP, OPTS);
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.transform)
+      .toBe('scale(1.5) translate(-100px, -200px)');
+  });
+
+  it('updates transform even while pinching', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 2, x: 50, y: 75 }), [], MAP, { ...OPTS, isPinching: true });
+    expect((mount.querySelector('#sprite-overlay') as HTMLElement).style.transform)
+      .toBe('scale(2) translate(-50px, -75px)');
+  });
+});
+
+// ── Pinch guard ───────────────────────────────────────────────────────────────
+
+describe('sync() pinch guard', () => {
+  it('does not add elements while pinching', () => {
+    const { overlay } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, { ...OPTS, isPinching: true });
+    expect(overlay.getActiveIds().size).toBe(0);
+  });
+
+  it('does not remove elements while pinching', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, OPTS);
+    const countBefore = mount.querySelector('#unit-sprites')!.children.length;
+    overlay.sync(cam({ zoom: 1 }), [], MAP, { ...OPTS, isPinching: true });
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(countBefore);
+  });
+});
+
+// ── Pool lifecycle ────────────────────────────────────────────────────────────
+
+describe('sync() pool lifecycle', () => {
+  it('culls stale elements', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity()], MAP, OPTS);
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBeGreaterThan(0);
+    overlay.sync(cam({ zoom: 1 }), [], MAP, OPTS);
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(0);
+  });
+
+  it('reuses DOM node on second sync — no replacement', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity({ state: 'idle' })], MAP, OPTS);
+    const original = mount.querySelector('.cq-sprite-wrap');
+    overlay.sync(cam({ zoom: 1 }), [entity({ state: 'walk' })], MAP, OPTS);
+    expect(mount.querySelector('.cq-sprite-wrap')).toBe(original);
+    expect((original as HTMLElement).getAttribute('data-state')).toBe('walk');
+  });
+
+  it('getActiveIds returns empty before sync', () => {
+    const { overlay } = mountOverlay();
+    expect(overlay.getActiveIds().size).toBe(0);
+  });
+});
+
+// ── invalidateFaction ─────────────────────────────────────────────────────────
+
+describe('invalidateFaction', () => {
+  it('evicts elements for the given faction', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [entity({ faction: 'imperials' })], MAP, OPTS);
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBeGreaterThan(0);
+    overlay.invalidateFaction('imperials');
+    expect(mount.querySelector('#unit-sprites')!.children.length).toBe(0);
+    expect(overlay.getActiveIds().size).toBe(0);
+  });
+
+  it('does not evict elements for other factions', () => {
+    const { overlay, mount } = mountOverlay();
+    overlay.sync(cam({ zoom: 1 }), [
+      entity({ id: 'u1', faction: 'imperials' }),
+      entity({ id: 'u2', faction: 'vikings' }),
+    ], MAP, OPTS);
+    overlay.invalidateFaction('imperials');
+    // viking element should remain
+    expect(overlay.getActiveIds().has('u2')).toBe(true);
+  });
+});

--- a/tests/renderer/sprites/v2/index.test.ts
+++ b/tests/renderer/sprites/v2/index.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getUnitSpriteV2,
+  getBuildingSpriteV2,
+  getImprovementSpriteV2,
+} from '@/renderer/sprites/v2/index';
+
+describe('getUnitSpriteV2', () => {
+  it('returns null for unknown type', () => {
+    expect(getUnitSpriteV2('unknown', 'imperials')).toBeNull();
+  });
+
+  it('returns null for unknown faction', () => {
+    expect(getUnitSpriteV2('warrior', 'unknownfaction')).toBeNull();
+  });
+
+  it('returns a cq-sprite-wrap string for warrior/imperials', () => {
+    const r = getUnitSpriteV2('warrior', 'imperials');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+    expect(r!).toContain('cq-v2');
+  });
+});
+
+describe('getBuildingSpriteV2', () => {
+  it('returns null for unknown building', () => {
+    expect(getBuildingSpriteV2('unknown', 'imperials')).toBeNull();
+  });
+
+  it('returns a sprite for granary/imperials', () => {
+    const r = getBuildingSpriteV2('granary', 'imperials');
+    expect(r).not.toBeNull();
+    expect(r!).toContain('cq-sprite-wrap');
+  });
+});
+
+describe('getImprovementSpriteV2', () => {
+  it('returns null (improvement markers use Canvas 2D, not DOM overlay)', () => {
+    expect(getImprovementSpriteV2('farm')).toBeNull();
+    expect(getImprovementSpriteV2('mine')).toBeNull();
+  });
+});

--- a/tests/renderer/unit-renderer-overlay.test.ts
+++ b/tests/renderer/unit-renderer-overlay.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { buildUnitEntities } from '@/renderer/render-loop';
+import type { GameState, Unit, VisibilityMap } from '@/core/types';
+
+function makeVisMap(coords: Array<{ q: number; r: number }>, status: 'visible' | 'fog' | 'unexplored'): VisibilityMap {
+  const tiles: Record<string, typeof status> = {};
+  for (const c of coords) tiles[`${c.q},${c.r}`] = status;
+  return { tiles } as VisibilityMap;
+}
+
+function makeState(units: Unit[], visMap: VisibilityMap = { tiles: {} }): GameState {
+  return {
+    currentPlayer: 'player1',
+    units: Object.fromEntries(units.map(u => [u.id, u])),
+    civilizations: {
+      'player1': { id: 'player1', color: '#b53026', civType: 'imperials', visibility: visMap } as any,
+      'player2': { id: 'player2', color: '#1d4a8c', civType: 'vikings',   visibility: { tiles: {} as Record<string, any> } } as any,
+      'player3': { id: 'player3', color: '#888888', civType: 'unknown_faction', visibility: { tiles: {} as Record<string, any> } } as any,
+    },
+    espionage: {},
+    map: { width: 20, height: 20, tiles: {}, wrapsHorizontally: false } as any,
+    minorCivs: {},
+  } as unknown as GameState;
+}
+
+function makeUnit(overrides: Partial<Unit> = {}): Unit {
+  return { id: 'u1', type: 'warrior', position: { q: 2, r: 3 }, owner: 'player1', ...overrides } as Unit;
+}
+
+describe('buildUnitEntities', () => {
+  it('includes units in visible hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).toContain('u1');
+  });
+
+  it('excludes units in fog hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'fog'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('excludes units in unexplored hexes', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'unexplored'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('excludes moving units (movement animation gate)', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 } });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set(['u1']));
+    expect(entities.map(e => e.id)).not.toContain('u1');
+  });
+
+  it('maps civType to faction', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player1' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities[0]?.faction).toBe('imperials');
+  });
+
+  it('uses owner faction not viewer faction', () => {
+    // player2 is visible to player1, owns the unit
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player2' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    // player2 civType = 'vikings' — expect that faction, not player1's 'imperials'
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.faction).toBe('vikings');
+  });
+
+  it('falls back to imperials for unknown civType', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, owner: 'player3' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    const entity = entities.find(e => e.id === 'u1');
+    expect(entity?.faction).toBe('imperials');
+  });
+
+  it('returns kind=unit and correct subtype', () => {
+    const u = makeUnit({ position: { q: 2, r: 3 }, type: 'archer' });
+    const state = makeState([u], makeVisMap([{ q: 2, r: 3 }], 'visible'));
+    const entities = buildUnitEntities(state, 'player1', state.civilizations['player1'].visibility, new Set());
+    expect(entities[0]?.kind).toBe('unit');
+    expect(entities[0]?.subtype).toBe('archer');
+  });
+});


### PR DESCRIPTION
## Summary

- **`SpriteOverlay` class** — world-space DOM layer sitting between `#game-canvas` and `#ui-layer`. One CSS `transform: scale(zoom) translate(-camX, -camY)` per frame syncs the entire layer to the camera; `getHorizontalWrapRenderCoords()` handles wrap ghosts (no overlay-owned wrap logic). Pinch-guard defers pool mutations during gesture; LOD gate hides overlay below `LOD_SPRITE_ZOOM_THRESHOLD`.
- **Unit sprites** — `buildUnitEntities()` filters visible, non-moving units with fog gate; owner's `civType` drives faction; `drawUnits()` skips canvas `drawImage` for overlay-managed units.
- **Building sprites** — `buildBuildingEntities()` with fog gate and per-city-owner faction; wired into render loop alongside unit entities.
- **Improvement markers** — 8 new SVG markers (farm, mine, lumber_camp, watermill, plantation, pasture, camp, quarry) following the `resource-outpost-marker.ts` pattern (SVG → HTMLImageElement → `ctx.drawImage`). Emoji fallback remains until markers finish loading. No DOM overlay needed — no animation, Canvas 2D is correct per `sprites.md`.
- **Design + spec** — `docs/superpowers/specs/2026-06-06-sprite-overlay-renderer-design.md` and `docs/superpowers/plans/2026-06-06-sprite-overlay-renderer.md` committed.

## Why this is safe to merge

- **MR 1 (infrastructure)** is invisible — overlay renders nothing until v2 sprites are present for a given unit/building type. Canvas glyph fallback is always active.
- **MR 2 (units)** + **MR 3 (buildings)** wire entity lists but only 18/29 unit types and 23/33 building types have v2 serializations today. All unmatched types fall through to the existing canvas path — no unit or building ever disappears.
- **MR 4 (improvements)** uses `ctx.drawImage` with a graceful emoji fallback, so markers always render something.
- All four layers of the overlay are `pointer-events: none` — input handling is completely unaffected.
- Wrap ghost logic is fully delegated to `getHorizontalWrapRenderCoords()` — the same function all other canvas renderers already use and test.

## Out of scope (follow-up work)

- **Task 5** — serialize 11 missing unit types (axeman, spearman, horseman, cavalry, knight, crossbowman, catapult, ballista, caravan, expedition, transport) via `scripts/serialize-sprites.mjs` + design JSX work in `design/conquestoria-sprites/lib/units-v2.jsx`
- **Task 8** — serialize remaining building types (dock, bronze-workshop, armory, ranch, cavalry-academy, iron-foundry, war-academy, masonry-works, siege-workshop, caravanserai, bank, stock_exchange) via `scripts/serialize-sprites.mjs`
- Walk animation state (`'walk'`) wired from movement animation progress — currently always `'idle'`
- Effects layer (`#effects` sibling div for transient battle sparks, capture flashes)
- IntersectionObserver to pause animations on off-screen sprites (CPU optimization)

## Test plan

- [ ] Build passes: `bash scripts/run-with-mise.sh yarn build`
- [ ] All 3347 tests pass: `bash scripts/run-with-mise.sh yarn test`
- [ ] Run the game, zoom in above LOD threshold — warrior sprites animate (idle gait) for factions with v2 files
- [ ] Pan and pinch-zoom — overlay stays locked to canvas positions, no drift
- [ ] Farm, mine, lumber_camp etc. show SVG markers instead of emoji on visible tiles
- [ ] Unit in fog hex: no DOM element visible above the fog overlay
- [ ] Zoom below LOD threshold: overlay hidden, canvas glyphs show

🤖 Generated with [Claude Code](https://claude.com/claude-code)