### PR TITLE
fix(badges): replace cryptic F/2 unit badges with 🛡️ and 🪖️×N icons

### DIFF
--- a/docs/superpowers/plans/2026-06-15-badge-clarity.md
+++ b/docs/superpowers/plans/2026-06-15-badge-clarity.md
@@ -1,0 +1,268 @@
+# Badge Clarity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace cryptic "F" and "2" unit badges with self-explanatory 🛡️ (fortified) and 🪖️×N (stack count) icons in both the Canvas and DOM unit renderers.
+
+**Architecture:** Two source files touch badge rendering — `unit-renderer.ts` (Canvas, low zoom) and `sprite-overlay.ts` (DOM, high zoom). Each has an existing failing test that must be updated first; the implementation follows the red→green cycle. No logic changes — purely visual glyph and layout substitutions.
+
+**Tech Stack:** TypeScript, Canvas 2D API, jsdom (vitest), `replaceChildren()` DOM API.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/renderer/unit-renderer.ts` | `'F'` → `'🛡️'` for fortified; `String(count)` → `'🪖️×'+count` + 1.2× radius for stack |
+| `src/renderer/sprite-overlay.ts` | `'F'` → `'🛡️'` for fortified; circle badge → pill with two child spans for stack |
+| `tests/renderer/unit-renderer.test.ts` | Update 3 assertions: `'F'`×2 → `'🛡️'`, `'2'` → `'🪖️×2'` |
+| `tests/renderer/sprite-overlay.test.ts` | Update 2 assertions in "renders stack…decorations" test |
+
+---
+
+## Task 1: Fix fortified badge glyph in both renderers
+
+**Files:**
+- Modify: `tests/renderer/unit-renderer.test.ts` (lines 160, 177)
+- Modify: `tests/renderer/sprite-overlay.test.ts` (line 226)
+- Modify: `src/renderer/unit-renderer.ts` (line 121)
+- Modify: `src/renderer/sprite-overlay.ts` (line 294)
+
+- [ ] **Step 1: Update the Canvas fortified-badge test to expect the shield emoji**
+
+In `tests/renderer/unit-renderer.test.ts`, make these two changes:
+
+```ts
+// line 160 — "draws an F badge for a fortified unit"
+expect(ctx.fillText).toHaveBeenCalledWith('🛡️', expect.any(Number), expect.any(Number));
+
+// line 177 — "does not draw an F badge for a non-fortified unit"
+expect(fillTextCalls.some(([text]) => text === '🛡️')).toBe(false);
+```
+
+- [ ] **Step 2: Update the DOM fortified-badge test to expect the shield emoji**
+
+In `tests/renderer/sprite-overlay.test.ts`, find the test `'renders stack, selection, health, fortified, and role decorations for DOM units'` (around line 211) and change line 226:
+
+```ts
+// before
+expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('F');
+// after
+expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('🛡️');
+```
+
+- [ ] **Step 3: Run tests and confirm they fail for the right reason**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/unit-renderer.test.ts tests/renderer/sprite-overlay.test.ts
+```
+
+Expected: 3 failures, all mentioning `'F'` vs `'🛡️'`.
+
+- [ ] **Step 4: Fix the Canvas renderer**
+
+In `src/renderer/unit-renderer.ts` line 121, change:
+
+```ts
+ctx.fillText('F', badgeX, badgeY);
+```
+to:
+```ts
+ctx.fillText('🛡️', badgeX, badgeY);
+```
+
+- [ ] **Step 5: Fix the DOM renderer**
+
+In `src/renderer/sprite-overlay.ts` line 294, change:
+
+```ts
+fortified.textContent = 'F';
+```
+to:
+```ts
+fortified.textContent = '🛡️';
+```
+
+- [ ] **Step 6: Run tests and confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/unit-renderer.test.ts tests/renderer/sprite-overlay.test.ts
+```
+
+Expected: all passing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/unit-renderer.ts src/renderer/sprite-overlay.ts \
+        tests/renderer/unit-renderer.test.ts tests/renderer/sprite-overlay.test.ts
+git commit -m "fix(badges): fortified badge F → 🛡️ in canvas and DOM renderers"
+```
+
+---
+
+## Task 2: Fix stack count badge in DOM renderer (pill layout)
+
+**Files:**
+- Modify: `tests/renderer/sprite-overlay.test.ts` (line 222)
+- Modify: `src/renderer/sprite-overlay.ts` (lines 265–274)
+
+- [ ] **Step 1: Update the DOM stack-count test to check the pill structure**
+
+In `tests/renderer/sprite-overlay.test.ts`, replace line 222:
+
+```ts
+// before
+expect(mount.querySelector('.cq-unit-stack-count')?.textContent).toBe('2');
+
+// after — pill has two child spans; combined textContent reads '🪖️×2'
+const pill = mount.querySelector('.cq-unit-stack-count') as HTMLElement | null;
+expect(pill).not.toBeNull();
+const spans = pill!.querySelectorAll('span');
+expect(spans.length).toBe(2);
+expect(spans[0].textContent).toBe('🪖️');
+expect(spans[1].textContent).toBe('×2');
+```
+
+- [ ] **Step 2: Run tests and confirm they fail for the right reason**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts
+```
+
+Expected: 1 failure — `.cq-unit-stack-count` textContent is `'2'`, not the pill structure.
+
+- [ ] **Step 3: Replace the stack count circle with a pill in sprite-overlay.ts**
+
+In `src/renderer/sprite-overlay.ts`, replace lines 265–274 (the `if ((entity.stackCount ?? 1) > 1)` block):
+
+```ts
+if ((entity.stackCount ?? 1) > 1) {
+  const pill = getOrCreateDecoration(wrapper, 'cq-unit-stack-count');
+  pill.style.cssText =
+    'position:absolute;right:2%;top:2%;min-width:42%;height:28%;border-radius:999px;' +
+    'background:rgba(0,0,0,.82);border:1px solid rgba(255,255,255,.85);color:#fff;' +
+    'font:700 0.65em system-ui;display:flex;align-items:center;justify-content:center;' +
+    'gap:2px;padding:0 3%;pointer-events:none';
+  const icon = document.createElement('span');
+  icon.textContent = '🪖️';
+  icon.style.cssText = 'font-size:0.9em;line-height:1';
+  const label = document.createElement('span');
+  label.textContent = `×${entity.stackCount}`;
+  label.style.cssText = 'font-weight:700';
+  pill.replaceChildren(icon, label);
+} else {
+  removeDecoration(wrapper, 'cq-unit-stack-count');
+}
+```
+
+**Why `replaceChildren` not `innerHTML`:** Project rules prohibit `innerHTML` for game-generated strings (XSS risk, see `.claude/rules/ui-panels.md`). `replaceChildren()` rebuilds children safely each render cycle; `getOrCreateDecoration` reuses the outer div across renders so children must be replaced explicitly.
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts
+```
+
+Expected: all passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/sprite-overlay.ts tests/renderer/sprite-overlay.test.ts
+git commit -m "fix(badges): stack count badge DOM — circle → helmet pill (🪖️×N)"
+```
+
+---
+
+## Task 3: Fix stack count badge in Canvas renderer
+
+**Files:**
+- Modify: `tests/renderer/unit-renderer.test.ts` (line 123)
+- Modify: `src/renderer/unit-renderer.ts` (lines 196–218)
+
+- [ ] **Step 1: Update the Canvas stack-count test**
+
+In `tests/renderer/unit-renderer.test.ts`, change line 123:
+
+```ts
+// before
+expect(ctx.fillText).toHaveBeenCalledWith('2', expect.any(Number), expect.any(Number));
+
+// after
+expect(ctx.fillText).toHaveBeenCalledWith('🪖️×2', expect.any(Number), expect.any(Number));
+```
+
+Leave line 124 unchanged — it checks the warrior unit glyph `'⚔️'`, not the badge.
+
+- [ ] **Step 2: Run tests and confirm they fail for the right reason**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/unit-renderer.test.ts
+```
+
+Expected: 1 failure — `fillText` was called with `'2'`, not `'🪖️×2'`.
+
+- [ ] **Step 3: Fix the Canvas stack badge in unit-renderer.ts**
+
+In `src/renderer/unit-renderer.ts`, find the `if (presentation.stackCount > 1)` block (around lines 196–218). Replace it with:
+
+```ts
+if (presentation.stackCount > 1) {
+  ctx.beginPath();
+  ctx.arc(
+    screen.x + metrics.countBadge.x,
+    screen.y + metrics.countBadge.y,
+    metrics.countBadge.radius * 1.2,   // wider to fit icon + number
+    0,
+    Math.PI * 2,
+  );
+  ctx.fillStyle = 'rgba(0,0,0,0.82)';
+  ctx.fill();
+  ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+  ctx.stroke();
+  ctx.font = `${size * 0.18}px system-ui`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = 'white';
+  ctx.fillText(
+    `🪖️×${presentation.stackCount}`,
+    screen.x + metrics.countBadge.x,
+    screen.y + metrics.countBadge.y,
+  );
+}
+```
+
+- [ ] **Step 4: Run tests and confirm they pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/unit-renderer.test.ts
+```
+
+Expected: all passing.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: all 267 test files passing, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/unit-renderer.ts tests/renderer/unit-renderer.test.ts
+git commit -m "fix(badges): stack count badge canvas — wider circle with 🪖️×N glyph"
+```
+
+---
+
+## Manual Verification Checklist
+
+After all three tasks pass:
+
+1. **Low zoom (Canvas):** Start the dev server (`bash scripts/run-with-mise.sh yarn dev`). Zoom out on the map. Fortified unit: gold circle shows 🛡️. Stacked units: dark wider circle shows 🪖️×N.
+2. **High zoom (DOM sprites):** Zoom in until sprites appear. Fortified unit: gold circle shows 🛡️. Stacked units: dark pill shows 🪖️ on left, ×N on right.
+3. **Both badges together:** A fortified unit in a 2+ stack shows 🛡️ top-left and 🪖️×N pill top-right, no overlap.

--- a/docs/superpowers/plans/2026-06-15-badge-clarity.md
+++ b/docs/superpowers/plans/2026-06-15-badge-clarity.md
@@ -4,9 +4,11 @@
 
 **Goal:** Replace cryptic "F" and "2" unit badges with self-explanatory 🛡️ (fortified) and 🪖️×N (stack count) icons in both the Canvas and DOM unit renderers.
 
-**Architecture:** Two source files touch badge rendering — `unit-renderer.ts` (Canvas, low zoom) and `sprite-overlay.ts` (DOM, high zoom). Each has an existing failing test that must be updated first; the implementation follows the red→green cycle. No logic changes — purely visual glyph and layout substitutions.
+**Architecture:** Two source files touch badge rendering — `unit-renderer.ts` (Canvas, low zoom) and `sprite-overlay.ts` (DOM, high zoom). Each has existing tests that must be updated first (TDD: red→green). No logic changes — purely visual glyph and layout substitutions.
 
 **Tech Stack:** TypeScript, Canvas 2D API, jsdom (vitest), `replaceChildren()` DOM API.
+
+**Emoji note:** Every emoji in this plan includes the invisible Unicode variation selector-16 (U+FE0F) appended, which forces colour-emoji rendering on all platforms. Copy emoji strings from this document rather than retyping them.
 
 ---
 
@@ -14,36 +16,42 @@
 
 | File | Change |
 |------|--------|
-| `src/renderer/unit-renderer.ts` | `'F'` → `'🛡️'` for fortified; `String(count)` → `'🪖️×'+count` + 1.2× radius for stack |
+| `src/renderer/unit-renderer.ts` | `'F'` → `'🛡️'` for fortified; `String(count)` → `` `🪖️×${count}` `` + 1.2× radius for stack |
 | `src/renderer/sprite-overlay.ts` | `'F'` → `'🛡️'` for fortified; circle badge → pill with two child spans for stack |
-| `tests/renderer/unit-renderer.test.ts` | Update 3 assertions: `'F'`×2 → `'🛡️'`, `'2'` → `'🪖️×2'` |
-| `tests/renderer/sprite-overlay.test.ts` | Update 2 assertions in "renders stack…decorations" test |
+| `tests/renderer/unit-renderer.test.ts` | Update 3 assertions + 2 test description strings |
+| `tests/renderer/sprite-overlay.test.ts` | Update 2 assertions + add re-render regression test |
 
 ---
 
 ## Task 1: Fix fortified badge glyph in both renderers
 
 **Files:**
-- Modify: `tests/renderer/unit-renderer.test.ts` (lines 160, 177)
+- Modify: `tests/renderer/unit-renderer.test.ts` (lines 146, 160, 163, 177)
 - Modify: `tests/renderer/sprite-overlay.test.ts` (line 226)
 - Modify: `src/renderer/unit-renderer.ts` (line 121)
 - Modify: `src/renderer/sprite-overlay.ts` (line 294)
 
-- [ ] **Step 1: Update the Canvas fortified-badge test to expect the shield emoji**
+- [ ] **Step 1: Update Canvas fortified-badge test — description and assertion**
 
-In `tests/renderer/unit-renderer.test.ts`, make these two changes:
+In `tests/renderer/unit-renderer.test.ts`, make these changes:
 
 ```ts
-// line 160 — "draws an F badge for a fortified unit"
+// line 146 — update the test description
+it('draws a 🛡️ badge for a fortified unit', () => {
+
+// line 160 — update the assertion (inside that test)
 expect(ctx.fillText).toHaveBeenCalledWith('🛡️', expect.any(Number), expect.any(Number));
 
-// line 177 — "does not draw an F badge for a non-fortified unit"
+// line 163 — update the sibling test description
+it('does not draw a 🛡️ badge for a non-fortified unit', () => {
+
+// line 177 — update the negative assertion (inside that test)
 expect(fillTextCalls.some(([text]) => text === '🛡️')).toBe(false);
 ```
 
-- [ ] **Step 2: Update the DOM fortified-badge test to expect the shield emoji**
+- [ ] **Step 2: Update DOM fortified-badge test assertion**
 
-In `tests/renderer/sprite-overlay.test.ts`, find the test `'renders stack, selection, health, fortified, and role decorations for DOM units'` (around line 211) and change line 226:
+In `tests/renderer/sprite-overlay.test.ts`, find the test `'renders stack, selection, health, fortified, and role decorations for DOM units'` (around line 211). Change line 226:
 
 ```ts
 // before
@@ -58,7 +66,7 @@ expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('🛡️');
 bash scripts/run-with-mise.sh yarn test tests/renderer/unit-renderer.test.ts tests/renderer/sprite-overlay.test.ts
 ```
 
-Expected: 3 failures, all mentioning `'F'` vs `'🛡️'`.
+Expected: 3 failures, each showing received `'F'` vs expected `'🛡️'`.
 
 - [ ] **Step 4: Fix the Canvas renderer**
 
@@ -105,18 +113,20 @@ git commit -m "fix(badges): fortified badge F → 🛡️ in canvas and DOM rend
 ## Task 2: Fix stack count badge in DOM renderer (pill layout)
 
 **Files:**
-- Modify: `tests/renderer/sprite-overlay.test.ts` (line 222)
+- Modify: `tests/renderer/sprite-overlay.test.ts` (lines 222–222 and new test after line 237)
 - Modify: `src/renderer/sprite-overlay.ts` (lines 265–274)
 
 - [ ] **Step 1: Update the DOM stack-count test to check the pill structure**
 
-In `tests/renderer/sprite-overlay.test.ts`, replace line 222:
+In `tests/renderer/sprite-overlay.test.ts`, the test `'renders stack, selection, health, fortified...'` starts at line 211. Currently line 222 is:
 
 ```ts
-// before
 expect(mount.querySelector('.cq-unit-stack-count')?.textContent).toBe('2');
+```
 
-// after — pill has two child spans; combined textContent reads '🪖️×2'
+Replace that **single line** with this block (everything else in the `it` stays the same):
+
+```ts
 const pill = mount.querySelector('.cq-unit-stack-count') as HTMLElement | null;
 expect(pill).not.toBeNull();
 const spans = pill!.querySelectorAll('span');
@@ -125,17 +135,36 @@ expect(spans[0].textContent).toBe('🪖️');
 expect(spans[1].textContent).toBe('×2');
 ```
 
-- [ ] **Step 2: Run tests and confirm they fail for the right reason**
+- [ ] **Step 2: Add a re-render regression test**
+
+Still in `tests/renderer/sprite-overlay.test.ts`, after the closing `});` of the `'renders stack, selection, health, fortified...'` test (around line 228), add:
+
+```ts
+it('pill children are replaced cleanly on re-render, not accumulated', () => {
+  const { overlay, mount } = mountOverlay();
+  const e = entity({ stackCount: 2, memberIds: ['u1', 'u2'] });
+  overlay.sync(cam({ zoom: 1 }), [e], MAP, OPTS);
+  overlay.sync(cam({ zoom: 1 }), [e], MAP, OPTS);
+  const pill = mount.querySelector('.cq-unit-stack-count') as HTMLElement | null;
+  expect(pill?.querySelectorAll('span').length).toBe(2); // not 4 — replaceChildren, not appendChild
+});
+```
+
+This guards against a future regression where `replaceChildren()` is swapped for `appendChild()`, which would silently double the spans on each re-render.
+
+- [ ] **Step 3: Run tests and confirm they fail for the right reason**
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts
 ```
 
-Expected: 1 failure — `.cq-unit-stack-count` textContent is `'2'`, not the pill structure.
+Expected: 2 failures:
+- `'renders stack...'`: `spans.length` received 0, expected 2 (no child spans yet)
+- `'pill children...'`: `spans.length` received 0, expected 2
 
-- [ ] **Step 3: Replace the stack count circle with a pill in sprite-overlay.ts**
+- [ ] **Step 4: Replace the stack count circle with a pill in sprite-overlay.ts**
 
-In `src/renderer/sprite-overlay.ts`, replace lines 265–274 (the `if ((entity.stackCount ?? 1) > 1)` block):
+In `src/renderer/sprite-overlay.ts`, replace lines 265–274 (the entire `if ((entity.stackCount ?? 1) > 1)` block, which currently uses `const count`). The new variable name is `pill` (the old `count` is replaced):
 
 ```ts
 if ((entity.stackCount ?? 1) > 1) {
@@ -157,9 +186,9 @@ if ((entity.stackCount ?? 1) > 1) {
 }
 ```
 
-**Why `replaceChildren` not `innerHTML`:** Project rules prohibit `innerHTML` for game-generated strings (XSS risk, see `.claude/rules/ui-panels.md`). `replaceChildren()` rebuilds children safely each render cycle; `getOrCreateDecoration` reuses the outer div across renders so children must be replaced explicitly.
+**Why `replaceChildren` not `innerHTML`:** Project rules prohibit `innerHTML` for game-generated strings (XSS risk, per `.claude/rules/ui-panels.md`). `replaceChildren()` rebuilds children safely on every render cycle. `getOrCreateDecoration` reuses the outer div across renders, so children must be replaced explicitly — otherwise a second call would append duplicates.
 
-- [ ] **Step 4: Run tests and confirm they pass**
+- [ ] **Step 5: Run tests and confirm they pass**
 
 ```bash
 bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts
@@ -167,7 +196,7 @@ bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts
 
 Expected: all passing.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
 git add src/renderer/sprite-overlay.ts tests/renderer/sprite-overlay.test.ts
@@ -206,7 +235,11 @@ Expected: 1 failure — `fillText` was called with `'2'`, not `'🪖️×2'`.
 
 - [ ] **Step 3: Fix the Canvas stack badge in unit-renderer.ts**
 
-In `src/renderer/unit-renderer.ts`, find the `if (presentation.stackCount > 1)` block (around lines 196–218). Replace it with:
+In `src/renderer/unit-renderer.ts`, replace lines 196–218 (the `if (presentation.stackCount > 1)` block).
+
+**Context:** this block lives inside `drawUnitPresentations()`, in a `for (const renderCoord of renderCoords)` loop. The variable `size` is already defined two lines above the block as `const size = camera.hexSize * camera.zoom` (line 165) — it is in scope here.
+
+Replace the block with:
 
 ```ts
 if (presentation.stackCount > 1) {
@@ -214,7 +247,7 @@ if (presentation.stackCount > 1) {
   ctx.arc(
     screen.x + metrics.countBadge.x,
     screen.y + metrics.countBadge.y,
-    metrics.countBadge.radius * 1.2,   // wider to fit icon + number
+    metrics.countBadge.radius * 1.2,   // wider to fit emoji + number
     0,
     Math.PI * 2,
   );
@@ -248,7 +281,7 @@ Expected: all passing.
 bash scripts/run-with-mise.sh yarn test
 ```
 
-Expected: all 267 test files passing, 0 failures.
+Expected: all 267 test files passing, 0 failures. (No new test files were added; existing files were modified.)
 
 - [ ] **Step 6: Commit**
 

--- a/docs/superpowers/specs/2026-06-15-issue-377-badge-clarity-design.md
+++ b/docs/superpowers/specs/2026-06-15-issue-377-badge-clarity-design.md
@@ -1,0 +1,78 @@
+# Issue #377: Badge Clarity Fix
+
+**Date:** 2026-06-15  
+**Issue:** https://github.com/a1flecke/conquestoria/issues/377  
+**Problem:** Unit badges "F" (fortified) and "2" (stack count) are cryptic to players.
+
+## Goal
+
+Replace opaque letter/number badges on map units with self-explanatory icons so players immediately understand unit state without tapping.
+
+## Scope
+
+Two badges, two renderers each:
+
+| Badge | Before | After | Renderer paths |
+|-------|--------|-------|---------------|
+| Fortified | `F` in gold circle | `🛡` in gold circle | Canvas (`unit-renderer.ts`) + DOM (`sprite-overlay.ts`) |
+| Stack count | `2` in dark circle | `⚔ ×2` in dark pill | DOM only at high zoom; `⚔2` in wider circle on Canvas |
+
+No logic changes. No tooltip infrastructure. No panel changes.
+
+## Fortified Badge
+
+### Canvas path (`src/renderer/unit-renderer.ts`)
+
+`ctx.fillText('F', badgeX, badgeY)` → `ctx.fillText('🛡', badgeX, badgeY)`
+
+Badge circle geometry (position, radius, color) stays identical. Only the glyph changes.
+
+### DOM/sprite path (`src/renderer/sprite-overlay.ts`)
+
+`fortified.textContent = 'F'` → `fortified.textContent = '🛡'`
+
+All CSS (position, background, border, size) stays identical.
+
+## Stack Count Badge
+
+### DOM/sprite path (`src/renderer/sprite-overlay.ts`)
+
+Change from a circle to a pill layout with two child elements:
+
+```
+[⚔  ×N]
+```
+
+- Outer wrapper: `border-radius: 999px` (pill), `display: flex`, `flex-direction: row`, `gap: 2px`, `padding: 1px 4px`
+- Left child `<span>`: `⚔` emoji, `font-size: 0.6em`
+- Right child `<span>`: `×N` text, `font-size: 0.65em`, `font-weight: 700`
+- Same colors as current badge: `background: rgba(0,0,0,.82)`, `border: 1px solid rgba(255,255,255,.85)`, `color: #fff`
+- Width: `auto` with `min-width: 42%` so it doesn't pinch at count=2
+- Position stays top-right corner
+
+### Canvas path (`src/renderer/unit-renderer.ts`)
+
+At low zoom the sprite is ~30–40px; a two-child flex layout isn't feasible on canvas. Instead:
+
+- Widen the badge radius by ~20% (multiply current radius by 1.2)
+- `ctx.fillText('⚔' + stackCount, badgeX, badgeY)` — e.g. `⚔2`, `⚔4`
+- Font size stays the same
+
+## What Does Not Change
+
+- Fortify logic, stack logic, selection logic
+- Selected-unit panel (already shows "Fortify/Unfortify" button and "Stack: N units here" text)
+- Badge positions, colors, or z-order
+- Any other badge type (health bar, role marker, selected ring)
+
+## Testing
+
+Existing visual regression coverage (screenshot/render tests) if any should update automatically. Unit tests do not cover badge rendering directly. Verify manually at two zoom levels:
+
+1. Low zoom (Canvas renderer active, LOD below sprite threshold): fortified unit shows 🛡 badge; stacked unit shows ⚔2 badge
+2. High zoom (DOM sprite overlay active): fortified unit shows 🛡 badge; stacked units show ⚔ ×2 pill
+
+## Files Changed
+
+- `src/renderer/unit-renderer.ts` — Canvas fortified glyph + canvas stack badge
+- `src/renderer/sprite-overlay.ts` — DOM fortified glyph + DOM stack badge pill

--- a/docs/superpowers/specs/2026-06-15-issue-377-badge-clarity-design.md
+++ b/docs/superpowers/specs/2026-06-15-issue-377-badge-clarity-design.md
@@ -14,49 +14,66 @@ Two badges, two renderers each:
 
 | Badge | Before | After | Renderer paths |
 |-------|--------|-------|---------------|
-| Fortified | `F` in gold circle | `🛡` in gold circle | Canvas (`unit-renderer.ts`) + DOM (`sprite-overlay.ts`) |
-| Stack count | `2` in dark circle | `⚔ ×2` in dark pill | DOM only at high zoom; `⚔2` in wider circle on Canvas |
+| Fortified | `F` in gold circle | `🛡️` in gold circle | Canvas (`unit-renderer.ts`) + DOM (`sprite-overlay.ts`) |
+| Stack count | `2` in dark circle | `🪖️ ×2` in dark pill | DOM only at high zoom; `🪖×2` in wider circle on Canvas |
 
 No logic changes. No tooltip infrastructure. No panel changes.
+
+**Emoji presentation rule:** Always append `️` (Unicode variation selector 16) to `🛡` and `🪖` in both canvas `fillText` calls and DOM `textContent` assignments. Without it, some platforms render these as black-and-white text glyphs rather than coloured emoji. The literal string in source should be `'🛡️'` and `'🪖️'`.
+
+**Stack emoji rationale:** `🪖` (military helmet) is used rather than `⚔` (crossed swords) because crossed swords conventionally signals "in combat" — using it for a stack count would confuse the intent.
 
 ## Fortified Badge
 
 ### Canvas path (`src/renderer/unit-renderer.ts`)
 
-`ctx.fillText('F', badgeX, badgeY)` → `ctx.fillText('🛡', badgeX, badgeY)`
+`ctx.fillText('F', badgeX, badgeY)` → `ctx.fillText('🛡️', badgeX, badgeY)`
 
-Badge circle geometry (position, radius, color) stays identical. Only the glyph changes.
+Badge circle geometry (position, radius, color) stays identical. The font size (`size * 0.18`) may be tuned ±20% during implementation if the shield emoji renders too large or too small inside the circle — emoji visual extent differs from ASCII glyphs.
 
 ### DOM/sprite path (`src/renderer/sprite-overlay.ts`)
 
-`fortified.textContent = 'F'` → `fortified.textContent = '🛡'`
+`fortified.textContent = 'F'` → `fortified.textContent = '🛡️'`
 
-All CSS (position, background, border, size) stays identical.
+All CSS (position, background, border, size) stays identical. Same ±20% font-size tuning latitude applies.
 
 ## Stack Count Badge
 
 ### DOM/sprite path (`src/renderer/sprite-overlay.ts`)
 
-Change from a circle to a pill layout with two child elements:
+Change from a circle to a pill layout. Because `getOrCreateDecoration` reuses the existing div on every re-render, the implementation must manage child spans explicitly — **do not use `innerHTML`** (XSS risk per project rules). Use `replaceChildren()` to rebuild child spans on each update:
 
-```
-[⚔  ×N]
+```ts
+const pill = getOrCreateDecoration(wrapper, 'cq-unit-stack-count');
+pill.style.cssText =
+  'position:absolute;right:2%;top:2%;min-width:42%;height:28%;border-radius:999px;' +
+  'background:rgba(0,0,0,.82);border:1px solid rgba(255,255,255,.85);color:#fff;' +
+  'font:700 0.65em system-ui;display:flex;align-items:center;justify-content:center;' +
+  'gap:2px;padding:0 3%;pointer-events:none';
+const icon = document.createElement('span');
+icon.textContent = '🪖️';
+icon.style.cssText = 'font-size:0.9em;line-height:1';
+const label = document.createElement('span');
+label.textContent = `×${entity.stackCount}`;  // ×N
+label.style.cssText = 'font-weight:700';
+pill.replaceChildren(icon, label);
 ```
 
-- Outer wrapper: `border-radius: 999px` (pill), `display: flex`, `flex-direction: row`, `gap: 2px`, `padding: 1px 4px`
-- Left child `<span>`: `⚔` emoji, `font-size: 0.6em`
-- Right child `<span>`: `×N` text, `font-size: 0.65em`, `font-weight: 700`
-- Same colors as current badge: `background: rgba(0,0,0,.82)`, `border: 1px solid rgba(255,255,255,.85)`, `color: #fff`
-- Width: `auto` with `min-width: 42%` so it doesn't pinch at count=2
-- Position stays top-right corner
+Layout: pill (`border-radius: 999px`), `display: flex`, icon on left, `×N` on right.  
+Colors: same dark badge (`rgba(0,0,0,.82)`, white border, white text).  
+Position stays top-right corner.
+
+**Coexistence note:** When a unit is both fortified (🛡 top-left) and stacked (🪖×N pill top-right), the two badges do not collide — fortified is anchored at `left:3%;top:3%` and the pill at `right:2%;top:2%`. At very high stack counts (≥10) the pill may grow wide; this is acceptable since counts that high are rare and the unit remains legible.
 
 ### Canvas path (`src/renderer/unit-renderer.ts`)
 
-At low zoom the sprite is ~30–40px; a two-child flex layout isn't feasible on canvas. Instead:
+At low zoom the sprite is ~30–40px; a flex layout is not feasible on canvas. Use a single `fillText` string instead:
 
-- Widen the badge radius by ~20% (multiply current radius by 1.2)
-- `ctx.fillText('⚔' + stackCount, badgeX, badgeY)` — e.g. `⚔2`, `⚔4`
-- Font size stays the same
+- Keep badge as a circle; widen radius by ×1.2 relative to `metrics.countBadge.radius` to accommodate two glyphs
+- Draw: `ctx.fillText('🪖️×' + stackCount, badgeX, badgeY)` — e.g. `🪖×2`, `🪖×4`
+- Font size stays the same (`size * 0.18`)
+
+**Canvas/DOM format difference:** The canvas renders `🪖×2` (no space, tighter) while the DOM renders `🪖 ×2` (flex gap provides visual spacing). This is intentional — canvas cannot do two-child flex layout at this size, and the tighter format reads clearly at low zoom. Both convey the same meaning.
 
 ## What Does Not Change
 
@@ -67,10 +84,11 @@ At low zoom the sprite is ~30–40px; a two-child flex layout isn't feasible on 
 
 ## Testing
 
-Existing visual regression coverage (screenshot/render tests) if any should update automatically. Unit tests do not cover badge rendering directly. Verify manually at two zoom levels:
+No automated tests cover badge rendering directly. Verify manually at two zoom levels:
 
-1. Low zoom (Canvas renderer active, LOD below sprite threshold): fortified unit shows 🛡 badge; stacked unit shows ⚔2 badge
-2. High zoom (DOM sprite overlay active): fortified unit shows 🛡 badge; stacked units show ⚔ ×2 pill
+1. **Low zoom** (Canvas renderer active): fortified unit shows 🛡 badge; stacked unit shows 🪖×2 badge
+2. **High zoom** (DOM sprite overlay active): fortified unit shows 🛡 badge; stacked units show 🪖 ×2 pill
+3. **Both badges together**: a fortified unit in a 2-unit stack shows both badges without overlap
 
 ## Files Changed
 

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -291,7 +291,7 @@ function updateUnitDecorations(wrapper: HTMLElement, entity: SpriteEntity): void
 
   if (entity.fortified) {
     const fortified = getOrCreateDecoration(wrapper, 'cq-unit-fortified');
-    fortified.textContent = 'F';
+    fortified.textContent = '🛡️';
     fortified.style.cssText =
       'position:absolute;left:3%;top:3%;width:28%;height:28%;border-radius:50%;' +
       'background:rgba(200,150,0,.92);border:1px solid #fff;color:#fff;' +

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -263,12 +263,19 @@ function updateUnitDecorations(wrapper: HTMLElement, entity: SpriteEntity): void
   }
 
   if ((entity.stackCount ?? 1) > 1) {
-    const count = getOrCreateDecoration(wrapper, 'cq-unit-stack-count');
-    count.textContent = String(entity.stackCount);
-    count.style.cssText =
-      'position:absolute;right:2%;top:2%;min-width:28%;height:28%;border-radius:50%;' +
+    const pill = getOrCreateDecoration(wrapper, 'cq-unit-stack-count');
+    pill.style.cssText =
+      'position:absolute;right:2%;top:2%;min-width:42%;height:28%;border-radius:999px;' +
       'background:rgba(0,0,0,.82);border:1px solid rgba(255,255,255,.85);color:#fff;' +
-      'font:700 0.72em system-ui;display:flex;align-items:center;justify-content:center;pointer-events:none';
+      'font:700 0.65em system-ui;display:flex;align-items:center;justify-content:center;' +
+      'gap:2px;padding:0 3%;pointer-events:none';
+    const icon = document.createElement('span');
+    icon.textContent = '🪖️';
+    icon.style.cssText = 'font-size:0.9em;line-height:1';
+    const label = document.createElement('span');
+    label.textContent = `×${entity.stackCount}`;
+    label.style.cssText = 'font-weight:700';
+    pill.replaceChildren(icon, label);
   } else {
     removeDecoration(wrapper, 'cq-unit-stack-count');
   }

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -198,7 +198,7 @@ export function drawUnitPresentations(
         ctx.arc(
           screen.x + metrics.countBadge.x,
           screen.y + metrics.countBadge.y,
-          metrics.countBadge.radius * 1.2,   // wider to fit emoji + number
+          metrics.countBadge.radius * 1.2,   // wider to fit ×N label
           0,
           Math.PI * 2,
         );
@@ -211,7 +211,7 @@ export function drawUnitPresentations(
         ctx.textBaseline = 'middle';
         ctx.fillStyle = 'white';
         ctx.fillText(
-          `🪖️×${presentation.stackCount}`,
+          `×${presentation.stackCount}`,
           screen.x + metrics.countBadge.x,
           screen.y + metrics.countBadge.y,
         );

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -198,7 +198,7 @@ export function drawUnitPresentations(
         ctx.arc(
           screen.x + metrics.countBadge.x,
           screen.y + metrics.countBadge.y,
-          metrics.countBadge.radius,
+          metrics.countBadge.radius * 1.2,   // wider to fit emoji + number
           0,
           Math.PI * 2,
         );
@@ -211,7 +211,7 @@ export function drawUnitPresentations(
         ctx.textBaseline = 'middle';
         ctx.fillStyle = 'white';
         ctx.fillText(
-          String(presentation.stackCount),
+          `🪖️×${presentation.stackCount}`,
           screen.x + metrics.countBadge.x,
           screen.y + metrics.countBadge.y,
         );

--- a/src/renderer/unit-renderer.ts
+++ b/src/renderer/unit-renderer.ts
@@ -118,7 +118,7 @@ export function drawUnitGlyph(
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = 'white';
-    ctx.fillText('F', badgeX, badgeY);
+    ctx.fillText('🛡️', badgeX, badgeY);
   }
 }
 

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -219,12 +219,26 @@ describe('sync() wrapper sizing', () => {
       roleMarker: 'chevron',
     })], MAP, OPTS);
 
-    expect(mount.querySelector('.cq-unit-stack-count')?.textContent).toBe('2');
+    const pill = mount.querySelector('.cq-unit-stack-count') as HTMLElement | null;
+    expect(pill).not.toBeNull();
+    const spans = pill!.querySelectorAll('span');
+    expect(spans.length).toBe(2);
+    expect(spans[0].textContent).toBe('🪖️');
+    expect(spans[1].textContent).toBe('×2');
     expect(mount.querySelector('.cq-unit-selected')).not.toBeNull();
     expect(mount.querySelector('.cq-unit-health-fill')).not.toBeNull();
     expect((mount.querySelector('.cq-unit-health-fill') as HTMLElement).style.width).toBe('55%');
     expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('🛡️');
     expect(mount.querySelector('.cq-unit-role')?.textContent).toBe('⌄');
+  });
+
+  it('pill children are replaced cleanly on re-render, not accumulated', () => {
+    const { overlay, mount } = mountOverlay();
+    const e = entity({ stackCount: 2, memberIds: ['u1', 'u2'] });
+    overlay.sync(cam({ zoom: 1 }), [e], MAP, OPTS);
+    overlay.sync(cam({ zoom: 1 }), [e], MAP, OPTS);
+    const pill = mount.querySelector('.cq-unit-stack-count') as HTMLElement | null;
+    expect(pill?.querySelectorAll('span').length).toBe(2); // not 4 — replaceChildren, not appendChild
   });
 
   it('wrapper has overflow:hidden to prevent label bleed', () => {

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -223,7 +223,7 @@ describe('sync() wrapper sizing', () => {
     expect(mount.querySelector('.cq-unit-selected')).not.toBeNull();
     expect(mount.querySelector('.cq-unit-health-fill')).not.toBeNull();
     expect((mount.querySelector('.cq-unit-health-fill') as HTMLElement).style.width).toBe('55%');
-    expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('F');
+    expect(mount.querySelector('.cq-unit-fortified')?.textContent).toBe('🛡️');
     expect(mount.querySelector('.cq-unit-role')?.textContent).toBe('⌄');
   });
 

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -120,7 +120,7 @@ describe('unit renderer wrap parity', () => {
 
     drawUnits(ctx, units, camera, visibility, state, 'player', { player: '#4a90d9' });
 
-    expect(ctx.fillText).toHaveBeenCalledWith('🪖️×2', expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith('×2', expect.any(Number), expect.any(Number));
     expect(ctx.fillText).toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
     expect(ctx.fillText).not.toHaveBeenCalledWith('👷', expect.any(Number), expect.any(Number));
   });

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -120,7 +120,7 @@ describe('unit renderer wrap parity', () => {
 
     drawUnits(ctx, units, camera, visibility, state, 'player', { player: '#4a90d9' });
 
-    expect(ctx.fillText).toHaveBeenCalledWith('2', expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith('🪖️×2', expect.any(Number), expect.any(Number));
     expect(ctx.fillText).toHaveBeenCalledWith('⚔️', expect.any(Number), expect.any(Number));
     expect(ctx.fillText).not.toHaveBeenCalledWith('👷', expect.any(Number), expect.any(Number));
   });

--- a/tests/renderer/unit-renderer.test.ts
+++ b/tests/renderer/unit-renderer.test.ts
@@ -143,7 +143,7 @@ describe('fortified unit badge', () => {
     } as unknown as GameState;
   }
 
-  it('draws an F badge for a fortified unit', () => {
+  it('draws a 🛡️ badge for a fortified unit', () => {
     const ctx = createContext();
     const units: Record<string, Unit> = {
       'unit-1': {
@@ -157,10 +157,10 @@ describe('fortified unit badge', () => {
 
     drawUnits(ctx, units, makeCamera(), visibility, makeState(), 'player', { player: '#4a90d9' });
 
-    expect(ctx.fillText).toHaveBeenCalledWith('F', expect.any(Number), expect.any(Number));
+    expect(ctx.fillText).toHaveBeenCalledWith('🛡️', expect.any(Number), expect.any(Number));
   });
 
-  it('does not draw an F badge for a non-fortified unit', () => {
+  it('does not draw a 🛡️ badge for a non-fortified unit', () => {
     const ctx = createContext();
     const units: Record<string, Unit> = {
       'unit-1': {
@@ -174,7 +174,7 @@ describe('fortified unit badge', () => {
     drawUnits(ctx, units, makeCamera(), visibility, makeState(), 'player', { player: '#4a90d9' });
 
     const fillTextCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls as [string, ...unknown[]][];
-    expect(fillTextCalls.some(([text]) => text === 'F')).toBe(false);
+    expect(fillTextCalls.some(([text]) => text === '🛡️')).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #377

## Summary

- **Fortified badge:** `F` in gold circle → `🛡️` in gold circle, in both the Canvas renderer (low zoom) and DOM sprite overlay (high zoom)
- **Stack count badge (DOM):** dark circle with bare number → dark pill showing `🪖️` + `×N` (flex layout, `replaceChildren()` for XSS-safe re-renders)
- **Stack count badge (Canvas):** bare number → `×N` with 1.2× wider circle — emoji dropped from canvas path because the badge circle (~16px diameter) can't fit the full `🪖️×N` string (~18px wide) without overflowing

## Why these icons

- 🛡️ universally signals protection/defence; no ambiguity
- 🪖 (military helmet) signals "military unit", not "in combat" (which ⚔️ would imply)
- `×N` is a standard quantity multiplier; combined with the existing depth-offset stack shadow it's immediately clear

## Test plan

- [ ] Zoom out: stacked unit shows dark circle with `×2`, fortified unit shows 🛡️ gold circle
- [ ] Zoom in past sprite threshold: stacked unit shows dark `🪖️ ×2` pill, fortified unit shows 🛡️ gold circle
- [ ] Fortified unit in a 2+ stack: both badges visible, no overlap (🛡️ top-left, pill top-right)
- [ ] Re-render regression: sync same stacked unit twice → pill still has exactly 2 child spans (not 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)