### PR TITLE
[codex] Fix bug-hunt regressions

### DIFF
--- a/src/audio/sfx-catalog.ts
+++ b/src/audio/sfx-catalog.ts
@@ -179,8 +179,8 @@ const LOCOMOTION_CLASS: Record<UnitType, LocomotionClass> = {
   cavalry:       'animal',
   knight:        'animal',
   crossbowman:   'humanoid',
-  catapult:      'naval',
-  ballista:      'naval',
+  catapult:      'humanoid',
+  ballista:      'humanoid',
   caravan:       'humanoid',
   expedition:    'humanoid',
 };

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -64,8 +64,8 @@ const UNIT_MOTION_STYLES: Record<UnitType, UnitMotionStyle> = {
   cavalry: 'animal',
   knight: 'animal',
   crossbowman: 'humanoid',
-  catapult: 'naval',
-  ballista: 'naval',
+  catapult: 'humanoid',
+  ballista: 'humanoid',
   caravan: 'humanoid',
   expedition: 'humanoid',
 };

--- a/src/renderer/unit-visual-resolver.ts
+++ b/src/renderer/unit-visual-resolver.ts
@@ -1,10 +1,10 @@
-import type { GameState, Unit } from '@/core/types';
+import type { GameState, Unit, UnitType } from '@/core/types';
 
 export type UnitOwnerRole = 'major' | 'minor' | 'barbarian';
 export type UnitRoleMarker = 'chevron' | 'diamond' | null;
 export type UnitMotionState = 'idle' | 'move-a' | 'move-b';
 
-const FALLBACK_ICONS: Record<string, string> = {
+const FALLBACK_ICONS: Record<UnitType, string> = {
   settler: '🏕️',
   worker: '👷',
   scout: '🔭',
@@ -24,6 +24,11 @@ const FALLBACK_ICONS: Record<string, string> = {
   ballista: '🎯',
   galley: '⛵',
   trireme: '🚢',
+  transport: '🛶',
+  carrack: '⛵',
+  galleon: '🚢',
+  steamship: '🚢',
+  troop_transport: '🛳️',
   spy_scout: '🕵️',
   spy_informant: '🕵️',
   spy_agent: '🕵️',

--- a/src/systems/minor-civ-presentation.ts
+++ b/src/systems/minor-civ-presentation.ts
@@ -21,7 +21,7 @@ export function getMinorCivPresentationForPlayer(
   return {
     known,
     name: known ? (def?.name ?? unknownName) : unknownName,
-    color: def?.color ?? '#888',
+    color: known ? (def?.color ?? '#888') : '#888',
   };
 }
 

--- a/tests/audio/sfx-catalog.test.ts
+++ b/tests/audio/sfx-catalog.test.ts
@@ -114,9 +114,15 @@ describe('getLocomotionClass', () => {
   });
 
   it('maps naval units correctly', () => {
-    const navalTypes: UnitType[] = ['galley', 'trireme', 'transport', 'catapult', 'ballista'];
+    const navalTypes: UnitType[] = ['galley', 'trireme', 'transport', 'carrack', 'galleon', 'steamship', 'troop_transport'];
     for (const t of navalTypes) {
       expect(getLocomotionClass(t), t).toBe('naval');
+    }
+  });
+
+  it('maps siege engines to land movement instead of ship movement', () => {
+    for (const t of SIEGE_TYPES) {
+      expect(getLocomotionClass(t), t).toBe('humanoid');
     }
   });
 

--- a/tests/renderer/sprites/sprite-catalog.test.ts
+++ b/tests/renderer/sprites/sprite-catalog.test.ts
@@ -42,6 +42,21 @@ describe('sprite-catalog coverage', () => {
         expect(movingB, `${unitType} move-b must differ from move-a`).not.toBe(movingA);
       }
     });
+
+    it('siege engines use land motion instead of naval bobbing', () => {
+      const palette = derivePalette('#4a90d9');
+      const siegeTypes: Array<keyof typeof UNIT_SPRITE_CATALOG> = ['catapult', 'ballista'];
+
+      for (const unitType of siegeTypes) {
+        const movingA = UNIT_SPRITE_CATALOG[unitType]({ palette, svgOnly: true, motion: 'move-a' });
+        const movingB = UNIT_SPRITE_CATALOG[unitType]({ palette, svgOnly: true, motion: 'move-b' });
+
+        expect(movingA, `${unitType} move-a should use the land pivot`).toContain('rotate(-2 64 70)');
+        expect(movingB, `${unitType} move-b should use the land pivot`).toContain('rotate(2 64 70)');
+        expect(movingA, `${unitType} move-a should not use the naval pivot`).not.toContain('64 82');
+        expect(movingB, `${unitType} move-b should not use the naval pivot`).not.toContain('64 82');
+      }
+    });
   });
 
   describe('BUILDING_SPRITE_CATALOG', () => {

--- a/tests/renderer/unit-visual-resolver.test.ts
+++ b/tests/renderer/unit-visual-resolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { resolveUnitVisual } from '@/renderer/unit-visual-resolver';
-import { createUnit } from '@/systems/unit-system';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import type { UnitType } from '@/core/types';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -37,5 +38,15 @@ describe('unit-visual-resolver', () => {
       roleMarker: 'diamond',
       color: '#8a6f2a',
     });
+  });
+
+  it('provides a concrete fallback icon for every defined unit type', () => {
+    const state = createNewGame(undefined, 'fallback-icon-coverage', 'small');
+
+    for (const unitType of Object.keys(UNIT_DEFINITIONS) as UnitType[]) {
+      const unit = { ...createUnit(unitType, 'player', { q: 0, r: 0 }, mkC()), id: unitType };
+
+      expect(resolveUnitVisual(state, unit).fallbackIcon, unitType).not.toBe('?');
+    }
   });
 });

--- a/tests/systems/minor-civ-presentation.test.ts
+++ b/tests/systems/minor-civ-presentation.test.ts
@@ -17,6 +17,22 @@ describe('minor-civ-presentation', () => {
     });
   });
 
+  it('masks city-state color until the viewer has discovered it', () => {
+    const state = createNewGame(undefined, 'mc-present-color-privacy', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const hiddenPresentation = getMinorCivPresentationForPlayer(state, 'player', mcId);
+    const city = state.cities[state.minorCivs[mcId].cityId];
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'fog';
+    const discoveredPresentation = getMinorCivPresentationForPlayer(state, 'player', mcId);
+
+    expect(hiddenPresentation).toMatchObject({
+      known: false,
+      color: '#888',
+    });
+    expect(discoveredPresentation.known).toBe(true);
+    expect(discoveredPresentation.color).not.toBe('#888');
+  });
+
   it('uses the real name after the city tile is discovered', () => {
     const state = createNewGame(undefined, 'mc-present-discovered', 'small');
     const mcId = Object.keys(state.minorCivs)[0]!;


### PR DESCRIPTION
## Summary

- Reclassify catapult and ballista movement as land-style in both SFX and sprite motion catalogs.
- Complete and type the renderer unit fallback icon catalog so valid units do not render as `?` while sprites are unavailable.
- Mask undiscovered minor-civ colors through the shared presentation helper, matching the existing name privacy behavior.

## Root Causes

- Siege engines were copy/pasted into the `naval` movement bucket in both audio and sprite catalogs.
- The fallback icon map used `Record<string, string>`, so new `UnitType` entries could be omitted without TypeScript or tests catching it.
- `getMinorCivPresentationForPlayer` masked unknown city-state names but always returned the definition color, leaking identity through UI styling.

## Verification

- `scripts/check-src-rule-violations.sh src/audio/sfx-catalog.ts src/renderer/sprites/sprite-catalog.ts src/renderer/unit-visual-resolver.ts src/systems/minor-civ-presentation.ts`
- `./scripts/run-with-mise.sh yarn vitest run tests/audio/sfx-catalog.test.ts tests/renderer/sprites/sprite-catalog.test.ts tests/renderer/unit-visual-resolver.test.ts tests/systems/minor-civ-presentation.test.ts`
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test`
- `git diff --check`
