### PR TITLE
feat(river): complete movement, combat, and yield mechanics

### DIFF
--- a/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
+++ b/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
@@ -1,0 +1,152 @@
+# River Mechanics Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. The user explicitly requested inline execution with no subagents.
+
+**Goal:** Complete issue 351 by applying the canonical river combat penalty across all combat actors and routing both worked-tile yield paths through the canonical river-yield helper without changing existing farm balance.
+
+**Architecture:** `resolveCombat` derives river crossing directly from `GameMap.rivers`, so player, AI, barbarian, and minor-civilization callers inherit one rule without new parameters. `city-work-system` and `resource-system` delegate only the base river yield to `getRiverYieldBonus`; completed-farm food and existing Irrigation behavior remain caller-owned.
+
+**Tech Stack:** TypeScript, Vitest, Vite, existing system helpers and seeded combat RNG.
+
+---
+
+### Task 1: Prove The Combat Contract
+
+**Files:**
+- Modify: `tests/systems/combat-system.test.ts`
+- Modify: `tests/ai/basic-ai.test.ts`
+
+- [ ] **Step 1: Add deterministic resolver regressions**
+
+Add a small handcrafted plains map fixture with an optional `rivers` array. Use identical warrior units and the same seed to assert that a river segment between attacker and defender lowers `defenderDamage` and raises `attackerDamage`. Add a negative test asserting an unrelated river segment produces exactly the same result as an empty river list.
+
+- [ ] **Step 2: Add the non-human parity regression**
+
+Use `makeAiRebelState()` twice with full-health adjacent warriors. Add the river edge to one state, collect each `combat:resolved` event, and assert the AI's river-crossing result deals less defender damage than the otherwise identical no-river result.
+
+- [ ] **Step 3: Run the new tests and verify RED**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
+```
+
+Expected: the new river comparisons fail because both combat paths currently produce identical damage.
+
+### Task 2: Apply The Canonical Combat Penalty
+
+**Files:**
+- Modify: `src/systems/combat-system.ts`
+- Test: `tests/systems/combat-system.test.ts`
+- Test: `tests/ai/basic-ai.test.ts`
+
+- [ ] **Step 1: Implement the minimal resolver change**
+
+Import `getRiverDefensePenalty` and `isRiverBetween` from `river-system`. After constructing attacker strength, apply:
+
+```ts
+atkStrength *= 1 + getRiverDefensePenalty(
+  isRiverBetween(map, attacker.position, defender.position),
+);
+```
+
+Do not add a context flag or modify any caller. Valid river segments already represent a single crossed edge in either direction, while non-adjacent ranged attacks have no matching segment.
+
+- [ ] **Step 2: Run the focused combat tests and verify GREEN**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
+```
+
+Expected: both files pass, including direct resolver and AI parity coverage.
+
+### Task 3: Characterize And Canonicalize River Yields
+
+**Files:**
+- Modify: `tests/systems/city-work-system.test.ts`
+- Modify: `tests/systems/resource-system.test.ts`
+- Modify: `src/systems/city-work-system.ts`
+- Modify: `src/systems/resource-system.ts`
+
+- [ ] **Step 1: Add exact preservation regressions**
+
+In `city-work-system.test.ts`, compare otherwise identical completed farms with and without `hasRiver`. With no completed technologies, assert the river variant has exactly `+1 gold`, exactly `+1 food`, and unchanged production. Keep the existing Irrigation tests as the production-gate coverage.
+
+In `resource-system.test.ts`, compare otherwise identical cities working completed farms with and without `hasRiver`. Assert the river city total has exactly `+1 gold` and exactly `+1 food`, with production unchanged.
+
+- [ ] **Step 2: Run the characterization tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
+```
+
+Expected: PASS, confirming the pre-refactor balance contract.
+
+- [ ] **Step 3: Replace both inline base-river bonuses**
+
+In `city-work-system.ts`, import `getRiverYieldBonus`, call `addYield(total, getRiverYieldBonus(tile.hasRiver))`, and leave completed-farm food plus Irrigation production under the existing `tile.hasRiver` condition.
+
+In `resource-system.ts`, import `getRiverYieldBonus`, obtain its `ResourceYield`, and add all four fields to the city total before the existing completed-farm food branch. Do not move farm food into the river helper or add technology inputs to it.
+
+- [ ] **Step 4: Re-run the yield tests and verify GREEN**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
+```
+
+Expected: PASS with exact yield preservation.
+
+### Task 4: Verify The Complete Change
+
+**Files:**
+- Review: all changed files
+
+- [ ] **Step 1: Run source policy checks**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts
+```
+
+Expected: exit 0 with no rule violations.
+
+- [ ] **Step 2: Run all targeted regressions together**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts
+```
+
+Expected: all selected test files pass.
+
+- [ ] **Step 3: Run TypeScript and production build verification**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: TypeScript and Vite production build exit 0.
+
+- [ ] **Step 4: Run the full suite**
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: all Vitest files and hook smoke tests pass.
+
+- [ ] **Step 5: Inspect committed and uncommitted scope**
+
+Run `git diff --stat origin/main...HEAD`, `git diff --stat`, `git diff origin/main...HEAD`, and `git diff`. Confirm the branch contains only issue 351 documentation, combat wiring, canonical river-yield wiring, and their regressions.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md docs/superpowers/plans/2026-06-11-river-mechanics-completion.md src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/ai/basic-ai.test.ts
+git commit -m "feat(river): complete combat and yield mechanics"
+```

--- a/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
+++ b/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
@@ -4,7 +4,7 @@
 
 **Goal:** Complete issue 351 by applying the canonical river combat penalty across all combat actors and routing both worked-tile yield paths through the canonical river-yield helper without changing existing farm balance.
 
-**Architecture:** `resolveCombat` derives river crossing directly from `GameMap.rivers`, so player, AI, barbarian, and minor-civilization callers inherit one rule without new parameters. `city-work-system` and `resource-system` delegate only the base river yield to `getRiverYieldBonus`; completed-farm food and existing Irrigation behavior remain caller-owned.
+**Architecture:** `calculateCombatStrengths` derives river crossing directly from `GameMap.rivers`; both `resolveCombat` and the live combat preview consume its breakdown, so every actor and the player-facing forecast share one rule without new caller flags. `city-work-system` and `resource-system` delegate only the base river yield to `getRiverYieldBonus`; completed-farm food and existing Irrigation behavior remain caller-owned.
 
 **Tech Stack:** TypeScript, Vitest, Vite, existing system helpers and seeded combat RNG.
 
@@ -111,7 +111,7 @@ Expected: PASS with exact yield preservation.
 - [x] **Step 1: Run source policy checks**
 
 ```bash
-scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts
+scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts src/systems/unit-system.ts src/systems/unit-movement-system.ts src/ui/combat-preview.ts src/main.ts
 ```
 
 Expected: exit 0 with no rule violations.
@@ -119,7 +119,7 @@ Expected: exit 0 with no rule violations.
 - [x] **Step 2: Run all targeted regressions together**
 
 ```bash
-./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts tests/ui/combat-preview.test.ts
 ```
 
 Expected: all selected test files pass.
@@ -150,3 +150,55 @@ Run `git diff --stat origin/main...HEAD`, `git diff --stat`, `git diff origin/ma
 git add docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md docs/superpowers/plans/2026-06-11-river-mechanics-completion.md src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/ai/basic-ai.test.ts
 git commit -m "feat(river): complete combat and yield mechanics"
 ```
+
+### Review Correction: Keep Combat Preview Honest
+
+**Files:**
+- Modify: `src/systems/combat-system.ts`
+- Modify: `src/main.ts`
+- Create: `src/ui/combat-preview.ts`
+- Modify: `tests/systems/combat-system.test.ts`
+- Create: `tests/ui/combat-preview.test.ts`
+
+- [x] **Step 1: Add a failing shared-strength regression**
+
+Prove the strength breakdown exposes `-0.2` for a river crossing, reduces attacker strength by exactly 20 percent, preserves defender strength, and recognizes a river segment stored in reverse direction.
+
+- [x] **Step 2: Share strength calculation between resolution and preview**
+
+Move veterancy, terrain, wonder, fortification, civilization, and river modifiers into `calculateCombatStrengths`. Use its returned strengths in `resolveCombat` and in the live Combat Preview.
+
+- [x] **Step 3: Add and wire a tested player-facing warning**
+
+Use `formatCombatPreviewDetails` to show `-20% river crossing` only when the shared breakdown reports the penalty. Preserve terrain and defender-health details.
+
+- [x] **Step 4: Run focused review regressions**
+
+```bash
+./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts tests/ui/combat-preview.test.ts
+```
+
+Expected: all focused combat and presentation tests pass.
+
+### Review Correction: Canonicalize Movement Step Cost
+
+**Files:**
+- Modify: `src/systems/unit-system.ts`
+- Modify: `src/systems/unit-movement-system.ts`
+- Modify: `tests/systems/unit-system.test.ts`
+
+- [x] **Step 1: Add failing route and blocker regressions**
+
+Prove pathfinding avoids a two-river shortcut when a cheaper detour exists, Bridge Building restores the shortcut, and blocker messaging reports insufficient movement when river cost is the deciding factor.
+
+- [x] **Step 2: Introduce one movement-step cost helper**
+
+Implement `getMovementStepCost` with terrain, unit domain, naval exemption, Bridge Building, and river-edge handling. Use it from pathfinding, movement range, blocker messaging, and execution.
+
+- [x] **Step 3: Run focused movement regressions**
+
+```bash
+./scripts/run-with-mise.sh yarn vitest run tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts
+```
+
+Expected: all movement routing, highlighting, validation, and execution tests pass.

--- a/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
+++ b/docs/superpowers/plans/2026-06-11-river-mechanics-completion.md
@@ -16,20 +16,20 @@
 - Modify: `tests/systems/combat-system.test.ts`
 - Modify: `tests/ai/basic-ai.test.ts`
 
-- [ ] **Step 1: Add deterministic resolver regressions**
+- [x] **Step 1: Add deterministic resolver regressions**
 
 Add a small handcrafted plains map fixture with an optional `rivers` array. Use identical warrior units and the same seed to assert that a river segment between attacker and defender lowers `defenderDamage` and raises `attackerDamage`. Add a negative test asserting an unrelated river segment produces exactly the same result as an empty river list.
 
-- [ ] **Step 2: Add the non-human parity regression**
+- [x] **Step 2: Add the non-human parity regression**
 
 Use `makeAiRebelState()` twice with full-health adjacent warriors. Add the river edge to one state, collect each `combat:resolved` event, and assert the AI's river-crossing result deals less defender damage than the otherwise identical no-river result.
 
-- [ ] **Step 3: Run the new tests and verify RED**
+- [x] **Step 3: Run the new tests and verify RED**
 
 Run:
 
 ```bash
-./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
 ```
 
 Expected: the new river comparisons fail because both combat paths currently produce identical damage.
@@ -41,7 +41,7 @@ Expected: the new river comparisons fail because both combat paths currently pro
 - Test: `tests/systems/combat-system.test.ts`
 - Test: `tests/ai/basic-ai.test.ts`
 
-- [ ] **Step 1: Implement the minimal resolver change**
+- [x] **Step 1: Implement the minimal resolver change**
 
 Import `getRiverDefensePenalty` and `isRiverBetween` from `river-system`. After constructing attacker strength, apply:
 
@@ -53,12 +53,12 @@ atkStrength *= 1 + getRiverDefensePenalty(
 
 Do not add a context flag or modify any caller. Valid river segments already represent a single crossed edge in either direction, while non-adjacent ranged attacks have no matching segment.
 
-- [ ] **Step 2: Run the focused combat tests and verify GREEN**
+- [x] **Step 2: Run the focused combat tests and verify GREEN**
 
 Run:
 
 ```bash
-./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/ai/basic-ai.test.ts
 ```
 
 Expected: both files pass, including direct resolver and AI parity coverage.
@@ -71,34 +71,34 @@ Expected: both files pass, including direct resolver and AI parity coverage.
 - Modify: `src/systems/city-work-system.ts`
 - Modify: `src/systems/resource-system.ts`
 
-- [ ] **Step 1: Add exact preservation regressions**
+- [x] **Step 1: Add exact preservation regressions**
 
 In `city-work-system.test.ts`, compare otherwise identical completed farms with and without `hasRiver`. With no completed technologies, assert the river variant has exactly `+1 gold`, exactly `+1 food`, and unchanged production. Keep the existing Irrigation tests as the production-gate coverage.
 
 In `resource-system.test.ts`, compare otherwise identical cities working completed farms with and without `hasRiver`. Assert the river city total has exactly `+1 gold` and exactly `+1 food`, with production unchanged.
 
-- [ ] **Step 2: Run the characterization tests**
+- [x] **Step 2: Run the characterization tests**
 
 Run:
 
 ```bash
-./scripts/run-with-mise.sh yarn test --run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
 ```
 
 Expected: PASS, confirming the pre-refactor balance contract.
 
-- [ ] **Step 3: Replace both inline base-river bonuses**
+- [x] **Step 3: Replace both inline base-river bonuses**
 
 In `city-work-system.ts`, import `getRiverYieldBonus`, call `addYield(total, getRiverYieldBonus(tile.hasRiver))`, and leave completed-farm food plus Irrigation production under the existing `tile.hasRiver` condition.
 
 In `resource-system.ts`, import `getRiverYieldBonus`, obtain its `ResourceYield`, and add all four fields to the city total before the existing completed-farm food branch. Do not move farm food into the river helper or add technology inputs to it.
 
-- [ ] **Step 4: Re-run the yield tests and verify GREEN**
+- [x] **Step 4: Re-run the yield tests and verify GREEN**
 
 Run:
 
 ```bash
-./scripts/run-with-mise.sh yarn test --run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts
 ```
 
 Expected: PASS with exact yield preservation.
@@ -108,7 +108,7 @@ Expected: PASS with exact yield preservation.
 **Files:**
 - Review: all changed files
 
-- [ ] **Step 1: Run source policy checks**
+- [x] **Step 1: Run source policy checks**
 
 ```bash
 scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts
@@ -116,15 +116,15 @@ scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/ci
 
 Expected: exit 0 with no rule violations.
 
-- [ ] **Step 2: Run all targeted regressions together**
+- [x] **Step 2: Run all targeted regressions together**
 
 ```bash
-./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts
+./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts
 ```
 
 Expected: all selected test files pass.
 
-- [ ] **Step 3: Run TypeScript and production build verification**
+- [x] **Step 3: Run TypeScript and production build verification**
 
 ```bash
 ./scripts/run-with-mise.sh yarn build
@@ -132,7 +132,7 @@ Expected: all selected test files pass.
 
 Expected: TypeScript and Vite production build exit 0.
 
-- [ ] **Step 4: Run the full suite**
+- [x] **Step 4: Run the full suite**
 
 ```bash
 ./scripts/run-with-mise.sh yarn test
@@ -140,11 +140,11 @@ Expected: TypeScript and Vite production build exit 0.
 
 Expected: all Vitest files and hook smoke tests pass.
 
-- [ ] **Step 5: Inspect committed and uncommitted scope**
+- [x] **Step 5: Inspect committed and uncommitted scope**
 
 Run `git diff --stat origin/main...HEAD`, `git diff --stat`, `git diff origin/main...HEAD`, and `git diff`. Confirm the branch contains only issue 351 documentation, combat wiring, canonical river-yield wiring, and their regressions.
 
-- [ ] **Step 6: Commit the implementation**
+- [x] **Step 6: Commit the implementation**
 
 ```bash
 git add docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md docs/superpowers/plans/2026-06-11-river-mechanics-completion.md src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/ai/basic-ai.test.ts

--- a/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
+++ b/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
@@ -1,0 +1,73 @@
+# River Mechanics Completion Design
+
+**Issue:** [#351](https://github.com/a1flecke/conquestoria/issues/351)
+
+## Context
+
+Issue 351 was written against an older repository state. On current `origin/main`, the following acceptance criteria are already implemented:
+
+- Land units pay one additional movement point for each crossed river edge.
+- Naval units are exempt from the river movement surcharge.
+- Civilizations with `bridge-building` ignore the surcharge.
+- Bridge Building exists in the exploration track at era 3 and requires `road-building`.
+- Unit movement regressions cover the surcharge, the technology exemption, forced march, and naval movement.
+
+The remaining work is to apply the existing combat helper and make the existing river-yield helper canonical without changing current farm balance.
+
+## Gameplay Contract
+
+### Combat
+
+When an attacker and defender occupy adjacent hexes separated by a river edge, the attacker's effective combat strength is reduced by 20 percent. `getRiverDefensePenalty(true)` is the canonical source of the modifier.
+
+The penalty is determined inside `resolveCombat` from the attacker's position, the defender's position, and `GameMap.rivers`. Callers do not pass a separate crossing flag. This makes the rule apply consistently to player combat, AI combat, turn-manager combat, and minor-civilization combat.
+
+Attacks that do not cross a river receive no river modifier. Ranged attacks cannot cross a single map edge between non-adjacent units, so they receive no river-crossing penalty under this design.
+
+### Worked-Tile Yields
+
+`getRiverYieldBonus(tile.hasRiver)` supplies the canonical base river yield and is added to the worked tile total. Its current contract remains `+1 gold` for a river tile and no bonus otherwise.
+
+A completed farm on a river tile continues to receive an unconditional `+1 food`. This behavior is intentionally preserved and is not gated by Bridge Building or Irrigation. The existing Irrigation rule also remains unchanged: a completed riverside farm owned by a civilization with Irrigation receives `+1 production`.
+
+## Architecture
+
+`src/systems/combat-system.ts` will import `isRiverBetween` and `getRiverDefensePenalty`. During strength calculation, it will multiply attacker strength by `1 + penalty`, where the penalty is derived from the two unit positions. Keeping this inside the canonical combat resolver avoids duplicated logic and ensures all actors use the same rule.
+
+`src/systems/city-work-system.ts` will import `getRiverYieldBonus` and add its result through the existing `addYield` helper. Farm-specific food and Irrigation production remain in `city-work-system.ts` because they depend on improvement state and civilization technology rather than river presence alone.
+
+No types, save schema, events, UI, renderer, movement logic, or technology definitions change.
+
+## Testing
+
+`tests/systems/combat-system.test.ts` will prove both sides of the combat boundary with deterministic seeds:
+
+- an otherwise identical river-crossing attack deals less damage to the defender than a non-crossing attack;
+- a river segment elsewhere on the map does not affect combat.
+
+`tests/systems/city-work-system.test.ts` will prove the refactor preserves visible game balance:
+
+- a river tile receives the canonical `+1 gold` bonus;
+- a completed riverside farm still receives `+1 food` without Bridge Building or Irrigation;
+- Irrigation still adds only its existing `+1 production` bonus.
+
+Existing river-system and movement-system tests remain unchanged unless they expose a regression during implementation.
+
+## Verification
+
+After implementation, run:
+
+- `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts`
+- `./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts`
+- `./scripts/run-with-mise.sh yarn build`
+- `./scripts/run-with-mise.sh yarn test`
+
+Review both `git diff --stat origin/main...HEAD` and `git diff --stat`, then inspect the corresponding full diffs before reporting completion.
+
+## Out Of Scope
+
+- Changing the Bridge Building technology or its tech-tree placement.
+- Changing river movement costs or forced-march behavior.
+- Gating river-farm food behind any technology.
+- Adding river combat preview text or renderer effects.
+- Applying a river-edge modifier to non-adjacent ranged attacks.

--- a/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
+++ b/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
@@ -34,7 +34,7 @@ A completed farm on a river tile continues to receive an unconditional `+1 food`
 
 `src/systems/combat-system.ts` will import `isRiverBetween` and `getRiverDefensePenalty`. During strength calculation, it will multiply attacker strength by `1 + penalty`, where the penalty is derived from the two unit positions. Keeping this inside the canonical combat resolver avoids duplicated logic and ensures all actors use the same rule.
 
-`src/systems/city-work-system.ts` will import `getRiverYieldBonus` and add its result through the existing `addYield` helper. Farm-specific food and Irrigation production remain in `city-work-system.ts` because they depend on improvement state and civilization technology rather than river presence alone.
+`src/systems/city-work-system.ts` will import `getRiverYieldBonus` and add its result through the existing `addYield` helper. `src/systems/resource-system.ts`, which supplies live turn yields and projected city totals, will use the same helper instead of maintaining a second inline base-river bonus. Farm-specific food remains local to both callers because it depends on improvement state rather than river presence alone. The existing Irrigation production rule remains in `city-work-system.ts`; expanding its live-economy wiring is outside this issue's approved contract.
 
 No types, save schema, events, UI, renderer, movement logic, or technology definitions change.
 
@@ -45,11 +45,15 @@ No types, save schema, events, UI, renderer, movement logic, or technology defin
 - an otherwise identical river-crossing attack deals less damage to the defender than a non-crossing attack;
 - a river segment elsewhere on the map does not affect combat.
 
+`tests/ai/basic-ai.test.ts` will prove a non-human attack receives the same penalty through the live AI combat path.
+
 `tests/systems/city-work-system.test.ts` will prove the refactor preserves visible game balance:
 
 - a river tile receives the canonical `+1 gold` bonus;
 - a completed riverside farm still receives `+1 food` without Bridge Building or Irrigation;
 - Irrigation still adds only its existing `+1 production` bonus.
+
+`tests/systems/resource-system.test.ts` will characterize the matching live city-yield behavior so refactoring that path to the canonical helper cannot change river gold or completed riverside farm food.
 
 Existing river-system and movement-system tests remain unchanged unless they expose a regression during implementation.
 
@@ -57,8 +61,8 @@ Existing river-system and movement-system tests remain unchanged unless they exp
 
 After implementation, run:
 
-- `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts`
-- `./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts`
+- `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts`
+- `./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts`
 - `./scripts/run-with-mise.sh yarn build`
 - `./scripts/run-with-mise.sh yarn test`
 

--- a/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
+++ b/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
@@ -62,7 +62,7 @@ Existing river-system and movement-system tests remain unchanged unless they exp
 After implementation, run:
 
 - `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts`
-- `./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts`
+- `./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts`
 - `./scripts/run-with-mise.sh yarn build`
 - `./scripts/run-with-mise.sh yarn test`
 

--- a/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
+++ b/docs/superpowers/specs/2026-06-11-river-mechanics-completion-design.md
@@ -14,13 +14,15 @@ Issue 351 was written against an older repository state. On current `origin/main
 
 The remaining work is to apply the existing combat helper and make the existing river-yield helper canonical without changing current farm balance.
 
+Review also requires the already-present movement rule to use one step-cost calculation across pathfinding, reachable highlights, blocker messaging, and execution. This prevents the UI and executor from disagreeing about river cost and lets route selection avoid unnecessarily expensive crossings.
+
 ## Gameplay Contract
 
 ### Combat
 
 When an attacker and defender occupy adjacent hexes separated by a river edge, the attacker's effective combat strength is reduced by 20 percent. `getRiverDefensePenalty(true)` is the canonical source of the modifier.
 
-The penalty is determined inside `resolveCombat` from the attacker's position, the defender's position, and `GameMap.rivers`. Callers do not pass a separate crossing flag. This makes the rule apply consistently to player combat, AI combat, turn-manager combat, and minor-civilization combat.
+The penalty is determined by the canonical combat-strength calculation from the attacker's position, the defender's position, and `GameMap.rivers`. `resolveCombat` and the player-facing combat preview consume that same calculation. Callers do not pass a separate crossing flag. This makes the rule apply consistently to player combat, AI combat, turn-manager combat, and minor-civilization combat.
 
 Attacks that do not cross a river receive no river modifier. Ranged attacks cannot cross a single map edge between non-adjacent units, so they receive no river-crossing penalty under this design.
 
@@ -32,9 +34,11 @@ A completed farm on a river tile continues to receive an unconditional `+1 food`
 
 ## Architecture
 
-`src/systems/combat-system.ts` will import `isRiverBetween` and `getRiverDefensePenalty`. During strength calculation, it will multiply attacker strength by `1 + penalty`, where the penalty is derived from the two unit positions. Keeping this inside the canonical combat resolver avoids duplicated logic and ensures all actors use the same rule.
+`src/systems/combat-system.ts` will import `isRiverBetween` and `getRiverDefensePenalty`. `calculateCombatStrengths` will multiply attacker strength by `1 + penalty`, where the penalty is derived from the two unit positions, and will return the modifier breakdown used by both combat resolution and presentation. `src/main.ts` will render the resulting attacker strength and a visible river-crossing warning through `src/ui/combat-preview.ts`. Keeping resolution and preview on one calculation avoids duplicated logic and misleading pre-attack information.
 
 `src/systems/city-work-system.ts` will import `getRiverYieldBonus` and add its result through the existing `addYield` helper. `src/systems/resource-system.ts`, which supplies live turn yields and projected city totals, will use the same helper instead of maintaining a second inline base-river bonus. Farm-specific food remains local to both callers because it depends on improvement state rather than river presence alone. The existing Irrigation production rule remains in `city-work-system.ts`; expanding its live-economy wiring is outside this issue's approved contract.
+
+`src/systems/unit-system.ts` will own `getMovementStepCost`, including terrain, naval domain, Bridge Building, and river-edge rules. Pathfinding, movement range, blocker messaging, and `src/systems/unit-movement-system.ts` execution will all call it.
 
 No types, save schema, events, UI, renderer, movement logic, or technology definitions change.
 
@@ -46,6 +50,10 @@ No types, save schema, events, UI, renderer, movement logic, or technology defin
 - a river segment elsewhere on the map does not affect combat.
 
 `tests/ai/basic-ai.test.ts` will prove a non-human attack receives the same penalty through the live AI combat path.
+
+`tests/ui/combat-preview.test.ts` will prove the player-facing detail text shows the river penalty only when the shared strength breakdown reports one.
+
+`tests/systems/unit-system.test.ts` will prove pathfinding prefers a river-free detour when cheaper, Bridge Building restores the shorter route, and blocker messaging reports river-caused insufficient movement.
 
 `tests/systems/city-work-system.test.ts` will prove the refactor preserves visible game balance:
 
@@ -61,8 +69,8 @@ Existing river-system and movement-system tests remain unchanged unless they exp
 
 After implementation, run:
 
-- `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts`
-- `./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts`
+- `scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/systems/city-work-system.ts src/systems/resource-system.ts src/systems/unit-system.ts src/systems/unit-movement-system.ts src/ui/combat-preview.ts src/main.ts`
+- `./scripts/run-with-mise.sh yarn vitest run tests/systems/combat-system.test.ts tests/systems/city-work-system.test.ts tests/systems/resource-system.test.ts tests/systems/river-system.test.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai.test.ts tests/ui/combat-preview.test.ts`
 - `./scripts/run-with-mise.sh yarn build`
 - `./scripts/run-with-mise.sh yarn test`
 
@@ -73,5 +81,5 @@ Review both `git diff --stat origin/main...HEAD` and `git diff --stat`, then ins
 - Changing the Bridge Building technology or its tech-tree placement.
 - Changing river movement costs or forced-march behavior.
 - Gating river-farm food behind any technology.
-- Adding river combat preview text or renderer effects.
+- Adding river renderer effects.
 - Applying a river-edge modifier to non-adjacent ranged attacks.

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
 import { createWorkerReplacementConfirmPanel, createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
-import { resolveCombat, getTerrainDefenseBonus, selectDefenderForAttack } from '@/systems/combat-system';
+import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
@@ -63,6 +63,7 @@ import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-ch
 import { showCampaignSetup } from '@/ui/campaign-setup';
 import { showGameModeSelect } from '@/ui/game-mode-select';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
+import { formatCombatPreviewDetails } from '@/ui/combat-preview';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { canInspectUnitForViewer } from '@/systems/viewer-intel';
 import {
@@ -2425,10 +2426,17 @@ function handleHexTap(rawCoord: HexCoord): void {
       const defender = defenderEntry[1];
       const atkDef = UNIT_DEFINITIONS[unit.type];
       const defDef = UNIT_DEFINITIONS[defender.type];
-      const atkStr = Math.round(atkDef.strength * (unit.health / 100));
-      const defTile = gameState.map.tiles[hexKey(defender.position)];
-      const terrainBonus = defTile ? getTerrainDefenseBonus(defTile.terrain) : 0;
-      const defStr = Math.round(defDef.strength * (defender.health / 100) * (1 + terrainBonus));
+      const attackerBonus = currentCivDef()?.bonusEffect;
+      const defenderBonus = resolveCivDefinition(
+        gameState,
+        gameState.civilizations[defender.owner]?.civType ?? '',
+      )?.bonusEffect;
+      const strengthPreview = calculateCombatStrengths(unit, defender, gameState.map, {
+        attackerBonus,
+        defenderBonus,
+      });
+      const atkStr = Math.round(strengthPreview.attackerStrength);
+      const defStr = Math.round(strengthPreview.defenderStrength);
 
       const isBarbarian = defender.owner === 'barbarian';
       const isMinorCiv = defender.owner.startsWith('mc-');
@@ -2472,7 +2480,7 @@ function handleHexTap(rawCoord: HexCoord): void {
 
         const info = document.createElement('div');
         info.style.cssText = 'font-size:10px;opacity:0.6;margin-bottom:8px;';
-        info.textContent = `${ownerName} · HP: ${defender.health}/100${terrainBonus > 0 ? ` · +${Math.round(terrainBonus * 100)}% terrain` : ''}`;
+        info.textContent = formatCombatPreviewDetails(ownerName, defender.health, strengthPreview);
         previewDiv.appendChild(info);
 
         const hostileStackSize = visibleHostileUnitEntriesAtKey(key).length;

--- a/src/systems/city-work-system.ts
+++ b/src/systems/city-work-system.ts
@@ -4,6 +4,7 @@ import { getImprovementYieldBonus } from './improvement-system';
 import { calculateCityYields, TERRAIN_YIELDS } from './resource-system';
 import { getWonderDefinition } from './wonder-definitions';
 import { getWonderYieldBonus } from './wonder-system';
+import { getRiverYieldBonus } from './river-system';
 import {
   buildCityWorkClaimIndex,
   canonicalizeCityCoord,
@@ -42,16 +43,14 @@ export function calculateWorkedTileYield(state: GameState, coord: HexCoord): Res
   const terrain = TERRAIN_YIELDS[tile.terrain] ?? total;
   addYield(total, terrain);
 
-  if (tile.hasRiver) {
-    total.gold += 1;
-    if (tile.improvement === 'farm' && tile.improvementTurnsLeft === 0) {
-      total.food += 1;
-      const completedTechs = tile.owner != null
-        ? (state.civilizations[tile.owner]?.techState.completed ?? [])
-        : [];
-      if (completedTechs.includes('irrigation')) {
-        total.production += 1;
-      }
+  addYield(total, getRiverYieldBonus(tile.hasRiver));
+  if (tile.hasRiver && tile.improvement === 'farm' && tile.improvementTurnsLeft === 0) {
+    total.food += 1;
+    const completedTechs = tile.owner != null
+      ? (state.civilizations[tile.owner]?.techState.completed ?? [])
+      : [];
+    if (completedTechs.includes('irrigation')) {
+      total.production += 1;
     }
   }
 

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -47,6 +47,66 @@ export interface CombatContext {
   defenderInFortifiedCity?: boolean;
 }
 
+export interface CombatStrengthBreakdown {
+  attackerStrength: number;
+  defenderStrength: number;
+  terrainDefenseBonus: number;
+  riverAttackPenalty: number;
+}
+
+export function calculateCombatStrengths(
+  attacker: Unit,
+  defender: Unit,
+  map: GameMap,
+  context?: CombatContext,
+): CombatStrengthBreakdown {
+  const attackerDefinition = UNIT_DEFINITIONS[attacker.type];
+  const defenderDefinition = UNIT_DEFINITIONS[defender.type];
+  const riverAttackPenalty = getRiverDefensePenalty(
+    isRiverBetween(map, attacker.position, defender.position),
+  );
+  let attackerStrength = attackerDefinition.strength
+    * (attacker.health / 100)
+    * (1 + getVeterancyCombatModifier(attacker))
+    * (1 + riverAttackPenalty);
+  let defenderStrength = defenderDefinition.strength
+    * (defender.health / 100)
+    * (1 + getVeterancyCombatModifier(defender));
+  const defenderTile = map.tiles[hexKey(defender.position)];
+  const terrainDefenseBonus = defenderTile ? getTerrainDefenseBonus(defenderTile.terrain) : 0;
+
+  if (defenderTile) {
+    defenderStrength *= 1 + terrainDefenseBonus;
+    if (defenderTile.wonder) {
+      defenderStrength *= 1 + getWonderCombatBonus(defenderTile.wonder);
+    }
+    if (context?.defenderBonus?.type === 'homeland_defense' && defenderTile.owner === defender.owner) {
+      defenderStrength *= 1 + context.defenderBonus.defenseBonus;
+    }
+    if (context?.defenderBonus?.type === 'forest_guardians' && defenderTile.terrain === 'forest') {
+      defenderStrength *= 1 + context.defenderBonus.defenseBonus;
+    }
+  }
+
+  if (defender.isFortified) {
+    defenderStrength *= 1.25;
+  }
+
+  if (
+    context?.attackerBonus?.type === 'coastal_science'
+    && (attacker.type === 'galley' || attacker.type === 'trireme')
+  ) {
+    attackerStrength *= 1 + context.attackerBonus.navalCombatBonus;
+  }
+
+  return {
+    attackerStrength,
+    defenderStrength,
+    terrainDefenseBonus,
+    riverAttackPenalty,
+  };
+}
+
 function canCounterAttackAtDistance(defender: Unit, distance: number): boolean {
   const definition = UNIT_DEFINITIONS[defender.type];
   const profile = definition.attackProfile;
@@ -69,42 +129,9 @@ export function resolveCombat(
     rngState = (rngState * 48271) % 2147483647;
     return rngState / 2147483647;
   };
-  const atkDef = UNIT_DEFINITIONS[attacker.type];
-  const defDef = UNIT_DEFINITIONS[defender.type];
-
-  let atkStrength = atkDef.strength * (attacker.health / 100) * (1 + getVeterancyCombatModifier(attacker));
-  let defStrength = defDef.strength * (defender.health / 100) * (1 + getVeterancyCombatModifier(defender));
-
-  atkStrength *= 1 + getRiverDefensePenalty(
-    isRiverBetween(map, attacker.position, defender.position),
-  );
-
-  // Terrain defense bonus
-  const defTile = map.tiles[hexKey(defender.position)];
-  if (defTile) {
-    defStrength *= (1 + getTerrainDefenseBonus(defTile.terrain));
-    // Wonder defense bonus
-    if (defTile.wonder) {
-      defStrength *= (1 + getWonderCombatBonus(defTile.wonder));
-    }
-    if (context?.defenderBonus?.type === 'homeland_defense' && defTile.owner === defender.owner) {
-      defStrength *= (1 + context.defenderBonus.defenseBonus);
-    }
-    if (context?.defenderBonus?.type === 'forest_guardians' && defTile.terrain === 'forest') {
-      defStrength *= (1 + context.defenderBonus.defenseBonus);
-    }
-  }
-
-  if (defender.isFortified) {
-    defStrength *= 1.25;
-  }
-
-  if (
-    context?.attackerBonus?.type === 'coastal_science'
-    && (attacker.type === 'galley' || attacker.type === 'trireme')
-  ) {
-    atkStrength *= (1 + context.attackerBonus.navalCombatBonus);
-  }
+  const strengths = calculateCombatStrengths(attacker, defender, map, context);
+  const atkStrength = strengths.attackerStrength;
+  const defStrength = strengths.defenderStrength;
 
   // Non-combat units auto-lose
   if (defStrength === 0) {

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -3,6 +3,7 @@ import { hexDistance, hexKey } from './hex-utils';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { getWonderCombatBonus } from './wonder-system';
 import { getVeterancyCombatModifier } from './combat-reward-system';
+import { getRiverDefensePenalty, isRiverBetween } from './river-system';
 
 export function getTerrainDefenseBonus(terrain: string): number {
   const bonuses: Record<string, number> = {
@@ -73,6 +74,10 @@ export function resolveCombat(
 
   let atkStrength = atkDef.strength * (attacker.health / 100) * (1 + getVeterancyCombatModifier(attacker));
   let defStrength = defDef.strength * (defender.health / 100) * (1 + getVeterancyCombatModifier(defender));
+
+  atkStrength *= 1 + getRiverDefensePenalty(
+    isRiverBetween(map, attacker.position, defender.position),
+  );
 
   // Terrain defense bonus
   const defTile = map.tiles[hexKey(defender.position)];

--- a/src/systems/resource-system.ts
+++ b/src/systems/resource-system.ts
@@ -6,6 +6,7 @@ import { getTotalAdjacencyYields } from './adjacency-system';
 import { getWonderYieldBonus } from './wonder-system';
 import { getWonderDefinition } from './wonder-definitions';
 import { canonicalizeCityCoord } from './city-territory-system';
+import { getRiverYieldBonus } from './river-system';
 
 export const TERRAIN_YIELDS: Record<string, ResourceYield> = {
   grassland:  { food: 2, production: 0, gold: 0, science: 0 },
@@ -48,9 +49,13 @@ export function calculateCityYields(city: City, map: GameMap, bonusEffect?: CivB
     yields.gold += terrainYield.gold;
     yields.science += terrainYield.science;
 
-    // River bonus
+    const riverBonus = getRiverYieldBonus(tile.hasRiver);
+    yields.food += riverBonus.food;
+    yields.production += riverBonus.production;
+    yields.gold += riverBonus.gold;
+    yields.science += riverBonus.science;
+
     if (tile.hasRiver) {
-      yields.gold += 1;
       if (tile.improvement === 'farm' && tile.improvementTurnsLeft === 0) {
         yields.food += 1;
       }

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -6,6 +6,7 @@ import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import {
   moveUnit,
   getMovementCostForUnitInContext,
+  getMovementStepCost,
   findPath,
   UNIT_DEFINITIONS,
   type UnitMovementBlockerCode,
@@ -17,7 +18,6 @@ import { isAtWar } from '@/systems/diplomacy-system';
 import { removeRouteForUnit } from '@/systems/trade-system';
 import { buildUnitOccupancy, getUnitIdsAtCoord } from '@/systems/unit-occupancy';
 import { syncTransportCargoPositions } from '@/systems/transport-system';
-import { isRiverBetween } from '@/systems/river-system';
 
 export interface ExecuteUnitMoveOptions {
   actor: 'player' | 'automation' | 'ai';
@@ -283,15 +283,7 @@ export function validateUnitMove(
 
   let cost = 0;
   for (let i = 1; i < path.length; i++) {
-    const stepTile = state.map.tiles[hexKey(path[i])];
-    cost += stepTile ? getMovementCostForUnitInContext(unit, stepTile.terrain, { completedTechs }) : Infinity;
-    if (
-      domain !== 'naval' &&
-      !completedTechs.includes('bridge-building') &&
-      isRiverBetween(state.map, path[i - 1]!, path[i]!)
-    ) {
-      cost += 1;
-    }
+    cost += getMovementStepCost(unit, state.map, path[i - 1]!, path[i]!, { completedTechs });
   }
 
   const distance = state.map.wrapsHorizontally

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -429,6 +429,26 @@ export function getMovementCostForUnitInContext(
   return getMovementCost(terrain);
 }
 
+export function getMovementStepCost(
+  unit: Unit,
+  map: GameMap,
+  from: HexCoord,
+  to: HexCoord,
+  context: UnitMovementContext = {},
+): number {
+  const tile = map.tiles[hexKey(to)];
+  if (!tile) return Infinity;
+
+  const terrainCost = getMovementCostForUnitInContext(unit, tile.terrain, context);
+  if (terrainCost === Infinity) return Infinity;
+
+  const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+  const crossesUnbridgedRiver = domain !== 'naval'
+    && !context.completedTechs?.includes('bridge-building')
+    && isRiverBetween(map, from, to);
+  return terrainCost + (crossesUnbridgedRiver ? 1 : 0);
+}
+
 function isPassableForUnit(
   terrain: string,
   domain: 'land' | 'naval',
@@ -497,10 +517,16 @@ export function getMovementBlockerReason(
     return { code: 'unreachable', message: 'No passable route to that tile.' };
   }
 
-  const pathCost = path.slice(1).reduce((total, coord) => {
-    const stepTile = map.tiles[hexKey(coord)];
-    return total + (stepTile ? getMovementCostForUnitInContext(unit, stepTile.terrain, { completedTechs: options.completedTechs }) : Infinity);
-  }, 0);
+  const pathCost = path.slice(1).reduce(
+    (total, coord, index) => total + getMovementStepCost(
+      unit,
+      map,
+      path[index]!,
+      coord,
+      { completedTechs: options.completedTechs },
+    ),
+    0,
+  );
 
   // Forced march: a unit can always move to an adjacent passable tile with ≥1 move remaining.
   const isAdjacentMove = path.length === 2;
@@ -547,14 +573,7 @@ export function getMovementRange(
       const tile = map.tiles[key];
       if (!tile || !isPassableForUnitInContext(unit, tile.terrain, options)) continue;
 
-      const terrainCost = getMovementCostForUnitInContext(unit, tile.terrain, options);
-      const riverPenalty =
-        UNIT_DEFINITIONS[unit.type]?.domain !== 'naval' &&
-        !options.completedTechs?.includes('bridge-building') &&
-        isRiverBetween(map, current.coord, neighbor)
-          ? 1
-          : 0;
-      const cost = terrainCost + riverPenalty;
+      const cost = getMovementStepCost(unit, map, current.coord, neighbor, options);
       const remaining = current.remaining - cost;
 
       // Forced march: if this is a direct neighbor of the start position and the unit
@@ -671,7 +690,7 @@ export function findPath(
       const tile = map.tiles[nKey];
       if (!tile) continue;
       const stepCost = options.unit
-        ? getMovementCostForUnitInContext(options.unit, tile.terrain, options)
+        ? getMovementStepCost(options.unit, map, currentCoord, neighbor, options)
         : getMovementCostForUnit(tile.terrain, domain);
       if (stepCost === Infinity) continue;
 

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -1,0 +1,16 @@
+import type { CombatStrengthBreakdown } from '@/systems/combat-system';
+
+export function formatCombatPreviewDetails(
+  ownerName: string,
+  defenderHealth: number,
+  preview: CombatStrengthBreakdown,
+): string {
+  const details = [ownerName, `HP: ${defenderHealth}/100`];
+  if (preview.terrainDefenseBonus > 0) {
+    details.push(`+${Math.round(preview.terrainDefenseBonus * 100)}% terrain`);
+  }
+  if (preview.riverAttackPenalty < 0) {
+    details.push(`${Math.round(preview.riverAttackPenalty * 100)}% river crossing`);
+  }
+  return details.join(' | ');
+}

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1281,6 +1281,34 @@ describe('processAITurn', () => {
     expect(newState.units['unit-rebel']).toBeUndefined();
   });
 
+  it('applies the river crossing combat penalty to AI attacks', () => {
+    const openState = makeAiRebelState();
+    const crossingState = makeAiRebelState();
+    openState.units['unit-rebel'].health = 100;
+    crossingState.units['unit-rebel'].health = 100;
+    crossingState.map.rivers = [{
+      from: crossingState.units['unit-ai'].position,
+      to: crossingState.units['unit-rebel'].position,
+    }];
+
+    const resolveAttack = (state: GameState) => {
+      const events: GameEvents['combat:resolved'][] = [];
+      const bus = new EventBus();
+      bus.on('combat:resolved', event => events.push(event));
+
+      processAITurn(state, 'ai-1', bus);
+
+      expect(events).toHaveLength(1);
+      return events[0]!.result;
+    };
+
+    const openResult = resolveAttack(openState);
+    const crossingResult = resolveAttack(crossingState);
+
+    expect(crossingResult.defenderDamage).toBeLessThan(openResult.defenderDamage);
+    expect(crossingResult.attackerDamage).toBeGreaterThan(openResult.attackerDamage);
+  });
+
   it('awards AI units combat rewards when they defeat an adjacent enemy', () => {
     const state = makeAiRebelState();
     state.units['unit-ai'] = { ...state.units['unit-ai'], health: 60 };

--- a/tests/systems/city-work-system.test.ts
+++ b/tests/systems/city-work-system.test.ts
@@ -494,6 +494,17 @@ describe('river production bonus', () => {
     return { state, coord };
   }
 
+  it('preserves the base river gold and completed farm food bonuses without tech', () => {
+    const { state, coord } = riverFarmState([]);
+    const riverYield = calculateWorkedTileYield(state, coord);
+    state.map.tiles[hexKey(coord)]!.hasRiver = false;
+    const inlandYield = calculateWorkedTileYield(state, coord);
+
+    expect(riverYield.gold).toBe(inlandYield.gold + 1);
+    expect(riverYield.food).toBe(inlandYield.food + 1);
+    expect(riverYield.production).toBe(inlandYield.production);
+  });
+
   it('gives no production bonus without irrigation tech', () => {
     const { state, coord } = riverFarmState([]);
     expect(calculateWorkedTileYield(state, coord).production).toBe(0);

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -1,4 +1,9 @@
-import { resolveCombat, getTerrainDefenseBonus, selectDefenderForAttack } from '@/systems/combat-system';
+import {
+  calculateCombatStrengths,
+  getTerrainDefenseBonus,
+  resolveCombat,
+  selectDefenderForAttack,
+} from '@/systems/combat-system';
 import type { GameMap } from '@/core/types';
 import { createUnit } from '@/systems/unit-system';
 import { generateMap } from '@/systems/map-generator';
@@ -88,6 +93,19 @@ describe('resolveCombat', () => {
 
     expect(crossingResult.defenderDamage).toBeLessThan(openResult.defenderDamage);
     expect(crossingResult.attackerDamage).toBeGreaterThan(openResult.attackerDamage);
+  });
+
+  it('exposes the river penalty through the shared combat preview data', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 0, r: 0 }, mkC());
+    const defender = createUnit('warrior', 'p2', { q: 1, r: 0 }, mkC());
+    const openPreview = calculateCombatStrengths(attacker, defender, makeRiverCombatMap());
+    const crossingPreview = calculateCombatStrengths(attacker, defender, makeRiverCombatMap([
+      { from: defender.position, to: attacker.position },
+    ]));
+
+    expect(crossingPreview.riverAttackPenalty).toBe(-0.2);
+    expect(crossingPreview.attackerStrength).toBeCloseTo(openPreview.attackerStrength * 0.8);
+    expect(crossingPreview.defenderStrength).toBe(openPreview.defenderStrength);
   });
 
   it('ignores river segments that are not between the combatants', () => {

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -5,6 +5,41 @@ import { generateMap } from '@/systems/map-generator';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
+function makeRiverCombatMap(
+  rivers: GameMap['rivers'] = [],
+): GameMap {
+  return {
+    width: 4,
+    height: 4,
+    wrapsHorizontally: false,
+    rivers,
+    tiles: {
+      '0,0': {
+        coord: { q: 0, r: 0 },
+        terrain: 'plains',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: 'p1',
+        improvementTurnsLeft: 0,
+        hasRiver: true,
+        wonder: null,
+      },
+      '1,0': {
+        coord: { q: 1, r: 0 },
+        terrain: 'plains',
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        owner: 'p2',
+        improvementTurnsLeft: 0,
+        hasRiver: true,
+        wonder: null,
+      },
+    },
+  };
+}
+
 describe('resolveCombat', () => {
   let map: GameMap;
 
@@ -41,6 +76,29 @@ describe('resolveCombat', () => {
     const veteranResult = resolveCombat(veteran, defender, map, 2);
 
     expect(veteranResult.defenderDamage).toBeGreaterThan(recruitResult.defenderDamage);
+  });
+
+  it('reduces attacker effectiveness when combat crosses a river edge', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 0, r: 0 }, mkC());
+    const defender = createUnit('warrior', 'p2', { q: 1, r: 0 }, mkC());
+    const openResult = resolveCombat(attacker, defender, makeRiverCombatMap(), 42);
+    const crossingResult = resolveCombat(attacker, defender, makeRiverCombatMap([
+      { from: attacker.position, to: defender.position },
+    ]), 42);
+
+    expect(crossingResult.defenderDamage).toBeLessThan(openResult.defenderDamage);
+    expect(crossingResult.attackerDamage).toBeGreaterThan(openResult.attackerDamage);
+  });
+
+  it('ignores river segments that are not between the combatants', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 0, r: 0 }, mkC());
+    const defender = createUnit('warrior', 'p2', { q: 1, r: 0 }, mkC());
+    const openResult = resolveCombat(attacker, defender, makeRiverCombatMap(), 42);
+    const unrelatedRiverResult = resolveCombat(attacker, defender, makeRiverCombatMap([
+      { from: { q: 2, r: 2 }, to: { q: 3, r: 2 } },
+    ]), 42);
+
+    expect(unrelatedRiverResult).toEqual(openResult);
   });
 
   it('defender on hills takes less damage than on plains (same seed)', () => {

--- a/tests/systems/resource-system.test.ts
+++ b/tests/systems/resource-system.test.ts
@@ -138,6 +138,31 @@ describe('calculateCityYields', () => {
     expect(yields.production).toBeGreaterThanOrEqual(2);
   });
 
+  it('preserves river gold and completed farm food in live city yields', () => {
+    const map = generateMap(10, 10, 'river-farm-live-yield');
+    const center = { q: 2, r: 2 };
+    const worked = { q: 2, r: 3 };
+    map.tiles['2,2'] = {
+      coord: center, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    map.tiles['2,3'] = {
+      coord: worked, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'farm', owner: 'player', improvementTurnsLeft: 0, hasRiver: true, wonder: null,
+    };
+    const city = foundCity('player', center, map, mkC());
+    city.population = 1;
+    city.workedTiles = [worked];
+
+    const riverYield = calculateCityYields(city, map);
+    map.tiles['2,3'].hasRiver = false;
+    const inlandYield = calculateCityYields(city, map);
+
+    expect(riverYield.gold).toBe(inlandYield.gold + 1);
+    expect(riverYield.food).toBe(inlandYield.food + 1);
+    expect(riverYield.production).toBe(inlandYield.production);
+  });
+
   it('counts a transferred completed farm only for the new owner after reassignment', () => {
     const state = createNewGame(undefined, 'farm-transfer-yield', 'small');
     state.cities = {};

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -71,6 +71,38 @@ function createStackCorridorMap(): GameMap {
   };
 }
 
+function createRiverDetourMap(): GameMap {
+  const coords = [
+    { q: 0, r: 0 },
+    { q: 1, r: 0 },
+    { q: 2, r: 0 },
+    { q: 0, r: 1 },
+    { q: 1, r: 1 },
+  ];
+  const tiles = Object.fromEntries(coords.map(coord => [hexKey(coord), {
+    coord,
+    terrain: 'grassland' as const,
+    elevation: 'lowland' as const,
+    resource: null,
+    improvement: 'none' as const,
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  }]));
+
+  return {
+    width: 3,
+    height: 2,
+    wrapsHorizontally: false,
+    tiles,
+    rivers: [
+      { from: { q: 0, r: 0 }, to: { q: 1, r: 0 } },
+      { from: { q: 1, r: 0 }, to: { q: 2, r: 0 } },
+    ],
+  };
+}
+
 describe('createUnit', () => {
   it('creates a unit with full movement points', () => {
     const unit = createUnit('warrior', 'p1', { q: 5, r: 5 }, mkC());
@@ -298,6 +330,15 @@ describe('getMovementBlockerReason', () => {
     expect(getMovementBlockerReason(scout, { q: 2, r: 0 }, map)?.code).toBe('insufficient-movement');
   });
 
+  it('explains when a river crossing makes a multi-step move too expensive', () => {
+    const map = createStackCorridorMap();
+    const warrior = createUnit('warrior', 'player', { q: 1, r: 1 }, mkC());
+    map.rivers = [{ from: { q: 1, r: 1 }, to: { q: 2, r: 1 } }];
+
+    expect(getMovementBlockerReason(warrior, { q: 3, r: 1 }, map)?.code)
+      .toBe('insufficient-movement');
+  });
+
   it('uses the scouting message for an unexplored tapped tile', () => {
     const map = createWrappedGrasslandMap(5, 5);
     const scout = createUnit('scout', 'player', { q: 2, r: 1 }, mkC());
@@ -355,6 +396,36 @@ describe('findPath', () => {
     const wrappedMap = createWrappedGrasslandMap(5, 3);
     const path = findPath({ q: 0, r: 1 }, { q: 4, r: 1 }, wrappedMap);
     expect(path).toEqual([{ q: 0, r: 1 }, { q: 4, r: 1 }]);
+  });
+
+  it('prefers a longer route when it avoids more expensive river crossings', () => {
+    const riverMap = createRiverDetourMap();
+    const warrior = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+
+    const path = findPath(warrior.position, { q: 2, r: 0 }, riverMap, 'land', { unit: warrior });
+
+    expect(path).toEqual([
+      { q: 0, r: 0 },
+      { q: 0, r: 1 },
+      { q: 1, r: 1 },
+      { q: 2, r: 0 },
+    ]);
+  });
+
+  it('takes the shorter river route after Bridge Building removes the surcharge', () => {
+    const riverMap = createRiverDetourMap();
+    const warrior = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+
+    const path = findPath(warrior.position, { q: 2, r: 0 }, riverMap, 'land', {
+      unit: warrior,
+      completedTechs: ['bridge-building'],
+    });
+
+    expect(path).toEqual([
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+    ]);
   });
 });
 

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatCombatPreviewDetails } from '@/ui/combat-preview';
+
+describe('formatCombatPreviewDetails', () => {
+  it('shows the river crossing penalty when present', () => {
+    const details = formatCombatPreviewDetails('Rival', 80, {
+      attackerStrength: 8,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0.25,
+      riverAttackPenalty: -0.2,
+    });
+
+    expect(details).toContain('Rival');
+    expect(details).toContain('HP: 80/100');
+    expect(details).toContain('+25% terrain');
+    expect(details).toContain('-20% river crossing');
+  });
+
+  it('does not claim a river crossing without a penalty', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 10,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+    });
+
+    expect(details).not.toContain('river crossing');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #351.

- Applies the canonical +1 river-crossing movement cost, with Bridge Building and naval exemptions consistently shared by pathfinding, reachable highlights, blocker messaging, and movement execution.
- Applies the canonical -20% attacker strength penalty when combat crosses a river edge across player, AI, barbarian, and minor-civilization combat paths.
- Uses the same combat-strength breakdown for resolution and the live Combat Preview, including a visible `-20% river crossing` warning.
- Routes worked-tile and live city base river yields through `getRiverYieldBonus` while preserving unconditional completed riverside-farm food.

## Review fixes

- Combat resolution applied the river penalty while Combat Preview still displayed unpenalized strength.
- Movement range understood river cost, but pathfinding and blocker messaging did not, which could choose an expensive route or fail to explain an unavailable destination.

## Gameplay impact

River crossings now create consistent tactical friction in movement and combat. Bridge Building removes movement friction without removing the combat penalty. Existing riverside farm food and Irrigation behavior remain unchanged.

## Tests

- Source rule checks passed for all changed source files.
- Targeted Vitest: 8 files, 167 tests passed.
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test`: 247 files, 3511 tests passed plus hook smoke tests.

## UI

Combat Preview now shows the river penalty in text and uses the same effective strengths as combat resolution.