### PR TITLE
feat(beasts): MR2 — bestiary panel + sighting flow

### DIFF
--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
@@ -12,8 +12,8 @@
 
 | MR | Plan file | Ships | Status |
 |---|---|---|---|
-| MR1 | [2026-06-11-legendary-beasts-mr1-core-boar.md](2026-06-11-legendary-beasts-mr1-core-boar.md) | Core system + Giant Boar + setup toggle + lair rendering | ☐ not started |
-| MR2 | [2026-06-11-legendary-beasts-mr2-bestiary.md](2026-06-11-legendary-beasts-mr2-bestiary.md) | Bestiary panel + sighting banner + per-civ sighting tracking | ☐ not started |
+| MR1 | [2026-06-11-legendary-beasts-mr1-core-boar.md](2026-06-11-legendary-beasts-mr1-core-boar.md) | Core system + Giant Boar + setup toggle + lair rendering | ✅ merged |
+| MR2 | [2026-06-11-legendary-beasts-mr2-bestiary.md](2026-06-11-legendary-beasts-mr2-bestiary.md) | Bestiary panel + sighting banner + per-civ sighting tracking | ◐ in progress ([PR #366](https://github.com/a1flecke/conquestoria/pull/366)) |
 | MR3 | [2026-06-11-legendary-beasts-mr3-wolves-basilisk.md](2026-06-11-legendary-beasts-mr3-wolves-basilisk.md) | Dire Wolf Pack + Emerald Basilisk + habitat concealment | ☐ not started |
 | MR4 | [2026-06-11-legendary-beasts-mr4-hoard-trophies.md](2026-06-11-legendary-beasts-mr4-hoard-trophies.md) | Hoard choice panel + lair trophies + AI auto-resolve | ☐ not started |
 | MR5 | [2026-06-11-legendary-beasts-mr5-serpent-wurm.md](2026-06-11-legendary-beasts-mr5-serpent-wurm.md) | Sea Serpent + Dune Wurm + naval passability + `beast-serpent` rig | ☐ not started |

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1231,6 +1231,7 @@ export interface GameEvents {
   'barbarian:spawned': { campId: string; unitId: string };
   'beast:awakened': { lairId: string; beastId: BeastId; position: HexCoord };
   'beast:slain': { lairId: string; beastId: BeastId; slayerCivId: string; slayerUnitId: string; goldAwarded: number };
+  'beast:sighted': { beastId: BeastId; civId: string };
   'barbarian:camp-destroyed': { campId: string; reward: number };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,9 @@ import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-o
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, placeBeastLairs } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
+import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
+import { createBestiaryPanel } from '@/ui/bestiary-panel';
 import { autoSave, loadAutoSave, saveGame, loadGame, listSaves, loadSettings, saveSettings } from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX, routeSfxThrough } from '@/audio/sfx';
@@ -342,6 +345,7 @@ function createUI(): void {
         },
         onNewGame: () => showGameModeSelection(),
         autoSave: () => autoSave(gameState),
+        onOpenBestiary: () => openBestiary(),
         // Spec 3: per-channel audio settings
         audioSettings: {
           masterVolume:   currentMasterVolume,   // tracked in memory across menu reopens
@@ -376,6 +380,26 @@ function createUI(): void {
       });
     },
   });
+}
+
+function openBestiary(): void {
+  createBestiaryPanel(uiLayer, getBestiaryEntriesForPlayer(gameState, gameState.currentPlayer), {
+    onClose: () => {},
+    slayerNameFor: (civId) => gameState.civilizations[civId]?.name ?? civId,
+  });
+}
+
+function scanBeastSightings(): void {
+  const visTiles = currentCiv()?.visibility?.tiles;
+  if (!visTiles) return;
+  const visibleKeys = new Set(
+    Object.entries(visTiles).filter(([, v]) => v === 'visible').map(([k]) => k),
+  );
+  const sightingResult = recordBeastSightings(gameState, gameState.currentPlayer, visibleKeys);
+  gameState = sightingResult.state;
+  for (const beastId of sightingResult.newSightings) {
+    bus.emit('beast:sighted', { beastId, civId: gameState.currentPlayer });
+  }
 }
 
 function openWonderAtlas(initialWonderId?: string): void {
@@ -1874,6 +1898,8 @@ function refreshCurrentPlayerVisibility(): void {
   for (const contact of syncCivilizationContactsFromVisibility(gameState, gameState.currentPlayer)) {
     bus.emit('civilization:first-contact', contact);
   }
+
+  scanBeastSightings();
 }
 
 function getUnitTurnFlow() {
@@ -2824,6 +2850,8 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
           centerOnCurrentPlayer();
           renderLoop.setGameState(gameState);
           updateHUD();
+          // Scan for beast sightings at turn start (units may have gained vision from prior turns)
+          scanBeastSightings();
           // Compute audio-state snapshot for the incoming player (Spec 3 hot-seat drift fix)
           const nextCiv = gameState.civilizations[nextSlotId];
           const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
@@ -3258,6 +3286,20 @@ bus.on('beast:slain', ({ beastId, slayerCivId, goldAwarded }) => {
   // Prominent toast for the current player
   if (slayerCivId === gameState.currentPlayer) {
     showNotification(`🏆 ${def.name} slain! +${goldAwarded} gold`, 'success');
+  }
+});
+
+bus.on('beast:sighted', ({ beastId, civId }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  appendToCivLog(civId, def.sightingFlavor, 'info');
+  if (civId === gameState.currentPlayer) {
+    showBeastSightingBanner(uiLayer, {
+      name: def.name,
+      flavor: def.sightingFlavor,
+      unitType: def.unitType,
+      onContinue: () => {},
+      onOpenBestiary: () => openBestiary(),
+    });
   }
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3291,7 +3291,9 @@ bus.on('beast:slain', ({ beastId, slayerCivId, goldAwarded }) => {
 
 bus.on('beast:sighted', ({ beastId, civId }) => {
   const def = BEAST_DEFINITIONS[beastId];
-  appendToCivLog(civId, def.sightingFlavor, 'info');
+  const lair = gameState.beasts ? Object.values(gameState.beasts.lairs).find(l => l.beastId === beastId) : undefined;
+  const target = lair ? { kind: 'map' as const, coord: lair.position, label: def.name } : undefined;
+  appendToCivLog(civId, def.sightingFlavor, 'info', target);
   if (civId === gameState.currentPlayer) {
     showBeastSightingBanner(uiLayer, {
       name: def.name,

--- a/src/renderer/sprites/sprite-system.tsx
+++ b/src/renderer/sprites/sprite-system.tsx
@@ -1,5 +1,7 @@
 export type FactionPalette = { dark: string; mid: string; bright: string; trim: string };
 
+export const NEUTRAL_FACTION_PALETTE: FactionPalette = { dark: '#555', mid: '#888', bright: '#bbb', trim: '#999' };
+
 export const LOD_SPRITE_ZOOM_THRESHOLD = 0.4;
 
 // --- HSL helpers ---

--- a/src/systems/beast-presentation.ts
+++ b/src/systems/beast-presentation.ts
@@ -1,0 +1,81 @@
+import type { BeastId, GameState, UnitType } from '@/core/types';
+import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
+import { BEAST_OWNER } from '@/systems/beast-system';
+import { hexKey } from '@/systems/hex-utils';
+
+export type BestiaryStatus = 'unknown' | 'sighted' | 'slain';
+
+/** Viewer-safe bestiary entry. Unknown entries carry ONLY the hint — masking every other field is a privacy contract. */
+export interface BestiaryEntry {
+  lairId: string;
+  status: BestiaryStatus;
+  hint: string;
+  name?: string;
+  unitType?: UnitType;
+  tier?: number;
+  sightingFlavor?: string;
+  slainBy?: string;
+  slainTurn?: number;
+}
+
+export function getBestiaryEntriesForPlayer(state: GameState, civId: string): BestiaryEntry[] {
+  if (!state.beasts) return [];
+  const sighted = new Set(state.beasts.sightingsByCiv[civId] ?? []);
+  return Object.values(state.beasts.lairs).map(lair => {
+    const def = BEAST_DEFINITIONS[lair.beastId];
+    const isSlain = lair.status === 'slain' || lair.status === 'claimed';
+    if (isSlain) {
+      return {
+        lairId: lair.id, status: 'slain' as const, hint: def.dangerHint,
+        name: def.name, unitType: def.unitType, tier: def.tier,
+        slainBy: lair.slainBy, slainTurn: lair.slainTurn,
+      };
+    }
+    if (sighted.has(lair.beastId)) {
+      return {
+        lairId: lair.id, status: 'sighted' as const, hint: def.dangerHint,
+        name: def.name, unitType: def.unitType, tier: def.tier,
+        sightingFlavor: def.sightingFlavor,
+      };
+    }
+    return { lairId: lair.id, status: 'unknown' as const, hint: def.dangerHint };
+  });
+}
+
+/**
+ * Transition-owned sighting scan: returns the beasts that became sighted in THIS call.
+ * visibleTileKeys: hexKey set of tiles currently visible to civId.
+ */
+export function recordBeastSightings(
+  state: GameState,
+  civId: string,
+  visibleTileKeys: ReadonlySet<string>,
+): { state: GameState; newSightings: BeastId[] } {
+  if (!state.beasts) return { state, newSightings: [] };
+  const already = new Set(state.beasts.sightingsByCiv[civId] ?? []);
+  const newSightings: BeastId[] = [];
+
+  for (const unit of Object.values(state.units)) {
+    if (unit.owner !== BEAST_OWNER) continue;
+    if (!visibleTileKeys.has(hexKey(unit.position))) continue;
+    const lair = Object.values(state.beasts.lairs).find(l => l.unitIds.includes(unit.id));
+    if (!lair || already.has(lair.beastId)) continue;
+    already.add(lair.beastId);
+    newSightings.push(lair.beastId);
+  }
+
+  if (newSightings.length === 0) return { state, newSightings };
+  return {
+    state: {
+      ...state,
+      beasts: {
+        ...state.beasts,
+        sightingsByCiv: {
+          ...state.beasts.sightingsByCiv,
+          [civId]: [...(state.beasts.sightingsByCiv[civId] ?? []), ...newSightings],
+        },
+      },
+    },
+    newSightings,
+  };
+}

--- a/src/ui/beast-sighting-banner.ts
+++ b/src/ui/beast-sighting-banner.ts
@@ -1,0 +1,61 @@
+import type { UnitType } from '@/core/types';
+import type { FactionPalette } from '@/renderer/sprites/sprite-system';
+import { createGameButton } from '@/ui/ui-kit';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+
+export interface BeastSightingBannerOptions {
+  name: string;
+  flavor: string;
+  unitType: UnitType;
+  onContinue: () => void;
+  onOpenBestiary: () => void;
+}
+
+const NEUTRAL_PALETTE: FactionPalette = { dark: '#555', mid: '#888', bright: '#bbb', trim: '#999' };
+
+export function showBeastSightingBanner(container: HTMLElement, options: BeastSightingBannerOptions): HTMLElement {
+  container.querySelector('#beast-sighting-banner')?.remove();
+
+  const overlay = document.createElement('div');
+  overlay.id = 'beast-sighting-banner';
+  overlay.style.cssText = 'position:absolute;inset:0;background:rgba(8,8,18,0.9);z-index:60;display:flex;align-items:center;justify-content:center;';
+
+  const card = document.createElement('div');
+  card.style.cssText = 'max-width:340px;background:#1a1a2e;border:2px solid #e8c170;border-radius:14px;padding:20px;text-align:center;';
+
+  const kicker = document.createElement('div');
+  kicker.textContent = 'BEAST SIGHTED';
+  kicker.style.cssText = 'font-size:12px;letter-spacing:3px;color:#d1a35a;margin-bottom:8px;';
+  card.appendChild(kicker);
+
+  const art = document.createElement('div');
+  art.style.cssText = 'width:120px;height:120px;margin:0 auto 8px;';
+  const sprite = UNIT_SPRITE_CATALOG[options.unitType];
+  // Sprite SVGs are module-authored strings, never game/user input — safe for innerHTML.
+  art.innerHTML = sprite({ palette: NEUTRAL_PALETTE, svgOnly: true });
+  card.appendChild(art);
+
+  const nameEl = document.createElement('h2');
+  nameEl.textContent = options.name;
+  nameEl.style.cssText = 'font-size:22px;color:#e8c170;margin:0 0 8px;';
+  card.appendChild(nameEl);
+
+  const flavorEl = document.createElement('p');
+  flavorEl.textContent = options.flavor;
+  flavorEl.style.cssText = 'font-size:13px;opacity:0.85;margin:0 0 16px;';
+  card.appendChild(flavorEl);
+
+  const buttonRow = document.createElement('div');
+  buttonRow.style.cssText = 'display:flex;gap:8px;justify-content:center;';
+  const continueButton = createGameButton('Continue', 'primary');
+  continueButton.addEventListener('click', () => { overlay.remove(); options.onContinue(); });
+  buttonRow.appendChild(continueButton);
+  const bestiaryButton = createGameButton('Open Bestiary', 'secondary');
+  bestiaryButton.addEventListener('click', () => { overlay.remove(); options.onOpenBestiary(); });
+  buttonRow.appendChild(bestiaryButton);
+  card.appendChild(buttonRow);
+
+  overlay.appendChild(card);
+  container.appendChild(overlay);
+  return overlay;
+}

--- a/src/ui/beast-sighting-banner.ts
+++ b/src/ui/beast-sighting-banner.ts
@@ -1,5 +1,5 @@
 import type { UnitType } from '@/core/types';
-import type { FactionPalette } from '@/renderer/sprites/sprite-system';
+import { NEUTRAL_FACTION_PALETTE } from '@/renderer/sprites/sprite-system';
 import { createGameButton } from '@/ui/ui-kit';
 import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
 
@@ -11,14 +11,12 @@ export interface BeastSightingBannerOptions {
   onOpenBestiary: () => void;
 }
 
-const NEUTRAL_PALETTE: FactionPalette = { dark: '#555', mid: '#888', bright: '#bbb', trim: '#999' };
-
 export function showBeastSightingBanner(container: HTMLElement, options: BeastSightingBannerOptions): HTMLElement {
   container.querySelector('#beast-sighting-banner')?.remove();
 
   const overlay = document.createElement('div');
   overlay.id = 'beast-sighting-banner';
-  overlay.style.cssText = 'position:absolute;inset:0;background:rgba(8,8,18,0.9);z-index:60;display:flex;align-items:center;justify-content:center;';
+  overlay.style.cssText = 'position:absolute;inset:0;background:rgba(8,8,18,0.9);z-index:65;display:flex;align-items:center;justify-content:center;';
 
   const card = document.createElement('div');
   card.style.cssText = 'max-width:340px;background:#1a1a2e;border:2px solid #e8c170;border-radius:14px;padding:20px;text-align:center;';
@@ -32,7 +30,7 @@ export function showBeastSightingBanner(container: HTMLElement, options: BeastSi
   art.style.cssText = 'width:120px;height:120px;margin:0 auto 8px;';
   const sprite = UNIT_SPRITE_CATALOG[options.unitType];
   // Sprite SVGs are module-authored strings, never game/user input — safe for innerHTML.
-  art.innerHTML = sprite({ palette: NEUTRAL_PALETTE, svgOnly: true });
+  art.innerHTML = sprite({ palette: NEUTRAL_FACTION_PALETTE, svgOnly: true });
   card.appendChild(art);
 
   const nameEl = document.createElement('h2');

--- a/src/ui/bestiary-panel.ts
+++ b/src/ui/bestiary-panel.ts
@@ -1,0 +1,109 @@
+import type { BestiaryEntry } from '@/systems/beast-presentation';
+import type { FactionPalette } from '@/renderer/sprites/sprite-system';
+import { createGameButton } from '@/ui/ui-kit';
+import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
+
+export interface BestiaryPanelCallbacks {
+  onClose: () => void;
+  slayerNameFor: (civId: string) => string;
+}
+
+const NEUTRAL_PALETTE: FactionPalette = { dark: '#555', mid: '#888', bright: '#bbb', trim: '#999' };
+
+const TIER_LABELS: Record<number, string> = {
+  1: 'Dangerous', 2: 'Fearsome', 3: 'Terrifying', 4: 'Legendary',
+};
+
+export function createBestiaryPanel(
+  container: HTMLElement,
+  entries: BestiaryEntry[],
+  callbacks: BestiaryPanelCallbacks,
+): HTMLElement {
+  container.querySelector('#bestiary-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'bestiary-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:40;padding:16px;overflow:auto;';
+
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:4px;';
+  const title = document.createElement('h2');
+  title.textContent = 'Bestiary';
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0;';
+  header.appendChild(title);
+  const closeButton = createGameButton('✕', 'close');
+  closeButton.dataset.action = 'close';
+  closeButton.setAttribute('aria-label', 'Close panel');
+  closeButton.addEventListener('click', () => { panel.remove(); callbacks.onClose(); });
+  header.appendChild(closeButton);
+  panel.appendChild(header);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Legendary beasts of this land. Sight them to learn their nature; slay them to claim their hoards.';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  panel.appendChild(intro);
+
+  for (const entry of entries) {
+    const card = document.createElement('section');
+    card.dataset.bestiaryEntry = entry.lairId;
+    card.style.cssText = 'display:flex;gap:12px;align-items:center;margin-bottom:12px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+
+    const art = document.createElement('div');
+    art.style.cssText = 'width:72px;height:72px;flex:none;display:flex;align-items:center;justify-content:center;';
+    if (entry.status === 'unknown') {
+      art.textContent = '❓';
+      art.style.fontSize = '40px';
+    } else if (entry.unitType) {
+      const sprite = UNIT_SPRITE_CATALOG[entry.unitType];
+      const holder = document.createElement('div');
+      holder.style.cssText = 'width:72px;height:72px;';
+      // Sprite SVGs are module-authored strings, never game/user input — safe for innerHTML.
+      holder.innerHTML = sprite({ palette: NEUTRAL_PALETTE, svgOnly: true });
+      art.appendChild(holder);
+    }
+    card.appendChild(art);
+
+    const body = document.createElement('div');
+    if (entry.status === 'unknown') {
+      const label = document.createElement('div');
+      label.textContent = 'Unknown Beast';
+      label.style.cssText = 'font-size:15px;color:#e8c170;';
+      body.appendChild(label);
+      const hint = document.createElement('div');
+      hint.textContent = entry.hint;
+      hint.style.cssText = 'font-size:12px;opacity:0.75;font-style:italic;';
+      body.appendChild(hint);
+    } else {
+      const label = document.createElement('div');
+      label.textContent = entry.name ?? '';
+      label.style.cssText = 'font-size:15px;color:#e8c170;';
+      body.appendChild(label);
+      const statusLine = document.createElement('div');
+      if (entry.status === 'slain') {
+        const slayer = entry.slainBy ? callbacks.slayerNameFor(entry.slainBy) : '';
+        statusLine.textContent = `Slain — by ${slayer || 'an unknown power'}, turn ${entry.slainTurn ?? '?'}`;
+        statusLine.style.cssText = 'font-size:12px;color:#9ad17b;';
+      } else {
+        statusLine.textContent = `Sighted · ${TIER_LABELS[entry.tier ?? 1]}`;
+        statusLine.style.cssText = 'font-size:12px;color:#d1a35a;';
+      }
+      body.appendChild(statusLine);
+      const hint = document.createElement('div');
+      hint.textContent = entry.hint;
+      hint.style.cssText = 'font-size:12px;opacity:0.75;font-style:italic;';
+      body.appendChild(hint);
+    }
+    card.appendChild(body);
+    panel.appendChild(card);
+  }
+
+  if (entries.length === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No legendary beasts dwell in this land.';
+    empty.style.cssText = 'font-size:13px;opacity:0.7;';
+    panel.appendChild(empty);
+  }
+
+  container.appendChild(panel);
+  return panel;
+}

--- a/src/ui/bestiary-panel.ts
+++ b/src/ui/bestiary-panel.ts
@@ -1,5 +1,5 @@
 import type { BestiaryEntry } from '@/systems/beast-presentation';
-import type { FactionPalette } from '@/renderer/sprites/sprite-system';
+import { NEUTRAL_FACTION_PALETTE } from '@/renderer/sprites/sprite-system';
 import { createGameButton } from '@/ui/ui-kit';
 import { UNIT_SPRITE_CATALOG } from '@/renderer/sprites/sprite-catalog';
 
@@ -7,8 +7,6 @@ export interface BestiaryPanelCallbacks {
   onClose: () => void;
   slayerNameFor: (civId: string) => string;
 }
-
-const NEUTRAL_PALETTE: FactionPalette = { dark: '#555', mid: '#888', bright: '#bbb', trim: '#999' };
 
 const TIER_LABELS: Record<number, string> = {
   1: 'Dangerous', 2: 'Fearsome', 3: 'Terrifying', 4: 'Legendary',
@@ -58,7 +56,7 @@ export function createBestiaryPanel(
       const holder = document.createElement('div');
       holder.style.cssText = 'width:72px;height:72px;';
       // Sprite SVGs are module-authored strings, never game/user input — safe for innerHTML.
-      holder.innerHTML = sprite({ palette: NEUTRAL_PALETTE, svgOnly: true });
+      holder.innerHTML = sprite({ palette: NEUTRAL_FACTION_PALETTE, svgOnly: true });
       art.appendChild(holder);
     }
     card.appendChild(art);

--- a/src/ui/pause-menu-panel.ts
+++ b/src/ui/pause-menu-panel.ts
@@ -20,6 +20,7 @@ export interface PauseMenuCallbacks {
   onSave: (slotId: string, name: string) => Promise<void>;
   onNewGame: () => void;
   autoSave: () => Promise<void>;
+  onOpenBestiary: () => void;
   // Spec 3: per-channel audio settings
   audioSettings: AudioSettingsSnapshot;
   onAudioSettingChange: (key: keyof AudioSettingsSnapshot, value: number | boolean) => void;
@@ -185,6 +186,15 @@ function buildMainView(
     }, 'save');
   });
   body.appendChild(saveBtn);
+
+  const bestiaryBtn = createGameButton('Bestiary', 'secondary');
+  bestiaryBtn.style.width = '100%';
+  bestiaryBtn.style.marginBottom = '8px';
+  bestiaryBtn.addEventListener('click', () => {
+    panel.remove();
+    callbacks.onOpenBestiary();
+  });
+  body.appendChild(bestiaryBtn);
 
   const newGameBtn = createGameButton('New Game…', 'secondary');
   newGameBtn.style.width = '100%';

--- a/tests/systems/beast-presentation.test.ts
+++ b/tests/systems/beast-presentation.test.ts
@@ -65,6 +65,23 @@ describe('getBestiaryEntriesForPlayer', () => {
     const entries = getBestiaryEntriesForPlayer(state, 'player');
     expect(entries.map(e => e.lairId)).toEqual(['lair-giant_boar']);
   });
+
+  it('shows slain status for claimed lairs (hoard already taken)', () => {
+    const state = stateWithLair();
+    state.beasts!.lairs['lair-giant_boar'].status = 'claimed';
+    state.beasts!.lairs['lair-giant_boar'].slainBy = 'player';
+    state.beasts!.lairs['lair-giant_boar'].slainTurn = 5;
+    const entries = getBestiaryEntriesForPlayer(state, 'ai-1');
+    expect(entries[0].status).toBe('slain');
+    expect(entries[0].name).toBe('Giant Boar');
+    expect(entries[0].slainBy).toBe('player');
+  });
+
+  it('returns empty array for legacy saves with no beasts state', () => {
+    const state = stateWithLair();
+    state.beasts = undefined;
+    expect(getBestiaryEntriesForPlayer(state, 'player')).toEqual([]);
+  });
 });
 
 describe('recordBeastSightings', () => {
@@ -83,5 +100,13 @@ describe('recordBeastSightings', () => {
   it('does not sight beasts outside visible tiles', () => {
     const result = recordBeastSightings(stateWithLair(), 'player', new Set(['0,0']));
     expect(result.newSightings).toEqual([]);
+  });
+
+  it('returns unmodified state for legacy saves with no beasts', () => {
+    const state = stateWithLair();
+    state.beasts = undefined;
+    const result = recordBeastSightings(state, 'player', new Set(['10,10']));
+    expect(result.newSightings).toEqual([]);
+    expect(result.state).toBe(state);
   });
 });

--- a/tests/systems/beast-presentation.test.ts
+++ b/tests/systems/beast-presentation.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { getBestiaryEntriesForPlayer, recordBeastSightings } from '@/systems/beast-presentation';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, Unit } from '@/core/types';
+
+function stateWithLair(): GameState {
+  const state = createNewGame('rome', 'bestiary-seed', 'small', 'Bestiary Test');
+  state.beasts = {
+    mode: 'wild',
+    lairs: {
+      'lair-giant_boar': {
+        id: 'lair-giant_boar', beastId: 'giant_boar', position: { q: 10, r: 10 },
+        status: 'awake', strength: 0, unitIds: ['beast-1'],
+      },
+    },
+    sightingsByCiv: {},
+  };
+  state.units['beast-1'] = {
+    id: 'beast-1', type: 'beast_boar', owner: 'beasts', position: { q: 10, r: 10 },
+    movementPointsLeft: 2, health: 100, experience: 0,
+    hasMoved: false, hasActed: false, isResting: false,
+  } as Unit;
+  return state;
+}
+
+describe('getBestiaryEntriesForPlayer', () => {
+  it('masks EVERYTHING except the hint for unsighted beasts', () => {
+    const entries = getBestiaryEntriesForPlayer(stateWithLair(), 'player');
+    expect(entries).toHaveLength(1);
+    const entry = entries[0];
+    expect(entry.status).toBe('unknown');
+    expect(entry.hint.length).toBeGreaterThan(10);
+    expect(entry.name).toBeUndefined();
+    expect(entry.unitType).toBeUndefined();
+    expect(entry.tier).toBeUndefined();
+    expect(entry.slainBy).toBeUndefined();
+  });
+
+  it('reveals name/tier/unitType after sighting, per civ', () => {
+    const state = stateWithLair();
+    state.beasts!.sightingsByCiv['player'] = ['giant_boar'];
+    const mine = getBestiaryEntriesForPlayer(state, 'player');
+    expect(mine[0].status).toBe('sighted');
+    expect(mine[0].name).toBe('Giant Boar');
+    expect(mine[0].unitType).toBe('beast_boar');
+    const theirs = getBestiaryEntriesForPlayer(state, 'ai-1');
+    expect(theirs[0].status).toBe('unknown');
+    expect(theirs[0].name).toBeUndefined();
+  });
+
+  it('shows slain status with slayer to everyone', () => {
+    const state = stateWithLair();
+    state.beasts!.lairs['lair-giant_boar'].status = 'slain';
+    state.beasts!.lairs['lair-giant_boar'].slainBy = 'ai-1';
+    state.beasts!.lairs['lair-giant_boar'].slainTurn = 12;
+    const entries = getBestiaryEntriesForPlayer(state, 'player');
+    expect(entries[0].status).toBe('slain');
+    expect(entries[0].name).toBe('Giant Boar');
+    expect(entries[0].slainBy).toBe('ai-1');
+    expect(entries[0].slainTurn).toBe(12);
+  });
+
+  it('lists only beasts whose lairs exist on this map', () => {
+    const state = stateWithLair();
+    const entries = getBestiaryEntriesForPlayer(state, 'player');
+    expect(entries.map(e => e.lairId)).toEqual(['lair-giant_boar']);
+  });
+});
+
+describe('recordBeastSightings', () => {
+  it('returns new sightings exactly once (transition-owned)', () => {
+    const state = stateWithLair();
+    const visible = new Set(['10,10']);   // beast position is visible
+    const first = recordBeastSightings(state, 'player', visible);
+    expect(first.newSightings).toEqual(['giant_boar']);
+    expect(first.state.beasts!.sightingsByCiv['player']).toEqual(['giant_boar']);
+    const second = recordBeastSightings(first.state, 'player', visible);
+    expect(second.newSightings).toEqual([]);
+    // input state not mutated
+    expect(state.beasts!.sightingsByCiv['player']).toBeUndefined();
+  });
+
+  it('does not sight beasts outside visible tiles', () => {
+    const result = recordBeastSightings(stateWithLair(), 'player', new Set(['0,0']));
+    expect(result.newSightings).toEqual([]);
+  });
+});

--- a/tests/ui/beast-sighting-banner.test.ts
+++ b/tests/ui/beast-sighting-banner.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
+
+const BASE_OPTIONS = {
+  name: 'Giant Boar',
+  flavor: 'Your scouts lay eyes on the Giant Boar — a beast of legend!',
+  unitType: 'beast_boar' as const,
+  onContinue: vi.fn(),
+  onOpenBestiary: vi.fn(),
+};
+
+describe('beast-sighting-banner', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    vi.clearAllMocks();
+  });
+
+  it('renders beast name and flavor text', () => {
+    showBeastSightingBanner(container, BASE_OPTIONS);
+    const banner = container.querySelector('#beast-sighting-banner')!;
+    expect(banner.textContent).toContain('Giant Boar');
+    expect(banner.textContent).toContain('Your scouts lay eyes on the Giant Boar');
+    expect(banner.textContent).toContain('BEAST SIGHTED');
+  });
+
+  it('Continue button removes banner and calls onContinue', () => {
+    showBeastSightingBanner(container, BASE_OPTIONS);
+    const continueBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Continue')) as HTMLButtonElement;
+    expect(continueBtn).not.toBeNull();
+    continueBtn.click();
+    expect(container.querySelector('#beast-sighting-banner')).toBeNull();
+    expect(BASE_OPTIONS.onContinue).toHaveBeenCalledOnce();
+    expect(BASE_OPTIONS.onOpenBestiary).not.toHaveBeenCalled();
+  });
+
+  it('Open Bestiary button removes banner and calls onOpenBestiary', () => {
+    showBeastSightingBanner(container, BASE_OPTIONS);
+    const bestiaryBtn = Array.from(container.querySelectorAll('button'))
+      .find(b => b.textContent?.includes('Open Bestiary')) as HTMLButtonElement;
+    expect(bestiaryBtn).not.toBeNull();
+    bestiaryBtn.click();
+    expect(container.querySelector('#beast-sighting-banner')).toBeNull();
+    expect(BASE_OPTIONS.onOpenBestiary).toHaveBeenCalledOnce();
+    expect(BASE_OPTIONS.onContinue).not.toHaveBeenCalled();
+  });
+
+  it('reopening replaces the old banner (no duplicates)', () => {
+    showBeastSightingBanner(container, BASE_OPTIONS);
+    showBeastSightingBanner(container, BASE_OPTIONS);
+    expect(container.querySelectorAll('#beast-sighting-banner')).toHaveLength(1);
+  });
+});

--- a/tests/ui/bestiary-panel.test.ts
+++ b/tests/ui/bestiary-panel.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBestiaryPanel } from '@/ui/bestiary-panel';
+import type { BestiaryEntry } from '@/systems/beast-presentation';
+
+const unknownEntry: BestiaryEntry = {
+  lairId: 'lair-giant_boar', status: 'unknown',
+  hint: 'Trees splinter and the ground is churned in the deep woods. Something heavy lives there.',
+};
+const sightedEntry: BestiaryEntry = {
+  ...unknownEntry, status: 'sighted', name: 'Giant Boar', unitType: 'beast_boar', tier: 1,
+  sightingFlavor: 'Your scouts lay eyes on the Giant Boar — a beast of legend!',
+};
+const slainEntry: BestiaryEntry = {
+  ...sightedEntry, status: 'slain', slainBy: 'player', slainTurn: 22,
+};
+
+describe('bestiary panel', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  it('renders unknown entries with hint only — never the name (negative privacy test)', () => {
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Something heavy lives there');
+    expect(panel.textContent).not.toContain('Giant Boar');
+    expect(panel.textContent).not.toContain('forest'); // habitat must not leak via labels
+  });
+
+  it('renders sighted entries with name and tier', () => {
+    createBestiaryPanel(container, [sightedEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Giant Boar');
+    expect(panel.textContent).toContain('Sighted');
+  });
+
+  it('renders slain entries with slayer credit and turn', () => {
+    createBestiaryPanel(container, [slainEntry], { onClose: () => {}, slayerNameFor: () => 'Rome' });
+    const panel = container.querySelector('#bestiary-panel')!;
+    expect(panel.textContent).toContain('Slain');
+    expect(panel.textContent).toContain('Rome');
+    expect(panel.textContent).toContain('22');
+  });
+
+  it('close button removes the panel; reopening never duplicates', () => {
+    let closed = 0;
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => { closed++; }, slayerNameFor: () => '' });
+    createBestiaryPanel(container, [unknownEntry], { onClose: () => { closed++; }, slayerNameFor: () => '' });
+    expect(container.querySelectorAll('#bestiary-panel')).toHaveLength(1);
+    (container.querySelector('#bestiary-panel button[data-action="close"]') as HTMLButtonElement).click();
+    expect(container.querySelector('#bestiary-panel')).toBeNull();
+    expect(closed).toBe(1);
+  });
+
+  it('lists every provided entry (catalog completeness)', () => {
+    createBestiaryPanel(container, [unknownEntry, sightedEntry], { onClose: () => {}, slayerNameFor: () => '' });
+    expect(container.querySelectorAll('#bestiary-panel [data-bestiary-entry]')).toHaveLength(2);
+  });
+});

--- a/tests/ui/pause-menu-panel.test.ts
+++ b/tests/ui/pause-menu-panel.test.ts
@@ -17,6 +17,7 @@ function makeCallbacks(overrides: Partial<Parameters<typeof showPauseMenu>[1]> =
     onSave: vi.fn(async () => {}),
     onNewGame: vi.fn(),
     autoSave: vi.fn(async () => {}),
+    onOpenBestiary: vi.fn(),
     audioSettings: { ...DEFAULT_TEST_AUDIO },
     onAudioSettingChange: vi.fn(),
     ...overrides,

--- a/tests/ui/pause-menu-panel.test.ts
+++ b/tests/ui/pause-menu-panel.test.ts
@@ -87,6 +87,14 @@ describe('pause-menu-panel', () => {
     expect(document.body.textContent).not.toContain('Save before leaving?');
   });
 
+  it('"Bestiary" button closes the menu and calls onOpenBestiary', () => {
+    const callbacks = makeCallbacks();
+    showPauseMenu(document.body, callbacks);
+    clickButton('Bestiary');
+    expect(callbacks.onOpenBestiary).toHaveBeenCalledOnce();
+    expect(document.getElementById('pause-menu')).toBeNull();
+  });
+
   it('replaces stale pause panels when reopened', () => {
     showPauseMenu(document.body, makeCallbacks({ turn: 5, civName: 'Rome' }));
     showPauseMenu(document.body, makeCallbacks({ turn: 8, civName: 'Egypt' }));


### PR DESCRIPTION
## Summary
- Per-civ Bestiary collection book (Unknown / Sighted / Slain) opening from pause menu
- Privacy-masked unknown entries: hint only — never name, sprite, habitat, or map location
- Transition-owned first-sighting flow: banner + notification, fires exactly once per civ per beast
- `recordBeastSightings` is called on every visibility refresh AND at hot-seat turn handoff start

## Files added/modified
- `src/core/types.ts` — `beast:sighted` event
- `src/systems/beast-presentation.ts` — `getBestiaryEntriesForPlayer`, `recordBeastSightings`
- `src/ui/bestiary-panel.ts` — collection-book panel
- `src/ui/beast-sighting-banner.ts` — first-sighting modal banner
- `src/ui/pause-menu-panel.ts` — Bestiary button + `onOpenBestiary` callback
- `src/main.ts` — sighting scan, `beast:sighted` listener, `openBestiary()` helper

## Out of scope (see [MR index](docs/superpowers/plans/2026-06-11-legendary-beasts-index.md))
- MR3: Dire Wolf Pack + Emerald Basilisk + habitat concealment
- MR4: Hoard choice panel + lair trophies + AI auto-resolve
- MR5–MR7: remaining beasts
- MR8: Audio + AI hunting + balance

## Why this is safe to merge partial
All player-visible surfaces are fully wired and testable: the Bestiary panel opens from the pause menu and lists the Giant Boar (the only MR1 beast), the sighting banner fires once when the player's scout spots the boar, and the "Open Bestiary" button in the banner leads to the collection panel. No dead UX — every introduced affordance has a working destination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)