### PR TITLE
feat(beasts): MR5 — sea serpent + dune wurm

### DIFF
--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -49,9 +49,9 @@ Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 
 | Unit | Status | data-kind |
 |------|--------|-----------|
-| beast_boar | ✅ sprite | hound |
-| beast_wolf | ✅ sprite | hound |
-| beast_basilisk | ✅ sprite | hound |
+| beast_boar | ✅ sprite | — |
+| beast_wolf | ✅ sprite | — |
+| beast_basilisk | ✅ sprite | — |
 | beast_sea_serpent | ✅ sprite | beast-serpent |
 | beast_wurm | ✅ sprite | beast-serpent |
 

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -44,6 +44,17 @@ Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 | caravan | ✅ sprite | civilian |
 | expedition | ✅ sprite | civilian |
 
+### Legendary Beasts — `src/renderer/sprites/beasts.tsx`
+Registered in `UNIT_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
+
+| Unit | Status | data-kind |
+|------|--------|-----------|
+| beast_boar | ✅ sprite | hound |
+| beast_wolf | ✅ sprite | hound |
+| beast_basilisk | ✅ sprite | hound |
+| beast_sea_serpent | ✅ sprite | beast-serpent |
+| beast_wurm | ✅ sprite | beast-serpent |
+
 ### Buildings — `src/renderer/sprites/buildings.tsx`
 Registered in `BUILDING_SPRITE_CATALOG` in `src/renderer/sprites/sprite-catalog.ts`.
 
@@ -239,6 +250,7 @@ All animation is CSS-driven via `src/assets/sprite-animations-v2.css`. Sprites s
 | `naval` | galley, trireme, catapult, ballista | ship rock + sail billow |
 | `hound` | scout_hound, war_hound | quadruped diagonal-pair legs |
 | `spy` | spy_* family | cape sway, cloak |
+| `beast-serpent` | beast_sea_serpent, beast_wurm | phase-offset segment undulation (`cq-segment-1..4`) |
 
 ### Building effect classes
 | Class | Effect | Example buildings |

--- a/src/assets/sprite-animations-v2.css
+++ b/src/assets/sprite-animations-v2.css
@@ -612,13 +612,24 @@
 .cq-deliver { opacity: 0; }
 [data-state="work"] .cq-deliver { animation: cq-shimmer 1.1s ease-in-out infinite; }
 
+/* === beast-serpent: segmented undulation === */
+@keyframes cq-serpent-undulate {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+[data-kind="beast-serpent"] .cq-segment-1 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s); }
+[data-kind="beast-serpent"] .cq-segment-2 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.3s); }
+[data-kind="beast-serpent"] .cq-segment-3 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.6s); }
+[data-kind="beast-serpent"] .cq-segment-4 { animation: cq-serpent-undulate 2.4s ease-in-out infinite; animation-delay: calc(var(--phase, 0) * -2.4s - 0.9s); }
+
 /* Pause everything when prefers-reduced-motion */
 @media (prefers-reduced-motion: reduce) {
   .cq-sprite-figure, .cq-weapon, .cq-tool, .cq-smoke, .cq-dust, .cq-work-dust,
   .cq-spark, .cq-glow, .cq-fire, .cq-wheel, .cq-water-stream, .cq-spotlight,
   .cq-camera-led, .cq-beacon, .cq-crowd-fig, .cq-trade-fig, .cq-coin-shimmer,
   .cq-deliver, .cq-peek, .cq-mark, .cq-candle, .cq-shimmer,
-  .cq-banner-cloth, .cq-muzzle-flash, .cq-cape {
+  .cq-banner-cloth, .cq-muzzle-flash, .cq-cape,
+  .cq-segment-1, .cq-segment-2, .cq-segment-3, .cq-segment-4 {
     animation: none !important;
   }
 }

--- a/src/audio/sfx-catalog.ts
+++ b/src/audio/sfx-catalog.ts
@@ -186,6 +186,8 @@ const LOCOMOTION_CLASS: Record<UnitType, LocomotionClass> = {
   beast_boar:    'animal',
   beast_wolf:    'animal',
   beast_basilisk: 'animal',
+  beast_sea_serpent: 'naval',
+  beast_wurm:    'animal',
 };
 
 export function getLocomotionClass(unitType: UnitType): LocomotionClass {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -292,7 +292,7 @@ export type UnitType =
   | 'expedition'
   | 'transport'
   | 'carrack' | 'galleon' | 'steamship' | 'troop_transport'
-  | 'beast_boar' | 'beast_wolf' | 'beast_basilisk';
+  | 'beast_boar' | 'beast_wolf' | 'beast_basilisk' | 'beast_sea_serpent' | 'beast_wurm';
 
 export interface UnitAttackProfile {
   kind: 'melee' | 'ranged' | 'siege' | 'bombard';
@@ -798,7 +798,7 @@ export interface BarbarianCamp {
 
 // --- Legendary Beasts ---
 
-export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk';   // union grows one MR at a time — see beasts index plan
+export type BeastId = 'giant_boar' | 'dire_wolf' | 'emerald_basilisk' | 'sea_serpent' | 'dune_wurm';
 
 export type BeastsMode = 'off' | 'calm' | 'wild';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
-import { recordBeastSlain, placeBeastLairs, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview } from '@/systems/beast-system';
+import { recordBeastSlain, placeBeastLairs, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast } from '@/systems/beast-system';
 import { createBeastHoardPanel } from '@/ui/beast-hoard-panel';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/beast-presentation';
@@ -2512,6 +2512,12 @@ function handleHexTap(rawCoord: HexCoord): void {
     const defenderEntry = selectDefenderEntryAtKey(key);
     if (selectedUnitCanAttackTappedHex && defenderEntry) {
       const defender = defenderEntry[1];
+      const navalGate = canUnitAttackBeast(unit, defender);
+      if (!navalGate.allowed) {
+        showNotification(navalGate.reason ?? 'Cannot attack that target.', 'warning');
+        selectUnit(selectedUnitId);
+        return;
+      }
       const atkDef = UNIT_DEFINITIONS[unit.type];
       const defDef = UNIT_DEFINITIONS[defender.type];
       const attackerBonus = currentCivDef()?.bonusEffect;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2402,6 +2402,17 @@ function handleHexTap(rawCoord: HexCoord): void {
         selectUnit(selectedUnitId);
         return;
       }
+      // Check for a navalOnly beast before falling through to the generic movement blocker —
+      // "Ocean is impassable" is less useful than the specific combat restriction reason.
+      const defenderAtHex = selectDefenderEntryAtKey(key)?.[1];
+      if (defenderAtHex) {
+        const navalGate = canUnitAttackBeast(selectedUnit, defenderAtHex);
+        if (!navalGate.allowed) {
+          showNotification(navalGate.reason ?? 'Cannot attack that target.', 'warning');
+          selectUnit(selectedUnitId);
+          return;
+        }
+      }
       const civ = currentCiv();
       const visibilityState = civ.visibility ? getVisibility(civ.visibility, coord) : undefined;
       const completedTechs = gameState.civilizations[selectedUnit.owner]?.techState.completed ?? [];

--- a/src/renderer/sprites/beasts.tsx
+++ b/src/renderer/sprites/beasts.tsx
@@ -129,28 +129,30 @@ export function SeaSerpentSprite({ svgOnly = false }: UnitSpriteProps): string {
   return (
     <SpriteFrame svgOnly={svgOnly}>
       <Shadow cx={64} cy={95} rx={30} />
-      <g data-kind="beast-serpent" className="cq-sprite-figure">
-        {/* three coils breaking the water, phase-offset segments */}
-        <g className="cq-segment-1">
-          <path d="M28,84 Q36,62 48,84" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+      <g className="cq-sprite-figure">
+        <g data-kind="beast-serpent">
+          {/* three coils breaking the water, phase-offset segments */}
+          <g className="cq-segment-1">
+            <path d="M28,84 Q36,62 48,84" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+          </g>
+          <g className="cq-segment-2">
+            <path d="M52,84 Q62,58 74,84" fill="none" stroke={SERPENT.scale} strokeWidth="13" strokeLinecap="round" />
+            <path d="M58,68 L62,58 L66,68" fill={SERPENT.fin} />
+          </g>
+          <g className="cq-segment-3">
+            <path d="M78,84 Q88,64 98,82" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+          </g>
+          {/* head rearing */}
+          <g className="cq-segment-4">
+            <path d="M98,82 Q108,70 104,56 Q102,46 92,48" fill="none" stroke={SERPENT.scale} strokeWidth="10" strokeLinecap="round" />
+            <ellipse cx="91" cy="49" rx="9" ry="7" fill={SERPENT.scale} stroke={P.ink.line} strokeWidth="1.5" />
+            <path d="M83,50 L76,52 L83,55 Z" fill={SERPENT.scaleDark} />
+            <circle cx="89" cy="47" r="2.4" fill={SERPENT.eye} />
+            <path d="M92,42 L95,34 L98,43" fill={SERPENT.fin} />
+          </g>
+          {/* waterline froth */}
+          <path d="M24,86 Q40,82 56,86 Q72,90 88,86 Q100,83 108,86" fill="none" stroke="#bfe6f2" strokeWidth="2" opacity="0.7" />
         </g>
-        <g className="cq-segment-2">
-          <path d="M52,84 Q62,58 74,84" fill="none" stroke={SERPENT.scale} strokeWidth="13" strokeLinecap="round" />
-          <path d="M58,68 L62,58 L66,68" fill={SERPENT.fin} />
-        </g>
-        <g className="cq-segment-3">
-          <path d="M78,84 Q88,64 98,82" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
-        </g>
-        {/* head rearing */}
-        <g className="cq-segment-4">
-          <path d="M98,82 Q108,70 104,56 Q102,46 92,48" fill="none" stroke={SERPENT.scale} strokeWidth="10" strokeLinecap="round" />
-          <ellipse cx="91" cy="49" rx="9" ry="7" fill={SERPENT.scale} stroke={P.ink.line} strokeWidth="1.5" />
-          <path d="M83,50 L76,52 L83,55 Z" fill={SERPENT.scaleDark} />
-          <circle cx="89" cy="47" r="2.4" fill={SERPENT.eye} />
-          <path d="M92,42 L95,34 L98,43" fill={SERPENT.fin} />
-        </g>
-        {/* waterline froth */}
-        <path d="M24,86 Q40,82 56,86 Q72,90 88,86 Q100,83 108,86" fill="none" stroke="#bfe6f2" strokeWidth="2" opacity="0.7" />
       </g>
     </SpriteFrame>
   );
@@ -167,21 +169,23 @@ export function DuneWurmSprite({ svgOnly = false }: UnitSpriteProps): string {
   return (
     <SpriteFrame svgOnly={svgOnly}>
       <Shadow cx={64} cy={95} rx={26} />
-      <g data-kind="beast-serpent" className="cq-sprite-figure">
-        {/* erupting body arc */}
-        <g className="cq-segment-1">
-          <path d="M40,92 Q44,60 64,52 Q84,46 92,66 Q96,78 90,92" fill="none" stroke={WURM.hide} strokeWidth="16" strokeLinecap="round" />
-          <path d="M46,80 q6,-2 10,2 M54,66 q6,-2 10,2 M70,54 q6,-2 10,2" fill="none" stroke={WURM.hideDark} strokeWidth="2" />
+      <g className="cq-sprite-figure">
+        <g data-kind="beast-serpent">
+          {/* erupting body arc */}
+          <g className="cq-segment-1">
+            <path d="M40,92 Q44,60 64,52 Q84,46 92,66 Q96,78 90,92" fill="none" stroke={WURM.hide} strokeWidth="16" strokeLinecap="round" />
+            <path d="M46,80 q6,-2 10,2 M54,66 q6,-2 10,2 M70,54 q6,-2 10,2" fill="none" stroke={WURM.hideDark} strokeWidth="2" />
+          </g>
+          {/* tri-split maw */}
+          <g className="cq-segment-2">
+            <path d="M58,50 L50,34 L64,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+            <path d="M64,44 L66,28 L74,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+            <path d="M74,44 L86,34 L78,50 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+            <path d="M58,46 l3,-4 M66,40 l2,-5 M76,46 l3,-4" stroke={WURM.tooth} strokeWidth="2" strokeLinecap="round" />
+          </g>
+          {/* sand spray */}
+          <path d="M34,92 q4,-8 0,-14 M104,92 q-4,-8 0,-14 M44,94 q2,-5 -1,-9" fill="none" stroke="#dcc88e" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
         </g>
-        {/* tri-split maw */}
-        <g className="cq-segment-2">
-          <path d="M58,50 L50,34 L64,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
-          <path d="M64,44 L66,28 L74,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
-          <path d="M74,44 L86,34 L78,50 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
-          <path d="M58,46 l3,-4 M66,40 l2,-5 M76,46 l3,-4" stroke={WURM.tooth} strokeWidth="2" strokeLinecap="round" />
-        </g>
-        {/* sand spray */}
-        <path d="M34,92 q4,-8 0,-14 M104,92 q-4,-8 0,-14 M44,94 q2,-5 -1,-9" fill="none" stroke="#dcc88e" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
       </g>
     </SpriteFrame>
   );

--- a/src/renderer/sprites/beasts.tsx
+++ b/src/renderer/sprites/beasts.tsx
@@ -117,3 +117,72 @@ export function EmeraldBasiliskSprite({ svgOnly = false }: UnitSpriteProps): str
     </SpriteFrame>
   );
 }
+
+const SERPENT = {
+  scale: '#2e6e8c',
+  scaleDark: '#1c4a61',
+  fin: '#5ec0d8',
+  eye: '#ffd34d',
+};
+
+export function SeaSerpentSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow cx={64} cy={95} rx={30} />
+      <g data-kind="beast-serpent" className="cq-sprite-figure">
+        {/* three coils breaking the water, phase-offset segments */}
+        <g className="cq-segment-1">
+          <path d="M28,84 Q36,62 48,84" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+        </g>
+        <g className="cq-segment-2">
+          <path d="M52,84 Q62,58 74,84" fill="none" stroke={SERPENT.scale} strokeWidth="13" strokeLinecap="round" />
+          <path d="M58,68 L62,58 L66,68" fill={SERPENT.fin} />
+        </g>
+        <g className="cq-segment-3">
+          <path d="M78,84 Q88,64 98,82" fill="none" stroke={SERPENT.scale} strokeWidth="11" strokeLinecap="round" />
+        </g>
+        {/* head rearing */}
+        <g className="cq-segment-4">
+          <path d="M98,82 Q108,70 104,56 Q102,46 92,48" fill="none" stroke={SERPENT.scale} strokeWidth="10" strokeLinecap="round" />
+          <ellipse cx="91" cy="49" rx="9" ry="7" fill={SERPENT.scale} stroke={P.ink.line} strokeWidth="1.5" />
+          <path d="M83,50 L76,52 L83,55 Z" fill={SERPENT.scaleDark} />
+          <circle cx="89" cy="47" r="2.4" fill={SERPENT.eye} />
+          <path d="M92,42 L95,34 L98,43" fill={SERPENT.fin} />
+        </g>
+        {/* waterline froth */}
+        <path d="M24,86 Q40,82 56,86 Q72,90 88,86 Q100,83 108,86" fill="none" stroke="#bfe6f2" strokeWidth="2" opacity="0.7" />
+      </g>
+    </SpriteFrame>
+  );
+}
+
+const WURM = {
+  hide: '#b08a52',
+  hideDark: '#84653a',
+  maw: '#5e2f2a',
+  tooth: '#e8e0cc',
+};
+
+export function DuneWurmSprite({ svgOnly = false }: UnitSpriteProps): string {
+  return (
+    <SpriteFrame svgOnly={svgOnly}>
+      <Shadow cx={64} cy={95} rx={26} />
+      <g data-kind="beast-serpent" className="cq-sprite-figure">
+        {/* erupting body arc */}
+        <g className="cq-segment-1">
+          <path d="M40,92 Q44,60 64,52 Q84,46 92,66 Q96,78 90,92" fill="none" stroke={WURM.hide} strokeWidth="16" strokeLinecap="round" />
+          <path d="M46,80 q6,-2 10,2 M54,66 q6,-2 10,2 M70,54 q6,-2 10,2" fill="none" stroke={WURM.hideDark} strokeWidth="2" />
+        </g>
+        {/* tri-split maw */}
+        <g className="cq-segment-2">
+          <path d="M58,50 L50,34 L64,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M64,44 L66,28 L74,44 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M74,44 L86,34 L78,50 Z" fill={WURM.maw} stroke={WURM.hideDark} strokeWidth="1.5" />
+          <path d="M58,46 l3,-4 M66,40 l2,-5 M76,46 l3,-4" stroke={WURM.tooth} strokeWidth="2" strokeLinecap="round" />
+        </g>
+        {/* sand spray */}
+        <path d="M34,92 q4,-8 0,-14 M104,92 q-4,-8 0,-14 M44,94 q2,-5 -1,-9" fill="none" stroke="#dcc88e" strokeWidth="2" strokeLinecap="round" opacity="0.8" />
+      </g>
+    </SpriteFrame>
+  );
+}

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -27,7 +27,7 @@ import {
 import {
   PyramidsSprite, ColosseumSprite, GreatLibrarySprite, LighthouseSprite,
 } from './wonders';
-import { GiantBoarSprite, DireWolfSprite, EmeraldBasiliskSprite } from './beasts';
+import { GiantBoarSprite, DireWolfSprite, EmeraldBasiliskSprite, SeaSerpentSprite, DuneWurmSprite } from './beasts';
 
 export type UnitSpriteComponent = (props: UnitSpriteProps) => string;
 export type BuildingSpriteComponent = (props: BuildingSpriteProps) => string;
@@ -140,9 +140,11 @@ export const UNIT_SPRITE_CATALOG: Record<UnitType, UnitSpriteComponent> = {
   ballista:       withMotion('ballista', BallistaSprite),
   caravan:        withMotion('caravan', CaravanSprite),
   expedition:     withMotion('expedition', ExpeditionSprite),
-  beast_boar:     withMotion('beast_boar', GiantBoarSprite),
-  beast_wolf:     withMotion('beast_wolf', DireWolfSprite),
-  beast_basilisk: withMotion('beast_basilisk', EmeraldBasiliskSprite),
+  beast_boar:         withMotion('beast_boar', GiantBoarSprite),
+  beast_wolf:         withMotion('beast_wolf', DireWolfSprite),
+  beast_basilisk:     withMotion('beast_basilisk', EmeraldBasiliskSprite),
+  beast_sea_serpent:  withMotion('beast_sea_serpent', SeaSerpentSprite),
+  beast_wurm:         withMotion('beast_wurm', DuneWurmSprite),
 };
 
 export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = {

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -72,6 +72,8 @@ const UNIT_MOTION_STYLES: Record<UnitType, UnitMotionStyle> = {
   beast_boar: 'animal',
   beast_wolf: 'animal',
   beast_basilisk: 'animal',
+  beast_sea_serpent: 'naval',
+  beast_wurm: 'animal',
 };
 
 function motionTransform(style: UnitMotionStyle, motion: UnitSpriteMotion): string {

--- a/src/renderer/unit-visual-resolver.ts
+++ b/src/renderer/unit-visual-resolver.ts
@@ -44,6 +44,8 @@ const FALLBACK_ICONS: Record<UnitType, string> = {
   beast_boar: '🐗',
   beast_wolf: '🐺',
   beast_basilisk: '🦎',
+  beast_sea_serpent: '🐉',
+  beast_wurm: '🪱',
 };
 
 export interface UnitVisual {

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -4,7 +4,7 @@ import { getVisibility } from '@/systems/fog-of-war';
 import { hexDistance, hexKey, hexesInRange, getWrappedHexesInRange, wrappedHexDistance } from '@/systems/hex-utils';
 import { selectDefenderForAttack } from '@/systems/combat-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { isBeastConcealedFrom } from '@/systems/beast-system';
+import { isBeastConcealedFrom, canUnitAttackBeast } from '@/systems/beast-system';
 
 export type AttackTargetFailure =
   | 'missing-attacker'
@@ -112,6 +112,7 @@ export function canUnitAttackTarget(
     if (!canAttackOwner(state, attacker.owner, targetUnit[1].owner)) return { ok: false, reason: 'not-hostile' };
     const attackerOwnerUnits = Object.values(state.units).filter(u => u.owner === attacker.owner && !u.transportId);
     if (isBeastConcealedFrom(targetUnit[1], state.map, attackerOwnerUnits)) return { ok: false, reason: 'not-visible' };
+    if (!canUnitAttackBeast(attacker, targetUnit[1]).allowed) return { ok: false, reason: 'unsupported-target' };
     if (!profile.targets.includes('unit')) return { ok: false, reason: 'unsupported-target' };
     return { ok: true, targetType: 'unit', targetUnitId: targetUnit[0], coord, range };
   }

--- a/src/systems/beast-definitions.ts
+++ b/src/systems/beast-definitions.ts
@@ -11,6 +11,7 @@ export interface BeastDefinition {
   packSize: number;                 // units spawned on awakening
   hoardGoldBase: number;            // base hoard gold; scaled by era at slay time
   concealedInHabitat?: boolean;     // hidden on habitat terrain unless a viewer unit is adjacent
+  navalOnly?: boolean;              // only naval-domain or ranged units may attack this beast
   dangerHint: string;               // bestiary riddle shown before first sighting (MR2)
   awakeningFlavor: string;          // map-wide notification on awakening
   sightingFlavor: string;           // first-sighting notification/ceremony text (MR2)
@@ -59,6 +60,36 @@ export const BEAST_DEFINITIONS: Record<BeastId, BeastDefinition> = {
     dangerHint: 'Expeditions vanish in the green depths. Survivors speak of unblinking emerald eyes.',
     awakeningFlavor: 'Something ancient stirs beneath the canopy. Travelers, beware the green depths.',
     sightingFlavor: 'The Emerald Basilisk reveals itself — eyes like cold gems in the gloom!',
+  },
+  sea_serpent: {
+    id: 'sea_serpent',
+    unitType: 'beast_sea_serpent',
+    name: 'Sea Serpent',
+    habitatTerrains: ['ocean'],
+    awakenEra: 3,
+    tier: 3,
+    leashRadius: 5,
+    packSize: 1,
+    hoardGoldBase: 150,
+    navalOnly: true,
+    dangerHint: 'Ships vanish on the deep crossing. Sailors whisper of coils vast as harbor walls.',
+    awakeningFlavor: 'The deep water churns. Captains report a vast shadow beneath the waves.',
+    sightingFlavor: 'The Sea Serpent breaches — coils glinting above the waves!',
+  },
+  dune_wurm: {
+    id: 'dune_wurm',
+    unitType: 'beast_wurm',
+    name: 'Dune Wurm',
+    habitatTerrains: ['desert'],
+    awakenEra: 2,
+    tier: 2,
+    leashRadius: 3,
+    packSize: 1,
+    hoardGoldBase: 80,
+    concealedInHabitat: true,
+    dangerHint: 'Caravans tell of dunes that ripple and shift where no wind blows.',
+    awakeningFlavor: 'The sands tremble. Something colossal moves beneath the dunes.',
+    sightingFlavor: 'The Dune Wurm erupts from the sand in a storm of grit and teeth!',
   },
 };
 

--- a/src/systems/beast-system.ts
+++ b/src/systems/beast-system.ts
@@ -1,8 +1,9 @@
-import type { BeastHoardChoice, BeastId, BeastLair, BeastsMode, GameMap, GameState, HexCoord, Unit } from '@/core/types';
+import type { BeastHoardChoice, BeastId, BeastLair, BeastsMode, GameMap, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import { applyResearchBonus } from '@/systems/tech-system';
 import { BEAST_DEFINITIONS, getBeastDefinitionByUnitType, type BeastDefinition } from '@/systems/beast-definitions';
 import { hexKey, hexDistance, hexNeighbors } from '@/systems/hex-utils';
 import { createRng } from '@/systems/map-generator';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 
 export const BEAST_OWNER = 'beasts';
 
@@ -91,7 +92,26 @@ export interface BeastProcessResult {
   awakenings: BeastAwakening[];
 }
 
-const IMPASSABLE_FOR_BEASTS = new Set(['ocean', 'coast', 'mountain']);
+const IMPASSABLE_FOR_LAND_BEASTS = new Set(['ocean', 'coast', 'mountain']);
+const WATER_TERRAINS = new Set(['ocean', 'coast']);
+
+export function isTerrainPassableForBeast(unitType: UnitType, terrain: string): boolean {
+  const domain = UNIT_DEFINITIONS[unitType]?.domain;
+  if (domain === 'naval') return WATER_TERRAINS.has(terrain);
+  return !IMPASSABLE_FOR_LAND_BEASTS.has(terrain);
+}
+
+export interface BeastAttackEligibility { allowed: boolean; reason?: string }
+
+export function canUnitAttackBeast(attacker: Unit, target: Unit): BeastAttackEligibility {
+  const def = getBeastDefinitionByUnitType(target.type);
+  if (!def?.navalOnly || target.owner !== BEAST_OWNER) return { allowed: true };
+  const attackerDef = UNIT_DEFINITIONS[attacker.type];
+  const isNaval = attackerDef?.domain === 'naval';
+  const isRanged = attackerDef?.attackProfile?.kind === 'ranged';
+  if (isNaval || isRanged) return { allowed: true };
+  return { allowed: false, reason: `Only ships and ranged units can fight the ${def.name}.` };
+}
 
 export function processBeasts(
   lairs: BeastLair[],
@@ -125,7 +145,7 @@ export function processBeasts(
       for (const n of hexNeighbors(lair.position)) {
         if (spawnTiles.length >= def.packSize) break;
         const tile = map.tiles[hexKey(n)];
-        if (tile && !IMPASSABLE_FOR_BEASTS.has(tile.terrain) && !occupied.has(hexKey(n))) spawnTiles.push(n);
+        if (tile && isTerrainPassableForBeast(def.unitType, tile.terrain) && !occupied.has(hexKey(n))) spawnTiles.push(n);
       }
       for (const pos of spawnTiles.slice(0, def.packSize)) {
         spawnOrders.push({ lairId: lair.id, beastId: lair.beastId, position: { ...pos } });
@@ -166,7 +186,7 @@ export function processBeasts(
     const step = hexNeighbors(beast.position)
       .filter(n => {
         const tile = map.tiles[hexKey(n)];
-        return tile && !IMPASSABLE_FOR_BEASTS.has(tile.terrain) && !occupied.has(hexKey(n)) && inLeash(n);
+        return tile && isTerrainPassableForBeast(def.unitType, tile.terrain) && !occupied.has(hexKey(n)) && inLeash(n);
       })
       .sort((a, b) => hexDistance(a, goal) - hexDistance(b, goal))[0];
     if (step && hexDistance(step, goal) < hexDistance(beast.position, goal)) {

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -221,6 +221,16 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     visionRange: 2, strength: 26, canFoundCity: false,
     canBuildImprovements: false, productionCost: 0,
   },
+  beast_sea_serpent: {
+    type: 'beast_sea_serpent', name: 'Sea Serpent', movementPoints: 3,
+    visionRange: 3, strength: 38, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0, domain: 'naval',
+  },
+  beast_wurm: {
+    type: 'beast_wurm', name: 'Dune Wurm', movementPoints: 2,
+    visionRange: 2, strength: 30, canFoundCity: false,
+    canBuildImprovements: false, productionCost: 0,
+  },
 };
 
 const VIKING_MOBILITY_UNITS = new Set<UnitType>(['scout', 'warrior', 'archer', 'swordsman']);
@@ -367,6 +377,8 @@ export const UNIT_DESCRIPTIONS: Record<UnitType, string> = {
   beast_boar: 'A legendary boar of monstrous size. Territorial — it defends its forest den but never wanders far. Slay it to claim its hoard.',
   beast_wolf: 'One of the Dire Wolf Pack. Fast, relentless, and never alone — defeat the whole pack to claim their hoard.',
   beast_basilisk: 'The Emerald Basilisk lies hidden in the jungle until prey wanders close. Approach with overwhelming force.',
+  beast_sea_serpent: 'A serpent of the deep ocean. It drags ships under within its hunting waters — only ships and ranged units can fight it.',
+  beast_wurm: 'The Dune Wurm swims beneath the sand, invisible until you stand beside it. Bring ranged units and overwhelming force.',
 };
 
 export function getUnmovedUnits(

--- a/tests/systems/beast-system.test.ts
+++ b/tests/systems/beast-system.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { placeBeastLairs, BEAST_OWNER, LAIR_COUNTS, processBeasts, recordBeastSlain, getBeastHoardGold, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, getClaimedTrophyGoldPerTurn } from '@/systems/beast-system';
+import { placeBeastLairs, BEAST_OWNER, LAIR_COUNTS, processBeasts, recordBeastSlain, getBeastHoardGold, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, getClaimedTrophyGoldPerTurn, isTerrainPassableForBeast, canUnitAttackBeast } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { generateMap } from '@/systems/map-generator';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
@@ -308,5 +308,50 @@ describe('pack spawning', () => {
       return;
     }
     throw new Error('no seed awakened the wolf lair in 60 tries');
+  });
+});
+
+describe('beast passability', () => {
+  it('naval beasts move only on water; land beasts only on land', () => {
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'ocean')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'coast')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_sea_serpent', 'grassland')).toBe(false);
+    expect(isTerrainPassableForBeast('beast_boar', 'ocean')).toBe(false);
+    expect(isTerrainPassableForBeast('beast_boar', 'forest')).toBe(true);
+    expect(isTerrainPassableForBeast('beast_boar', 'mountain')).toBe(false);
+  });
+
+  it('serpent move orders never target land (no beaching)', () => {
+    const map = tinyMap({
+      '10,10': 'ocean', '11,10': 'ocean', '12,10': 'grassland',
+      '9,10': 'ocean', '10,9': 'ocean', '10,11': 'coast', '11,9': 'grassland', '9,11': 'ocean',
+    });
+    const lair = makeLair({ id: 'lair-sea_serpent', beastId: 'sea_serpent', position: { q: 10, r: 10 }, status: 'awake', unitIds: ['serp-1'] });
+    const serpent = makeUnit({ id: 'serp-1', type: 'beast_sea_serpent', owner: 'beasts', position: { q: 10, r: 10 } });
+    const ship = makeUnit({ id: 'ship-1', type: 'galley', position: { q: 11, r: 10 } });
+    const result = processBeasts([lair], map, [ship], [serpent], 3, 'wild', 7);
+    for (const order of result.moveOrders) {
+      const terrain = map.tiles[`${order.toCoord.q},${order.toCoord.r}`].terrain;
+      expect(['ocean', 'coast']).toContain(terrain);
+    }
+  });
+});
+
+describe('canUnitAttackBeast', () => {
+  const serpent = makeUnit({ id: 's', type: 'beast_sea_serpent', owner: 'beasts' });
+  const boar = makeUnit({ id: 'b', type: 'beast_boar', owner: 'beasts' });
+
+  it('land melee cannot attack a navalOnly beast', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), serpent).allowed).toBe(false);
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), serpent).reason).toContain('ships and ranged');
+  });
+
+  it('naval and ranged units can attack a navalOnly beast', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'galley' }), serpent).allowed).toBe(true);
+    expect(canUnitAttackBeast(makeUnit({ type: 'archer' }), serpent).allowed).toBe(true);
+  });
+
+  it('everything can attack normal beasts', () => {
+    expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), boar).allowed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- **Sea Serpent** (tier 3, ocean): definition-driven naval passability — only moves on water, never beaches; only ships and ranged units can engage, with a player-facing warning gated before the combat preview and before the generic movement blocker
- **Dune Wurm** (tier 2, desert): reuses MR3 `concealedInHabitat` burrowing — invisible on desert until a unit stands adjacent
- **New `beast-serpent` animation rig**: phase-offset segment undulation (`cq-segment-1..4`), documented in the sprite design system; `data-kind` placed on an inner group so `applyUnitMotion` correctly applies naval motion transforms to the outer `cq-sprite-figure`
- **Passability refactor**: `IMPASSABLE_FOR_BEASTS` replaced with `isTerrainPassableForBeast(unitType, terrain)` — domain-driven; land beasts unchanged, naval beasts route through `WATER_TERRAINS`
- **navalOnly gate**: `canUnitAttackBeast` wired into `attack-targeting.ts` (AI path included via `getAttackTargets`) and `main.ts` (before combat preview AND before movement blocker)

## Why this is safe to merge partial
Both beasts complete end-to-end: lairs place, beasts awaken, beasts move/attack correctly, player gets correct feedback. Remaining: MR6 (Roc + Hydra), MR7 (Ancient Dragon), MR8 (audio/AI/balance) — see [docs/superpowers/plans/2026-06-11-legendary-beasts-index.md](docs/superpowers/plans/2026-06-11-legendary-beasts-index.md).

## Test plan
- [ ] `yarn build && yarn test` both exit 0 (3649 tests pass)
- [ ] Wild game on large/continents map → sail toward serpent lair: serpent patrols ocean, attacks ships in its waters
- [ ] Land warrior tapping serpent gets "Only ships and ranged units can fight the Sea Serpent" (not "Ocean is impassable")
- [ ] Archer or galley gets combat preview against serpent
- [ ] Wurm: invisible on desert until adjacent; conceal test confirms hint text has no literal "desert"

🤖 Generated with [Claude Code](https://claude.com/claude-code)