### PR TITLE
feat(beasts): MR4 — hoard choices + lair trophies

### DIFF
--- a/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
+++ b/docs/superpowers/plans/2026-06-11-legendary-beasts-index.md
@@ -14,8 +14,8 @@
 |---|---|---|---|
 | MR1 | [2026-06-11-legendary-beasts-mr1-core-boar.md](2026-06-11-legendary-beasts-mr1-core-boar.md) | Core system + Giant Boar + setup toggle + lair rendering | ✅ merged |
 | MR2 | [2026-06-11-legendary-beasts-mr2-bestiary.md](2026-06-11-legendary-beasts-mr2-bestiary.md) | Bestiary panel + sighting banner + per-civ sighting tracking | ◐ in progress ([PR #366](https://github.com/a1flecke/conquestoria/pull/366)) |
-| MR3 | [2026-06-11-legendary-beasts-mr3-wolves-basilisk.md](2026-06-11-legendary-beasts-mr3-wolves-basilisk.md) | Dire Wolf Pack + Emerald Basilisk + habitat concealment | ◐ in progress |
-| MR4 | [2026-06-11-legendary-beasts-mr4-hoard-trophies.md](2026-06-11-legendary-beasts-mr4-hoard-trophies.md) | Hoard choice panel + lair trophies + AI auto-resolve | ☐ not started |
+| MR3 | [2026-06-11-legendary-beasts-mr3-wolves-basilisk.md](2026-06-11-legendary-beasts-mr3-wolves-basilisk.md) | Dire Wolf Pack + Emerald Basilisk + habitat concealment | ✅ merged ([PR #367](https://github.com/a1flecke/conquestoria/pull/367)) |
+| MR4 | [2026-06-11-legendary-beasts-mr4-hoard-trophies.md](2026-06-11-legendary-beasts-mr4-hoard-trophies.md) | Hoard choice panel + lair trophies + AI auto-resolve | ◐ in progress |
 | MR5 | [2026-06-11-legendary-beasts-mr5-serpent-wurm.md](2026-06-11-legendary-beasts-mr5-serpent-wurm.md) | Sea Serpent + Dune Wurm + naval passability + `beast-serpent` rig | ☐ not started |
 | MR6 | [2026-06-11-legendary-beasts-mr6-roc-hydra.md](2026-06-11-legendary-beasts-mr6-roc-hydra.md) | Storm Roc + Swamp Hydra + flight + regen + `beast-winged` rig | ☐ not started |
 | MR7 | [2026-06-11-legendary-beasts-mr7-ancient-dragon.md](2026-06-11-legendary-beasts-mr7-ancient-dragon.md) | Ancient Dragon apex + ranged breath + slay ceremony + apex reward | ☐ not started |

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -11,6 +11,7 @@ import { processBarbarians } from '@/systems/barbarian-system';
 import {
   processBeasts, recordBeastSlain, BEAST_OWNER,
   LAIR_GROWTH_INTERVAL_TURNS, LAIR_GROWTH_CAP, LAIR_GROWTH_EXPERIENCE,
+  applyHoardChoice, getClaimedTrophyGoldPerTurn,
 } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { resolveCombat } from '@/systems/combat-system';
@@ -907,6 +908,18 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     bus.emit('era:advanced', { era: newEra });
     for (const mc of Object.values(newState.minorCivs)) {
       processMinorCivEraUpgrade(newState, mc);
+    }
+  }
+
+  // --- Beasts MR4: AI hoard auto-resolve + per-turn trophy income ---
+  if (newState.beasts) {
+    for (const pending of [...(newState.beasts.pendingHoardChoices ?? [])]) {
+      if (pending.civId === newState.currentPlayer) continue;
+      newState = applyHoardChoice(newState, pending.lairId, pending.civId, 'gold');
+    }
+    for (const civId of Object.keys(newState.civilizations)) {
+      const trophyGold = getClaimedTrophyGoldPerTurn(newState, civId);
+      if (trophyGold > 0) grossGoldByCiv[civId] = (grossGoldByCiv[civId] ?? 0) + trophyGold;
     }
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -911,7 +911,6 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     }
   }
 
-  // --- Beasts MR4: AI hoard auto-resolve + per-turn trophy income ---
   if (newState.beasts) {
     for (const pending of [...(newState.beasts.pendingHoardChoices ?? [])]) {
       if (pending.civId === newState.currentPlayer) continue;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -804,6 +804,13 @@ export type BeastsMode = 'off' | 'calm' | 'wild';
 
 export type BeastLairStatus = 'dormant' | 'awake' | 'slain' | 'claimed';
 
+export type BeastHoardChoice = 'gold' | 'lore' | 'trophy';
+
+export interface PendingHoardChoice {
+  lairId: string;
+  civId: string;     // slayer civ; only this civ may resolve it
+}
+
 export interface BeastLair {
   id: string;                 // `lair-${beastId}`
   beastId: BeastId;
@@ -813,6 +820,7 @@ export interface BeastLair {
   awakenedTurn?: number;
   slainBy?: string;           // civ id that landed the killing blow
   slainTurn?: number;
+  claimedBy?: string;         // civ that chose the Trophy option (MR4)
   unitIds: string[];          // live beast unit ids leashed to this lair
 }
 
@@ -820,6 +828,7 @@ export interface BeastsState {
   mode: BeastsMode;
   lairs: Record<string, BeastLair>;
   sightingsByCiv: Record<string, BeastId[]>;   // per-civ bestiary sightings (MR2 populates)
+  pendingHoardChoices?: PendingHoardChoice[];   // queued for human players (MR4)
 }
 
 // --- Minor Civilizations ---
@@ -1261,6 +1270,7 @@ export interface GameEvents {
   'beast:awakened': { lairId: string; beastId: BeastId; position: HexCoord };
   'beast:slain': { lairId: string; beastId: BeastId; slayerCivId: string; slayerUnitId: string; goldAwarded: number };
   'beast:sighted': { beastId: BeastId; civId: string };
+  'beast:hoard-claimed': { lairId: string; beastId: BeastId; civId: string; choice: BeastHoardChoice };
   'barbarian:camp-destroyed': { campId: string; reward: number };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3356,8 +3356,11 @@ bus.on('beast:slain', ({ beastId, slayerCivId, goldAwarded }) => {
 
 bus.on('beast:hoard-claimed', ({ beastId, civId, choice }) => {
   const def = BEAST_DEFINITIONS[beastId];
-  const label = choice === 'gold' ? 'took the Gold Hoard' : choice === 'lore' ? 'claimed the Ancient Lore' : 'raised a Beast Trophy';
-  appendToCivLog(civId, `You ${label} of the ${def.name}.`, 'success');
+  let message: string;
+  if (choice === 'gold') message = `You took the Gold Hoard of the ${def.name}.`;
+  else if (choice === 'lore') message = `You claimed the Ancient Lore of the ${def.name}.`;
+  else message = `You raised a ${def.name} Trophy.`;
+  appendToCivLog(civId, message, 'success');
 });
 
 bus.on('beast:sighted', ({ beastId, civId }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,8 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
-import { recordBeastSlain, placeBeastLairs, isBeastConcealedFrom } from '@/systems/beast-system';
+import { recordBeastSlain, placeBeastLairs, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview } from '@/systems/beast-system';
+import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
 import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
@@ -415,6 +416,20 @@ function scanBeastSightings(): void {
   for (const beastId of sightingResult.newSightings) {
     bus.emit('beast:sighted', { beastId, civId: gameState.currentPlayer });
   }
+}
+
+function maybeShowPendingHoardChoice(): void {
+  const pending = (gameState.beasts?.pendingHoardChoices ?? [])
+    .find(p => p.civId === gameState.currentPlayer);
+  if (!pending) return;
+  const preview = getHoardChoicePreview(gameState, pending.lairId);
+  const lair = gameState.beasts!.lairs[pending.lairId];
+  createBeastHoardPanel(uiLayer, preview, choice => {
+    gameState = applyHoardChoice(gameState, pending.lairId, pending.civId, choice);
+    bus.emit('beast:hoard-claimed', { lairId: pending.lairId, beastId: lair.beastId, civId: pending.civId, choice });
+    updateHUD();
+    maybeShowPendingHoardChoice();
+  });
 }
 
 function openWonderAtlas(initialWonderId?: string): void {
@@ -2210,6 +2225,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
     if (slayResult.slain) {
       bus.emit('beast:slain', slayResult.slain);
     }
+    maybeShowPendingHoardChoice();
 
     const destroyedCamp = applyCampDestructionAtTarget(gameState, gameState.currentPlayer, defender.position, gameState.turn);
     if (destroyedCamp.campId) {
@@ -2898,6 +2914,7 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
           updateHUD();
           // Scan for beast sightings at turn start (units may have gained vision from prior turns)
           scanBeastSightings();
+          maybeShowPendingHoardChoice();
           // Compute audio-state snapshot for the incoming player (Spec 3 hot-seat drift fix)
           const nextCiv = gameState.civilizations[nextSlotId];
           const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
@@ -3323,16 +3340,24 @@ bus.on('beast:awakened', ({ beastId, position }) => {
 bus.on('beast:slain', ({ beastId, slayerCivId, goldAwarded }) => {
   const def = BEAST_DEFINITIONS[beastId];
   const slayerName = gameState.civilizations[slayerCivId]?.name ?? slayerCivId;
+  const isChoiceTier = def.tier >= 2;
   for (const civId of Object.keys(gameState.civilizations)) {
-    const message = civId === slayerCivId
-      ? `Your forces have slain the ${def.name}! Hoard claimed: +${goldAwarded} gold.`
-      : `${slayerName} has slain the ${def.name}!`;
+    const slayerMsg = isChoiceTier
+      ? `Your forces have slain the ${def.name}! Choose your reward.`
+      : `Your forces have slain the ${def.name}! Hoard claimed: +${goldAwarded} gold.`;
+    const message = civId === slayerCivId ? slayerMsg : `${slayerName} has slain the ${def.name}!`;
     appendToCivLog(civId, message, civId === slayerCivId ? 'success' : 'info');
   }
-  // Prominent toast for the current player
   if (slayerCivId === gameState.currentPlayer) {
-    showNotification(`🏆 ${def.name} slain! +${goldAwarded} gold`, 'success');
+    const toast = isChoiceTier ? `🏆 ${def.name} slain! Choose your reward.` : `🏆 ${def.name} slain! +${goldAwarded} gold`;
+    showNotification(toast, 'success');
   }
+});
+
+bus.on('beast:hoard-claimed', ({ beastId, civId, choice }) => {
+  const def = BEAST_DEFINITIONS[beastId];
+  const label = choice === 'gold' ? 'took the Gold Hoard' : choice === 'lore' ? 'claimed the Ancient Lore' : 'raised a Beast Trophy';
+  appendToCivLog(civId, `You ${label} of the ${def.name}.`, 'success');
 });
 
 bus.on('beast:sighted', ({ beastId, civId }) => {
@@ -3763,6 +3788,7 @@ function startGame(): void {
   renderLoop.setGameState(gameState);
   updateHUD();
   maybeShowCouncilInterrupt();
+  maybeShowPendingHoardChoice();
 
   // Auto-save immediately so closing before turn 1 doesn't lose the game
   autoSave(gameState).catch(() => {});

--- a/src/systems/beast-system.ts
+++ b/src/systems/beast-system.ts
@@ -284,9 +284,7 @@ export function recordBeastSlain(
   };
 }
 
-// --- MR4: Hoard choices ---
-
-const TROPHY_GOLD_PER_TURN: Record<number, number> = { 1: 2, 2: 3, 3: 5, 4: 8 };
+const TROPHY_GOLD_PER_TURN: Record<number, number> = { 2: 3, 3: 5, 4: 8 };
 
 export interface HoardChoicePreview {
   gold: number;

--- a/src/systems/beast-system.ts
+++ b/src/systems/beast-system.ts
@@ -1,4 +1,5 @@
-import type { BeastId, BeastLair, BeastsMode, GameMap, GameState, HexCoord, Unit } from '@/core/types';
+import type { BeastHoardChoice, BeastId, BeastLair, BeastsMode, GameMap, GameState, HexCoord, Unit } from '@/core/types';
+import { applyResearchBonus } from '@/systems/tech-system';
 import { BEAST_DEFINITIONS, getBeastDefinitionByUnitType, type BeastDefinition } from '@/systems/beast-definitions';
 import { hexKey, hexDistance, hexNeighbors } from '@/systems/hex-utils';
 import { createRng } from '@/systems/map-generator';
@@ -240,7 +241,8 @@ export function recordBeastSlain(
   }
 
   const def = BEAST_DEFINITIONS[lair.beastId];
-  const gold = getBeastHoardGold(def, state.era);
+  const isChoiceTier = def.tier >= 2;
+  const gold = isChoiceTier ? 0 : getBeastHoardGold(def, state.era);
   const slayerCiv = state.civilizations[victor.owner];
   const updatedLair: BeastLair = {
     ...lair, unitIds: [], status: 'slain', slainBy: victor.owner, slainTurn: state.turn,
@@ -250,12 +252,21 @@ export function recordBeastSlain(
     ...state,
     beasts: { ...state.beasts, lairs: { ...state.beasts.lairs, [lair.id]: updatedLair } },
   };
-  if (slayerCiv) {
+  if (slayerCiv && gold > 0) {
     next = {
       ...next,
       civilizations: {
         ...next.civilizations,
         [victor.owner]: { ...slayerCiv, gold: slayerCiv.gold + gold },
+      },
+    };
+  }
+  if (isChoiceTier && slayerCiv) {
+    next = {
+      ...next,
+      beasts: {
+        ...next.beasts!,
+        pendingHoardChoices: [...(next.beasts!.pendingHoardChoices ?? []), { lairId: lair.id, civId: victor.owner }],
       },
     };
   }
@@ -271,4 +282,89 @@ export function recordBeastSlain(
       ? { lairId: lair.id, beastId: lair.beastId, slayerCivId: victor.owner, slayerUnitId: victor.id, goldAwarded: gold }
       : undefined,
   };
+}
+
+// --- MR4: Hoard choices ---
+
+const TROPHY_GOLD_PER_TURN: Record<number, number> = { 1: 2, 2: 3, 3: 5, 4: 8 };
+
+export interface HoardChoicePreview {
+  gold: number;
+  lore: number;
+  trophyGoldPerTurn: number;
+  beastName: string;
+}
+
+export function getHoardChoicePreview(state: GameState, lairId: string): HoardChoicePreview {
+  const lair = state.beasts!.lairs[lairId];
+  const def = BEAST_DEFINITIONS[lair.beastId];
+  const baseGold = getBeastHoardGold(def, state.era);
+  return {
+    gold: baseGold * 2,
+    lore: Math.round(baseGold * 1.5),
+    trophyGoldPerTurn: TROPHY_GOLD_PER_TURN[def.tier],
+    beastName: def.name,
+  };
+}
+
+export function getClaimedTrophyGoldPerTurn(state: GameState, civId: string): number {
+  if (!state.beasts) return 0;
+  let total = 0;
+  for (const lair of Object.values(state.beasts.lairs)) {
+    if (lair.status === 'claimed' && lair.claimedBy === civId) {
+      total += TROPHY_GOLD_PER_TURN[BEAST_DEFINITIONS[lair.beastId].tier];
+    }
+  }
+  return total;
+}
+
+function applyBeastLoreResearch(state: GameState, civId: string, amount: number): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+  const result = applyResearchBonus(civ.techState, amount);
+  return {
+    ...state,
+    civilizations: { ...state.civilizations, [civId]: { ...civ, techState: result.state } },
+  };
+}
+
+export function applyHoardChoice(
+  state: GameState,
+  lairId: string,
+  civId: string,
+  choice: BeastHoardChoice,
+): GameState {
+  const beasts = state.beasts;
+  const pending = beasts?.pendingHoardChoices?.find(p => p.lairId === lairId && p.civId === civId);
+  if (!beasts || !pending) return state;
+
+  const preview = getHoardChoicePreview(state, lairId);
+  const lair = beasts.lairs[lairId];
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  let next: GameState = {
+    ...state,
+    beasts: {
+      ...beasts,
+      pendingHoardChoices: (beasts.pendingHoardChoices ?? []).filter(
+        p => !(p.lairId === lairId && p.civId === civId),
+      ),
+    },
+  };
+
+  if (choice === 'gold') {
+    next = { ...next, civilizations: { ...next.civilizations, [civId]: { ...civ, gold: civ.gold + preview.gold } } };
+  } else if (choice === 'lore') {
+    next = applyBeastLoreResearch(next, civId, preview.lore);
+  } else {
+    next = {
+      ...next,
+      beasts: {
+        ...next.beasts!,
+        lairs: { ...next.beasts!.lairs, [lairId]: { ...lair, status: 'claimed', claimedBy: civId } },
+      },
+    };
+  }
+  return next;
 }

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -13,6 +13,7 @@ import { calculateProjectedCityYields } from './city-work-system';
 import { createSpyFromUnit, isSpyUnitType } from './espionage-system';
 import { getLegendaryWonderCityYieldBonus, getLegendaryWonderCivYieldBonus } from './legendary-wonder-system';
 import { processTradeRouteIncome } from './trade-system';
+import { getClaimedTrophyGoldPerTurn } from './beast-system';
 import { createUnit, UNIT_DEFINITIONS } from './unit-system';
 import { resolveCivDefinition } from './civ-registry';
 
@@ -492,6 +493,8 @@ export function projectCivGrossGold(state: GameState, civId: string): number {
       state.marketplace.tradeRoutes.filter(route => state.cities[route.fromCityId]?.owner === civId),
     );
   }
+
+  grossGold += getClaimedTrophyGoldPerTurn(state, civId);
 
   return grossGold;
 }

--- a/src/ui/beast-hoard-panel.ts
+++ b/src/ui/beast-hoard-panel.ts
@@ -1,0 +1,59 @@
+import type { BeastHoardChoice } from '@/core/types';
+import type { HoardChoicePreview } from '@/systems/beast-system';
+import { createGameButton } from '@/ui/ui-kit';
+
+export function createBeastHoardPanel(
+  container: HTMLElement,
+  preview: HoardChoicePreview,
+  onChoose: (choice: BeastHoardChoice) => void,
+): HTMLElement {
+  container.querySelector('#beast-hoard-panel')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'beast-hoard-panel';
+  panel.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:50;padding:16px;overflow:auto;';
+
+  const title = document.createElement('h2');
+  title.textContent = `The ${preview.beastName} is slain!`;
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0 0 8px;';
+  panel.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Claim your prize. Choose one:';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  panel.appendChild(intro);
+
+  let fired = false;
+
+  const options: Array<{ choice: BeastHoardChoice; label: string; detail: string }> = [
+    { choice: 'gold', label: `\u{1F4B0} Gold Hoard — +${preview.gold} gold`, detail: 'The beast guarded a fortune. Take it all, right now.' },
+    { choice: 'lore', label: `\u{1F4DC} Ancient Lore — +${preview.lore} research`, detail: 'Secrets of a forgotten age speed your current research.' },
+    { choice: 'trophy', label: `\u{1F3C6} Beast Trophy — +${preview.trophyGoldPerTurn} gold every turn`, detail: 'Claim the lair as a monument. Pilgrims and traders pay tribute forever.' },
+  ];
+
+  for (const option of options) {
+    const card = document.createElement('section');
+    card.style.cssText = 'margin-bottom:12px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+
+    const button = createGameButton(option.label, 'primary');
+    button.dataset.choice = option.choice;
+    button.style.width = '100%';
+    button.addEventListener('click', () => {
+      if (fired) return;
+      fired = true;
+      panel.remove();
+      onChoose(option.choice);
+    });
+    card.appendChild(button);
+
+    const detail = document.createElement('div');
+    detail.textContent = option.detail;
+    detail.style.cssText = 'font-size:12px;opacity:0.75;margin-top:6px;';
+    card.appendChild(detail);
+
+    panel.appendChild(card);
+  }
+
+  container.appendChild(panel);
+  return panel;
+}

--- a/tests/core/turn-manager-beasts.test.ts
+++ b/tests/core/turn-manager-beasts.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { processTurn } from '@/core/turn-manager';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
-import { BEAST_OWNER } from '@/systems/beast-system';
+import { BEAST_OWNER, getClaimedTrophyGoldPerTurn } from '@/systems/beast-system';
 
 describe('turn-manager beast wiring', () => {
   it('eventually spawns a beast unit from an awakened lair and emits beast:awakened', () => {
@@ -30,5 +30,49 @@ describe('turn-manager beast wiring', () => {
     let s = state;
     for (let i = 0; i < 30; i++) s = processTurn(s, bus);
     expect(Object.values(s.units).some(u => u.owner === BEAST_OWNER)).toBe(false);
+  });
+});
+
+describe('turn-manager hoard handling', () => {
+  it('AI pending hoard choices auto-resolve to gold during processTurn', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'AI Hoard Test');
+    const aiCivId = Object.keys(state.civilizations).find(id => id !== state.currentPlayer)!;
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-emerald_basilisk': {
+          id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk',
+          position: { q: 10, r: 10 }, status: 'slain', strength: 0, unitIds: [],
+          slainBy: aiCivId, slainTurn: 1,
+        },
+      },
+      sightingsByCiv: {},
+      pendingHoardChoices: [{ lairId: 'lair-emerald_basilisk', civId: aiCivId }],
+    };
+    const goldBefore = state.civilizations[aiCivId].gold;
+    const next = processTurn(state, new EventBus());
+    expect(next.beasts!.pendingHoardChoices).toEqual([]);
+    expect(next.civilizations[aiCivId].gold).toBeGreaterThan(goldBefore);
+  });
+
+  it('claimed trophies pay per-turn gold during processTurn', () => {
+    const state = createNewGame('rome', 'beast-turn-seed', 'small', 'Trophy Test');
+    const me = state.currentPlayer;
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-emerald_basilisk': {
+          id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk',
+          position: { q: 10, r: 10 }, status: 'claimed', claimedBy: me,
+          strength: 0, unitIds: [], slainBy: me, slainTurn: 1,
+        },
+      },
+      sightingsByCiv: {},
+    };
+    const baseline = createNewGame('rome', 'beast-turn-seed', 'small', 'Trophy Baseline');
+    const withTrophy = processTurn(state, new EventBus());
+    const withoutTrophy = processTurn(baseline, new EventBus());
+    const delta = withTrophy.civilizations[me].gold - withoutTrophy.civilizations[me].gold;
+    expect(delta).toBe(getClaimedTrophyGoldPerTurn(state, me));
   });
 });

--- a/tests/systems/beast-system.test.ts
+++ b/tests/systems/beast-system.test.ts
@@ -4,6 +4,7 @@ import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { generateMap } from '@/systems/map-generator';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
 import { createNewGame } from '@/core/game-state';
+import { startResearch } from '@/systems/tech-system';
 import type { BeastLair, Unit } from '@/core/types';
 
 describe('placeBeastLairs', () => {
@@ -252,6 +253,25 @@ describe('hoard choices', () => {
     expect(next.civilizations[victor.owner].gold).toBe(goldBefore + preview.gold);
     expect(next.beasts!.pendingHoardChoices).toEqual([]);
     expect(next.beasts!.lairs['lair-emerald_basilisk'].status).toBe('slain');
+  });
+
+  it('applyHoardChoice lore advances research progress and clears the pending entry', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const civId = victor.owner;
+    const civ = slainState.civilizations[civId];
+    const withResearch = {
+      ...slainState,
+      civilizations: {
+        ...slainState.civilizations,
+        [civId]: { ...civ, techState: startResearch(civ.techState, 'stone-weapons') },
+      },
+    };
+    const next = applyHoardChoice(withResearch, 'lair-emerald_basilisk', civId, 'lore');
+    expect(next.beasts!.pendingHoardChoices).toEqual([]);
+    const nextTech = next.civilizations[civId].techState;
+    // lore bonus >> stone-weapons cost (4), so the tech should complete
+    expect(nextTech.completed).toContain('stone-weapons');
   });
 
   it('applyHoardChoice trophy claims the lair and produces per-turn income', () => {

--- a/tests/systems/beast-system.test.ts
+++ b/tests/systems/beast-system.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { placeBeastLairs, BEAST_OWNER, LAIR_COUNTS, processBeasts, recordBeastSlain, getBeastHoardGold, isBeastConcealedFrom } from '@/systems/beast-system';
+import { placeBeastLairs, BEAST_OWNER, LAIR_COUNTS, processBeasts, recordBeastSlain, getBeastHoardGold, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, getClaimedTrophyGoldPerTurn } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { generateMap } from '@/systems/map-generator';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
@@ -194,6 +194,81 @@ describe('isBeastConcealedFrom', () => {
     expect(isBeastConcealedFrom(boar, jungleMap, [])).toBe(false);
     const warrior = makeUnit({ id: 'w1', position: { q: 5, r: 5 } });
     expect(isBeastConcealedFrom(warrior, jungleMap, [])).toBe(false);
+  });
+});
+
+describe('hoard choices', () => {
+  function stateWithSlainBasilisk() {
+    const state = createNewGame('rome', 'beast-test-seed', 'small', 'Hoard Test');
+    state.era = 2;
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-emerald_basilisk': makeLair({ id: 'lair-emerald_basilisk', beastId: 'emerald_basilisk', status: 'awake', unitIds: ['beast-1'] }),
+      },
+      sightingsByCiv: {},
+    };
+    const beast = makeUnit({ id: 'beast-1', type: 'beast_basilisk', owner: 'beasts' });
+    const victor = makeUnit({ id: 'hero-1', owner: state.currentPlayer, position: { q: 11, r: 10 } });
+    state.units[beast.id] = beast;
+    state.units[victor.id] = victor;
+    return { state, beast, victor };
+  }
+
+  it('tier >= 2 slay queues a pending choice and awards NO automatic gold', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const goldBefore = state.civilizations[victor.owner].gold;
+    const { state: next, slain } = recordBeastSlain(state, beast, victor);
+    expect(slain).toBeDefined();
+    expect(slain!.goldAwarded).toBe(0);
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore);
+    expect(next.beasts!.pendingHoardChoices).toEqual([{ lairId: 'lair-emerald_basilisk', civId: victor.owner }]);
+  });
+
+  it('tier 1 slay still auto-pays gold and queues nothing', () => {
+    const { state, victor } = stateWithSlainBasilisk();
+    state.beasts!.lairs['lair-giant_boar'] = makeLair({ status: 'awake', unitIds: ['boar-1'] });
+    const boar = makeUnit({ id: 'boar-1', type: 'beast_boar', owner: 'beasts' });
+    state.units[boar.id] = boar;
+    const { state: next, slain } = recordBeastSlain(state, boar, victor);
+    expect(slain!.goldAwarded).toBeGreaterThan(0);
+    expect(next.beasts!.pendingHoardChoices ?? []).toEqual([]);
+  });
+
+  it('preview exposes concrete numbers for all three options', () => {
+    const { state } = stateWithSlainBasilisk();
+    const preview = getHoardChoicePreview(state, 'lair-emerald_basilisk');
+    expect(preview.gold).toBeGreaterThan(0);
+    expect(preview.lore).toBeGreaterThan(0);
+    expect(preview.trophyGoldPerTurn).toBeGreaterThan(0);
+  });
+
+  it('applyHoardChoice gold pays out and clears the pending entry', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const goldBefore = slainState.civilizations[victor.owner].gold;
+    const preview = getHoardChoicePreview(slainState, 'lair-emerald_basilisk');
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', victor.owner, 'gold');
+    expect(next.civilizations[victor.owner].gold).toBe(goldBefore + preview.gold);
+    expect(next.beasts!.pendingHoardChoices).toEqual([]);
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].status).toBe('slain');
+  });
+
+  it('applyHoardChoice trophy claims the lair and produces per-turn income', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', victor.owner, 'trophy');
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].status).toBe('claimed');
+    expect(next.beasts!.lairs['lair-emerald_basilisk'].claimedBy).toBe(victor.owner);
+    expect(getClaimedTrophyGoldPerTurn(next, victor.owner)).toBeGreaterThan(0);
+    expect(getClaimedTrophyGoldPerTurn(next, 'someone-else')).toBe(0);
+  });
+
+  it('applyHoardChoice refuses the wrong civ', () => {
+    const { state, beast, victor } = stateWithSlainBasilisk();
+    const { state: slainState } = recordBeastSlain(state, beast, victor);
+    const next = applyHoardChoice(slainState, 'lair-emerald_basilisk', 'ai-1', 'gold');
+    expect(next).toBe(slainState);
   });
 });
 

--- a/tests/ui/beast-hoard-panel.test.ts
+++ b/tests/ui/beast-hoard-panel.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
+
+describe('beast hoard panel', () => {
+  let container: HTMLElement;
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  const preview = { gold: 160, lore: 120, trophyGoldPerTurn: 3, beastName: 'Emerald Basilisk' };
+
+  it('shows all three options with concrete numbers', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    const panel = container.querySelector('#beast-hoard-panel')!;
+    expect(panel.textContent).toContain('Emerald Basilisk');
+    expect(panel.textContent).toContain('160');
+    expect(panel.textContent).toContain('120');
+    expect(panel.textContent).toContain('3');
+    expect(panel.querySelectorAll('button[data-choice]')).toHaveLength(3);
+  });
+
+  it('applies exactly once even on double-click (replay safety)', () => {
+    const chosen: string[] = [];
+    createBeastHoardPanel(container, preview, choice => chosen.push(choice));
+    const goldButton = container.querySelector('button[data-choice="gold"]') as HTMLButtonElement;
+    goldButton.click();
+    goldButton.click();
+    expect(chosen).toEqual(['gold']);
+    expect(container.querySelector('#beast-hoard-panel')).toBeNull();
+  });
+
+  it('has no dismiss/close affordance (blocking by design)', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    expect(container.querySelector('#beast-hoard-panel button[data-action="close"]')).toBeNull();
+  });
+
+  it('reopening never duplicates', () => {
+    createBeastHoardPanel(container, preview, () => {});
+    createBeastHoardPanel(container, preview, () => {});
+    expect(container.querySelectorAll('#beast-hoard-panel')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Tier ≥ 2 beast slays now present a blocking choose-one reward panel: **Gold Hoard** (instant gold ×2), **Ancient Lore** (instant research), or **Beast Trophy** (+gold/turn permanently)
- Choices queue in `BeastsState.pendingHoardChoices` — reload-safe and multi-slay-safe (two slays in one turn = two sequential panels)
- AI civs auto-resolve to gold during turn processing; human players get the panel
- Trophy income accrues in turn processing AND is included in `projectCivGrossGold` — HUD rate and actual accrual share the same source (`getClaimedTrophyGoldPerTurn`), so the HUD can't lie
- Claimed lairs render 🏆 glyph (already wired in MR1's render-loop; `'claimed'` status was already handled)
- Tier-1 beasts (boar, wolves) keep the existing auto-gold path unchanged

## Out of scope (see [MR index](docs/superpowers/plans/2026-06-11-legendary-beasts-index.md))
- Sea Serpent + Dune Wurm (MR5), Storm Roc + Swamp Hydra (MR6), Ancient Dragon (MR7), audio/AI/balance (MR8)

## Why this is safe to merge partial
All MR4 surfaces are fully wired end-to-end: the panel appears, choices apply to state, trophy income accrues, the HUD updates, and the notification logs the claim. No dead-end UX — tier-1 beasts continue to auto-pay gold exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)