### PR TITLE
docs: legendary beasts implementation plans (8-MR series + index)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
@@ -1,0 +1,90 @@
+# Legendary Beasts — MR Index & Tracker
+
+> **For agentic workers:** This is the tracking index for the 8-MR Legendary Beasts feature. Execute one MR at a time, in order, each in its own worktree branched from `main` (never commit to main directly). Each MR plan is self-contained; this file holds the shared contract, ordering, and status.
+
+**Feature goal:** Unique, named, neutral mythic creatures tied to terrain-specific lairs. Era-gated awakening, territorial (leashed) behavior — they never attack cities and never roam. Slaying one is a permanent recorded achievement with escalating rewards by tier. Designed for family hot-seat play (kids 7/10/12): PvE excitement that doesn't pit siblings against each other, with a Calm mode and an Off switch.
+
+**Design summary:** see the conversation/design notes captured in MR1's header and the shared contract below.
+
+---
+
+## Status
+
+| MR | Plan file | Ships | Status |
+|---|---|---|---|
+| MR1 | [2026-06-11-legendary-beasts-mr1-core-boar.md](2026-06-11-legendary-beasts-mr1-core-boar.md) | Core system + Giant Boar + setup toggle + lair rendering | ☐ not started |
+| MR2 | [2026-06-11-legendary-beasts-mr2-bestiary.md](2026-06-11-legendary-beasts-mr2-bestiary.md) | Bestiary panel + sighting banner + per-civ sighting tracking | ☐ not started |
+| MR3 | [2026-06-11-legendary-beasts-mr3-wolves-basilisk.md](2026-06-11-legendary-beasts-mr3-wolves-basilisk.md) | Dire Wolf Pack + Emerald Basilisk + habitat concealment | ☐ not started |
+| MR4 | [2026-06-11-legendary-beasts-mr4-hoard-trophies.md](2026-06-11-legendary-beasts-mr4-hoard-trophies.md) | Hoard choice panel + lair trophies + AI auto-resolve | ☐ not started |
+| MR5 | [2026-06-11-legendary-beasts-mr5-serpent-wurm.md](2026-06-11-legendary-beasts-mr5-serpent-wurm.md) | Sea Serpent + Dune Wurm + naval passability + `beast-serpent` rig | ☐ not started |
+| MR6 | [2026-06-11-legendary-beasts-mr6-roc-hydra.md](2026-06-11-legendary-beasts-mr6-roc-hydra.md) | Storm Roc + Swamp Hydra + flight + regen + `beast-winged` rig | ☐ not started |
+| MR7 | [2026-06-11-legendary-beasts-mr7-ancient-dragon.md](2026-06-11-legendary-beasts-mr7-ancient-dragon.md) | Ancient Dragon apex + ranged breath + slay ceremony + apex reward | ☐ not started |
+| MR8 | [2026-06-11-legendary-beasts-mr8-audio-ai-balance.md](2026-06-11-legendary-beasts-mr8-audio-ai-balance.md) | Roar SFX + tension music layer + gated AI hunting + balance bands | ☐ not started |
+
+Update this table as MRs land: ☐ not started → ◐ in progress (PR #N) → ✅ merged (PR #N).
+
+## Ordering & dependencies
+
+```
+MR1 ──► MR2 ──► MR3 ──► MR4 ──► MR5 ──► MR6 ──► MR7 ──► MR8
+```
+
+Strictly sequential — each plan's code blocks assume the previous MRs are merged to `main`. The game is fully playable (no dead surfaces) after every MR. If an MR must be skipped or reordered, re-read the later plans for references to the skipped pieces before executing.
+
+---
+
+## Shared design contract (authoritative — all plans conform to this)
+
+**Names that must never drift between MRs:**
+
+- Owner constant: `BEAST_OWNER = 'beasts'` (exported from `src/systems/beast-system.ts`)
+- `BeastId` union (grows per MR; every `Record<BeastId, …>` stays exhaustive):
+  - MR1 `'giant_boar'` · MR3 `'dire_wolf'`, `'emerald_basilisk'` · MR5 `'sea_serpent'`, `'dune_wurm'` · MR6 `'storm_roc'`, `'swamp_hydra'` · MR7 `'ancient_dragon'`
+- `UnitType` additions (each forces entries in SIX exhaustive maps — `UNIT_DEFINITIONS`, `UNIT_DESCRIPTIONS`, `FALLBACK_ICONS`, `UNIT_MOTION_STYLES`, `UNIT_SPRITE_CATALOG`, `LOCOMOTION_CLASS`):
+  - `beast_boar`, `beast_wolf`, `beast_basilisk`, `beast_sea_serpent`, `beast_wurm`, `beast_roc`, `beast_hydra`, `beast_dragon`
+- State: `GameState.beasts?: BeastsState` — `{ mode, lairs, sightingsByCiv, pendingHoardChoices? }`; `BeastLair` `{ id: 'lair-<beastId>', beastId, position, status: 'dormant'|'awake'|'slain'|'claimed', strength, awakenedTurn?, slainBy?, slainTurn?, claimedBy?, unitIds }`
+- Settings: `GameSettings.beastsMode?: 'off' | 'calm' | 'wild'` (default `'wild'` for new games; `undefined` legacy saves = no beasts); MR8 adds `aiContestsBeasts?: boolean` (default false)
+- Events: `'beast:awakened'`, `'beast:slain'` (MR1) · `'beast:sighted'` (MR2) · `'beast:hoard-claimed'` (MR4)
+- Key exports from `beast-system.ts`: `placeBeastLairs`, `processBeasts` (orders-out, mirroring `processBarbarians`), `recordBeastSlain` (shared, actor-complete), `getBeastHoardGold`, `isBeastUnit` (MR1) · `isBeastConcealedFrom` (MR3) · `applyHoardChoice`, `getHoardChoicePreview`, `getClaimedTrophyGoldPerTurn` (MR4) · `isTerrainPassableForBeast`, `canUnitAttackBeast` (MR5) · `isCivUnitInBeastTerritory` (MR8)
+- Definitions: `BEAST_DEFINITIONS: Record<BeastId, BeastDefinition>` in `src/systems/beast-definitions.ts`; flags accumulate: `concealedInHabitat` (MR3), `navalOnly` (MR5), `flying` + `regenPerTurn` (MR6)
+
+**Reward ladder:**
+
+| Tier | Beasts | On slay |
+|---|---|---|
+| 1 | boar, wolves | auto gold (era-scaled) + Victory Feast full heal |
+| 2 | basilisk, wurm | choose one: Gold ×2 / Lore (research) / Trophy (+3 gold/turn) |
+| 3 | serpent, roc, hydra | slay ceremony, then the tier-2 choice (Trophy +5 gold/turn) |
+| 4 (apex) | dragon | ceremony + EVERYTHING (gold ×2 + lore + trophy +8/turn) + slayer becomes max veterancy |
+
+**Behavior invariants (enforced by tests in MR1/MR5/MR6):**
+
+- Beasts are territorial: leashed to their lair radius, never attack cities, never roam
+- `calm` mode: beasts exist, regen, and defend, but never initiate movement or attacks; `off`: no lairs placed
+- All RNG seeded (`createRng` for placement, local LCG for turns); zero `Math.random`
+- Spawn occupancy: never stack on existing units; skip spawn if no free tile
+- `recordBeastSlain` is the only slay consequence path — called from main.ts player combat AND turn-manager (actor-complete)
+- Legacy saves (`state.beasts === undefined`) load and play normally
+
+**Rules-file exemption (MR1):** beast unit types are intentionally NOT trainable — documented in `.claude/rules/game-systems.md`.
+
+## Roster reference
+
+| Beast | Habitat | Awakens | Tier | Pack | Leash | Signature |
+|---|---|---|---|---|---|---|
+| Giant Boar | forest | era 1 | 1 | 1 | 3 | the "tutorial" beast |
+| Dire Wolf Pack | tundra/snow | era 1 | 1 | 3 | 4 | pack of three |
+| Emerald Basilisk | jungle | era 2 | 2 | 1 | 3 | concealed in habitat (ambush) |
+| Dune Wurm | desert | era 2 | 2 | 1 | 3 | concealed in habitat (burrow) |
+| Sea Serpent | ocean | era 3 | 3 | 1 | 5 | naval-only target; hunts ships |
+| Storm Roc | mountain | era 3 | 3 | 1 | 4 | flies over any land terrain |
+| Swamp Hydra | swamp | era 3 | 3 | 1 | 3 | regenerates 10 HP/turn |
+| Ancient Dragon | volcanic | era 4 | 4 | 1 | 4 | flying + 2-hex fire breath |
+
+## Execution notes for every MR
+
+- Branch from fresh `main` in a new worktree; PR per MR; **never commit to main**
+- Gates before any push: `bash scripts/run-with-mise.sh yarn build` AND `bash scripts/run-with-mise.sh yarn test` both exit 0
+- Always use `bash scripts/run-with-mise.sh yarn <cmd>` — never `eval "$(mise activate bash)"`
+- Each plan carries an Out-of-scope + "Why this is safe to merge partial" PR body per `.claude/rules/incremental-mr-completion.md`
+- Follow-up candidates intentionally NOT in any MR: minor-civ "slay the beast" quests (pairs with quest chains, issue #352); beast-slay videos via the wonder-video pipeline; bestiary entries in the wonder atlas

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr1-core-boar.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr1-core-boar.md
@@ -1,0 +1,1421 @@
+# Legendary Beasts MR1 — Core System + Giant Boar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Every code block is real code grounded in the current codebase — do not improvise APIs. If a referenced symbol is missing, stop and re-read the named file rather than inventing a replacement.
+
+**Goal:** Ship the Legendary Beasts foundation end-to-end with one playable beast — the Giant Boar — including lair placement at map generation, era-gated awakening, territorial behavior, combat, slay rewards, a setup toggle, sprite, and notifications.
+
+**Architecture:** Beasts are regular `Unit` records owned by the constant `'beasts'` (mirroring the `'barbarian'` owner pattern). A new `beast-system.ts` produces orders the same way `processBarbarians` does, and `turn-manager.ts` applies them. Lairs live in a new optional `GameState.beasts` slice (optional = old saves keep working). Beasts are deliberately **territorial**: they never leave a leash radius around their lair and never attack cities.
+
+**Tech Stack:** TypeScript, vitest, Canvas 2D, JSX→SVG sprite pipeline. All commands run through `bash scripts/run-with-mise.sh yarn <cmd>`.
+
+**Dependencies:** None. Branches from `main`.
+
+**Index:** This is MR1 of 8 — see `2026-06-11-legendary-beasts-index.md`.
+
+---
+
+## Design contract (shared across all 8 MRs — do not rename)
+
+- Owner string: `BEAST_OWNER = 'beasts'`
+- `BeastId` union grows one MR at a time (MR1 ships only `'giant_boar'`), so every `Record<BeastId, …>` stays exhaustive.
+- New `UnitType` values are prefixed `beast_`. Adding one forces TypeScript errors in exactly six exhaustive maps; fixing all six is part of the task:
+  1. `UNIT_DEFINITIONS` — `src/systems/unit-system.ts:12`
+  2. `UNIT_DESCRIPTIONS` — `src/systems/unit-system.ts:308`
+  3. `FALLBACK_ICONS` — `src/renderer/unit-visual-resolver.ts:7`
+  4. `UNIT_MOTION_STYLES` — `src/renderer/sprites/sprite-catalog.ts:36`
+  5. `UNIT_SPRITE_CATALOG` — `src/renderer/sprites/sprite-catalog.ts:103`
+  6. `LOCOMOTION_CLASS` — `src/audio/sfx-catalog.ts:152`
+- Beast unit types are **not** trainable. This is a deliberate, documented exemption from the "every UnitType must be in TRAINABLE_UNITS" rule (Task 10 updates the rule file).
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastId`, `BeastsMode`, `BeastLair`, `BeastsState`, `GameState.beasts`, `GameSettings.beastsMode`, `'beast_boar'` UnitType, beast events |
+| `src/systems/beast-definitions.ts` | Create | Static metadata per beast (habitat, tier, leash, flavor) |
+| `src/systems/beast-system.ts` | Create | Lair placement, awakening, territorial orders, slay rewards |
+| `src/systems/unit-system.ts` | Modify | `beast_boar` definition + description |
+| `src/systems/attack-targeting.ts` | Modify | Beasts attackable without war declaration |
+| `src/systems/combat-reward-system.ts` | Modify | Beasts can't receive gold; slain beasts give no per-kill gold (hoard instead) |
+| `src/core/turn-manager.ts` | Modify | Wire `processBeasts` after the barbarian block |
+| `src/core/game-state.ts` | Modify | Place lairs at game creation, honor `beastsMode` |
+| `src/main.ts` | Modify | Slay handling on player kills, awakening/slay notifications |
+| `src/renderer/sprites/beasts.tsx` | Create | `GiantBoarSprite` |
+| `src/renderer/sprites/sprite-catalog.ts` | Modify | Register boar sprite + motion style |
+| `src/renderer/unit-visual-resolver.ts` | Modify | `'beast'` owner role, fixed color, fallback icon |
+| `src/renderer/hex-renderer.ts` | Modify | Lair glyph on explored tiles |
+| `src/renderer/render-loop.ts` | Modify | Pass lair glyph map into `drawHexMap` |
+| `src/audio/sfx-catalog.ts` | Modify | `LOCOMOTION_CLASS` entry for `beast_boar` |
+| `src/ui/campaign-setup.ts` | Modify | Legendary Beasts mode selector |
+| `.claude/rules/game-systems.md` | Modify | Document the beast trainability exemption |
+| `tests/systems/beast-system.test.ts` | Create | Placement, awakening, leash, slay tests |
+| `tests/systems/beast-definitions.test.ts` | Create | Definition invariants |
+| `tests/core/turn-manager-beasts.test.ts` | Create | Turn wiring + actor-parity regression |
+
+---
+
+### Task 1: Types — the beast state slice
+
+**Files:**
+- Modify: `src/core/types.ts`
+
+- [ ] **Step 1: Add beast types to `src/core/types.ts`**
+
+Insert after the `BarbarianCamp` interface (around line 796, before `// --- Minor Civilizations ---`):
+
+```typescript
+// --- Legendary Beasts ---
+
+export type BeastId = 'giant_boar';   // union grows one MR at a time — see beasts index plan
+
+export type BeastsMode = 'off' | 'calm' | 'wild';
+
+export type BeastLairStatus = 'dormant' | 'awake' | 'slain' | 'claimed';
+
+export interface BeastLair {
+  id: string;                 // `lair-${beastId}`
+  beastId: BeastId;
+  position: HexCoord;
+  status: BeastLairStatus;
+  strength: number;           // bonus experience fed to beast units while the lair is ignored
+  awakenedTurn?: number;
+  slainBy?: string;           // civ id that landed the killing blow
+  slainTurn?: number;
+  unitIds: string[];          // live beast unit ids leashed to this lair
+}
+
+export interface BeastsState {
+  mode: BeastsMode;
+  lairs: Record<string, BeastLair>;
+  sightingsByCiv: Record<string, BeastId[]>;   // per-civ bestiary sightings (MR2 populates)
+}
+```
+
+- [ ] **Step 2: Extend `UnitType`, `GameState`, `GameSettings`, and `GameEvents`**
+
+In the `UnitType` union (line 284), append a new line before the closing `;`:
+
+```typescript
+  | 'beast_boar';
+```
+
+In `GameState` (line 1104), after `tribalVillages: Record<string, TribalVillage>;`:
+
+```typescript
+  beasts?: BeastsState;       // optional: legacy saves have no beasts
+```
+
+In `GameSettings` (line 1141), after `tutorialEnabled: boolean;`:
+
+```typescript
+  beastsMode?: BeastsMode;    // default 'wild' for new games; undefined on legacy saves
+```
+
+In the `GameEvents` interface, next to `'barbarian:spawned'` (line 1202):
+
+```typescript
+  'beast:awakened': { lairId: string; beastId: BeastId; position: HexCoord };
+  'beast:slain': { lairId: string; beastId: BeastId; slayerCivId: string; slayerUnitId: string; goldAwarded: number };
+```
+
+- [ ] **Step 3: Compile to find the six exhaustive-map errors**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: FAIL with TS2741/TS2739 errors in `unit-system.ts`, `unit-visual-resolver.ts`, `sprite-catalog.ts` (×2), `sfx-catalog.ts` — these are the maps Tasks 2 and 5 fill in. If you see errors in OTHER files, fix those too before proceeding (they are also exhaustive over `UnitType`).
+
+- [ ] **Step 4: Commit (types only — build is red, that's expected mid-stack; do not push)**
+
+```bash
+git add src/core/types.ts
+git commit -m "feat(beasts): add beast state types, settings mode, and events"
+```
+
+---
+
+### Task 2: Unit definition, description, audio + visual map entries
+
+**Files:**
+- Modify: `src/systems/unit-system.ts`
+- Modify: `src/audio/sfx-catalog.ts`
+- Modify: `src/renderer/unit-visual-resolver.ts`
+
+- [ ] **Step 1: Add the boar to `UNIT_DEFINITIONS` (`src/systems/unit-system.ts:12`)**
+
+Add at the end of the map, before the closing `};`:
+
+```typescript
+  beast_boar: {
+    type: 'beast_boar', name: 'Giant Boar', movementPoints: 2,
+    visionRange: 2, strength: 18, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+```
+
+(`productionCost: 0` is fine — beasts are never trainable, so no production path reads it.)
+
+- [ ] **Step 2: Add to `UNIT_DESCRIPTIONS` (`src/systems/unit-system.ts:308`)**
+
+```typescript
+  beast_boar: 'A legendary boar of monstrous size. Territorial — it defends its forest den but never wanders far. Slay it to claim its hoard.',
+```
+
+- [ ] **Step 3: Add to `LOCOMOTION_CLASS` (`src/audio/sfx-catalog.ts:152`)**
+
+Find the locomotion class used by `scout_hound` / `war_hound` in that map and use the same value for `beast_boar` (it is a quadruped). Example, if hounds use `'paws'`:
+
+```typescript
+  beast_boar: 'paws',
+```
+
+Use the literal value the hounds use — do not invent a new `LocomotionClass` member.
+
+- [ ] **Step 4: Add the fallback icon (`src/renderer/unit-visual-resolver.ts:7`)**
+
+```typescript
+  beast_boar: '🐗',
+```
+
+- [ ] **Step 5: Add the `'beast'` owner role to `unit-visual-resolver.ts`**
+
+Line 3 currently reads:
+
+```typescript
+export type UnitOwnerRole = 'major' | 'minor' | 'barbarian';
+```
+
+Change to:
+
+```typescript
+export type UnitOwnerRole = 'major' | 'minor' | 'barbarian' | 'beast';
+```
+
+In the role-resolution function (line 56 area) add **above** the barbarian check:
+
+```typescript
+  if (unit.owner === 'beasts') return 'beast';
+```
+
+In the color fallback (line 70 area), extend so beasts get a fixed dark-crimson accent:
+
+```typescript
+    ?? (role === 'barbarian' ? '#8b4513' : role === 'beast' ? '#7a1f2b' : '#888');
+```
+
+In the `roleMarker` expression (line 73), beasts get no chevron/diamond — extend the ternary so `'beast'` maps to `null` (the existing `null` fallback already does this if you only matched `'barbarian'`/`'minor'` explicitly; verify by reading the line).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/unit-system.ts src/audio/sfx-catalog.ts src/renderer/unit-visual-resolver.ts
+git commit -m "feat(beasts): boar unit definition, description, icon, audio class, owner role"
+```
+
+---
+
+### Task 3: Beast definitions module
+
+**Files:**
+- Create: `src/systems/beast-definitions.ts`
+- Test: `tests/systems/beast-definitions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/systems/beast-definitions.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { BEAST_DEFINITIONS, getBeastDefinitionByUnitType } from '@/systems/beast-definitions';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+describe('beast definitions', () => {
+  it('every beast has a real unit definition with positive strength', () => {
+    for (const def of Object.values(BEAST_DEFINITIONS)) {
+      const unitDef = UNIT_DEFINITIONS[def.unitType];
+      expect(unitDef, `${def.id} missing UNIT_DEFINITIONS entry`).toBeDefined();
+      expect(unitDef.strength).toBeGreaterThan(0);
+    }
+  });
+
+  it('every beast has habitat terrains, a leash radius, and player-facing flavor', () => {
+    for (const def of Object.values(BEAST_DEFINITIONS)) {
+      expect(def.habitatTerrains.length).toBeGreaterThan(0);
+      expect(def.leashRadius).toBeGreaterThanOrEqual(2);
+      expect(def.packSize).toBeGreaterThanOrEqual(1);
+      expect(def.dangerHint.length).toBeGreaterThan(10);
+      expect(def.awakeningFlavor.length).toBeGreaterThan(10);
+      expect(def.sightingFlavor.length).toBeGreaterThan(10);
+    }
+  });
+
+  it('resolves a beast definition from its unit type', () => {
+    expect(getBeastDefinitionByUnitType('beast_boar')?.id).toBe('giant_boar');
+    expect(getBeastDefinitionByUnitType('warrior')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-definitions.test.ts`
+Expected: FAIL — cannot resolve `@/systems/beast-definitions`.
+
+- [ ] **Step 3: Create `src/systems/beast-definitions.ts`**
+
+```typescript
+import type { BeastId, TerrainType, UnitType } from '@/core/types';
+
+export interface BeastDefinition {
+  id: BeastId;
+  unitType: UnitType;
+  name: string;
+  habitatTerrains: TerrainType[];   // lair may only be placed on these
+  awakenEra: number;                // dormant until state.era reaches this
+  tier: 1 | 2 | 3 | 4;              // reward scale; 4 = apex
+  leashRadius: number;              // beasts never move beyond this distance from the lair
+  packSize: number;                 // units spawned on awakening
+  hoardGoldBase: number;            // base hoard gold; scaled by era at slay time
+  dangerHint: string;               // bestiary riddle shown before first sighting (MR2)
+  awakeningFlavor: string;          // map-wide notification on awakening
+  sightingFlavor: string;           // first-sighting notification/ceremony text (MR2)
+}
+
+export const BEAST_DEFINITIONS: Record<BeastId, BeastDefinition> = {
+  giant_boar: {
+    id: 'giant_boar',
+    unitType: 'beast_boar',
+    name: 'Giant Boar',
+    habitatTerrains: ['forest'],
+    awakenEra: 1,
+    tier: 1,
+    leashRadius: 3,
+    packSize: 1,
+    hoardGoldBase: 40,
+    dangerHint: 'Trees splinter and the ground is churned in the deep woods. Something heavy lives there.',
+    awakeningFlavor: 'A thunder of hooves shakes the forest. The Giant Boar has awoken!',
+    sightingFlavor: 'Your scouts lay eyes on the Giant Boar — a beast of legend!',
+  },
+};
+
+const BY_UNIT_TYPE = new Map(
+  Object.values(BEAST_DEFINITIONS).map(def => [def.unitType, def]),
+);
+
+export function getBeastDefinitionByUnitType(type: UnitType): BeastDefinition | undefined {
+  return BY_UNIT_TYPE.get(type);
+}
+```
+
+If `TerrainType` is not exported from `@/core/types`, check its actual export site with `grep -n "TerrainType" src/core/types.ts` and import from there.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-definitions.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/beast-definitions.ts tests/systems/beast-definitions.test.ts
+git commit -m "feat(beasts): beast definition metadata module"
+```
+
+---
+
+### Task 4: Beast system — lair placement
+
+**Files:**
+- Create: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+Model placement on `placeVillages` in `src/systems/village-system.ts` (read it first — same shuffle-candidates pattern).
+
+- [ ] **Step 1: Write failing placement tests**
+
+Create `tests/systems/beast-system.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { placeBeastLairs, BEAST_OWNER, LAIR_COUNTS } from '@/systems/beast-system';
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { generateMap } from '@/systems/map-generator';
+import { hexDistance, hexKey } from '@/systems/hex-utils';
+
+describe('placeBeastLairs', () => {
+  const map = generateMap(40, 30, 'beast-test-seed');
+  const starts = [{ q: 5, r: 5 }, { q: 30, r: 20 }];
+
+  it('places lairs only on matching habitat terrain, away from starts', () => {
+    const lairs = placeBeastLairs(map, starts, 'medium', 'beast-test-seed');
+    for (const lair of Object.values(lairs)) {
+      const def = BEAST_DEFINITIONS[lair.beastId];
+      const tile = map.tiles[hexKey(lair.position)];
+      expect(def.habitatTerrains).toContain(tile.terrain);
+      expect(tile.wonder).toBeNull();
+      for (const start of starts) {
+        expect(hexDistance(lair.position, start)).toBeGreaterThanOrEqual(6);
+      }
+      expect(lair.status).toBe('dormant');
+      expect(lair.unitIds).toEqual([]);
+      expect(lair.strength).toBe(0);
+    }
+  });
+
+  it('is deterministic for the same seed', () => {
+    const a = placeBeastLairs(map, starts, 'medium', 'beast-test-seed');
+    const b = placeBeastLairs(map, starts, 'medium', 'beast-test-seed');
+    expect(a).toEqual(b);
+  });
+
+  it('never places more lairs than the map-size budget', () => {
+    const lairs = placeBeastLairs(map, starts, 'small', 'beast-test-seed');
+    expect(Object.keys(lairs).length).toBeLessThanOrEqual(LAIR_COUNTS.small);
+  });
+
+  it('exports the beasts owner constant', () => {
+    expect(BEAST_OWNER).toBe('beasts');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: FAIL — cannot resolve `@/systems/beast-system`.
+
+- [ ] **Step 3: Create `src/systems/beast-system.ts` with placement**
+
+```typescript
+import type { BeastId, BeastLair, BeastsMode, GameMap, GameState, HexCoord, Unit } from '@/core/types';
+import { BEAST_DEFINITIONS, getBeastDefinitionByUnitType, type BeastDefinition } from '@/systems/beast-definitions';
+import { hexKey, hexDistance, hexNeighbors } from '@/systems/hex-utils';
+import { createRng } from '@/systems/map-generator';
+
+export const BEAST_OWNER = 'beasts';
+
+export const LAIR_COUNTS = { small: 3, medium: 5, large: 7 } as const;
+
+const MIN_DISTANCE_FROM_START = 6;
+const MIN_DISTANCE_BETWEEN_LAIRS = 5;
+
+export function placeBeastLairs(
+  map: GameMap,
+  startPositions: HexCoord[],
+  mapSize: 'small' | 'medium' | 'large',
+  seed: string,
+): Record<string, BeastLair> {
+  const rng = createRng(seed + '-beasts');
+  const budget = LAIR_COUNTS[mapSize];
+  const lairs: Record<string, BeastLair> = {};
+  const placed: HexCoord[] = [];
+
+  // Deterministic beast order: shuffle the roster, then take up to budget
+  const roster: BeastDefinition[] = Object.values(BEAST_DEFINITIONS);
+  for (let i = roster.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [roster[i], roster[j]] = [roster[j], roster[i]];
+  }
+
+  for (const def of roster) {
+    if (placed.length >= budget) break;
+    const candidates = Object.values(map.tiles).filter(tile =>
+      def.habitatTerrains.includes(tile.terrain)
+      && tile.wonder === null
+      && startPositions.every(s => hexDistance(tile.coord, s) >= MIN_DISTANCE_FROM_START)
+      && placed.every(p => hexDistance(tile.coord, p) >= MIN_DISTANCE_BETWEEN_LAIRS),
+    );
+    if (candidates.length === 0) continue;   // no valid habitat — skip this beast, never force-place
+    const tile = candidates[Math.floor(rng() * candidates.length)];
+    const lair: BeastLair = {
+      id: `lair-${def.id}`,
+      beastId: def.id,
+      position: { ...tile.coord },
+      status: 'dormant',
+      strength: 0,
+      unitIds: [],
+    };
+    lairs[lair.id] = lair;
+    placed.push(tile.coord);
+  }
+  return lairs;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS (4 tests). Note: with only one beast in the MR1 roster, at most 1 lair places — the budget test still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): deterministic lair placement"
+```
+
+---
+
+### Task 5: Beast system — awakening + territorial turn processing
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+This mirrors `processBarbarians` (`src/systems/barbarian-system.ts:133`): pure function in, orders out; `turn-manager.ts` applies the orders. Read that function before writing this one.
+
+- [ ] **Step 1: Write failing behavior tests (append to `tests/systems/beast-system.test.ts`)**
+
+```typescript
+import { processBeasts } from '@/systems/beast-system';
+import type { BeastLair, Unit } from '@/core/types';
+
+function makeLair(overrides: Partial<BeastLair> = {}): BeastLair {
+  return {
+    id: 'lair-giant_boar', beastId: 'giant_boar',
+    position: { q: 10, r: 10 }, status: 'dormant',
+    strength: 0, unitIds: [], ...overrides,
+  };
+}
+
+function makeUnit(overrides: Partial<Unit> = {}): Unit {
+  return {
+    id: 'u1', type: 'warrior', owner: 'player', position: { q: 12, r: 10 },
+    movementPointsLeft: 2, health: 100, experience: 0,
+    hasMoved: false, hasActed: false, isResting: false, ...overrides,
+  } as Unit;
+}
+
+describe('processBeasts', () => {
+  const map = generateMap(40, 30, 'beast-test-seed');
+
+  it('awakens a dormant lair once the era requirement is met (seeded chance)', () => {
+    // 25%/turn: across 40 seeds at era 1, the boar must awaken at least once and not always
+    let awakened = 0;
+    for (let seed = 1; seed <= 40; seed++) {
+      const result = processBeasts([makeLair()], map, [], [], 1, 'wild', seed);
+      if (result.awakenings.length > 0) awakened++;
+    }
+    expect(awakened).toBeGreaterThan(0);
+    expect(awakened).toBeLessThan(40);
+  });
+
+  it('never awakens before the awaken era', () => {
+    for (let seed = 1; seed <= 40; seed++) {
+      const result = processBeasts([makeLair()], map, [], [], 0, 'wild', seed);
+      expect(result.awakenings).toEqual([]);
+    }
+  });
+
+  it('does nothing in off mode', () => {
+    const result = processBeasts([makeLair()], map, [], [], 3, 'off', 7);
+    expect(result.awakenings).toEqual([]);
+    expect(result.spawnOrders).toEqual([]);
+  });
+
+  it('orders an attack when an intruder is adjacent, in wild mode only', () => {
+    const lair = makeLair({ status: 'awake', unitIds: ['beast-1'] });
+    const beast = makeUnit({ id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 } });
+    const intruder = makeUnit({ id: 'u1', position: { q: 11, r: 10 } });
+    const wild = processBeasts([lair], map, [intruder], [beast], 1, 'wild', 7);
+    expect(wild.attackOrders).toEqual([{ attackerUnitId: 'beast-1', defenderUnitId: 'u1' }]);
+    const calm = processBeasts([lair], map, [intruder], [beast], 1, 'calm', 7);
+    expect(calm.attackOrders).toEqual([]);
+  });
+
+  it('never moves a beast beyond its leash radius', () => {
+    const lair = makeLair({ status: 'awake', unitIds: ['beast-1'] });
+    const beast = makeUnit({ id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 13, r: 10 } }); // at leash edge (3)
+    const farIntruder = makeUnit({ id: 'u1', position: { q: 17, r: 10 } });
+    const result = processBeasts([lair], map, [farIntruder], [beast], 1, 'wild', 7);
+    for (const order of result.moveOrders) {
+      expect(hexDistance(order.toCoord, lair.position)).toBeLessThanOrEqual(3);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: FAIL — `processBeasts` is not exported.
+
+- [ ] **Step 3: Implement awakening + territorial orders (append to `src/systems/beast-system.ts`)**
+
+```typescript
+function lcg(seed: number): () => number {
+  let s = seed === 0 ? 1 : seed;
+  return () => {
+    s = (s * 48271) % 2147483647;
+    return s / 2147483647;
+  };
+}
+
+const AWAKEN_CHANCE_PER_TURN = 0.25;
+// Growth-while-ignored: applied by turn-manager (it owns the turn counter)
+export const LAIR_GROWTH_INTERVAL_TURNS = 10;
+export const LAIR_GROWTH_CAP = 5;
+export const LAIR_GROWTH_EXPERIENCE = 16;   // one veterancy tier worth per growth tick
+
+export interface BeastMoveOrder { unitId: string; toCoord: HexCoord }
+export interface BeastAttackOrder { attackerUnitId: string; defenderUnitId: string }
+export interface BeastSpawnOrder { lairId: string; beastId: BeastId; position: HexCoord }
+export interface BeastAwakening { lairId: string; beastId: BeastId; position: HexCoord }
+
+export interface BeastProcessResult {
+  updatedLairs: BeastLair[];
+  spawnOrders: BeastSpawnOrder[];
+  moveOrders: BeastMoveOrder[];
+  attackOrders: BeastAttackOrder[];
+  awakenings: BeastAwakening[];
+}
+
+const IMPASSABLE_FOR_BEASTS = new Set(['ocean', 'coast', 'mountain']);
+
+export function processBeasts(
+  lairs: BeastLair[],
+  map: GameMap,
+  intruderUnits: Unit[],   // every non-beast, non-barbarian unit on the map
+  beastUnits: Unit[],
+  era: number,
+  mode: BeastsMode,
+  seed: number,
+): BeastProcessResult {
+  const empty: BeastProcessResult = { updatedLairs: lairs, spawnOrders: [], moveOrders: [], attackOrders: [], awakenings: [] };
+  if (mode === 'off') return empty;
+
+  const rng = lcg(seed ^ 0xbea57);
+  const updatedLairs: BeastLair[] = [];
+  const spawnOrders: BeastSpawnOrder[] = [];
+  const awakenings: BeastAwakening[] = [];
+  const moveOrders: BeastMoveOrder[] = [];
+  const attackOrders: BeastAttackOrder[] = [];
+
+  const occupied = new Map<string, string>();
+  for (const u of [...beastUnits, ...intruderUnits]) occupied.set(hexKey(u.position), u.id);
+
+  for (const lair of lairs) {
+    const def = BEAST_DEFINITIONS[lair.beastId];
+    if (lair.status === 'dormant' && era >= def.awakenEra && rng() < AWAKEN_CHANCE_PER_TURN) {
+      awakenings.push({ lairId: lair.id, beastId: lair.beastId, position: lair.position });
+      // Spawn packSize beasts: first on the lair tile, rest on free passable neighbors
+      const spawnTiles: HexCoord[] = [];
+      if (!occupied.has(hexKey(lair.position))) spawnTiles.push(lair.position);
+      for (const n of hexNeighbors(lair.position)) {
+        if (spawnTiles.length >= def.packSize) break;
+        const tile = map.tiles[hexKey(n)];
+        if (tile && !IMPASSABLE_FOR_BEASTS.has(tile.terrain) && !occupied.has(hexKey(n))) spawnTiles.push(n);
+      }
+      for (const pos of spawnTiles.slice(0, def.packSize)) {
+        spawnOrders.push({ lairId: lair.id, beastId: lair.beastId, position: { ...pos } });
+        occupied.set(hexKey(pos), 'pending-spawn');
+      }
+      updatedLairs.push({ ...lair, status: 'awake' });
+    } else {
+      updatedLairs.push(lair);
+    }
+  }
+
+  if (mode === 'calm') {
+    // Calm: beasts exist and defend themselves, but never initiate movement or attacks
+    return { updatedLairs, spawnOrders, moveOrders: [], attackOrders: [], awakenings };
+  }
+
+  const lairByUnitId = new Map<string, BeastLair>();
+  for (const lair of updatedLairs) for (const id of lair.unitIds) lairByUnitId.set(id, lair);
+
+  for (const beast of beastUnits) {
+    if (beast.movementPointsLeft <= 0) continue;
+    const lair = lairByUnitId.get(beast.id);
+    if (!lair) continue;
+    const def = BEAST_DEFINITIONS[lair.beastId];
+
+    const inLeash = (c: HexCoord) => hexDistance(c, lair.position) <= def.leashRadius;
+    const targets = intruderUnits
+      .filter(u => inLeash(u.position))
+      .sort((a, b) => hexDistance(a.position, beast.position) - hexDistance(b.position, beast.position));
+    const target = targets[0];
+
+    if (target && hexDistance(target.position, beast.position) === 1) {
+      attackOrders.push({ attackerUnitId: beast.id, defenderUnitId: target.id });
+      continue;
+    }
+
+    const goal = target ? target.position : lair.position;
+    if (hexKey(goal) === hexKey(beast.position)) continue;
+    const step = hexNeighbors(beast.position)
+      .filter(n => {
+        const tile = map.tiles[hexKey(n)];
+        return tile && !IMPASSABLE_FOR_BEASTS.has(tile.terrain) && !occupied.has(hexKey(n)) && inLeash(n);
+      })
+      .sort((a, b) => hexDistance(a, goal) - hexDistance(b, goal))[0];
+    if (step && hexDistance(step, goal) < hexDistance(beast.position, goal)) {
+      occupied.delete(hexKey(beast.position));
+      occupied.set(hexKey(step), beast.id);
+      moveOrders.push({ unitId: beast.id, toCoord: step });
+    }
+  }
+
+  return { updatedLairs, spawnOrders, moveOrders, attackOrders, awakenings };
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS. If the leash test fails because hex coords `{q:13,r:10}` aren't distance 3 from `{q:10,r:10}` in axial math, recompute the test coordinates with `hexDistance` semantics from `src/systems/hex-utils.ts` — adjust the test, not the leash logic.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): era-gated awakening and territorial turn orders"
+```
+
+---
+
+### Task 6: Slay rewards (shared, actor-complete)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Modify: `src/systems/combat-reward-system.ts`
+- Modify: `src/systems/attack-targeting.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing slay tests (append to the beast-system test file)**
+
+```typescript
+import { recordBeastSlain, getBeastHoardGold } from '@/systems/beast-system';
+import { createNewGame } from '@/core/game-state';
+
+describe('recordBeastSlain', () => {
+  function stateWithSlainBoar() {
+    const state = createNewGame('rome', 'beast-test-seed', 'small', 'Beast Test');
+    const beast: Unit = makeUnit({ id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 } });
+    const victor: Unit = makeUnit({ id: 'hero-1', owner: state.currentPlayer, health: 40, position: { q: 11, r: 10 } });
+    state.units[beast.id] = beast;
+    state.units[victor.id] = victor;
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-giant_boar': makeLair({ status: 'awake', unitIds: ['beast-1'] }) },
+      sightingsByCiv: {},
+    };
+    return { state, beast, victor };
+  }
+
+  it('marks the lair slain, awards hoard gold, and fully heals the victor', () => {
+    const { state, beast, victor } = stateWithSlainBoar();
+    const goldBefore = state.civilizations[victor.owner].gold;
+    const { state: next, slain } = recordBeastSlain(state, beast, victor);
+    expect(slain).toBeDefined();
+    expect(next.beasts!.lairs['lair-giant_boar'].status).toBe('slain');
+    expect(next.beasts!.lairs['lair-giant_boar'].slainBy).toBe(victor.owner);
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore + slain!.goldAwarded);
+    expect(next.units['hero-1'].health).toBe(100);
+    // immutability: input state untouched
+    expect(state.beasts!.lairs['lair-giant_boar'].status).toBe('awake');
+  });
+
+  it('returns no slain payload for non-beast defenders', () => {
+    const { state, victor } = stateWithSlainBoar();
+    const barb = makeUnit({ id: 'barb-1', owner: 'barbarian' });
+    expect(recordBeastSlain(state, barb, victor).slain).toBeUndefined();
+  });
+
+  it('only marks the lair slain when its last unit dies', () => {
+    const { state, beast, victor } = stateWithSlainBoar();
+    state.beasts!.lairs['lair-giant_boar'].unitIds = ['beast-1', 'beast-2'];
+    const { state: next, slain } = recordBeastSlain(state, beast, victor);
+    expect(slain).toBeUndefined();
+    expect(next.beasts!.lairs['lair-giant_boar'].status).toBe('awake');
+    expect(next.beasts!.lairs['lair-giant_boar'].unitIds).toEqual(['beast-2']);
+  });
+
+  it('scales hoard gold with era', () => {
+    const def = BEAST_DEFINITIONS.giant_boar;
+    expect(getBeastHoardGold(def, 1)).toBe(40);
+    expect(getBeastHoardGold(def, 3)).toBeGreaterThan(getBeastHoardGold(def, 1));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: FAIL — `recordBeastSlain` not exported.
+
+- [ ] **Step 3: Implement (append to `src/systems/beast-system.ts`)**
+
+```typescript
+export function isBeastUnit(unit: Pick<Unit, 'owner'>): boolean {
+  return unit.owner === BEAST_OWNER;
+}
+
+export function getBeastHoardGold(def: BeastDefinition, era: number): number {
+  // Tier base, +50% per era past the awaken era — late kills stay worthwhile
+  const eraBonus = Math.max(0, era - def.awakenEra);
+  return Math.round(def.hoardGoldBase * (1 + 0.5 * eraBonus));
+}
+
+export interface BeastSlainPayload {
+  lairId: string;
+  beastId: BeastId;
+  slayerCivId: string;
+  slayerUnitId: string;
+  goldAwarded: number;
+}
+
+/**
+ * Shared slay consequence — MUST be called from every path that kills a beast
+ * (player attack in main.ts, AI/beast combat in turn-manager.ts).
+ * Returns a new GameState; never mutates the input.
+ */
+export function recordBeastSlain(
+  state: GameState,
+  defeated: Unit,
+  victor: Unit,
+): { state: GameState; slain?: BeastSlainPayload } {
+  if (!isBeastUnit(defeated) || !state.beasts) return { state };
+
+  const lair = Object.values(state.beasts.lairs).find(l => l.unitIds.includes(defeated.id));
+  if (!lair) return { state };
+
+  const remaining = lair.unitIds.filter(id => id !== defeated.id);
+  if (remaining.length > 0) {
+    const updatedLair: BeastLair = { ...lair, unitIds: remaining };
+    return {
+      state: { ...state, beasts: { ...state.beasts, lairs: { ...state.beasts.lairs, [lair.id]: updatedLair } } },
+    };
+  }
+
+  const def = BEAST_DEFINITIONS[lair.beastId];
+  const gold = getBeastHoardGold(def, state.era);
+  const slayerCiv = state.civilizations[victor.owner];
+  const updatedLair: BeastLair = {
+    ...lair, unitIds: [], status: 'slain', slainBy: victor.owner, slainTurn: state.turn,
+  };
+
+  let next: GameState = {
+    ...state,
+    beasts: { ...state.beasts, lairs: { ...state.beasts.lairs, [lair.id]: updatedLair } },
+  };
+  if (slayerCiv) {
+    next = {
+      ...next,
+      civilizations: {
+        ...next.civilizations,
+        [victor.owner]: { ...slayerCiv, gold: slayerCiv.gold + gold },
+      },
+    };
+  }
+  // Victory Feast: the slaying unit is fully healed (if it survived and still exists)
+  const victorUnit = next.units[victor.id];
+  if (victorUnit) {
+    next = { ...next, units: { ...next.units, [victor.id]: { ...victorUnit, health: 100 } } };
+  }
+
+  return {
+    state: next,
+    slain: slayerCiv
+      ? { lairId: lair.id, beastId: lair.beastId, slayerCivId: victor.owner, slayerUnitId: victor.id, goldAwarded: gold }
+      : undefined,
+  };
+}
+```
+
+Check the `Civilization` interface for the gold field name with `grep -n "gold" src/core/types.ts | head` — if the civ treasury field is not literally `gold`, use the real field name in both code and test.
+
+- [ ] **Step 4: Attack targeting + gold-reward gating**
+
+In `src/systems/attack-targeting.ts` (lines 54–55), extend the early-allow block:
+
+```typescript
+  if (attackerOwner === 'barbarian' || attackerOwner === 'rebels') return true;
+  if (targetOwner === 'barbarian' || targetOwner === 'rebels') return true;
+  if (attackerOwner === 'beasts' || targetOwner === 'beasts') return true;
+```
+
+In `src/systems/combat-reward-system.ts:65` (`canReceiveGoldReward`):
+
+```typescript
+  return owner !== 'barbarian' && owner !== 'rebels' && owner !== 'beasts' && !owner.startsWith('mc-');
+```
+
+In `calculateDefeatReward` (line 95), beasts must NOT grant per-kill gold (the hoard replaces it). Change the baseGold ternary so a `'beasts'` defeated-owner yields `0`:
+
+```typescript
+  const defeatedIsHorde = input.defeated.owner === 'barbarian' || input.defeated.owner === 'rebels';
+  const baseGold = canReceiveGold
+    ? (input.defeated.owner === 'beasts' ? 0 : (defeatedCanFight ? (defeatedIsHorde ? 8 : 4) : 1))
+    : 0;
+```
+
+- [ ] **Step 5: Run the full suites for the touched systems**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts tests/systems/combat-reward-system.test.ts tests/systems/attack-targeting.test.ts`
+Expected: PASS (if the latter two test files have different names, find them with `ls tests/systems | grep -E "reward|targeting"`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/beast-system.ts src/systems/attack-targeting.ts src/systems/combat-reward-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): shared slay rewards, hoard gold, targeting and gold-gating rules"
+```
+
+---
+
+### Task 7: Turn-manager wiring (awakening, spawns, moves, beast attacks)
+
+**Files:**
+- Modify: `src/core/turn-manager.ts`
+- Test: `tests/core/turn-manager-beasts.test.ts`
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Create `tests/core/turn-manager-beasts.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { processTurn } from '@/core/turn-manager';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { BEAST_OWNER } from '@/systems/beast-system';
+
+describe('turn-manager beast wiring', () => {
+  it('eventually spawns a beast unit from an awakened lair and emits beast:awakened', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'Beast Turn Test');
+    if (!state.beasts || Object.keys(state.beasts.lairs).length === 0) {
+      // Map seed produced no forest lair candidates — regenerate with a different seed until one places.
+      // If this trips repeatedly, loosen MIN_DISTANCE_FROM_START in the test by picking a larger map.
+      throw new Error('test seed produced no lairs; pick a seed that places a lair');
+    }
+    const bus = new EventBus();
+    let awakened = 0;
+    bus.on('beast:awakened', () => { awakened++; });
+    let s = state;
+    for (let i = 0; i < 60 && awakened === 0; i++) s = processTurn(s, bus);
+    expect(awakened).toBeGreaterThan(0);
+    const beastUnits = Object.values(s.units).filter(u => u.owner === BEAST_OWNER);
+    expect(beastUnits.length).toBeGreaterThan(0);
+    const lair = Object.values(s.beasts!.lairs).find(l => l.status === 'awake')!;
+    expect(lair.unitIds).toContain(beastUnits[0].id);
+  });
+
+  it('does not process beasts when mode is off', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'Beast Off Test');
+    if (state.beasts) state.beasts.mode = 'off';
+    const bus = new EventBus();
+    let s = state;
+    for (let i = 0; i < 30; i++) s = processTurn(s, bus);
+    expect(Object.values(s.units).some(u => u.owner === BEAST_OWNER)).toBe(false);
+  });
+});
+```
+
+Check `EventBus` construction first: `grep -n "export class EventBus\|export function createEventBus" src/core/event-bus.ts` — use whichever factory exists; mirror an existing turn-manager test's setup (see `ls tests/core/`). Note this test depends on Task 9 (game-state seeding); write it now, expect failure until Task 9, but the wiring below is testable through the second test immediately.
+
+- [ ] **Step 2: Wire into `processTurn` (`src/core/turn-manager.ts`)**
+
+Add imports at the top:
+
+```typescript
+import {
+  processBeasts, recordBeastSlain, BEAST_OWNER,
+  LAIR_GROWTH_INTERVAL_TURNS, LAIR_GROWTH_CAP, LAIR_GROWTH_EXPERIENCE,
+} from '@/systems/beast-system';
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+```
+
+First, fix the barbarian intruder filter at line 496 so barbarians ignore beasts:
+
+```typescript
+  const playerUnits = Object.values(newState.units).filter(u => u.owner !== 'barbarian' && u.owner !== BEAST_OWNER && !u.owner.startsWith('mc-'));
+```
+
+Then insert a beast block **after** the barbarian block (after the camp-evolution handling around line 561), following the same style as the barbarian code (this file works on a `structuredClone`, so local mutation of `newState` is the established convention here):
+
+```typescript
+  // --- Process legendary beasts ---
+  if (newState.beasts && newState.beasts.mode !== 'off') {
+    for (const unit of Object.values(newState.units)) {
+      if (unit.owner === BEAST_OWNER) {
+        unit.movementPointsLeft = UNIT_DEFINITIONS[unit.type].movementPoints;
+        unit.hasMoved = false;
+      }
+    }
+    const beastUnits = Object.values(newState.units).filter(u => u.owner === BEAST_OWNER);
+    const intruders = Object.values(newState.units).filter(u => u.owner !== BEAST_OWNER && u.owner !== 'barbarian');
+    const beastResult = processBeasts(
+      Object.values(newState.beasts.lairs),
+      newState.map,
+      intruders,
+      beastUnits,
+      newState.era,
+      newState.beasts.mode,
+      newState.turn * 7919 + 13,
+    );
+    newState.beasts.lairs = {};
+    for (const lair of beastResult.updatedLairs) newState.beasts.lairs[lair.id] = lair;
+
+    for (const spawn of beastResult.spawnOrders) {
+      const def = BEAST_DEFINITIONS[spawn.beastId];
+      const beast = createUnit(def.unitType, BEAST_OWNER, spawn.position, newState.idCounters);
+      newState.units[beast.id] = beast;
+      newState.beasts.lairs[spawn.lairId].unitIds.push(beast.id);
+    }
+    for (const awakening of beastResult.awakenings) {
+      newState.beasts.lairs[awakening.lairId].awakenedTurn = newState.turn;
+      bus.emit('beast:awakened', awakening);
+    }
+    // Growth while ignored: every N turns an awake lair hardens and its beasts gain veterancy.
+    // An unhunted boar is a real fight three eras later — and its hoard grew too (era-scaled).
+    if (newState.turn % LAIR_GROWTH_INTERVAL_TURNS === 0) {
+      for (const lair of Object.values(newState.beasts.lairs)) {
+        if (lair.status !== 'awake' || lair.strength >= LAIR_GROWTH_CAP) continue;
+        lair.strength += 1;
+        for (const unitId of lair.unitIds) {
+          const beast = newState.units[unitId];
+          if (beast) beast.experience += LAIR_GROWTH_EXPERIENCE;
+        }
+      }
+    }
+    for (const move of beastResult.moveOrders) {
+      const beast = newState.units[move.unitId];
+      if (beast) { beast.position = { ...move.toCoord }; beast.movementPointsLeft -= 1; }
+    }
+    for (const order of beastResult.attackOrders) {
+      const attacker = newState.units[order.attackerUnitId];
+      const defender = newState.units[order.defenderUnitId];
+      if (!attacker || !defender) continue;
+      // Reuse the exact combat-resolution call pattern the barbarian attack block uses
+      // a few lines above this code (resolveCombat + damage application + death cleanup).
+      // Beasts attacking units never produces a hoard; if the BEAST dies on counterattack,
+      // route through recordBeastSlain:
+      // const { state: afterSlay, slain } = recordBeastSlain(newState, attacker, defender);
+      // newState = afterSlay as typeof newState;
+      // if (slain) bus.emit('beast:slain', slain);
+    }
+  }
+```
+
+For the attack block: read how the barbarian attack orders are applied (the code directly below `// Move barbarian units`, lines ~518–560) and replicate it exactly for beasts, adding the `recordBeastSlain` counterattack branch shown in the comment. Since `recordBeastSlain` returns a fresh state, change `let newState` handling accordingly (the function head already declares `let newState` at line 67, so reassignment is legal).
+
+- [ ] **Step 3: Run the off-mode test**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/core/turn-manager-beasts.test.ts -t "off"`
+Expected: PASS (the awakening test still fails until Task 9 seeds lairs — that's expected).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/turn-manager.ts tests/core/turn-manager-beasts.test.ts
+git commit -m "feat(beasts): turn-manager processing for awakening, movement, and attacks"
+```
+
+---
+
+### Task 8: Player combat path — slay on player kills (actor parity)
+
+**Files:**
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Find the player-attack death branches**
+
+Run: `grep -n "isBarbarian" src/main.ts`
+Expected hits at ~2101, ~2337, ~2433 — these are the combat-resolution paths where a defender (or attacker) dies.
+
+- [ ] **Step 2: Add the slay hook to each defender-death branch**
+
+In each branch where a defeated unit is removed from `gameState.units` after combat, add **before** the deletion (so `recordBeastSlain` can still find the lair membership):
+
+```typescript
+      const slayResult = recordBeastSlain(gameState, defender, attacker);
+      gameState = slayResult.state;
+      if (slayResult.slain) {
+        bus.emit('beast:slain', slayResult.slain);
+      }
+```
+
+Adapt local variable names (`defender`/`attacker`) to each branch's actual names. Import at top of `main.ts`:
+
+```typescript
+import { recordBeastSlain } from '@/systems/beast-system';
+```
+
+If `gameState` is not reassignable in that scope (check how the existing code updates state after combat — main.ts may mutate in place), then instead apply the returned state's changed slices: `gameState.beasts = slayResult.state.beasts; gameState.civilizations = slayResult.state.civilizations; gameState.units = slayResult.state.units;` — match whichever pattern the surrounding code uses.
+
+- [ ] **Step 3: Add notification listeners (near the `'barbarian:spawned'` listener at main.ts:3211)**
+
+```typescript
+bus.on('beast:awakened', ({ beastId, position }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  for (const civId of Object.keys(gameState.civilizations)) {
+    appendNotification(notificationLog, civId, {
+      message: def.awakeningFlavor,
+      type: 'warning',
+      turn: gameState.turn,
+      target: { kind: 'map', coord: position, label: `${def.name} lair` },
+    });
+  }
+});
+
+bus.on('beast:slain', ({ beastId, slayerCivId, goldAwarded }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  const slayerName = gameState.civilizations[slayerCivId]?.name ?? slayerCivId;
+  for (const civId of Object.keys(gameState.civilizations)) {
+    appendNotification(notificationLog, civId, {
+      message: civId === slayerCivId
+        ? `Your forces have slain the ${def.name}! Hoard claimed: +${goldAwarded} gold.`
+        : `${slayerName} has slain the ${def.name}!`,
+      type: civId === slayerCivId ? 'success' : 'info',
+      turn: gameState.turn,
+    });
+  }
+});
+```
+
+Import `BEAST_DEFINITIONS` from `@/systems/beast-definitions`. Check the `Civilization` display-name field (`grep -n "interface Civilization" -A 10 src/core/types.ts`) and use the real field.
+
+- [ ] **Step 4: Build to verify wiring compiles**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: remaining errors only in `sprite-catalog.ts` / `UNIT_SPRITE_CATALOG` and `UNIT_MOTION_STYLES` (fixed in Task 11). If main.ts shows errors, fix them now.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "feat(beasts): player slay path and beast notifications"
+```
+
+---
+
+### Task 9: Game creation — seed lairs + settings default
+
+**Files:**
+- Modify: `src/core/game-state.ts`
+- Modify: `src/core/types.ts` (none — already done)
+
+- [ ] **Step 1: Default the mode in `createDefaultSettings` (`src/core/game-state.ts:38`)**
+
+Add to the returned settings object:
+
+```typescript
+    beastsMode: 'wild',
+```
+
+- [ ] **Step 2: Seed lairs in BOTH game constructors**
+
+In `createNewGame` (line 109 implementation) and `createHotSeatGame` (line 306), find where `tribalVillages` is assigned from `placeVillages(...)` and add immediately after (reusing the same `startPositions`/`seed` variables in scope):
+
+```typescript
+  const beastsMode = settings.beastsMode ?? 'wild';
+  const beastLairs = beastsMode === 'off'
+    ? {}
+    : placeBeastLairs(map, startPositions, mapSize, seed);
+```
+
+And in the returned `GameState` object literal, alongside `tribalVillages`:
+
+```typescript
+    beasts: { mode: beastsMode, lairs: beastLairs, sightingsByCiv: {} },
+```
+
+Import at top:
+
+```typescript
+import { placeBeastLairs } from '@/systems/beast-system';
+```
+
+Adapt local variable names (`settings`, `map`, `startPositions`, `mapSize`, `seed`) to what each constructor actually has in scope — read both functions first.
+
+- [ ] **Step 3: Run the full turn-manager beast test**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/core/turn-manager-beasts.test.ts`
+Expected: PASS (both tests). If the awakening test throws `'test seed produced no lairs'`, change the test's seed string until placement succeeds (forest tiles within constraints), and note the working seed in the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/core/game-state.ts tests/core/turn-manager-beasts.test.ts
+git commit -m "feat(beasts): seed lairs at game creation with beastsMode setting"
+```
+
+---
+
+### Task 10: Rules doc — trainability exemption
+
+**Files:**
+- Modify: `.claude/rules/game-systems.md`
+
+- [ ] **Step 1: Amend the Unit Types rule**
+
+In `.claude/rules/game-systems.md`, under `## Unit Types`, append:
+
+```markdown
+- **Exception — beast units:** `UnitType` values prefixed `beast_` are legendary-beast units spawned exclusively by `beast-system.ts`. They are intentionally NOT in `TRAINABLE_UNITS`, have `productionCost: 0`, and are owned by the `'beasts'` owner constant. Do not add them to city production, AI training, or tech `unlocksUnits`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .claude/rules/game-systems.md
+git commit -m "docs(rules): document beast unit trainability exemption"
+```
+
+---
+
+### Task 11: Giant Boar sprite + catalog registration
+
+**Files:**
+- Create: `src/renderer/sprites/beasts.tsx`
+- Modify: `src/renderer/sprites/sprite-catalog.ts`
+
+Read `.claude/rules/sprites.md` and one existing quadruped sprite (`ScoutHoundSprite` in `src/renderer/sprites/units.tsx`) before writing. The boar reuses the existing `hound` animation rig (`data-kind="hound"`, `cq-leg-l/r` classes) — no new CSS needed in MR1.
+
+- [ ] **Step 1: Create `src/renderer/sprites/beasts.tsx`**
+
+```tsx
+import {
+  type FactionPalette,
+  MATERIAL_PALETTE as P,
+  Shadow,
+  SpriteFrame,
+} from './sprite-system';
+import type { UnitSpriteProps } from './units';
+
+/**
+ * Legendary beasts use fixed palettes — they have no faction owner, so the
+ * `palette` prop is accepted (catalog contract) but intentionally unused.
+ * No <Banner> — beasts fly no flag.
+ */
+
+const BOAR = {
+  hide: '#6b4a32',
+  hideDark: '#4d3422',
+  belly: '#8a6a4e',
+  tusk: '#e8e0cc',
+  eye: '#c43b2e',
+};
+
+export function GiantBoarSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="hound" className="cq-sprite-figure">
+        {/* hind + front legs (hound rig classes drive the walk cycle) */}
+        <rect className="cq-leg-l" x="44" y="84" width="7" height="16" rx="3" fill={BOAR.hideDark} />
+        <rect className="cq-leg-r" x="56" y="84" width="7" height="16" rx="3" fill={BOAR.hide} />
+        <rect className="cq-leg-l" x="74" y="84" width="7" height="16" rx="3" fill={BOAR.hideDark} />
+        <rect className="cq-leg-r" x="84" y="84" width="7" height="16" rx="3" fill={BOAR.hide} />
+        {/* massive body */}
+        <ellipse cx="66" cy="72" rx="30" ry="20" fill={BOAR.hide} stroke={P.ink.line} strokeWidth="1.5" />
+        <ellipse cx="66" cy="80" rx="26" ry="11" fill={BOAR.belly} opacity="0.7" />
+        {/* bristle ridge */}
+        <path d="M40,62 Q50,50 66,52 Q82,50 92,60" fill="none" stroke={BOAR.hideDark} strokeWidth="5" strokeLinecap="round" />
+        {/* head, snout, tusks */}
+        <ellipse cx="92" cy="68" rx="14" ry="12" fill={BOAR.hide} stroke={P.ink.line} strokeWidth="1.5" />
+        <rect x="100" y="66" width="12" height="9" rx="4" fill={BOAR.hideDark} />
+        <path d="M102,76 Q108,84 114,78" fill="none" stroke={BOAR.tusk} strokeWidth="3.5" strokeLinecap="round" />
+        <path d="M100,74 Q105,81 110,76" fill="none" stroke={BOAR.tusk} strokeWidth="3" strokeLinecap="round" />
+        {/* glowing eye */}
+        <circle cx="94" cy="64" r="2.5" fill={BOAR.eye} />
+        {/* ears + tail */}
+        <path d="M86,56 L90,48 L95,56 Z" fill={BOAR.hideDark} />
+        <path d="M37,68 Q30,64 32,58" fill="none" stroke={BOAR.hideDark} strokeWidth="2.5" strokeLinecap="round" />
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+Note: if `SpriteFrame` requires `<HexBase />` per the sprite rules, check how `ScoutHoundSprite` does it and match exactly — copy its frame skeleton (Shadow/HexBase order) and keep the boar art.
+
+- [ ] **Step 2: Register in `src/renderer/sprites/sprite-catalog.ts`**
+
+Add the import:
+
+```typescript
+import { GiantBoarSprite } from './beasts';
+```
+
+In `UNIT_MOTION_STYLES` (line 36):
+
+```typescript
+  beast_boar: 'animal',
+```
+
+In `UNIT_SPRITE_CATALOG` (line 103):
+
+```typescript
+  beast_boar: GiantBoarSprite,
+```
+
+- [ ] **Step 3: Build + sprite-catalog tests**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn vitest run tests/renderer/sprites/sprite-catalog.test.ts`
+Expected: build PASSES now (all six exhaustive maps complete); sprite-catalog tests PASS. If the catalog test asserts every sprite renders, the boar must produce non-empty SVG — debug by importing and logging `GiantBoarSprite({ palette: <any existing palette>, svgOnly: true })` in a scratch test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/sprites/beasts.tsx src/renderer/sprites/sprite-catalog.ts
+git commit -m "feat(beasts): Giant Boar sprite with hound walk rig"
+```
+
+---
+
+### Task 12: Lair rendering (explored tiles show the den)
+
+**Files:**
+- Modify: `src/renderer/hex-renderer.ts`
+- Modify: `src/renderer/render-loop.ts`
+
+Lairs render exactly like tribal-village glyphs: a `Set`/`Map` keyed by `"q,r"` passed into `drawHexMap`, drawn only on explored tiles (visibility filtering already happens inside `drawHexMap` for villages — mirror it).
+
+- [ ] **Step 1: Extend `drawHexMap` (`src/renderer/hex-renderer.ts:117`)**
+
+Add a parameter after `villagePositions`:
+
+```typescript
+  villagePositions?: Set<string>,
+  beastLairGlyphs?: Map<string, string>,   // "q,r" -> glyph; built by render-loop from state.beasts
+```
+
+Inside the per-tile loop where `isVillage` is computed (line 136):
+
+```typescript
+    const lairGlyph = beastLairGlyphs?.get(`${tile.coord.q},${tile.coord.r}`);
+```
+
+Where the village indicator is drawn (line ~394), add an equivalent block after it, drawing the glyph at the same anchor with the same font sizing the village glyph uses:
+
+```typescript
+      if (lairGlyph) {
+        // same canvas setup as the village glyph above — copy its ctx.font / fillText pattern
+        ctx.fillText(lairGlyph, /* same x */ 0, /* same y */ 0);
+      }
+```
+
+Copy the literal coordinates/offsets from the village-drawing code three lines above — do not guess; the two glyphs should be visually consistent. **Callers must update**: search all `drawHexMap(` call sites (`grep -rn "drawHexMap(" src/ tests/`) and pass `undefined` where no lairs are available.
+
+- [ ] **Step 2: Build the glyph map in `src/renderer/render-loop.ts` (call site line 294)**
+
+Above the `drawHexMap` call:
+
+```typescript
+    const beastLairGlyphs = new Map<string, string>();
+    if (this.state.beasts) {
+      for (const lair of Object.values(this.state.beasts.lairs)) {
+        const glyph = lair.status === 'slain' || lair.status === 'claimed' ? '🏆' : '🐾';
+        beastLairGlyphs.set(`${lair.position.q},${lair.position.r}`, glyph);
+      }
+    }
+```
+
+And pass it as the new argument in the `drawHexMap(...)` call.
+
+- [ ] **Step 3: Build + visual smoke**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: PASS.
+Then: `bash scripts/run-with-mise.sh yarn dev`, start a new medium game, and pan the map: an explored forest tile far from spawn should show 🐾. (If no lair placed on this seed, start a couple of new games.) Stop the dev server after checking.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/hex-renderer.ts src/renderer/render-loop.ts
+git commit -m "feat(beasts): render lair glyphs on explored tiles"
+```
+
+---
+
+### Task 13: Setup toggle (campaign setup UI)
+
+**Files:**
+- Modify: `src/ui/campaign-setup.ts`
+
+#### Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Setup screen shows map-size selector; beasts row shows "Wild" preselected | Player taps "Calm" | "Calm" highlights; help text below updates to the calm description |
+| Beasts row shows "Off" | Player starts the game | New game has `beasts.mode === 'off'`, zero lairs, zero 🐾 glyphs |
+
+#### Misleading-UI risks
+
+- The three mode labels must describe behavior, not just names ("self-explanatory UI" rule). Each option carries one help sentence (below).
+- The control must reflect the actual default (`wild`) on first render — never render unselected.
+
+- [ ] **Step 1: Read the existing setup controls**
+
+Run: `grep -n "mapSize\|select\|createGameButton" src/ui/campaign-setup.ts | head -30` and read the surrounding code. Mirror whichever control pattern the map-size selector uses (buttons or `<select>`).
+
+- [ ] **Step 2: Add the Legendary Beasts control**
+
+Insert a labeled control after the map-size control, following its exact DOM/style pattern, with these three options and help texts (use `textContent`, never `innerHTML`):
+
+- `Wild` (default): "Legendary beasts roam near their lairs and attack intruders."
+- `Calm`: "Beasts appear and can be hunted, but never attack first."
+- `Off`: "No legendary beasts this game."
+
+Wire the selection into the config the Start button builds: set `settingsOverrides = { ...existing, beastsMode: selected }` on the `SoloSetupConfig` (field exists at `src/core/types.ts:923`). If hotseat setup (`src/ui/hotseat-setup.ts`) shares the same settings panel, add it there identically; if it has no settings section, defer hot-seat UI to the existing shared default (`wild`) and note that in the PR body.
+
+- [ ] **Step 3: Manual verification**
+
+Run: `bash scripts/run-with-mise.sh yarn dev` — create one game with each mode; confirm Off ⇒ no 🐾 anywhere (check several explored forests), Wild ⇒ lairs appear. Stop the server.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/campaign-setup.ts src/ui/hotseat-setup.ts
+git commit -m "feat(beasts): legendary beasts mode selector in game setup"
+```
+
+---
+
+### Task 14: Final verification + PR
+
+- [ ] **Step 1: Full gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0. Fix anything red before proceeding (the `require-green-before-push` hook will block otherwise).
+
+- [ ] **Step 2: Combat-preview check (strategy-game-mechanics rule)**
+
+Run: `bash scripts/run-with-mise.sh yarn dev`, awaken a boar (play ~10 turns near a lair with a warrior — or temporarily set `AWAKEN_CHANCE_PER_TURN = 1` locally, verify, then revert). Tap-attack the boar: the combat preview must show "Giant Boar", the beast description, and odds. This works for free if previews read `UNIT_DEFINITIONS`/`UNIT_DESCRIPTIONS` — verify visually, fix if the preview panel special-cases owners.
+
+- [ ] **Step 3: Create the PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR1 — legendary beast core system + Giant Boar" --body "$(cat <<'EOF'
+## Summary
+- New legendary-beast system: deterministic lair placement, era-gated awakening, territorial (leashed) behavior — beasts never attack cities and never leave their lair radius
+- One beast ships fully playable: the Giant Boar (forest, era 1, tier 1)
+- Slaying awards a hoard (era-scaled gold) + full-heal "Victory Feast"; shared `recordBeastSlain` covers player, AI, and counterattack paths
+- Setup toggle: Wild / Calm / Off
+- Lair glyphs render on explored tiles; boar sprite rides the existing hound animation rig
+
+## Out of scope (future MRs — see docs/superpowers/plans/2026-06-11-legendary-beasts-index.md)
+- Bestiary panel + sighting ceremonies (MR2)
+- Remaining 7 beasts (MR3, MR5–MR7), hoard choice rewards + lair trophies (MR4), audio/AI/balance (MR8)
+
+## Why this is safe to merge partial
+Player-visible surfaces introduced: lair glyphs, beast units with combat preview, slay notifications with gold, and the setup toggle. Each is fully wired end-to-end — there are no dead buttons or half-built panels. The bestiary is not referenced anywhere yet, so no dead-end UX exists.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (executor: verify before opening the PR)
+
+- [ ] All six exhaustive `Record<UnitType, …>` maps have `beast_boar` entries
+- [ ] `recordBeastSlain` is called from BOTH main.ts player path and turn-manager counterattack path (actor-complete rule)
+- [ ] `processBeasts` uses only seeded RNG — `grep -n "Math.random" src/systems/beast-system.ts` returns nothing
+- [ ] No mutation of input state in `beast-system.ts` exports (turn-manager's clone-mutation is the only mutation site)
+- [ ] Barbarian `playerUnits` filter excludes `BEAST_OWNER` (barbarians must not chase beasts)
+- [ ] Old saves load: a save without `state.beasts` plays normally (`beasts?` optional + every read guarded)

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr2-bestiary.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr2-bestiary.md
@@ -1,0 +1,675 @@
+# Legendary Beasts MR2 — Bestiary Panel + Sighting Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Code blocks are grounded in the codebase as it exists **after MR1 merged**. If a `beast-*` symbol is missing, MR1 has not merged — stop.
+
+**Goal:** Give players a per-civ Bestiary (Unknown / Sighted / Slain collection book), first-sighting banners, and per-civ sighting tracking — the 10-year-old's collection layer.
+
+**Architecture:** A viewer-safe presentation module (`beast-presentation.ts`) follows the `*ForPlayer` privacy pattern: unknown beasts expose ONLY the riddle hint — never name, sprite, or habitat. Sightings are recorded by a transition-owned helper that returns explicit payloads (no re-derivation from steady state). UI is DOM/CSS like every other panel; the Bestiary opens from the pause menu.
+
+**Tech Stack:** TypeScript, vitest (jsdom for DOM tests — mirror existing `tests/ui/` setup), DOM/CSS panels, `createGameButton` from `src/ui/ui-kit.ts`.
+
+**Dependencies:** MR1 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `'beast:sighted'` event |
+| `src/systems/beast-presentation.ts` | Create | `getBestiaryEntriesForPlayer` (privacy-masked), `recordBeastSightings` (transition-owned) |
+| `src/ui/bestiary-panel.ts` | Create | The collection-book panel |
+| `src/ui/beast-sighting-banner.ts` | Create | First-sighting modal banner |
+| `src/ui/pause-menu-panel.ts` | Modify | "Bestiary" button |
+| `src/main.ts` | Modify | Wire sighting scan + banner + panel opening |
+| `tests/systems/beast-presentation.test.ts` | Create | Masking + transition tests |
+| `tests/ui/bestiary-panel.test.ts` | Create | Rendered-DOM tests |
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Pause menu open | Tap "Bestiary" | Bestiary panel opens listing every beast on this map as Unknown/Sighted/Slain |
+| A beast unit enters my vision for the first time | (passive) | Sighting banner appears: sprite, name, "Sighted!" + Continue / Open Bestiary buttons |
+| Sighting banner shown | Tap "Open Bestiary" | Banner closes, Bestiary opens, that beast now renders as Sighted with full art |
+| Bestiary open, beast was slain by my civ last turn | Reopen Bestiary | Entry shows "Slain — by <my civ>, turn N" |
+| Hot-seat: player 2 sighted the boar, player 1 did not | Player 1 opens Bestiary | Player 1 still sees Unknown (riddle only) — sightings are per-civ |
+
+## Misleading-UI risks
+
+- **"Unknown" must leak nothing**: not the name, not the habitat terrain, not the sprite, not the map location. Only `dangerHint`. A negative test proves the rendered Unknown entry contains neither the beast name nor a habitat word.
+- **"Sighted" ≠ "Slain"**: sighted shows art + name + danger tier; slain-by info appears ONLY when `lair.status === 'slain'`.
+- **Slain is global, sightings are per-civ**: any player sees who slew a beast (public glory), but an unsighted *living* beast stays Unknown even if another civ has seen it.
+- The panel lists only beasts whose lairs exist **on this map** — never the full roster (small maps place 3 lairs; listing 8 entries would promise beasts that don't exist).
+
+## Interaction replay checklist (tests must cover)
+
+1. Open Bestiary with zero sightings → all entries Unknown
+2. Record a sighting → reopen → entry Sighted
+3. Mark lair slain → reopen → entry Slain with slayer
+4. Open → close → reopen (no duplicate panels; `container.querySelector('#bestiary-panel')` count is 1)
+5. Sighting banner Continue closes it; second sighting of the SAME beast never re-banners (transition-owned)
+
+---
+
+### Task 1: `beast:sighted` event
+
+**Files:**
+- Modify: `src/core/types.ts`
+
+- [ ] **Step 1: Add to `GameEvents`** (next to the MR1 beast events):
+
+```typescript
+  'beast:sighted': { beastId: BeastId; civId: string };
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/core/types.ts
+git commit -m "feat(beasts): beast:sighted event"
+```
+
+---
+
+### Task 2: Presentation module — masking + sighting transitions
+
+**Files:**
+- Create: `src/systems/beast-presentation.ts`
+- Test: `tests/systems/beast-presentation.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/systems/beast-presentation.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { getBestiaryEntriesForPlayer, recordBeastSightings } from '@/systems/beast-presentation';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, Unit } from '@/core/types';
+
+function stateWithLair(): GameState {
+  const state = createNewGame('rome', 'bestiary-seed', 'small', 'Bestiary Test');
+  state.beasts = {
+    mode: 'wild',
+    lairs: {
+      'lair-giant_boar': {
+        id: 'lair-giant_boar', beastId: 'giant_boar', position: { q: 10, r: 10 },
+        status: 'awake', strength: 0, unitIds: ['beast-1'],
+      },
+    },
+    sightingsByCiv: {},
+  };
+  state.units['beast-1'] = {
+    id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 },
+    movementPointsLeft: 2, health: 100, experience: 0,
+    hasMoved: false, hasActed: false, isResting: false,
+  } as Unit;
+  return state;
+}
+
+describe('getBestiaryEntriesForPlayer', () => {
+  it('masks EVERYTHING except the hint for unsighted beasts', () => {
+    const entries = getBestiaryEntriesForPlayer(stateWithLair(), 'player');
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.status).toBe('unknown');
+    expect(entry.hint.length).toBeGreaterThan(10);
+    expect(entry.name).toBeUndefined();
+    expect(entry.unitType).toBeUndefined();
+    expect(entry.tier).toBeUndefined();
+    expect(entry.slainBy).toBeUndefined();
+  });
+
+  it('reveals name/tier/unitType after sighting, per civ', () => {
+    const state = stateWithLair();
+    state.beasts!.sightingsByCiv['player'] = ['giant_boar'];
+    const mine = getBestiaryEntriesForPlayer(state, 'player');
+    expect(mine[0].status).toBe('sighted');
+    expect(mine[0].name).toBe('Giant Boar');
+    expect(mine[0].unitType).toBe('beast_boar');
+    const theirs = getBestiaryEntriesForPlayer(state, 'ai-1');
+    expect(theirs[0].status).toBe('unknown');
+    expect(theirs[0].name).toBeUndefined();
+  });
+
+  it('shows slain status with slayer to everyone', () => {
+    const state = stateWithLair();
+    state.beasts!.lairs['lair-giant_boar'].status = 'slain';
+    state.beasts!.lairs['lair-giant_boar'].slainBy = 'ai-1';
+    state.beasts!.lairs['lair-giant_boar'].slainTurn = 12;
+    const entries = getBestiaryEntriesForPlayer(state, 'player');
+    expect(entries[0].status).toBe('slain');
+    expect(entries[0].name).toBe('Giant Boar');
+    expect(entries[0].slainBy).toBe('ai-1');
+    expect(entries[0].slainTurn).toBe(12);
+  });
+
+  it('lists only beasts whose lairs exist on this map', () => {
+    const state = stateWithLair();
+    const entries = getBestiaryEntriesForPlayer(state, 'player');
+    expect(entries.map(e => e.lairId)).toEqual(['lair-giant_boar']);
+  });
+});
+
+describe('recordBeastSightings', () => {
+  it('returns new sightings exactly once (transition-owned)', () => {
+    const state = stateWithLair();
+    const visible = new Set(['10,10']);   // beast position is visible
+    const first = recordBeastSightings(state, 'player', visible);
+    expect(first.newSightings).toEqual(['giant_boar']);
+    expect(first.state.beasts!.sightingsByCiv['player']).toEqual(['giant_boar']);
+    const second = recordBeastSightings(first.state, 'player', visible);
+    expect(second.newSightings).toEqual([]);
+    // input state not mutated
+    expect(state.beasts!.sightingsByCiv['player']).toBeUndefined();
+  });
+
+  it('does not sight beasts outside visible tiles', () => {
+    const result = recordBeastSightings(stateWithLair(), 'player', new Set(['0,0']));
+    expect(result.newSightings).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-presentation.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/systems/beast-presentation.ts`**
+
+```typescript
+import type { BeastId, GameState, HexCoord, UnitType } from '@/core/types';
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { BEAST_OWNER } from '@/systems/beast-system';
+import { hexKey } from '@/systems/hex-utils';
+
+export type BestiaryStatus = 'unknown' | 'sighted' | 'slain';
+
+/** Viewer-safe bestiary entry. Unknown entries carry ONLY the hint — masking every other field is a privacy contract. */
+export interface BestiaryEntry {
+  lairId: string;
+  status: BestiaryStatus;
+  hint: string;
+  name?: string;
+  unitType?: UnitType;
+  tier?: number;
+  sightingFlavor?: string;
+  slainBy?: string;
+  slainTurn?: number;
+}
+
+export function getBestiaryEntriesForPlayer(state: GameState, civId: string): BestiaryEntry[] {
+  if (!state.beasts) return [];
+  const sighted = new Set(state.beasts.sightingsByCiv[civId] ?? []);
+  return Object.values(state.beasts.lairs).map(lair => {
+    const def = BEAST_DEFINITIONS[lair.beastId];
+    const isSlain = lair.status === 'slain' || lair.status === 'claimed';
+    if (isSlain) {
+      return {
+        lairId: lair.id, status: 'slain' as const, hint: def.dangerHint,
+        name: def.name, unitType: def.unitType, tier: def.tier,
+        slainBy: lair.slainBy, slainTurn: lair.slainTurn,
+      };
+    }
+    if (sighted.has(lair.beastId)) {
+      return {
+        lairId: lair.id, status: 'sighted' as const, hint: def.dangerHint,
+        name: def.name, unitType: def.unitType, tier: def.tier,
+        sightingFlavor: def.sightingFlavor,
+      };
+    }
+    return { lairId: lair.id, status: 'unknown' as const, hint: def.dangerHint };
+  });
+}
+
+/**
+ * Transition-owned sighting scan: returns the beasts that became sighted in THIS call.
+ * visibleTileKeys: hexKey set of tiles currently visible to civId
+ * (callers pass the civ's VisibilityMap keys with state 'visible').
+ */
+export function recordBeastSightings(
+  state: GameState,
+  civId: string,
+  visibleTileKeys: ReadonlySet<string>,
+): { state: GameState; newSightings: BeastId[] } {
+  if (!state.beasts) return { state, newSightings: [] };
+  const already = new Set(state.beasts.sightingsByCiv[civId] ?? []);
+  const newSightings: BeastId[] = [];
+
+  for (const unit of Object.values(state.units)) {
+    if (unit.owner !== BEAST_OWNER) continue;
+    if (!visibleTileKeys.has(hexKey(unit.position))) continue;
+    const lair = Object.values(state.beasts.lairs).find(l => l.unitIds.includes(unit.id));
+    if (!lair || already.has(lair.beastId)) continue;
+    already.add(lair.beastId);
+    newSightings.push(lair.beastId);
+  }
+
+  if (newSightings.length === 0) return { state, newSightings };
+  return {
+    state: {
+      ...state,
+      beasts: {
+        ...state.beasts,
+        sightingsByCiv: {
+          ...state.beasts.sightingsByCiv,
+          [civId]: [...(state.beasts.sightingsByCiv[civId] ?? []), ...newSightings],
+        },
+      },
+    },
+    newSightings,
+  };
+}
+```
+
+Check `hexKey` output format (`grep -n "export function hexKey" -A 3 src/systems/hex-utils.ts`). If it isn't `"q,r"`, align the test's `visible` sets with the real format.
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-presentation.test.ts`
+Expected: PASS.
+
+```bash
+git add src/systems/beast-presentation.ts tests/systems/beast-presentation.test.ts
+git commit -m "feat(beasts): viewer-safe bestiary presentation and sighting transitions"
+```
+
+---
+
+### Task 3: Bestiary panel UI
+
+**Files:**
+- Create: `src/ui/bestiary-panel.ts`
+- Test: `tests/ui/bestiary-panel.test.ts`
+
+Before writing buttons, invoke the project skill `.claude/skills/button-styling.md` (Skill tool) — all buttons via `createGameButton`, 44px min-height.
+
+- [ ] **Step 1: Write failing DOM tests**
+
+Look at an existing UI test first (`ls tests/ui/`, open one) and copy its jsdom setup. Create `tests/ui/bestiary-panel.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBestiaryPanel } from '@/ui/bestiary-panel';
+import type { BestiaryEntry } from '@/systems/beast-presentation';
+
+const unknownEntry: BestiaryEntry = {
+  lairId: 'lair-giant_boar', status: 'unknown',
+  hint: 'Trees splinter and the ground is churned in the deep woods. Something heavy lives there.',
+};
+const sightedEntry: BestiaryEntry = {
+  ...unknownEntry, status: 'sighted', name: 'Giant Boar', unitType: 'beast_boar', tier: 1,
+  sightingFlavor: 'Your scouts lay eyes on the Giant Boar — a beast of legend!',
+};
+const slainEntry: BestiaryEntry = {
+  ...sightedEntry, status: 'slain', slainBy: 'player', slainTurn: 22,
+};
+
+describe('bestiary panel', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('renders unknown entries with hint only — never the name (negative privacy test)', () => {
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Something heavy lives there');
+    expect(panel.textContent).not.toContain('Giant Boar');
+    expect(panel.textContent).not.toContain('forest'); // habitat must not leak via labels
+  });
+
+  it('renders sighted entries with name and tier', () => {
+    createBestiaryPanel(container, [sightedEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Giant Boar');
+    expect(panel.textContent).toContain('Sighted');
+  });
+
+  it('renders slain entries with slayer credit and turn', () => {
+    createBestiaryPanel(container, [slainEntry], { onClose: () => {}, slayerNameFor: () => 'Rome' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Slain');
+    expect(panel.textContent).toContain('Rome');
+    expect(panel.textContent).toContain('22');
+  });
+
+  it('close button removes the panel; reopening never duplicates', () => {
+    let closed = 0;
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => { closed++; }, slayerNameFor: () => '' });
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => { closed++; }, slayerNameFor: () => '' });
+    expect(container.querySelectorAll('#bestiary-panel')).toHaveLength(1);
+    (container.querySelector('#bestiary-panel button[data-action="close"]') as HTMLButtonElement).click();
+    expect(container.querySelector('#bestiary-panel')).toBeNull();
+    expect(closed).toBe(1);
+  });
+
+  it('lists every provided entry (catalog completeness)', () => {
+    createBestiaryPanel(container, [unknownEntry, sightedEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    expect(container.querySelectorAll('#bestiary-panel [data-bestiary-entry]')).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/bestiary-panel.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 3: Implement `src/ui/bestiary-panel.ts`**
+
+```typescript
+import type { BestiaryEntry } from '@/systems/beast-presentation';
+import { createGameButton } from '@/ui/ui-kit';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+
+export interface BestiaryPanelCallbacks {
+  onClose: () => void;
+  slayerNameFor: (civId: string) => string;   // resolve civ display name; '' if unknown
+}
+
+const TIER_LABELS: Record<number, string> = {
+  1: 'Dangerous', 2: 'Fearsome', 3: 'Terrifying', 4: 'Legendary',
+};
+
+export function createBestiaryPanel(
+  container: HTMLElement,
+  entries: BestiaryEntry[],
+  callbacks: BestiaryPanelCallbacks,
+): HTMLElement {
+  container.querySelector('#bestiary-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'bestiary-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:40;padding:16px;overflow:auto;';
+
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;';
+  const title = document.createElement('h2');
+  title.textContent = 'Bestiary';
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0;';
+  header.appendChild(title);
+  const closeButton = createGameButton('✕', 'close');
+  closeButton.dataset.action = 'close';
+  closeButton.addEventListener('click', () => { panel.remove(); callbacks.onClose(); });
+  header.appendChild(closeButton);
+  panel.appendChild(header);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Legendary beasts of this land. Sight them to learn their nature; slay them to claim their hoards.';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  panel.appendChild(intro);
+
+  for (const entry of entries) {
+    const card = document.createElement('section');
+    card.dataset.bestiaryEntry = entry.lairId;
+    card.style.cssText = 'display:flex;gap:12px;align-items:center;margin-bottom:12px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+
+    const art = document.createElement('div');
+    art.style.cssText = 'width:72px;height:72px;flex:none;display:flex;align-items:center;justify-content:center;';
+    if (entry.status === 'unknown') {
+      art.textContent = '❓';
+      art.style.fontSize = '40px';
+    } else if (entry.unitType) {
+      const sprite = UNIT_SPRITE_CATALOG[entry.unitType];
+      const svg = sprite({ palette: { mid: '#888', dark: '#555', bright: '#bbb', trim: '#999' } as never, svgOnly: true });
+      const holder = document.createElement('div');
+      holder.style.cssText = 'width:72px;height:72px;';
+      // Sprite SVGs are module-authored strings, never game/user input — safe to parse.
+      holder.innerHTML = svg;
+      art.appendChild(holder);
+    }
+    card.appendChild(art);
+
+    const body = document.createElement('div');
+    if (entry.status === 'unknown') {
+      const label = document.createElement('div');
+      label.textContent = 'Unknown Beast';
+      label.style.cssText = 'font-size:15px;color:#e8c170;';
+      body.appendChild(label);
+      const hint = document.createElement('div');
+      hint.textContent = entry.hint;
+      hint.style.cssText = 'font-size:12px;opacity:0.75;font-style:italic;';
+      body.appendChild(hint);
+    } else {
+      const label = document.createElement('div');
+      label.textContent = entry.name ?? '';
+      label.style.cssText = 'font-size:15px;color:#e8c170;';
+      body.appendChild(label);
+      const statusLine = document.createElement('div');
+      if (entry.status === 'slain') {
+        const slayer = entry.slainBy ? callbacks.slayerNameFor(entry.slainBy) : '';
+        statusLine.textContent = `Slain — by ${slayer || 'an unknown power'}, turn ${entry.slainTurn ?? '?'}`;
+        statusLine.style.cssText = 'font-size:12px;color:#9ad17b;';
+      } else {
+        statusLine.textContent = `Sighted · ${TIER_LABELS[entry.tier ?? 1]}`;
+        statusLine.style.cssText = 'font-size:12px;color:#d1a35a;';
+      }
+      body.appendChild(statusLine);
+      const hint = document.createElement('div');
+      hint.textContent = entry.hint;
+      hint.style.cssText = 'font-size:12px;opacity:0.75;font-style:italic;';
+      body.appendChild(hint);
+    }
+    card.appendChild(body);
+    panel.appendChild(card);
+  }
+
+  if (entries.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No legendary beasts dwell in this land.';
+    empty.style.cssText = 'font-size:13px;opacity:0.7;';
+    panel.appendChild(empty);
+  }
+
+  container.appendChild(panel);
+  return panel;
+}
+```
+
+Check the `FactionPalette` field names (`grep -n "interface FactionPalette" -A 8 src/renderer/sprites/sprite-system.tsx`) and pass a real neutral palette object instead of the `as never` cast if the shape differs. The `innerHTML` use is acceptable ONLY because sprite SVG is module-authored; do not extend it to any game-state string.
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/bestiary-panel.test.ts`
+Expected: PASS.
+
+```bash
+git add src/ui/bestiary-panel.ts tests/ui/bestiary-panel.test.ts
+git commit -m "feat(beasts): bestiary collection panel"
+```
+
+---
+
+### Task 4: Sighting banner
+
+**Files:**
+- Create: `src/ui/beast-sighting-banner.ts`
+
+- [ ] **Step 1: Implement (same modal pattern as the wonder discovery ceremony — read `src/ui/wonder-discovery-ceremony.ts:26` first)**
+
+```typescript
+import { createGameButton } from '@/ui/ui-kit';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import type { UnitType } from '@/core/types';
+
+export interface BeastSightingBannerOptions {
+  name: string;
+  flavor: string;
+  unitType: UnitType;
+  onContinue: () => void;
+  onOpenBestiary: () => void;
+}
+
+export function showBeastSightingBanner(container: HTMLElement, options: BeastSightingBannerOptions): HTMLElement {
+  container.querySelector('#beast-sighting-banner')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'beast-sighting-banner';
+  overlay.style.cssText = 'position:absolute;inset:0;background:rgba(8,8,18,0.9);z-index:60;display:flex;align-items:center;justify-content:center;';
+
+  const card = document.createElement('div');
+  card.style.cssText = 'max-width:340px;background:#1a1a2e;border:2px solid #e8c170;border-radius:14px;padding:20px;text-align:center;';
+
+  const kicker = document.createElement('div');
+  kicker.textContent = 'BEAST SIGHTED';
+  kicker.style.cssText = 'font-size:12px;letter-spacing:3px;color:#d1a35a;margin-bottom:8px;';
+  card.appendChild(kicker);
+
+  const art = document.createElement('div');
+  art.style.cssText = 'width:120px;height:120px;margin:0 auto 8px;';
+  const sprite = UNIT_SPRITE_CATALOG[options.unitType];
+  art.innerHTML = sprite({ palette: { mid: '#888', dark: '#555', bright: '#bbb', trim: '#999' } as never, svgOnly: true });
+  card.appendChild(art);
+
+  const name = document.createElement('h2');
+  name.textContent = options.name;
+  name.style.cssText = 'font-size:22px;color:#e8c170;margin:0 0 8px;';
+  card.appendChild(name);
+
+  const flavor = document.createElement('p');
+  flavor.textContent = options.flavor;
+  flavor.style.cssText = 'font-size:13px;opacity:0.85;margin:0 0 16px;';
+  card.appendChild(flavor);
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.cssText = 'display:flex;gap:8px;justify-content:center;';
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.addEventListener('click', () => { overlay.remove(); options.onContinue(); });
+  buttonRow.appendChild(continueButton);
+  const bestiaryButton = createGameButton('Open Bestiary', 'secondary');
+  bestiaryButton.addEventListener('click', () => { overlay.remove(); options.onOpenBestiary(); });
+  buttonRow.appendChild(bestiaryButton);
+  card.appendChild(buttonRow);
+
+  overlay.appendChild(card);
+  container.appendChild(overlay);
+  return overlay;
+}
+```
+
+Use the same neutral-palette fix as Task 3.
+
+- [ ] **Step 2: Build, then commit**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: PASS.
+
+```bash
+git add src/ui/beast-sighting-banner.ts
+git commit -m "feat(beasts): first-sighting banner"
+```
+
+---
+
+### Task 5: Wire it all in main.ts + pause menu
+
+**Files:**
+- Modify: `src/main.ts`
+- Modify: `src/ui/pause-menu-panel.ts`
+
+- [ ] **Step 1: Sighting scan after visibility updates**
+
+Run: `grep -n "updateVisibility" src/main.ts` — every call site that refreshes the **current player's** visibility (after moves, turn start) is followed by:
+
+```typescript
+  const visibleKeys = new Set(
+    Object.entries(/* the current player's VisibilityMap object */)
+      .filter(([, v]) => v === 'visible')
+      .map(([k]) => k),
+  );
+  const sightingResult = recordBeastSightings(gameState, gameState.currentPlayer, visibleKeys);
+  gameState = sightingResult.state; // or copy .beasts slice, matching surrounding state-update style
+  for (const beastId of sightingResult.newSightings) {
+    bus.emit('beast:sighted', { beastId, civId: gameState.currentPlayer });
+  }
+```
+
+If multiple call sites exist, extract this into one local function `scanBeastSightings()` in main.ts and call it from each. Check how the per-civ VisibilityMap is stored (`grep -n "visibility" src/core/types.ts | head`) to enumerate visible keys correctly.
+
+- [ ] **Step 2: Banner + notification on `beast:sighted`**
+
+Next to the MR1 beast listeners (~main.ts:3211):
+
+```typescript
+bus.on('beast:sighted', ({ beastId, civId }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  appendNotification(notificationLog, civId, {
+    message: def.sightingFlavor, type: 'info', turn: gameState.turn,
+  });
+  if (civId === gameState.currentPlayer) {
+    showBeastSightingBanner(uiContainer, {
+      name: def.name, flavor: def.sightingFlavor, unitType: def.unitType,
+      onContinue: () => {},
+      onOpenBestiary: () => openBestiary(),
+    });
+  }
+});
+```
+
+Find the container element other modals use (`grep -n "showPauseMenu(" src/main.ts` shows the container argument) and use the same one for `uiContainer`.
+
+- [ ] **Step 3: `openBestiary` helper + pause menu button**
+
+In main.ts:
+
+```typescript
+function openBestiary(): void {
+  createBestiaryPanel(uiContainer, getBestiaryEntriesForPlayer(gameState, gameState.currentPlayer), {
+    onClose: () => {},
+    slayerNameFor: (civId) => gameState.civilizations[civId]?.name ?? civId,
+  });
+}
+```
+
+In `src/ui/pause-menu-panel.ts` (`showPauseMenu`, line 242): add an `onOpenBestiary: () => void` callback to `PauseMenuCallbacks` and a `createGameButton('Bestiary', 'secondary')` row alongside the existing menu buttons (mirror their layout exactly). Wire it in main.ts's `showPauseMenu` call: `onOpenBestiary: () => openBestiary()`. The pause menu should close itself when the bestiary opens (match how other pause-menu buttons dismiss the menu).
+
+- [ ] **Step 4: Hot-seat turn handoff scan**
+
+Sightings must also fire at the start of each hot-seat player's turn (their units may have gained vision during other players' turns). Find the turn-handoff completion path (`grep -n "turn-handoff\|handoff" src/main.ts | head`) and call the same `scanBeastSightings()` helper there.
+
+- [ ] **Step 5: Full verification**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+Manual: `yarn dev` → new Wild game → march a scout to a 🐾 forest → when the boar awakens and enters vision, the banner appears once; Bestiary shows Sighted; pause menu button opens the Bestiary; restarting the panel never duplicates.
+
+- [ ] **Step 6: Commit + PR**
+
+```bash
+git add src/main.ts src/ui/pause-menu-panel.ts
+git commit -m "feat(beasts): wire sighting scan, banner, and bestiary into game shell"
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR2 — bestiary panel + sighting flow" --body "$(cat <<'EOF'
+## Summary
+- Per-civ Bestiary collection book (Unknown / Sighted / Slain) with privacy-masked unknown entries
+- Transition-owned first-sighting flow: banner + notification, fires exactly once per civ per beast
+- Pause-menu entry point
+
+## Out of scope (see docs/superpowers/plans/2026-06-11-legendary-beasts-index.md)
+- Remaining beasts (MR3, MR5–MR7), hoard choices/trophies (MR4), audio (MR8)
+
+## Why this is safe to merge partial
+All surfaces introduced (bestiary panel, sighting banner, pause-menu button) are fully wired and tested against rendered DOM. With only the Giant Boar in the roster the book simply has one entry per placed lair.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Unknown entries leak NOTHING (negative test asserts no name AND no habitat word in DOM)
+- [ ] `recordBeastSightings` returns transition payloads; no steady-state re-derivation; second call returns `[]`
+- [ ] Banner shows only for `state.currentPlayer` (hot-seat privacy)
+- [ ] All buttons via `createGameButton`; no bare buttons (hook will flag)
+- [ ] All dynamic text via `textContent`; the only `innerHTML` is module-authored sprite SVG
+- [ ] Panel reopen never duplicates (`#bestiary-panel` singleton)

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr3-wolves-basilisk.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr3-wolves-basilisk.md
@@ -1,0 +1,467 @@
+# Legendary Beasts MR3 — Dire Wolf Pack + Emerald Basilisk Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1 + MR2 merged**.
+
+**Goal:** Add two beasts — the Dire Wolf Pack (tundra/snow, spawns as 3 wolves) and the Emerald Basilisk (jungle, concealed in its habitat until you stand next to it) — plus the shared habitat-concealment mechanic.
+
+**Architecture:** Pack spawning is already generic in MR1 (`packSize` spawns N units on lair + free neighbors). The new mechanic is **habitat concealment**: a `concealedInHabitat` flag on `BeastDefinition`, one shared predicate `isBeastConcealedFrom`, wired into (a) renderer unit filtering, (b) attack targeting. This is the same shape as the existing `isForestConcealedUnit` in `src/systems/fog-of-war.ts:199` — read that function and its call sites first; the wiring must be parallel.
+
+**Tech Stack:** TypeScript, vitest, JSX→SVG sprites.
+
+**Dependencies:** MR1 + MR2 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastId` += `'dire_wolf' \| 'emerald_basilisk'`; `UnitType` += `'beast_wolf' \| 'beast_basilisk'` |
+| `src/systems/beast-definitions.ts` | Modify | Two new definitions; `concealedInHabitat?: boolean` field |
+| `src/systems/beast-system.ts` | Modify | `isBeastConcealedFrom` predicate |
+| `src/systems/unit-system.ts` | Modify | Definitions + descriptions (2 new types) |
+| `src/systems/attack-targeting.ts` | Modify | Concealed beasts are not valid targets |
+| `src/renderer/unit-visual-resolver.ts` | Modify | Fallback icons |
+| `src/renderer/sprites/beasts.tsx` | Modify | `DireWolfSprite`, `EmeraldBasiliskSprite` |
+| `src/renderer/sprites/sprite-catalog.ts` | Modify | Register both (motion + catalog) |
+| `src/renderer/render-loop.ts` | Modify | Filter concealed beasts out of `visibleUnits` |
+| `src/audio/sfx-catalog.ts` | Modify | `LOCOMOTION_CLASS` entries |
+| `tests/systems/beast-system.test.ts` | Modify | Pack-spawn + concealment tests |
+
+## Misleading-UI risks
+
+- A concealed basilisk must be **completely absent** from the player's view: not rendered, not tappable, not a combat-preview target — but it can still attack you (ambush!). Partial hiding (hidden sprite, still attackable) would be a lie in the other direction.
+- Negative test required: basilisk on jungle with a viewer unit 2 tiles away → concealed. Same position, viewer adjacent → revealed.
+- A basilisk standing OFF its habitat terrain (chasing within leash) is always visible.
+- Bestiary "Unknown" hints for these two must not name the habitat directly (privacy test from MR2 covers the rendered panel; keep the hint text evocative, not literal).
+
+---
+
+### Task 1: Type + definition extensions
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/systems/beast-definitions.ts`
+
+- [ ] **Step 1: Extend the unions in `src/core/types.ts`**
+
+```typescript
+export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk';
+```
+
+`UnitType` union — replace the MR1 tail line with:
+
+```typescript
+  | 'beast_boar' | 'beast_wolf' | 'beast_basilisk';
+```
+
+- [ ] **Step 2: Compile to enumerate forced updates**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: FAIL in `BEAST_DEFINITIONS` plus the six exhaustive `Record<UnitType, …>` maps (`UNIT_DEFINITIONS`, `UNIT_DESCRIPTIONS`, `FALLBACK_ICONS`, `UNIT_MOTION_STYLES`, `UNIT_SPRITE_CATALOG`, `LOCOMOTION_CLASS`). Tasks 1–3 fix all of them.
+
+- [ ] **Step 3: Add the definitions (`src/systems/beast-definitions.ts`)**
+
+Add the optional field to `BeastDefinition`:
+
+```typescript
+  concealedInHabitat?: boolean;     // hidden on habitat terrain unless a viewer unit is adjacent
+```
+
+Add the entries:
+
+```typescript
+  dire_wolf: {
+    id: 'dire_wolf',
+    unitType: 'beast_wolf',
+    name: 'Dire Wolf Pack',
+    habitatTerrains: ['tundra', 'snow'],
+    awakenEra: 1,
+    tier: 1,
+    leashRadius: 4,
+    packSize: 3,
+    hoardGoldBase: 50,
+    dangerHint: 'Howls echo across the frozen wastes at night. They hunt as one.',
+    awakeningFlavor: 'Howls rise from the frozen north. The Dire Wolves are hunting!',
+    sightingFlavor: 'Your scouts spot the Dire Wolf Pack prowling the snows!',
+  },
+  emerald_basilisk: {
+    id: 'emerald_basilisk',
+    unitType: 'beast_basilisk',
+    name: 'Emerald Basilisk',
+    habitatTerrains: ['jungle'],
+    awakenEra: 2,
+    tier: 2,
+    leashRadius: 3,
+    packSize: 1,
+    hoardGoldBase: 80,
+    concealedInHabitat: true,
+    dangerHint: 'Expeditions vanish in the green depths. Survivors speak of unblinking emerald eyes.',
+    awakeningFlavor: 'Something ancient stirs beneath the canopy. Travelers, beware the green depths.',
+    sightingFlavor: 'The Emerald Basilisk reveals itself — eyes like cold gems in the gloom!',
+  },
+```
+
+- [ ] **Step 4: Unit definitions + descriptions (`src/systems/unit-system.ts`)**
+
+`UNIT_DEFINITIONS`:
+
+```typescript
+  beast_wolf: {
+    type: 'beast_wolf', name: 'Dire Wolf', movementPoints: 3,
+    visionRange: 2, strength: 12, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+  beast_basilisk: {
+    type: 'beast_basilisk', name: 'Emerald Basilisk', movementPoints: 2,
+    visionRange: 2, strength: 26, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+```
+
+`UNIT_DESCRIPTIONS`:
+
+```typescript
+  beast_wolf: 'One of the Dire Wolf Pack. Fast, relentless, and never alone — defeat the whole pack to claim their hoard.',
+  beast_basilisk: 'The Emerald Basilisk lies hidden in the jungle until prey wanders close. Approach with overwhelming force.',
+```
+
+- [ ] **Step 5: Icons, motion, locomotion**
+
+`src/renderer/unit-visual-resolver.ts` `FALLBACK_ICONS`:
+
+```typescript
+  beast_wolf: '🐺',
+  beast_basilisk: '🦎',
+```
+
+`src/renderer/sprites/sprite-catalog.ts` `UNIT_MOTION_STYLES`:
+
+```typescript
+  beast_wolf: 'animal',
+  beast_basilisk: 'animal',
+```
+
+(Catalog entries land in Task 3 with the sprites.)
+
+`src/audio/sfx-catalog.ts` `LOCOMOTION_CLASS`: same class the hounds use, for both types.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/types.ts src/systems/beast-definitions.ts src/systems/unit-system.ts src/renderer/unit-visual-resolver.ts src/renderer/sprites/sprite-catalog.ts src/audio/sfx-catalog.ts
+git commit -m "feat(beasts): dire wolf and emerald basilisk definitions"
+```
+
+---
+
+### Task 2: Concealment mechanic (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Modify: `src/systems/attack-targeting.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing tests (append to `tests/systems/beast-system.test.ts`)**
+
+```typescript
+import { isBeastConcealedFrom } from '@/systems/beast-system';
+
+// Module-scope helper: build a tiny map by hand so terrain is fully controlled.
+// IMPORTANT: define this at the top level of the test file (next to makeLair/makeUnit),
+// NOT inside a describe block — MR5/MR6/MR7 tests reuse it from other describes.
+function tinyMap(terrainAt: Record<string, string>) {
+    const tiles: Record<string, any> = {};
+    for (const [key, terrain] of Object.entries(terrainAt)) {
+      const [q, r] = key.split(',').map(Number);
+      tiles[key] = { coord: { q, r }, terrain, elevation: 'flat', resource: null, improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null };
+    }
+  return { width: 40, height: 30, tiles, wrapsHorizontally: false } as any;
+}
+
+describe('isBeastConcealedFrom', () => {
+  const jungleMap = tinyMap({ '5,5': 'jungle', '6,5': 'grassland', '7,5': 'grassland' });
+  const basilisk = makeUnit({ id: 'beast-bas', type: 'beast_basilisk', owner: 'beasts', position: { q: 5, r: 5 } });
+
+  it('conceals a basilisk on jungle when no viewer unit is adjacent', () => {
+    const farViewer = makeUnit({ id: 'v1', position: { q: 7, r: 5 } });
+    expect(isBeastConcealedFrom(basilisk, jungleMap, [farViewer])).toBe(true);
+  });
+
+  it('reveals a basilisk when a viewer unit is adjacent', () => {
+    const nearViewer = makeUnit({ id: 'v1', position: { q: 6, r: 5 } });
+    expect(isBeastConcealedFrom(basilisk, jungleMap, [nearViewer])).toBe(false);
+  });
+
+  it('never conceals a basilisk off its habitat terrain', () => {
+    const offHabitat = { ...basilisk, position: { q: 6, r: 5 } };
+    expect(isBeastConcealedFrom(offHabitat, jungleMap, [])).toBe(false);
+  });
+
+  it('never conceals non-stealth beasts (boar) or non-beasts', () => {
+    const boar = makeUnit({ id: 'beast-boar', type: 'beast_boar', owner: 'beasts', position: { q: 5, r: 5 } });
+    expect(isBeastConcealedFrom(boar, jungleMap, [])).toBe(false);
+    const warrior = makeUnit({ id: 'w1', position: { q: 5, r: 5 } });
+    expect(isBeastConcealedFrom(warrior, jungleMap, [])).toBe(false);
+  });
+});
+```
+
+(`makeUnit` is the MR1 test helper in the same file.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts -t "isBeastConcealedFrom"`
+Expected: FAIL — not exported.
+
+- [ ] **Step 3: Implement (append to `src/systems/beast-system.ts`)**
+
+```typescript
+/**
+ * Habitat concealment: a beast with concealedInHabitat is invisible to a viewer civ
+ * while it stands on its habitat terrain and none of that civ's units are adjacent.
+ * Mirrors isForestConcealedUnit (fog-of-war.ts) — keep the two consistent if either changes.
+ */
+export function isBeastConcealedFrom(
+  beast: Unit,
+  map: GameMap,
+  viewerUnits: Array<Pick<Unit, 'position'>>,
+): boolean {
+  if (beast.owner !== BEAST_OWNER) return false;
+  const def = getBeastDefinitionByUnitType(beast.type);
+  if (!def?.concealedInHabitat) return false;
+  const tile = map.tiles[hexKey(beast.position)];
+  if (!tile || !def.habitatTerrains.includes(tile.terrain)) return false;
+  return !viewerUnits.some(v => hexDistance(v.position, beast.position) === 1);
+}
+```
+
+- [ ] **Step 4: Run to verify pass, then commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS.
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): habitat concealment predicate"
+```
+
+- [ ] **Step 5: Wire into rendering and targeting**
+
+Renderer — `src/renderer/render-loop.ts` builds `visibleUnits` before `drawUnits` (line ~378). Find how `isForestConcealedUnit` is applied there (`grep -n "isForestConcealedUnit" src/renderer/render-loop.ts src/main.ts`) and apply `isBeastConcealedFrom(unit, this.state.map, viewerUnitsOfCurrentPlayer)` in the same filter, where `viewerUnitsOfCurrentPlayer` is the current viewer civ's units (the forest-concealment call already has this list in scope — reuse it).
+
+Targeting — in `src/systems/attack-targeting.ts`, where candidate targets are enumerated (read the file; find where target validity is computed against fog/visibility), exclude concealed beasts from the attacker's owner's perspective:
+
+```typescript
+import { isBeastConcealedFrom } from '@/systems/beast-system';
+// inside target filtering, with attackerOwnerUnits available:
+if (isBeastConcealedFrom(candidate, map, attackerOwnerUnits)) continue;
+```
+
+If `attack-targeting.ts` does not have the attacker's full unit list in scope, follow how `isForestConcealedUnit` gets its viewer list at ITS call sites and replicate. Also check `src/main.ts` tap-target resolution (the `isBarbarian` branches around lines 2337/2433) — if tap-to-attack resolves targets there rather than via attack-targeting, apply the same exclusion there.
+
+- [ ] **Step 6: Build + full tests, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: exit 0 (sprites still pending — if build fails ONLY on `UNIT_SPRITE_CATALOG` missing entries, proceed to Task 3 and run this gate after).
+
+```bash
+git add src/renderer/render-loop.ts src/systems/attack-targeting.ts src/main.ts
+git commit -m "feat(beasts): concealment wired into rendering and targeting"
+```
+
+---
+
+### Task 3: Sprites
+
+**Files:**
+- Modify: `src/renderer/sprites/beasts.tsx`
+- Modify: `src/renderer/sprites/sprite-catalog.ts`
+
+Both reuse the `hound` rig (`data-kind="hound"`, `cq-leg-l/r`), like the MR1 boar. Match the boar's frame skeleton exactly (SpriteFrame/Shadow/HexBase order).
+
+- [ ] **Step 1: Add `DireWolfSprite` to `src/renderer/sprites/beasts.tsx`**
+
+```tsx
+const WOLF = {
+  fur: '#7d8a99',
+  furDark: '#55606e',
+  belly: '#aab4c0',
+  eye: '#d8b13a',
+};
+
+export function DireWolfSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="hound" className="cq-sprite-figure">
+        <rect className="cq-leg-l" x="48" y="86" width="6" height="14" rx="3" fill={WOLF.furDark} />
+        <rect className="cq-leg-r" x="58" y="86" width="6" height="14" rx="3" fill={WOLF.fur} />
+        <rect className="cq-leg-l" x="74" y="86" width="6" height="14" rx="3" fill={WOLF.furDark} />
+        <rect className="cq-leg-r" x="82" y="86" width="6" height="14" rx="3" fill={WOLF.fur} />
+        {/* lean body, low head, raised hackles */}
+        <path d="M44,80 Q42,64 58,62 Q76,58 88,66 L96,60 Q104,58 106,64 Q108,70 100,73 L92,76 Q90,84 76,86 Q56,90 44,80 Z"
+          fill={WOLF.fur} stroke={P.ink.line} strokeWidth="1.5" />
+        <path d="M56,64 Q66,58 80,62" fill="none" stroke={WOLF.furDark} strokeWidth="4" strokeLinecap="round" />
+        <ellipse cx="66" cy="82" rx="18" ry="6" fill={WOLF.belly} opacity="0.5" />
+        {/* muzzle, fangs, ear, eye, tail */}
+        <path d="M104,66 L112,68 L105,71 Z" fill={WOLF.furDark} />
+        <path d="M104,70 l2,3 M107,70 l2,3" stroke="#e8e0cc" strokeWidth="1.5" strokeLinecap="round" />
+        <path d="M94,58 L97,50 L101,58 Z" fill={WOLF.furDark} />
+        <circle cx="98" cy="63" r="2.2" fill={WOLF.eye} />
+        <path d="M44,78 Q34,74 33,64" fill="none" stroke={WOLF.fur} strokeWidth="4" strokeLinecap="round" />
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+- [ ] **Step 2: Add `EmeraldBasiliskSprite`**
+
+```tsx
+const BASILISK = {
+  scale: '#2f7d4f',
+  scaleDark: '#1d5535',
+  frill: '#46b878',
+  eye: '#9aedc0',
+};
+
+export function EmeraldBasiliskSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="hound" className="cq-sprite-figure">
+        {/* low splayed legs */}
+        <rect className="cq-leg-l" x="46" y="88" width="7" height="11" rx="3" fill={BASILISK.scaleDark} />
+        <rect className="cq-leg-r" x="60" y="88" width="7" height="11" rx="3" fill={BASILISK.scale} />
+        <rect className="cq-leg-l" x="78" y="88" width="7" height="11" rx="3" fill={BASILISK.scaleDark} />
+        <rect className="cq-leg-r" x="90" y="88" width="7" height="11" rx="3" fill={BASILISK.scale} />
+        {/* long low body + curling tail */}
+        <path d="M36,84 Q30,72 42,70 Q40,60 52,62 Q50,52 64,56 Q78,52 86,62 Q100,60 104,70 Q112,74 108,82 Q104,90 88,90 L52,90 Q40,92 36,84 Z"
+          fill={BASILISK.scale} stroke={P.ink.line} strokeWidth="1.5" />
+        <path d="M36,84 Q22,86 20,76 Q19,68 28,68" fill="none" stroke={BASILISK.scale} strokeWidth="5" strokeLinecap="round" />
+        {/* dorsal frill */}
+        <path d="M48,64 L52,54 L58,62 L64,50 L70,60 L78,52 L84,62" fill={BASILISK.frill} stroke={BASILISK.scaleDark} strokeWidth="1" />
+        {/* head with unblinking gem eye */}
+        <ellipse cx="104" cy="74" rx="11" ry="8" fill={BASILISK.scale} stroke={P.ink.line} strokeWidth="1.5" />
+        <path d="M113,73 L120,75 L113,78 Z" fill={BASILISK.scaleDark} />
+        <circle cx="106" cy="71" r="3" fill={BASILISK.eye} />
+        <circle cx="106" cy="71" r="1.2" fill={P.ink.line} />
+        {/* scale texture */}
+        <path d="M52,74 q4,-3 8,0 M62,70 q4,-3 8,0 M72,74 q4,-3 8,0" fill="none" stroke={BASILISK.scaleDark} strokeWidth="1" />
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+- [ ] **Step 3: Register both in `UNIT_SPRITE_CATALOG`**
+
+```typescript
+import { GiantBoarSprite, DireWolfSprite, EmeraldBasiliskSprite } from './beasts';
+// in UNIT_SPRITE_CATALOG:
+  beast_wolf: DireWolfSprite,
+  beast_basilisk: EmeraldBasiliskSprite,
+```
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn vitest run tests/renderer/sprites/sprite-catalog.test.ts`
+Expected: PASS.
+
+```bash
+git add src/renderer/sprites/beasts.tsx src/renderer/sprites/sprite-catalog.ts
+git commit -m "feat(beasts): dire wolf and basilisk sprites"
+```
+
+---
+
+### Task 4: Pack-spawn regression
+
+**Files:**
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write the test (append)**
+
+```typescript
+describe('pack spawning', () => {
+  it('spawns up to packSize wolves on awakening, never stacking', () => {
+    const map = generateMap(40, 30, 'beast-test-seed');
+    // Force a tundra lair position by scanning the generated map for tundra
+    const tundraTile = Object.values(map.tiles).find(t => t.terrain === 'tundra');
+    if (!tundraTile) return; // seed has no tundra — placement would skip the wolf anyway
+    const lair = makeLair({ id: 'lair-dire_wolf', beastId: 'dire_wolf', position: tundraTile.coord });
+    // Awaken deterministically: scan seeds until one awakens
+    for (let seed = 1; seed <= 60; seed++) {
+      const result = processBeasts([lair], map, [], [], 1, 'wild', seed);
+      if (result.awakenings.length === 0) continue;
+      expect(result.spawnOrders.length).toBeGreaterThanOrEqual(1);
+      expect(result.spawnOrders.length).toBeLessThanOrEqual(3);
+      const keys = result.spawnOrders.map(o => `${o.position.q},${o.position.r}`);
+      expect(new Set(keys).size).toBe(keys.length);   // no two spawns share a tile
+      return;
+    }
+    throw new Error('no seed awakened the wolf lair in 60 tries');
+  });
+});
+```
+
+- [ ] **Step 2: Run**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS (MR1's spawn logic already handles packs). If spawn count exceeds packSize or stacks, fix `processBeasts` — the bug is real.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/systems/beast-system.test.ts
+git commit -m "test(beasts): pack spawn occupancy regression"
+```
+
+---
+
+### Task 5: Final verification + PR
+
+- [ ] **Step 1: Gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+
+- [ ] **Step 2: Manual ambush check**
+
+`yarn dev` → Wild game on a map with jungle → move a unit toward a basilisk lair: the basilisk must be invisible until adjacent, then appear; combat preview shows its description warning. Wolves: confirm 2–3 wolves spawn and chase within leash, return to lair when you retreat ≥5 tiles.
+
+- [ ] **Step 3: PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR3 — dire wolf pack + emerald basilisk" --body "$(cat <<'EOF'
+## Summary
+- Dire Wolf Pack: era-1 tundra/snow beast, spawns as a pack of 3 (occupancy-safe)
+- Emerald Basilisk: era-2 jungle ambusher with the new habitat-concealment mechanic (hidden until adjacent), wired into rendering AND attack targeting
+- Both fully end-to-end: definitions, sprites, icons, audio class, bestiary entries
+
+## Out of scope (see docs/superpowers/plans/2026-06-11-legendary-beasts-index.md)
+- Hoard choice rewards (MR4) — basilisk tier-2 hoard currently pays the MR1 gold reward; MR4 upgrades it to a choice
+- Remaining beasts (MR5–MR7), audio/AI/balance (MR8)
+
+## Why this is safe to merge partial
+Both beasts are complete playable content. The tier-2 basilisk paying flat gold (instead of MR4's choice panel) is a smaller reward, not a dead end.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Both new `UnitType`s present in all six exhaustive maps (build passes)
+- [ ] Concealment excluded from BOTH rendering and targeting — and beasts can still attack while concealed (ambush preserved)
+- [ ] Negative tests: off-habitat basilisk visible; adjacent viewer reveals; boar never concealed
+- [ ] Pack spawns never stack (occupancy regression)
+- [ ] Bestiary panel from MR2 renders three entry kinds without code changes (presentation is definition-driven)

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr4-hoard-trophies.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr4-hoard-trophies.md
@@ -1,0 +1,577 @@
+# Legendary Beasts MR4 — Hoard Choices + Lair Trophies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1–MR3 merged**.
+
+**Goal:** Slaying a tier ≥ 2 beast now presents a choose-one hoard reward — **Gold Hoard** (instant gold), **Ancient Lore** (instant research progress), or **Beast Trophy** (claim the lair for permanent +gold/turn) — with AI auto-resolution and hot-seat-safe queueing. Tier 1 beasts keep MR1's automatic gold.
+
+**Architecture:** `recordBeastSlain` stops auto-paying gold for tier ≥ 2 and instead queues a pending choice on `BeastsState`. Human players resolve it via a blocking panel (modeled on `src/ui/required-choice-panel.ts`); AI civs auto-resolve to Gold during turn processing. Trophy income is a per-turn civ yield applied where per-turn gold already accrues, and surfaced in the same per-turn rate the HUD shows (misleading-HUD rule).
+
+**Tech Stack:** TypeScript, vitest, DOM/CSS panel via `createGameButton`.
+
+**Dependencies:** MR1–MR3 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastHoardChoice`, `pendingHoardChoices` on `BeastsState`, `claimedBy` on `BeastLair`, `'beast:hoard-claimed'` event |
+| `src/systems/beast-system.ts` | Modify | `recordBeastSlain` queues choices; `applyHoardChoice`; `getHoardChoicePreview`; `getClaimedTrophyGoldPerTurn` |
+| `src/core/turn-manager.ts` | Modify | AI auto-resolve pending choices; trophy income accrual |
+| `src/ui/beast-hoard-panel.ts` | Create | The choose-one panel |
+| `src/main.ts` | Modify | Show panel for human slayer; resolve queue at turn start |
+| `tests/systems/beast-system.test.ts` | Modify | Choice application + queue + income tests |
+| `tests/ui/beast-hoard-panel.test.ts` | Create | Rendered-DOM replay tests |
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| My attack kills the basilisk (tier 2) | (combat resolves) | Hoard panel appears: three options with explicit numbers ("+160 gold", "+120 research", "Trophy: +3 gold/turn forever") |
+| Hoard panel open | Tap "Ancient Lore" | Panel closes; notification "Ancient Lore claimed: +120 research"; research progress visibly advanced next time tech panel opens |
+| Hoard panel open | Tap "Beast Trophy" | Panel closes; lair glyph becomes 🏆; HUD per-turn gold rate increases by the trophy amount immediately |
+| AI slays a tier-2 beast | (their turn processes) | Everyone gets the "X slew the beast" notification; AI silently took Gold; no panel ever shows for AI |
+| Hot-seat: I slew a beast, then the app reloaded mid-choice | My turn starts | The pending choice panel re-appears (queued in state, not in DOM) |
+
+## Misleading-UI risks + queue checklist
+
+- The three option labels MUST show the actual computed numbers for THIS beast at THIS era — never generic text. `getHoardChoicePreview` is the single source; the panel renders only what it returns.
+- HUD per-turn gold must include trophy income the same turn it's claimed, or the HUD lies. Task 4 wires the same helper into both accrual and the displayed rate.
+- Pending choices are a queue (`pendingHoardChoices` array): two slain beasts in one turn = two sequential panels. Replay test covers resolve→next-panel.
+- The panel is blocking by design (matches `required-choice-panel` UX); it must never be dismissible without choosing — no close button — but it only ever appears for the slayer civ on their own turn.
+- Repeat-click: buttons remove the panel synchronously on first click; a second click can't fire (replay test asserts single application).
+
+---
+
+### Task 1: Types
+
+**Files:**
+- Modify: `src/core/types.ts`
+
+- [ ] **Step 1: Extend the beast types**
+
+```typescript
+export type BeastHoardChoice = 'gold' | 'lore' | 'trophy';
+
+export interface PendingHoardChoice {
+  lairId: string;
+  civId: string;       // the slayer; only this civ may resolve it
+}
+```
+
+`BeastLair` gains:
+
+```typescript
+  claimedBy?: string;   // civ that took the Trophy option
+```
+
+`BeastsState` gains:
+
+```typescript
+  pendingHoardChoices?: PendingHoardChoice[];
+```
+
+`GameEvents` gains:
+
+```typescript
+  'beast:hoard-claimed': { lairId: string; beastId: BeastId; civId: string; choice: BeastHoardChoice };
+```
+
+- [ ] **Step 2: Build (expect green — all fields optional), commit**
+
+```bash
+git add src/core/types.ts
+git commit -m "feat(beasts): hoard choice types"
+```
+
+---
+
+### Task 2: System — queue, preview, apply (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+import { applyHoardChoice, getHoardChoicePreview, getClaimedTrophyGoldPerTurn } from '@/systems/beast-system';
+
+describe('hoard choices', () => {
+  function stateWithSlainBasilisk() {
+    const state = createNewGame('rome', 'beast-test-seed', 'small', 'Hoard Test');
+    state.era = 2;
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-emerald_basilisk': makeLair({ id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk', status: 'awake', unitIds: ['beast-1'] }),
+      },
+      sightingsByCiv: {},
+    };
+    const beast = makeUnit({ id: 'beast-1', type: 'beast_basilisk', owner: 'beasts' });
+    const victor = makeUnit({ id: 'hero-1', owner: state.currentPlayer, position: { q: 11, r: 10 } });
+    state.units[beast.id] = beast;
+    state.units[victor.id] = victor;
+    return { state, beast, victor };
+  }
+
+  it('tier >= 2 slay queues a pending choice and awards NO automatic gold', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const goldBefore = state.civilizations[victor.owner].gold;
+    const { state: next, slain } = recordBeastSlain(state, beast, victor);
+    expect(slain).toBeDefined();
+    expect(slain!.goldAwarded).toBe(0);
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore);
+    expect(next.beasts!.pendingHoardChoices).toEqual([{ lairId: 'lair-emerald_basilisk', civId: victor.owner }]);
+  });
+
+  it('tier 1 slay still auto-pays gold and queues nothing', () => {
+    const { state, victor } = stateWithSlainBasilisk();
+    state.beasts!.lairs['lair-giant_boar'] = makeLair({ status: 'awake', unitIds: ['boar-1'] });
+    const boar = makeUnit({ id: 'boar-1', type: 'beast_boar', owner: 'beasts' });
+    state.units[boar.id] = boar;
+    const { state: next, slain } = recordBeastSlain(state, boar, victor);
+    expect(slain!.goldAwarded).toBeGreaterThan(0);
+    expect(next.beasts!.pendingHoardChoices ?? []).toEqual([]);
+  });
+
+  it('preview exposes concrete numbers for all three options', () => {
+    const { state } = stateWithSlainBasilisk();
+    const preview = getHoardChoicePreview(state, 'lair-emerald_basilisk');
+    expect(preview.gold).toBeGreaterThan(0);
+    expect(preview.lore).toBeGreaterThan(0);
+    expect(preview.trophyGoldPerTurn).toBeGreaterThan(0);
+  });
+
+  it('applyHoardChoice gold pays out and clears the pending entry', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const goldBefore = slainState.civilizations[victor.owner].gold;
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', victor.owner, 'gold');
+    const preview = getHoardChoicePreview(slainState, 'lair-emerald_basilisk');
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore + preview.gold);
+    expect(next.beasts!.pendingHoardChoices).toEqual([]);
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].status).toBe('slain');
+  });
+
+  it('applyHoardChoice trophy claims the lair and produces per-turn income', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', victor.owner, 'trophy');
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].status).toBe('claimed');
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].claimedBy).toBe(victor.owner);
+    expect(getClaimedTrophyGoldPerTurn(next, victor.owner)).toBeGreaterThan(0);
+    expect(getClaimedTrophyGoldPerTurn(next, 'someone-else')).toBe(0);
+  });
+
+  it('applyHoardChoice refuses the wrong civ', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', 'ai-1', 'gold');
+    expect(next).toBe(slainState);   // no-op, same reference
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts -t "hoard"`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement (modify + append in `src/systems/beast-system.ts`)**
+
+Modify `recordBeastSlain`: where it currently pays `gold` to the slayer (MR1 Task 6), branch on tier:
+
+```typescript
+  const def = BEAST_DEFINITIONS[lair.beastId];
+  const isChoiceTier = def.tier >= 2;
+  const gold = isChoiceTier ? 0 : getBeastHoardGold(def, state.era);
+  // ...existing lair-slain update...
+  // gold payment block: only when gold > 0
+  // after building `next`, queue the choice:
+  if (isChoiceTier && slayerCiv) {
+    next = {
+      ...next,
+      beasts: {
+        ...next.beasts!,
+        pendingHoardChoices: [...(next.beasts!.pendingHoardChoices ?? []), { lairId: lair.id, civId: victor.owner }],
+      },
+    };
+  }
+```
+
+Append the new exports:
+
+```typescript
+const TROPHY_GOLD_PER_TURN: Record<number, number> = { 1: 2, 2: 3, 3: 5, 4: 8 };
+
+export interface HoardChoicePreview {
+  gold: number;             // instant gold option
+  lore: number;             // instant research-progress option
+  trophyGoldPerTurn: number;
+  beastName: string;
+}
+
+export function getHoardChoicePreview(state: GameState, lairId: string): HoardChoicePreview {
+  const lair = state.beasts!.lairs[lairId];
+  const def = BEAST_DEFINITIONS[lair.beastId];
+  const baseGold = getBeastHoardGold(def, state.era);
+  return {
+    gold: baseGold * 2,                       // choice gold is richer than tier-1 auto-gold
+    lore: Math.round(baseGold * 1.5),
+    trophyGoldPerTurn: TROPHY_GOLD_PER_TURN[def.tier],
+    beastName: def.name,
+  };
+}
+
+export function getClaimedTrophyGoldPerTurn(state: GameState, civId: string): number {
+  if (!state.beasts) return 0;
+  let total = 0;
+  for (const lair of Object.values(state.beasts.lairs)) {
+    if (lair.status === 'claimed' && lair.claimedBy === civId) {
+      total += TROPHY_GOLD_PER_TURN[BEAST_DEFINITIONS[lair.beastId].tier];
+    }
+  }
+  return total;
+}
+
+export function applyHoardChoice(
+  state: GameState,
+  lairId: string,
+  civId: string,
+  choice: BeastHoardChoice,
+): GameState {
+  const beasts = state.beasts;
+  const pending = beasts?.pendingHoardChoices?.find(p => p.lairId === lairId && p.civId === civId);
+  if (!beasts || !pending) return state;
+  const preview = getHoardChoicePreview(state, lairId);
+  const lair = beasts.lairs[lairId];
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  let next: GameState = {
+    ...state,
+    beasts: {
+      ...beasts,
+      pendingHoardChoices: (beasts.pendingHoardChoices ?? []).filter(p => !(p.lairId === lairId && p.civId === civId)),
+    },
+  };
+
+  if (choice === 'gold') {
+    next = { ...next, civilizations: { ...next.civilizations, [civId]: { ...civ, gold: civ.gold + preview.gold } } };
+  } else if (choice === 'lore') {
+    next = applyBeastLoreResearch(next, civId, preview.lore);
+  } else {
+    next = {
+      ...next,
+      beasts: {
+        ...next.beasts!,
+        lairs: { ...next.beasts!.lairs, [lairId]: { ...lair, status: 'claimed', claimedBy: civId } },
+      },
+    };
+  }
+  return next;
+}
+```
+
+For `applyBeastLoreResearch`: the tribal-village system already grants instant research (see `applyResearchBonus` imported in `src/systems/village-system.ts` from `@/systems/tech-system`). Read `grep -n "applyResearchBonus" -B2 -A12 src/systems/village-system.ts src/systems/tech-system.ts` and implement `applyBeastLoreResearch(state, civId, amount)` as a thin immutable wrapper around the exact same call the village outcome uses (same fields, same progress semantics). Do not invent a new research-progress mechanism.
+
+Also import `BeastHoardChoice` in beast-system.ts from `@/core/types`.
+
+- [ ] **Step 4: Run to verify pass, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS. (The MR1 test "marks the lair slain, awards hoard gold" covers a tier-1 boar — it must still pass unchanged. If you changed its expectations, you broke tier-1; fix the code, not the test.)
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): hoard choice queue, preview, and application"
+```
+
+---
+
+### Task 3: Turn-manager — AI auto-resolve + trophy income
+
+**Files:**
+- Modify: `src/core/turn-manager.ts`
+- Test: `tests/core/turn-manager-beasts.test.ts`
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+import { applyHoardChoice, getClaimedTrophyGoldPerTurn } from '@/systems/beast-system';
+
+describe('turn-manager hoard handling', () => {
+  it('AI pending hoard choices auto-resolve to gold during processTurn', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'AI Hoard Test');
+    const aiCivId = Object.keys(state.civilizations).find(id => id !== state.currentPlayer)!;
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-emerald_basilisk': { id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk', position: { q: 10, r: 10 }, status: 'slain', strength: 0, unitIds: [], slainBy: aiCivId, slainTurn: 1 } },
+      sightingsByCiv: {},
+      pendingHoardChoices: [{ lairId: 'lair-emerald_basilisk', civId: aiCivId }],
+    };
+    const goldBefore = state.civilizations[aiCivId].gold;
+    const next = processTurn(state, new EventBus());
+    expect(next.beasts!.pendingHoardChoices).toEqual([]);
+    expect(next.civilizations[aiCivId].gold).toBeGreaterThan(goldBefore);
+  });
+
+  it('claimed trophies pay per-turn gold during processTurn', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'Trophy Test');
+    const me = state.currentPlayer;
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-emerald_basilisk': { id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk', position: { q: 10, r: 10 }, status: 'claimed', claimedBy: me, strength: 0, unitIds: [], slainBy: me, slainTurn: 1 } },
+      sightingsByCiv: {},
+    };
+    const baseline = createNewGame('rome', 'beast-turn-seed', 'small', 'Trophy Baseline');
+    const withTrophy = processTurn(state, new EventBus());
+    const withoutTrophy = processTurn(baseline, new EventBus());
+    const delta = withTrophy.civilizations[me].gold - withoutTrophy.civilizations[me].gold;
+    expect(delta).toBe(getClaimedTrophyGoldPerTurn(state, me));
+  });
+});
+```
+
+(Adjust `EventBus` construction to match the file's existing tests. The pending-choice auto-resolve must only fire for civs that are NOT the human `currentPlayer` — check how turn-manager distinguishes AI civs, e.g. the loop that runs `basic-ai` per civ, and resolve inside that loop.)
+
+- [ ] **Step 2: Implement in `processTurn`**
+
+Inside the per-civ AI processing loop (find it: `grep -n "basic-ai\|runAi\|processAi" src/core/turn-manager.ts src/ai/basic-ai.ts | head`), for each AI civ:
+
+```typescript
+    for (const pending of [...(newState.beasts?.pendingHoardChoices ?? [])]) {
+      if (pending.civId !== aiCivId) continue;
+      newState = applyHoardChoice(newState, pending.lairId, pending.civId, 'gold') as typeof newState;
+    }
+```
+
+Trophy income: find where per-turn civ gold accrues (the economy block — `grep -n "gold +=\|goldPerTurn" src/core/turn-manager.ts src/systems/economy-system.ts | head`) and add, per civ, in the same place city gold is added:
+
+```typescript
+    civ.gold += getClaimedTrophyGoldPerTurn(newState, civId);
+```
+
+**HUD rule:** the HUD per-turn gold rate must include this. Find the helper that computes the displayed per-turn gold (`grep -rn "perTurn\|goldRate" src/ui/ | head`) and add `getClaimedTrophyGoldPerTurn(state, state.currentPlayer)` there too, so accrual and display can't drift.
+
+- [ ] **Step 3: Run, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/core/turn-manager-beasts.test.ts`
+Expected: PASS.
+
+```bash
+git add src/core/turn-manager.ts src/ui tests/core/turn-manager-beasts.test.ts
+git commit -m "feat(beasts): AI hoard auto-resolve and per-turn trophy income"
+```
+
+---
+
+### Task 4: Hoard panel UI (TDD)
+
+**Files:**
+- Create: `src/ui/beast-hoard-panel.ts`
+- Test: `tests/ui/beast-hoard-panel.test.ts`
+
+- [ ] **Step 1: Write failing DOM tests**
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
+
+describe('beast hoard panel', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  const preview = { gold: 160, lore: 120, trophyGoldPerTurn: 3, beastName: 'Emerald Basilisk' };
+
+  it('shows all three options with concrete numbers', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    const panel = container.querySelector('#beast-hoard-panel')!;
+    expect(panel.textContent).toContain('Emerald Basilisk');
+    expect(panel.textContent).toContain('160');
+    expect(panel.textContent).toContain('120');
+    expect(panel.textContent).toContain('3');
+    expect(panel.querySelectorAll('button[data-choice]')).toHaveLength(3);
+  });
+
+  it('applies exactly once even on double-click (replay safety)', () => {
+    const chosen: string[] = [];
+    createBeastHoardPanel(container, preview, choice => chosen.push(choice));
+    const goldButton = container.querySelector('button[data-choice="gold"]') as HTMLButtonElement;
+    goldButton.click();
+    goldButton.click();
+    expect(chosen).toEqual(['gold']);
+    expect(container.querySelector('#beast-hoard-panel')).toBeNull();
+  });
+
+  it('has no dismiss/close affordance (blocking by design)', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    expect(container.querySelector('#beast-hoard-panel button[data-action="close"]')).toBeNull();
+  });
+
+  it('reopening never duplicates', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    createBeastHoardPanel(container, preview, () => {});
+    expect(container.querySelectorAll('#beast-hoard-panel')).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure, then implement `src/ui/beast-hoard-panel.ts`**
+
+```typescript
+import type { BeastHoardChoice } from '@/core/types';
+import type { HoardChoicePreview } from '@/systems/beast-system';
+import { createGameButton } from '@/ui/ui-kit';
+
+export function createBeastHoardPanel(
+  container: HTMLElement,
+  preview: HoardChoicePreview,
+  onChoose: (choice: BeastHoardChoice) => void,
+): HTMLElement {
+  container.querySelector('#beast-hoard-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'beast-hoard-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:50;padding:16px;overflow:auto;';
+
+  const title = document.createElement('h2');
+  title.textContent = `The ${preview.beastName} is slain!`;
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0 0 8px;';
+  panel.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Claim your prize. Choose one:';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  panel.appendChild(intro);
+
+  const options: Array<{ choice: BeastHoardChoice; label: string; detail: string }> = [
+    { choice: 'gold', label: `💰 Gold Hoard — +${preview.gold} gold`, detail: 'The beast guarded a fortune. Take it all, right now.' },
+    { choice: 'lore', label: `📜 Ancient Lore — +${preview.lore} research`, detail: 'Secrets of a forgotten age speed your current research.' },
+    { choice: 'trophy', label: `🏆 Beast Trophy — +${preview.trophyGoldPerTurn} gold every turn`, detail: 'Claim the lair as a monument. Pilgrims and traders pay tribute forever.' },
+  ];
+
+  for (const option of options) {
+    const card = document.createElement('section');
+    card.style.cssText = 'margin-bottom:12px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+    const button = createGameButton(option.label, 'primary');
+    button.dataset.choice = option.choice;
+    button.style.width = '100%';
+    button.addEventListener('click', () => { panel.remove(); onChoose(option.choice); });
+    card.appendChild(button);
+    const detail = document.createElement('div');
+    detail.textContent = option.detail;
+    detail.style.cssText = 'font-size:12px;opacity:0.75;margin-top:6px;';
+    card.appendChild(detail);
+    panel.appendChild(card);
+  }
+
+  container.appendChild(panel);
+  return panel;
+}
+```
+
+- [ ] **Step 3: Run to verify pass, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/beast-hoard-panel.test.ts`
+Expected: PASS.
+
+```bash
+git add src/ui/beast-hoard-panel.ts tests/ui/beast-hoard-panel.test.ts
+git commit -m "feat(beasts): blocking hoard choice panel"
+```
+
+---
+
+### Task 5: main.ts wiring — show, resolve, persist across reload
+
+**Files:**
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Resolve helper**
+
+```typescript
+function maybeShowPendingHoardChoice(): void {
+  const pending = (gameState.beasts?.pendingHoardChoices ?? [])
+    .find(p => p.civId === gameState.currentPlayer);
+  if (!pending) return;
+  const preview = getHoardChoicePreview(gameState, pending.lairId);
+  createBeastHoardPanel(uiContainer, preview, choice => {
+    const lair = gameState.beasts!.lairs[pending.lairId];
+    gameState = applyHoardChoice(gameState, pending.lairId, pending.civId, choice) as typeof gameState;
+    bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
+    refreshHud();                       // per-turn rates may have changed (trophy)
+    maybeShowPendingHoardChoice();      // next pending choice, if any (queue)
+  });
+}
+```
+
+Use the actual HUD-refresh function name (`grep -n "function refreshHud\|updateHud" src/main.ts`). Match the state-update idiom of surrounding code (reassign vs slice-copy), as in MR1 Task 8.
+
+- [ ] **Step 2: Call sites**
+
+1. Immediately after the player slay path (MR1 Task 8's `recordBeastSlain` block in each combat branch): `maybeShowPendingHoardChoice();`
+2. At the start of each human player's turn (same place MR2's sighting scan runs on turn handoff) — this covers both the multi-slay queue and the reload-mid-choice case, since pending choices live in the save.
+
+- [ ] **Step 3: Notification on claim**
+
+```typescript
+bus.on('beast:hoard-claimed', ({ beastId, civId, choice }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  const label = choice === 'gold' ? 'took the Gold Hoard' : choice === 'lore' ? 'claimed the Ancient Lore' : 'raised a Beast Trophy';
+  appendNotification(notificationLog, civId, {
+    message: `You ${label} of the ${def.name}.`, type: 'success', turn: gameState.turn,
+  });
+});
+```
+
+- [ ] **Step 4: Lair glyph for claimed lairs**
+
+MR1's render-loop glyph map already shows 🏆 for `'claimed'` (and `'slain'`). Verify the MR1 code includes `'claimed'`; if not, update the glyph expression:
+
+```typescript
+const glyph = lair.status === 'slain' || lair.status === 'claimed' ? '🏆' : '🐾';
+```
+
+- [ ] **Step 5: Gates + manual check, then PR**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+Manual (`yarn dev`): slay a basilisk (temporarily raise its awaken chance locally if needed; revert) → panel shows with numbers → pick Trophy → HUD gold rate increases, lair shows 🏆, notification logged. Save+reload mid-choice → panel reappears.
+
+```bash
+git add src/main.ts src/renderer/render-loop.ts
+git commit -m "feat(beasts): hoard choice flow wired into game shell"
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR4 — hoard choices + lair trophies" --body "$(cat <<'EOF'
+## Summary
+- Tier ≥ 2 beast slays now present a blocking choose-one reward: Gold Hoard / Ancient Lore (instant research) / Beast Trophy (permanent +gold per turn)
+- AI civs auto-resolve to gold during turn processing; choices queue in save state (reload-safe, multi-slay-safe)
+- Trophy income accrues in turn processing AND is included in the HUD per-turn gold rate (no lying HUD)
+
+## Why this is safe to merge partial
+All surfaces fully wired; tier-1 beasts keep the existing auto-gold flow unchanged. See docs/superpowers/plans/2026-06-11-legendary-beasts-index.md for the remaining MRs.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Tier-1 auto-gold path unchanged (MR1 tests pass untouched)
+- [ ] `applyHoardChoice` is the only mutation path for choices; wrong-civ calls are no-ops (test)
+- [ ] AI resolution lives in turn processing, not UI (actor-complete)
+- [ ] HUD rate and accrual share `getClaimedTrophyGoldPerTurn`
+- [ ] Queue handles multiple pending choices sequentially; double-click safe
+- [ ] Lore reuses the village-system research-bonus mechanism — no parallel invention

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr5-serpent-wurm.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr5-serpent-wurm.md
@@ -1,0 +1,445 @@
+# Legendary Beasts MR5 — Sea Serpent + Dune Wurm Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1–MR4 merged**.
+
+**Goal:** Add the Sea Serpent (deep-ocean tier 3 — finally makes the ocean dangerous; only naval or ranged units can fight it) and the Dune Wurm (desert tier 2 burrower reusing MR3's concealment), plus the serpent-body animation rig.
+
+**Architecture:** Two generalizations of MR1's beast movement: (1) passability becomes definition-driven (`domain: 'naval'` beasts move on water, land beasts on land) and (2) a `navalOnly` flag gates who may attack the serpent. The wurm is pure content — `concealedInHabitat` already does burrowing. New `beast-serpent` CSS animation kind (segmented undulation) lands in `sprite-animations-v2.css`.
+
+**Tech Stack:** TypeScript, vitest, JSX→SVG sprites, CSS keyframe animation.
+
+**Dependencies:** MR1–MR4 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastId` += `'sea_serpent' \| 'dune_wurm'`; `UnitType` += `'beast_sea_serpent' \| 'beast_wurm'` |
+| `src/systems/beast-definitions.ts` | Modify | Two definitions; `navalOnly?: boolean` field |
+| `src/systems/beast-system.ts` | Modify | Definition-driven passability; `canUnitAttackBeast` |
+| `src/systems/unit-system.ts` | Modify | Definitions (`domain: 'naval'` for serpent) + descriptions |
+| `src/systems/attack-targeting.ts` | Modify | `navalOnly` gating |
+| `src/main.ts` | Modify | navalOnly gating on the tap-attack path with player-facing warning |
+| `src/renderer/sprites/beasts.tsx` | Modify | `SeaSerpentSprite`, `DuneWurmSprite` (`data-kind="beast-serpent"`) |
+| `src/renderer/sprites/sprite-catalog.ts` | Modify | Register both |
+| `src/renderer/unit-visual-resolver.ts` | Modify | Icons |
+| `src/audio/sfx-catalog.ts` | Modify | Locomotion classes |
+| `src/assets/sprite-animations-v2.css` | Modify | `beast-serpent` undulation keyframes |
+| `docs/sprite-design-system.md` | Modify | Document the new animation kind |
+| `tests/systems/beast-system.test.ts` | Modify | Passability + navalOnly tests |
+
+## Misleading-UI risks
+
+- If a land melee unit taps the serpent, the game must show a clear warning ("Only ships and ranged units can fight the Sea Serpent") — NOT silently ignore the tap, and NOT show a combat preview that then refuses. The gate must run **before** the preview.
+- The serpent must never beach itself: a passability regression test proves naval beasts never receive move orders onto land, and land beasts never onto water.
+- The wurm's Unknown bestiary hint must not literally say "desert" (MR2 privacy test pattern).
+
+---
+
+### Task 1: Types + definitions
+
+**Files:**
+- Modify: `src/core/types.ts`, `src/systems/beast-definitions.ts`, `src/systems/unit-system.ts`, `src/renderer/unit-visual-resolver.ts`, `src/renderer/sprites/sprite-catalog.ts` (motion only), `src/audio/sfx-catalog.ts`
+
+- [ ] **Step 1: Unions in `src/core/types.ts`**
+
+```typescript
+export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk' | 'sea_serpent' | 'dune_wurm';
+```
+
+`UnitType` beast tail becomes:
+
+```typescript
+  | 'beast_boar' | 'beast_wolf' | 'beast_basilisk' | 'beast_sea_serpent' | 'beast_wurm';
+```
+
+- [ ] **Step 2: `BeastDefinition` field + entries (`src/systems/beast-definitions.ts`)**
+
+New optional field:
+
+```typescript
+  navalOnly?: boolean;     // only naval-domain or ranged units may attack this beast
+```
+
+Entries:
+
+```typescript
+  sea_serpent: {
+    id: 'sea_serpent',
+    unitType: 'beast_sea_serpent',
+    name: 'Sea Serpent',
+    habitatTerrains: ['ocean'],
+    awakenEra: 3,
+    tier: 3,
+    leashRadius: 5,
+    packSize: 1,
+    hoardGoldBase: 150,
+    navalOnly: true,
+    dangerHint: 'Ships vanish on the deep crossing. Sailors whisper of coils vast as harbor walls.',
+    awakeningFlavor: 'The deep water churns. Captains report a vast shadow beneath the waves.',
+    sightingFlavor: 'The Sea Serpent breaches — coils glinting above the waves!',
+  },
+  dune_wurm: {
+    id: 'dune_wurm',
+    unitType: 'beast_wurm',
+    name: 'Dune Wurm',
+    habitatTerrains: ['desert'],
+    awakenEra: 2,
+    tier: 2,
+    leashRadius: 3,
+    packSize: 1,
+    hoardGoldBase: 80,
+    concealedInHabitat: true,
+    dangerHint: 'Caravans tell of dunes that ripple and shift where no wind blows.',
+    awakeningFlavor: 'The sands tremble. Something colossal moves beneath the dunes.',
+    sightingFlavor: 'The Dune Wurm erupts from the sand in a storm of grit and teeth!',
+  },
+```
+
+- [ ] **Step 3: Unit definitions + descriptions (`src/systems/unit-system.ts`)**
+
+```typescript
+  beast_sea_serpent: {
+    type: 'beast_sea_serpent', name: 'Sea Serpent', movementPoints: 3,
+    visionRange: 3, strength: 38, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0, domain: 'naval',
+  },
+  beast_wurm: {
+    type: 'beast_wurm', name: 'Dune Wurm', movementPoints: 2,
+    visionRange: 2, strength: 30, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+```
+
+```typescript
+  beast_sea_serpent: 'A serpent of the deep ocean. It drags ships under within its hunting waters — only ships and ranged units can fight it.',
+  beast_wurm: 'The Dune Wurm swims beneath the sand, invisible until you stand beside it. Bring ranged units and overwhelming force.',
+```
+
+- [ ] **Step 4: Icons / motion / locomotion**
+
+`FALLBACK_ICONS`: `beast_sea_serpent: '🐉',` `beast_wurm: '🪱',`
+`UNIT_MOTION_STYLES`: `beast_sea_serpent: 'naval',` `beast_wurm: 'animal',`
+`LOCOMOTION_CLASS`: serpent → the class ships use (check what `galley` uses); wurm → the hound class.
+
+- [ ] **Step 5: Build (only `UNIT_SPRITE_CATALOG` should still error), commit**
+
+```bash
+git add src/core/types.ts src/systems/beast-definitions.ts src/systems/unit-system.ts src/renderer/unit-visual-resolver.ts src/renderer/sprites/sprite-catalog.ts src/audio/sfx-catalog.ts
+git commit -m "feat(beasts): sea serpent and dune wurm definitions"
+```
+
+---
+
+### Task 2: Definition-driven passability (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+import { isTerrainPassableForBeast } from '@/systems/beast-system';
+
+describe('beast passability', () => {
+  it('naval beasts move only on water; land beasts only on land', () => {
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'ocean')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'coast')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'grassland')).toBe(false);
+    expect(isTerrainPassableForBeast('beast_boar', 'ocean')).toBe(false);
+    expect(isTerrainPassableForBeast('beast_boar', 'forest')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_boar', 'mountain')).toBe(false);
+  });
+
+  it('serpent move orders never target land (no beaching)', () => {
+    const map = tinyMap({
+      '10,10': 'ocean', '11,10': 'ocean', '12,10': 'grassland',
+      '9,10': 'ocean', '10,9': 'ocean', '10,11': 'coast', '11,9': 'grassland', '9,11': 'ocean',
+    });
+    const lair = makeLair({ id: 'lair-sea_serpent', beastId: 'sea_serpent', position: { q: 10, r: 10 }, status: 'awake', unitIds: ['serp-1'] });
+    const serpent = makeUnit({ id: 'serp-1', type: 'beast_sea_serpent', owner: 'beasts', position: { q: 10, r: 10 } });
+    const ship = makeUnit({ id: 'ship-1', type: 'galley', position: { q: 12, r: 10 } });   // unreachable by water here
+    const result = processBeasts([lair], map, [ship], [serpent], 3, 'wild', 7);
+    for (const order of result.moveOrders) {
+      const terrain = map.tiles[`${order.toCoord.q},${order.toCoord.r}`].terrain;
+      expect(['ocean', 'coast']).toContain(terrain);
+    }
+  });
+});
+```
+
+(`tinyMap` is MR3's test helper in the same file.)
+
+- [ ] **Step 2: Run to verify failure, then implement**
+
+In `src/systems/beast-system.ts`, replace the hardcoded `IMPASSABLE_FOR_BEASTS` usage:
+
+```typescript
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+const IMPASSABLE_FOR_LAND_BEASTS = new Set(['ocean', 'coast', 'mountain']);
+const WATER_TERRAINS = new Set(['ocean', 'coast']);
+
+export function isTerrainPassableForBeast(unitType: UnitType, terrain: string): boolean {
+  const domain = UNIT_DEFINITIONS[unitType]?.domain;
+  if (domain === 'naval') return WATER_TERRAINS.has(terrain);
+  return !IMPASSABLE_FOR_LAND_BEASTS.has(terrain);
+}
+```
+
+Update the two places in `processBeasts` that consult passability (the awakening spawn-tile filter and the move-step filter) to call `isTerrainPassableForBeast(def.unitType, tile.terrain)`. Note: the spawn-tile loop currently checks `IMPASSABLE_FOR_BEASTS` — the serpent's lair tile is ocean, so the lair-tile spawn check must also use the definition-driven predicate (otherwise the serpent can never spawn). Check import direction: `unit-system.ts` must not import `beast-system.ts` back (it doesn't today — verify with `grep -n "beast" src/systems/unit-system.ts`).
+
+- [ ] **Step 3: Run all beast tests, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS — including MR1's tests (the boar's behavior is unchanged by the refactor).
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): definition-driven beast passability (naval serpent)"
+```
+
+---
+
+### Task 3: navalOnly attack gating (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`, `src/systems/attack-targeting.ts`, `src/main.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+import { canUnitAttackBeast } from '@/systems/beast-system';
+
+describe('canUnitAttackBeast', () => {
+  const serpent = makeUnit({ id: 's', type: 'beast_sea_serpent', owner: 'beasts' });
+  const boar = makeUnit({ id: 'b', type: 'beast_boar', owner: 'beasts' });
+
+  it('land melee cannot attack a navalOnly beast', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), serpent).allowed).toBe(false);
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), serpent).reason).toContain('ships and ranged');
+  });
+
+  it('naval and ranged units can attack a navalOnly beast', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'galley' }), serpent).allowed).toBe(true);
+    expect(canUnitAttackBeast(makeUnit({ type: 'archer' }), serpent).allowed).toBe(true);
+  });
+
+  it('everything can attack normal beasts and non-beasts', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), boar).allowed).toBe(true);
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), makeUnit({ type: 'warrior', owner: 'ai-1' })).allowed).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+export interface BeastAttackEligibility { allowed: boolean; reason?: string }
+
+/** Movement-validation rule pattern: return a structured reason so UI/AI callers can show it. */
+export function canUnitAttackBeast(attacker: Unit, target: Unit): BeastAttackEligibility {
+  const def = getBeastDefinitionByUnitType(target.type);
+  if (!def?.navalOnly || target.owner !== BEAST_OWNER) return { allowed: true };
+  const attackerDef = UNIT_DEFINITIONS[attacker.type];
+  const isNaval = attackerDef.domain === 'naval';
+  const isRanged = attackerDef.attackProfile?.kind === 'ranged';
+  if (isNaval || isRanged) return { allowed: true };
+  return { allowed: false, reason: `Only ships and ranged units can fight the ${def.name}.` };
+}
+```
+
+Wire into `src/systems/attack-targeting.ts` target enumeration (alongside MR3's concealment exclusion):
+
+```typescript
+if (!canUnitAttackBeast(attacker, candidate).allowed) continue;
+```
+
+Wire into `src/main.ts` tap-attack path BEFORE any combat preview is built: when the gate fails, show the `reason` through the same player-facing warning channel movement failures use (find it: `grep -n "warning" src/main.ts | head` — the movement-safety warning path), and do not open the preview.
+
+- [ ] **Step 3: Run, build, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts && bash scripts/run-with-mise.sh yarn build`
+Expected: tests PASS; build fails only on missing sprites (Task 4).
+
+```bash
+git add src/systems/beast-system.ts src/systems/attack-targeting.ts src/main.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): navalOnly attack gating with player-facing reason"
+```
+
+---
+
+### Task 4: Serpent animation rig + sprites
+
+**Files:**
+- Modify: `src/assets/sprite-animations-v2.css`
+- Modify: `src/renderer/sprites/beasts.tsx`
+- Modify: `src/renderer/sprites/sprite-catalog.ts`
+- Modify: `docs/sprite-design-system.md`
+
+- [ ] **Step 1: Add the `beast-serpent` rig to `src/assets/sprite-animations-v2.css`**
+
+Read the existing `[data-kind="hound"]` blocks first and match their structure (state selectors, `--phase` usage). Add:
+
+```css
+/* === beast-serpent: segmented undulation === */
+@keyframes cq-serpent-undulate {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+[data-kind="beast-serpent"] .cq-segment-1 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s); }
+[data-kind="beast-serpent"] .cq-segment-2 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.3s); }
+[data-kind="beast-serpent"] .cq-segment-3 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.6s); }
+[data-kind="beast-serpent"] .cq-segment-4 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.9s); }
+```
+
+If the file scopes animations under `data-state` (e.g. only `idle`/`walk` animate), mirror that scoping exactly as the hound rig does.
+
+- [ ] **Step 2: Add sprites to `src/renderer/sprites/beasts.tsx`**
+
+```tsx
+const SERPENT = {
+  scale: '#2e6e8c',
+  scaleDark: '#1c4a61',
+  fin: '#5ec0d8',
+  eye: '#ffd34d',
+};
+
+export function SeaSerpentSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="beast-serpent" className="cq-sprite-figure">
+        {/* three coils breaking the water, phase-offset segments */}
+        <g className="cq-segment-1">
+          <path d="M28,84 Q36,62 48,84" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+        </g>
+        <g className="cq-segment-2">
+          <path d="M52,84 Q62,58 74,84" fill="none" stroke={SERPENT.scale} strokeWidth="13" strokeLinecap="round" />
+          <path d="M58,68 L62,58 L66,68" fill={SERPENT.fin} />
+        </g>
+        <g className="cq-segment-3">
+          <path d="M78,84 Q88,64 98,82" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+        </g>
+        {/* head rearing */}
+        <g className="cq-segment-4">
+          <path d="M98,82 Q108,70 104,56 Q102,46 92,48" fill="none" stroke={SERPENT.scale} strokeWidth="10" strokeLinecap="round" />
+          <ellipse cx="91" cy="49" rx="9" ry="7" fill={SERPENT.scale} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M83,50 L76,52 L83,55 Z" fill={SERPENT.scaleDark} />
+          <circle cx="89" cy="47" r="2.4" fill={SERPENT.eye} />
+          <path d="M92,42 L95,34 L98,43" fill={SERPENT.fin} />
+        </g>
+        {/* waterline froth */}
+        <path d="M24,86 Q40,82 56,86 Q72,90 88,86 Q100,83 108,86" fill="none" stroke="#bfe6f2" strokeWidth="2" opacity="0.7" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
+const WURM = {
+  hide: '#b08a52',
+  hideDark: '#84653a',
+  maw: '#5e2f2a',
+  tooth: '#e8e0cc',
+};
+
+export function DuneWurmSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="beast-serpent" className="cq-sprite-figure">
+        {/* erupting body arc */}
+        <g className="cq-segment-1">
+          <path d="M40,92 Q44,60 64,52 Q84,46 92,66 Q96,78 90,92" fill="none" stroke={WURM.hide} strokeWidth="16" strokeLinecap="round" />
+          <path d="M46,80 q6,-2 10,2 M54,66 q6,-2 10,2 M70,54 q6,-2 10,2" fill="none" stroke={WURM.hideDark} strokeWidth="2" />
+        </g>
+        {/* tri-split maw */}
+        <g className="cq-segment-2">
+          <path d="M58,50 L50,34 L64,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M64,44 L66,28 L74,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M74,44 L86,34 L78,50 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M58,46 l3,-4 M66,40 l2,-5 M76,46 l3,-4" stroke={WURM.tooth} strokeWidth="2" strokeLinecap="round" />
+        </g>
+        {/* sand spray */}
+        <path d="M34,92 q4,-8 0,-14 M104,92 q-4,-8 0,-14 M44,94 q2,-5 -1,-9" fill="none" stroke="#dcc88e" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+- [ ] **Step 3: Register in `UNIT_SPRITE_CATALOG`**
+
+```typescript
+import { GiantBoarSprite, DireWolfSprite, EmeraldBasiliskSprite, SeaSerpentSprite, DuneWurmSprite } from './beasts';
+// ...
+  beast_sea_serpent: SeaSerpentSprite,
+  beast_wurm: DuneWurmSprite,
+```
+
+- [ ] **Step 4: Document the new kind in `docs/sprite-design-system.md`**
+
+In the "Body-plan kinds" table add:
+
+```markdown
+| `beast-serpent` | beast_sea_serpent, beast_wurm | phase-offset segment undulation (`cq-segment-1..4`) |
+```
+
+Also add the two sprites to the unit inventory table with `data-kind` `beast-serpent`.
+
+- [ ] **Step 5: Build + sprite tests + commit**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn vitest run tests/renderer/sprites/sprite-catalog.test.ts`
+Expected: PASS.
+
+```bash
+git add src/assets/sprite-animations-v2.css src/renderer/sprites/beasts.tsx src/renderer/sprites/sprite-catalog.ts docs/sprite-design-system.md
+git commit -m "feat(beasts): serpent animation rig, sea serpent and dune wurm sprites"
+```
+
+---
+
+### Task 5: Final verification + PR
+
+- [ ] **Step 1: Gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+
+- [ ] **Step 2: Manual**
+
+`yarn dev` → Wild game on a large/continents map → sail toward the serpent lair: serpent attacks ships in its waters; a land warrior tapping it from shore gets the warning, an archer gets a combat preview. Wurm: invisible on desert until adjacent.
+
+- [ ] **Step 3: PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR5 — sea serpent + dune wurm" --body "$(cat <<'EOF'
+## Summary
+- Sea Serpent: tier-3 deep-ocean beast; naval passability is now definition-driven; only ships/ranged units may engage (with player-facing warning, gated before the combat preview)
+- Dune Wurm: tier-2 desert burrower riding the MR3 concealment mechanic
+- New `beast-serpent` animation rig (phase-offset segment undulation), documented in the sprite design system
+
+## Why this is safe to merge partial
+Both beasts complete end-to-end. Remaining: MR6 (roc + hydra), MR7 (dragon), MR8 (audio/AI/balance) — see docs/superpowers/plans/2026-06-11-legendary-beasts-index.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Serpent can spawn on its ocean lair tile (spawn check uses definition-driven passability)
+- [ ] No-beaching regression passes; boar tests unchanged
+- [ ] navalOnly gate runs BEFORE the combat preview on the tap path and shows a reason
+- [ ] AI also respects the gate (it goes through attack-targeting — verify with `grep -n "attack-targeting\|canAttack" src/ai/basic-ai.ts`)
+- [ ] New animation kind documented; CSS scoped exactly like the hound rig

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr6-roc-hydra.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr6-roc-hydra.md
@@ -1,0 +1,452 @@
+# Legendary Beasts MR6 — Storm Roc + Swamp Hydra Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1–MR5 merged**.
+
+**Goal:** Add the Storm Roc (mountain tier 3, flies over any land terrain) and the Swamp Hydra (swamp tier 3, regenerates 10 HP/turn — punishes hit-and-run, rewards committed assaults), plus the `beast-winged` animation rig.
+
+**Architecture:** Two final definition flags: `flying` (passability: any land terrain including mountains) extends MR5's definition-driven passability, and `regenPerTurn` adds a `regenOrders` output to `processBeasts` (orders-out pattern — turn-manager applies the healing). Combat preview must surface the hydra's regeneration so players understand why chip damage fails (combat-preview visibility rule).
+
+**Tech Stack:** TypeScript, vitest, JSX→SVG sprites, CSS keyframes.
+
+**Dependencies:** MR1–MR5 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastId` += `'storm_roc' \| 'swamp_hydra'`; `UnitType` += `'beast_roc' \| 'beast_hydra'` |
+| `src/systems/beast-definitions.ts` | Modify | Two definitions; `flying?: boolean`, `regenPerTurn?: number` |
+| `src/systems/beast-system.ts` | Modify | Flying passability; `regenOrders` in `BeastProcessResult` |
+| `src/core/turn-manager.ts` | Modify | Apply regen orders |
+| `src/systems/unit-system.ts` | Modify | Definitions + descriptions |
+| `src/main.ts` | Modify | Combat preview shows "Regenerates" trait line for hydra |
+| `src/renderer/sprites/beasts.tsx` | Modify | `StormRocSprite` (`data-kind="beast-winged"`), `SwampHydraSprite` (`data-kind="beast-serpent"`) |
+| `src/renderer/sprites/sprite-catalog.ts` | Modify | Register both |
+| `src/renderer/unit-visual-resolver.ts` | Modify | Icons |
+| `src/audio/sfx-catalog.ts` | Modify | Locomotion classes |
+| `src/assets/sprite-animations-v2.css` | Modify | `beast-winged` wing-flap + hover keyframes |
+| `docs/sprite-design-system.md` | Modify | Document `beast-winged` |
+| `tests/systems/beast-system.test.ts` | Modify | Flying + regen tests |
+
+## Misleading-UI risks
+
+- **Hydra regen must be visible before you commit**: the combat preview against a hydra must include a trait line ("Regenerates 10 HP every turn"). Without it the player can't understand why their two-turn plan fails — that's a lying preview.
+- The roc flying over mountains must not imply player units can follow — no pathing change for players.
+
+---
+
+### Task 1: Types + definitions
+
+**Files:**
+- Modify: `src/core/types.ts`, `src/systems/beast-definitions.ts`, `src/systems/unit-system.ts`, `src/renderer/unit-visual-resolver.ts`, `src/renderer/sprites/sprite-catalog.ts` (motion), `src/audio/sfx-catalog.ts`
+
+- [ ] **Step 1: Unions**
+
+```typescript
+export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk' | 'sea_serpent' | 'dune_wurm' | 'storm_roc' | 'swamp_hydra';
+```
+
+`UnitType` beast tail:
+
+```typescript
+  | 'beast_boar' | 'beast_wolf' | 'beast_basilisk' | 'beast_sea_serpent' | 'beast_wurm' | 'beast_roc' | 'beast_hydra';
+```
+
+- [ ] **Step 2: Definition fields + entries**
+
+New optional fields on `BeastDefinition`:
+
+```typescript
+  flying?: boolean;        // passable on ANY land terrain including mountains
+  regenPerTurn?: number;   // HP restored each beast turn
+```
+
+Entries:
+
+```typescript
+  storm_roc: {
+    id: 'storm_roc',
+    unitType: 'beast_roc',
+    name: 'Storm Roc',
+    habitatTerrains: ['mountain'],
+    awakenEra: 3,
+    tier: 3,
+    leashRadius: 4,
+    packSize: 1,
+    hoardGoldBase: 150,
+    flying: true,
+    dangerHint: 'Herdsmen swear a shadow the size of a cloud sweeps the high peaks before a storm.',
+    awakeningFlavor: 'A scream splits the thunder. Wings vast as sails circle the high peaks.',
+    sightingFlavor: 'The Storm Roc wheels overhead — lightning dancing along its wings!',
+  },
+  swamp_hydra: {
+    id: 'swamp_hydra',
+    unitType: 'beast_hydra',
+    name: 'Swamp Hydra',
+    habitatTerrains: ['swamp'],
+    awakenEra: 3,
+    tier: 3,
+    leashRadius: 3,
+    packSize: 1,
+    hoardGoldBase: 150,
+    regenPerTurn: 10,
+    dangerHint: 'The marsh-folk say wounds dealt to the thing in the bog are gone by morning.',
+    awakeningFlavor: 'The bog exhales. Many heads rise where one fell long ago.',
+    sightingFlavor: 'The Swamp Hydra rears from the mire — heads weaving, wounds closing as you watch!',
+  },
+```
+
+- [ ] **Step 3: Unit definitions + descriptions**
+
+```typescript
+  beast_roc: {
+    type: 'beast_roc', name: 'Storm Roc', movementPoints: 4,
+    visionRange: 3, strength: 34, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+  beast_hydra: {
+    type: 'beast_hydra', name: 'Swamp Hydra', movementPoints: 1,
+    visionRange: 2, strength: 36, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
+```
+
+```typescript
+  beast_roc: 'The Storm Roc nests on the high peaks and dives on anything that crosses its skies. It flies over terrain that would stop an army.',
+  beast_hydra: 'The Swamp Hydra regrows flesh as fast as you can cut it — 10 health every turn. Strike hard and finish it in one assault.',
+```
+
+- [ ] **Step 4: Icons / motion / locomotion**
+
+`FALLBACK_ICONS`: `beast_roc: '🦅',` `beast_hydra: '🐍',`
+`UNIT_MOTION_STYLES`: both `'animal'`.
+`LOCOMOTION_CLASS`: both use the hound class (or, if a flying/silent class exists in the union, use it for the roc — check the `LocomotionClass` type first).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/types.ts src/systems/beast-definitions.ts src/systems/unit-system.ts src/renderer/unit-visual-resolver.ts src/renderer/sprites/sprite-catalog.ts src/audio/sfx-catalog.ts
+git commit -m "feat(beasts): storm roc and swamp hydra definitions"
+```
+
+---
+
+### Task 2: Flying passability + regen orders (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`, `src/core/turn-manager.ts`
+- Test: `tests/systems/beast-system.test.ts`, `tests/core/turn-manager-beasts.test.ts`
+
+- [ ] **Step 1: Write failing tests (append to beast-system tests)**
+
+```typescript
+describe('flying and regen', () => {
+  it('the roc may move onto mountains; land beasts may not', () => {
+    expect(isTerrainPassableForBeast('beast_roc', 'mountain')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_roc', 'grassland')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_roc', 'ocean')).toBe(false);
+    expect(isTerrainPassableForBeast('beast_boar', 'mountain')).toBe(false);
+  });
+
+  it('processBeasts emits regen orders for wounded hydras only', () => {
+    const map = tinyMap({ '10,10': 'swamp', '11,10': 'swamp', '9,10': 'swamp' });
+    const lair = makeLair({ id: 'lair-swamp_hydra', beastId: 'swamp_hydra', position: { q: 10, r: 10 }, status: 'awake', unitIds: ['hydra-1'] });
+    const wounded = makeUnit({ id: 'hydra-1', type: 'beast_hydra', owner: 'beasts', position: { q: 10, r: 10 }, health: 60 });
+    const result = processBeasts([lair], map, [], [wounded], 3, 'wild', 7);
+    expect(result.regenOrders).toEqual([{ unitId: 'hydra-1', amount: 10 }]);
+
+    const healthy = { ...wounded, health: 100 };
+    const none = processBeasts([lair], map, [], [healthy], 3, 'wild', 7);
+    expect(none.regenOrders).toEqual([]);
+  });
+
+  it('regen never exceeds 100 (turn-manager clamps)', () => {
+    // covered in turn-manager test below; the order carries the raw amount
+    const map = tinyMap({ '10,10': 'swamp' });
+    const lair = makeLair({ id: 'lair-swamp_hydra', beastId: 'swamp_hydra', position: { q: 10, r: 10 }, status: 'awake', unitIds: ['hydra-1'] });
+    const nearly = makeUnit({ id: 'hydra-1', type: 'beast_hydra', owner: 'beasts', position: { q: 10, r: 10 }, health: 95 });
+    const result = processBeasts([lair], map, [], [nearly], 3, 'wild', 7);
+    expect(result.regenOrders).toEqual([{ unitId: 'hydra-1', amount: 10 }]);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+In `isTerrainPassableForBeast`, consult the beast definition:
+
+```typescript
+export function isTerrainPassableForBeast(unitType: UnitType, terrain: string): boolean {
+  const beastDef = getBeastDefinitionByUnitType(unitType);
+  if (beastDef?.flying) return !WATER_TERRAINS.has(terrain);
+  const domain = UNIT_DEFINITIONS[unitType]?.domain;
+  if (domain === 'naval') return WATER_TERRAINS.has(terrain);
+  return !IMPASSABLE_FOR_LAND_BEASTS.has(terrain);
+}
+```
+
+In `BeastProcessResult` add:
+
+```typescript
+  regenOrders: Array<{ unitId: string; amount: number }>;
+```
+
+In `processBeasts`, before the per-beast movement loop (and in BOTH the `'calm'` early-return and the final return — calm beasts still regenerate):
+
+```typescript
+  const regenOrders: Array<{ unitId: string; amount: number }> = [];
+  for (const beast of beastUnits) {
+    const def = getBeastDefinitionByUnitType(beast.type);
+    if (def?.regenPerTurn && beast.health < 100) {
+      regenOrders.push({ unitId: beast.id, amount: def.regenPerTurn });
+    }
+  }
+```
+
+Update the `empty` result object and all return statements to include `regenOrders` (the `'off'` early-return keeps `[]`).
+
+In `src/core/turn-manager.ts`, in the beast block after move orders:
+
+```typescript
+    for (const regen of beastResult.regenOrders) {
+      const beast = newState.units[regen.unitId];
+      if (beast) beast.health = Math.min(100, beast.health + regen.amount);
+    }
+```
+
+- [ ] **Step 3: Turn-manager clamp test (append to `tests/core/turn-manager-beasts.test.ts`)**
+
+```typescript
+  it('hydra regen is applied and clamped at 100 by processTurn', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'Hydra Regen Test');
+    state.era = 3;
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-swamp_hydra': { id: 'lair-swamp_hydra', beastId: 'swamp_hydra', position: { q: 10, r: 10 }, status: 'awake', strength: 0, unitIds: ['hydra-1'] } },
+      sightingsByCiv: {},
+    };
+    state.units['hydra-1'] = { id: 'hydra-1', type: 'beast_hydra', owner: 'beasts', position: { q: 10, r: 10 }, movementPointsLeft: 1, health: 95, experience: 0, hasMoved: false, hasActed: false, isResting: false } as any;
+    const next = processTurn(state, new EventBus());
+    expect(next.units['hydra-1'].health).toBe(100);
+  });
+```
+
+(If the chosen seed's tile at 10,10 is water, pick coordinates on land — check with the map or relocate the lair/unit to a land tile found by scanning `next.map.tiles`.)
+
+- [ ] **Step 4: Run, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts tests/core/turn-manager-beasts.test.ts`
+Expected: PASS.
+
+```bash
+git add src/systems/beast-system.ts src/core/turn-manager.ts tests/
+git commit -m "feat(beasts): roc flight passability and hydra regeneration"
+```
+
+---
+
+### Task 3: Combat preview trait line
+
+**Files:**
+- Modify: `src/main.ts` (or the combat-preview module if previews are built elsewhere — find with `grep -rn "combat preview\|attackPreview\|preview" src/ui/ src/main.ts | head`)
+
+- [ ] **Step 1: Add the trait line**
+
+Where the combat preview panel composes the defender's info (it already shows `UNIT_DESCRIPTIONS`), append a highlighted trait line when the defender is a beast with special mechanics:
+
+```typescript
+import { getBeastDefinitionByUnitType } from '@/systems/beast-definitions';
+// when building the preview for defender:
+const beastDef = getBeastDefinitionByUnitType(defender.type);
+if (beastDef?.regenPerTurn) {
+  // add a line styled like existing bonus/penalty lines:
+  // `⚠ Regenerates ${beastDef.regenPerTurn} HP every turn`
+}
+if (beastDef?.navalOnly) {
+  // `⚠ Only ships and ranged units can fight it`
+}
+```
+
+Use `textContent` for the line; mirror the styling of existing preview detail rows.
+
+- [ ] **Step 2: Manual check + commit**
+
+`yarn dev` → preview an attack on a hydra → the regen line shows.
+
+```bash
+git add src/main.ts src/ui
+git commit -m "feat(beasts): combat preview surfaces beast traits"
+```
+
+---
+
+### Task 4: Winged rig + sprites
+
+**Files:**
+- Modify: `src/assets/sprite-animations-v2.css`, `src/renderer/sprites/beasts.tsx`, `src/renderer/sprites/sprite-catalog.ts`, `docs/sprite-design-system.md`
+
+- [ ] **Step 1: `beast-winged` CSS (match the hound rig's state scoping, as in MR5)**
+
+```css
+/* === beast-winged: wing flap + hover bob === */
+@keyframes cq-wing-flap-l {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(-18deg); }
+}
+@keyframes cq-wing-flap-r {
+  0%, 100% { transform: rotate(0deg); }
+  50% { transform: rotate(18deg); }
+}
+@keyframes cq-hover-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-4px); }
+}
+[data-kind="beast-winged"] .cq-wing-l { transform-origin: 64px 60px; animation: cq-wing-flap-l 1.1s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -1.1s); }
+[data-kind="beast-winged"] .cq-wing-r { transform-origin: 64px 60px; animation: cq-wing-flap-r 1.1s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -1.1s); }
+[data-kind="beast-winged"] .cq-hover-body { animation: cq-hover-bob 2.2s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.2s); }
+[data-kind="beast-winged"] .cq-shadow-detached { transform: scale(0.7); opacity: 0.5; }
+```
+
+- [ ] **Step 2: Sprites**
+
+```tsx
+const ROC = {
+  feather: '#5a6b8a',
+  featherDark: '#3c4a63',
+  beak: '#d9a23a',
+  spark: '#9ed0ff',
+};
+
+export function StormRocSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g className="cq-shadow-detached"><Shadow /></g>
+      <g data-kind="beast-winged" className="cq-sprite-figure">
+        <g className="cq-hover-body">
+          <g className="cq-wing-l">
+            <path d="M58,60 Q34,40 16,48 Q30,56 34,64 Q44,62 58,66 Z" fill={ROC.feather} stroke={P.ink.line} strokeWidth="1.5" />
+            <path d="M22,48 l6,4 M30,46 l5,5 M38,48 l4,5" stroke={ROC.featherDark} strokeWidth="1.5" />
+          </g>
+          <g className="cq-wing-r">
+            <path d="M70,60 Q94,40 112,48 Q98,56 94,64 Q84,62 70,66 Z" fill={ROC.feather} stroke={P.ink.line} strokeWidth="1.5" />
+            <path d="M106,48 l-6,4 M98,46 l-5,5 M90,48 l-4,5" stroke={ROC.featherDark} strokeWidth="1.5" />
+          </g>
+          {/* body, tail, head */}
+          <ellipse cx="64" cy="64" rx="12" ry="16" fill={ROC.feather} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M60,78 L56,92 L64,84 L72,92 L68,78 Z" fill={ROC.featherDark} />
+          <circle cx="64" cy="48" r="8" fill={ROC.feather} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M64,50 L72,54 L64,57 Z" fill={ROC.beak} />
+          <circle cx="61" cy="47" r="1.8" fill="#ffd34d" />
+          {/* storm sparks */}
+          <path d="M40,42 l-3,6 4,-1 -3,6 M90,40 l-3,6 4,-1 -3,6" fill="none" stroke={ROC.spark} strokeWidth="1.5" strokeLinecap="round" />
+        </g>
+      </g>
+    </SpriteFrame>
+  );
+}
+
+const HYDRA = {
+  scale: '#4a6b4a',
+  scaleDark: '#2f4a2f',
+  belly: '#7e9a6a',
+  eye: '#e0d34d',
+};
+
+export function SwampHydraSprite({ svgOnly = false }: UnitSpriteProps): string {
+  const head = (cx: number, cy: number, flip: number) => (
+    <g>
+      <ellipse cx={cx} cy={cy} rx="7" ry="6" fill={HYDRA.scale} stroke={P.ink.line} strokeWidth="1.2" />
+      <path d={`M${cx + 6 * flip},${cy} L${cx + 12 * flip},${cy + 2} L${cx + 6 * flip},${cy + 4} Z`} fill={HYDRA.scaleDark} />
+      <circle cx={cx + 2 * flip} cy={cy - 2} r="1.6" fill={HYDRA.eye} />
+    </g>
+  );
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow />
+      <g data-kind="beast-serpent" className="cq-sprite-figure">
+        {/* squat body in the mire */}
+        <ellipse cx="64" cy="80" rx="26" ry="14" fill={HYDRA.scale} stroke={P.ink.line} strokeWidth="1.5" />
+        <ellipse cx="64" cy="86" rx="20" ry="7" fill={HYDRA.belly} opacity="0.6" />
+        {/* three weaving necks + heads, phase-offset */}
+        <g className="cq-segment-1">
+          <path d="M52,72 Q40,56 44,44" fill="none" stroke={HYDRA.scale} strokeWidth="7" strokeLinecap="round" />
+          {head(44, 42, -1)}
+        </g>
+        <g className="cq-segment-2">
+          <path d="M64,70 Q64,52 64,40" fill="none" stroke={HYDRA.scale} strokeWidth="8" strokeLinecap="round" />
+          {head(64, 37, 1)}
+        </g>
+        <g className="cq-segment-3">
+          <path d="M76,72 Q88,56 84,44" fill="none" stroke={HYDRA.scale} strokeWidth="7" strokeLinecap="round" />
+          {head(84, 42, 1)}
+        </g>
+        {/* marsh bubbles */}
+        <circle cx="40" cy="92" r="2" fill="#9ec79e" opacity="0.6" />
+        <circle cx="90" cy="90" r="1.5" fill="#9ec79e" opacity="0.6" />
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+If JSX helpers-as-functions (the `head` lambda) don't fit the project's JSX-to-string pipeline, inline the three head groups literally — check how existing sprites compose repeated elements first.
+
+- [ ] **Step 3: Register**
+
+```typescript
+  beast_roc: StormRocSprite,
+  beast_hydra: SwampHydraSprite,
+```
+
+- [ ] **Step 4: Document `beast-winged` in `docs/sprite-design-system.md`** (body-plan kinds table + unit inventory rows for both sprites).
+
+- [ ] **Step 5: Build + sprite tests + commit**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn vitest run tests/renderer/sprites/sprite-catalog.test.ts`
+Expected: PASS.
+
+```bash
+git add src/assets/sprite-animations-v2.css src/renderer/sprites/beasts.tsx src/renderer/sprites/sprite-catalog.ts docs/sprite-design-system.md
+git commit -m "feat(beasts): winged rig, storm roc and swamp hydra sprites"
+```
+
+---
+
+### Task 5: Final verification + PR
+
+- [ ] **Step 1: Gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+
+- [ ] **Step 2: PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR6 — storm roc + swamp hydra" --body "$(cat <<'EOF'
+## Summary
+- Storm Roc: tier-3 mountain beast that flies over any land terrain (definition-driven `flying` flag)
+- Swamp Hydra: tier-3 swamp beast regenerating 10 HP/turn via new `regenOrders` in the beast turn pipeline; regen is clamped at 100 and surfaced in the combat preview so players understand the fight
+- New `beast-winged` animation rig (wing flap + hover bob + detached shadow), documented
+
+## Why this is safe to merge partial
+Both beasts complete end-to-end. Remaining: MR7 (Ancient Dragon apex), MR8 (audio/AI/balance) — see docs/superpowers/plans/2026-06-11-legendary-beasts-index.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Roc never receives water move orders; boar/serpent passability unchanged (all prior tests green)
+- [ ] Hydra regens in calm mode too (calm early-return includes regenOrders)
+- [ ] Regen clamped at 100 in turn-manager (test)
+- [ ] Combat preview shows regen + navalOnly trait lines via `textContent`
+- [ ] Both new types in all six exhaustive maps

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr7-ancient-dragon.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr7-ancient-dragon.md
@@ -1,0 +1,477 @@
+# Legendary Beasts MR7 — Ancient Dragon (Apex) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1–MR6 merged**.
+
+**Goal:** Ship the endgame boss: the Ancient Dragon (volcanic, era 4, tier 4) with a 2-hex fire-breath ranged attack, an apex reward (ALL THREE hoard rewards at once + the slaying unit becomes a maximum-veterancy legend), and a full-screen slay ceremony for tier ≥ 3 beasts.
+
+**Architecture:** The dragon is pure definition content on top of MR5/MR6 flags (`flying`) plus one new capability that already exists in the engine: `attackProfile: { kind: 'ranged', range: 2 }` on its `UnitDefinition` — `resolveCombat` and counterattack logic already honor `attackProfile` (see `canCounterAttackAtDistance`, `src/systems/combat-system.ts:50`). Beast ranged attacks in `processBeasts` need one generalization: the attack-order trigger distance becomes the beast's attack range instead of hardcoded `1`. The apex reward is a tier-4 branch in `recordBeastSlain`. The slay ceremony follows the wonder-discovery-ceremony pattern.
+
+**Tech Stack:** TypeScript, vitest, JSX→SVG sprites.
+
+**Dependencies:** MR1–MR6 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/core/types.ts` | Modify | `BeastId` += `'ancient_dragon'`; `UnitType` += `'beast_dragon'` |
+| `src/systems/beast-definitions.ts` | Modify | Dragon definition |
+| `src/systems/beast-system.ts` | Modify | Range-aware attack orders; tier-4 apex reward branch |
+| `src/systems/unit-system.ts` | Modify | Dragon definition with `attackProfile` + description |
+| `src/ui/beast-slay-ceremony.ts` | Create | Full-screen ceremony for tier ≥ 3 slays |
+| `src/main.ts` | Modify | Ceremony trigger; apex notification |
+| `src/renderer/sprites/beasts.tsx` | Modify | `AncientDragonSprite` (`beast-winged` rig + ember glow) |
+| `src/renderer/sprites/sprite-catalog.ts` | Modify | Register |
+| `src/renderer/unit-visual-resolver.ts` | Modify | Icon |
+| `src/audio/sfx-catalog.ts` | Modify | Locomotion class |
+| `tests/systems/beast-system.test.ts` | Modify | Ranged attack orders + apex reward tests |
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Era reaches 4, dragon lair dormant | (turn processing awakens it) | EVERY civ gets a warning notification with a map target on the lair |
+| My unit stands 2 hexes from the dragon, in its territory | (dragon's turn) | Fire breath: my unit takes damage at range — combat log/notification says the Dragon attacked |
+| My catapult kills the dragon | (combat resolves) | Full-screen slay ceremony: dragon art, "The Ancient Dragon has fallen", reward summary (gold + lore + trophy), Continue button |
+| Ceremony dismissed | Open Bestiary | Dragon entry: Slain, my civ credited |
+| Any later turn | Check HUD | Trophy income (+8/turn) included in per-turn gold rate |
+
+## Misleading-UI risks
+
+- The apex reward shows NO choice panel — the ceremony must clearly list everything granted (gold amount, research amount, trophy income), or players will think they missed a choice.
+- The dragon's 2-hex breath must appear in the combat preview trait lines (MR6 pattern): "⚠ Fire breath strikes from 2 hexes".
+- The slay ceremony fires for tier ≥ 3 (serpent, roc, hydra get it retroactively) — exactly once per slay (transition-owned: triggered by the `beast:slain` event, which fires once from `recordBeastSlain` callers).
+
+---
+
+### Task 1: Types + definitions
+
+**Files:**
+- Modify: `src/core/types.ts`, `src/systems/beast-definitions.ts`, `src/systems/unit-system.ts`, `src/renderer/unit-visual-resolver.ts`, `src/renderer/sprites/sprite-catalog.ts` (motion), `src/audio/sfx-catalog.ts`
+
+- [ ] **Step 1: Unions**
+
+```typescript
+export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk' | 'sea_serpent' | 'dune_wurm' | 'storm_roc' | 'swamp_hydra' | 'ancient_dragon';
+```
+
+`UnitType` beast tail gains `| 'beast_dragon'`.
+
+- [ ] **Step 2: Beast definition**
+
+```typescript
+  ancient_dragon: {
+    id: 'ancient_dragon',
+    unitType: 'beast_dragon',
+    name: 'Ancient Dragon',
+    habitatTerrains: ['volcanic'],
+    awakenEra: 4,
+    tier: 4,
+    leashRadius: 4,
+    packSize: 1,
+    hoardGoldBase: 300,
+    flying: true,
+    dangerHint: 'The mountain that burns has a heartbeat. The oldest maps mark it with a single word: NO.',
+    awakeningFlavor: 'The burning mountain splits open. The Ancient Dragon has awoken — and the world holds its breath.',
+    sightingFlavor: 'The Ancient Dragon — wings of ember, eyes of molten gold. May fortune favor the bold.',
+  },
+```
+
+- [ ] **Step 3: Unit definition with ranged breath**
+
+```typescript
+  beast_dragon: {
+    type: 'beast_dragon', name: 'Ancient Dragon', movementPoints: 3,
+    visionRange: 3, strength: 55, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+    attackProfile: { kind: 'ranged', range: 2, targets: ['unit'] },
+  },
+```
+
+(Check `UnitAttackProfile`'s exact shape at `src/core/types.ts:296` and match the `targets` field's real values — copy from the `archer` entry.)
+
+`UNIT_DESCRIPTIONS`:
+
+```typescript
+  beast_dragon: 'The Ancient Dragon, terror of the volcanic peaks. Its fire breath strikes from 2 hexes away. Slaying it is the deed of a lifetime — the hoard contains everything.',
+```
+
+- [ ] **Step 4: Icon / motion / locomotion**
+
+`FALLBACK_ICONS`: `beast_dragon: '🐲',` · `UNIT_MOTION_STYLES`: `'animal'` · `LOCOMOTION_CLASS`: same as the roc.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/types.ts src/systems/beast-definitions.ts src/systems/unit-system.ts src/renderer/unit-visual-resolver.ts src/renderer/sprites/sprite-catalog.ts src/audio/sfx-catalog.ts
+git commit -m "feat(beasts): ancient dragon definitions with ranged breath"
+```
+
+---
+
+### Task 2: Range-aware beast attacks (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+describe('dragon ranged attacks', () => {
+  it('orders an attack at 2-hex range', () => {
+    const map = tinyMap({ '10,10': 'volcanic', '11,10': 'grassland', '12,10': 'grassland' });
+    const lair = makeLair({ id: 'lair-ancient_dragon', beastId: 'ancient_dragon', position: { q: 10, r: 10 }, status: 'awake', unitIds: ['drg-1'] });
+    const dragon = makeUnit({ id: 'drg-1', type: 'beast_dragon', owner: 'beasts', position: { q: 10, r: 10 } });
+    const intruder = makeUnit({ id: 'u1', position: { q: 12, r: 10 } });
+    const result = processBeasts([lair], map, [intruder], [dragon], 4, 'wild', 7);
+    expect(result.attackOrders).toEqual([{ attackerUnitId: 'drg-1', defenderUnitId: 'u1' }]);
+  });
+
+  it('melee beasts still require adjacency', () => {
+    const map = tinyMap({ '10,10': 'forest', '11,10': 'grassland', '12,10': 'grassland' });
+    const lair = makeLair({ status: 'awake', unitIds: ['beast-1'] });
+    const boar = makeUnit({ id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 } });
+    const intruder = makeUnit({ id: 'u1', position: { q: 12, r: 10 } });
+    const result = processBeasts([lair], map, [intruder], [boar], 1, 'wild', 7);
+    expect(result.attackOrders).toEqual([]);   // moves toward instead
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+In `processBeasts`'s per-beast loop, replace the hardcoded adjacency check:
+
+```typescript
+    const attackRange = UNIT_DEFINITIONS[beast.type].attackProfile?.kind === 'ranged'
+      ? UNIT_DEFINITIONS[beast.type].attackProfile!.range
+      : 1;
+    if (target && hexDistance(target.position, beast.position) <= attackRange) {
+      attackOrders.push({ attackerUnitId: beast.id, defenderUnitId: target.id });
+      continue;
+    }
+```
+
+Verify the turn-manager's beast attack-order application uses `resolveCombat` (which already handles ranged profiles and counterattack range via `canCounterAttackAtDistance`) — no turn-manager change should be needed; confirm by reading the block.
+
+- [ ] **Step 3: Run, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS.
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): range-aware beast attack orders"
+```
+
+---
+
+### Task 3: Apex reward (TDD)
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+Apex (tier 4) slays grant **everything**: the gold option's amount, the lore option's research, the trophy auto-claimed, AND the slaying unit's experience raised to the top veterancy tier. No choice panel.
+
+- [ ] **Step 1: Write failing tests (append)**
+
+```typescript
+import { VETERANCY_TIERS } from '@/systems/combat-reward-system';
+
+describe('apex reward', () => {
+  function stateWithSlainDragon() {
+    const state = createNewGame('rome', 'beast-test-seed', 'small', 'Apex Test');
+    state.era = 4;
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-ancient_dragon': makeLair({ id: 'lair-ancient_dragon', beastId: 'ancient_dragon', status: 'awake', unitIds: ['drg-1'] }) },
+      sightingsByCiv: {},
+    };
+    const dragon = makeUnit({ id: 'drg-1', type: 'beast_dragon', owner: 'beasts' });
+    const victor = makeUnit({ id: 'hero-1', owner: state.currentPlayer, experience: 0 });
+    state.units[dragon.id] = dragon;
+    state.units[victor.id] = victor;
+    return { state, dragon, victor };
+  }
+
+  it('grants gold + trophy claim + max veterancy with NO pending choice', () => {
+    const { state, dragon, victor } = stateWithSlainDragon();
+    const goldBefore = state.civilizations[victor.owner].gold;
+    const { state: next, slain } = recordBeastSlain(state, dragon, victor);
+    expect(slain).toBeDefined();
+    expect(slain!.goldAwarded).toBeGreaterThan(0);
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore + slain!.goldAwarded);
+    expect(next.beasts!.lairs['lair-ancient_dragon'].status).toBe('claimed');
+    expect(next.beasts!.lairs['lair-ancient_dragon'].claimedBy).toBe(victor.owner);
+    expect(next.beasts!.pendingHoardChoices ?? []).toEqual([]);
+    const topTier = VETERANCY_TIERS[VETERANCY_TIERS.length - 1];
+    expect(next.units['hero-1'].experience).toBeGreaterThanOrEqual(topTier.minExperience ?? 0);
+  });
+});
+```
+
+Check `VeterancyTier`'s field names (`grep -n "interface VeterancyTier" -A 8 src/systems/combat-reward-system.ts`) — if the threshold field isn't `minExperience`, use the real name in test and code.
+
+- [ ] **Step 2: Implement — tier-4 branch in `recordBeastSlain`**
+
+Where MR4 branches on `def.tier >= 2`, refine:
+
+```typescript
+  const isApex = def.tier >= 4;
+  const isChoiceTier = def.tier >= 2 && !isApex;
+```
+
+The apex amounts are computed inline from `def` and `state.era` using the same formulas as `getHoardChoicePreview` (gold ×2, lore ×1.5) — do not call the preview helper here, the lair record is mid-update. Apex branch after the base slain-lair update:
+
+```typescript
+  if (isApex && slayerCiv) {
+    const apexGold = getBeastHoardGold(def, state.era) * 2;
+    const apexLore = Math.round(getBeastHoardGold(def, state.era) * 1.5);
+    next = { ...next, civilizations: { ...next.civilizations, [victor.owner]: { ...next.civilizations[victor.owner], gold: next.civilizations[victor.owner].gold + apexGold } } };
+    next = applyBeastLoreResearch(next, victor.owner, apexLore);
+    next = {
+      ...next,
+      beasts: {
+        ...next.beasts!,
+        lairs: { ...next.beasts!.lairs, [lair.id]: { ...next.beasts!.lairs[lair.id], status: 'claimed', claimedBy: victor.owner } },
+      },
+    };
+    // legendary veterancy for the slayer
+    const topTier = VETERANCY_TIERS[VETERANCY_TIERS.length - 1];
+    const hero = next.units[victor.id];
+    if (hero) {
+      next = { ...next, units: { ...next.units, [victor.id]: { ...hero, experience: Math.max(hero.experience, topTier.minExperience ?? 0) } } };
+    }
+    // goldAwarded in the payload reports the apex gold so notifications/ceremony can show it
+  }
+```
+
+Set the returned payload's `goldAwarded` to `apexGold` for apex, `0` for choice tiers, tier-1 gold otherwise. Import `VETERANCY_TIERS` from `@/systems/combat-reward-system` (verify no import cycle: combat-reward-system must not import beast-system — check with `grep -n "beast" src/systems/combat-reward-system.ts`).
+
+- [ ] **Step 3: Run all beast + MR4 tests, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts`
+Expected: PASS — tier-1, tier-2, and tier-4 paths all green.
+
+```bash
+git add src/systems/beast-system.ts tests/systems/beast-system.test.ts
+git commit -m "feat(beasts): apex reward — everything at once plus legendary veterancy"
+```
+
+---
+
+### Task 4: Slay ceremony (tier ≥ 3)
+
+**Files:**
+- Create: `src/ui/beast-slay-ceremony.ts`
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Implement the ceremony (read `src/ui/wonder-discovery-ceremony.ts` and `src/ui/beast-sighting-banner.ts` first; this is the banner pattern, bigger)**
+
+```typescript
+import { createGameButton } from '@/ui/ui-kit';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+import type { UnitType } from '@/core/types';
+
+export interface BeastSlayCeremonyOptions {
+  beastName: string;
+  unitType: UnitType;
+  slayerName: string;
+  rewardLines: string[];     // pre-formatted: ['+600 gold', '+450 research', 'Beast Trophy: +8 gold/turn', 'Your hero is now Legendary']
+  onContinue: () => void;
+}
+
+export function showBeastSlayCeremony(container: HTMLElement, options: BeastSlayCeremonyOptions): HTMLElement {
+  container.querySelector('#beast-slay-ceremony')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'beast-slay-ceremony';
+  overlay.style.cssText = 'position:absolute;inset:0;background:rgba(8,8,18,0.95);z-index:60;display:flex;align-items:center;justify-content:center;';
+
+  const card = document.createElement('div');
+  card.style.cssText = 'max-width:360px;background:#1a1a2e;border:2px solid #e8c170;border-radius:14px;padding:24px;text-align:center;';
+
+  const kicker = document.createElement('div');
+  kicker.textContent = 'A LEGEND FALLS';
+  kicker.style.cssText = 'font-size:12px;letter-spacing:3px;color:#d1a35a;margin-bottom:8px;';
+  card.appendChild(kicker);
+
+  const art = document.createElement('div');
+  art.style.cssText = 'width:140px;height:140px;margin:0 auto 8px;filter:drop-shadow(0 0 12px rgba(232,193,112,0.5));';
+  art.innerHTML = UNIT_SPRITE_CATALOG[options.unitType]({ palette: { mid: '#888', dark: '#555', bright: '#bbb', trim: '#999' } as never, svgOnly: true });
+  card.appendChild(art);
+
+  const title = document.createElement('h2');
+  title.textContent = `The ${options.beastName} has fallen!`;
+  title.style.cssText = 'font-size:22px;color:#e8c170;margin:0 0 4px;';
+  card.appendChild(title);
+
+  const credit = document.createElement('p');
+  credit.textContent = `Slain by the forces of ${options.slayerName}. Bards will sing of this day.`;
+  credit.style.cssText = 'font-size:13px;opacity:0.85;margin:0 0 12px;';
+  card.appendChild(credit);
+
+  const rewards = document.createElement('div');
+  rewards.style.cssText = 'background:rgba(255,255,255,0.06);border-radius:10px;padding:10px;margin-bottom:16px;';
+  for (const line of options.rewardLines) {
+    const row = document.createElement('div');
+    row.textContent = line;
+    row.style.cssText = 'font-size:14px;color:#9ad17b;padding:2px 0;';
+    rewards.appendChild(row);
+  }
+  card.appendChild(rewards);
+
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.addEventListener('click', () => { overlay.remove(); options.onContinue(); });
+  card.appendChild(continueButton);
+
+  overlay.appendChild(card);
+  container.appendChild(overlay);
+  return overlay;
+}
+```
+
+(Same neutral-palette adjustment as MR2.)
+
+- [ ] **Step 2: Trigger from the `beast:slain` listener in `src/main.ts`**
+
+Extend the MR1 listener: when the slain beast's tier ≥ 3 AND the slayer is `gameState.currentPlayer`, show the ceremony instead of just the notification (the notification still logs for everyone):
+
+```typescript
+  const def = BEAST_DEFINITIONS[beastId];
+  if (def.tier >= 3 && slayerCivId === gameState.currentPlayer) {
+    const rewardLines = def.tier >= 4
+      ? [`+${goldAwarded} gold`, 'Ancient Lore claimed (+research)', 'Beast Trophy raised (+8 gold/turn)', 'Your hero is now Legendary']
+      : ['Choose your hoard reward…'];
+    showBeastSlayCeremony(uiContainer, {
+      beastName: def.name, unitType: def.unitType,
+      slayerName: gameState.civilizations[slayerCivId]?.name ?? slayerCivId,
+      rewardLines,
+      onContinue: () => { maybeShowPendingHoardChoice(); },   // tier-3 flows into the MR4 choice panel
+    });
+  }
+```
+
+Note the ordering contract: for tier 3 the ceremony shows first, then `onContinue` opens the hoard choice panel (MR4's direct call after the slay must skip tiers ≥ 3 to avoid double-opening — adjust MR4's call site: only call `maybeShowPendingHoardChoice()` directly for tier 2).
+
+- [ ] **Step 3: Build + manual check, commit**
+
+```bash
+git add src/ui/beast-slay-ceremony.ts src/main.ts
+git commit -m "feat(beasts): slay ceremony for tier 3+ beasts"
+```
+
+---
+
+### Task 5: Dragon sprite
+
+**Files:**
+- Modify: `src/renderer/sprites/beasts.tsx`, `src/renderer/sprites/sprite-catalog.ts`
+
+- [ ] **Step 1: `AncientDragonSprite` (winged rig + ember glow)**
+
+```tsx
+const DRAGON = {
+  scale: '#8c2f2f',
+  scaleDark: '#5e1d1d',
+  wing: '#a8443a',
+  wingMembrane: '#d97f4a',
+  horn: '#e8e0cc',
+  fire: '#ffb13d',
+};
+
+export function AncientDragonSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <g className="cq-shadow-detached"><Shadow /></g>
+      <g data-kind="beast-winged" className="cq-sprite-figure">
+        <g className="cq-hover-body">
+          <g className="cq-wing-l">
+            <path d="M56,58 Q30,34 12,44 L20,50 L14,56 L24,58 L20,66 Q40,64 56,66 Z" fill={DRAGON.wing} stroke={P.ink.line} strokeWidth="1.5" />
+            <path d="M22,46 Q36,52 50,60 M18,56 Q34,58 50,63" fill="none" stroke={DRAGON.wingMembrane} strokeWidth="1.5" opacity="0.8" />
+          </g>
+          <g className="cq-wing-r">
+            <path d="M72,58 Q98,34 116,44 L108,50 L114,56 L104,58 L108,66 Q88,64 72,66 Z" fill={DRAGON.wing} stroke={P.ink.line} strokeWidth="1.5" />
+            <path d="M106,46 Q92,52 78,60 M110,56 Q94,58 78,63" fill="none" stroke={DRAGON.wingMembrane} strokeWidth="1.5" opacity="0.8" />
+          </g>
+          {/* body + tail */}
+          <ellipse cx="64" cy="66" rx="14" ry="17" fill={DRAGON.scale} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M58,80 Q48,94 36,96 L42,90 Q50,88 56,78" fill={DRAGON.scale} stroke={P.ink.line} strokeWidth="1" />
+          <path d="M60,54 L64,48 L68,54 M58,62 L62,57 L66,62" fill="none" stroke={DRAGON.scaleDark} strokeWidth="1.5" />
+          {/* head, horns, molten eyes, breath ember */}
+          <ellipse cx="64" cy="44" rx="10" ry="8" fill={DRAGON.scale} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M57,38 L52,28 L60,35 Z M71,38 L76,28 L68,35 Z" fill={DRAGON.horn} stroke={P.ink.line} strokeWidth="1" />
+          <circle cx="60" cy="43" r="2" fill={DRAGON.fire} className="cq-glow" />
+          <circle cx="68" cy="43" r="2" fill={DRAGON.fire} className="cq-glow" />
+          <path d="M62,50 Q64,56 66,50" fill="none" stroke={DRAGON.fire} strokeWidth="2" strokeLinecap="round" className="cq-glow" />
+        </g>
+      </g>
+    </SpriteFrame>
+  );
+}
+```
+
+(`.cq-glow` already exists as a building effect class — verify it animates standalone elements; if it's building-scoped, copy its keyframe under a `[data-kind="beast-winged"] .cq-glow` selector in the CSS.)
+
+- [ ] **Step 2: Register, build, sprite tests**
+
+```typescript
+  beast_dragon: AncientDragonSprite,
+```
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn vitest run tests/renderer/sprites/sprite-catalog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/sprites/beasts.tsx src/renderer/sprites/sprite-catalog.ts src/assets/sprite-animations-v2.css
+git commit -m "feat(beasts): ancient dragon sprite"
+```
+
+---
+
+### Task 6: Final verification + PR
+
+- [ ] **Step 1: Gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+
+- [ ] **Step 2: Manual boss-fight check**
+
+`yarn dev` → era-4 game near a volcanic region (temporarily set the dragon's `awakenEra` to 1 and awaken chance to 1 locally to test; **revert before committing**) → dragon breathes fire at 2 hexes; preview shows the trait warning; slaying it plays the ceremony listing all rewards; bestiary + HUD income verified.
+
+- [ ] **Step 3: PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR7 — the Ancient Dragon" --body "$(cat <<'EOF'
+## Summary
+- Ancient Dragon: apex (tier 4) volcanic beast, era 4, flying, 2-hex fire breath via the engine's existing ranged attackProfile machinery
+- Apex reward: gold + research + auto-claimed trophy + the slaying unit becomes max-veterancy — everything at once, no choice panel, all listed in the new slay ceremony
+- Slay ceremony now plays for all tier ≥ 3 beasts (serpent/roc/hydra retroactively), flowing into the hoard choice panel for tier 3
+
+## Why this is safe to merge partial
+The roster is complete (8/8 beasts). Remaining: MR8 (audio, AI engagement, balance tests) — polish only. See docs/superpowers/plans/2026-06-11-legendary-beasts-index.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] Tier-1/2/3/4 reward paths all distinct and tested (auto-gold / choice / ceremony+choice / ceremony+everything)
+- [ ] MR4's direct `maybeShowPendingHoardChoice()` call skips tier ≥ 3 (ceremony owns the flow) — no double panel
+- [ ] Ranged attack orders honor `attackProfile.range`; melee beasts unchanged
+- [ ] No temporary awaken-chance hacks left in committed code (`grep -n "AWAKEN_CHANCE" src/systems/beast-system.ts` shows 0.25)
+- [ ] `VETERANCY_TIERS` import creates no cycle

--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-mr8-audio-ai-balance.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-mr8-audio-ai-balance.md
@@ -1,0 +1,368 @@
+# Legendary Beasts MR8 — Audio, AI Engagement, Balance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Executor model:** Sonnet 4.5. Grounded in the codebase **after MR1–MR7 merged**.
+
+**Goal:** Finish the feature: beast roars (synthesized SFX), a "beast territory" music tension layer, opportunistic AI beast-hunting behind a setting, and statistical balance tests per era.
+
+**Architecture:** Audio rides the existing catalogs: `UNIT_SFX` (a `Partial` map — no exhaustiveness pressure) and the music-director's war-layer pattern. AI engagement is a conservative heuristic in `basic-ai.ts` gated by a new `aiContestsBeasts` setting (default **false** — the kids keep their kills). Balance is locked in with sampling tests per the strategy-game-mechanics rule.
+
+**Tech Stack:** TypeScript, vitest, ffmpeg 8.0.1 (on PATH — use `ffmpeg` directly), Web Audio via existing audio-system.
+
+**Dependencies:** MR1–MR7 merged. Branches from `main`.
+
+---
+
+## File structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `public/audio/sfx/beast-*.ogg` | Create | 8 synthesized roar/death sounds (check the real SFX asset directory first) |
+| `src/audio/sfx-catalog.ts` | Modify | `UNIT_SFX` entries for the 8 beast types |
+| `src/audio/music-director.ts` | Modify | `beast-territory` tension layer |
+| `src/systems/beast-system.ts` | Modify | `isCivUnitInBeastTerritory` helper |
+| `src/ai/basic-ai.ts` | Modify | Opportunistic beast hunting |
+| `src/core/types.ts` | Modify | `GameSettings.aiContestsBeasts?: boolean` |
+| `AUDIO-CREDITS.md` | Modify | Credit the synthesized assets |
+| `tests/systems/beast-balance.test.ts` | Create | Statistical combat sampling per tier/era |
+| `tests/ai/basic-ai-beasts.test.ts` | Create | AI engagement heuristic tests |
+
+---
+
+### Task 1: Synthesized roar SFX
+
+**Files:**
+- Create: 16 OGG files (attack + death per beast)
+- Modify: `src/audio/sfx-catalog.ts`, `AUDIO-CREDITS.md`
+
+- [ ] **Step 1: Discover the asset conventions**
+
+Run: `sed -n 1,60p src/audio/sfx-catalog.ts` and `ls public/audio* 2>/dev/null || grep -rn "\.ogg" src/audio/sfx-catalog.ts | head -5`
+Note the `TrackEntry` shape (path, volume, variants?) and the directory existing unit SFX live in. All paths below must be adjusted to the real directory.
+
+- [ ] **Step 2: Synthesize roars with ffmpeg**
+
+Layered noise+pitch sweeps read as creature sounds. Generate one pair per beast — vary the base frequency by size (boar 110Hz … dragon 55Hz). Template (run from repo root, output into the real SFX dir):
+
+```bash
+# Giant Boar attack: grunt — short low sweep + noise burst
+ffmpeg -y -f lavfi -i "sine=frequency=110:duration=0.5" -f lavfi -i "anoisesrc=color=brown:duration=0.5:amplitude=0.4" \
+  -filter_complex "[0]vibrato=f=9:d=0.6,atrim=0:0.5[a];[1]highpass=f=200,afade=t=out:st=0.2:d=0.3[b];[a][b]amix=2,afade=t=in:st=0:d=0.03,afade=t=out:st=0.35:d=0.15,volume=1.4" \
+  public/audio/sfx/beast-boar-attack.ogg
+
+# Giant Boar death: longer falling sweep
+ffmpeg -y -f lavfi -i "sine=frequency=140:duration=1.1" -f lavfi -i "anoisesrc=color=brown:duration=1.1:amplitude=0.3" \
+  -filter_complex "[0]vibrato=f=6:d=0.8,asetrate=44100*0.8,aresample=44100[a];[1]lowpass=f=900[b];[a][b]amix=2,afade=t=out:st=0.5:d=0.6,volume=1.3" \
+  public/audio/sfx/beast-boar-death.ogg
+```
+
+Repeat for each beast with these base frequencies and durations — keep the same filter graphs, change only frequency/duration/filename:
+
+| Beast | attack Hz / dur | death Hz / dur | flavor tweak |
+|---|---|---|---|
+| boar | 110 / 0.5s | 140 / 1.1s | as above |
+| wolf | 220 / 0.7s | 320 / 1.4s | add `vibrato=f=14` (howl warble) |
+| basilisk | 180 / 0.6s | 160 / 1.0s | add `highpass=f=400` hiss (raise noise amplitude to 0.6) |
+| sea_serpent | 80 / 0.9s | 70 / 1.6s | add `lowpass=f=600` + `aecho=0.8:0.7:60:0.4` (underwater) |
+| wurm | 65 / 0.8s | 60 / 1.3s | brown noise amplitude 0.7 (rumble dominates) |
+| roc | 480 / 0.6s | 380 / 1.2s | sine→`sawtooth` via `aeval`? keep sine, add `vibrato=f=18:d=0.9` (screech) |
+| hydra | 150 / 0.7s | 130 / 1.4s | run 3 detuned sines (150/157/164) mixed (many heads) |
+| dragon | 55 / 1.0s | 50 / 2.0s | noise amplitude 0.6 + `aecho=0.8:0.8:90:0.5` (cavernous) |
+
+Listen-check each file (`ffplay` or open in browser); regenerate any that clip or sound flat.
+
+- [ ] **Step 3: Catalog entries**
+
+In `UNIT_SFX` (`src/audio/sfx-catalog.ts:24` — a `Partial` map), add entries for all 8 beast types mirroring the hound entries' exact shape for the attack/death SFX classes (copy a hound entry, swap paths). Then verify the existing sfx-catalog test still passes — it may assert that every referenced file exists.
+
+- [ ] **Step 4: Credits**
+
+Append to `AUDIO-CREDITS.md`:
+
+```markdown
+## Legendary Beast SFX
+beast-*-attack.ogg / beast-*-death.ogg — synthesized in-project with ffmpeg 8.0.1 (lavfi sine + anoisesrc layering). No external sources.
+```
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/audio/sfx-catalog.test.ts && bash scripts/run-with-mise.sh yarn build`
+Expected: PASS.
+
+```bash
+git add public/audio src/audio/sfx-catalog.ts AUDIO-CREDITS.md
+git commit -m "feat(beasts): synthesized roar and death SFX for all eight beasts"
+```
+
+Manual: `yarn dev` → attack a beast → roar plays through the existing combat SFX path (sfx-director routes `UNIT_SFX` automatically; if beast sounds don't fire, read how `sfx-director.ts` picks attack/death tracks and confirm beast types flow through the same code path).
+
+---
+
+### Task 2: Beast-territory music layer
+
+**Files:**
+- Modify: `src/systems/beast-system.ts`, `src/audio/music-director.ts`
+- Test: `tests/systems/beast-system.test.ts`
+
+- [ ] **Step 1: Failing test for the helper (append)**
+
+```typescript
+import { isCivUnitInBeastTerritory } from '@/systems/beast-system';
+
+describe('isCivUnitInBeastTerritory', () => {
+  it('true only when a civ unit stands within an AWAKE lair leash radius', () => {
+    const state = createNewGame('rome', 'beast-test-seed', 'small', 'Territory Test');
+    state.beasts = {
+      mode: 'wild',
+      lairs: { 'lair-giant_boar': makeLair({ status: 'awake', unitIds: ['beast-1'] }) },   // at 10,10 leash 3
+      sightingsByCiv: {},
+    };
+    const me = state.currentPlayer;
+    state.units['scout-1'] = makeUnit({ id: 'scout-1', owner: me, position: { q: 12, r: 10 } });
+    expect(isCivUnitInBeastTerritory(state, me)).toBe(true);
+
+    state.units['scout-1'].position = { q: 20, r: 20 };
+    expect(isCivUnitInBeastTerritory(state, me)).toBe(false);
+
+    state.units['scout-1'].position = { q: 12, r: 10 };
+    state.beasts.lairs['lair-giant_boar'].status = 'dormant';
+    expect(isCivUnitInBeastTerritory(state, me)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```typescript
+export function isCivUnitInBeastTerritory(state: GameState, civId: string): boolean {
+  if (!state.beasts || state.beasts.mode === 'off') return false;
+  const awakeLairs = Object.values(state.beasts.lairs).filter(l => l.status === 'awake');
+  if (awakeLairs.length === 0) return false;
+  for (const unit of Object.values(state.units)) {
+    if (unit.owner !== civId) continue;
+    for (const lair of awakeLairs) {
+      if (hexDistance(unit.position, lair.position) <= BEAST_DEFINITIONS[lair.beastId].leashRadius) return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 3: Wire into the music director**
+
+Read `src/audio/music-director.ts` and find how the **war layer** activates (a per-state-evaluation boolean → layer gain). Add a `beast-territory` tension layer using the same mechanism, driven by `isCivUnitInBeastTerritory(state, state.currentPlayer)`. For the audio asset: reuse an existing tension/war layer track at reduced gain if the director supports per-layer source reuse; otherwise synthesize a 30s low drone loop with ffmpeg (`sine=55` + brown noise, `afade` in/out, loopable) into the music directory and register it the way era bases are registered. Match whatever the war-layer code does for crossfade timing.
+
+- [ ] **Step 4: Verify + commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-system.test.ts && bash scripts/run-with-mise.sh yarn test`
+Manual: walk a unit into an awake lair radius → tension layer fades in; leave → fades out.
+
+```bash
+git add src/systems/beast-system.ts src/audio tests/systems/beast-system.test.ts public/audio
+git commit -m "feat(beasts): beast-territory music tension layer"
+```
+
+---
+
+### Task 3: AI beast hunting (gated, conservative)
+
+**Files:**
+- Modify: `src/core/types.ts`, `src/ai/basic-ai.ts`
+- Test: `tests/ai/basic-ai-beasts.test.ts`
+
+- [ ] **Step 1: Setting**
+
+`GameSettings` in `src/core/types.ts`:
+
+```typescript
+  aiContestsBeasts?: boolean;   // default false: AI ignores beasts, players keep the glory
+```
+
+(No UI control in this MR — `false` is the family-friendly default; a settings field without UI is not a player-visible dead surface.)
+
+- [ ] **Step 2: Failing tests**
+
+Create `tests/ai/basic-ai-beasts.test.ts`. First read how existing AI tests construct a state and invoke the AI (`ls tests/ai/`, open `basic-ai` tests, copy their harness). Then assert:
+
+```typescript
+// Pseudostructure — use the real AI test harness from the existing file:
+describe('AI vs beasts', () => {
+  it('never attacks a beast when aiContestsBeasts is false (default)', () => {
+    // state: AI warrior adjacent to a 60-health beast_boar; settings.aiContestsBeasts undefined
+    // run the AI decision function; assert no attack order targets the beast unit
+  });
+
+  it('attacks an adjacent beast when enabled AND local strength advantage >= 1.5x', () => {
+    // settings.aiContestsBeasts = true; AI swordsman (str 25 area) vs wounded boar at 30 health
+    // effective beast strength = base * health/100; assert the AI issues the attack
+  });
+
+  it('does not attack when enabled but the beast is healthy and stronger', () => {
+    // AI warrior (str 10) vs full-health basilisk (str 26); assert no attack
+  });
+});
+```
+
+Write these as REAL tests against the actual AI entry point — the existing `transportHostileOwners` set at `src/ai/basic-ai.ts:358` and `aiHostileOwners` at `:506` show where hostility is decided; your tests should drive the same function those lines live in.
+
+- [ ] **Step 3: Implement**
+
+In `src/ai/basic-ai.ts`, where hostile-owner sets are built (lines 358 and 506), beasts join only when contesting is enabled — and attack decisions additionally require a strength advantage:
+
+```typescript
+import { BEAST_OWNER, isBeastUnit } from '@/systems/beast-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';   // already imported? check
+
+// hostile sets (both sites):
+const contestsBeasts = state.settings.aiContestsBeasts === true;
+const hostileOwners = new Set<string>(['barbarian', ...(contestsBeasts ? [BEAST_OWNER] : []), ...(civ.diplomacy?.atWarWith ?? [])]);
+
+// at the attack-decision point for a candidate target:
+if (isBeastUnit(target)) {
+  const myStrength = UNIT_DEFINITIONS[unit.type].strength * (unit.health / 100);
+  const beastStrength = UNIT_DEFINITIONS[target.type].strength * (target.health / 100);
+  if (myStrength < beastStrength * 1.5) continue;   // only clearly-winnable fights
+}
+```
+
+Respect MR5's `canUnitAttackBeast` gate too — verify the AI's attack path flows through attack-targeting (it should after MR5; if it has a parallel direct path, add the gate there).
+
+- [ ] **Step 4: Run, commit**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ai/basic-ai-beasts.test.ts`
+Expected: PASS.
+
+```bash
+git add src/core/types.ts src/ai/basic-ai.ts tests/ai/basic-ai-beasts.test.ts
+git commit -m "feat(beasts): gated opportunistic AI beast hunting"
+```
+
+---
+
+### Task 4: Balance tests (statistical sampling)
+
+**Files:**
+- Create: `tests/systems/beast-balance.test.ts`
+
+Per `.claude/rules/strategy-game-mechanics.md`: balance must be tested at each era with sampling, not single rolls.
+
+- [ ] **Step 1: Write the suite**
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { resolveCombat } from '@/systems/combat-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { generateMap } from '@/systems/map-generator';
+import type { Unit, UnitType } from '@/core/types';
+
+const map = generateMap(20, 20, 'balance-seed');
+
+function unit(type: UnitType, overrides: Partial<Unit> = {}): Unit {
+  return {
+    id: `u-${type}-${Math.floor((overrides.position?.q ?? 1) * 1000)}`, type, owner: 'player',
+    position: { q: 1, r: 1 }, movementPointsLeft: 2, health: 100, experience: 0,
+    hasMoved: false, hasActed: false, isResting: false, ...overrides,
+  } as Unit;
+}
+
+/** Simulate full fights: era-appropriate attacker squad vs one beast; return win rate and avg exchanges. */
+function sampleFights(attackerType: UnitType, squadSize: number, beastType: UnitType, trials: number) {
+  let wins = 0; let totalExchanges = 0;
+  for (let trial = 0; trial < trials; trial++) {
+    let beast = unit(beastType, { owner: 'beasts', position: { q: 2, r: 1 } });
+    let exchanges = 0; let won = false;
+    for (let i = 0; i < squadSize && !won; i++) {
+      let attacker = unit(attackerType);
+      while (attacker.health > 0 && beast.health > 0 && exchanges < 30) {
+        const result = resolveCombat(attacker, beast, map, trial * 7919 + exchanges * 31 + i);
+        beast = { ...beast, health: Math.max(0, beast.health - result.defenderDamage) };
+        attacker = { ...attacker, health: Math.max(0, attacker.health - result.attackerDamage) };
+        exchanges++;
+      }
+      if (beast.health <= 0) won = true;
+    }
+    if (won) wins++;
+    totalExchanges += exchanges;
+  }
+  return { winRate: wins / trials, avgExchanges: totalExchanges / trials };
+}
+
+describe('beast balance bands (N=200 per matchup)', () => {
+  it('era 1: three warriors beat the boar most of the time, one warrior usually dies trying', () => {
+    expect(sampleFights('warrior', 3, 'beast_boar', 200).winRate).toBeGreaterThan(0.7);
+    expect(sampleFights('warrior', 1, 'beast_boar', 200).winRate).toBeLessThan(0.45);
+  });
+
+  it('era 2: a small swordsman squad handles a single wolf comfortably', () => {
+    expect(sampleFights('swordsman', 2, 'beast_wolf', 200).winRate).toBeGreaterThan(0.85);
+  });
+
+  it('era 2-3: the basilisk demands a real squad', () => {
+    expect(sampleFights('swordsman', 1, 'beast_basilisk', 200).winRate).toBeLessThan(0.4);
+    expect(sampleFights('swordsman', 3, 'beast_basilisk', 200).winRate).toBeGreaterThan(0.7);
+  });
+
+  it('era 4: knights can fell the dragon only in numbers', () => {
+    expect(sampleFights('knight', 2, 'beast_dragon', 200).winRate).toBeLessThan(0.5);
+    expect(sampleFights('knight', 4, 'beast_dragon', 200).winRate).toBeGreaterThan(0.6);
+  });
+
+  it('fights resolve in a reasonable exchange count (no 30-exchange slogs on average)', () => {
+    expect(sampleFights('warrior', 3, 'beast_boar', 200).avgExchanges).toBeLessThan(15);
+  });
+});
+```
+
+(Check `CombatResult` field names — `attackerDamage`/`defenderDamage` — against `src/systems/combat-system.ts` and adjust. `resolveCombat`'s 4th arg is the seed.)
+
+- [ ] **Step 2: Run; tune STRENGTH, not the tests, if bands fail**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/systems/beast-balance.test.ts`
+If a band fails, adjust the beast's `strength` in `UNIT_DEFINITIONS` in steps of ±2 until all bands hold. The bands encode the design intent ("3 warriors for the boar", "4 knights for the dragon") — they are the spec; beast stats are the free variable. Document any stat change in the commit message.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/systems/beast-balance.test.ts src/systems/unit-system.ts
+git commit -m "test(beasts): statistical balance bands per era; tune beast strengths"
+```
+
+---
+
+### Task 5: Final verification + PR
+
+- [ ] **Step 1: Gates**
+
+Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test`
+Expected: both exit 0.
+
+- [ ] **Step 2: PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "feat(beasts): MR8 — roars, tension music, AI hunting, balance bands" --body "$(cat <<'EOF'
+## Summary
+- 16 synthesized roar/death SFX (ffmpeg lavfi, credited) wired through UNIT_SFX
+- "Beast territory" music tension layer using the war-layer mechanism
+- AI beast-hunting behind `aiContestsBeasts` (default OFF — players keep the glory), with a 1.5× strength-advantage guard
+- Statistical balance bands per era (N=200 sampling) locking the design intent: 3 warriors ≈ boar, 4 knights ≈ dragon
+
+## Completion
+This closes the Legendary Beasts feature (MR8/8). Index: docs/superpowers/plans/2026-06-11-legendary-beasts-index.md.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+- [ ] SFX files exist, are credited, and the catalog test passes
+- [ ] Music layer activates only for `state.currentPlayer`'s units (hot-seat correct)
+- [ ] AI default leaves beasts alone; enabled AI only takes winnable fights and respects navalOnly
+- [ ] Balance bands green; any stat tuning documented
+- [ ] `grep -rn "Math.random" src/systems/beast-* src/ai/basic-ai.ts` returns nothing


### PR DESCRIPTION
## Summary
Planning docs only — no code changes. Adds full implementation plans for the **Legendary Beasts** feature: unique, named, neutral mythic creatures with terrain-specific lairs, era-gated awakening, territorial (leashed) behavior, and tiered slay rewards. Designed for family hot-seat play: PvE goals that don't pit siblings against each other, with Calm/Off modes.

- `2026-06-11-legendary-beasts-index.md` — tracker: status table, strict MR ordering, the shared design contract (names/types/events that must not drift between MRs), reward ladder, roster
- MR1 — core system + Giant Boar + setup toggle + lair rendering
- MR2 — bestiary panel + sighting flow (per-civ, privacy-masked)
- MR3 — Dire Wolf Pack + Emerald Basilisk + habitat concealment
- MR4 — hoard choice rewards + lair trophies + AI auto-resolve
- MR5 — Sea Serpent + Dune Wurm + naval passability + serpent animation rig
- MR6 — Storm Roc + Swamp Hydra + flight + regeneration + winged rig
- MR7 — Ancient Dragon apex + fire breath + slay ceremony
- MR8 — roar SFX + tension music layer + gated AI hunting + statistical balance bands

Each plan targets a Sonnet 4.5 executor: bite-sized TDD tasks with complete code grounded in verified codebase APIs, exact paths/line refs, run commands with expected output, player truth tables for UI work, and per-MR PR bodies per the incremental-MR rules. Every MR leaves the game fully playable with no dead surfaces.

## Out of scope
All implementation — these are plans. Follow-up candidates deliberately excluded from the series are listed in the index (minor-civ beast quests, beast videos, atlas integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)