### PR TITLE
fix: barbarian city attacks, isCityCoastal adjacency, friendly stacking, sprite color flicker

### DIFF
--- a/docs/superpowers/plans/2026-06-15-bug-fixes.md
+++ b/docs/superpowers/plans/2026-06-15-bug-fixes.md
@@ -1,0 +1,1665 @@
+# Bug Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix four confirmed bugs: barbarians ignore empty cities (#387), friendly units block each other from stacking (#385), `isCityCoastal` uses owned territory instead of adjacent tiles so inland cities can build ships (#386), and unit colors flicker between the DOM sprite overlay (idle) and canvas (moving) rendering paths (#374).
+
+**Architecture:** Four independent surgical fixes. #385 is a single predicate change in `validateUnitMove`. #386 changes `isCityCoastal`'s radius source from `city.ownedTiles` to the 6 tiles adjacent to `city.position`, updates every caller's signature, and adds a save-migration step. #387 extends `processBarbarians` with city targets using the existing `city.hp` model already used by pirate siege. #374 injects the game-assigned civ color into DOM sprite SVG strings at mount time via string replacement of the baked-in faction accent color.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D, DOM sprite overlay (`SpriteOverlay`), EventBus, GitHub CLI (`gh`)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/systems/unit-movement-system.ts` | `validateUnitMove`: block only hostile occupants, not same-owner |
+| `src/systems/city-system.ts` | `isCityCoastal` new signature; update `getAvailableBuildings`, `getTrainableUnitsForCity`, and internal `processCity` calls |
+| `src/ui/city-panel.ts` | Update 4 caller sites to pass `state.map` instead of `state.map.tiles` |
+| `src/ai/basic-ai.ts` | Update 2 caller sites |
+| `src/systems/planning-system.ts` | Update 2 caller sites |
+| `src/systems/quest-objective-system.ts` | Update 1 caller site |
+| `src/storage/save-manager.ts` | Add `migrateLegacyCoastalData` + add to migration chain |
+| `src/systems/barbarian-system.ts` | Add `BarbarianCityAttackOrder`; extend `processBarbarians` with city targeting |
+| `src/core/types.ts` | Add `'barbarian:city-attacked'` and `'barbarian:city-destroyed'` to event map |
+| `src/core/turn-manager.ts` | Build `cityTargets`, update `processBarbarians` call, process `cityAttackOrders` |
+| `src/main.ts` | Listen on `'barbarian:city-attacked'` / `'barbarian:city-destroyed'` for player notification |
+| `src/renderer/sprite-overlay.ts` | Add `FACTION_SPRITE_ACCENT`, `applyFactionCivColor` export, `civId` on `SpriteEntity`, `civColor` on `PoolEntry`, `colorLookup` param on `sync()`, pool invalidation |
+| `src/renderer/render-loop.ts` | Add `civId` to unit entities; pass `colorLookup` to `spriteOverlay.sync()` |
+| `tests/systems/unit-movement-system.test.ts` | Add same-owner stacking tests |
+| `tests/input/selected-unit-tap-intent.test.ts` | Add friendly-stack regression |
+| `tests/systems/city-system.test.ts` | Update 14 `map.tiles` calls → `map`; add `isCityCoastal` tests |
+| `tests/storage/save-manager.test.ts` | Add `migrateLegacyCoastalData` tests (create if missing) |
+| `tests/systems/barbarian-system.test.ts` | Add city-targeting tests |
+| `tests/renderer/sprite-overlay.test.ts` | Add `applyFactionCivColor` unit tests + pool-invalidation integration test |
+
+---
+
+### Task 1: Comment on GitHub Issues
+
+Post a root-cause summary on each of the four open issues so the reporter knows a fix is in progress.
+
+**Files:** none (GitHub CLI only)
+
+- [ ] **Step 1: Post on #387 (Barbarians not attacking city)**
+
+```bash
+gh issue comment 387 --repo a1flecke/conquestoria --body "$(cat <<'EOF'
+**Root cause found.** \`processBarbarians()\` only receives player *units* as potential targets — cities are never passed in. Barbarians surrounding an empty city have no valid target and stand idle indefinitely.
+
+**Fix:** Extend \`processBarbarians\` with an optional \`playerCities\` param. Barbarians prefer player units (existing behaviour); when no unit is in chase range they target the nearest city. A new \`BarbarianCityAttackOrder\` reduces \`city.hp\` using the same model pirate siege already uses. Player receives a notification when their city is attacked.
+
+Fix in progress on \`worktree-feat+threat-pressure-system\`.
+EOF
+)"
+```
+
+- [ ] **Step 2: Post on #385 (Unit stacking bug)**
+
+```bash
+gh issue comment 385 --repo a1flecke/conquestoria --body "$(cat <<'EOF'
+**Root cause found.** \`validateUnitMove()\` blocks movement to any occupied hex, even a hex holding a same-owner unit. Meanwhile \`getMovementRange()\` correctly highlights friendly-unit tiles as reachable — so the hex is highlighted but the move always fails.
+
+**Fix:** Change the occupancy check to block only *different-owner* occupants. Same-owner units can share any tile.
+
+Fix in progress on \`worktree-feat+threat-pressure-system\`.
+EOF
+)"
+```
+
+- [ ] **Step 3: Post on #386 (Ships in non-coastal city)**
+
+```bash
+gh issue comment 386 --repo a1flecke/conquestoria --body "$(cat <<'EOF'
+**Root cause found — two issues:**
+
+1. \`isCityCoastal()\` checks \`city.ownedTiles\` (which can extend far from the city centre as territory expands). An inland city that expanded its territory to claim a distant coast tile is incorrectly treated as coastal, allowing ship production.
+2. Dock buildings and ship queue entries from old saves predate the \`coastalRequired\` flag and were not cleaned up on load.
+
+**Fix:** Change \`isCityCoastal\` to check only the six tiles adjacent to the city's own position. Add a save migration step that, on load, filters coastal-required items from the queue and buildings of non-coastal cities.
+
+Fix in progress on \`worktree-feat+threat-pressure-system\`.
+EOF
+)"
+```
+
+- [ ] **Step 4: Post on #374 (Rendering / color inconsistency)**
+
+```bash
+gh issue comment 374 --repo a1flecke/conquestoria --body "$(cat <<'EOF'
+**Root cause found.** There are two rendering paths for units:
+
+- **Idle at zoom ≥ 0.4** → DOM sprite overlay, which uses a baked-in faction accent color (e.g. Zulu → 'imperials' → #b53026 reddish-brown).
+- **Moving or low zoom** → Canvas path, which uses the game-assigned civ color (e.g. Zulu → green).
+
+When a unit starts or stops moving it switches between these paths and the color changes. The SVG fills are hardcoded at build time by \`scripts/serialize-sprites.mjs\`, so CSS custom properties cannot override them.
+
+**Fix:** At DOM sprite mount time, replace the faction accent color in the SVG string with the game-assigned civ color from \`colorLookup\`. Both paths then use the same color source.
+
+Fix in progress on \`worktree-feat+threat-pressure-system\`.
+EOF
+)"
+```
+
+---
+
+### Task 2: Unit Stacking (#385)
+
+**Files:**
+- Modify: `src/systems/unit-movement-system.ts` (~line 263)
+- Modify: `tests/systems/unit-movement-system.test.ts`
+- Modify: `tests/input/selected-unit-tap-intent.test.ts`
+
+- [ ] **Step 1: Write failing stacking tests in `tests/systems/unit-movement-system.test.ts`**
+
+Find the existing `movementState`, `mkC`, and `tile` helpers already defined in the file, then add a new `describe` block at the bottom of the file:
+
+```typescript
+describe('validateUnitMove — friendly stacking', () => {
+  function stackState(unitOwner: string, occupantOwner: string): GameState {
+    const counters = mkC();
+    const unit = createUnit('warrior', unitOwner, { q: 0, r: 0 }, counters);
+    const occupant = createUnit('warrior', occupantOwner, { q: 1, r: 0 }, counters);
+    const tiles = [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+      tile({ q: 2, r: 0 }),
+    ];
+    return movementState(unit, tiles, { extraUnits: [occupant] });
+  }
+
+  it('allows moving to a hex occupied by a same-owner unit', () => {
+    const state = stackState('civ-1', 'civ-1');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('blocks moving to a hex occupied by a different-owner unit', () => {
+    const state = stackState('civ-1', 'civ-2');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(false);
+    expect((result as any).reason).toBe('occupied');
+  });
+
+  it('blocks moving to a hex occupied by a barbarian unit', () => {
+    const state = stackState('civ-1', 'barbarian');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(false);
+    expect((result as any).reason).toBe('occupied');
+  });
+});
+```
+
+Note: The `movementState` helper must support `extraUnits` in its `options` param. Check whether it already does by searching for `extraUnits` in the file. If not, look at the helper definition and add support by spreading extra units into `state.units` in the helper.
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/unit-movement-system.test.ts 2>&1 | tail -20
+```
+
+Expected: the "allows moving to a hex occupied by a same-owner unit" test FAILs; the two blocking tests may already pass.
+
+- [ ] **Step 3: Fix `validateUnitMove` in `src/systems/unit-movement-system.ts`**
+
+Find the occupancy block (search for `'Another unit is already there'`). Replace:
+
+```typescript
+// BEFORE (~line 263):
+const occupants = getUnitIdsAtCoord(occupancy, target).filter(id => id !== unitId);
+if (occupants.length > 0) {
+  return movementFailure(from, target, [from, target], 'occupied', 'Another unit is already there.');
+}
+```
+
+With:
+
+```typescript
+// AFTER:
+const occupants = getUnitIdsAtCoord(occupancy, target).filter(id => id !== unitId);
+const hasHostileOccupant = occupants.some(id => occupancy.ownersByUnitId[id] !== unit.owner);
+if (hasHostileOccupant) {
+  return movementFailure(from, target, [from, target], 'occupied', 'An enemy unit is blocking the way.');
+}
+```
+
+- [ ] **Step 4: Run tests to confirm all three new tests pass**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/unit-movement-system.test.ts 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Add friendly-stack regression to `tests/input/selected-unit-tap-intent.test.ts`**
+
+Add a new `it` block inside the existing `describe('selected-unit-tap-intent', ...)` block at the bottom. The `createUnit` and `mkC` helpers may not be imported yet — add them if missing.
+
+```typescript
+it('returns move when tapping a friendly-occupied tile in range (stacking regression)', () => {
+  const state = createNewGame(undefined, 'stacking-regression', 'small');
+  state.currentPlayer = 'player';
+
+  const counters = mkC();
+  const movingUnit = createUnit('warrior', 'player', { q: 0, r: 0 }, counters);
+  state.units[movingUnit.id] = { ...movingUnit, movementPointsLeft: 2, hasMoved: false };
+
+  const occupant = createUnit('warrior', 'player', { q: 1, r: 0 }, counters);
+  state.units[occupant.id] = occupant;
+
+  // Pass explicit movementRange so the target is definitely "in range"
+  const intent = resolveSelectedUnitTapIntent(
+    state,
+    movingUnit.id,
+    { q: 1, r: 0 },
+    [{ q: 1, r: 0 }],
+  );
+  expect(intent).toEqual({ kind: 'move' });
+});
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/unit-movement-system.ts tests/systems/unit-movement-system.test.ts tests/input/selected-unit-tap-intent.test.ts
+git commit -m "$(cat <<'EOF'
+fix(movement): allow same-owner unit stacking on any tile (#385)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Fix `isCityCoastal` and Update All Callers (#386 part 1)
+
+**Files:**
+- Modify: `src/systems/city-system.ts`
+- Modify: `src/ui/city-panel.ts`
+- Modify: `src/ai/basic-ai.ts`
+- Modify: `src/systems/planning-system.ts`
+- Modify: `src/systems/quest-objective-system.ts`
+- Modify: `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Add `isCityCoastal` tests to `tests/systems/city-system.test.ts`**
+
+Add `isCityCoastal` to the imports at line 3 (alongside existing imports). Then add a new `describe` block after the existing `describe('getAvailableBuildings', ...)` block. The `tile` helper already exists in the file (search for `function tile(`) — use it. You need to know the `GameMap` type shape: `{ width, height, wrapsHorizontally, rivers, tiles }`.
+
+```typescript
+describe('isCityCoastal', () => {
+  function coastMap(centerTerrain: string, neighborTerrain: string): GameMap {
+    return {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        [hexKey({ q: 5, r: 5 })]: tile({ q: 5, r: 5 }, centerTerrain as any),
+        [hexKey({ q: 6, r: 5 })]: tile({ q: 6, r: 5 }, neighborTerrain as any),
+        [hexKey({ q: 4, r: 5 })]: tile({ q: 4, r: 5 }),
+        [hexKey({ q: 5, r: 4 })]: tile({ q: 5, r: 4 }),
+        [hexKey({ q: 6, r: 4 })]: tile({ q: 6, r: 4 }),
+        [hexKey({ q: 4, r: 6 })]: tile({ q: 4, r: 6 }),
+        [hexKey({ q: 5, r: 6 })]: tile({ q: 5, r: 6 }),
+        // distant tile for regression test
+        [hexKey({ q: 15, r: 15 })]: tile({ q: 15, r: 15 }, 'coast' as any),
+      },
+    } as GameMap;
+  }
+
+  function makeCity(ownedTiles?: HexCoord[]): City {
+    return {
+      id: 'c-coast',
+      name: 'Test',
+      owner: 'civ-1',
+      position: { q: 5, r: 5 },
+      population: 1,
+      food: 0,
+      foodNeeded: 15,
+      buildings: [],
+      productionQueue: [],
+      productionProgress: 0,
+      ownedTiles: ownedTiles ?? [{ q: 5, r: 5 }],
+      workedTiles: [],
+      focus: 'balanced',
+      grid: [],
+      gridSize: 1,
+      hp: 100,
+      maturity: 'core',
+    } as unknown as City;
+  }
+
+  it('returns true when an adjacent tile is coast', () => {
+    const city = makeCity();
+    const map = coastMap('plains', 'coast');
+    expect(isCityCoastal(city, map)).toBe(true);
+  });
+
+  it('returns true when the city centre tile itself is coast', () => {
+    const city = makeCity();
+    const map = coastMap('coast', 'plains');
+    expect(isCityCoastal(city, map)).toBe(true);
+  });
+
+  it('returns false for a landlocked city', () => {
+    const city = makeCity();
+    const map = coastMap('plains', 'plains');
+    expect(isCityCoastal(city, map)).toBe(false);
+  });
+
+  it('regression: returns false when a distant ownedTile is coast but no adjacent tile is (old bug)', () => {
+    // The city owns tile (15,15) which is coast, but none of the 6 adjacent tiles are.
+    const city = makeCity([{ q: 5, r: 5 }, { q: 15, r: 15 }]);
+    const map = coastMap('plains', 'plains'); // (15,15) is coast in this map
+    expect(isCityCoastal(city, map)).toBe(false);
+  });
+
+  it('returns true for a city at q=0 on a wrapping map when the wrapped neighbour is coast', () => {
+    const city = makeCity([{ q: 0, r: 5 }]);
+    city.position = { q: 0, r: 5 };
+    // On a width-20 wrapping map, q=-1 wraps to q=19
+    const wrappingMap: GameMap = {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: true,
+      rivers: [],
+      tiles: {
+        [hexKey({ q: 0, r: 5 })]: tile({ q: 0, r: 5 }),
+        [hexKey({ q: 19, r: 5 })]: tile({ q: 19, r: 5 }, 'coast' as any),
+      },
+    } as GameMap;
+    expect(isCityCoastal(city, wrappingMap)).toBe(true);
+  });
+});
+```
+
+Check the imports at the top of `tests/systems/city-system.test.ts` — you'll need `GameMap`, `HexCoord`, `City` from `@/core/types` and `hexKey` from `@/systems/hex-utils` if not already imported.
+
+- [ ] **Step 2: Run tests to confirm new tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts 2>&1 | tail -20
+```
+
+Expected: all new `isCityCoastal` tests fail (the function isn't exported yet, or has the wrong signature).
+
+- [ ] **Step 3: Update `isCityCoastal` in `src/systems/city-system.ts`**
+
+Add `hexNeighbors` to the hex-utils import at the top of `city-system.ts` (search for the existing import of `hexKey, hexesInRange, wrapHexCoord`):
+
+```typescript
+// BEFORE (line ~3):
+import { hexKey, hexesInRange, wrapHexCoord } from './hex-utils';
+
+// AFTER:
+import { hexKey, hexesInRange, hexNeighbors, wrapHexCoord } from './hex-utils';
+```
+
+Replace the `isCityCoastal` implementation (search for `export function isCityCoastal`):
+
+```typescript
+// BEFORE:
+export function isCityCoastal(city: City, mapTiles: GameMap['tiles']): boolean {
+  return (city.ownedTiles ?? []).some(coord => {
+    const tile = mapTiles[hexKey(coord)];
+    return tile?.terrain === 'ocean' || tile?.terrain === 'coast';
+  });
+}
+
+// AFTER:
+export function isCityCoastal(city: City, map: GameMap): boolean {
+  const coordsToCheck = [city.position, ...hexNeighbors(city.position)];
+  return coordsToCheck.some(coord => {
+    const wrapped = map.wrapsHorizontally ? wrapHexCoord(coord, map.width) : coord;
+    const t = map.tiles[hexKey(wrapped)];
+    return t?.terrain === 'ocean' || t?.terrain === 'coast';
+  });
+}
+```
+
+- [ ] **Step 4: Update `getTrainableUnitsForCity` signature in `src/systems/city-system.ts`**
+
+Find `export function getTrainableUnitsForCity` (around line 455). Change the parameter `mapTiles: GameMap['tiles']` to `map: GameMap`. Change the internal call from `isCityCoastal(city, mapTiles)` to `isCityCoastal(city, map)`.
+
+```typescript
+// BEFORE:
+export function getTrainableUnitsForCity(
+  city: City,
+  completedTechs: string[],
+  mapTiles: GameMap['tiles'],
+  civType?: string,
+  availableResources?: Set<ResourceType>,
+): TrainableUnit[] {
+  const coastal = isCityCoastal(city, mapTiles);
+
+// AFTER:
+export function getTrainableUnitsForCity(
+  city: City,
+  completedTechs: string[],
+  map: GameMap,
+  civType?: string,
+  availableResources?: Set<ResourceType>,
+): TrainableUnit[] {
+  const coastal = isCityCoastal(city, map);
+```
+
+- [ ] **Step 5: Update `getAvailableBuildings` signature in `src/systems/city-system.ts`**
+
+Find `export function getAvailableBuildings` (around line 531). Change `mapTiles: GameMap['tiles']` to `map: GameMap`. Change `isCityCoastal(city, mapTiles)` to `isCityCoastal(city, map)`.
+
+```typescript
+// BEFORE:
+export function getAvailableBuildings(
+  city: City,
+  completedTechs: string[],
+  mapTiles: GameMap['tiles'],
+  availableResources?: Set<ResourceType>,
+): Building[] {
+  const coastal = isCityCoastal(city, mapTiles);
+
+// AFTER:
+export function getAvailableBuildings(
+  city: City,
+  completedTechs: string[],
+  map: GameMap,
+  availableResources?: Set<ResourceType>,
+): Building[] {
+  const coastal = isCityCoastal(city, map);
+```
+
+- [ ] **Step 6: Update `processCity` internal calls in `src/systems/city-system.ts`**
+
+Search for `isCityCoastal(city, map.tiles)` — it appears at lines 722 and 728 inside `processCity`. Replace both occurrences:
+
+```typescript
+// BEFORE (both lines):
+isCityCoastal(city, map.tiles)
+
+// AFTER:
+isCityCoastal(city, map)
+```
+
+(`processCity` already receives `map: GameMap`, so no signature change needed.)
+
+- [ ] **Step 7: Update 14 test calls in `tests/systems/city-system.test.ts`**
+
+All occurrences of `map.tiles` as the third argument to `getAvailableBuildings` or `getTrainableUnitsForCity` need to become `map`. The `map` variable in the test file is already a full `GameMap`, so dropping `.tiles` is the only change.
+
+Run a search-and-replace within the test file for `getAvailableBuildings(city, ` — each call that passes `map.tiles` as third arg should become `map`. Same for `getTrainableUnitsForCity`. Lines to update: 107, 116, 131, 148, 165, 180, 197, 225, 226, 556, 763, 772, 780, 788.
+
+After the edit, double-check with:
+```bash
+grep -n "map\.tiles" tests/systems/city-system.test.ts
+```
+Expected: no output (all replaced).
+
+- [ ] **Step 8: Update callers in production source files**
+
+Update all remaining production callers. Make each change, then search to confirm none are left.
+
+**`src/ui/city-panel.ts`** — 4 occurrences at lines 178, 234, 237, 240:
+
+```typescript
+// Lines 178 and 240 — getAvailableBuildings:
+// BEFORE: getAvailableBuildings(city, ..., state.map.tiles, ...)
+// AFTER:  getAvailableBuildings(city, ..., state.map, ...)
+
+// Lines 234 and 237 — getTrainableUnitsForCity:
+// BEFORE: getTrainableUnitsForCity(city, completedTechs, state.map.tiles, currentCiv.civType, ...)
+// AFTER:  getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, ...)
+```
+
+**`src/ai/basic-ai.ts`** — 2 occurrences at lines 233 and ~712:
+
+```typescript
+// BEFORE: getAvailableBuildings(city, ..., state.map.tiles, ...)
+// AFTER:  getAvailableBuildings(city, ..., state.map, ...)
+
+// BEFORE: getAvailableBuildings(city, ..., newState.map.tiles, ...)
+// AFTER:  getAvailableBuildings(city, ..., newState.map, ...)
+```
+
+**`src/systems/planning-system.ts`** — 2 occurrences at lines 102 and 135:
+
+```typescript
+// BEFORE: getAvailableBuildings(city, completedTechs, state.map?.tiles ?? {})
+// AFTER:  getAvailableBuildings(city, completedTechs, state.map)
+```
+
+(Drop the optional chaining — `GameState.map` is required, not optional.)
+
+**`src/systems/quest-objective-system.ts`** — 1 occurrence at line ~102:
+
+```typescript
+// BEFORE: getTrainableUnitsForCity(city, civ.techState.completed, state.map.tiles, ...)
+// AFTER:  getTrainableUnitsForCity(city, civ.techState.completed, state.map, ...)
+```
+
+Verify all callers are updated:
+```bash
+grep -rn "\.map\.tiles\|\.map?\?\.tiles" src/ --include="*.ts" | grep -v "//\|isCityCoastal\|processCity\|mapTiles:"
+```
+Expected: no output.
+
+- [ ] **Step 9: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all tests pass including the new `isCityCoastal` tests.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/systems/city-system.ts src/ui/city-panel.ts src/ai/basic-ai.ts \
+        src/systems/planning-system.ts src/systems/quest-objective-system.ts \
+        tests/systems/city-system.test.ts
+git commit -m "$(cat <<'EOF'
+fix(city): isCityCoastal checks adjacent tiles not owned territory (#386 part 1)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Save Migration for Coastal Data (#386 part 2)
+
+**Files:**
+- Modify: `src/storage/save-manager.ts`
+- Create or modify: `tests/storage/save-manager.test.ts`
+
+- [ ] **Step 1: Check if `tests/storage/save-manager.test.ts` exists**
+
+```bash
+ls tests/storage/ 2>/dev/null || echo "no storage test dir"
+```
+
+If the file does not exist, create `tests/storage/save-manager.test.ts`.
+
+- [ ] **Step 2: Write failing migration tests**
+
+Add to `tests/storage/save-manager.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { migrateLegacyCoastalData } from '@/storage/save-manager';
+import type { City, GameMap, GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+
+function makeTile(q: number, r: number, terrain = 'plains') {
+  return {
+    coord: { q, r },
+    terrain: terrain as any,
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function makeCity(id: string, overrides: Partial<City> = {}): City {
+  return {
+    id,
+    name: id,
+    owner: 'civ-1',
+    position: { q: 5, r: 5 },
+    population: 1,
+    food: 0,
+    foodNeeded: 15,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [{ q: 5, r: 5 }],
+    workedTiles: [],
+    focus: 'balanced',
+    grid: [],
+    gridSize: 1,
+    hp: 100,
+    maturity: 'core',
+    ...overrides,
+  } as unknown as City;
+}
+
+function makeState(cities: City[], extraTiles: ReturnType<typeof makeTile>[] = []): GameState {
+  const baseTiles = [
+    makeTile(5, 5),   // city centre
+    makeTile(6, 5),   // neighbour (plains by default)
+    makeTile(4, 5),
+    makeTile(5, 4),
+    makeTile(6, 4),
+    makeTile(4, 6),
+    makeTile(5, 6),
+  ];
+  const allTiles = [...baseTiles, ...extraTiles];
+  return {
+    turn: 1,
+    era: 1,
+    gameId: 'migration-test',
+    currentPlayer: 'civ-1',
+    gameOver: false,
+    winner: null,
+    map: {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: Object.fromEntries(allTiles.map(t => [hexKey(t.coord), t])),
+    } as GameMap,
+    units: {},
+    cities: Object.fromEntries(cities.map(c => [c.id, c])),
+    civilizations: {},
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'welcome', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: true } as any,
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+  } as unknown as GameState;
+}
+
+describe('migrateLegacyCoastalData', () => {
+  it('removes coastal-required ship from productionQueue of a non-coastal city', () => {
+    const city = makeCity('c1', { productionQueue: ['galley', 'warrior'] });
+    const state = makeState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].productionQueue).toEqual(['warrior']);
+  });
+
+  it('removes coastal-required dock from city.buildings of a non-coastal city', () => {
+    const city = makeCity('c1', { buildings: ['dock', 'barracks'] });
+    const state = makeState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].buildings).toEqual(['barracks']);
+  });
+
+  it('does not modify a genuinely coastal city', () => {
+    const city = makeCity('c1', { buildings: ['dock'], productionQueue: ['galley'] });
+    // Make tile (6,5) a coast tile so city is coastal
+    const coastTile = makeTile(6, 5, 'coast');
+    const state = makeState([city], [coastTile]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].buildings).toEqual(['dock']);
+    expect(result.cities['c1'].productionQueue).toEqual(['galley']);
+  });
+
+  it('is idempotent — running twice produces the same result', () => {
+    const city = makeCity('c1', { productionQueue: ['galley', 'warrior'] });
+    const state = makeState([city]);
+    const once = migrateLegacyCoastalData(state);
+    const twice = migrateLegacyCoastalData(once);
+    expect(twice.cities['c1'].productionQueue).toEqual(once.cities['c1'].productionQueue);
+  });
+
+  it('returns state unchanged when no cities need migration', () => {
+    const city = makeCity('c1', { buildings: ['barracks'], productionQueue: ['warrior'] });
+    const state = makeState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result).toBe(state); // same reference if nothing changed
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/storage/save-manager.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `migrateLegacyCoastalData` is not exported.
+
+- [ ] **Step 4: Add `migrateLegacyCoastalData` to `src/storage/save-manager.ts`**
+
+First, check whether `isCityCoastal`, `BUILDINGS`, and `TRAINABLE_UNITS` are already imported at the top of `save-manager.ts`:
+
+```bash
+grep -n "isCityCoastal\|BUILDINGS\|TRAINABLE_UNITS" src/storage/save-manager.ts | head -5
+```
+
+Add to the imports if missing:
+
+```typescript
+import { isCityCoastal, BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+```
+
+Add the migration function before the main `normalizeGameState` export (search for the migration chain at line ~257):
+
+```typescript
+export function migrateLegacyCoastalData(state: GameState): GameState {
+  const cities = { ...state.cities };
+  let changed = false;
+  for (const [id, city] of Object.entries(cities)) {
+    if (isCityCoastal(city, state.map)) continue;
+
+    const cleanQueue = city.productionQueue.filter(item => {
+      if (BUILDINGS[item]?.coastalRequired) return false;
+      const unit = TRAINABLE_UNITS.find(u => u.type === item);
+      return !unit?.coastalRequired;
+    });
+    const cleanBuildings = city.buildings.filter(bId => !BUILDINGS[bId]?.coastalRequired);
+
+    if (
+      cleanQueue.length !== city.productionQueue.length ||
+      cleanBuildings.length !== city.buildings.length
+    ) {
+      cities[id] = { ...city, productionQueue: cleanQueue, buildings: cleanBuildings };
+      changed = true;
+    }
+  }
+  return changed ? { ...state, cities } : state;
+}
+```
+
+- [ ] **Step 5: Add to the migration chain**
+
+Find the migration chain line (around line 257 — search for `normalizeThreatPressureDefaults`). Wrap the outermost call with `migrateLegacyCoastalData(...)`:
+
+```typescript
+// BEFORE (find the exact line and wrap it):
+normalizeThreatPressureDefaults(
+  normalizeLandmassKeys(
+    normalizeLegacyCitySimState(
+      migrateLegacyPlanningState(
+        migrateLegacyNamingState(
+          ensureGameIdentity(state)
+        )
+      )
+    )
+  )
+)
+
+// AFTER:
+migrateLegacyCoastalData(
+  normalizeThreatPressureDefaults(
+    normalizeLandmassKeys(
+      normalizeLegacyCitySimState(
+        migrateLegacyPlanningState(
+          migrateLegacyNamingState(
+            ensureGameIdentity(state)
+          )
+        )
+      )
+    )
+  )
+)
+```
+
+- [ ] **Step 6: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/storage/save-manager.ts tests/storage/save-manager.test.ts
+git commit -m "$(cat <<'EOF'
+fix(saves): migrate non-coastal cities — remove stale coastal buildings/queue (#386 part 2)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Barbarian City Targeting — Types + `processBarbarians` (#387 part 1)
+
+**Files:**
+- Modify: `src/systems/barbarian-system.ts`
+- Modify: `tests/systems/barbarian-system.test.ts`
+
+- [ ] **Step 1: Write failing tests in `tests/systems/barbarian-system.test.ts`**
+
+The file already has imports for `createUnit`, `processBarbarians`, and a `mkC()` helper. Add a new `describe` block at the bottom:
+
+```typescript
+describe('processBarbarians — city targeting', () => {
+  const seed = 99999;
+
+  function flatMap(size = 16): GameMap {
+    const tiles: Record<string, any> = {};
+    for (let q = 0; q < size; q++) {
+      for (let r = 0; r < size; r++) {
+        tiles[`${q},${r}`] = {
+          coord: { q, r },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          owner: null,
+          improvementTurnsLeft: 0,
+          hasRiver: false,
+          wonder: null,
+        };
+      }
+    }
+    return { width: size, height: size, wrapsHorizontally: false, rivers: [], tiles };
+  }
+
+  it('produces a cityAttackOrders field even when no cities are provided', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const result = processBarbarians([], map, [], seed, [barb]);
+    expect(result.cityAttackOrders).toBeDefined();
+    expect(result.cityAttackOrders).toHaveLength(0);
+  });
+
+  it('issues a city attack order when a barbarian is adjacent to an empty city', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const city = { id: 'city-1', position: { q: 6, r: 5 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(1);
+    expect(result.cityAttackOrders[0].attackerUnitId).toBe(barb.id);
+    expect(result.cityAttackOrders[0].cityId).toBe('city-1');
+    expect(result.cityAttackOrders[0].damage).toBeGreaterThan(0);
+  });
+
+  it('prefers a player unit over an empty city when the unit is in chase range', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const playerUnit = createUnit('warrior', 'civ-1', { q: 6, r: 5 }, mkC());
+    const city = { id: 'city-1', position: { q: 6, r: 5 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [playerUnit], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(0);
+    expect(result.attackOrders).toHaveLength(1);
+    expect(result.attackOrders[0].attackerUnitId).toBe(barb.id);
+  });
+
+  it('moves toward an empty city when not yet adjacent', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    const city = { id: 'city-1', position: { q: 4, r: 0 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(0);
+    expect(result.moveOrders.some(o => o.unitId === barb.id)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/barbarian-system.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `cityAttackOrders` does not exist on the result.
+
+- [ ] **Step 3: Add `BarbarianCityAttackOrder` type to `src/systems/barbarian-system.ts`**
+
+Find `BarbarianAttackOrder` export. Add a new type immediately after it:
+
+```typescript
+export interface BarbarianCityAttackOrder {
+  attackerUnitId: string;
+  cityId: string;
+  damage: number;
+}
+```
+
+- [ ] **Step 4: Add `cityAttackOrders` to `BarbarianProcessResult`**
+
+Find the `export interface BarbarianProcessResult` and add the new field:
+
+```typescript
+export interface BarbarianProcessResult {
+  updatedCamps: BarbarianCamp[];
+  spawnedUnits: Array<{ campId: string; position: HexCoord }>;
+  moveOrders: BarbarianMoveOrder[];
+  attackOrders: BarbarianAttackOrder[];
+  cityAttackOrders: BarbarianCityAttackOrder[];  // ← add this
+}
+```
+
+- [ ] **Step 5: Add `playerCities` param and city logic to `processBarbarians`**
+
+The full function signature is around line 140 in `src/systems/barbarian-system.ts`. `hexNeighbors`, `hexDistance`, and `wrappedHexDistance` are already imported (line 3). `occupiedByUnit` is declared at line 173 and is `Map<string, string>` (hexKey → unitId). `BARBARIAN_CHASE_RANGE = 5` is at line 129.
+
+**a) Add `playerCities` to the function signature:**
+
+```typescript
+// BEFORE:
+export function processBarbarians(
+  camps: BarbarianCamp[],
+  map: GameMap,
+  playerUnits: Unit[],
+  seed: number,
+  barbarianUnits?: Unit[],
+): BarbarianProcessResult {
+
+// AFTER:
+export function processBarbarians(
+  camps: BarbarianCamp[],
+  map: GameMap,
+  playerUnits: Unit[],
+  seed: number,
+  barbarianUnits?: Unit[],
+  playerCities?: Array<{ id: string; position: HexCoord; owner: string }>,
+): BarbarianProcessResult {
+```
+
+**b) Initialize `cityAttackOrders` near the top of the function body, alongside `moveOrders` and `attackOrders`:**
+
+```typescript
+  const cityAttackOrders: BarbarianCityAttackOrder[] = [];
+```
+
+**c) Update the early return at line ~168 (no barbarian units):**
+
+```typescript
+// BEFORE (line ~169):
+    return { updatedCamps, spawnedUnits, moveOrders, attackOrders };
+
+// AFTER:
+    return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
+```
+
+**d) Replace `if (!nearestTarget) continue;` at line 197 with the city-fallback block:**
+
+```typescript
+// BEFORE (line 197):
+    if (!nearestTarget) continue;
+
+// AFTER:
+    if (!nearestTarget) {
+      if (playerCities && playerCities.length > 0) {
+        let nearestCity: (typeof playerCities)[0] | null = null;
+        let nearestCityDist = BARBARIAN_CHASE_RANGE + 1;
+        for (const city of playerCities) {
+          const dist = map.wrapsHorizontally
+            ? wrappedHexDistance(barbUnit.position, city.position, map.width)
+            : hexDistance(barbUnit.position, city.position);
+          if (dist < nearestCityDist) {
+            nearestCityDist = dist;
+            nearestCity = city;
+          }
+        }
+        if (nearestCity) {
+          if (nearestCityDist <= 1) {
+            cityAttackOrders.push({
+              attackerUnitId: barbUnit.id,
+              cityId: nearestCity.id,
+              damage: 10,
+            });
+          } else {
+            const neighbors = hexNeighbors(barbUnit.position);
+            const passable = neighbors.filter(coord => {
+              const t = map.tiles[hexKey(coord)];
+              if (!t) return false;
+              if (t.terrain === 'ocean' || t.terrain === 'coast' || t.terrain === 'mountain') return false;
+              return !occupiedByUnit.get(hexKey(coord));
+            });
+            if (passable.length > 0) {
+              let best = passable[0];
+              let bestD = hexDistance(passable[0], nearestCity.position);
+              for (const coord of passable) {
+                const d = hexDistance(coord, nearestCity.position);
+                if (d < bestD) { bestD = d; best = coord; }
+              }
+              moveOrders.push({ unitId: barbUnit.id, toCoord: best });
+              occupiedByUnit.delete(hexKey(barbUnit.position));
+              occupiedByUnit.set(hexKey(best), barbUnit.id);
+            }
+          }
+        }
+      }
+      continue;
+    }
+```
+
+**e) Update the final return at line 246:**
+
+```typescript
+// BEFORE:
+  return { updatedCamps, spawnedUnits, moveOrders, attackOrders };
+
+// AFTER:
+  return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/systems/barbarian-system.test.ts 2>&1 | tail -30
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/barbarian-system.ts tests/systems/barbarian-system.test.ts
+git commit -m "$(cat <<'EOF'
+feat(barbarian): city attack targeting — types and processBarbarians (#387 part 1)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Wire Barbarian City Attacks in Turn Manager (#387 part 2)
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/core/turn-manager.ts`
+
+- [ ] **Step 1: Add event types to `src/core/types.ts`**
+
+Search for `'threat:pirate-siege'` in `types.ts` (~line 1298). Add two new events adjacent to it:
+
+```typescript
+  'barbarian:city-attacked': { attackerUnitId: string; cityId: string; hpLost: number };
+  'barbarian:city-destroyed': { attackerUnitId: string; cityId: string; ownerId: string };
+```
+
+- [ ] **Step 2: Build city targets and update `processBarbarians` call in `src/core/turn-manager.ts`**
+
+Find the `processBarbarians(` call (around line 507). Before it, build `cityTargets`:
+
+```typescript
+  const cityTargets = Object.values(newState.cities)
+    .filter(city =>
+      city.owner !== 'barbarian' &&
+      !city.owner.startsWith('mc-') &&
+      city.owner !== 'beasts',
+    )
+    .map(city => ({ id: city.id, position: city.position, owner: city.owner }));
+```
+
+Add `cityTargets` as the sixth argument to `processBarbarians`:
+
+```typescript
+  const barbResult = processBarbarians(
+    Object.values(newState.barbarianCamps),
+    newState.map,
+    playerUnits,
+    barbSeed,
+    barbarianUnits,
+    cityTargets,   // ← add
+  );
+```
+
+- [ ] **Step 3: Process `cityAttackOrders` after the existing attack-orders loop**
+
+Find the existing `barbResult.attackOrders` processing loop (around line 520). After the loop ends, add:
+
+```typescript
+  // Barbarian city attacks
+  for (const order of barbResult.cityAttackOrders) {
+    const city = newState.cities[order.cityId];
+    if (!city) continue;
+    const currentHp = city.hp ?? 100;
+    const newHp = Math.max(0, currentHp - order.damage);
+    newState = {
+      ...newState,
+      cities: {
+        ...newState.cities,
+        [order.cityId]: { ...city, hp: newHp },
+      },
+    };
+    bus.emit('barbarian:city-attacked', {
+      attackerUnitId: order.attackerUnitId,
+      cityId: order.cityId,
+      hpLost: currentHp - newHp,
+    });
+
+    if (newHp === 0) {
+      const ownerId = city.owner;
+      // Remove city from state — follow the same pattern as pirate city destruction
+      const { [order.cityId]: _removed, ...remainingCities } = newState.cities;
+      newState = { ...newState, cities: remainingCities };
+      const ownerCiv = newState.civilizations[ownerId];
+      if (ownerCiv) {
+        newState = {
+          ...newState,
+          civilizations: {
+            ...newState.civilizations,
+            [ownerId]: {
+              ...ownerCiv,
+              cities: ownerCiv.cities.filter((cId: string) => cId !== order.cityId),
+            },
+          },
+        };
+      }
+      bus.emit('barbarian:city-destroyed', {
+        attackerUnitId: order.attackerUnitId,
+        cityId: order.cityId,
+        ownerId,
+      });
+    }
+  }
+```
+
+Check whether the existing barbarian-processing code uses `let newState =` (mutable reassignment) or a different pattern. If it uses `state = ` or another approach, match that pattern exactly.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/types.ts src/core/turn-manager.ts
+git commit -m "$(cat <<'EOF'
+feat(barbarian): wire city attack orders in turn manager with HP and events (#387 part 2)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Player Notification for Barbarian City Attacks (#387 part 3)
+
+**Files:**
+- Modify: `src/main.ts`
+
+- [ ] **Step 1: Wire notifications in `src/main.ts`**
+
+Find where `'threat:pirate-siege'` is handled (search for `bus.on('threat:pirate-siege'`). Add the two new handlers immediately after it:
+
+```typescript
+bus.on('barbarian:city-attacked', ({ cityId, hpLost }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (!gameState.civilizations[city.owner]?.isHuman) return;
+  appendToCivLog(city.owner, `Barbarians attack ${city.name}! (−${hpLost} HP)`, 'warning');
+});
+
+bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
+  if (!gameState.civilizations[ownerId]?.isHuman) return;
+  appendToCivLog(ownerId, `A city was destroyed by barbarian raiders!`, 'danger');
+});
+```
+
+Note: For `'barbarian:city-destroyed'`, the city has already been removed from `gameState.cities` by the time the handler fires (turn manager removes it before emitting). Use `ownerId` from the event payload, not `gameState.cities[cityId]`.
+
+Also note: `appendToCivLog` is already defined in `main.ts` — it is NOT an import. Verify this:
+
+```bash
+grep -n "const appendToCivLog\|function appendToCivLog\|appendToCivLog =" src/main.ts | head -3
+```
+
+- [ ] **Step 2: Run full test suite and production build**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -10
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "$(cat <<'EOF'
+feat(barbarian): notify player when city is attacked or destroyed by barbarians (#387 part 3)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: DOM Sprite Color Injection (#374 part 1)
+
+**Files:**
+- Modify: `src/renderer/sprite-overlay.ts`
+- Modify: `tests/renderer/sprite-overlay.test.ts`
+
+- [ ] **Step 1: Write failing tests in `tests/renderer/sprite-overlay.test.ts`**
+
+`LOD_SPRITE_ZOOM_THRESHOLD` is 0.4 — the existing `cam()` helper already returns `zoom: 1`, which is above the threshold (sprites DO render). The function `applyFactionCivColor` needs to be exported from `sprite-overlay.ts`.
+
+Add `applyFactionCivColor` to the import line at the top of the test file. Then add at the bottom of the file:
+
+```typescript
+// ── applyFactionCivColor — pure function tests ────────────────────────────────
+
+import { applyFactionCivColor } from '@/renderer/sprite-overlay';
+
+describe('applyFactionCivColor', () => {
+  it('replaces all occurrences of the faction accent color with the civ game color', () => {
+    const svg = `<div><rect fill="#b53026"/><path stroke="#b53026"/></div>`;
+    const result = applyFactionCivColor(svg, 'imperials', '#2d6a4f');
+    expect(result).not.toContain('#b53026');
+    expect(result.match(/#2d6a4f/g)?.length).toBe(2);
+  });
+
+  it('returns the original string when faction has no entry in FACTION_SPRITE_ACCENT', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'unknown-faction', '#2d6a4f')).toBe(svg);
+  });
+
+  it('returns the original string when civColor is empty', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'imperials', '')).toBe(svg);
+  });
+
+  it('returns the original string when civColor equals faction accent (no-op)', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'imperials', '#b53026')).toBe(svg);
+  });
+});
+
+// ── sync() colorLookup param ─────────────────────────────────────────────────
+
+describe('SpriteOverlay.sync() — colorLookup param', () => {
+  it('does not crash when called with no colorLookup (default empty)', () => {
+    const { overlay } = mountOverlay();
+    expect(() =>
+      overlay.sync(cam(), [], MAP, OPTS)
+    ).not.toThrow();
+  });
+
+  it('accepts colorLookup as the fifth argument without error', () => {
+    const { overlay } = mountOverlay();
+    expect(() =>
+      overlay.sync(cam(), [], MAP, OPTS, { 'civ-1': '#2d6a4f' })
+    ).not.toThrow();
+  });
+});
+```
+
+Note: the `import` for `applyFactionCivColor` should be added to the existing import statement at line 1 of the test file (alongside `SpriteOverlay`), not as a second import statement.
+
+- [ ] **Step 2: Add pool-invalidation integration test using `vi.spyOn`**
+
+Also add to the bottom of the test file (after the `sync()` tests):
+
+```typescript
+// ── pool invalidation on civColor change ─────────────────────────────────────
+
+import * as SpriteIndex from '@/renderer/sprites/v2/index';
+import { vi } from 'vitest';
+
+describe('SpriteOverlay.sync() — pool invalidation on civColor change', () => {
+  it('re-creates the DOM element when civColor changes between syncs', () => {
+    const mockSvg = '<div class="unit-sprite"><rect fill="#b53026"/></div>';
+    const spy = vi.spyOn(SpriteIndex, 'getUnitSpriteV2').mockReturnValue(mockSvg);
+
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ faction: 'imperials', civId: 'civ-1' });
+
+    // First sync — imperials accent replaced with green
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+    const el1 = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el1).not.toBeNull();
+    expect(el1.innerHTML).toContain('#2d6a4f');
+    expect(el1.innerHTML).not.toContain('#b53026');
+
+    // Second sync — same entity, but new color
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#ff0000' });
+    const el2 = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el2.innerHTML).toContain('#ff0000');
+    expect(el2.innerHTML).not.toContain('#2d6a4f');
+
+    spy.mockRestore();
+  });
+});
+```
+
+Note: both `import * as SpriteIndex` and `import { vi }` should be at the top of the test file, not inside the describe block. Add them to the existing imports at the top.
+
+- [ ] **Step 3: Run to confirm tests fail**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `applyFactionCivColor` is not exported; `sync()` does not accept a fifth arg.
+
+- [ ] **Step 4: Add `FACTION_SPRITE_ACCENT` constant and `applyFactionCivColor` export to `src/renderer/sprite-overlay.ts`**
+
+Insert after line 12 (`import type { UnitRoleMarker } from './unit-visual-resolver';`), before the `/** Sprite wrappers live in world-space... */` JSDoc comment on line 14:
+
+```typescript
+// Faction accent colors baked into serialized sprite SVG fills by scripts/serialize-sprites.mjs.
+// Must match the palette.secondary value from the source sprite TSX files.
+const FACTION_SPRITE_ACCENT: Record<string, string> = {
+  imperials: '#b53026',
+  vikings:   '#1d4a8c',
+  pharaohs:  '#d4a13c',
+  hellenes:  '#2c8a5a',
+  khanate:   '#7a3a14',
+  shogunate: '#5b4a7a',
+};
+
+export function applyFactionCivColor(svgHtml: string, faction: string, civColor: string): string {
+  const accent = FACTION_SPRITE_ACCENT[faction];
+  if (!accent || !civColor || civColor === accent) return svgHtml;
+  return svgHtml.replaceAll(accent, civColor);
+}
+```
+
+- [ ] **Step 5: Add `civId` to `SpriteEntity` (after `anchorOffsetFactor?` field, line 40)**
+
+```typescript
+// BEFORE — end of SpriteEntity interface:
+  anchorOffsetFactor?: { x: number; y: number };
+}
+
+// AFTER:
+  anchorOffsetFactor?: { x: number; y: number };
+  /** Owner civ ID used to look up the game-assigned color for accent replacement. */
+  civId?: string;
+}
+```
+
+- [ ] **Step 6: Add `civColor` to `PoolEntry` (lines 43–51)**
+
+```typescript
+// BEFORE:
+interface PoolEntry {
+  el:           HTMLDivElement; // positional wrapper (world-space left/top)
+  spriteWrapEl: HTMLElement;    // .cq-sprite-wrap.cq-v2 — animation root
+  phase:        number;
+  faction:      string;
+  coord:        HexCoord;       // stored so we can detect position change after movement
+  memberIds:    string[];
+  anchorOffsetFactor: { x: number; y: number };
+}
+
+// AFTER:
+interface PoolEntry {
+  el:           HTMLDivElement; // positional wrapper (world-space left/top)
+  spriteWrapEl: HTMLElement;    // .cq-sprite-wrap.cq-v2 — animation root
+  phase:        number;
+  faction:      string;
+  civColor:     string;
+  coord:        HexCoord;       // stored so we can detect position change after movement
+  memberIds:    string[];
+  anchorOffsetFactor: { x: number; y: number };
+}
+```
+
+- [ ] **Step 7: Update `sync()` with `colorLookup` param, invalidation, and color replacement**
+
+**a) Change `sync()` signature** (line 90):
+
+```typescript
+// BEFORE:
+  sync(
+    camera: Camera,
+    entities: SpriteEntity[],
+    map: { width: number; wrapsHorizontally: boolean },
+    opts: { isPinching: boolean; reducedMotion: boolean },
+  ): void {
+
+// AFTER:
+  sync(
+    camera: Camera,
+    entities: SpriteEntity[],
+    map: { width: number; wrapsHorizontally: boolean },
+    opts: { isPinching: boolean; reducedMotion: boolean },
+    colorLookup: Record<string, string> = {},
+  ): void {
+```
+
+**b) In the entity loop, replace the `const existing = this.pool.get(key);` line (line 124) and the `if (existing) {` branch (line 126) with the invalidation-aware version:**
+
+```typescript
+// BEFORE (lines 124–148):
+        const existing = this.pool.get(key);
+        const anchorOffsetFactor = entity.anchorOffsetFactor ?? { x: 0, y: 0 };
+        if (existing) {
+          // Pool hit — update state via setAttribute (no node replacement!)
+          existing.spriteWrapEl.setAttribute('data-state', entity.state);
+          existing.spriteWrapEl.setAttribute('data-damage', String(entity.damage ?? 0));
+          existing.memberIds = entity.memberIds ?? [entity.id];
+          existing.el.dataset.entityId = entity.id;
+          existing.el.dataset.memberIds = existing.memberIds.join(',');
+          if (entity.kind === 'unit') updateUnitDecorations(existing.el, entity);
+          // Update world position if unit moved hex after movement animation completed
+          if (
+            existing.coord.q !== coord.q
+            || existing.coord.r !== coord.r
+            || existing.anchorOffsetFactor.x !== anchorOffsetFactor.x
+            || existing.anchorOffsetFactor.y !== anchorOffsetFactor.y
+          ) {
+            const rawPx = hexToPixel(coord, camera.hexSize);
+            const px = applyUnitAnchorOffset(rawPx, camera.hexSize, anchorOffsetFactor);
+            existing.el.style.left = `${px.x}px`;
+            existing.el.style.top = `${px.y}px`;
+            existing.coord = coord;
+            existing.anchorOffsetFactor = anchorOffsetFactor;
+          }
+        } else {
+          // Pool miss — create element
+
+// AFTER:
+        const anchorOffsetFactor = entity.anchorOffsetFactor ?? { x: 0, y: 0 };
+        const newCivColor = entity.civId ? (colorLookup[entity.civId] ?? '') : '';
+        const poolEntry = this.pool.get(key);
+        // Invalidate if faction or civ color changed (e.g. unit captured)
+        if (poolEntry && (poolEntry.faction !== entity.faction || poolEntry.civColor !== newCivColor)) {
+          poolEntry.el.remove();
+          this.pool.delete(key);
+        }
+        if (this.pool.has(key)) {
+          const existing = this.pool.get(key)!;
+          // Pool hit — update state via setAttribute (no node replacement!)
+          existing.spriteWrapEl.setAttribute('data-state', entity.state);
+          existing.spriteWrapEl.setAttribute('data-damage', String(entity.damage ?? 0));
+          existing.memberIds = entity.memberIds ?? [entity.id];
+          existing.el.dataset.entityId = entity.id;
+          existing.el.dataset.memberIds = existing.memberIds.join(',');
+          if (entity.kind === 'unit') updateUnitDecorations(existing.el, entity);
+          // Update world position if unit moved hex after movement animation completed
+          if (
+            existing.coord.q !== coord.q
+            || existing.coord.r !== coord.r
+            || existing.anchorOffsetFactor.x !== anchorOffsetFactor.x
+            || existing.anchorOffsetFactor.y !== anchorOffsetFactor.y
+          ) {
+            const rawPx = hexToPixel(coord, camera.hexSize);
+            const px = applyUnitAnchorOffset(rawPx, camera.hexSize, anchorOffsetFactor);
+            existing.el.style.left = `${px.x}px`;
+            existing.el.style.top = `${px.y}px`;
+            existing.coord = coord;
+            existing.anchorOffsetFactor = anchorOffsetFactor;
+          }
+        } else {
+          // Pool miss — create element
+```
+
+**c) In the pool-miss branch, rename the SVG variable and apply color** (line 150):
+
+```typescript
+// BEFORE:
+          // Pool miss — create element
+          const svgHtml = this.lookupSprite(entity);
+          if (!svgHtml) continue; // no v2 sprite — canvas handles it
+
+// AFTER:
+          // Pool miss — create element
+          const rawSvgHtml = this.lookupSprite(entity);
+          if (!rawSvgHtml) continue; // no v2 sprite — canvas handles it
+          const svgHtml = applyFactionCivColor(rawSvgHtml, entity.faction, newCivColor);
+```
+
+(The rest of the pool-miss code at lines 153–189 uses `svgHtml` which now carries the color-replaced version — no further changes needed until the pool entry.)
+
+**d) Add `civColor` to the pool entry** (line 181):
+
+```typescript
+// BEFORE:
+          this.pool.set(key, {
+            el: wrapper,
+            spriteWrapEl,
+            phase,
+            faction: entity.faction,
+            coord,
+            memberIds: entity.memberIds ?? [entity.id],
+            anchorOffsetFactor,
+          });
+
+// AFTER:
+          this.pool.set(key, {
+            el: wrapper,
+            spriteWrapEl,
+            phase,
+            faction: entity.faction,
+            civColor: newCivColor,
+            coord,
+            memberIds: entity.memberIds ?? [entity.id],
+            anchorOffsetFactor,
+          });
+```
+
+**Never hardcode pixel sizes:** The existing `wrapSizePx` calculation at line 160 (`getUnitLayoutMetrics(camera.hexSize).displaySize`) is already correct — leave it unchanged.
+
+- [ ] **Step 8: Run tests**
+
+```bash
+bash scripts/run-with-mise.sh yarn test tests/renderer/sprite-overlay.test.ts 2>&1 | tail -30
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Run full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -20
+```
+
+Expected: all pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/renderer/sprite-overlay.ts tests/renderer/sprite-overlay.test.ts
+git commit -m "$(cat <<'EOF'
+fix(renderer): inject civ color into DOM sprites at mount — replace faction accent (#374 part 1)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 9: Wire `civId` and `colorLookup` in Render Loop (#374 part 2)
+
+**Files:**
+- Modify: `src/renderer/render-loop.ts`
+
+- [ ] **Step 1: Add `civId` to unit entities in `render-loop.ts`**
+
+Find the `unitEntities` construction block at lines 380–395. The object already has `presentation.leadUnit.type` (line 384) and `presentation.leadUnit.health` (line 391). Add `civId` after `anchorOffsetFactor`:
+
+```typescript
+// BEFORE (lines 380–395):
+      const unitEntities = unitPresentations.map(presentation => ({
+        id: presentation.leadUnitId,
+        memberIds: presentation.memberIds,
+        kind: 'unit' as const,
+        subtype: presentation.leadUnit.type,
+        coord: presentation.coord,
+        state: 'idle' as const,
+        faction: presentation.faction,
+        damage: presentation.damage,
+        stackCount: presentation.stackCount,
+        selected: presentation.isSelected,
+        health: presentation.leadUnit.health,
+        fortified: presentation.leadUnit.isFortified,
+        roleMarker: presentation.roleMarker,
+        anchorOffsetFactor: presentation.anchorOffsetFactor,
+      }));
+
+// AFTER:
+      const unitEntities = unitPresentations.map(presentation => ({
+        id: presentation.leadUnitId,
+        memberIds: presentation.memberIds,
+        kind: 'unit' as const,
+        subtype: presentation.leadUnit.type,
+        coord: presentation.coord,
+        state: 'idle' as const,
+        faction: presentation.faction,
+        damage: presentation.damage,
+        stackCount: presentation.stackCount,
+        selected: presentation.isSelected,
+        health: presentation.leadUnit.health,
+        fortified: presentation.leadUnit.isFortified,
+        roleMarker: presentation.roleMarker,
+        anchorOffsetFactor: presentation.anchorOffsetFactor,
+        civId: presentation.leadUnit.owner,
+      }));
+```
+
+- [ ] **Step 2: Pass `colorLookup` to `spriteOverlay.sync()`**
+
+The `sync()` call is at lines 396–407. Add `colorLookup` as the fifth argument:
+
+```typescript
+// BEFORE (lines 396–407):
+      this.spriteOverlay?.sync(
+        this.camera,
+        unitEntities,
+        {
+          width: this.state.map.width,
+          wrapsHorizontally: this.state.map.wrapsHorizontally,
+        },
+        {
+          isPinching: this.touchHandlerRef?.isPinching ?? false,
+          reducedMotion: prefersReducedMotion(),
+        },
+      );
+
+// AFTER:
+      this.spriteOverlay?.sync(
+        this.camera,
+        unitEntities,
+        {
+          width: this.state.map.width,
+          wrapsHorizontally: this.state.map.wrapsHorizontally,
+        },
+        {
+          isPinching: this.touchHandlerRef?.isPinching ?? false,
+          reducedMotion: prefersReducedMotion(),
+        },
+        colorLookup,
+      );
+```
+
+There is a second `this.spriteOverlay?.sync(` call at line 418 (the else-branch that passes empty entities when there's no viewer visibility). Leave that call unchanged — it passes `[]` entities, so `colorLookup` has no effect regardless.
+
+Verify that `colorLookup` is already in scope at this point in `render-loop.ts` (it was built around line 371–379 per the session context). If not already in scope, trace where it is computed and ensure the `sync()` call is inside the same block.
+
+- [ ] **Step 3: Run full test suite and production build**
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -10
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -10
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/render-loop.ts
+git commit -m "$(cat <<'EOF'
+fix(renderer): wire civId and colorLookup into sprite overlay for color consistency (#374 part 2)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final Verification
+
+After all 9 tasks are complete:
+
+```bash
+bash scripts/run-with-mise.sh yarn test 2>&1 | tail -5
+bash scripts/run-with-mise.sh yarn build 2>&1 | tail -5
+```
+
+Both must exit 0 before opening a PR.

--- a/docs/superpowers/specs/2026-06-15-bug-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-15-bug-fixes-design.md
@@ -1,0 +1,388 @@
+# Bug Fixes Design — Issues #387, #385, #386, #374
+
+Date: 2026-06-15
+
+---
+
+## Bug #387 — Barbarians Not Attacking Cities
+
+### Root Cause
+
+`processBarbarians` (in `src/systems/barbarian-system.ts`) receives only `playerUnits: Unit[]` as potential targets. It has no concept of cities. When barbarian units surround an empty city — a city with no player units on its tile — they have no valid target and stand idle indefinitely.
+
+### Fix
+
+**Add city targets to `processBarbarians`.**
+
+Add a new optional param `playerCities?: Array<{ id: string; position: HexCoord; owner: string }>`. Barbarians **prefer player units** (current behaviour) and only fall back to targeting a city when no player unit is within `BARBARIAN_CHASE_RANGE`.
+
+Add a new order type alongside the existing ones:
+
+```ts
+export interface BarbarianCityAttackOrder {
+  attackerUnitId: string;
+  cityId: string;
+  damage: number;  // era-scaled, e.g. 10 base
+}
+```
+
+Return `cityAttackOrders: BarbarianCityAttackOrder[]` in `BarbarianProcessResult`.
+
+Movement logic: if the nearest city is not adjacent, move toward it (same step logic as unit targeting). If adjacent, issue a `BarbarianCityAttackOrder` instead of a move order.
+
+In `turn-manager.ts`, after processing `barbResult.attackOrders`, process `barbResult.cityAttackOrders`:
+
+```ts
+for (const order of barbResult.cityAttackOrders) {
+  const city = newState.cities[order.cityId];
+  if (!city) continue;
+  const newHp = Math.max(0, (city.hp ?? 100) - order.damage);
+  newState.cities = {
+    ...newState.cities,
+    [order.cityId]: { ...city, hp: newHp },
+  };
+  bus.emit('barbarian:city-attacked', {
+    cityId: order.cityId,
+    attackerUnitId: order.attackerUnitId,
+    hpLost: (city.hp ?? 100) - newHp,
+  });
+  if (newHp === 0) {
+    // Destroy the city — follow the same cleanup path used by pirate city destruction
+    // in threat-pressure-system.ts (search for 'threat:pirate-city-destroyed').
+    // Remove city from state.cities, remove cityId from owning civ's cities array,
+    // and emit 'barbarian:city-destroyed' for the UI to show a persistent danger notification.
+  }
+}
+```
+
+`city.hp` already exists in the `City` type (`hp?: number`; default 100) and the pirate siege system already uses the same pattern.
+
+### UX
+
+- `main.ts` listens on `'barbarian:city-attacked'`: appends to the owning civ's notification log: `"Barbarians attack [City Name]! (−X HP)"`.
+- City panel: already renders HP via the threat-pressure HP bar (used by pirate siege); no new UI needed.
+- If the city owner is human and the city is destroyed, fire a persistent notification with type `'danger'`.
+
+### Data / Logic Constraints
+
+- Barbarians only target cities owned by non-barbarian, non-beast, non-pirate civs (same filter as `playerUnits`).
+- Barbarians must not target a city if a player unit is within `BARBARIAN_CHASE_RANGE` (unit takes priority).
+- A barbarian unit can only issue one order per turn (move OR attack unit OR attack city).
+- Damage is era-scaled: 10 HP per turn (consistent with pirate siege era-1 value). Can be tuned in a follow-up.
+
+### Tests
+
+- Barbarian unit adjacent to empty city issues a city attack order.
+- Barbarian unit that has a player unit within range ignores the city and targets the unit.
+- `applyBarbarianCityDamage` reduces `city.hp` correctly; HP cannot go below 0.
+- Barbarian city attack at `hp === 0` triggers city destruction.
+- `'barbarian:city-attacked'` event fires with correct `hpLost`.
+- No city attack order is issued when the city already has a unit on it (unit attack takes priority).
+
+---
+
+## Bug #385 — Unit Stacking
+
+### Root Cause
+
+`validateUnitMove` (in `src/systems/unit-movement-system.ts`) blocks movement to **any** occupied hex:
+
+```ts
+const occupants = getUnitIdsAtCoord(occupancy, target).filter(id => id !== unitId);
+if (occupants.length > 0) {
+  return movementFailure(from, target, [from, target], 'occupied', 'Another unit is already there.');
+}
+```
+
+Meanwhile `getMovementRange` already treats friendly tiles as valid destinations (falling through the occupancy check without a `continue`), so the hex is highlighted reachable but the move always fails.
+
+### Fix
+
+**Allow same-owner units to share any tile; block different-owner units.**
+
+Single change in `validateUnitMove`:
+
+```ts
+// Before:
+if (occupants.length > 0) {
+  return movementFailure(..., 'occupied', 'Another unit is already there.');
+}
+
+// After:
+const hasHostileOccupant = occupants.some(id => occupancy.ownersByUnitId[id] !== unit.owner);
+if (hasHostileOccupant) {
+  return movementFailure(..., 'occupied', 'An enemy unit is blocking the way.');
+}
+```
+
+No changes needed to `getMovementRange` — it already allows movement through and onto friendly tiles.
+
+### Data / Logic Constraints
+
+- `occupancy.ownersByUnitId` is populated by `buildUnitOccupancy`; it already tracks per-unit owners.
+- Barbarian AI movement goes through `moveUnit` directly (not `validateUnitMove`), so the barbarian collision-avoidance logic in `processBarbarians` is unaffected.
+- Pirate and beast units are separate owners; a player unit moving to a pirate/beast tile is still blocked (different owner = hostile).
+- The stack picker (`unit-stack-panel.ts`) already handles multi-unit stacks; no change needed there.
+- The sprite overlay `buildUnitMapPresentations` already groups co-located same-owner units into a single stack presentation; no change needed there either.
+
+### Tests
+
+- Moving a unit to a hex occupied by a same-owner unit succeeds.
+- Moving a unit to a hex occupied by a different-owner unit fails with `'occupied'`.
+- Moving a unit to a hex occupied by a barbarian unit fails with `'occupied'`.
+- Stack of 3 same-owner units on one hex renders correctly (stack count badge shows 3).
+- `resolveSelectedUnitTapIntent` resolves `{kind: 'move'}` when tapping a friendly-occupied tile in range (existing pass-through is already correct; add regression to lock it).
+
+---
+
+## Bug #386 — Ships in Non-Coastal City
+
+### Root Cause — Two Issues
+
+**Issue 1 — `isCityCoastal` uses `ownedTiles`:**
+
+```ts
+// Current (wrong):
+export function isCityCoastal(city: City, mapTiles: GameMap['tiles']): boolean {
+  return (city.ownedTiles ?? []).some(coord => {
+    const tile = mapTiles[hexKey(coord)];
+    return tile?.terrain === 'ocean' || tile?.terrain === 'coast';
+  });
+}
+```
+
+As a city grows, it claims tiles beyond the original radius-1. A landlocked city that expanded its territory to include a distant coast tile incorrectly returns `true`, making ships available for production.
+
+**Issue 2 — Stale coastal buildings/units from old saves:**
+
+Ships and docks queued or built before `coastalRequired` was added to their definitions persist in `city.productionQueue` / `city.buildings[]`. The queue-drain in `processCity` only drops the **head** of the queue and misses buildings entirely in its full-queue filter (lines 694–714 only check resource requirements for buildings, not `coastalRequired`).
+
+### Fix — Issue 1: Correct `isCityCoastal`
+
+Change `isCityCoastal` to check the city center and its 6 immediate neighbors only:
+
+```ts
+// New signature — accepts full map for wrapping support:
+export function isCityCoastal(city: City, map: GameMap): boolean {
+  const coordsToCheck = [city.position, ...hexNeighbors(city.position)];
+  return coordsToCheck.some(coord => {
+    const wrapped = map.wrapsHorizontally
+      ? wrapHexCoord(coord, map.width)
+      : coord;
+    const tile = map.tiles[hexKey(wrapped)];
+    return tile?.terrain === 'ocean' || tile?.terrain === 'coast';
+  });
+}
+```
+
+Add `hexNeighbors` to the existing `hex-utils` import in `city-system.ts`.
+
+**Update all callers** to pass `map` instead of `map.tiles`:
+
+- `getAvailableBuildings(city, completedTechs, mapTiles, ...)` → `getAvailableBuildings(city, completedTechs, map, ...)` (signature change)
+- `getTrainableUnitsForCiv` call site → pass `map`
+- `processCity` → already receives `map: GameMap`; update internal call
+- `basic-ai.ts` call to `getAvailableBuildings` → pass `state.map`
+
+### Fix — Issue 2: Save Migration
+
+Add `migrateLegacyCoastalData(state: GameState): GameState` to `src/storage/save-manager.ts`:
+
+```ts
+function migrateLegacyCoastalData(state: GameState): GameState {
+  const cities = { ...state.cities };
+  for (const [id, city] of Object.entries(cities)) {
+    if (isCityCoastal(city, state.map)) continue;
+
+    // Drop coastal-required items from the full queue (not just the head)
+    const cleanQueue = city.productionQueue.filter(item => {
+      const building = BUILDINGS[item];
+      if (building?.coastalRequired) return false;
+      const unit = TRAINABLE_UNITS.find(u => u.type === item);
+      if (unit?.coastalRequired) return false;
+      return true;
+    });
+
+    // Remove coastal-required buildings already built
+    const cleanBuildings = city.buildings.filter(bId => !BUILDINGS[bId]?.coastalRequired);
+
+    if (cleanQueue.length !== city.productionQueue.length || cleanBuildings.length !== city.buildings.length) {
+      cities[id] = { ...city, productionQueue: cleanQueue, buildings: cleanBuildings };
+    }
+  }
+  return { ...state, cities };
+}
+```
+
+Add to the migration chain in `save-manager.ts` (line 257):
+
+```ts
+migrateLegacyCoastalData(
+  normalizeThreatPressureDefaults(
+    normalizeLandmassKeys(
+      normalizeLegacyCitySimState(
+        migrateLegacyPlanningState(
+          migrateLegacyNamingState(
+            ensureGameIdentity(state)
+          )
+        )
+      )
+    )
+  )
+)
+```
+
+### UX
+
+No silent data loss: the city panel already refreshes on load and will show the cleaned queue/building list. No player notification needed for migration cleanup (old saves auto-heal silently, consistent with other migration behaviour).
+
+### Tests
+
+- `isCityCoastal` returns `true` for a city whose center tile is adjacent to a `'coast'` tile.
+- `isCityCoastal` returns `false` for a landlocked city.
+- **Regression**: `isCityCoastal` returns `false` for a city whose `ownedTiles` contains a distant coast tile but whose 6 immediate neighbors and own tile are all inland.
+- `isCityCoastal` returns `true` for a city at q=0 on a wrapping map when the adjacent wrapped tile at q=width-1 is coast.
+- `migrateLegacyCoastalData` removes coastal-required queue entries from a non-coastal city.
+- `migrateLegacyCoastalData` removes a built dock from `city.buildings[]` in a non-coastal city.
+- `migrateLegacyCoastalData` does not modify a coastal city.
+- `migrateLegacyCoastalData` is idempotent (safe to run twice).
+
+---
+
+## Bug #374 — Unit Color Inconsistency (Color Changes When Moving)
+
+### Root Cause
+
+There are two separate rendering paths for units, and they use different color sources:
+
+| Path | Trigger | Color source |
+|------|---------|-------------|
+| DOM sprite overlay | Idle, zoom ≥ `LOD_SPRITE_ZOOM_THRESHOLD` | Faction accent color baked into SVG fill attributes (e.g. Zulu → `'imperials'` → `#b53026`) |
+| Canvas glyph / `spriteCache` | Idle low zoom OR moving | `colorLookup[unit.owner]` = game-assigned civ color (e.g. Zulu → green) |
+
+When a unit starts moving, it transitions from DOM to canvas and the color changes. When it stops, it transitions back to DOM and changes again.
+
+**Key finding**: the v2 SVG sprites are **pre-serialized TypeScript files with hardcoded fill hex values** (auto-generated by `scripts/serialize-sprites.mjs`). CSS custom properties cannot override baked `fill="..."` attributes on inline SVG. The approach must instead do a targeted **string replacement** of the faction accent color before mounting the SVG into the DOM.
+
+### Fix
+
+**Step 1 — Define faction accent colors**
+
+Add a constant in `src/renderer/sprite-overlay.ts`:
+
+```ts
+// The per-faction "civ-identity" accent color baked into auto-generated SVG fills.
+// Must match the palette.secondary value used in the source sprite TSX files.
+const FACTION_SPRITE_ACCENT: Record<string, string> = {
+  imperials: '#b53026',
+  vikings:   '#1d4a8c',
+  pharaohs:  '#d4a13c',
+  hellenes:  '#2c8a5a',
+  khanate:   '#7a3a14',
+  shogunate: '#5b4a7a',
+};
+```
+
+**Step 2 — Add `civId` and `colorLookup` to the sprite overlay contract**
+
+In `SpriteEntity` (in `sprite-overlay.ts`):
+```ts
+/** Owner civ ID used to look up the game-assigned color for accent replacement. */
+civId?: string;
+```
+
+Change `SpriteOverlay.sync()` signature:
+```ts
+sync(
+  camera: Camera,
+  entities: SpriteEntity[],
+  map: { width: number; wrapsHorizontally: boolean },
+  opts: { isPinching: boolean; reducedMotion: boolean },
+  colorLookup: Record<string, string> = {},   // new param
+): void
+```
+
+Add `civColor` to the `PoolEntry` type:
+```ts
+interface PoolEntry {
+  // ...existing fields...
+  civColor: string;   // color used at creation; triggers re-create if it changes
+}
+```
+
+**Step 3 — Apply color at mount time (pool miss)**
+
+In the pool-miss branch, after `const svgHtml = this.lookupSprite(entity)`:
+
+```ts
+const accentColor = FACTION_SPRITE_ACCENT[entity.faction];
+const civColor = entity.civId ? (colorLookup[entity.civId] ?? '') : '';
+const coloredSvgHtml =
+  accentColor && civColor && civColor !== accentColor
+    ? svgHtml.replaceAll(accentColor, civColor)
+    : svgHtml;
+
+// ... then use coloredSvgHtml instead of svgHtml for wrapper.innerHTML
+```
+
+Store `civColor` in the pool entry.
+
+**Step 4 — Invalidate pool on color change (pool hit)**
+
+In the pool-hit branch, add a check:
+
+```ts
+const newCivColor = entity.civId ? (colorLookup[entity.civId] ?? '') : '';
+if (existing.faction !== entity.faction || existing.civColor !== newCivColor) {
+  // Force re-create: remove from pool and DOM, fall through to miss path
+  existing.el.remove();
+  this.pool.delete(key);
+  // ... re-create as pool miss (loop re-entry or refactor into shared helper)
+}
+```
+
+In practice this only fires when a unit changes owner (city capture) — very rare — so the overhead is negligible.
+
+**Step 5 — Populate `civId` in `buildUnitMapPresentations`**
+
+In `src/renderer/unit-map-presentation.ts`, the returned entity already flows into `SpriteEntity`. Add:
+```ts
+civId: leadUnit.owner,
+```
+to the entity object built in `render-loop.ts` (lines 380–395).
+
+**Step 6 — Pass `colorLookup` to `sync()` in `render-loop.ts`**
+
+```ts
+this.spriteOverlay?.sync(
+  this.camera,
+  unitEntities,
+  { width: this.state.map.width, wrapsHorizontally: this.state.map.wrapsHorizontally },
+  { isPinching: ..., reducedMotion: ... },
+  colorLookup,   // new arg
+);
+```
+
+### Color Coverage for All Unit Types
+
+| Owner type | colorLookup source | Result |
+|-----------|-------------------|--------|
+| Player civ | `civ.color` (render-loop line 372–374) | game-assigned color |
+| Barbarian | hardcoded `'#8b4513'` (render-loop line 371) | brown (no change — barbarians have no sprite overlay; `getUnitSpriteV2('warrior', 'barbarian')` returns `null`) |
+| Minor civ | `MINOR_CIV_DEFINITIONS[...].color` (render-loop line 376–378) | definition color |
+| Pirate | should be added to `colorLookup` using `PIRATE_FLEET_COLOR` or similar constant | pirate color |
+| Beast | should be added to `colorLookup` with `'#7a1f2b'` (the beast fallback in `resolveUnitVisual`) | dark red |
+
+**Verify in implementation**: pirate and beast units may not have a DOM sprite (their faction may return `null` from `getUnitSpriteV2`), in which case the canvas path handles them and no colorLookup entry is needed.
+
+### Moving Units
+
+Moving units are already rendered exclusively on canvas via `drawUnitMovementAnimations`, which uses `colorLookup[animation.unit.owner]`. No change needed. After this fix, idle DOM sprites use the same `colorLookup` color source → both paths consistent.
+
+### Tests
+
+- A unit entity with `civId = 'player-civ-1'`, `faction = 'imperials'`, and `colorLookup['player-civ-1'] = '#2d6a4f'` has `innerHTML` containing `#2d6a4f` and NOT `#b53026`.
+- A unit entity with no `civId` or no matching `colorLookup` entry uses the faction accent color as-is (no replacement).
+- A barbarian unit (`faction` lookup returns `null` from `getUnitSpriteV2`) still falls through to canvas — no DOM mount attempted.
+- Pool invalidation: when `civColor` changes on a pool hit, the old element is removed and a new element with the updated color is created.
+- `SpriteOverlay.sync()` called with empty `colorLookup` (default) does not crash.

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -230,7 +230,7 @@ function chooseLegendaryWonderFallback(
   const civDef = resolveCivDefinition(state, civilization.civType ?? '');
   const yields = calculateProjectedCityYields(state, cityId, civDef?.bonusEffect);
   const civResources = getCivAvailableResources(state, civId);
-  const availableBuildings = getAvailableBuildings(city, civilization.techState.completed, state.map.tiles, civResources).map(building => building.id);
+  const availableBuildings = getAvailableBuildings(city, civilization.techState.completed, state.map, civResources).map(building => building.id);
   const atWar = civilization.diplomacy.atWarWith.length > 0;
 
   if (yields.food <= city.population) {
@@ -712,7 +712,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       const availableBuildingsList = getAvailableBuildings(
         city,
         civ.techState.completed,
-        newState.map.tiles,
+        newState.map,
         civAvailableResources,
       ).map(b => b.id);
       const derivedItems = [...trainableUnits, ...availableBuildingsList];

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -504,12 +504,16 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   const playerUnits = Object.values(newState.units).filter(u => u.owner !== 'barbarian' && u.owner !== BEAST_OWNER && !u.owner.startsWith('mc-'));
   const barbarianUnits = Object.values(newState.units).filter(u => u.owner === 'barbarian');
   const barbSeed = newState.turn * 31337 + Object.keys(newState.barbarianCamps).length;
+  const cityTargets = Object.values(newState.cities)
+    .filter(city => city.owner !== 'barbarian' && !city.owner.startsWith('mc-') && city.owner !== 'beasts')
+    .map(city => ({ id: city.id, position: city.position, owner: city.owner }));
   const barbResult = processBarbarians(
     Object.values(newState.barbarianCamps),
     newState.map,
     playerUnits,
     barbSeed,
     barbarianUnits,
+    cityTargets,
   );
   newState.barbarianCamps = {};
   for (const camp of barbResult.updatedCamps) {
@@ -562,6 +566,36 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     bus.emit('combat:resolved', { result });
     for (const reward of applied.rewards) {
       bus.emit('combat:reward-earned', { reward });
+    }
+  }
+
+  // Barbarian city attacks
+  for (const order of barbResult.cityAttackOrders) {
+    const city = newState.cities[order.cityId];
+    if (!city) continue;
+    const currentHp = city.hp ?? 100;
+    const newHp = Math.max(0, currentHp - order.damage);
+    newState = {
+      ...newState,
+      cities: { ...newState.cities, [order.cityId]: { ...city, hp: newHp } },
+    };
+    bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: currentHp - newHp });
+
+    if (newHp === 0) {
+      const ownerId = city.owner;
+      const { [order.cityId]: _removed, ...remainingCities } = newState.cities;
+      newState = { ...newState, cities: remainingCities };
+      const ownerCiv = newState.civilizations[ownerId];
+      if (ownerCiv) {
+        newState = {
+          ...newState,
+          civilizations: {
+            ...newState.civilizations,
+            [ownerId]: { ...ownerCiv, cities: ownerCiv.cities.filter((cId: string) => cId !== order.cityId) },
+          },
+        };
+      }
+      bus.emit('barbarian:city-destroyed', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, ownerId });
     }
   }
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -505,7 +505,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   const barbarianUnits = Object.values(newState.units).filter(u => u.owner === 'barbarian');
   const barbSeed = newState.turn * 31337 + Object.keys(newState.barbarianCamps).length;
   const cityTargets = Object.values(newState.cities)
-    .filter(city => city.owner !== 'barbarian' && !city.owner.startsWith('mc-') && city.owner !== 'beasts')
+    .filter(city => city.owner !== 'barbarian' && !city.owner.startsWith('mc-') && city.owner !== BEAST_OWNER)
     .map(city => ({ id: city.id, position: city.position, owner: city.owner }));
   const barbResult = processBarbarians(
     Object.values(newState.barbarianCamps),
@@ -574,6 +574,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     const city = newState.cities[order.cityId];
     if (!city) continue;
     const currentHp = city.hp ?? 100;
+    if (currentHp <= 0) continue; // already at zero (shouldn't persist, but guard against legacy saves)
     const newHp = Math.max(0, currentHp - order.damage);
     newState = {
       ...newState,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1297,6 +1297,8 @@ export interface GameEvents {
   'threat:pirate-plunder': { fleetId: string; cityId: string; goldStolen: number };
   'threat:pirate-siege': { fleetId: string; cityId: string; hpLost: number };
   'threat:pirate-fleet-destroyed': { fleetId: string; civId: string; landmassId: string };
+  'barbarian:city-attacked': { attackerUnitId: string; cityId: string; hpLost: number };
+  'barbarian:city-destroyed': { attackerUnitId: string; cityId: string; ownerId: string };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3409,7 +3409,8 @@ bus.on('barbarian:city-attacked', ({ cityId, hpLost }) => {
 
 bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
   if (!gameState.civilizations[ownerId]?.isHuman) return;
-  appendToCivLog(ownerId, `A city was destroyed by barbarian raiders!`, 'warning');
+  const cityName = gameState.cities[cityId]?.name ?? 'A city';
+  appendToCivLog(ownerId, `${cityName} was destroyed by barbarian raiders!`, 'warning');
 });
 
 bus.on('beast:awakened', ({ beastId, position }) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3400,6 +3400,18 @@ bus.on('threat:pirate-fleet-destroyed', ({ civId }) => {
   SFX.pirateDestroyed?.();
 });
 
+bus.on('barbarian:city-attacked', ({ cityId, hpLost }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (!gameState.civilizations[city.owner]?.isHuman) return;
+  appendToCivLog(city.owner, `Barbarians attack ${city.name}! (−${hpLost} HP)`, 'warning');
+});
+
+bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
+  if (!gameState.civilizations[ownerId]?.isHuman) return;
+  appendToCivLog(ownerId, `A city was destroyed by barbarian raiders!`, 'warning');
+});
+
 bus.on('beast:awakened', ({ beastId, position }) => {
   const def = BEAST_DEFINITIONS[beastId];
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -392,6 +392,7 @@ export class RenderLoop {
         fortified: presentation.leadUnit.isFortified,
         roleMarker: presentation.roleMarker,
         anchorOffsetFactor: presentation.anchorOffsetFactor,
+        civId: presentation.leadUnit.owner,
       }));
       this.spriteOverlay?.sync(
         this.camera,
@@ -404,6 +405,7 @@ export class RenderLoop {
           isPinching: this.touchHandlerRef?.isPinching ?? false,
           reducedMotion: prefersReducedMotion(),
         },
+        colorLookup,
       );
       drawUnitPresentations(
         this.ctx,

--- a/src/renderer/sprite-overlay.ts
+++ b/src/renderer/sprite-overlay.ts
@@ -11,6 +11,23 @@ import type { HexCoord } from '@/core/types';
 import { applyUnitAnchorOffset, getUnitLayoutMetrics } from './unit-map-presentation';
 import type { UnitRoleMarker } from './unit-visual-resolver';
 
+// Faction accent colors baked into serialized sprite SVG fills by scripts/serialize-sprites.mjs.
+// Must match the palette.secondary value from the source sprite TSX files.
+const FACTION_SPRITE_ACCENT: Record<string, string> = {
+  imperials: '#b53026',
+  vikings:   '#1d4a8c',
+  pharaohs:  '#d4a13c',
+  hellenes:  '#2c8a5a',
+  khanate:   '#7a3a14',
+  shogunate: '#5b4a7a',
+};
+
+export function applyFactionCivColor(svgHtml: string, faction: string, civColor: string): string {
+  const accent = FACTION_SPRITE_ACCENT[faction];
+  if (!accent || !civColor || civColor === accent) return svgHtml;
+  return svgHtml.replaceAll(accent, civColor);
+}
+
 /** Sprite wrappers live in world-space; the container applies camera zoom. */
 export interface SpriteEntity {
   id:      string;
@@ -38,6 +55,8 @@ export interface SpriteEntity {
   fortified?: boolean;
   roleMarker?: UnitRoleMarker;
   anchorOffsetFactor?: { x: number; y: number };
+  /** Owner civ ID used to look up the game-assigned color for accent replacement. */
+  civId?: string;
 }
 
 interface PoolEntry {
@@ -45,6 +64,7 @@ interface PoolEntry {
   spriteWrapEl: HTMLElement;    // .cq-sprite-wrap.cq-v2 — animation root
   phase:        number;
   faction:      string;
+  civColor:     string;
   coord:        HexCoord;       // stored so we can detect position change after movement
   memberIds:    string[];
   anchorOffsetFactor: { x: number; y: number };
@@ -92,6 +112,7 @@ export class SpriteOverlay {
     entities: SpriteEntity[],
     map: { width: number; wrapsHorizontally: boolean },
     opts: { isPinching: boolean; reducedMotion: boolean },
+    colorLookup: Record<string, string> = {},
   ): void {
     // 1. LOD + reduced-motion gate
     if (camera.zoom < LOD_SPRITE_ZOOM_THRESHOLD || opts.reducedMotion) {
@@ -121,9 +142,16 @@ export class SpriteOverlay {
         const key = `${entity.id}:${i}`;
         seen.add(key);
 
-        const existing = this.pool.get(key);
         const anchorOffsetFactor = entity.anchorOffsetFactor ?? { x: 0, y: 0 };
-        if (existing) {
+        const newCivColor = entity.civId ? (colorLookup[entity.civId] ?? '') : '';
+        const poolEntry = this.pool.get(key);
+        // Invalidate if faction or civ color changed (e.g. unit captured or color reassigned)
+        if (poolEntry && (poolEntry.faction !== entity.faction || poolEntry.civColor !== newCivColor)) {
+          poolEntry.el.remove();
+          this.pool.delete(key);
+        }
+        if (this.pool.has(key)) {
+          const existing = this.pool.get(key)!;
           // Pool hit — update state via setAttribute (no node replacement!)
           existing.spriteWrapEl.setAttribute('data-state', entity.state);
           existing.spriteWrapEl.setAttribute('data-damage', String(entity.damage ?? 0));
@@ -147,8 +175,9 @@ export class SpriteOverlay {
           }
         } else {
           // Pool miss — create element
-          const svgHtml = this.lookupSprite(entity);
-          if (!svgHtml) continue; // no v2 sprite — canvas handles it
+          const rawSvgHtml = this.lookupSprite(entity);
+          if (!rawSvgHtml) continue; // no v2 sprite — canvas handles it
+          const svgHtml = applyFactionCivColor(rawSvgHtml, entity.faction, newCivColor);
 
           const phase = (hashCode(entity.id) % 100) / 100;
           const rawPx = hexToPixel(coord, camera.hexSize);
@@ -183,6 +212,7 @@ export class SpriteOverlay {
             spriteWrapEl,
             phase,
             faction: entity.faction,
+            civColor: newCivColor,
             coord,
             memberIds: entity.memberIds ?? [entity.id],
             anchorOffsetFactor,

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -1,6 +1,6 @@
 import { QUEST_TYPES, type City, type CityFocus, type CityMaturity, type GameState, type QuestTarget, type SaveSlotMeta } from '@/core/types';
 import { drawNextCityName } from '@/systems/city-name-system';
-import { createEmptyCityGrid } from '@/systems/city-system';
+import { createEmptyCityGrid, isCityCoastal, BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from '@/systems/city-maturity-system';
 import { canonicalizeCityCoord, normalizeCityWorkClaims, recalculateTerritory } from '@/systems/city-territory-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
@@ -252,9 +252,32 @@ function normalizeThreatPressureDefaults(state: GameState): GameState {
   };
 }
 
+export function migrateLegacyCoastalData(state: GameState): GameState {
+  if (!state.map) return state;
+  const cities = { ...state.cities };
+  let changed = false;
+  for (const [id, city] of Object.entries(cities)) {
+    if (isCityCoastal(city, state.map)) continue;
+    const cleanQueue = city.productionQueue.filter(item => {
+      if (BUILDINGS[item]?.coastalRequired) return false;
+      const unit = TRAINABLE_UNITS.find(u => u.type === item);
+      return !unit?.coastalRequired;
+    });
+    const cleanBuildings = city.buildings.filter(bId => !BUILDINGS[bId]?.coastalRequired);
+    if (
+      cleanQueue.length !== city.productionQueue.length ||
+      cleanBuildings.length !== city.buildings.length
+    ) {
+      cities[id] = { ...city, productionQueue: cleanQueue, buildings: cleanBuildings };
+      changed = true;
+    }
+  }
+  return changed ? { ...state, cities } : state;
+}
+
 function normalizeLoadedState(state: GameState): GameState {
   const normalizedCityState = normalizeMinorCivQuestState(
-    normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))))),
+    migrateLegacyCoastalData(normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state))))))),
   );
   if (!normalizedCityState.map?.tiles) {
     normalizedCityState.pendingDiplomacyRequests ??= [];

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -119,11 +119,18 @@ export interface BarbarianAttackOrder {
   defenderUnitId: string;
 }
 
+export interface BarbarianCityAttackOrder {
+  attackerUnitId: string;
+  cityId: string;
+  damage: number;
+}
+
 export interface BarbarianProcessResult {
   updatedCamps: BarbarianCamp[];
   spawnedUnits: Array<{ campId: string; position: HexCoord }>;
   moveOrders: BarbarianMoveOrder[];
   attackOrders: BarbarianAttackOrder[];
+  cityAttackOrders: BarbarianCityAttackOrder[];
 }
 
 const BARBARIAN_CHASE_RANGE = 5;
@@ -141,12 +148,14 @@ export function processBarbarians(
   playerUnits: Unit[],
   seed: number,
   barbarianUnits?: Unit[],
+  playerCities?: Array<{ id: string; position: HexCoord; owner: string }>,
 ): BarbarianProcessResult {
   const rng = lcg(seed ^ 0xdeadbeef);
   const updatedCamps: BarbarianCamp[] = [];
   const spawnedUnits: Array<{ campId: string; position: HexCoord }> = [];
   const moveOrders: BarbarianMoveOrder[] = [];
   const attackOrders: BarbarianAttackOrder[] = [];
+  const cityAttackOrders: BarbarianCityAttackOrder[] = [];
 
   // --- Camp processing: cooldowns and spawning ---
   for (const camp of camps) {
@@ -166,7 +175,7 @@ export function processBarbarians(
 
   // --- Barbarian unit movement and attack ---
   if (!barbarianUnits || barbarianUnits.length === 0) {
-    return { updatedCamps, spawnedUnits, moveOrders, attackOrders };
+    return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
   }
 
   // Build a set of all occupied positions (for collision avoidance)
@@ -194,7 +203,46 @@ export function processBarbarians(
       }
     }
 
-    if (!nearestTarget) continue;
+    if (!nearestTarget) {
+      if (playerCities && playerCities.length > 0) {
+        let nearestCity: (typeof playerCities)[0] | null = null;
+        let nearestCityDist = BARBARIAN_CHASE_RANGE + 1;
+        for (const city of playerCities) {
+          const dist = map.wrapsHorizontally
+            ? wrappedHexDistance(barbUnit.position, city.position, map.width)
+            : hexDistance(barbUnit.position, city.position);
+          if (dist < nearestCityDist) {
+            nearestCityDist = dist;
+            nearestCity = city;
+          }
+        }
+        if (nearestCity) {
+          if (nearestCityDist <= 1) {
+            cityAttackOrders.push({ attackerUnitId: barbUnit.id, cityId: nearestCity.id, damage: 10 });
+          } else {
+            const neighbors = hexNeighbors(barbUnit.position);
+            const passable = neighbors.filter(coord => {
+              const t = map.tiles[hexKey(coord)];
+              if (!t) return false;
+              if (t.terrain === 'ocean' || t.terrain === 'coast' || t.terrain === 'mountain') return false;
+              return !occupiedByUnit.get(hexKey(coord));
+            });
+            if (passable.length > 0) {
+              let best = passable[0]!;
+              let bestD = hexDistance(passable[0]!, nearestCity.position);
+              for (const coord of passable) {
+                const d = hexDistance(coord, nearestCity.position);
+                if (d < bestD) { bestD = d; best = coord; }
+              }
+              moveOrders.push({ unitId: barbUnit.id, toCoord: best });
+              occupiedByUnit.delete(hexKey(barbUnit.position));
+              occupiedByUnit.set(hexKey(best), barbUnit.id);
+            }
+          }
+        }
+      }
+      continue;
+    }
 
     // If adjacent to target, issue an attack order
     if (canAttackByProfileOnMap(barbUnit, nearestTarget, map)) {
@@ -243,5 +291,5 @@ export function processBarbarians(
     }
   }
 
-  return { updatedCamps, spawnedUnits, moveOrders, attackOrders };
+  return { updatedCamps, spawnedUnits, moveOrders, attackOrders, cityAttackOrders };
 }

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1,6 +1,6 @@
 import type { City, Building, HexCoord, GameMap, UnitType, CivBonusEffect, TrainableUnitEntry, IdCounters, ResourceType } from '@/core/types';
 import { isSpyUnitType } from './espionage-system';
-import { hexKey, hexesInRange, wrapHexCoord } from './hex-utils';
+import { hexKey, hexesInRange, hexNeighbors, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
 import { findOptimalSlot, isSlotUnlocked } from './adjacency-system';
@@ -455,11 +455,11 @@ export function getTrainableUnitsForCiv(
 export function getTrainableUnitsForCity(
   city: City,
   completedTechs: string[],
-  mapTiles: GameMap['tiles'],
+  map: GameMap,
   civType?: string,
   availableResources?: Set<ResourceType>,
 ): TrainableUnitEntry[] {
-  const coastal = isCityCoastal(city, mapTiles);
+  const coastal = isCityCoastal(city, map);
   return getTrainableUnitsForCiv(completedTechs, civType, availableResources)
     .filter(unit => !unit.coastalRequired || coastal);
 }
@@ -521,20 +521,22 @@ export function foundCity(owner: string, position: HexCoord, map: GameMap, count
   };
 }
 
-export function isCityCoastal(city: City, mapTiles: GameMap['tiles']): boolean {
-  return (city.ownedTiles ?? []).some(coord => {
-    const tile = mapTiles[hexKey(coord)];
-    return tile?.terrain === 'ocean' || tile?.terrain === 'coast';
+export function isCityCoastal(city: City, map: GameMap): boolean {
+  const coordsToCheck = [city.position, ...hexNeighbors(city.position)];
+  return coordsToCheck.some(coord => {
+    const wrapped = map.wrapsHorizontally ? wrapHexCoord(coord, map.width) : coord;
+    const t = map.tiles[hexKey(wrapped)];
+    return t?.terrain === 'ocean' || t?.terrain === 'coast';
   });
 }
 
 export function getAvailableBuildings(
   city: City,
   completedTechs: string[],
-  mapTiles: GameMap['tiles'],
+  map: GameMap,
   availableResources?: Set<ResourceType>,
 ): Building[] {
-  const coastal = isCityCoastal(city, mapTiles);
+  const coastal = isCityCoastal(city, map);
   return Object.values(BUILDINGS).filter(b => {
     if (city.buildings.includes(b.id)) return false;
     if (b.techRequired && !completedTechs.includes(b.techRequired)) return false;
@@ -719,13 +721,13 @@ export function processCity(
   // lost coastal access (e.g. map-script edge case), remove the item silently.
   if (newQueue.length > 0) {
     const headBuilding = BUILDINGS[newQueue[0]];
-    if (headBuilding?.coastalRequired && !isCityCoastal(city, map.tiles)) {
+    if (headBuilding?.coastalRequired && !isCityCoastal(city, map)) {
       droppedBuilding = newQueue.shift()!;
       droppedProductionItem = droppedBuilding;
       newProgress = 0;
     }
     const headUnit = TRAINABLE_UNITS.find(unit => unit.type === newQueue[0]);
-    if (headUnit?.coastalRequired && !isCityCoastal(city, map.tiles)) {
+    if (headUnit?.coastalRequired && !isCityCoastal(city, map)) {
       droppedUnit = newQueue.shift() as UnitType;
       droppedProductionItem = droppedUnit;
       newProgress = 0;

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -99,7 +99,7 @@ export function getIdleCityIds(state: GameState, civId: string): string[] {
     .filter(city => city.productionQueue.length === 0)
     .filter(city => !city.idleProduction)
     .filter(city => {
-      const buildableBuildings = getAvailableBuildings(city, completedTechs, state.map?.tiles ?? {}).length > 0;
+      const buildableBuildings = !!state.map && getAvailableBuildings(city, completedTechs, state.map).length > 0;
       const buildableUnits = getTrainableUnitsForCiv(completedTechs, civ.civType).length > 0;
       return buildableBuildings || buildableUnits;
     })
@@ -132,7 +132,7 @@ export function getRecommendedIdleCityChoice(
   const bonusEffect = resolveCivDefinition(state, civ.civType)?.bonusEffect;
   const productionPerTurn = Math.max(1, calculateProjectedCityYields(state, cityId, bonusEffect).production);
   const candidates = [
-    ...getAvailableBuildings(city, completedTechs, state.map?.tiles ?? {}).map(building => {
+    ...(state.map ? getAvailableBuildings(city, completedTechs, state.map) : []).map(building => {
       const cost = getProductionCostForItem(building.id, { city, bonusEffect, era: state.era });
       return {
         itemId: building.id,

--- a/src/systems/quest-objective-system.ts
+++ b/src/systems/quest-objective-system.ts
@@ -102,7 +102,7 @@ export function estimateCaravanReadyTurns(state: GameState, majorCivId: string, 
   const trainable = getTrainableUnitsForCity(
     city,
     civ.techState.completed,
-    state.map.tiles,
+    state.map,
     civ.civType,
     availableResources,
   ).some(unit => unit.type === 'caravan');

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -262,8 +262,9 @@ export function validateUnitMove(
 
   const occupancy = buildUnitOccupancy(state.units);
   const occupants = getUnitIdsAtCoord(occupancy, target).filter(id => id !== unitId);
-  if (occupants.length > 0) {
-    return movementFailure(from, target, [from, target], 'occupied', 'Another unit is already there.');
+  const hasHostileOccupant = occupants.some(id => occupancy.ownersByUnitId[id] !== unit.owner);
+  if (hasHostileOccupant) {
+    return movementFailure(from, target, [from, target], 'occupied', 'An enemy unit is blocking the way.');
   }
 
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -175,7 +175,7 @@ export function createCityPanel(
     bonusEffect: civDef?.bonusEffect,
     era: state.era,
   });
-  const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map.tiles, playerResources);
+  const availableBuildings = getAvailableBuildings(city, currentCiv.techState.completed, state.map, playerResources);
   const cityWonderEntries = getLegendaryWonderPresentationForCity(state, state.currentPlayer, city.id);
   const compactWonderEntries = getCompactLegendaryWonderEntriesForCity(state, state.currentPlayer, city.id, 4);
   const activeLegendaryEntry = city.productionQueue[0]?.startsWith('legendary:')
@@ -231,13 +231,13 @@ export function createCityPanel(
   }
 
   const completedTechs = currentCiv.techState.completed;
-  const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map.tiles, currentCiv.civType, playerResources);
+  const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, playerResources);
 
   // Locked items: tech met + resource NOT met (tech-missing items stay hidden entirely)
-  const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map.tiles, currentCiv.civType, undefined);
+  const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined);
   const lockedUnits = allTechUnlockedUnits.filter(u => !availableUnits.some(a => a.type === u.type));
 
-  const allTechUnlockedBuildings = getAvailableBuildings(city, completedTechs, state.map.tiles, undefined);
+  const allTechUnlockedBuildings = getAvailableBuildings(city, completedTechs, state.map, undefined);
   const lockedBuildings = allTechUnlockedBuildings.filter(b => !availableBuildings.some(a => a.id === b.id));
 
   const lockedItems: Array<{ id: string; name: string; missingResources: ResourceType[] }> = [

--- a/tests/input/selected-unit-tap-intent.test.ts
+++ b/tests/input/selected-unit-tap-intent.test.ts
@@ -239,4 +239,24 @@ describe('selected-unit-tap-intent', () => {
 
     expect(intent).toEqual({ kind: 'move' });
   });
+
+  it('returns move when tapping a friendly-occupied tile in range (stacking regression)', () => {
+    const state = createNewGame(undefined, 'stacking-regression', 'small');
+    state.currentPlayer = 'player';
+
+    const counters = mkC();
+    const movingUnit = createUnit('warrior', 'player', { q: 0, r: 0 }, counters);
+    state.units[movingUnit.id] = { ...movingUnit, movementPointsLeft: 2, hasMoved: false };
+
+    const occupant = createUnit('warrior', 'player', { q: 1, r: 0 }, counters);
+    state.units[occupant.id] = occupant;
+
+    const intent = resolveSelectedUnitTapIntent(
+      state,
+      movingUnit.id,
+      { q: 1, r: 0 },
+      [{ q: 1, r: 0 }],
+    );
+    expect(intent).toEqual({ kind: 'move' });
+  });
 });

--- a/tests/input/worker-movement-flow.test.ts
+++ b/tests/input/worker-movement-flow.test.ts
@@ -51,7 +51,7 @@ describe('worker-movement-flow', () => {
     state.units.blocker = {
       id: 'blocker',
       type: 'warrior',
-      owner: 'player',
+      owner: 'barbarian',
       position: { q: 1, r: 1 },
       movementPointsLeft: 2,
       health: 100,

--- a/tests/renderer/sprite-overlay.test.ts
+++ b/tests/renderer/sprite-overlay.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect, afterEach } from 'vitest';
-import { SpriteOverlay, hashCode } from '@/renderer/sprite-overlay';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { SpriteOverlay, hashCode, applyFactionCivColor } from '@/renderer/sprite-overlay';
+import * as SpriteIndex from '@/renderer/sprites/v2/index';
 import { getUnitLayoutMetrics } from '@/renderer/unit-map-presentation';
 import type { SpriteEntity } from '@/renderer/sprite-overlay';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from '@/renderer/sprites/sprite-system';
@@ -271,5 +272,76 @@ describe('invalidateFaction', () => {
     overlay.invalidateFaction('imperials');
     // viking element should remain
     expect(overlay.getActiveIds().has('u2')).toBe(true);
+  });
+});
+
+// ── applyFactionCivColor — pure function tests ────────────────────────────────
+
+describe('applyFactionCivColor', () => {
+  it('replaces all occurrences of the faction accent color with the civ game color', () => {
+    const svg = `<div><rect fill="#b53026"/><path stroke="#b53026"/></div>`;
+    const result = applyFactionCivColor(svg, 'imperials', '#2d6a4f');
+    expect(result).not.toContain('#b53026');
+    expect(result.match(/#2d6a4f/g)?.length).toBe(2);
+  });
+
+  it('returns the original string when faction has no entry in FACTION_SPRITE_ACCENT', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'unknown-faction', '#2d6a4f')).toBe(svg);
+  });
+
+  it('returns the original string when civColor is empty', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'imperials', '')).toBe(svg);
+  });
+
+  it('returns the original string when civColor equals faction accent (no-op)', () => {
+    const svg = `<div><rect fill="#b53026"/></div>`;
+    expect(applyFactionCivColor(svg, 'imperials', '#b53026')).toBe(svg);
+  });
+});
+
+// ── sync() colorLookup param ─────────────────────────────────────────────────
+
+describe('SpriteOverlay.sync() — colorLookup param', () => {
+  it('does not crash when called with no colorLookup (default empty)', () => {
+    const { overlay } = mountOverlay();
+    expect(() =>
+      overlay.sync(cam(), [], MAP, OPTS),
+    ).not.toThrow();
+  });
+
+  it('accepts colorLookup as the fifth argument without error', () => {
+    const { overlay } = mountOverlay();
+    expect(() =>
+      overlay.sync(cam(), [], MAP, OPTS, { 'civ-1': '#2d6a4f' }),
+    ).not.toThrow();
+  });
+});
+
+// ── pool invalidation on civColor change ─────────────────────────────────────
+
+describe('SpriteOverlay.sync() — pool invalidation on civColor change', () => {
+  it('re-creates the DOM element when civColor changes between syncs', () => {
+    const mockSvg = '<div class="unit-sprite"><rect fill="#b53026"/></div>';
+    const spy = vi.spyOn(SpriteIndex, 'getUnitSpriteV2').mockReturnValue(mockSvg);
+
+    const { overlay, mount } = mountOverlay();
+    const ent = entity({ faction: 'imperials', civId: 'civ-1' });
+
+    // First sync — imperials accent replaced with green
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#2d6a4f' });
+    const el1 = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el1).not.toBeNull();
+    expect(el1.innerHTML).toContain('#2d6a4f');
+    expect(el1.innerHTML).not.toContain('#b53026');
+
+    // Second sync — same entity, but new color
+    overlay.sync(cam(), [ent], MAP, OPTS, { 'civ-1': '#ff0000' });
+    const el2 = mount.querySelector('[data-entity-id="u1"]') as HTMLElement;
+    expect(el2.innerHTML).toContain('#ff0000');
+    expect(el2.innerHTML).not.toContain('#2d6a4f');
+
+    spy.mockRestore();
   });
 });

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { City, GameMap, GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { migrateLegacyCoastalData } from '@/storage/save-manager';
 
 const dbState = new Map<string, unknown>();
 
@@ -383,5 +386,122 @@ describe('save-manager autosave listing', () => {
     const loaded = await loadGame('slot-auto-explore');
 
     expect(loaded?.units[unitId].automation).toEqual(state.units[unitId].automation);
+  });
+});
+
+// ─── migrateLegacyCoastalData ───────────────────────────────────────────────
+
+function makeTileMigration(q: number, r: number, terrain = 'plains') {
+  return {
+    coord: { q, r },
+    terrain: terrain as any,
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function makeCityMigration(id: string, overrides: Partial<City> = {}): City {
+  return {
+    id,
+    name: id,
+    owner: 'civ-1',
+    position: { q: 5, r: 5 },
+    population: 1,
+    food: 0,
+    foodNeeded: 15,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [{ q: 5, r: 5 }],
+    workedTiles: [],
+    focus: 'balanced',
+    grid: [],
+    gridSize: 1,
+    hp: 100,
+    maturity: 'core',
+    ...overrides,
+  } as unknown as City;
+}
+
+function makeMigrationState(cities: City[], extraTiles: ReturnType<typeof makeTileMigration>[] = []): GameState {
+  const baseTiles = [
+    makeTileMigration(5, 5),
+    makeTileMigration(6, 5),
+    makeTileMigration(4, 5),
+    makeTileMigration(5, 4),
+    makeTileMigration(6, 4),
+    makeTileMigration(4, 6),
+    makeTileMigration(5, 6),
+  ];
+  const tileMap = Object.fromEntries(
+    [...baseTiles, ...extraTiles].map(t => [hexKey(t.coord), t]),
+  );
+  return {
+    turn: 1,
+    era: 1,
+    gameId: 'migration-test',
+    currentPlayer: 'civ-1',
+    gameOver: false,
+    winner: null,
+    map: {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: tileMap,
+    } as GameMap,
+    units: {},
+    cities: Object.fromEntries(cities.map(c => [c.id, c])),
+    civilizations: {},
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'welcome', completedSteps: [] },
+    settings: { mapSize: 'small', soundEnabled: true } as any,
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+  } as unknown as GameState;
+}
+
+describe('migrateLegacyCoastalData', () => {
+  it('removes coastal-required ship from productionQueue of a non-coastal city', () => {
+    const city = makeCityMigration('c1', { productionQueue: ['galley', 'warrior'] });
+    const state = makeMigrationState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].productionQueue).toEqual(['warrior']);
+  });
+
+  it('removes coastal-required dock from city.buildings of a non-coastal city', () => {
+    const city = makeCityMigration('c1', { buildings: ['dock', 'barracks'] });
+    const state = makeMigrationState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].buildings).toEqual(['barracks']);
+  });
+
+  it('does not modify a genuinely coastal city', () => {
+    const city = makeCityMigration('c1', { buildings: ['dock'], productionQueue: ['galley'] });
+    const coastTile = makeTileMigration(6, 5, 'coast');
+    const state = makeMigrationState([city], [coastTile]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result.cities['c1'].buildings).toEqual(['dock']);
+    expect(result.cities['c1'].productionQueue).toEqual(['galley']);
+  });
+
+  it('is idempotent — running twice produces the same result', () => {
+    const city = makeCityMigration('c1', { productionQueue: ['galley', 'warrior'] });
+    const state = makeMigrationState([city]);
+    const once = migrateLegacyCoastalData(state);
+    const twice = migrateLegacyCoastalData(once);
+    expect(twice.cities['c1'].productionQueue).toEqual(once.cities['c1'].productionQueue);
+  });
+
+  it('returns state unchanged when no cities need migration', () => {
+    const city = makeCityMigration('c1', { buildings: ['barracks'], productionQueue: ['warrior'] });
+    const state = makeMigrationState([city]);
+    const result = migrateLegacyCoastalData(state);
+    expect(result).toBe(state);
   });
 });

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -224,3 +224,72 @@ describe('barbarian camp evolution', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('processBarbarians — city targeting', () => {
+  const seed = 99999;
+
+  function flatMap(size = 16): GameMap {
+    const tiles: Record<string, any> = {};
+    for (let q = 0; q < size; q++) {
+      for (let r = 0; r < size; r++) {
+        tiles[`${q},${r}`] = {
+          coord: { q, r },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          owner: null,
+          improvementTurnsLeft: 0,
+          hasRiver: false,
+          wonder: null,
+        };
+      }
+    }
+    return { width: size, height: size, wrapsHorizontally: false, rivers: [], tiles };
+  }
+
+  it('produces a cityAttackOrders field even when no cities are provided', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const result = processBarbarians([], map, [], seed, [barb]);
+    expect(result.cityAttackOrders).toBeDefined();
+    expect(result.cityAttackOrders).toHaveLength(0);
+  });
+
+  it('issues a city attack order when a barbarian is adjacent to an empty city', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const city = { id: 'city-1', position: { q: 6, r: 5 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(1);
+    expect(result.cityAttackOrders[0].attackerUnitId).toBe(barb.id);
+    expect(result.cityAttackOrders[0].cityId).toBe('city-1');
+    expect(result.cityAttackOrders[0].damage).toBeGreaterThan(0);
+  });
+
+  it('prefers a player unit over an empty city when the unit is in chase range', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, mkC());
+    const playerUnit = createUnit('warrior', 'civ-1', { q: 6, r: 5 }, mkC());
+    const city = { id: 'city-1', position: { q: 6, r: 5 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [playerUnit], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(0);
+    expect(result.attackOrders).toHaveLength(1);
+    expect(result.attackOrders[0].attackerUnitId).toBe(barb.id);
+  });
+
+  it('moves toward an empty city when not yet adjacent', () => {
+    const map = flatMap();
+    const barb = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    const city = { id: 'city-1', position: { q: 4, r: 0 }, owner: 'civ-1' };
+
+    const result = processBarbarians([], map, [], seed, [barb], [city]);
+
+    expect(result.cityAttackOrders).toHaveLength(0);
+    expect(result.moveOrders.some(o => o.unitId === barb.id)).toBe(true);
+  });
+});

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -2,6 +2,7 @@ import {
   foundCity,
   getAvailableBuildings,
   getTrainableUnitsForCity,
+  isCityCoastal,
   getTrainableUnitsForCiv,
   getProductionCostForItem,
   processCity,
@@ -20,9 +21,10 @@ import {
   getProductionIconForItem,
   getSettlerProductionCost,
 } from '@/systems/city-system';
-import type { City, GameMap, ResourceType, UnitType } from '@/core/types';
+import type { City, GameMap, HexCoord, ResourceType, UnitType } from '@/core/types';
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS } from '@/systems/unit-system';
 import { generateMap } from '@/systems/map-generator';
+import { hexKey } from '@/systems/hex-utils';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -99,12 +101,109 @@ describe('foundCity', () => {
   });
 });
 
+describe('isCityCoastal', () => {
+  function makeTile(coord: HexCoord, terrain = 'plains') {
+    return {
+      coord,
+      terrain: terrain as any,
+      elevation: 'lowland',
+      resource: null,
+      improvement: 'none',
+      owner: null,
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+    };
+  }
+
+  function coastMap(centerTerrain: string, neighborTerrain: string): GameMap {
+    return {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        [hexKey({ q: 5, r: 5 })]: makeTile({ q: 5, r: 5 }, centerTerrain),
+        [hexKey({ q: 6, r: 5 })]: makeTile({ q: 6, r: 5 }, neighborTerrain),
+        [hexKey({ q: 4, r: 5 })]: makeTile({ q: 4, r: 5 }),
+        [hexKey({ q: 5, r: 4 })]: makeTile({ q: 5, r: 4 }),
+        [hexKey({ q: 6, r: 4 })]: makeTile({ q: 6, r: 4 }),
+        [hexKey({ q: 4, r: 6 })]: makeTile({ q: 4, r: 6 }),
+        [hexKey({ q: 5, r: 6 })]: makeTile({ q: 5, r: 6 }),
+        [hexKey({ q: 15, r: 15 })]: makeTile({ q: 15, r: 15 }, 'coast'),
+      },
+    } as GameMap;
+  }
+
+  function makeCity(ownedTiles?: HexCoord[]): City {
+    return {
+      id: 'c-coast',
+      name: 'Test',
+      owner: 'civ-1',
+      position: { q: 5, r: 5 },
+      population: 1,
+      food: 0,
+      foodNeeded: 15,
+      buildings: [],
+      productionQueue: [],
+      productionProgress: 0,
+      ownedTiles: ownedTiles ?? [{ q: 5, r: 5 }],
+      workedTiles: [],
+      focus: 'balanced',
+      grid: [],
+      gridSize: 1,
+      hp: 100,
+      maturity: 'core',
+    } as unknown as City;
+  }
+
+  it('returns true when an adjacent tile is coast', () => {
+    const city = makeCity();
+    const map = coastMap('plains', 'coast');
+    expect(isCityCoastal(city, map)).toBe(true);
+  });
+
+  it('returns true when the city centre tile itself is coast', () => {
+    const city = makeCity();
+    const map = coastMap('coast', 'plains');
+    expect(isCityCoastal(city, map)).toBe(true);
+  });
+
+  it('returns false for a landlocked city', () => {
+    const city = makeCity();
+    const map = coastMap('plains', 'plains');
+    expect(isCityCoastal(city, map)).toBe(false);
+  });
+
+  it('regression: returns false when a distant ownedTile is coast but no adjacent tile is (old bug)', () => {
+    const city = makeCity([{ q: 5, r: 5 }, { q: 15, r: 15 }]);
+    const map = coastMap('plains', 'plains');
+    expect(isCityCoastal(city, map)).toBe(false);
+  });
+
+  it('returns true for a city at q=0 on a wrapping map when the wrapped neighbour is coast', () => {
+    const city = makeCity([{ q: 0, r: 5 }]);
+    city.position = { q: 0, r: 5 };
+    const wrappingMap: GameMap = {
+      width: 20,
+      height: 20,
+      wrapsHorizontally: true,
+      rivers: [],
+      tiles: {
+        [hexKey({ q: 0, r: 5 })]: makeTile({ q: 0, r: 5 }),
+        [hexKey({ q: 19, r: 5 })]: makeTile({ q: 19, r: 5 }, 'coast'),
+      },
+    } as GameMap;
+    expect(isCityCoastal(city, wrappingMap)).toBe(true);
+  });
+});
+
 describe('getAvailableBuildings', () => {
   it('returns buildings the city can build', () => {
     const map = generateMap(30, 30, 'city-test');
     const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', landTile.coord, map, mkC());
-    const available = getAvailableBuildings(city, [], map.tiles);
+    const available = getAvailableBuildings(city, [], map);
     expect(available.length).toBeGreaterThan(0);
   });
 
@@ -113,7 +212,7 @@ describe('getAvailableBuildings', () => {
     const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', landTile.coord, map, mkC());
     city.buildings = ['granary'];
-    const available = getAvailableBuildings(city, [], map.tiles);
+    const available = getAvailableBuildings(city, [], map);
     expect(available.find(b => b.id === 'granary')).toBeUndefined();
   });
 
@@ -128,7 +227,7 @@ describe('getAvailableBuildings', () => {
       )
     )!;
     const city = foundCity('p1', inlandTile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['fishing'], map.tiles);
+    const available = getAvailableBuildings(city, ['fishing'], map);
     expect(available.find(b => b.id === 'dock')).toBeUndefined();
   });
 
@@ -145,7 +244,7 @@ describe('getAvailableBuildings', () => {
       ...foundCity('p1', nearTile.coord, map, mkC()),
       ownedTiles: [nearTile.coord, waterTile.coord],
     };
-    const available = getAvailableBuildings(city, ['fishing'], map.tiles);
+    const available = getAvailableBuildings(city, ['fishing'], map);
     expect(available.find(b => b.id === 'dock')).toBeDefined();
   });
 
@@ -162,7 +261,7 @@ describe('getAvailableBuildings', () => {
       ...foundCity('p1', nearTile.coord, map, mkC()),
       ownedTiles: [nearTile.coord, waterTile.coord],
     };
-    const available = getAvailableBuildings(city, [], map.tiles); // no fishing tech
+    const available = getAvailableBuildings(city, [], map); // no fishing tech
     expect(available.find(b => b.id === 'dock')).toBeUndefined();
   });
 
@@ -177,7 +276,7 @@ describe('getAvailableBuildings', () => {
       )
     )!;
     const city = foundCity('p1', inlandTile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['harbor-tech'], map.tiles);
+    const available = getAvailableBuildings(city, ['harbor-tech'], map);
     expect(available.find(b => b.id === 'harbor')).toBeUndefined();
   });
 
@@ -194,7 +293,7 @@ describe('getAvailableBuildings', () => {
       ...foundCity('p1', nearTile.coord, map, mkC()),
       ownedTiles: [nearTile.coord, waterTile.coord],
     };
-    const available = getAvailableBuildings(city, ['harbor-tech'], map.tiles);
+    const available = getAvailableBuildings(city, ['harbor-tech'], map);
     expect(available.find(b => b.id === 'harbor')).toBeDefined();
   });
 });
@@ -222,8 +321,8 @@ describe('getTrainableUnitsForCity', () => {
     inlandCity.ownedTiles = [{ q: 3, r: 0 }];
     const techs = ['galleys', 'triremes'];
 
-    const coastalTypes = getTrainableUnitsForCity(coastalCity, techs, map.tiles).map(unit => unit.type);
-    const inlandTypes = getTrainableUnitsForCity(inlandCity, techs, map.tiles).map(unit => unit.type);
+    const coastalTypes = getTrainableUnitsForCity(coastalCity, techs, map).map(unit => unit.type);
+    const inlandTypes = getTrainableUnitsForCity(inlandCity, techs, map).map(unit => unit.type);
 
     expect(coastalTypes).toEqual(expect.arrayContaining(['galley', 'trireme', 'transport']));
     expect(inlandTypes).not.toContain('galley');
@@ -553,7 +652,7 @@ describe('expanded buildings', () => {
   it('getAvailableBuildings filters by tech requirements', () => {
     const map = generateMap(30, 30, 'building-test');
     const city = foundCity('player', { q: 15, r: 15 }, map, mkC());
-    const available = getAvailableBuildings(city, [], map.tiles);
+    const available = getAvailableBuildings(city, [], map);
     for (const b of available) {
       expect(b.techRequired).toBeNull();
     }
@@ -760,7 +859,7 @@ describe('getAvailableBuildings — resource gate', () => {
     const map = generateMap(30, 30, 'res-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['stone-weapons'], map.tiles, undefined);
+    const available = getAvailableBuildings(city, ['stone-weapons'], map, undefined);
     // bronze-workshop requires stone-weapons + copper; no filter → should appear
     expect(available.some(b => b.id === 'bronze-workshop')).toBe(true);
   });
@@ -769,7 +868,7 @@ describe('getAvailableBuildings — resource gate', () => {
     const map = generateMap(30, 30, 'res-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['stone-weapons'], map.tiles, new Set<ResourceType>());
+    const available = getAvailableBuildings(city, ['stone-weapons'], map, new Set<ResourceType>());
     expect(available.some(b => b.id === 'bronze-workshop')).toBe(false);
   });
 
@@ -777,7 +876,7 @@ describe('getAvailableBuildings — resource gate', () => {
     const map = generateMap(30, 30, 'res-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['stone-weapons'], map.tiles, new Set<ResourceType>(['copper']));
+    const available = getAvailableBuildings(city, ['stone-weapons'], map, new Set<ResourceType>(['copper']));
     expect(available.some(b => b.id === 'bronze-workshop')).toBe(true);
   });
 
@@ -785,7 +884,7 @@ describe('getAvailableBuildings — resource gate', () => {
     const map = generateMap(30, 30, 'res-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, [], map.tiles, new Set<ResourceType>(['copper']));
+    const available = getAvailableBuildings(city, [], map, new Set<ResourceType>(['copper']));
     expect(available.some(b => b.id === 'bronze-workshop')).toBe(false);
   });
 });
@@ -907,7 +1006,7 @@ describe('S4b — new buildings', () => {
     const map = generateMap(30, 30, 'bldg-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['stone-weapons'], map.tiles, new Set<ResourceType>());
+    const available = getAvailableBuildings(city, ['stone-weapons'], map, new Set<ResourceType>());
     expect(available.some(b => b.id === 'bronze-workshop')).toBe(false);
   });
 
@@ -915,7 +1014,7 @@ describe('S4b — new buildings', () => {
     const map = generateMap(30, 30, 'bldg-test');
     const tile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
     const city = foundCity('p1', tile.coord, map, mkC());
-    const available = getAvailableBuildings(city, ['iron-forging'], map.tiles, new Set<ResourceType>(['iron']));
+    const available = getAvailableBuildings(city, ['iron-forging'], map, new Set<ResourceType>(['iron']));
     expect(available.some(b => b.id === 'iron-foundry')).toBe(true);
   });
 });

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -445,3 +445,40 @@ describe('river crossing movement cost', () => {
     expect(state.units.mover.movementPointsLeft).toBe(0);
   });
 });
+
+describe('validateUnitMove — friendly stacking', () => {
+  function stackState(unitOwner: string, occupantOwner: string): GameState {
+    const counters = mkC();
+    const unit = createUnit('warrior', unitOwner, { q: 0, r: 0 }, counters);
+    const occupant = createUnit('warrior', occupantOwner, { q: 1, r: 0 }, counters);
+    const tiles = [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+      tile({ q: 2, r: 0 }),
+    ];
+    return movementState(unit, tiles, { extraUnits: [occupant] });
+  }
+
+  it('allows moving to a hex occupied by a same-owner unit', () => {
+    const state = stackState('civ-1', 'civ-1');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('blocks moving to a hex occupied by a different-owner unit', () => {
+    const state = stackState('civ-1', 'civ-2');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(false);
+    expect((result as any).reason).toBe('occupied');
+  });
+
+  it('blocks moving to a hex occupied by a barbarian unit', () => {
+    const state = stackState('civ-1', 'barbarian');
+    const unitId = Object.values(state.units).find(u => u.position.q === 0)!.id;
+    const result = executeUnitMove(state, unitId, { q: 1, r: 0 }, { actor: 'player', civId: 'civ-1' });
+    expect(result.ok).toBe(false);
+    expect((result as any).reason).toBe('occupied');
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -1302,8 +1302,9 @@ describe('city-panel coastal unit gating', () => {
     const inlandText = (inlandPanel as unknown as { innerHTML?: string; textContent?: string }).innerHTML ?? inlandPanel.textContent ?? '';
     expect(inlandText).not.toContain('Transport');
 
-    state.map.tiles['99,99'] = {
-      coord: { q: 99, r: 99 },
+    // Place coast tile adjacent to city (q:2,r:2) so isCityCoastal sees it
+    state.map.tiles['2,1'] = {
+      coord: { q: 2, r: 1 },
       terrain: 'coast',
       elevation: 'lowland',
       resource: null,
@@ -1313,7 +1314,7 @@ describe('city-panel coastal unit gating', () => {
       hasRiver: false,
       wonder: null,
     };
-    const coastalCity = { ...city, ownedTiles: [city.position, { q: 99, r: 99 }] };
+    const coastalCity = { ...city };
     const coastalPanel = createCityPanel(container, coastalCity, state, {
       onBuild: () => {},
       onOpenWonderPanel: () => {},


### PR DESCRIPTION
## Summary

Four bugs fixed across three separate feature areas:

- **#385 — Friendly units block each other**: `validateUnitMove` was blocking ALL occupied tiles regardless of owner. Now only blocks tiles with a *hostile* occupant; same-owner units can stack freely.
- **#386 — Inland cities can build ships**: `isCityCoastal` was iterating `city.ownedTiles` (which cultural expansion pushes outward), causing inland cities to appear coastal. Fixed to check only the 6 hexes adjacent to the city position. A save migration (`migrateLegacyCoastalData`) strips coastal-gated buildings and queue items from any city that the new check deems inland.
- **#387 — Barbarians don't attack empty cities**: `processBarbarians` never received cities as targets. Adds `playerCities` optional param: when no player unit is in chase range, barbarians target the nearest player city instead — adjacent → 10 HP siege hit; farther → step toward it. Turn manager wires up HP deduction, city destruction at 0 HP, and human-player civ log notifications.
- **#374 — Unit color flickers between idle and moving**: DOM sprite overlays have the faction accent baked into SVG fills at build time; the canvas glyph path uses `colorLookup` at runtime. Added `applyFactionCivColor()` which string-replaces the baked accent with the game-assigned civ color at mount time. Pool entries now track `civColor`; a change invalidates the cached element so the next sync re-creates it in the correct color.

## Code Review Fixes (on top of implementation)

- `cityTargets` filter: `'beasts'` literal → `BEAST_OWNER` constant
- Barbarian city attack loop: guard against `hp <= 0` to avoid spurious re-destruction in legacy saves
- `barbarian:city-destroyed` notification: include city name (pre-turn `gameState` is still valid during synchronous event handling)

## Test Plan

- [ ] 3800 tests pass (`yarn test`)
- [ ] TypeScript build clean (`yarn build`)
- [ ] Friendly warrior can move onto a tile occupied by another friendly warrior
- [ ] Enemy unit still blocks movement to its tile
- [ ] A city built inland (no coast/ocean within 1 hex) cannot train Galley or build Harbor
- [ ] A city built adjacent to coast CAN train Galley
- [ ] Loading a save where an inland city had `galley` queued: queue is clean after load
- [ ] Barbarian units with no nearby player units will walk toward an empty city and eventually attack it (10 HP per turn)
- [ ] City destroyed at 0 HP produces civ log entry with city name
- [ ] DOM unit sprites show consistent color at rest and during move animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)