### PR TITLE
feat(threat): Unified Threat Pressure System — landmass tagging, barbarian resurgence, pirate raiders

### DIFF
--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -92,6 +92,81 @@ export const SFX = {
     }
   },
 
+  seaHorn: () => {
+    try {
+      const ctx = getContext();
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'sawtooth';
+      osc.frequency.setValueAtTime(55, now);
+      osc.frequency.linearRampToValueAtTime(45, now + 1.2);
+      gain.gain.setValueAtTime(0, now);
+      gain.gain.linearRampToValueAtTime(0.5, now + 0.2);
+      gain.gain.setValueAtTime(0.5, now + 0.8);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 1.5);
+      osc.connect(gain);
+      gain.connect(sfxDestination ?? ctx.destination);
+      osc.start(now);
+      osc.stop(now + 1.5);
+    } catch { /* audio unavailable */ }
+  },
+
+  piratePlunder: () => {
+    try {
+      const ctx = getContext();
+      const now = ctx.currentTime;
+      // White noise burst (impact)
+      const bufferSize = Math.floor(ctx.sampleRate * 0.08);
+      const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+      const data = buffer.getChannelData(0);
+      let noiseSeed = 42;
+      for (let i = 0; i < bufferSize; i++) {
+        noiseSeed = (noiseSeed * 1664525 + 1013904223) & 0xffffffff;
+        data[i] = (noiseSeed / 0x80000000) - 1;
+      }
+      const noise = ctx.createBufferSource();
+      noise.buffer = buffer;
+      const noiseGain = ctx.createGain();
+      noiseGain.gain.setValueAtTime(0.7, now);
+      noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08);
+      noise.connect(noiseGain);
+      noiseGain.connect(sfxDestination ?? ctx.destination);
+      noise.start(now);
+
+      // Rising sine sweep
+      const sweep = ctx.createOscillator();
+      const sweepGain = ctx.createGain();
+      sweep.type = 'sine';
+      sweep.frequency.setValueAtTime(200, now + 0.08);
+      sweep.frequency.linearRampToValueAtTime(800, now + 0.4);
+      sweepGain.gain.setValueAtTime(0.3, now + 0.08);
+      sweepGain.gain.exponentialRampToValueAtTime(0.001, now + 0.5);
+      sweep.connect(sweepGain);
+      sweepGain.connect(sfxDestination ?? ctx.destination);
+      sweep.start(now + 0.08);
+      sweep.stop(now + 0.5);
+    } catch { /* audio unavailable */ }
+  },
+
+  pirateDestroyed: () => {
+    try {
+      const ctx = getContext();
+      const now = ctx.currentTime;
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = 'square';
+      osc.frequency.setValueAtTime(220, now);
+      osc.frequency.exponentialRampToValueAtTime(55, now + 0.5);
+      gain.gain.setValueAtTime(0.4, now);
+      gain.gain.exponentialRampToValueAtTime(0.001, now + 0.6);
+      osc.connect(gain);
+      gain.connect(sfxDestination ?? ctx.destination);
+      osc.start(now);
+      osc.stop(now + 0.6);
+    } catch { /* audio unavailable */ }
+  },
+
   barbarianResurgence: () => {
     try {
       const ctx = getContext();

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -91,4 +91,31 @@ export const SFX = {
       setTimeout(() => playTone(330, 0.1, 0.12, 'triangle'), 80);
     }
   },
+
+  barbarianResurgence: () => {
+    try {
+      const ctx = getContext();
+      const now = ctx.currentTime;
+      const filter = ctx.createBiquadFilter();
+      filter.type = 'lowpass';
+      filter.frequency.setValueAtTime(300, now);
+      filter.connect(sfxDestination ?? ctx.destination);
+
+      for (const [freq, detune] of [[80, 0], [120, 3]] as const) {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = 'triangle';
+        osc.frequency.setValueAtTime(freq, now);
+        osc.detune.setValueAtTime(detune, now);
+        gain.gain.setValueAtTime(0, now);
+        gain.gain.linearRampToValueAtTime(0.6, now + 0.3);
+        gain.gain.setValueAtTime(0.6, now + 0.5);
+        gain.gain.exponentialRampToValueAtTime(0.001, now + 1.3);
+        osc.connect(gain);
+        gain.connect(filter);
+        osc.start(now);
+        osc.stop(now + 1.3);
+      }
+    } catch { /* audio unavailable */ }
+  },
 };

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -614,7 +614,9 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       }
     }
     const beastUnits = Object.values(newState.units).filter(u => u.owner === BEAST_OWNER);
-    const intruders = Object.values(newState.units).filter(u => u.owner !== BEAST_OWNER && u.owner !== 'barbarian');
+    const intruders = Object.values(newState.units).filter(u =>
+      u.owner !== BEAST_OWNER && u.owner !== 'barbarian' && u.owner !== PIRATE_OWNER
+    );
     const beastSeed = newState.turn * 7919 + 13;
     const beastResult = processBeasts(
       Object.values(newState.beasts!.lairs),

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -705,6 +705,9 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     }
   }
 
+  // --- Threat pressure (spawn phase: land resurgence) ---
+  newState = processThreatPressure(newState, newState.currentPlayer, bus);
+
   // --- Process espionage ---
   newState = processEspionageTurn(newState, bus);
   newState = processDetection(newState, bus);

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -17,7 +17,7 @@ import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { resolveCombat } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import { PIRATE_OWNER, recordCombatForCiv, processThreatPressure } from '@/systems/threat-pressure-system';
+import { PIRATE_OWNER, recordCombatForCiv, processThreatPressure, processPirateFleets } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { hexKey } from '@/systems/hex-utils';
@@ -705,8 +705,10 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     }
   }
 
-  // --- Threat pressure (spawn phase: land resurgence) ---
+  // --- Threat pressure (spawn phase: land resurgence + pirate spawn) ---
   newState = processThreatPressure(newState, newState.currentPlayer, bus);
+  // --- Pirate fleet movement (runs every turn) ---
+  newState = processPirateFleets(newState, bus);
 
   // --- Process espionage ---
   newState = processEspionageTurn(newState, bus);

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -17,6 +17,7 @@ import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { resolveCombat } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { PIRATE_OWNER, recordCombatForCiv, processThreatPressure } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { hexKey } from '@/systems/hex-utils';
@@ -543,9 +544,13 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     // Capture route IDs before combat (units may be removed from state after)
     const attackerRouteId = attacker.committedToRouteId;
     const defenderRouteId = defender.committedToRouteId;
+    const defenderPosBarbarian = { ...defender.position };
     const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
     const applied = applyCombatOutcomeToState(newState, result, combatSeed);
     newState = applied.state;
+    if (newState.civilizations[defender.owner]?.isHuman) {
+      newState = recordCombatForCiv(newState, defender.owner, defenderPosBarbarian);
+    }
     emitMinorCivQuestTransitions(bus, applied.questTransitions, newState);
     // Clean up trade routes for any committed caravans that died
     if (applied.attackerDefeated && attackerRouteId) {
@@ -676,9 +681,13 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       const defender = newState.units[order.defenderUnitId];
       if (!attacker || !defender) continue;
       const combatSeed = beastSeed ^ order.attackerUnitId.charCodeAt(0);
+      const defenderPosBeast = { ...defender.position };
       const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
       const applied = applyCombatOutcomeToState(newState, result, combatSeed);
       newState = applied.state;
+      if (newState.civilizations[defender.owner]?.isHuman) {
+        newState = recordCombatForCiv(newState, defender.owner, defenderPosBeast);
+      }
       emitMinorCivQuestTransitions(bus, applied.questTransitions, newState);
       // If the beast died on counterattack, record the slay
       if (applied.attackerDefeated) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -231,6 +231,7 @@ export interface HexTile {
   improvementOwner?: string;        // civ that started the in-progress improvement
   hasRiver: boolean;
   wonder: string | null;           // wonder definition ID
+  regionKey?: string;              // landmass ID for threat pressure (e.g. 'continent-0', 'island-2')
 }
 
 export interface GameMap {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -405,6 +405,7 @@ export interface City {
   spyUnrestBonus: number;      // bonus pressure injected by enemy espionage; decays 5/turn
   productionDisabledTurns?: number; // late-game sabotage/cyber effect timer
   idleProduction?: 'gold' | 'science' | null; // conversion mode when queue is empty
+  hp?: number;               // city hit points for pirate siege (default 100)
 }
 
 // --- Economy ---
@@ -796,6 +797,18 @@ export interface BarbarianCamp {
   position: HexCoord;
   strength: number;          // grows over time
   spawnCooldown: number;     // turns until next raider spawns
+  resurgent?: boolean;       // true for threat-pressure spawned camps
+  banditLordName?: string;   // named leader for high-threat resurgent camps
+}
+
+export interface PirateFleet {
+  id: string;
+  unitId: string;            // Unit in state.units with owner === 'pirate'
+  targetCivId: string;       // player civ the fleet is pressuring
+  targetCityId: string;      // nearest coastal city at spawn time
+  landmassId: string;
+  era: number;               // era at spawn time, governs siege damage
+  plunderCooldown: number;   // turns remaining before next plunder attempt
 }
 
 // --- Legendary Beasts ---
@@ -1192,6 +1205,9 @@ export interface GameState {
   councilMemory?: CouncilMemoryState;
   tribalVillages: Record<string, TribalVillage>;
   beasts?: BeastsState;       // optional: legacy saves have no beasts
+  pirateFleets?: Record<string, PirateFleet>;
+  pirateFleetCooldownByCivLandmass?: Record<string, number>; // key: '${civId}:${landmassId}'
+  resurgentCampCooldownByCivLandmass?: Record<string, number>; // key: '${civId}:${landmassId}'
   discoveredWonders: Record<string, string>;       // wonderId -> first discoverer civId
   wonderDiscoverers: Record<string, string[]>;     // wonderId -> all discoverer civIds
   legendaryWonderProjects?: Record<string, LegendaryWonderProject>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -778,6 +778,7 @@ export interface Civilization {
   satelliteSurveillanceTargets?: Record<string, number>;
   breakaway?: BreakawayMetadata;
   nearDefeat?: boolean;   // true when cities.length <= 1; used by audio system
+  lastCombatTurnByLandmass?: Record<string, number>; // landmassId → turn of last combat
 }
 
 export interface BreakawayMetadata {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1292,6 +1292,11 @@ export interface GameEvents {
   'beast:sighted': { beastId: BeastId; civId: string };
   'beast:hoard-claimed': { lairId: string; beastId: BeastId; civId: string; choice: BeastHoardChoice };
   'barbarian:camp-destroyed': { campId: string; reward: number };
+  'threat:barbarian-resurgence': { civId: string; landmassId: string; campId: string; position: HexCoord; isBanditLord: boolean; banditLordName?: string };
+  'threat:pirate-fleet-spawned': { fleetId: string; civId: string; landmassId: string; position: HexCoord };
+  'threat:pirate-plunder': { fleetId: string; cityId: string; goldStolen: number };
+  'threat:pirate-siege': { fleetId: string; cityId: string; hpLost: number };
+  'threat:pirate-fleet-destroyed': { fleetId: string; civId: string; landmassId: string };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3366,6 +3366,14 @@ bus.on('barbarian:spawned', ({ campId, unitId }) => {
   );
 });
 
+bus.on('threat:barbarian-resurgence', ({ civId, isBanditLord, banditLordName }) => {
+  const message = isBanditLord
+    ? `${banditLordName ?? 'A bandit lord'} has united the raiders and threatens your lands!`
+    : 'Barbarian forces are resurgent on your lands!';
+  appendToCivLog(civId, message, 'warning');
+  SFX.barbarianResurgence?.();
+});
+
 bus.on('beast:awakened', ({ beastId, position }) => {
   const def = BEAST_DEFINITIONS[beastId];
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {
@@ -3748,6 +3756,9 @@ function migrateLegacySave(): void {
   // giving them a moment to orient before the map changes.
   if (!gameState.beasts) {
     (gameState as any).beasts = { mode: 'wild', lairs: {}, sightingsByCiv: {}, migrationPending: true };
+  }
+  if (!gameState.resurgentCampCooldownByCivLandmass) {
+    (gameState as any).resurgentCampCooldownByCivLandmass = {};
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
@@ -2185,6 +2186,8 @@ function executeAttack(attackerId: string, targetKey: string): void {
   const seed = gameState.turn * 16807 + attacker.id.charCodeAt(0) + defender.id.charCodeAt(0);
   const attackerBonus = currentCivDef()?.bonusEffect;
   const defenderBonus = resolveCivDefinition(gameState, gameState.civilizations[defender.owner]?.civType ?? '')?.bonusEffect;
+  // Capture defender position before combat (defender may be removed from state after)
+  const defenderPosition = { ...defender.position };
   // Capture route IDs before combat (units may be removed from state after)
   const attackerRouteId = attacker.committedToRouteId;
   const defenderRouteId = defender.committedToRouteId;
@@ -2200,6 +2203,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
 
   const applied = applyCombatOutcomeToState(gameState, result, seed);
   gameState = applied.state;
+  gameState = recordCombatForCiv(gameState, gameState.currentPlayer, defenderPosition);
   emitMinorCivQuestTransitions(bus, applied.questTransitions, gameState);
   // Clean up trade routes for any committed caravans that died
   if (applied.attackerDefeated && attackerRouteId) {
@@ -3627,6 +3631,7 @@ function migrateLegacySave(): void {
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {
     if (!civ.civType) (civ as any).civType = 'generic';
     if (!civ.knownCivilizations) (civ as any).knownCivilizations = [];
+    if (!civ.lastCombatTurnByLandmass) (civ as any).lastCombatTurnByLandmass = {};
     if (!civ.diplomacy) {
       const relationships: Record<string, number> = {};
       for (const otherId of Object.keys(gameState.civilizations)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3374,8 +3374,8 @@ bus.on('threat:barbarian-resurgence', ({ civId, isBanditLord, banditLordName }) 
   SFX.barbarianResurgence?.();
 });
 
-bus.on('threat:pirate-fleet-spawned', ({ civId, fleetId }) => {
-  appendToCivLog(civId, `A pirate fleet has been spotted in your waters! (fleet ${fleetId})`, 'warning');
+bus.on('threat:pirate-fleet-spawned', ({ civId }) => {
+  appendToCivLog(civId, 'A pirate fleet has been spotted in your waters!', 'warning');
   SFX.seaHorn?.();
 });
 
@@ -3395,8 +3395,8 @@ bus.on('threat:pirate-siege', ({ cityId, hpLost }) => {
   SFX.piratePlunder?.();
 });
 
-bus.on('threat:pirate-fleet-destroyed', ({ civId, fleetId }) => {
-  appendToCivLog(civId, `Pirate fleet ${fleetId} has been driven off!`, 'info');
+bus.on('threat:pirate-fleet-destroyed', ({ civId }) => {
+  appendToCivLog(civId, 'A pirate fleet in your waters has been driven off!', 'info');
   SFX.pirateDestroyed?.();
 });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3374,6 +3374,32 @@ bus.on('threat:barbarian-resurgence', ({ civId, isBanditLord, banditLordName }) 
   SFX.barbarianResurgence?.();
 });
 
+bus.on('threat:pirate-fleet-spawned', ({ civId, fleetId }) => {
+  appendToCivLog(civId, `A pirate fleet has been spotted in your waters! (fleet ${fleetId})`, 'warning');
+  SFX.seaHorn?.();
+});
+
+bus.on('threat:pirate-plunder', ({ cityId, goldStolen }) => {
+  const city = gameState.cities[cityId];
+  const civId = city?.owner ?? '';
+  const cityName = city?.name ?? cityId;
+  appendToCivLog(civId, `Pirates plundered ${cityName} — ${goldStolen} gold stolen!`, 'warning');
+  SFX.piratePlunder?.();
+});
+
+bus.on('threat:pirate-siege', ({ cityId, hpLost }) => {
+  const city = gameState.cities[cityId];
+  const civId = city?.owner ?? '';
+  const cityName = city?.name ?? cityId;
+  appendToCivLog(civId, `Pirates bombard ${cityName} for ${hpLost} damage!`, 'warning');
+  SFX.piratePlunder?.();
+});
+
+bus.on('threat:pirate-fleet-destroyed', ({ civId, fleetId }) => {
+  appendToCivLog(civId, `Pirate fleet ${fleetId} has been driven off!`, 'info');
+  SFX.pirateDestroyed?.();
+});
+
 bus.on('beast:awakened', ({ beastId, position }) => {
   const def = BEAST_DEFINITIONS[beastId];
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {
@@ -3759,6 +3785,12 @@ function migrateLegacySave(): void {
   }
   if (!gameState.resurgentCampCooldownByCivLandmass) {
     (gameState as any).resurgentCampCooldownByCivLandmass = {};
+  }
+  if (!gameState.pirateFleets) {
+    (gameState as any).pirateFleets = {};
+  }
+  if (!gameState.pirateFleetCooldownByCivLandmass) {
+    (gameState as any).pirateFleetCooldownByCivLandmass = {};
   }
 }
 

--- a/src/renderer/unit-map-presentation.ts
+++ b/src/renderer/unit-map-presentation.ts
@@ -1,4 +1,5 @@
 import type { GameState, HexCoord, Unit, VisibilityMap } from '@/core/types';
+import { PIRATE_OWNER } from '@/systems/threat-pressure-system';
 import { selectDefenderForAttack } from '@/systems/combat-system';
 import { isForestConcealedUnit } from '@/systems/fog-of-war';
 import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
@@ -86,6 +87,7 @@ function chooseLead(state: GameState, viewerId: string, stack: Unit[], selectedU
   const hostile = owner === 'barbarian'
     || owner === 'beasts'
     || owner === 'rebels'
+    || owner === PIRATE_OWNER
     || Boolean(owner && viewerDiplomacy?.atWarWith?.includes(owner));
   if (hostile) return selectDefenderForAttack(stack, state.map) ?? stack[0];
   return [...stack].sort((a, b) => a.id.localeCompare(b.id))[0];

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -8,6 +8,7 @@ import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { getQuestChain, getQuestChainForArchetype } from '@/systems/quest-chain-definitions';
 import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
 import { dbGet, dbPut, dbDelete, dbGetAllKeys } from './db';
+import { tagLandmassRegions } from '@/systems/landmass-tagger';
 
 const SAVE_PREFIX = 'save:';
 const META_PREFIX = 'meta:';
@@ -229,9 +230,19 @@ function normalizeMinorCivQuestState(state: GameState): GameState {
   return nextState;
 }
 
+function normalizeLandmassKeys(state: GameState): GameState {
+  if (!state.map?.tiles) return state;
+  const anyLandMissingKey = Object.values(state.map.tiles).some(
+    t => t.terrain !== 'ocean' && t.terrain !== 'coast' && !t.regionKey
+  );
+  if (!anyLandMissingKey) return state;
+  const taggedTiles = tagLandmassRegions(state.map);
+  return { ...state, map: { ...state.map, tiles: taggedTiles } };
+}
+
 function normalizeLoadedState(state: GameState): GameState {
   const normalizedCityState = normalizeMinorCivQuestState(
-    normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))),
+    normalizeLandmassKeys(normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state))))),
   );
   if (!normalizedCityState.map?.tiles) {
     normalizedCityState.pendingDiplomacyRequests ??= [];

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -240,9 +240,21 @@ function normalizeLandmassKeys(state: GameState): GameState {
   return { ...state, map: { ...state.map, tiles: taggedTiles } };
 }
 
+function normalizeThreatPressureDefaults(state: GameState): GameState {
+  if (state.pirateFleets !== undefined && state.pirateFleetCooldownByCivLandmass !== undefined) {
+    return state;
+  }
+  return {
+    ...state,
+    pirateFleets: state.pirateFleets ?? {},
+    pirateFleetCooldownByCivLandmass: state.pirateFleetCooldownByCivLandmass ?? {},
+    resurgentCampCooldownByCivLandmass: state.resurgentCampCooldownByCivLandmass ?? {},
+  };
+}
+
 function normalizeLoadedState(state: GameState): GameState {
   const normalizedCityState = normalizeMinorCivQuestState(
-    normalizeLandmassKeys(normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state))))),
+    normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))))),
   );
   if (!normalizedCityState.map?.tiles) {
     normalizedCityState.pendingDiplomacyRequests ??= [];

--- a/src/systems/balanced-map-generator.ts
+++ b/src/systems/balanced-map-generator.ts
@@ -1,4 +1,5 @@
 import type { GameMap, HexTile, HexCoord } from '@/core/types';
+import { tagLandmassRegions } from './landmass-tagger';
 import {
   generateBaseTerrain,
   findStartPositions,
@@ -159,9 +160,11 @@ export function generateBalancedMap(
     }
   }
 
-  const map: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
-  const rivers = generateRivers(map, seed);
-  applyRiversToMap(map, rivers);
+  const mapWithRivers: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
+  const rivers = generateRivers(mapWithRivers, seed);
+  applyRiversToMap(mapWithRivers, rivers);
 
+  const taggedTiles = tagLandmassRegions(mapWithRivers);
+  const map: GameMap = { ...mapWithRivers, tiles: taggedTiles };
   return { map, startPositions };
 }

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -64,7 +64,7 @@ function seededRoll(seed: number, victorId: string, defeatedId: string): number 
 }
 
 function canReceiveGoldReward(owner: string): boolean {
-  return owner !== 'barbarian' && owner !== 'rebels' && owner !== 'beasts' && !owner.startsWith('mc-');
+  return owner !== 'barbarian' && owner !== 'rebels' && owner !== 'beasts' && owner !== 'pirate' && !owner.startsWith('mc-');
 }
 
 export function getVeterancyTierForExperience(experience: number): VeterancyTier {

--- a/src/systems/continent-map-generator.ts
+++ b/src/systems/continent-map-generator.ts
@@ -2,6 +2,7 @@ import type { GameMap, HexCoord } from '@/core/types';
 import { getLandTerrain, placeResources, createRng, createNoise } from './map-generator';
 import { hexKey } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
+import { tagLandmassRegions } from './landmass-tagger';
 
 const ISLAND_RESOURCES = ['gems', 'ivory', 'spices'] as const;
 
@@ -174,9 +175,11 @@ export function generateContinentMap(
     }
   }
 
-  const map: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
-  const rivers = generateRivers(map, seed);
-  applyRiversToMap(map, rivers);
+  const mapWithRivers: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
+  const rivers = generateRivers(mapWithRivers, seed);
+  applyRiversToMap(mapWithRivers, rivers);
 
+  const taggedTiles = tagLandmassRegions(mapWithRivers);
+  const map: GameMap = { ...mapWithRivers, tiles: taggedTiles };
   return { map, continentHexes };
 }

--- a/src/systems/landmass-tagger.ts
+++ b/src/systems/landmass-tagger.ts
@@ -1,0 +1,52 @@
+import type { GameMap, HexTile } from '@/core/types';
+import { hexKey, hexNeighbors } from './hex-utils';
+
+const MIN_CONTINENT_TILES = 9;
+
+export function tagLandmassRegions(map: GameMap): Record<string, HexTile> {
+  const tiles = { ...map.tiles };
+  const visited = new Set<string>();
+  const components: string[][] = [];
+
+  for (const key of Object.keys(tiles)) {
+    const tile = tiles[key];
+    if (visited.has(key)) continue;
+    if (tile.terrain === 'ocean' || tile.terrain === 'coast') continue;
+
+    // BFS flood-fill
+    const component: string[] = [];
+    const queue: string[] = [key];
+    visited.add(key);
+    while (queue.length > 0) {
+      const cur = queue.shift()!;
+      component.push(cur);
+      const [q, r] = cur.split(',').map(Number);
+      for (const nb of hexNeighbors({ q, r })) {
+        const nbKey = hexKey(nb);
+        if (visited.has(nbKey)) continue;
+        const nbTile = tiles[nbKey];
+        if (!nbTile) continue;
+        if (nbTile.terrain === 'ocean' || nbTile.terrain === 'coast') continue;
+        visited.add(nbKey);
+        queue.push(nbKey);
+      }
+    }
+    components.push(component);
+  }
+
+  // Sort largest first
+  components.sort((a, b) => b.length - a.length);
+
+  let continentIdx = 0;
+  let islandIdx = 0;
+  for (const component of components) {
+    const id = component.length >= MIN_CONTINENT_TILES
+      ? `continent-${continentIdx++}`
+      : `island-${islandIdx++}`;
+    for (const key of component) {
+      tiles[key] = { ...tiles[key], regionKey: id };
+    }
+  }
+
+  return tiles;
+}

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -1,6 +1,7 @@
-import type { BarbarianCamp, GameState, GameMap, HexCoord } from '@/core/types';
+import type { BarbarianCamp, City, PirateFleet, GameState, GameMap, HexCoord } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { hexKey, hexNeighbors, hexDistance } from './hex-utils';
+import { createUnit } from './unit-system';
 
 export const PIRATE_OWNER = 'pirate';
 
@@ -187,9 +188,255 @@ export function processLandResurgence(
   return updatedState;
 }
 
-// ── Spawn-phase dispatcher ────────────────────────────────────────────────────
+// ── Pirate fleet spawn ────────────────────────────────────────────────────────
 
 const PIRATE_FLEET_THRESHOLD = 4.0;
+const PIRATE_FLEET_CAP = 2;
+const PIRATE_FLEET_COOLDOWN = 10;
+
+function pirateUnitType(era: number): 'galley' | 'carrack' | 'trireme' {
+  if (era >= 4) return 'trireme';
+  if (era === 3) return 'carrack';
+  return 'galley';
+}
+
+export function processPirateSpawn(
+  state: GameState,
+  civId: string,
+  landmassId: string,
+  bus: EventBus,
+): GameState {
+  const cooldownKey = `${civId}:${landmassId}`;
+  const cooldownUntil = state.pirateFleetCooldownByCivLandmass?.[cooldownKey] ?? 0;
+  if (state.turn < cooldownUntil) return state;
+
+  const score = computeThreatScore(state, civId, landmassId);
+  if (score < PIRATE_FLEET_THRESHOLD) return state;
+
+  // Check fleet cap for this civ+landmass
+  const activeFleets = Object.values(state.pirateFleets ?? {}).filter(
+    f => f.targetCivId === civId && f.landmassId === landmassId
+  );
+  if (activeFleets.length >= PIRATE_FLEET_CAP) return state;
+
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  // Find coastal cities on landmass
+  const coastalCities = civ.cities.flatMap(cityId => {
+    const city = state.cities[cityId];
+    if (!city) return [];
+    const tile = state.map.tiles[hexKey(city.position)];
+    const isCoastal = tile?.terrain === 'coast'
+      || hexNeighbors(city.position).some(nb => {
+        const t = state.map.tiles[hexKey(nb)];
+        return t?.terrain === 'ocean' || t?.terrain === 'coast';
+      });
+    const onLandmass = tile?.regionKey === landmassId;
+    return isCoastal && onLandmass ? [city] : [];
+  });
+  if (coastalCities.length === 0) return state;
+
+  // Find spawn tile: ocean tile adjacent to landmass coastline, ≥ 5 tiles from any city
+  const cityPositions = Object.values(state.cities).map(c => c.position);
+  const spawnSeed = state.turn * 73937 + civId.charCodeAt(0) * 13 + landmassId.charCodeAt(0) * 5;
+  const rng = lcg(spawnSeed);
+
+  const spawnCandidates = Object.values(state.map.tiles).filter(tile => {
+    if (tile.terrain !== 'ocean') return false;
+    // Must be adjacent to a land tile on the target landmass
+    const nearLandmass = hexNeighbors(tile.coord).some(nb => {
+      const t = state.map.tiles[hexKey(nb)];
+      return t?.regionKey === landmassId;
+    });
+    if (!nearLandmass) return false;
+    // Must be ≥ 5 tiles from any city
+    for (const pos of cityPositions) {
+      if (hexDistance(tile.coord, pos) < 5) return false;
+    }
+    return true;
+  });
+
+  if (spawnCandidates.length === 0) return state;
+
+  const spawnTile = spawnCandidates[Math.floor(rng() * spawnCandidates.length)];
+
+  // Pick nearest coastal city as target
+  const targetCity = coastalCities.reduce((nearest, city) => {
+    const d1 = hexDistance(city.position, spawnTile.coord);
+    const d2 = hexDistance(nearest.position, spawnTile.coord);
+    return d1 < d2 ? city : nearest;
+  });
+
+  const unitType = pirateUnitType(state.era);
+  const pirateUnit = createUnit(unitType, PIRATE_OWNER, spawnTile.coord, state.idCounters);
+  const fleetId = `fleet-${pirateUnit.id}`;
+  const fleet: PirateFleet = {
+    id: fleetId,
+    unitId: pirateUnit.id,
+    targetCivId: civId,
+    targetCityId: targetCity.id,
+    landmassId,
+    era: state.era,
+    plunderCooldown: 0,
+  };
+
+  const updatedState: GameState = {
+    ...state,
+    units: { ...state.units, [pirateUnit.id]: pirateUnit },
+    pirateFleets: { ...(state.pirateFleets ?? {}), [fleetId]: fleet },
+  };
+
+  bus.emit('threat:pirate-fleet-spawned', {
+    fleetId, civId, landmassId, position: spawnTile.coord,
+  });
+
+  return updatedState;
+}
+
+// ── Pirate fleet movement + plunder/siege ─────────────────────────────────────
+
+const PLUNDER_COOLDOWN_TURNS = 3;
+const ADJACENT_HEX_DIST = 2;
+
+function movePirateTowardCity(
+  state: GameState,
+  unitId: string,
+  targetCityId: string,
+): GameState {
+  const unit = state.units[unitId];
+  const city = state.cities[targetCityId];
+  if (!unit || !city) return state;
+  if (hexDistance(unit.position, city.position) <= ADJACENT_HEX_DIST) return state;
+
+  // BFS to find next step on ocean/coast path
+  const start = hexKey(unit.position);
+  const visited = new Set<string>([start]);
+  const queue: Array<{ key: string; path: HexCoord[] }> = [{ key: start, path: [] }];
+
+  while (queue.length > 0) {
+    const { key, path } = queue.shift()!;
+    const [q, r] = key.split(',').map(Number);
+    const coord = { q, r };
+    for (const nb of hexNeighbors(coord)) {
+      const nbKey = hexKey(nb);
+      if (visited.has(nbKey)) continue;
+      visited.add(nbKey);
+      const tile = state.map.tiles[nbKey];
+      if (!tile) continue;
+      const newPath = [...path, nb];
+      if (tile.terrain === 'ocean' || tile.terrain === 'coast') {
+        if (hexKey(nb) === hexKey(city.position) || hexDistance(nb, city.position) <= ADJACENT_HEX_DIST) {
+          // First step is our move
+          const nextPos = newPath[0] ?? nb;
+          return {
+            ...state,
+            units: { ...state.units, [unitId]: { ...unit, position: { ...nextPos } } },
+          };
+        }
+        queue.push({ key: nbKey, path: newPath });
+      }
+    }
+  }
+  return state;
+}
+
+export function processPirateFleets(state: GameState, bus: EventBus): GameState {
+  if (!state.pirateFleets || Object.keys(state.pirateFleets).length === 0) return state;
+
+  let nextState = state;
+
+  for (const [fleetId, fleet] of Object.entries(nextState.pirateFleets ?? {})) {
+    const unit = nextState.units[fleet.unitId];
+
+    // Fleet unit was destroyed — clean up and set cooldown
+    if (!unit) {
+      const cooldownKey = `${fleet.targetCivId}:${fleet.landmassId}`;
+      nextState = {
+        ...nextState,
+        pirateFleets: Object.fromEntries(
+          Object.entries(nextState.pirateFleets ?? {}).filter(([id]) => id !== fleetId)
+        ),
+        pirateFleetCooldownByCivLandmass: {
+          ...(nextState.pirateFleetCooldownByCivLandmass ?? {}),
+          [cooldownKey]: nextState.turn + PIRATE_FLEET_COOLDOWN,
+        },
+      };
+      bus.emit('threat:pirate-fleet-destroyed', {
+        fleetId, civId: fleet.targetCivId, landmassId: fleet.landmassId,
+      });
+      continue;
+    }
+
+    // Retarget if city no longer valid
+    let targetCity = nextState.cities[fleet.targetCityId];
+    let updatedFleet = fleet;
+    if (!targetCity || targetCity.owner !== fleet.targetCivId) {
+      const civ = nextState.civilizations[fleet.targetCivId];
+      const civCities = (civ?.cities ?? []).map(id => nextState.cities[id]).filter((c): c is City => !!c);
+      const newTarget: City | undefined = civCities.reduce<City | undefined>((nearest, city) => {
+        if (!nearest) return city;
+        const d1 = hexDistance(city.position, unit.position);
+        const d2 = hexDistance(nearest.position, unit.position);
+        return d1 < d2 ? city : nearest;
+      }, undefined);
+      if (!newTarget) continue;
+      targetCity = newTarget;
+      updatedFleet = { ...updatedFleet, targetCityId: newTarget.id };
+    }
+
+    // Move toward target
+    nextState = movePirateTowardCity(nextState, fleet.unitId, updatedFleet.targetCityId);
+    const updatedUnit = nextState.units[fleet.unitId];
+    if (!updatedUnit) continue;
+
+    const isAdjacent = hexDistance(updatedUnit.position, targetCity.position) <= ADJACENT_HEX_DIST;
+
+    // Plunder: once adjacent, steal gold on cooldown
+    if (isAdjacent && updatedFleet.plunderCooldown === 0) {
+      const targetCiv = nextState.civilizations[fleet.targetCivId];
+      if (targetCiv) {
+        const goldStolen = Math.floor((1 + (nextState.era - 1) * 0.5) * 5);
+        nextState = {
+          ...nextState,
+          civilizations: {
+            ...nextState.civilizations,
+            [fleet.targetCivId]: { ...targetCiv, gold: Math.max(0, targetCiv.gold - goldStolen) },
+          },
+        };
+        bus.emit('threat:pirate-plunder', { fleetId, cityId: targetCity.id, goldStolen });
+        updatedFleet = { ...updatedFleet, plunderCooldown: PLUNDER_COOLDOWN_TURNS };
+      }
+    } else {
+      updatedFleet = { ...updatedFleet, plunderCooldown: Math.max(0, updatedFleet.plunderCooldown - 1) };
+    }
+
+    // Siege (era 2+): damage city hp every turn when adjacent
+    if (isAdjacent && fleet.era >= 2) {
+      const hpLost = fleet.era >= 3 ? 20 : 10;
+      const city = nextState.cities[fleet.targetCityId];
+      if (city) {
+        nextState = {
+          ...nextState,
+          cities: {
+            ...nextState.cities,
+            [fleet.targetCityId]: { ...city, hp: Math.max(0, (city.hp ?? 100) - hpLost) },
+          },
+        };
+      }
+      bus.emit('threat:pirate-siege', { fleetId, cityId: fleet.targetCityId, hpLost });
+    }
+
+    nextState = {
+      ...nextState,
+      pirateFleets: { ...(nextState.pirateFleets ?? {}), [fleetId]: updatedFleet },
+    };
+  }
+
+  return nextState;
+}
+
+// ── Spawn-phase dispatcher ────────────────────────────────────────────────────
 
 export function processThreatPressure(state: GameState, civId: string, bus: EventBus): GameState {
   const civ = state.civilizations[civId];
@@ -209,6 +456,9 @@ export function processThreatPressure(state: GameState, civId: string, bus: Even
     const score = computeThreatScore(nextState, civId, landmassId);
     if (score >= LAND_RESURGENCE_THRESHOLD) {
       nextState = processLandResurgence(nextState, civId, landmassId, bus);
+    }
+    if (score >= PIRATE_FLEET_THRESHOLD) {
+      nextState = processPirateSpawn(nextState, civId, landmassId, bus);
     }
   }
 

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -1,5 +1,6 @@
-import type { GameState, GameMap, HexCoord } from '@/core/types';
-import { hexKey, hexNeighbors } from './hex-utils';
+import type { BarbarianCamp, GameState, GameMap, HexCoord } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { hexKey, hexNeighbors, hexDistance } from './hex-utils';
 
 export const PIRATE_OWNER = 'pirate';
 
@@ -55,6 +56,163 @@ export function computeThreatScore(state: GameState, civId: string, landmassId: 
   const idleFactor = Math.min(idleTurns / 10, 1.5);
 
   return state.era * (1.0 + share + idleFactor);
+}
+
+// ── Seeded LCG — no Math.random() per project rules ─────────────────────────
+function lcg(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = Math.imul(1664525, s) + 1013904223;
+    return (s >>> 0) / 0xffffffff;
+  };
+}
+
+// ── Bandit lord name pool ────────────────────────────────────────────────────
+const BANDIT_LORD_NAMES: Record<string, string[]> = {
+  generic: ['The Iron Fist', 'Greymantle', 'The Scarred One', 'Black Hand', 'The Reaver'],
+  egypt: ['Amenhotep the Black', 'Kha-em-waset', 'Neferkare', 'Paneb', 'Userhat'],
+  rome: ['Spartacus II', 'The Conqueror', 'Henry II', 'Richard III', 'Cromwell', 'Edward I', 'Robin Hood'],
+  aztec: ['Montezuma II', 'Cuauhtémoc', 'Itzcoatl', 'Ahuitzotl', 'Tlacaelel'],
+  japan: ['Nobunaga', 'Hideyoshi', 'Ieyasu', 'Takeda Shingen', 'Uesugi Kenshin', 'Miyamoto Musashi'],
+  india: ['Chandragupta', 'Ashoka', 'Prithviraj Chauhan', 'Shivaji', 'Tipu Sultan', 'Akbar'],
+  france: ['Charlemagne', 'Charles Martel', 'Robespierre', 'Du Guesclin', 'Napoleon'],
+  germany: ['Arminius', 'Frederick Barbarossa', 'Otto the Great', 'Odoacer', 'Alaric'],
+  russia: ['Ivan the Terrible', 'Peter the Great', 'Alexander Nevsky', 'Pugachev', 'Stenka Razin'],
+  ottoman: ['Suleiman', 'Mehmed II', 'Selim I', 'Osman I', 'Murad I'],
+  spain: ['El Cid', 'Cortés', 'Pizarro', 'Gonzalo de Córdoba', 'Ferdinand I'],
+  viking: ['Ragnar Lothbrok', 'Eric Bloodaxe', 'Ivar the Boneless', 'Harald Hardrada', 'Björn Ironside', 'Leif Erikson'],
+  gondor: ['Aragorn', 'Boromir', 'Faramir', 'Denethor', 'Isildur', 'Anárion'],
+  rohan: ['Théoden', 'Éomer', 'Helm Hammerhand', 'Erkenbrand', 'Grimbold'],
+  isengard: ['Saruman', 'Grima Wormtongue', 'Uglúk', 'Grishnákh', 'Mauhúr'],
+};
+
+function pickBanditName(civType: string, seed: number): string {
+  const pool = BANDIT_LORD_NAMES[civType] ?? BANDIT_LORD_NAMES['generic'];
+  const rng = lcg(seed);
+  return pool[Math.floor(rng() * pool.length)];
+}
+
+// ── Resurgent camp strength by era ───────────────────────────────────────────
+const ERA_STRENGTH: Record<number, [number, number]> = {
+  1: [3, 6], 2: [6, 10], 3: [10, 14], 4: [14, 18],
+};
+
+function resurgenceCampStrength(era: number, rng: () => number): number {
+  const [low, high] = ERA_STRENGTH[era] ?? ERA_STRENGTH[4];
+  return low + Math.floor(rng() * (high - low));
+}
+
+// ── Land resurgence ──────────────────────────────────────────────────────────
+
+const RESURGENCE_CAP = 2;
+const RESURGENCE_COOLDOWN_TURNS = 8;
+const LAND_RESURGENCE_THRESHOLD = 2.5;
+const BANDIT_LORD_THRESHOLD = 7.0;
+
+export function processLandResurgence(
+  state: GameState,
+  civId: string,
+  landmassId: string,
+  bus: EventBus,
+): GameState {
+  const cooldownKey = `${civId}:${landmassId}`;
+  const cooldownUntil = state.resurgentCampCooldownByCivLandmass?.[cooldownKey] ?? 0;
+  if (state.turn < cooldownUntil) return state;
+
+  const score = computeThreatScore(state, civId, landmassId);
+  if (score < LAND_RESURGENCE_THRESHOLD) return state;
+
+  // Count active resurgent camps on landmass
+  const resurgentCount = Object.values(state.barbarianCamps).filter(c => {
+    if (!c.resurgent) return false;
+    const tile = state.map.tiles[hexKey(c.position)];
+    return tile?.regionKey === landmassId;
+  }).length;
+  if (resurgentCount >= RESURGENCE_CAP) return state;
+
+  const landmassTiles = Object.values(state.map.tiles).filter(t => t.regionKey === landmassId);
+  const allCamps = Object.values(state.barbarianCamps);
+  const cityPositions = Object.values(state.cities).map(c => c.position);
+  const spawnSeed = state.turn * 99991 + landmassId.charCodeAt(0) * 7 + civId.charCodeAt(0) * 3;
+  const rng = lcg(spawnSeed);
+
+  const candidates = landmassTiles.filter(tile => {
+    if (NON_VIABLE_TERRAIN.has(tile.terrain)) return false;
+    if (state.barbarianCamps[hexKey(tile.coord)]) return false;
+    // Must be far from cities and existing camps
+    for (const pos of cityPositions) {
+      if (hexDistance(tile.coord, pos) < 4) return false;
+    }
+    for (const camp of allCamps) {
+      if (hexDistance(tile.coord, camp.position) < 3) return false;
+    }
+    return true;
+  });
+
+  if (candidates.length === 0) return state;
+
+  const chosen = candidates[Math.floor(rng() * candidates.length)];
+  const isBanditLord = score >= BANDIT_LORD_THRESHOLD;
+  const strength = resurgenceCampStrength(state.era, rng);
+  const civ = state.civilizations[civId];
+
+  const campId = `camp-${state.idCounters.nextCampId++}`;
+  const camp: BarbarianCamp = {
+    id: campId,
+    position: { ...chosen.coord },
+    strength,
+    spawnCooldown: 5,
+    resurgent: true,
+    ...(isBanditLord ? { banditLordName: pickBanditName(civ?.civType ?? 'generic', spawnSeed + 1) } : {}),
+  };
+
+  const updatedState: GameState = {
+    ...state,
+    barbarianCamps: { ...state.barbarianCamps, [campId]: camp },
+    resurgentCampCooldownByCivLandmass: {
+      ...(state.resurgentCampCooldownByCivLandmass ?? {}),
+      [cooldownKey]: state.turn + RESURGENCE_COOLDOWN_TURNS,
+    },
+  };
+
+  bus.emit('threat:barbarian-resurgence', {
+    civId,
+    landmassId,
+    campId,
+    position: chosen.coord,
+    isBanditLord,
+    banditLordName: (camp as any).banditLordName,
+  });
+
+  return updatedState;
+}
+
+// ── Spawn-phase dispatcher ────────────────────────────────────────────────────
+
+const PIRATE_FLEET_THRESHOLD = 4.0;
+
+export function processThreatPressure(state: GameState, civId: string, bus: EventBus): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ || !civ.isHuman) return state;
+
+  // Collect unique landmass IDs where civ has cities
+  const landmassIds = new Set<string>();
+  for (const cityId of civ.cities) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+    const tile = state.map.tiles[hexKey(city.position)];
+    if (tile?.regionKey) landmassIds.add(tile.regionKey);
+  }
+
+  let nextState = state;
+  for (const landmassId of landmassIds) {
+    const score = computeThreatScore(nextState, civId, landmassId);
+    if (score >= LAND_RESURGENCE_THRESHOLD) {
+      nextState = processLandResurgence(nextState, civId, landmassId, bus);
+    }
+  }
+
+  return nextState;
 }
 
 export function recordCombatForCiv(state: GameState, civId: string, position: HexCoord): GameState {

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -72,7 +72,7 @@ function lcg(seed: number): () => number {
 const BANDIT_LORD_NAMES: Record<string, string[]> = {
   generic: ['The Iron Fist', 'Greymantle', 'The Scarred One', 'Black Hand', 'The Reaver'],
   egypt: ['Amenhotep the Black', 'Kha-em-waset', 'Neferkare', 'Paneb', 'Userhat'],
-  rome: ['Spartacus II', 'The Conqueror', 'Henry II', 'Richard III', 'Cromwell', 'Edward I', 'Robin Hood'],
+  rome: ['Spartacus', 'Catilina', 'Viriathus', 'Bulla Felix', 'Salvian the Red', 'Maternus', 'Aelianus'],
   aztec: ['Montezuma II', 'Cuauhtémoc', 'Itzcoatl', 'Ahuitzotl', 'Tlacaelel'],
   japan: ['Nobunaga', 'Hideyoshi', 'Ieyasu', 'Takeda Shingen', 'Uesugi Kenshin', 'Miyamoto Musashi'],
   india: ['Chandragupta', 'Ashoka', 'Prithviraj Chauhan', 'Shivaji', 'Tipu Sultan', 'Akbar'],
@@ -182,7 +182,7 @@ export function processLandResurgence(
     campId,
     position: chosen.coord,
     isBanditLord,
-    banditLordName: (camp as any).banditLordName,
+    banditLordName: camp.banditLordName,
   });
 
   return updatedState;
@@ -194,10 +194,8 @@ const PIRATE_FLEET_THRESHOLD = 4.0;
 const PIRATE_FLEET_CAP = 2;
 const PIRATE_FLEET_COOLDOWN = 10;
 
-function pirateUnitType(era: number): 'galley' | 'carrack' | 'trireme' {
-  if (era >= 4) return 'trireme';
-  if (era === 3) return 'carrack';
-  return 'galley';
+function pirateUnitType(era: number): 'galley' | 'trireme' {
+  return era >= 3 ? 'trireme' : 'galley';
 }
 
 export function processPirateSpawn(

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -1,0 +1,84 @@
+import type { GameState, GameMap, HexCoord } from '@/core/types';
+import { hexKey, hexNeighbors } from './hex-utils';
+
+export const PIRATE_OWNER = 'pirate';
+
+const NON_VIABLE_TERRAIN = new Set(['ocean', 'coast', 'mountain', 'snow']);
+
+// ── Pure helpers ─────────────────────────────────────────────────────────────
+
+export function empireShare(state: GameState, civId: string, landmassId: string): number {
+  const tiles = Object.values(state.map.tiles).filter(t => t.regionKey === landmassId);
+  const viable = tiles.filter(t => !NON_VIABLE_TERRAIN.has(t.terrain));
+  if (viable.length === 0) return 0;
+  const owned = viable.filter(t => t.owner === civId).length;
+  return Math.min(owned / viable.length, 1.0);
+}
+
+export function nearestLandmassId(position: HexCoord, map: GameMap): string | null {
+  const visited = new Set<string>([hexKey(position)]);
+  let frontier: HexCoord[] = [position];
+
+  for (let depth = 0; depth < 10 && frontier.length > 0; depth++) {
+    const nextFrontier: HexCoord[] = [];
+    for (const coord of frontier) {
+      for (const nb of hexNeighbors(coord)) {
+        const key = hexKey(nb);
+        if (visited.has(key)) continue;
+        visited.add(key);
+        const tile = map.tiles[key];
+        if (!tile) continue;
+        if (tile.regionKey) return tile.regionKey;
+        nextFrontier.push(nb);
+      }
+    }
+    frontier = nextFrontier;
+  }
+  return null;
+}
+
+export function computeThreatScore(state: GameState, civId: string, landmassId: string): number {
+  const civ = state.civilizations[civId];
+  if (!civ || !civ.isHuman) return 0;
+
+  // Only evaluate landmasses where civ has at least one city
+  const hasCityOnLandmass = civ.cities.some(cityId => {
+    const city = state.cities[cityId];
+    if (!city) return false;
+    const tile = state.map.tiles[hexKey(city.position)];
+    return tile?.regionKey === landmassId;
+  });
+  if (!hasCityOnLandmass) return 0;
+
+  const share = empireShare(state, civId, landmassId);
+  const idleTurns = state.turn - (civ.lastCombatTurnByLandmass?.[landmassId] ?? state.turn);
+  const idleFactor = Math.min(idleTurns / 10, 1.5);
+
+  return state.era * (1.0 + share + idleFactor);
+}
+
+export function recordCombatForCiv(state: GameState, civId: string, position: HexCoord): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  const tile = state.map.tiles[hexKey(position)];
+  let landmassId: string | null = tile?.regionKey ?? null;
+  if (!landmassId) {
+    landmassId = nearestLandmassId(position, state.map);
+  }
+  if (!landmassId) return state;
+
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civId]: {
+        ...civ,
+        lastCombatTurnByLandmass: {
+          ...(civ.lastCombatTurnByLandmass ?? {}),
+          [landmassId]: state.turn,
+        },
+      },
+    },
+  };
+}

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -446,6 +446,18 @@ export function createCityPanel(
       </div>`
     : '';
 
+  const cityHp = city.hp ?? 100;
+  const cityUnderSiege = cityHp < 100;
+  const siegeHpPct = Math.max(0, cityHp);
+  const siegeBarHtml = cityUnderSiege
+    ? `<div style="margin-top:6px;">
+        <div style="font-size:12px;color:#f87171;font-weight:bold;">⚔️ Under siege — ${cityHp}/100 HP</div>
+        <div style="background:rgba(0,0,0,0.4);border-radius:4px;height:6px;margin-top:4px;width:120px;">
+          <div style="background:#ef4444;border-radius:4px;height:6px;width:${siegeHpPct}%;transition:width 0.3s;"></div>
+        </div>
+      </div>`
+    : '';
+
   const html = `
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
       <div>
@@ -453,6 +465,7 @@ export function createCityPanel(
         <div style="font-size:12px;opacity:0.7;">Population: <span data-text="city-pop"></span></div>
         ${city.occupation ? '<div style="font-size:12px;color:#e8c170;" data-text="occupied-status"></div>' : ''}
         ${occupiedMoodText ? '<div style="font-size:12px;color:#d9a25c;" data-text="occupied-mood"></div>' : ''}
+        ${siegeBarHtml}
       </div>
       <div style="display:flex;align-items:center;gap:8px;">
         ${navHtml}

--- a/tests/storage/save-migration-landmass.test.ts
+++ b/tests/storage/save-migration-landmass.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState, HexTile } from '@/core/types';
+
+vi.mock('@/storage/db', () => ({
+  dbGet: vi.fn(),
+  dbPut: vi.fn(),
+  dbDelete: vi.fn(),
+  dbGetAllKeys: vi.fn(async () => []),
+}));
+
+import { vi } from 'vitest';
+import { normalizeLoadedStateForTest } from '@/storage/save-manager';
+
+function makeLegacyState(): GameState {
+  const tiles: Record<string, HexTile> = {
+    '0,0': { coord: { q:0, r:0 }, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+    '1,0': { coord: { q:1, r:0 }, terrain: 'plains', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+    '0,1': { coord: { q:0, r:1 }, terrain: 'ocean', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null },
+  };
+  return {
+    map: { width: 5, height: 5, tiles, wrapsHorizontally: false, rivers: [] },
+    civilizations: {},
+    units: {},
+    cities: {},
+    barbarianCamps: {},
+    minorCivs: {},
+    currentPlayer: 'p1',
+    turn: 1,
+    era: 1,
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    gameOver: false,
+    winner: null,
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+  } as unknown as GameState;
+}
+
+describe('normalizeLandmassKeys migration', () => {
+  it('adds regionKey to land tiles on old saves with no regionKey', () => {
+    const state = makeLegacyState();
+    expect(state.map.tiles['0,0'].regionKey).toBeUndefined();
+
+    const normalized = normalizeLoadedStateForTest(state);
+    expect(normalized.map.tiles['0,0'].regionKey).toMatch(/^(continent|island)-\d+$/);
+    expect(normalized.map.tiles['1,0'].regionKey).toMatch(/^(continent|island)-\d+$/);
+    expect(normalized.map.tiles['0,1'].regionKey).toBeUndefined();
+  });
+
+  it('is idempotent — already-tagged tiles are not re-tagged', () => {
+    const state = makeLegacyState();
+    state.map.tiles['0,0'] = { ...state.map.tiles['0,0'], regionKey: 'continent-0' };
+    state.map.tiles['1,0'] = { ...state.map.tiles['1,0'], regionKey: 'continent-0' };
+
+    const normalized = normalizeLoadedStateForTest(state);
+    expect(normalized.map.tiles['0,0'].regionKey).toBe('continent-0');
+    expect(normalized.map.tiles['1,0'].regionKey).toBe('continent-0');
+  });
+});

--- a/tests/storage/save-migration-landmass.test.ts
+++ b/tests/storage/save-migration-landmass.test.ts
@@ -43,6 +43,34 @@ function makeLegacyState(): GameState {
   } as unknown as GameState;
 }
 
+describe('pirate fleet migration defaults', () => {
+  it('adds pirateFleets: {} to old saves lacking the field', () => {
+    const state = makeLegacyState();
+    expect((state as any).pirateFleets).toBeUndefined();
+    const normalized = normalizeLoadedStateForTest(state);
+    expect(normalized.pirateFleets).toBeDefined();
+    expect(typeof normalized.pirateFleets).toBe('object');
+  });
+
+  it('adds pirateFleetCooldownByCivLandmass: {} to old saves lacking the field', () => {
+    const state = makeLegacyState();
+    expect((state as any).pirateFleetCooldownByCivLandmass).toBeUndefined();
+    const normalized = normalizeLoadedStateForTest(state);
+    expect(normalized.pirateFleetCooldownByCivLandmass).toBeDefined();
+    expect(typeof normalized.pirateFleetCooldownByCivLandmass).toBe('object');
+  });
+
+  it('does not overwrite existing pirate fleet data', () => {
+    const state = makeLegacyState();
+    (state as any).pirateFleets = { 'unit-42': { id: 'unit-42' } };
+    (state as any).pirateFleetCooldownByCivLandmass = { 'p1:continent-0': 5 };
+
+    const normalized = normalizeLoadedStateForTest(state);
+    expect(normalized.pirateFleets).toHaveProperty('unit-42');
+    expect(normalized.pirateFleetCooldownByCivLandmass?.['p1:continent-0']).toBe(5);
+  });
+});
+
 describe('normalizeLandmassKeys migration', () => {
   it('adds regionKey to land tiles on old saves with no regionKey', () => {
     const state = makeLegacyState();

--- a/tests/systems/threat-pressure-balance.test.ts
+++ b/tests/systems/threat-pressure-balance.test.ts
@@ -18,7 +18,7 @@ function makeScenario(era: number, idleTurns: number, dominanceRatio: number): G
     id: 'p1', name: 'P1', color: '#fff', isHuman: true, civType: 'egypt',
     cities: ['c1'], units: [], gold: 0, visibility: { tiles: {} }, score: 0,
     techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
-    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [] },
+    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 0, protectionTimers: [], peakCities: 1, peakMilitary: 0 } },
     lastCombatTurnByLandmass: { 'continent-0': lastCombatTurn },
   };
   return {

--- a/tests/systems/threat-pressure-balance.test.ts
+++ b/tests/systems/threat-pressure-balance.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { computeThreatScore } from '@/systems/threat-pressure-system';
+import type { GameState, HexTile, Civilization } from '@/core/types';
+
+function makeScenario(era: number, idleTurns: number, dominanceRatio: number): GameState {
+  const tiles: Record<string, HexTile> = {};
+  const totalTiles = 20;
+  const ownedCount = Math.round(totalTiles * dominanceRatio);
+  for (let q = 0; q < totalTiles; q++) {
+    tiles[`${q},0`] = {
+      coord: { q, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: q < ownedCount ? 'p1' : null,
+      improvementTurnsLeft: 0, hasRiver: false, wonder: null, regionKey: 'continent-0',
+    };
+  }
+  const lastCombatTurn = 100 - idleTurns;
+  const p1: Civilization = {
+    id: 'p1', name: 'P1', color: '#fff', isHuman: true, civType: 'egypt',
+    cities: ['c1'], units: [], gold: 0, visibility: { tiles: {} }, score: 0,
+    techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
+    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [] },
+    lastCombatTurnByLandmass: { 'continent-0': lastCombatTurn },
+  };
+  return {
+    turn: 100, era,
+    civilizations: { p1 },
+    map: { width: 25, height: 5, tiles, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { c1: { id: 'c1', owner: 'p1', position: { q: 0, r: 0 } } as any },
+    barbarianCamps: {}, minorCivs: {}, currentPlayer: 'p1',
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    gameOver: false, winner: null,
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+  } as unknown as GameState;
+}
+
+describe('threat score balance bands', () => {
+  it('era-2, 6 idle turns, 50% dominance: score ≥ 2.5 (land resurgence eligible)', () => {
+    const state = makeScenario(2, 6, 0.5);
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBeGreaterThanOrEqual(2.5);
+  });
+
+  it('era-2, 10 idle turns, 70% dominance: score ≥ 4.0 (pirate eligible)', () => {
+    const state = makeScenario(2, 10, 0.7);
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBeGreaterThanOrEqual(4.0);
+  });
+
+  it('era-3, dominant + 15 idle turns: score > 8 (bandit lord eligible)', () => {
+    const state = makeScenario(3, 15, 0.9);
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBeGreaterThan(8);
+  });
+
+  it('idleFactor caps at 1.5 — score does not increase past 20+ idle turns', () => {
+    const s15 = makeScenario(3, 15, 0.9);
+    const s25 = makeScenario(3, 25, 0.9);
+    expect(computeThreatScore(s15, 'p1', 'continent-0')).toBeCloseTo(
+      computeThreatScore(s25, 'p1', 'continent-0'), 5
+    );
+  });
+});

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { generateContinentMap } from '@/systems/continent-map-generator';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
-import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv, processLandResurgence, processThreatPressure } from '@/systems/threat-pressure-system';
+import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv, processLandResurgence, processThreatPressure, processPirateSpawn, processPirateFleets, PIRATE_OWNER } from '@/systems/threat-pressure-system';
 import type { GameMap, GameState, HexTile, Civilization } from '@/core/types';
 
 function makeTestState(overrides: Partial<GameState> = {}): GameState {
@@ -194,6 +194,115 @@ describe('processThreatPressure — hot-seat isolation', () => {
     const score1 = computeThreatScore(state, 'p1', 'continent-1');
     expect(score0).toBeGreaterThan(2.5);
     expect(score1).toBeGreaterThan(2.5);
+  });
+});
+
+describe('processPirateSpawn', () => {
+  function makeCoastalState(): GameState {
+    const state = makeTestState({ era: 2, turn: 40 });
+    // High idle — score ≥ 4.0 needed for pirate spawn
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 0 }; // 40 turns idle
+    // City at 0,0 (coast). Landmass tiles at 0,0 through 9,0 (from makeTestState).
+    // Ocean tiles at 10..15,0 — adjacent to 9,0 (continent-0), 10+ tiles from city.
+    state.map.tiles['0,0'] = { ...state.map.tiles['0,0'], terrain: 'coast', owner: 'p1' };
+    for (let q = 10; q <= 15; q++) {
+      state.map.tiles[`${q},0`] = {
+        coord: { q, r: 0 }, terrain: 'ocean', elevation: 'lowland', resource: null,
+        improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+      };
+    }
+    state.cities['city-1'] = { ...state.cities['city-1'], position: { q: 0, r: 0 } } as any;
+    return state;
+  }
+
+  it('spawns a pirate fleet when score ≥ 4.0 and no cooldown', () => {
+    const state = makeCoastalState();
+    const events: any[] = [];
+    const bus = { emit: (e: string, p: any) => events.push({ e, ...p }) } as any;
+    const updated = processPirateSpawn(state, 'p1', 'continent-0', bus);
+    expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(1);
+    expect(events.some(e => e.e === 'threat:pirate-fleet-spawned')).toBe(true);
+  });
+
+  it('does not spawn when max 2 fleets already active for this civ+landmass', () => {
+    const state = makeCoastalState();
+    state.pirateFleets = {
+      'fleet-1': { id: 'fleet-1', unitId: 'u1', targetCivId: 'p1', targetCityId: 'city-1', landmassId: 'continent-0', era: 2, plunderCooldown: 0 },
+      'fleet-2': { id: 'fleet-2', unitId: 'u2', targetCivId: 'p1', targetCityId: 'city-1', landmassId: 'continent-0', era: 2, plunderCooldown: 0 },
+    };
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateSpawn(state, 'p1', 'continent-0', bus);
+    expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(2);
+  });
+
+  it('does not spawn when score < 4.0', () => {
+    const state = makeCoastalState();
+    // Low idle so score is low
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 39 }; // 1 turn idle
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateSpawn(state, 'p1', 'continent-0', bus);
+    expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(0);
+  });
+});
+
+describe('processPirateFleets', () => {
+  function makeFleetState(): GameState {
+    const state = makeTestState({ era: 2, turn: 50 });
+    // Add ocean path between spawn and target city
+    for (let r = 1; r <= 7; r++) {
+      state.map.tiles[`5,${r}`] = {
+        coord: { q: 5, r }, terrain: 'ocean', elevation: 'lowland', resource: null,
+        improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+      };
+    }
+    state.map.tiles['5,0'] = { ...state.map.tiles['5,0'], terrain: 'coast' };
+    state.cities['city-1'] = { ...state.cities['city-1'], position: { q: 5, r: 0 } } as any;
+
+    const unit = {
+      id: 'u-pirate', type: 'galley' as const, owner: PIRATE_OWNER,
+      position: { q: 5, r: 7 }, health: 100, movementPointsLeft: 2,
+      hasMoved: false, experience: 0, isFortified: false,
+    } as any;
+    state.units['u-pirate'] = unit;
+    state.pirateFleets = {
+      'fleet-1': {
+        id: 'fleet-1', unitId: 'u-pirate', targetCivId: 'p1',
+        targetCityId: 'city-1', landmassId: 'continent-0', era: 2, plunderCooldown: 0,
+      },
+    };
+    return state;
+  }
+
+  it('moves pirate fleet toward target city', () => {
+    const state = makeFleetState();
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateFleets(state, bus);
+    const unit = updated.units['u-pirate'];
+    // Should have moved closer to city at 5,0
+    expect(unit.position.r).toBeLessThan(7);
+  });
+
+  it('removes fleet from state when its unit is destroyed', () => {
+    const state = makeFleetState();
+    delete state.units['u-pirate']; // unit died in combat
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateFleets(state, bus);
+    expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(0);
+  });
+});
+
+describe('pirate hot-seat behavior', () => {
+  it('fleet destruction sets cooldown for civ+landmass pair', () => {
+    const state = makeTestState({ era: 2, turn: 50 });
+    state.pirateFleets = {
+      'fleet-1': { id: 'fleet-1', unitId: 'u-gone', targetCivId: 'p1', targetCityId: 'city-1',
+        landmassId: 'continent-0', era: 2, plunderCooldown: 0 },
+    };
+    // Unit not present (already destroyed)
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateFleets(state, bus);
+    expect(updated.pirateFleetCooldownByCivLandmass?.['p1:continent-0']).toBe(60); // turn 50 + 10
+    expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(0);
   });
 });
 

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -289,6 +289,40 @@ describe('processPirateFleets', () => {
     const updated = processPirateFleets(state, bus);
     expect(Object.keys(updated.pirateFleets ?? {}).length).toBe(0);
   });
+
+  it('plunder steals gold from target civ when adjacent', () => {
+    const state = makeFleetState();
+    state.civilizations['p1'].gold = 80;
+    // Place unit adjacent to city (distance ≤ 2)
+    state.units['u-pirate'] = { ...state.units['u-pirate'], position: { q: 5, r: 2 } } as any;
+    state.pirateFleets = { ...state.pirateFleets, 'fleet-1': { ...state.pirateFleets!['fleet-1'], plunderCooldown: 0 } };
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateFleets(state, bus);
+    // era-2 plunder: Math.floor((1 + (2-1)*0.5) * 5) = Math.floor(1.5*5) = 7
+    expect(updated.civilizations['p1'].gold).toBeLessThan(80);
+  });
+
+  it('siege deals HP damage to city when adjacent (era ≥ 2)', () => {
+    const state = makeFleetState();
+    // Place unit adjacent to city
+    state.units['u-pirate'] = { ...state.units['u-pirate'], position: { q: 5, r: 2 } } as any;
+    state.pirateFleets = { ...state.pirateFleets, 'fleet-1': { ...state.pirateFleets!['fleet-1'], plunderCooldown: 1 } }; // suppress plunder
+    const bus = { emit: () => {} } as any;
+    const updated = processPirateFleets(state, bus);
+    const cityHp = updated.cities['city-1'].hp ?? 100;
+    expect(cityHp).toBeLessThan(100);
+    expect(cityHp).toBe(90); // era-2 siege: 10 HP lost
+  });
+
+  it('siege event fires exactly once per turn regardless of repeated calls', () => {
+    const state = makeFleetState();
+    state.units['u-pirate'] = { ...state.units['u-pirate'], position: { q: 5, r: 2 } } as any;
+    state.pirateFleets = { ...state.pirateFleets, 'fleet-1': { ...state.pirateFleets!['fleet-1'], plunderCooldown: 1 } };
+    const events: string[] = [];
+    const bus = { emit: (e: string) => events.push(e) } as any;
+    processPirateFleets(state, bus);
+    expect(events.filter(e => e === 'threat:pirate-siege').length).toBe(1);
+  });
 });
 
 describe('pirate hot-seat behavior', () => {

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -174,6 +174,27 @@ describe('processThreatPressure — hot-seat isolation', () => {
     processThreatPressure(state, 'p1', bus);
     expect(events.filter(e => e.e === 'threat:barbarian-resurgence').length).toBe(0);
   });
+
+  it('multi-landmass: evaluates each landmass independently', () => {
+    const state = makeTestState({ era: 2, turn: 30 });
+    // Add continent-1 tiles
+    for (let q = 20; q < 30; q++) {
+      state.map.tiles[`${q},0`] = {
+        coord: { q, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null,
+        improvement: 'none', owner: 'p1', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+        regionKey: 'continent-1',
+      };
+    }
+    // Add city on continent-1
+    state.cities['city-2'] = { id: 'city-2', owner: 'p1', position: { q: 20, r: 0 } } as any;
+    state.civilizations['p1'].cities.push('city-2');
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 15, 'continent-1': 15 };
+
+    const score0 = computeThreatScore(state, 'p1', 'continent-0');
+    const score1 = computeThreatScore(state, 'p1', 'continent-1');
+    expect(score0).toBeGreaterThan(2.5);
+    expect(score1).toBeGreaterThan(2.5);
+  });
 });
 
 describe('continent-map-generator landmass tagging', () => {

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -2,7 +2,50 @@ import { describe, it, expect } from 'vitest';
 import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { generateContinentMap } from '@/systems/continent-map-generator';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
-import type { GameMap, HexTile } from '@/core/types';
+import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv } from '@/systems/threat-pressure-system';
+import type { GameMap, GameState, HexTile, Civilization } from '@/core/types';
+
+function makeTestState(overrides: Partial<GameState> = {}): GameState {
+  const tiles: Record<string, HexTile> = {};
+  // 10 land tiles tagged continent-0
+  for (let q = 0; q < 10; q++) {
+    tiles[`${q},0`] = {
+      coord: { q, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: q < 8 ? 'p1' : null, improvementTurnsLeft: 0,
+      hasRiver: false, wonder: null, regionKey: 'continent-0',
+    };
+  }
+  // ocean tile adjacent for nearestLandmassId test
+  tiles['0,1'] = {
+    coord: { q: 0, r: 1 }, terrain: 'ocean', elevation: 'lowland', resource: null,
+    improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+  };
+
+  const p1: Civilization = {
+    id: 'p1', name: 'Player 1', color: '#fff', isHuman: true, civType: 'rome',
+    cities: ['city-1'], units: [],
+    techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
+    gold: 0, visibility: { tiles: {} }, score: 0,
+    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [] },
+    lastCombatTurnByLandmass: {},
+  };
+
+  return {
+    turn: 10, era: 2,
+    civilizations: { p1 },
+    map: { width: 15, height: 5, tiles, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { 'city-1': { id: 'city-1', owner: 'p1', position: { q: 0, r: 0 } } as any },
+    barbarianCamps: {}, minorCivs: {}, currentPlayer: 'p1',
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    gameOver: false, winner: null,
+    settings: { mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0, tutorialEnabled: false },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    ...overrides,
+  } as unknown as GameState;
+}
 
 describe('landmass tagging', () => {
   it('generateBalancedMap assigns regionKey to all land tiles', () => {
@@ -84,5 +127,87 @@ describe('continent-map-generator landmass tagging', () => {
     for (const tile of landTiles) {
       expect(tile.regionKey).toMatch(/^(continent|island)-\d+$/);
     }
+  });
+});
+
+describe('empireShare', () => {
+  it('returns ~0.8 when 8 of 10 viable tiles are owned by player', () => {
+    const state = makeTestState();
+    const share = empireShare(state, 'p1', 'continent-0');
+    expect(share).toBeCloseTo(0.8, 1);
+  });
+
+  it('returns 0 when player owns no tiles', () => {
+    const state = makeTestState();
+    Object.values(state.map.tiles).forEach(t => { if (t.owner === 'p1') t.owner = null; });
+    expect(empireShare(state, 'p1', 'continent-0')).toBe(0);
+  });
+});
+
+describe('computeThreatScore', () => {
+  it('returns ~1 for era-1 player with no empire share and 0 idle turns', () => {
+    const state = makeTestState({ era: 1, turn: 5 });
+    // Remove all ownership so empireShare = 0
+    Object.values(state.map.tiles).forEach(t => { if (t.owner === 'p1') t.owner = null; });
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 5 }; // no idle
+    const score = computeThreatScore(state, 'p1', 'continent-0');
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeCloseTo(1.0, 1); // era 1 × (1 + 0 + 0) = 1.0
+  });
+
+  it('returns > 5 for era-2 dominant player with 10 idle turns', () => {
+    const state = makeTestState({ era: 2, turn: 20 });
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 10 };
+    const score = computeThreatScore(state, 'p1', 'continent-0');
+    expect(score).toBeGreaterThan(5);
+  });
+
+  it('returns 0 for AI civ', () => {
+    const state = makeTestState();
+    state.civilizations['p1'].isHuman = false;
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBe(0);
+  });
+
+  it('returns 0 when civ has no city on landmass', () => {
+    const state = makeTestState();
+    state.civilizations['p1'].cities = [];
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBe(0);
+  });
+});
+
+describe('nearestLandmassId', () => {
+  it('finds continent-0 from adjacent ocean tile', () => {
+    const state = makeTestState();
+    // tile '0,1' is ocean adjacent to '0,0' which has regionKey continent-0
+    const id = nearestLandmassId({ q: 0, r: 1 }, state.map);
+    expect(id).toBe('continent-0');
+  });
+
+  it('returns null when no land within 10 tiles', () => {
+    const state = makeTestState();
+    // Replace all land tiles with ocean
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key] = { ...state.map.tiles[key], terrain: 'ocean', regionKey: undefined };
+    }
+    const id = nearestLandmassId({ q: 0, r: 0 }, state.map);
+    expect(id).toBeNull();
+  });
+});
+
+describe('recordCombatForCiv', () => {
+  it('updates lastCombatTurnByLandmass for the combat landmass', () => {
+    const state = makeTestState({ turn: 15 });
+    state.civilizations['p1'].lastCombatTurnByLandmass = {};
+    // tile '0,0' has regionKey 'continent-0'
+    const updated = recordCombatForCiv(state, 'p1', { q: 0, r: 0 });
+    expect(updated.civilizations['p1'].lastCombatTurnByLandmass?.['continent-0']).toBe(15);
+  });
+
+  it('uses nearestLandmassId when the combat tile has no regionKey', () => {
+    const state = makeTestState({ turn: 20 });
+    state.civilizations['p1'].lastCombatTurnByLandmass = {};
+    // tile '0,1' is ocean with no regionKey, but adjacent to continent-0
+    const updated = recordCombatForCiv(state, 'p1', { q: 0, r: 1 });
+    expect(updated.civilizations['p1'].lastCombatTurnByLandmass?.['continent-0']).toBe(20);
   });
 });

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { generateContinentMap } from '@/systems/continent-map-generator';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
-import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv } from '@/systems/threat-pressure-system';
+import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv, processLandResurgence, processThreatPressure } from '@/systems/threat-pressure-system';
 import type { GameMap, GameState, HexTile, Civilization } from '@/core/types';
 
 function makeTestState(overrides: Partial<GameState> = {}): GameState {
@@ -26,7 +26,7 @@ function makeTestState(overrides: Partial<GameState> = {}): GameState {
     cities: ['city-1'], units: [],
     techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
     gold: 0, visibility: { tiles: {} }, score: 0,
-    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [] },
+    diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 0, protectionTimers: [], peakCities: 1, peakMilitary: 0 } },
     lastCombatTurnByLandmass: {},
   };
 
@@ -114,6 +114,65 @@ describe('tagLandmassRegions', () => {
 
     const tagged = tagLandmassRegions(map);
     expect(tagged['1,0'].regionKey).toBeUndefined();
+  });
+});
+
+describe('processLandResurgence', () => {
+  function makeResurgenceState(): GameState {
+    const state = makeTestState({ era: 2, turn: 30 });
+    // Player idle for 15 turns (score ≥ 2.5)
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 15 };
+    // 8 of 10 tiles owned = 80% dominance
+    return state;
+  }
+
+  it('spawns a resurgent camp when score ≥ 2.5 and cooldown passed', () => {
+    const state = makeResurgenceState();
+    const bus = { emit: () => {} } as any;
+    const updated = processLandResurgence(state, 'p1', 'continent-0', bus);
+    const resurgentCamps = Object.values(updated.barbarianCamps).filter(c => c.resurgent);
+    expect(resurgentCamps.length).toBeGreaterThan(0);
+  });
+
+  it('does not spawn when score < 2.5', () => {
+    const state = makeTestState({ era: 1, turn: 5 });
+    // Low score: era 1, idle 0 turns, low ownership
+    Object.values(state.map.tiles).forEach(t => { if (t.owner === 'p1') t.owner = null; });
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 5 };
+    const bus = { emit: () => {} } as any;
+    const updated = processLandResurgence(state, 'p1', 'continent-0', bus);
+    const resurgentCamps = Object.values(updated.barbarianCamps).filter(c => c.resurgent);
+    expect(resurgentCamps.length).toBe(0);
+  });
+
+  it('does not spawn when cooldown is active', () => {
+    const state = makeResurgenceState();
+    state.resurgentCampCooldownByCivLandmass = { 'p1:continent-0': 35 }; // cooldown until turn 35
+    const bus = { emit: () => {} } as any;
+    const updated = processLandResurgence(state, 'p1', 'continent-0', bus);
+    const resurgentCamps = Object.values(updated.barbarianCamps).filter(c => c.resurgent);
+    expect(resurgentCamps.length).toBe(0);
+  });
+
+  it('camp strength scales with era', () => {
+    const state = makeResurgenceState();
+    const bus = { emit: () => {} } as any;
+    const updated = processLandResurgence(state, 'p1', 'continent-0', bus);
+    const camp = Object.values(updated.barbarianCamps).find(c => c.resurgent);
+    expect(camp?.strength).toBeGreaterThanOrEqual(6); // era-2 minimum
+    expect(camp?.strength).toBeLessThanOrEqual(10);   // era-2 maximum
+  });
+});
+
+describe('processThreatPressure — hot-seat isolation', () => {
+  it('only evaluates human players — AI civ never gets resurgence', () => {
+    const state = makeTestState({ era: 3, turn: 30 });
+    state.civilizations['p1'].isHuman = false;
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 10 };
+    const events: any[] = [];
+    const bus = { emit: (e: string, p: any) => events.push({ e, ...p }) } as any;
+    processThreatPressure(state, 'p1', bus);
+    expect(events.filter(e => e.e === 'threat:barbarian-resurgence').length).toBe(0);
   });
 });
 

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { generateBalancedMap } from '@/systems/balanced-map-generator';
+import { generateContinentMap } from '@/systems/continent-map-generator';
+import { tagLandmassRegions } from '@/systems/landmass-tagger';
+import type { GameMap, HexTile } from '@/core/types';
+
+describe('landmass tagging', () => {
+  it('generateBalancedMap assigns regionKey to all land tiles', () => {
+    const { map } = generateBalancedMap(30, 30, 'test-seed', 2);
+    const landTiles = Object.values(map.tiles).filter(
+      t => t.terrain !== 'ocean' && t.terrain !== 'coast'
+    );
+    expect(landTiles.length).toBeGreaterThan(0);
+    for (const tile of landTiles) {
+      expect(tile.regionKey, `tile at ${tile.coord.q},${tile.coord.r} missing regionKey`).toBeDefined();
+      expect(tile.regionKey).toMatch(/^(continent|island)-\d+$/);
+    }
+  });
+
+  it('ocean tiles have no regionKey', () => {
+    const { map } = generateBalancedMap(30, 30, 'test-seed-2', 2);
+    const oceanTiles = Object.values(map.tiles).filter(t => t.terrain === 'ocean');
+    for (const tile of oceanTiles) {
+      expect(tile.regionKey).toBeUndefined();
+    }
+  });
+});
+
+describe('tagLandmassRegions', () => {
+  function makeTile(q: number, r: number, terrain: string): HexTile {
+    return {
+      coord: { q, r }, terrain: terrain as any, elevation: 'lowland', resource: null,
+      improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+  }
+
+  it('assigns continent-0 to the largest connected land component (≥9 tiles)', () => {
+    const tiles: Record<string, HexTile> = {};
+    // 10-tile connected component (large enough for continent threshold=9)
+    [[0,0],[1,0],[2,0],[3,0],[4,0],[0,1],[1,1],[2,1],[3,1],[4,1]].forEach(([q,r]) => {
+      tiles[`${q},${r}`] = makeTile(q, r, 'grassland');
+    });
+    // 2-tile isolated component (island)
+    [[8,8],[8,9]].forEach(([q,r]) => { tiles[`${q},${r}`] = makeTile(q, r, 'plains'); });
+    const map: GameMap = { width: 15, height: 15, tiles, wrapsHorizontally: false, rivers: [] };
+
+    const tagged = tagLandmassRegions(map);
+    expect(tagged['0,0'].regionKey).toBe('continent-0');
+    expect(tagged['4,1'].regionKey).toBe('continent-0');
+  });
+
+  it('labels components under 9 tiles as island-N', () => {
+    const tiles: Record<string, HexTile> = {};
+    // 10-tile large component
+    [[0,0],[1,0],[2,0],[3,0],[4,0],[0,1],[1,1],[2,1],[3,1],[4,1]].forEach(([q,r]) => {
+      tiles[`${q},${r}`] = makeTile(q, r, 'grassland');
+    });
+    // 2-tile isolated component
+    [[8,8],[8,9]].forEach(([q,r]) => { tiles[`${q},${r}`] = makeTile(q, r, 'plains'); });
+    const map: GameMap = { width: 15, height: 15, tiles, wrapsHorizontally: false, rivers: [] };
+
+    const tagged = tagLandmassRegions(map);
+    expect(tagged['8,8'].regionKey).toMatch(/^island-\d+$/);
+  });
+
+  it('leaves ocean tiles without regionKey', () => {
+    const tiles: Record<string, HexTile> = {};
+    tiles['0,0'] = makeTile(0, 0, 'grassland');
+    tiles['1,0'] = makeTile(1, 0, 'ocean');
+    const map: GameMap = { width: 5, height: 5, tiles, wrapsHorizontally: false, rivers: [] };
+
+    const tagged = tagLandmassRegions(map);
+    expect(tagged['1,0'].regionKey).toBeUndefined();
+  });
+});
+
+describe('continent-map-generator landmass tagging', () => {
+  it('assigns regionKey to all non-ocean tiles', () => {
+    const { map } = generateContinentMap(40, 40, 'continent-test');
+    const landTiles = Object.values(map.tiles).filter(
+      t => t.terrain !== 'ocean' && t.terrain !== 'coast'
+    );
+    expect(landTiles.length).toBeGreaterThan(0);
+    for (const tile of landTiles) {
+      expect(tile.regionKey).toMatch(/^(continent|island)-\d+$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **MR1 — Landmass tagging**: BFS flood-fill assigns `regionKey` (`continent-N` / `island-N`) to all non-ocean hex tiles; wired into both map generators and save-migration (`normalizeLandmassKeys`)
- **MR2 — Threat scoring**: `computeThreatScore = era × (1.0 + empireShare + idleFactor)` where `idleFactor = min(idleTurns/10, 1.5)`; `recordCombatForCiv` resets the idle clock on all combat paths (player attacks, barbarian attacks, beast attacks)
- **MR3 — Land resurgence**: `processThreatPressure` spawns resurgent barbarian camps (threshold 2.5) and named Bandit Lords (threshold 7.0) with era-scaled strength; per-civ-landmass cooldown prevents spam; drum SFX + civ-log notifications
- **MR4 — Sea raiders**: `processPirateSpawn` places galley/trireme pirate fleets on ocean tiles adjacent to continental coasts; `processPirateFleets` moves via BFS, plunders gold, and sieges city HP with per-fleet cooldowns; sea-horn/cannon/destroyed SFX

## Code review fixes (inline, same PR)

- **Bug**: `pirateUnitType` was returning `carrack` (strength=0, transport ship) for era 3 — pirates would have been defenseless. Fixed to galley (era 1-2) / trireme (era 3+)
- **Data**: Rome bandit lord pool contained English monarchs (Henry II, Richard III, Robin Hood). Replaced with Roman rebels: Spartacus, Catilina, Viriathus, Bulla Felix, Maternus
- **Code smell**: `(camp as any).banditLordName` removed — field is already on `BarbarianCamp` type
- **UX**: Raw internal `fleetId` was shown in player notifications ("fleet fleet-unit-42 has been spotted"). Removed
- **End-to-end wiring**: City `hp` was computed and mutated by siege but never displayed. Added red siege HP bar to city panel header (only shown when `hp < 100`)
- **Tests**: Added plunder-steals-gold, siege-damages-city-hp, and event-fires-exactly-once regressions

## Architecture

- All randomness uses seeded LCG (no `Math.random()`)
- All state mutations return new `GameState` (immutable pattern)
- `processThreatPressure` gates on `isHuman` — AI civs never receive threat pressure
- `PIRATE_OWNER = 'pirate'` added to all hostile-owner filters (combat rewards, unit presentation, intruder filter)
- Save migration in `normalizeThreatPressureDefaults` adds `pirateFleets: {}` and `pirateFleetCooldownByCivLandmass: {}` to old saves
- Hot-seat safe: `appendToCivLog` already gates toasts to `currentPlayer`; pirate notifications route by `civId` (target civ), not `currentPlayer`

## Test plan

- [ ] 3775 tests pass, build clean
- [ ] New map generates with `regionKey` on all land tiles
- [ ] Old save loads without errors (landmass migration runs on load)
- [ ] After 10+ idle turns on a dominated continent, a resurgent camp appears in the civ log
- [ ] At high threat score, a bandit lord camp spawns with a named leader
- [ ] Coastal civ at era 2+ with high idle score sees pirate fleet spawned in civ log with sea-horn SFX
- [ ] City under pirate siege shows red HP bar in city panel
- [ ] Defeating the pirate unit removes the fleet and shows "driven off" notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)