### PR TITLE
fix: era detection, building upkeep, spy disguise scaling, treasury P&L drawer

### DIFF
--- a/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
@@ -16,15 +16,18 @@
 Additionally, legacy saves that predate the `era` field store `state.era = undefined`. `undefined + 1 = NaN`, `NaN > undefined = false`, so `state.era` is never updated.
 
 ### Fix
-Replace the 60%-threshold logic with: **`state.era` = highest era of any tech completed by any civ.** This is intuitive (the world's technological era reflects the most advanced research done), removes the hidden threshold, and immediately corrects stale state.
+Replace the 60%-threshold logic with: **`state.era` = highest era of any `countsForEraAdvancement !== false` tech completed by any civ.** Era 5 techs are all marked `countsForEraAdvancement: false` and must remain excluded — advancing to era 5 would produce `ERA_UNIT_MAP[5] ?? 'warrior'` regressions in minor civ upgrades. Restricting to `countsForEraAdvancement !== false` techs (same flag used by the old threshold check) naturally caps at era 4.
 
 ```typescript
-// minor-civ-system.ts
+// minor-civ-system.ts — add TECH_TREE to existing import from './tech-definitions'
+// Change: import { hasReachedEraThreshold } from './tech-definitions';
+// To:     import { hasReachedEraThreshold, TECH_TREE } from './tech-definitions';
+
 export function checkEraAdvancement(state: GameState): number {
   let maxEra = state.era ?? 1;
   for (const civ of Object.values(state.civilizations)) {
     for (const techId of civ.techState.completed) {
-      const tech = TECH_TREE.find(t => t.id === techId);
+      const tech = TECH_TREE.find(t => t.id === techId && t.countsForEraAdvancement !== false);
       if (tech && tech.era > maxEra) maxEra = tech.era;
     }
   }
@@ -32,12 +35,16 @@ export function checkEraAdvancement(state: GameState): number {
 }
 ```
 
-Also add `era ?? 1` normalization to `normalizeLoadedState` in `save-manager.ts` to fix any existing stuck saves on load.
+Also add `era ?? 1` normalization to `normalizeLoadedState` in `save-manager.ts` to fix any existing stuck saves on load. Place it inside the spread that already normalizes other defaults on the state object.
+
+**Note on multi-era jump for stuck saves:** When a legacy save loads with `state.era = undefined` and the player already has era 4 techs, the era jumps directly to 4 on the first turn-end. `processMinorCivEraUpgrade` is only called with the final era level, so minor civs get era 4 upgrades only (skipping eras 2 and 3). This is acceptable — the alternative of replaying intermediate upgrades would over-power minor civs in an old save.
 
 ### Test contract
-- A state with `state.era = 1` and one civ having an era 4 tech → `checkEraAdvancement` returns 4.
-- A state with `state.era = undefined` and era 2 techs → returns 2 (not NaN/undefined).
-- No techs completed → returns 1.
+- State with `state.era = 1`, one civ having `musketeer` (era 4, `countsForEraAdvancement` not false) → returns 4.
+- State with `state.era = undefined`, one civ having an era 2 tech → returns 2.
+- State with `state.era = 3`, one civ having an era 5 tech (`global-logistics`, `countsForEraAdvancement: false`) → returns 3 (era 5 excluded).
+- No advancement-eligible techs completed → returns 1.
+- `normalizeLoadedState` on a save with no `era` field → resulting state has `era: 1`.
 
 ---
 
@@ -62,23 +69,27 @@ function getFreeBuildingSlots(city: City): number {
 }
 ```
 
-**Resulting free slots by city size:**
+**Resulting free slots by city size** (illustrative — actual slots depend on realized population at each maturity level):
 
-| Maturity | Pop | Free paid slots | First paid building costs |
-|----------|-----|-----------------|--------------------------|
-| Outpost  | 1   | 0               | 1–2 gold/turn immediately |
-| Village  | 3   | 1               | 1 building covered        |
-| Town     | 5   | 3               | 3 buildings covered       |
-| City     | 7   | 5               | 5 buildings covered       |
-| Metropolis | 10 | 8             | 8 buildings covered       |
+| Maturity | Example Pop | Free paid slots | Typical feel |
+|----------|-------------|-----------------|--------------|
+| Outpost  | 1           | 0               | First paid building costs immediately |
+| Village  | 2           | 1               | One slot of grace |
+| Town     | 4           | 3               | Most early-game paid buildings covered |
+| City     | 6           | 5               | Substantial relief for large cities |
+| Metropolis | 9         | 7               | High-pop capitals earn broad coverage |
 
 Early players feel the first forge/harbor immediately. Large empires with high-population cities earn natural relief. The `coreFreeBuildings` set (city-center, barracks, granary, library, workshop, shrine, herbalist) remains permanently exempt — basic infrastructure never costs gold.
 
+The city panel already reads upkeep from `calculateCityBuildingMaintenance` and displays `'Upkeep: -X gold/turn'` vs `'Free support'` based on whether `upkeep > 0`. No UI code changes are needed — the display fixes itself once the formula changes.
+
 ### Test contract
 - Outpost city with pop 1: `getFreeBuildingSlots` returns 0.
+- Village with pop 2: returns `1 + 0 = 1`.
 - Town with pop 4: returns `2 + 1 = 3`.
 - Metropolis with pop 10: returns `5 + 3 = 8`.
-- `calculateCityBuildingMaintenance` for a city with forge (2/turn) and 0 free slots → `upkeep = 2`.
+- `calculateCityBuildingMaintenance` for an outpost city (pop 1) with a forge (advanced, 2/turn) and 0 free slots → `upkeep = 2`, `paidBuildings` has 1 entry with `upkeep: 2`.
+- Regression: same city with granary (coreFreeBuildings member) added → granary in `exemptBuildings`, upkeep unchanged at 2.
 
 ---
 
@@ -90,11 +101,16 @@ Read-only verification that unit upkeep is correctly deducted each turn (via `ap
 ### UI fix
 The selected-unit info panel currently shows no upkeep line for units. Add a one-line upkeep display below the unit description matching the building row format:
 
-- Free units (settler, worker, scout): show nothing (same as coreFreeBuildings)
-- Free via free-support slot: `Free support`
-- Paid: `Upkeep: -1 gold/turn` or `Upkeep: -2 gold/turn` (advanced)
+- Units in `freeUnitTypes` (settler, worker, scout): show nothing — these are categorically free and the label would just add noise.
+- Units covered by a free slot (exempt defender, or within free general slots): `Free support`
+- Paid units: `Upkeep: -1 gold/turn` or `Upkeep: -2 gold/turn` (advanced unit types)
 
-This is display-only — call `calculateCivUnitMaintenance` and look up the unit's row.
+Implementation: call `calculateCivUnitMaintenance(state, unit.owner)` and look up `unit.id` across `exemptUnits`, `freeUnits`, and `paidUnits` arrays to determine the label. `freeUnitTypes` members appear in `exemptUnits` (reason: 'exempt'); show nothing for those. All others in non-`paidUnits` lists show "Free support". `paidUnits` members show the upkeep amount.
+
+### Test contract (unit upkeep display)
+- `spy_scout` unit owned by a civ with 0 free unit slots (enough paid units to exhaust them) → upkeep line shows "Upkeep: -2 gold/turn".
+- `settler` unit → no upkeep line rendered in the panel.
+- `warrior` unit within free defender slots → "Free support" line rendered.
 
 ---
 
@@ -113,11 +129,13 @@ Replace tech-gating with spy **unit type** gating. Since training a higher spy t
 | `spy_agent` | + As Scout, As Archer |
 | `spy_operative`, `spy_hacker` | + As Worker |
 
+The local `DisguiseOption` type definition in `selected-unit-info.ts` changes from `{ label, value, tech?: string }` to `{ label, value, minTier?: number }` — remove the `tech` field, add `minTier`.
+
 ```typescript
 const SPY_DISGUISE_TIERS: Partial<Record<UnitType, number>> = {
   spy_scout: 0, spy_informant: 1, spy_agent: 2, spy_operative: 3, spy_hacker: 3,
 };
-const spyTier = SPY_DISGUISE_TIERS[unit.type as UnitType] ?? 0;
+const spyTier = SPY_DISGUISE_TIERS[unit.type] ?? 0;  // unit.type is already UnitType — no cast needed
 
 const allDisguises: DisguiseOption[] = [
   { label: 'No Disguise', value: null },
@@ -128,14 +146,18 @@ const allDisguises: DisguiseOption[] = [
   { label: 'As Worker',    value: 'worker',    minTier: 3 },
 ];
 const disguiseOptions = allDisguises.filter(opt => !opt.minTier || spyTier >= opt.minTier);
-// Show section only when disguiseOptions.length > 1 (spy_scout: hidden entirely)
+// Show section only when disguiseOptions.length > 1 (spy_scout tier=0: only 'No Disguise' → length=1 → hidden)
 ```
 
+**Data migration:** A `spy_scout` may have `disguiseAs` set from before this fix. The disguise section is hidden in the UI, but the disguise remains active silently. Add to the save-migration chain: for each spy record where the unit type is `spy_scout`, set `disguiseAs: null`. This prevents the unit from operating disguised with no UI affordance to clear it.
+
 ### Test contract
-- `spy_scout` → no disguise buttons rendered.
-- `spy_informant` → barbarian + warrior buttons.
-- `spy_agent` → barbarian + warrior + scout + archer.
-- `spy_operative` → all 5 options.
+- `spy_scout` → disguise section not rendered at all (length check is 1, not > 1).
+- `spy_informant` → barbarian + warrior buttons rendered (2 disguise options + "No Disguise" = 3 total).
+- `spy_agent` → 4 options + "No Disguise" = 5 total rendered.
+- `spy_operative` → all 5 disguise options + "No Disguise" = 6 total rendered.
+- `spy_hacker` → same as `spy_operative` (tier 3 = same options).
+- Migration: `spy_scout` with `disguiseAs: 'barbarian'` in a loaded save → after `normalizeLoadedState`, `disguiseAs` is `null`.
 
 ---
 
@@ -170,13 +192,19 @@ The gold chip becomes a **tap-to-toggle** button (min-height 44px). Tapping open
       ↑ drawer (left 66%, below HUD, z-index 25)
 ```
 
-- **Drawer position**: `position:absolute; top:44px; left:0; width:66%; background:rgba(0,0,0,0.85); border-radius:0 0 8px 0; padding:8px 12px; z-index:25`
+- **Drawer position**: `position:absolute; top:44px; left:0; width:66%; background:rgba(0,0,0,0.85); border-radius:0 0 8px 0; padding:8px 12px; z-index:25; pointer-events:auto`  
+  The `pointer-events:auto` is required: without it, taps on the drawer propagate to the canvas beneath, which would close the drawer immediately via the canvas `pointerdown` handler.
 - **Row height**: each row `min-height:36px; display:flex; align-items:center; justify-content:space-between; font-size:13px`
-- **Net row color**: green (`#4ade80`) when ≥0, yellow (`#facc15`) when strain='low'/'high', red (`#f87171`) when strain='critical'
-- **Close button** (×): top-right of drawer, `min-height:44px; min-width:44px` touch target — satisfies the 44px rule
-- **Canvas close**: `main.ts` adds a `pointerdown` listener on `#game-canvas` that calls `drawer.close()` when the drawer is open. This fires before tile-selection logic so the drawer dismisses cleanly without also selecting the tile under the finger.
-- **Panel close**: `drawer.close()` is called by `main.ts` whenever any other panel opens (city, espionage, etc.)
-- No "link to city panel" from the drawer — keeps the drawer simple and prevents accidental navigation on touch
+- **Net row color**: driven by `strainLevel` (authoritative), not by net sign. `strainLevel` can be non-'none' even when net > 0 if the treasury balance is very low. Mapping:
+  - `'none'` → green (`#4ade80`)
+  - `'low'` → yellow (`#facc15`)
+  - `'high'` → yellow (`#facc15`)
+  - `'critical'` → red (`#f87171`)
+- **Close button** (×): top-right of drawer, `min-height:44px; min-width:44px; background:rgba(255,255,255,0.1); color:#e0d6c8` — must include `background` and `color` per the no-bare-buttons rule (hook enforces this on all buttons in `src/ui/`).
+- **Gold chip button** (in `main.ts` replacing `goldSpan`): must also include `background` and `color` in its inline `style.cssText` to pass the hook. Use `background:transparent; color:inherit` to match the existing HUD text style. Also remove the old `goldSpan.title = formatMaintenanceTooltip(...)` line — the drawer is now the sole breakdown surface.
+- **Canvas close**: `main.ts` adds a `pointerdown` listener on `#game-canvas` that calls `if (drawer.isOpen()) drawer.close()`. The listener fires first (registered before tile-selection) so the drawer dismisses without selecting the tile beneath.
+- **Panel close**: `drawer.close()` called by `main.ts` at every panel-open call-site (city, espionage, tech, diplomacy, etc.)
+- No "link to city panel" from the drawer — prevents accidental navigation on touch
 
 ### Implementation
 
@@ -192,16 +220,20 @@ export function createTreasuryDrawer(): {
 ```
 
 In `main.ts`:
-1. The existing plain `goldSpan` is replaced by a `<button>` (styled inline, not via `createGameButton` — the HUD chip has its own compact style) that calls `drawer.toggle()`.
-2. `drawer.element` is appended to `game-shell` immediately after `#hud`.
-3. A `pointerdown` handler on `#game-canvas` calls `drawer.close()` when `drawer.isOpen()`.
-4. Every panel-open call-site (city, espionage, tech, etc.) calls `drawer.close()` before opening.
+1. `createTreasuryDrawer()` is called **before** the first `updateHUD()` call, and the drawer element is appended to the game-shell. This ordering matters — `updateHUD()` calls `drawer.update()` on every invocation.
+2. The existing `goldSpan` (plain `<span>`) is replaced by a `<button>` with inline `style.cssText` that includes `background:transparent; color:inherit; border:none; font-size:inherit; padding:0; cursor:pointer; min-height:44px`. Calls `drawer.toggle()` on click.
+3. The old `goldSpan.title = formatMaintenanceTooltip(economyStatus)` line is **deleted** — the drawer is the sole breakdown surface.
+4. A `pointerdown` handler is registered on `#game-canvas` after the canvas is in the DOM: `canvas.addEventListener('pointerdown', () => { if (drawer.isOpen()) drawer.close(); })`. Must be registered **before** the existing tile-selection `pointerdown` handler so it fires first.
+5. Every panel-open call-site (city, espionage, tech, diplomacy, beast, wonder, etc.) calls `drawer.close()` as the first line.
 
-The `updateHUD()` function calls `drawer.update(economyStatus, civ.gold)` so the drawer content stays current without requiring a separate refresh cycle.
+The `updateHUD()` function calls `drawer.update(economyStatus, civ.gold)` so the drawer content stays current without requiring a separate refresh cycle. `update()` must be safe to call while the drawer is hidden — it simply pre-populates the DOM so the content is ready on first open.
 
 ### Test contract
-- `createTreasuryDrawer().update(economy, gold)` with known values → drawer element contains correct revenue/maintenance/net text nodes.
-- `toggle()` → `element.style.display` toggles between `'block'` and `'none'`; `isOpen()` reflects state.
-- Strain level `'critical'` → net value element has red color in `style.color`.
-- Strain level `'none'` with positive net → net value element has green color.
+- `createTreasuryDrawer()` → `element.style.display` starts as `'none'`; `isOpen()` is false.
+- `update(economy, gold)` with known values (grossGoldIncome=32, buildingMaintenance=8, unitMaintenance=12, netGoldPerTurn=12, strainLevel='none') → drawer element text includes "32", "8", "12", "+12".
+- `toggle()` once → `isOpen()` true; `toggle()` again → `isOpen()` false.
+- `strainLevel: 'critical'` → net value element `style.color` is `#f87171`.
+- `strainLevel: 'high'` → net value element `style.color` is `#facc15`.
+- `strainLevel: 'none'` → net value element `style.color` is `#4ade80`.
 - `close()` when already closed → no error, `isOpen()` returns false.
+- Regression: opening the city panel while the drawer is open → drawer `isOpen()` becomes false.

--- a/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
@@ -1,0 +1,182 @@
+# Economy, Era Detection & Espionage Fixes Design
+
+**Issues addressed:** #375 (era detection, building upkeep), #376 (disguise scaling)
+
+**Goal:** Fix era advancement stalling, make building upkeep create real economic pressure, scale spy disguises by tier, and surface a civ-wide revenue/P&L view in the HUD.
+
+**Architecture:** All fixes touch existing systems only — no new files needed except `src/ui/treasury-drawer.ts` for the HUD expansion. The economy rebalance changes `getFreeBuildingSlots` in `economy-system.ts`. Era fix changes `checkEraAdvancement` in `minor-civ-system.ts`. Disguise fix changes `selected-unit-info.ts`. Unit upkeep audit is read-only verification + display polish.
+
+---
+
+## 1. Era Detection Fix (`minor-civ-system.ts`)
+
+### Root Cause
+`checkEraAdvancement` requires ≥60% of each era's techs to advance, checked one era per turn. A player who follows the prerequisite chain to reach era 4 techs may have only completed 5–8 era 2 techs (well below the 18-of-30 threshold), leaving `state.era` permanently stuck at 1.
+
+Additionally, legacy saves that predate the `era` field store `state.era = undefined`. `undefined + 1 = NaN`, `NaN > undefined = false`, so `state.era` is never updated.
+
+### Fix
+Replace the 60%-threshold logic with: **`state.era` = highest era of any tech completed by any civ.** This is intuitive (the world's technological era reflects the most advanced research done), removes the hidden threshold, and immediately corrects stale state.
+
+```typescript
+// minor-civ-system.ts
+export function checkEraAdvancement(state: GameState): number {
+  let maxEra = state.era ?? 1;
+  for (const civ of Object.values(state.civilizations)) {
+    for (const techId of civ.techState.completed) {
+      const tech = TECH_TREE.find(t => t.id === techId);
+      if (tech && tech.era > maxEra) maxEra = tech.era;
+    }
+  }
+  return maxEra;
+}
+```
+
+Also add `era ?? 1` normalization to `normalizeLoadedState` in `save-manager.ts` to fix any existing stuck saves on load.
+
+### Test contract
+- A state with `state.era = 1` and one civ having an era 4 tech → `checkEraAdvancement` returns 4.
+- A state with `state.era = undefined` and era 2 techs → returns 2 (not NaN/undefined).
+- No techs completed → returns 1.
+
+---
+
+## 2. Building Upkeep Rebalance (`economy-system.ts`)
+
+### Root Cause
+`getFreeBuildingSlots` returns `4 + floor(population/2) + maturityBonus`. Even a starting outpost (pop 1) gets 4 free paid-building slots. Combined with the 7 buildings already exempt via `coreFreeBuildings`, all buildings a player typically owns fit inside the free budget — making upkeep invisible.
+
+### Fix
+Remove the base 4 and reduce maturity bonuses so early cities pay immediately and larger cities earn meaningful relief:
+
+```typescript
+function getFreeBuildingSlots(city: City): number {
+  const maturityBonusByLevel: Record<City['maturity'], number> = {
+    outpost:    0,
+    village:    0,
+    town:       1,
+    city:       2,
+    metropolis: 3,
+  };
+  return Math.floor(city.population / 2) + maturityBonusByLevel[city.maturity];
+}
+```
+
+**Resulting free slots by city size:**
+
+| Maturity | Pop | Free paid slots | First paid building costs |
+|----------|-----|-----------------|--------------------------|
+| Outpost  | 1   | 0               | 1–2 gold/turn immediately |
+| Village  | 3   | 1               | 1 building covered        |
+| Town     | 5   | 3               | 3 buildings covered       |
+| City     | 7   | 5               | 5 buildings covered       |
+| Metropolis | 10 | 8             | 8 buildings covered       |
+
+Early players feel the first forge/harbor immediately. Large empires with high-population cities earn natural relief. The `coreFreeBuildings` set (city-center, barracks, granary, library, workshop, shrine, herbalist) remains permanently exempt — basic infrastructure never costs gold.
+
+### Test contract
+- Outpost city with pop 1: `getFreeBuildingSlots` returns 0.
+- Town with pop 4: returns `2 + 1 = 3`.
+- Metropolis with pop 10: returns `5 + 3 = 8`.
+- `calculateCityBuildingMaintenance` for a city with forge (2/turn) and 0 free slots → `upkeep = 2`.
+
+---
+
+## 3. Unit Upkeep Audit
+
+### Approach
+Read-only verification that unit upkeep is correctly deducted each turn (via `applyEconomyTurn` in `turn-manager.ts`). No number changes — the current formula (`2 + cities×2 + floor(totalPop/3)` free general slots, plus 2 free defenders per city) is appropriate and the user confirmed units feel fine.
+
+### UI fix
+The selected-unit info panel currently shows no upkeep line for units. Add a one-line upkeep display below the unit description matching the building row format:
+
+- Free units (settler, worker, scout): show nothing (same as coreFreeBuildings)
+- Free via free-support slot: `Free support`
+- Paid: `Upkeep: -1 gold/turn` or `Upkeep: -2 gold/turn` (advanced)
+
+This is display-only — call `calculateCivUnitMaintenance` and look up the unit's row.
+
+---
+
+## 4. Disguise Scaling by Spy Tier (`selected-unit-info.ts`)
+
+### Root Cause
+Disguise options are gated by civ tech IDs. Higher disguises require `spy-networks`, which requires both `espionage-informants` AND `disguise` — the `disguise` tech is a separate era-2 branch (`lookouts` → `disguise`) that is easy to miss. Players who research the main espionage prerequisite chain never see advanced disguise options even with era 4 tech.
+
+### Fix
+Replace tech-gating with spy **unit type** gating. Since training a higher spy tier already requires the corresponding tech (you need `espionage-informants` to train `spy_informant`, etc.), the gate is already implicit:
+
+| Spy type | Disguise options |
+|----------|-----------------|
+| `spy_scout` | None (section hidden) |
+| `spy_informant` | As Barbarian, As Warrior |
+| `spy_agent` | + As Scout, As Archer |
+| `spy_operative`, `spy_hacker` | + As Worker |
+
+```typescript
+const SPY_DISGUISE_TIERS: Partial<Record<UnitType, number>> = {
+  spy_scout: 0, spy_informant: 1, spy_agent: 2, spy_operative: 3, spy_hacker: 3,
+};
+const spyTier = SPY_DISGUISE_TIERS[unit.type as UnitType] ?? 0;
+
+const allDisguises: DisguiseOption[] = [
+  { label: 'No Disguise', value: null },
+  { label: 'As Barbarian', value: 'barbarian', minTier: 1 },
+  { label: 'As Warrior',   value: 'warrior',   minTier: 1 },
+  { label: 'As Scout',     value: 'scout',     minTier: 2 },
+  { label: 'As Archer',    value: 'archer',    minTier: 2 },
+  { label: 'As Worker',    value: 'worker',    minTier: 3 },
+];
+const disguiseOptions = allDisguises.filter(opt => !opt.minTier || spyTier >= opt.minTier);
+// Show section only when disguiseOptions.length > 1 (spy_scout: hidden entirely)
+```
+
+### Test contract
+- `spy_scout` → no disguise buttons rendered.
+- `spy_informant` → barbarian + warrior buttons.
+- `spy_agent` → barbarian + warrior + scout + archer.
+- `spy_operative` → all 5 options.
+
+---
+
+## 5. HUD Treasury Drawer (`src/ui/treasury-drawer.ts`)
+
+### Design
+The gold chip in the HUD (`💰 {gold} (+{net} net)`) becomes a **tap-to-toggle** button. Tapping it opens a drawer row below the main HUD yields row. Tapping again collapses it.
+
+### Drawer layout
+```
+┌─────────────────────────────────────────────────┐
+│  💰 450 (+12 net)                    [tap to close]
+├─────────────────────────────────────────────────┤
+│  Revenue      +32/turn   (gold from all cities)  │
+│  Buildings     -8/turn   (6 paid × avg 1.3/turn) │
+│  Units        -12/turn   (4 paid units)           │
+│  Net          +12/turn                            │
+│  Treasury     450 gold                            │
+│  Strain       None                                │
+└─────────────────────────────────────────────────┘
+```
+
+- Strain states color the "Net" row: green (none), yellow (low/high), red (critical).
+- "Buildings" row links to city panel (tap opens city panel for current city).
+- "Units" row is informational only.
+- Drawer closes automatically when the city panel or any other panel opens.
+
+### Implementation
+New file `src/ui/treasury-drawer.ts` exports:
+```typescript
+export function createTreasuryDrawer(): {
+  element: HTMLElement;
+  update(economy: EconomyProjection, currentGold: number): void;
+  toggle(): void;
+  close(): void;
+}
+```
+
+The existing `goldSpan` in `main.ts` is replaced by a `createGameButton` call (`'ghost'` variant styled as a chip) that calls `drawer.toggle()`. The drawer element is inserted immediately after the HUD yields row.
+
+### Test contract
+- `createTreasuryDrawer().update(economy, gold)` with known values → drawer element contains correct revenue/maintenance/net text.
+- Toggle hides/shows the drawer.
+- Strain level 'critical' → net row has red color in cssText.

--- a/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-16-economy-era-espionage-fixes-design.md
@@ -141,42 +141,67 @@ const disguiseOptions = allDisguises.filter(opt => !opt.minTier || spyTier >= op
 
 ## 5. HUD Treasury Drawer (`src/ui/treasury-drawer.ts`)
 
+### Mobile-first layout constraints
+
+The game targets tablet/phone as primary input. Key constraints from the current shell layout:
+
+- `#hud` is `position:absolute; top:0; left:0; right:0; z-index:10`. Height is approximately 44px (two lines of content at 13px + 8px padding).
+- Floating action buttons (`📜 🗺️ ✦ ☰ ⏩`) are at `position:absolute; top:44px; right:X`. Any drawer must co-exist with them.
+- Notifications sit at `top:40px; z-index:20`. Drawer needs `z-index:25` to overlay them while open.
+- The game canvas handles `pointerdown` for tile selection — a canvas tap must close the drawer.
+- No hover/title tooltip available on touch. The existing `goldSpan.title` only works on desktop; the drawer fully replaces it.
+- Touch targets must be `min-height:44px` per project rules.
+- Safe-area: viewport uses `viewport-fit=cover` and `black-translucent` status bar. The HUD top of 0 already accounts for this via the OS — no additional offset needed in the drawer.
+
 ### Design
-The gold chip in the HUD (`💰 {gold} (+{net} net)`) becomes a **tap-to-toggle** button. Tapping it opens a drawer row below the main HUD yields row. Tapping again collapses it.
 
-### Drawer layout
+The gold chip becomes a **tap-to-toggle** button (min-height 44px). Tapping opens an overlay drawer anchored to the top of the screen at the HUD bottom edge (`top:44px`). The drawer spans the **left two-thirds** of the screen, leaving the right third free for the floating buttons. Tapping outside the drawer (canvas or any other area) closes it.
+
 ```
-┌─────────────────────────────────────────────────┐
-│  💰 450 (+12 net)                    [tap to close]
-├─────────────────────────────────────────────────┤
-│  Revenue      +32/turn   (gold from all cities)  │
-│  Buildings     -8/turn   (6 paid × avg 1.3/turn) │
-│  Units        -12/turn   (4 paid units)           │
-│  Net          +12/turn                            │
-│  Treasury     450 gold                            │
-│  Strain       None                                │
-└─────────────────────────────────────────────────┘
+┌──────────────────────────────────┐  [📜][🗺️][✦][☰]
+│ 💰 450 (+12 net)  [×]            │   ← HUD bar
+├──────────────────────────────────┤
+│ Revenue       +32/turn           │
+│ Buildings      -8/turn           │
+│ Units         -12/turn           │
+│ Net           +12/turn ████████  │  ← colored bar
+│ Treasury      450 gold           │
+└──────────────────────────────────┘
+      ↑ drawer (left 66%, below HUD, z-index 25)
 ```
 
-- Strain states color the "Net" row: green (none), yellow (low/high), red (critical).
-- "Buildings" row links to city panel (tap opens city panel for current city).
-- "Units" row is informational only.
-- Drawer closes automatically when the city panel or any other panel opens.
+- **Drawer position**: `position:absolute; top:44px; left:0; width:66%; background:rgba(0,0,0,0.85); border-radius:0 0 8px 0; padding:8px 12px; z-index:25`
+- **Row height**: each row `min-height:36px; display:flex; align-items:center; justify-content:space-between; font-size:13px`
+- **Net row color**: green (`#4ade80`) when ≥0, yellow (`#facc15`) when strain='low'/'high', red (`#f87171`) when strain='critical'
+- **Close button** (×): top-right of drawer, `min-height:44px; min-width:44px` touch target — satisfies the 44px rule
+- **Canvas close**: `main.ts` adds a `pointerdown` listener on `#game-canvas` that calls `drawer.close()` when the drawer is open. This fires before tile-selection logic so the drawer dismisses cleanly without also selecting the tile under the finger.
+- **Panel close**: `drawer.close()` is called by `main.ts` whenever any other panel opens (city, espionage, etc.)
+- No "link to city panel" from the drawer — keeps the drawer simple and prevents accidental navigation on touch
 
 ### Implementation
+
 New file `src/ui/treasury-drawer.ts` exports:
 ```typescript
 export function createTreasuryDrawer(): {
-  element: HTMLElement;
+  element: HTMLElement;                               // insert into game-shell
+  isOpen: () => boolean;
   update(economy: EconomyProjection, currentGold: number): void;
   toggle(): void;
   close(): void;
 }
 ```
 
-The existing `goldSpan` in `main.ts` is replaced by a `createGameButton` call (`'ghost'` variant styled as a chip) that calls `drawer.toggle()`. The drawer element is inserted immediately after the HUD yields row.
+In `main.ts`:
+1. The existing plain `goldSpan` is replaced by a `<button>` (styled inline, not via `createGameButton` — the HUD chip has its own compact style) that calls `drawer.toggle()`.
+2. `drawer.element` is appended to `game-shell` immediately after `#hud`.
+3. A `pointerdown` handler on `#game-canvas` calls `drawer.close()` when `drawer.isOpen()`.
+4. Every panel-open call-site (city, espionage, tech, etc.) calls `drawer.close()` before opening.
+
+The `updateHUD()` function calls `drawer.update(economyStatus, civ.gold)` so the drawer content stays current without requiring a separate refresh cycle.
 
 ### Test contract
-- `createTreasuryDrawer().update(economy, gold)` with known values → drawer element contains correct revenue/maintenance/net text.
-- Toggle hides/shows the drawer.
-- Strain level 'critical' → net row has red color in cssText.
+- `createTreasuryDrawer().update(economy, gold)` with known values → drawer element contains correct revenue/maintenance/net text nodes.
+- `toggle()` → `element.style.display` toggles between `'block'` and `'none'`; `isOpen()` reflects state.
+- Strain level `'critical'` → net value element has red color in `style.color`.
+- Strain level `'none'` with positive net → net value element has green color.
+- `close()` when already closed → no error, `isOpen()` returns false.

--- a/src/main.ts
+++ b/src/main.ts
@@ -182,7 +182,8 @@ import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel'
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
-import { calculateCivEconomy, formatGoldHudText, formatMaintenanceTooltip, rushBuyActiveProduction } from '@/systems/economy-system';
+import { calculateCivEconomy, formatGoldHudText, rushBuyActiveProduction } from '@/systems/economy-system';
+import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
 import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
 import { fireResourceDiscoveredTip } from '@/ui/advisor-system';
 import { createWonderDiscoveryRevealQueue } from '@/ui/wonder-discovery-queue';
@@ -197,6 +198,7 @@ import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
 
 // --- App State ---
 let gameState: GameState;
+let drawer: TreasuryDrawer;
 let selectedUnitId: string | null = null;
 let movementRange: HexCoord[] = [];
 let attackRange: HexCoord[] = [];
@@ -433,6 +435,7 @@ function maybeShowPendingHoardChoice(): void {
 }
 
 function openWonderAtlas(initialWonderId?: string): void {
+  drawer?.close();
   audio.stopNaturalWonderAmbient('codex-page-hidden');
   createWonderAtlasPanel(uiLayer, gameState, {
     initialWonderId,
@@ -492,10 +495,13 @@ function updateHUD(): void {
   prodSpan.textContent = `⚒️ ${totalProd}`;
   yieldsRow.appendChild(prodSpan);
 
-  const goldSpan = document.createElement('span');
-  goldSpan.textContent = `💰 ${formatGoldHudText(economyStatus, civ.gold)}`;
-  goldSpan.title = formatMaintenanceTooltip(economyStatus);
-  yieldsRow.appendChild(goldSpan);
+  const goldBtn = document.createElement('button');
+  goldBtn.style.cssText =
+    'background:transparent;color:inherit;border:none;font-size:inherit;padding:0;cursor:pointer;min-height:44px;';
+  goldBtn.textContent = `💰 ${formatGoldHudText(economyStatus, civ.gold)}`;
+  goldBtn.addEventListener('click', () => drawer?.toggle());
+  yieldsRow.appendChild(goldBtn);
+  drawer?.update(economyStatus, civ.gold);
 
   const sciSpan = document.createElement('span');
   sciSpan.textContent = `🔬 ${techName !== 'None' ? techName : 'None'} (+${totalScience})`;
@@ -748,6 +754,7 @@ function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
 }
 
 function openDiplomacyPanel(): void {
+  drawer?.close();
   document.getElementById('diplomacy-panel')?.remove();
   createDiplomacyPanel(uiLayer, gameState, {
     onAction: handleDiplomaticAction,
@@ -761,6 +768,7 @@ function openDiplomacyPanel(): void {
 }
 
 function openMarketplacePanel(): void {
+  drawer?.close();
   document.getElementById('marketplace-panel')?.remove();
   createMarketplacePanel(uiLayer, gameState, {
     onClose: () => {},
@@ -833,6 +841,7 @@ function openWonderPanelForCityId(selectedCityId: string): void {
 }
 
 function openCityPanelForCity(city: import('@/core/types').City): void {
+  drawer?.close();
   if (city.owner !== gameState.currentPlayer) return;
   const playerCities = currentCiv().cities;
   const idx = playerCities.indexOf(city.id);
@@ -1056,6 +1065,7 @@ function showRequiredChoicesIfNeeded(): boolean {
 }
 
 function togglePanel(panel: string): void {
+  drawer?.close();
   // Remove any existing panel
   document.getElementById('tech-panel')?.remove();
   document.getElementById('city-panel')?.remove();
@@ -3878,6 +3888,12 @@ function showGameModeSelection(): void {
 }
 
 function startGame(): void {
+  // Initialize treasury drawer once
+  if (!drawer) {
+    drawer = createTreasuryDrawer();
+    (document.getElementById('game-shell') ?? document.body).appendChild(drawer.element);
+  }
+
   // Warm sprite cache non-blocking — renderers fall back to emoji while loading
   const civColors: Record<string, string> = {};
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {
@@ -3901,6 +3917,8 @@ function startGame(): void {
 
   // Input (only set up once)
   if (!inputInitialized) {
+    canvas.addEventListener('pointerdown', () => { if (drawer?.isOpen()) drawer.close(); });
+
     const callbacks: InputCallbacks = {
       onHexTap: handleHexTap,
       onHexLongPress: handleHexLongPress,

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -290,6 +290,7 @@ function normalizeLoadedState(state: GameState): GameState {
   }).state;
   const normalized = normalizeCityWorkClaims(territoryNormalized).state;
   normalized.pendingDiplomacyRequests ??= [];
+  normalized.era ??= 1;
   return normalized;
 }
 

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -294,8 +294,8 @@ function normalizeLoadedState(state: GameState): GameState {
   // Clear stale disguise on spy_scouts — they have no tier-1+ options
   if (normalized.espionage) {
     for (const espState of Object.values(normalized.espionage)) {
-      for (const spyRecord of Object.values(espState.spies)) {
-        const unit = normalized.units[spyRecord.unitId];
+      for (const [unitId, spyRecord] of Object.entries(espState.spies)) {
+        const unit = normalized.units[unitId];
         if (unit?.type === 'spy_scout' && spyRecord.disguiseAs != null) {
           spyRecord.disguiseAs = null;
         }

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -291,6 +291,17 @@ function normalizeLoadedState(state: GameState): GameState {
   const normalized = normalizeCityWorkClaims(territoryNormalized).state;
   normalized.pendingDiplomacyRequests ??= [];
   normalized.era ??= 1;
+  // Clear stale disguise on spy_scouts — they have no tier-1+ options
+  if (normalized.espionage) {
+    for (const espState of Object.values(normalized.espionage)) {
+      for (const spyRecord of Object.values(espState.spies)) {
+        const unit = normalized.units[spyRecord.unitId];
+        if (unit?.type === 'spy_scout' && spyRecord.disguiseAs != null) {
+          spyRecord.disguiseAs = null;
+        }
+      }
+    }
+  }
   return normalized;
 }
 

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -369,8 +369,8 @@ export function calculateCivUnitMaintenance(state: GameState, civId: string): Ci
     };
   }
 
-  const cities = civ.cities.map(cityId => state.cities[cityId]).filter((city): city is City => Boolean(city));
-  const units = civ.units.map(unitId => state.units[unitId]).filter((unit): unit is Unit => Boolean(unit));
+  const cities = (civ.cities ?? []).map(cityId => state.cities[cityId]).filter((city): city is City => Boolean(city));
+  const units = (civ.units ?? []).map(unitId => state.units[unitId]).filter((unit): unit is Unit => Boolean(unit));
   const exemptUnitIds = new Set<string>();
   const exemptUnits: MaintenanceRow[] = [];
 

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -200,13 +200,13 @@ function getUnitLabel(unit: Unit): string {
 
 function getFreeBuildingSlots(city: City): number {
   const maturityBonusByLevel: Record<City['maturity'], number> = {
-    outpost: 0,
-    village: 1,
-    town: 2,
-    city: 3,
-    metropolis: 4,
+    outpost:    0,
+    village:    0,
+    town:       1,
+    city:       2,
+    metropolis: 3,
   };
-  return 4 + Math.floor(city.population / 2) + maturityBonusByLevel[city.maturity];
+  return Math.floor(city.population / 2) + maturityBonusByLevel[city.maturity];
 }
 
 function getFreeGeneralUnitSlots(cities: City[]): number {

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -1,7 +1,7 @@
 import type { GameState, MinorCivArchetype, MinorCivState, HexCoord, City, Unit, UnitType } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
-import { hasReachedEraThreshold } from './tech-definitions';
+import { hasReachedEraThreshold, TECH_TREE } from './tech-definitions';
 import { createDiplomacyState, modifyRelationship } from './diplomacy-system';
 import { applyResearchBonus } from './tech-system';
 import { hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
@@ -538,12 +538,14 @@ const ERA_UNIT_MAP: Record<number, UnitType> = {
 };
 
 export function checkEraAdvancement(state: GameState): number {
-  const nextEra = state.era + 1;
-  const anyAdvanced = Object.values(state.civilizations).some(
-    civ => hasReachedEraThreshold(civ.techState.completed, nextEra),
-  );
-
-  return anyAdvanced ? nextEra : state.era;
+  let maxEra = state.era ?? 1;
+  for (const civ of Object.values(state.civilizations)) {
+    for (const techId of civ.techState.completed) {
+      const tech = TECH_TREE.find(t => t.id === techId && t.countsForEraAdvancement !== false);
+      if (tech && tech.era > maxEra) maxEra = tech.era;
+    }
+  }
+  return maxEra;
 }
 
 export function processMinorCivEraUpgrade(state: GameState, mc: MinorCivState): void {

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -1,7 +1,7 @@
 import type { GameState, MinorCivArchetype, MinorCivState, HexCoord, City, Unit, UnitType } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
-import { hasReachedEraThreshold, TECH_TREE } from './tech-definitions';
+import { TECH_TREE } from './tech-definitions';
 import { createDiplomacyState, modifyRelationship } from './diplomacy-system';
 import { applyResearchBonus } from './tech-system';
 import { hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
@@ -537,12 +537,19 @@ const ERA_UNIT_MAP: Record<number, UnitType> = {
   4: 'musketeer',
 };
 
+// Pre-built for O(1) lookup in checkEraAdvancement (called every turn)
+const ERA_ADVANCEMENT_TECH_ERA = new Map<string, number>(
+  TECH_TREE
+    .filter(t => t.countsForEraAdvancement !== false)
+    .map(t => [t.id, t.era])
+);
+
 export function checkEraAdvancement(state: GameState): number {
   let maxEra = state.era ?? 1;
   for (const civ of Object.values(state.civilizations)) {
     for (const techId of civ.techState.completed) {
-      const tech = TECH_TREE.find(t => t.id === techId && t.countsForEraAdvancement !== false);
-      if (tech && tech.era > maxEra) maxEra = tech.era;
+      const era = ERA_ADVANCEMENT_TECH_ERA.get(techId);
+      if (era !== undefined && era > maxEra) maxEra = era;
     }
   }
   return maxEra;

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -21,6 +21,7 @@ import { canFoundCityAt, formatCityFoundingBlockerMessage, getCityFoundingBlocke
 import { resolveFromCity } from '@/systems/trade-system';
 import { canEstablishOutpost } from '@/systems/resource-acquisition-system';
 import { getTransportCargo, getTransportCapacity, getTransportCargoUsed } from '@/systems/transport-system';
+import { calculateCivUnitMaintenance } from '@/systems/economy-system';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -193,6 +194,25 @@ export function renderSelectedUnitInfo(
     ? `XP: ${unit.experience ?? 0} · ${tier.label} · +${combatBonus}% combat`
     : `XP: ${unit.experience ?? 0} · ${tier.label} · +${combatBonus}% combat · ${nextTierXp} XP to ${nextLabel}`;
   wrapper.appendChild(xpDiv);
+
+  if (unit.owner === state.currentPlayer) {
+    const unitMaint = calculateCivUnitMaintenance(state, unit.owner);
+    const freeEntry = unitMaint.freeDefenderUnits.find(r => r.id === unitId)
+      ?? unitMaint.supportedUnits.find(r => r.id === unitId);
+    const paidEntry = unitMaint.paidUnits.find(r => r.id === unitId);
+    if (freeEntry || paidEntry) {
+      const upkeepLine = document.createElement('div');
+      upkeepLine.style.cssText = 'font-size:10px;margin-top:2px;';
+      if (freeEntry) {
+        upkeepLine.textContent = 'Upkeep: Free support';
+        upkeepLine.style.color = '#4ade80';
+      } else {
+        upkeepLine.textContent = `Upkeep: -${paidEntry!.upkeep} 💰/turn`;
+        upkeepLine.style.color = '#f87171';
+      }
+      wrapper.appendChild(upkeepLine);
+    }
+  }
 
   const friendlyUnitsHere = Object.values(state.units).filter(other =>
     other.owner === unit.owner && !other.transportId && hexKey(other.position) === hexKey(unit.position),

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -465,17 +465,20 @@ export function renderSelectedUnitInfo(
   if (isSpyUnitType(unit.type) && !unit.hasActed && callbacks.onSetDisguise) {
     const spy = state.espionage?.[unit.owner]?.spies[unitId];
     if (spy?.status === 'idle') {
-    const ownerTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
-    type DisguiseOption = { label: string; value: DisguiseType | null; tech?: string };
+    const SPY_DISGUISE_TIERS: Partial<Record<string, number>> = {
+      spy_scout: 0, spy_informant: 1, spy_agent: 2, spy_operative: 3, spy_hacker: 3,
+    };
+    const spyTier = SPY_DISGUISE_TIERS[unit.type] ?? 0;
+    type DisguiseOption = { label: string; value: DisguiseType | null; minTier?: number };
     const allDisguises: DisguiseOption[] = [
-      { label: 'No Disguise', value: null },
-      { label: 'As Barbarian', value: 'barbarian', tech: 'espionage-informants' },
-      { label: 'As Warrior',   value: 'warrior',   tech: 'espionage-informants' },
-      { label: 'As Scout',     value: 'scout',     tech: 'spy-networks' },
-      { label: 'As Archer',    value: 'archer',    tech: 'spy-networks' },
-      { label: 'As Worker',    value: 'worker',    tech: 'cryptography' },
+      { label: 'No Disguise',   value: null },
+      { label: 'As Barbarian',  value: 'barbarian', minTier: 1 },
+      { label: 'As Warrior',    value: 'warrior',   minTier: 1 },
+      { label: 'As Scout',      value: 'scout',     minTier: 2 },
+      { label: 'As Archer',     value: 'archer',    minTier: 2 },
+      { label: 'As Worker',     value: 'worker',    minTier: 3 },
     ];
-    const disguiseOptions = allDisguises.filter(opt => !opt.tech || ownerTechs.includes(opt.tech));
+    const disguiseOptions = allDisguises.filter(opt => !opt.minTier || spyTier >= opt.minTier);
 
     if (disguiseOptions.length > 1) {
       const disguiseSection = document.createElement('div');

--- a/src/ui/treasury-drawer.ts
+++ b/src/ui/treasury-drawer.ts
@@ -1,0 +1,95 @@
+import type { EconomyProjection } from '@/systems/economy-system';
+import type { TreasuryStrainLevel } from '@/core/types';
+
+export interface TreasuryDrawer {
+  element: HTMLElement;
+  isOpen(): boolean;
+  update(economy: EconomyProjection, currentGold: number): void;
+  toggle(): void;
+  close(): void;
+}
+
+const NET_COLORS: Record<TreasuryStrainLevel, string> = {
+  none:     '#4ade80',
+  low:      '#facc15',
+  high:     '#facc15',
+  critical: '#f87171',
+};
+
+export function createTreasuryDrawer(): TreasuryDrawer {
+  let open = false;
+
+  const el = document.createElement('div');
+  el.style.cssText =
+    'position:absolute;top:44px;left:0;width:66%;background:rgba(0,0,0,0.85);' +
+    'border-radius:0 0 8px 0;padding:8px 12px;z-index:25;pointer-events:auto;color:#e0d6c8;';
+  el.style.display = 'none';
+
+  const header = document.createElement('div');
+  header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;';
+  const title = document.createElement('div');
+  title.textContent = 'Treasury';
+  title.style.cssText = 'font-weight:bold;font-size:13px;';
+  header.appendChild(title);
+
+  const closeBtn = document.createElement('button');
+  closeBtn.textContent = '×';
+  closeBtn.style.cssText =
+    'background:rgba(255,255,255,0.1);color:#e0d6c8;border:none;border-radius:4px;' +
+    'min-height:44px;min-width:44px;font-size:20px;cursor:pointer;';
+  closeBtn.addEventListener('click', () => close());
+  header.appendChild(closeBtn);
+  el.appendChild(header);
+
+  function makeRow(label: string, dataRow: string): { row: HTMLElement; value: HTMLElement } {
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;justify-content:space-between;font-size:12px;margin:2px 0;';
+    row.setAttribute('data-row', dataRow);
+    const labelEl = document.createElement('span');
+    labelEl.textContent = label;
+    const value = document.createElement('span');
+    row.appendChild(labelEl);
+    row.appendChild(value);
+    el.appendChild(row);
+    return { row, value };
+  }
+
+  const { value: revenueVal }  = makeRow('Revenue',   'revenue');
+  const { value: buildVal }    = makeRow('Buildings', 'buildings');
+  const { value: unitVal }     = makeRow('Units',     'units');
+  const { row: netRow, value: netVal } = makeRow('Net/turn', 'net');
+  const { value: treasuryVal } = makeRow('Treasury',  'treasury');
+
+  function update(economy: EconomyProjection, currentGold: number): void {
+    revenueVal.textContent  = `+${economy.grossGoldIncome} 💰`;
+    buildVal.textContent    = `-${economy.buildingMaintenance} 💰`;
+    unitVal.textContent     = `-${economy.unitMaintenance} 💰`;
+    const net = economy.netGoldPerTurn;
+    netVal.textContent = `${net >= 0 ? '+' : ''}${net} 💰`;
+    const strain = (economy.strainLevel as TreasuryStrainLevel) ?? 'none';
+    netRow.style.color = NET_COLORS[strain] ?? NET_COLORS.none;
+    treasuryVal.textContent = `${currentGold} 💰`;
+  }
+
+  function show(): void {
+    open = true;
+    el.style.display = '';
+  }
+
+  function close(): void {
+    open = false;
+    el.style.display = 'none';
+  }
+
+  function toggle(): void {
+    open ? close() : show();
+  }
+
+  return {
+    element: el,
+    isOpen:  () => open,
+    update,
+    toggle,
+    close,
+  };
+}

--- a/tests/systems/economy-system.test.ts
+++ b/tests/systems/economy-system.test.ts
@@ -55,7 +55,7 @@ function addUnits(state: GameState, count: number, type: UnitType = 'warrior'): 
 }
 
 describe('economy maintenance', () => {
-  it('keeps starter infrastructure and two defenders per city free', () => {
+  it('keeps core buildings exempt; gives one free slot to first non-exempt building', () => {
     const state = makeState();
     city(state).buildings = [
       'herbalist',
@@ -75,17 +75,18 @@ describe('economy maintenance', () => {
     const cityBreakdown = calculateCityBuildingMaintenance(state, 'capital');
     const unitBreakdown = calculateCivUnitMaintenance(state, 'player');
 
-    expect(maintenance.buildingUpkeep).toBe(0);
-    expect(maintenance.paidBuildings).toBe(0);
-    expect(maintenance.freeBuildings).toBe(10);
+    // outpost pop=2 → 1 free slot: marketplace (lowest priority) covered, forum/temple/monument paid
+    expect(maintenance.buildingUpkeep).toBe(3);
+    expect(maintenance.paidBuildings).toBe(3);
+    expect(maintenance.freeBuildings).toBe(7); // 6 exempt + 1 supported
     expect(maintenance.unitUpkeep).toBe(0);
     expect(maintenance.freeUnits).toBe(6);
-    expect(cityBreakdown.supportUsed).toBe(4);
+    expect(cityBreakdown.supportUsed).toBe(1);
     expect(unitBreakdown.defenderSlotsUsed).toBe(2);
     expect(unitBreakdown.supportUsed).toBe(4);
   });
 
-  it('charges upkeep only after generous free support is exhausted', () => {
+  it('charges upkeep for all non-exempt buildings beyond the single free slot', () => {
     const state = makeState();
     city(state).buildings = [
       'herbalist',
@@ -106,8 +107,9 @@ describe('economy maintenance', () => {
 
     const maintenance = calculateMaintenance(state, 'player');
 
-    expect(maintenance.paidBuildings).toBe(2);
-    expect(maintenance.buildingUpkeep).toBe(3);
+    // marketplace covered by 1 free slot; 6 non-exempt paid (forum+temple+monument@1 + forge+harbor+observatory@2)
+    expect(maintenance.paidBuildings).toBe(6);
+    expect(maintenance.buildingUpkeep).toBe(9);
     expect(maintenance.paidUnits).toBe(4);
     expect(maintenance.unitUpkeep).toBe(4);
   });

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -268,24 +268,45 @@ describe('era advancement', () => {
     expect(newEra).toBe(2);
   });
 
-  it('does not advance era below 60% threshold', () => {
-    const state = createNewGame(undefined, 'era-no-test', 'small');
+  it('advances era when any civ completes a single era-advancement tech of that era', () => {
+    const state = createNewGame(undefined, 'era-single-tech', 'small');
     state.era = 1;
-    const era2Techs = getEraAdvancementTechs(2);
-    const below = Math.floor(era2Techs.length * 0.6) - 1;
-    state.civilizations.player.techState.completed = era2Techs.slice(0, below).map(t => t.id);
+    const era2Tech = getEraAdvancementTechs(2)[0];
+    expect(era2Tech).toBeDefined();
+    state.civilizations.player.techState.completed = [era2Tech.id];
     const newEra = checkEraAdvancement(state);
-    expect(newEra).toBe(1);
+    expect(newEra).toBe(2);
   });
 
-  it('does not require late-era scaffolding techs to advance into era 5', () => {
-    const state = createNewGame(undefined, 'era-five-test', 'small');
+  it('does not advance era via scaffolding techs marked countsForEraAdvancement: false', () => {
+    const state = createNewGame(undefined, 'era-five-scaffold', 'small');
     state.era = 4;
-    state.civilizations.player.techState.completed = ['digital-surveillance', 'cyber-warfare'];
-
+    // global-logistics and nuclear-theory are era-5 techs with countsForEraAdvancement: false
+    state.civilizations.player.techState.completed = ['global-logistics', 'nuclear-theory'];
     const newEra = checkEraAdvancement(state);
+    // Should stay at era 4 — scaffold techs excluded from era advancement
+    expect(newEra).toBe(4);
+  });
 
+  it('advances era to 5 when a real era-5 advancement tech is completed', () => {
+    const state = createNewGame(undefined, 'era-five-advance', 'small');
+    state.era = 4;
+    // digital-surveillance is an era-5 tech without countsForEraAdvancement: false
+    state.civilizations.player.techState.completed = ['digital-surveillance'];
+    const newEra = checkEraAdvancement(state);
     expect(newEra).toBe(5);
+  });
+
+  it('tracks highest era across all civs, not just current player', () => {
+    const state = createNewGame(undefined, 'era-multiciv', 'small');
+    state.era = 1;
+    const era3Tech = getEraAdvancementTechs(3)[0];
+    expect(era3Tech).toBeDefined();
+    const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player');
+    if (!aiCivId) return;
+    state.civilizations[aiCivId].techState.completed = [era3Tech.id];
+    const newEra = checkEraAdvancement(state);
+    expect(newEra).toBe(3);
   });
 });
 

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -458,8 +458,9 @@ describe('city-panel navigation', () => {
     });
 
     const rendered = collectText(panel);
-    expect(rendered).toContain('Paid upkeep: -2 city');
-    expect(rendered).toContain('Upkeep: -2 gold/turn');
+    // outpost pop=5 → 2 free slots; 7 non-exempt buildings → 5 paid (harbor+forum+monument+temple+observatory = 7g)
+    expect(rendered).toContain('Paid upkeep: -7 city');
+    expect(rendered).toContain('Upkeep: -2 gold/turn'); // harbor & observatory each cost 2g/turn
   });
 
   it('renders Overview, Buildings/Core, and Worked Land And Water sections in the Grid tab', () => {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -82,16 +82,20 @@ function findButtons(node: unknown): MockElement[] {
   return result;
 }
 
-function makeSpyState(techs: string[], spyStatus: string = 'idle'): GameState {
+function makeSpyState(
+  techs: string[],
+  spyStatus: string = 'idle',
+  spyType: 'spy_scout' | 'spy_informant' | 'spy_agent' | 'spy_operative' | 'spy_hacker' = 'spy_scout',
+): GameState {
   let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
-  const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed');
+  const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', spyType, 'seed');
   civEsp = { ...esp, spies: { ...esp.spies, 'unit-1': { ...esp.spies['unit-1'], status: spyStatus as any } } };
   return {
     turn: 1, era: 1, currentPlayer: 'player', gameOver: false, winner: null,
     map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
     units: {
       'unit-1': {
-        id: 'unit-1', type: 'spy_scout', owner: 'player',
+        id: 'unit-1', type: spyType, owner: 'player',
         position: { q: 0, r: 0 }, health: 100, maxHealth: 100,
         movementPointsLeft: 2, movement: 2, hasActed: false, status: 'idle',
       } as any,
@@ -158,8 +162,8 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);
 
-  it('does not render "As Scout" button without spy-networks tech', () => {
-    const state = makeSpyState(['espionage-informants']); // spy-networks NOT researched
+  it('spy_scout (tier 0) does not render any disguise options', () => {
+    const state = makeSpyState([], 'idle', 'spy_scout');
     const container = new MockElement('div');
     renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
       onSetDisguise: () => {},
@@ -167,10 +171,11 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
     const btns = findButtons(container).map(b => b.textContent);
     expect(btns.some(t => t.includes('As Scout'))).toBe(false);
     expect(btns.some(t => t.includes('As Archer'))).toBe(false);
+    expect(btns.some(t => t.includes('As Barbarian'))).toBe(false);
   });
 
-  it('renders "As Scout" and "As Archer" buttons when spy-networks is researched', () => {
-    const state = makeSpyState(['espionage-informants', 'spy-networks']);
+  it('spy_agent (tier 2) renders "As Scout" and "As Archer" buttons', () => {
+    const state = makeSpyState([], 'idle', 'spy_agent');
     const container = new MockElement('div');
     renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
       onSetDisguise: () => {},
@@ -178,10 +183,12 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
     const btns = findButtons(container).map(b => b.textContent);
     expect(btns.some(t => t.includes('As Scout'))).toBe(true);
     expect(btns.some(t => t.includes('As Archer'))).toBe(true);
+    // tier 2 does NOT yet have As Worker
+    expect(btns.some(t => t.includes('As Worker'))).toBe(false);
   });
 
   it('does not render disguise section when spy is not idle', () => {
-    const state = makeSpyState(['espionage-informants', 'spy-networks'], 'on_mission');
+    const state = makeSpyState([], 'on_mission', 'spy_agent');
     const container = new MockElement('div');
     renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {
       onSetDisguise: () => {},
@@ -192,9 +199,9 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
 
   it('marks the active disguise with a checkmark', () => {
     let civEsp = { ...createEspionageCivState(), maxSpies: 1 };
-    const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_scout', 'seed');
+    const { state: esp } = createSpyFromUnit(civEsp, 'unit-1', 'player', 'spy_informant', 'seed');
     civEsp = setDisguise(esp, 'unit-1', 'barbarian');
-    const gameState = makeSpyState(['espionage-informants']);
+    const gameState = makeSpyState([], 'idle', 'spy_informant');
     (gameState.espionage as any).player = civEsp;
 
     const container = new MockElement('div');
@@ -207,7 +214,7 @@ describe('renderSelectedUnitInfo — spy disguise buttons', () => {
   });
 
   it('fires onSetDisguise with the correct value when a button is clicked', () => {
-    const state = makeSpyState(['espionage-informants', 'spy-networks']);
+    const state = makeSpyState([], 'idle', 'spy_agent');
     const container = new MockElement('div');
     let called: [string, unknown] | null = null;
     renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'unit-1', {

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -3,6 +3,8 @@ import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
 import { createEspionageCivState, createSpyFromUnit, setDisguise } from '@/systems/espionage-system';
 import type { GameState, HexCoord } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
+import { createNewGame } from '@/core/game-state';
+import { createUnit } from '@/systems/unit-system';
 
 class MockElement {
   tagName: string;
@@ -81,6 +83,7 @@ function findButtons(node: unknown): MockElement[] {
   for (const child of el.children ?? []) result.push(...findButtons(child));
   return result;
 }
+
 
 function makeSpyState(
   techs: string[],
@@ -1206,5 +1209,40 @@ describe('Expedition — Establish Outpost action', () => {
 
     const buttons = findButtons(container);
     expect(buttons.some(b => b.textContent?.includes('Establish Outpost'))).toBe(false);
+  });
+});
+
+describe('renderSelectedUnitInfo — unit upkeep display', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows Free support for a warrior covered by free unit slots', () => {
+    const state = createNewGame(undefined, 'upkeep-free-test', 'small');
+    const unit = createUnit('warrior', 'player', { q: 0, r: 0 }, state.idCounters);
+    state.units[unit.id] = unit;
+    state.civilizations.player.units = [unit.id];
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, unit.id, {});
+
+    const allText = collectAllText(container).join(' ');
+    expect(allText).toContain('Free support');
+  });
+
+  it('does not show upkeep line for enemy units', () => {
+    const state = createNewGame(undefined, 'upkeep-enemy-test', 'small');
+    const aiCivId = Object.keys(state.civilizations).find(id => id !== 'player');
+    if (!aiCivId) return;
+    const unit = createUnit('warrior', aiCivId, { q: 0, r: 0 }, state.idCounters);
+    state.units[unit.id] = unit;
+    state.civilizations[aiCivId].units = [unit.id];
+    state.currentPlayer = 'player';
+
+    const container = new MockElement('div');
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, unit.id, {});
+
+    const allText = collectAllText(container).join(' ');
+    expect(allText).not.toContain('Free support');
+    expect(allText).not.toContain('💰/turn');
   });
 });

--- a/tests/ui/treasury-drawer.test.ts
+++ b/tests/ui/treasury-drawer.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createTreasuryDrawer } from '@/ui/treasury-drawer';
+import type { EconomyProjection } from '@/systems/economy-system';
+
+function makeEconomy(overrides: Partial<EconomyProjection> = {}): EconomyProjection {
+  return {
+    civId: 'player',
+    startingGold: 50,
+    endingGold: 57,
+    grossGoldPerTurn: 10,
+    grossGoldIncome: 10,
+    maintenanceGoldPerTurn: 3,
+    buildingMaintenance: 2,
+    unitMaintenance: 1,
+    totalMaintenance: 3,
+    netGoldPerTurn: 7,
+    projectedGold: 57,
+    unpaidMaintenance: 0,
+    strainLevel: 'none',
+    rushBuyDisabled: false,
+    breakdown: {} as EconomyProjection['breakdown'],
+    ...overrides,
+  } as EconomyProjection;
+}
+
+// Minimal mock document for node environment
+class MockEl {
+  tagName: string;
+  children: MockEl[] = [];
+  style: Record<string, string> = {};
+  textContent = '';
+  dataset: Record<string, string> = {};
+  private _attrs: Record<string, string> = {};
+  private _listeners: Map<string, Array<() => void>> = new Map();
+
+  constructor(tag: string) { this.tagName = tag.toUpperCase(); }
+  appendChild(c: MockEl): MockEl { this.children.push(c); return c; }
+  addEventListener(e: string, fn: () => void): void {
+    if (!this._listeners.has(e)) this._listeners.set(e, []);
+    this._listeners.get(e)!.push(fn);
+  }
+  setAttribute(k: string, v: string): void { this._attrs[k] = v; }
+  getAttribute(k: string): string | null { return this._attrs[k] ?? null; }
+  click(): void { for (const fn of this._listeners.get('click') ?? []) fn(); }
+  querySelector(sel: string): MockEl | null {
+    const dataMatch = sel.match(/^\[data-row="(.+)"\]$/);
+    if (dataMatch) {
+      const key = dataMatch[1];
+      const found = this.children.find(c => c.getAttribute('data-row') === key);
+      if (found) return found;
+      for (const child of this.children) {
+        const inner = child.querySelector(sel);
+        if (inner) return inner;
+      }
+    }
+    return null;
+  }
+}
+
+class MockDoc {
+  createElement(tag: string): MockEl { return new MockEl(tag); }
+}
+
+function installDoc(): void { (globalThis as any).document = new MockDoc(); }
+function removeDoc(): void { (globalThis as any).document = undefined; }
+
+describe('createTreasuryDrawer', () => {
+  beforeEach(installDoc);
+  afterEach(removeDoc);
+
+  it('starts closed', () => {
+    const drawer = createTreasuryDrawer();
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style['display']).toBe('none');
+  });
+
+  it('toggle opens the drawer', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.toggle();
+    expect(drawer.isOpen()).toBe(true);
+    expect(drawer.element.style['display']).not.toBe('none');
+  });
+
+  it('toggle twice closes the drawer', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.toggle();
+    drawer.toggle();
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style['display']).toBe('none');
+  });
+
+  it('close() hides the drawer', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.toggle();
+    drawer.close();
+    expect(drawer.isOpen()).toBe(false);
+    expect(drawer.element.style['display']).toBe('none');
+  });
+
+  it('update() renders revenue and net in child elements', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.update(makeEconomy({ grossGoldIncome: 15, netGoldPerTurn: 8 }), 50);
+    const allText = collectText(drawer.element as unknown as MockEl);
+    expect(allText).toContain('15');
+    expect(allText).toContain('8');
+    expect(allText).toContain('50');
+  });
+
+  it('net row is green when strain is none', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.update(makeEconomy({ strainLevel: 'none', netGoldPerTurn: 5 }), 100);
+    const netEl = (drawer.element as unknown as MockEl).querySelector('[data-row="net"]');
+    expect(netEl?.style['color']).toBe('#4ade80');
+  });
+
+  it('net row is yellow when strain is low', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.update(makeEconomy({ strainLevel: 'low' as any, netGoldPerTurn: 1 }), 5);
+    const netEl = (drawer.element as unknown as MockEl).querySelector('[data-row="net"]');
+    expect(netEl?.style['color']).toBe('#facc15');
+  });
+
+  it('net row is red when strain is critical', () => {
+    const drawer = createTreasuryDrawer();
+    drawer.update(makeEconomy({ strainLevel: 'critical' as any, netGoldPerTurn: -3 }), 1);
+    const netEl = (drawer.element as unknown as MockEl).querySelector('[data-row="net"]');
+    expect(netEl?.style['color']).toBe('#f87171');
+  });
+});
+
+function collectText(node: MockEl): string {
+  const parts: string[] = [];
+  if (node.textContent) parts.push(node.textContent);
+  for (const child of node.children) parts.push(collectText(child));
+  return parts.join(' ');
+}


### PR DESCRIPTION
## Summary
- **fix(era):** `checkEraAdvancement` now returns the highest era of any completed tech with `countsForEraAdvancement !== false` across all civs, replacing the broken 60%-threshold formula. Also pre-builds a module-level `Map<techId, era>` for O(1) lookup instead of `Array.find` in a hot per-turn loop.
- **fix(economy):** Removes the base-4 free building slot so early expansion has real maintenance cost. New formula: `floor(pop/2) + maturityBonus` (outpost/village=0, town=1, city=2, metropolis=3).
- **fix(espionage):** Spy disguise options now gate by unit tier (0–3) rather than tech prerequisites, making them reachable during normal play. Adds save migration to clear stale `disguiseAs` values on `spy_scout` units.
- **feat(ui):** Adds per-unit upkeep line in the selected-unit info panel (green "Free support" or red "-N 💰/turn") for player-owned units only.
- **feat(hud):** New treasury P&L drawer (left 66% overlay) that opens/closes via the gold chip button. Shows Revenue, Buildings, Units, Net/turn (color-coded by strain level), and current Treasury. Canvas tap closes it; all panel openers close it too.
- **fix(minor-civ-system):** Removes dead import of `hasReachedEraThreshold` after era-detection rewrite.

Closes #375, #376 (era and disguise bugs), and adds the treasury HUD feature discussed in the design spec.

## Test Plan
- [ ] Run `yarn test` — all 3812 tests pass
- [ ] Run `yarn build` — TypeScript clean
- [ ] Verify gold chip button opens drawer, shows correct revenue/maintenance/net, closes on canvas tap
- [ ] Verify warrior upkeep line in selected-unit panel (Free support for small empire, paid for large)
- [ ] Verify spy disguise options scale by tier: spy_scout=none, spy_informant=barbarian+warrior, spy_agent=+scout+archer, spy_operative/hacker=+worker
- [ ] Verify era advances when any single era-N tech is completed, not when 60% are done

🤖 Generated with [Claude Code](https://claude.com/claude-code)