### PR TITLE
fix(renderer): fit city banner text by measured width

### DIFF
--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -252,7 +252,7 @@ export function drawCityLandmarkPass(ctx: CanvasRenderingContext2D, item: CityRe
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = '#f8e7af';
-    ctx.fillText(`+${selection.completedOverflowCount}`, x + radius * 0.72, y + radius * 0.72);
+    ctx.fillText(`+${selection.completedOverflowCount}`, x + radius * 0.72, y + radius * 0.72, radius * 1.4);
   }
 }
 
@@ -276,7 +276,7 @@ export function drawCityLabelPass(ctx: CanvasRenderingContext2D, item: CityRende
   ctx.fillStyle = getCityBannerTextColor(item.ownerColor);
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(label, item.screen.x, bannerY + bannerHeight / 2);
+  ctx.fillText(label, item.screen.x, bannerY + bannerHeight / 2, bannerWidth * 0.92);
 }
 
 export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {

--- a/src/renderer/city-render-passes.ts
+++ b/src/renderer/city-render-passes.ts
@@ -92,9 +92,76 @@ export function getCityDioramaBounds(size: number): { width: number; height: num
   return { width: size * 1.22, height: size * 0.96 };
 }
 
-export function formatCityBannerLabel(name: string, population: number, maxNameLength = 14): string {
-  const trimmed = name.length > maxNameLength ? `${name.slice(0, Math.max(1, maxNameLength - 1))}…` : name;
-  return `${trimmed} (${population})`;
+function truncateTextToWidth(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+): string {
+  if (ctx.measureText(text).width <= maxWidth) return text;
+  const characters = [...text];
+  for (let length = characters.length - 1; length >= 1; length--) {
+    const candidate = `${characters.slice(0, length).join('')}…`;
+    if (ctx.measureText(candidate).width <= maxWidth) return candidate;
+  }
+  return ctx.measureText('…').width <= maxWidth ? '…' : '';
+}
+
+export function fitCityBannerLabel(
+  ctx: CanvasRenderingContext2D,
+  name: string,
+  population: number,
+  maxWidth: number,
+  showPopulation: boolean,
+): string {
+  const normalizedName = name.trim() || 'City';
+  if (!showPopulation) return truncateTextToWidth(ctx, normalizedName, maxWidth);
+
+  const populationSuffix = ` (${population})`;
+  const fullLabel = `${normalizedName}${populationSuffix}`;
+  if (ctx.measureText(fullLabel).width <= maxWidth) return fullLabel;
+
+  const suffixWidth = ctx.measureText(populationSuffix).width;
+  const nameWidth = maxWidth - suffixWidth;
+  if (nameWidth > 0) {
+    const fittedName = truncateTextToWidth(ctx, normalizedName, nameWidth);
+    if (fittedName) {
+      const fittedLabel = `${fittedName}${populationSuffix}`;
+      if (ctx.measureText(fittedLabel).width <= maxWidth) return fittedLabel;
+    }
+  }
+
+  return truncateTextToWidth(ctx, normalizedName, maxWidth);
+}
+
+function setFittedFont(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  maxWidth: number,
+  maxFontSize: number,
+  minFontSize: number,
+  weight = '',
+): void {
+  let fontSize = maxFontSize;
+  const prefix = weight ? `${weight} ` : '';
+  ctx.font = `${prefix}${fontSize}px system-ui`;
+  while (fontSize > minFontSize && ctx.measureText(text).width > maxWidth) {
+    fontSize = Math.max(minFontSize, fontSize - 0.5);
+    ctx.font = `${prefix}${fontSize}px system-ui`;
+  }
+}
+
+function drawFittedText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  maxFontSize: number,
+  minFontSize = 5,
+  weight = '',
+): void {
+  setFittedFont(ctx, text, maxWidth, maxFontSize, minFontSize, weight);
+  ctx.fillText(text, x, y);
 }
 
 export function getCityBannerTextColor(backgroundColor: string): string {
@@ -208,11 +275,17 @@ export function drawCityIconPass(ctx: CanvasRenderingContext2D, item: CityRender
   }
 
   if (item.isMinorCiv && !item.lowZoom) {
-    ctx.font = `${item.size * 0.18}px system-ui`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = '#fff';
-    ctx.fillText(item.minorCivIcon ?? '📜', item.screen.x, item.screen.y + item.size * 0.03);
+    drawFittedText(
+      ctx,
+      item.minorCivIcon ?? '📜',
+      item.screen.x,
+      item.screen.y + item.size * 0.03,
+      item.size * 0.28,
+      item.size * 0.18,
+    );
   }
 }
 
@@ -248,18 +321,25 @@ export function drawCityLandmarkPass(ctx: CanvasRenderingContext2D, item: CityRe
     nowMs: item.nowMs,
   });
   if (selection.completedOverflowCount > 0 && !item.lowZoom) {
-    ctx.font = `bold ${Math.max(8, item.size * 0.13)}px system-ui`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle = '#f8e7af';
-    ctx.fillText(`+${selection.completedOverflowCount}`, x + radius * 0.72, y + radius * 0.72, radius * 1.4);
+    drawFittedText(
+      ctx,
+      `+${selection.completedOverflowCount}`,
+      x + radius * 0.72,
+      y + radius * 0.72,
+      radius * 1.4,
+      Math.max(8, item.size * 0.13),
+      5,
+      'bold',
+    );
   }
 }
 
 export function drawCityLabelPass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
   if (item.projection.renderMode === 'landmark-only') return;
   markPass(ctx, 'label');
-  const label = formatCityBannerLabel(item.projection.name, item.projection.population);
   const bannerWidth = item.size * 1.22;
   const bannerHeight = Math.max(13, item.size * 0.27);
   const bannerY = item.screen.y + item.size * 0.27;
@@ -272,11 +352,30 @@ export function drawCityLabelPass(ctx: CanvasRenderingContext2D, item: CityRende
     item.ownerColor,
     'rgba(255,255,255,0.82)',
   );
-  ctx.font = `bold ${Math.max(9, item.size * 0.18)}px system-ui`;
+  const availableTextWidth = bannerWidth * 0.92;
+  const preferredFontSize = Math.max(9, item.size * 0.18);
+  const desiredLabel = item.lowZoom
+    ? item.projection.name
+    : `${item.projection.name} (${item.projection.population})`;
+  setFittedFont(
+    ctx,
+    desiredLabel,
+    availableTextWidth,
+    preferredFontSize,
+    8,
+    'bold',
+  );
+  const label = fitCityBannerLabel(
+    ctx,
+    item.projection.name,
+    item.projection.population,
+    availableTextWidth,
+    !item.lowZoom,
+  );
   ctx.fillStyle = getCityBannerTextColor(item.ownerColor);
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
-  ctx.fillText(label, item.screen.x, bannerY + bannerHeight / 2, bannerWidth * 0.92);
+  ctx.fillText(label, item.screen.x, bannerY + bannerHeight / 2);
 }
 
 export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
@@ -293,11 +392,17 @@ export function drawCityStatusBadgePass(ctx: CanvasRenderingContext2D, item: Cit
         : null;
   if (!statusText) return;
 
-  ctx.font = `${item.size * 0.28}px system-ui`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillStyle = '#fff';
-  ctx.fillText(statusText, item.screen.x + item.size * 0.48, item.screen.y - item.size * 0.42);
+  drawFittedText(
+    ctx,
+    statusText,
+    item.screen.x + item.size * 0.48,
+    item.screen.y - item.size * 0.42,
+    item.size * 0.28,
+    item.size * 0.28,
+  );
 }
 
 export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
@@ -307,11 +412,17 @@ export function drawCityProductionBadgePass(ctx: CanvasRenderingContext2D, item:
 
   const buildIcon = getProductionBadgeIcon(item.city);
   if (!buildIcon) return;
-  ctx.font = `${item.size * 0.28}px system-ui`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillStyle = '#fff';
-  ctx.fillText(buildIcon, item.screen.x - item.size * 0.48, item.screen.y - item.size * 0.42);
+  drawFittedText(
+    ctx,
+    buildIcon,
+    item.screen.x - item.size * 0.48,
+    item.screen.y - item.size * 0.42,
+    item.size * 0.28,
+    item.size * 0.28,
+  );
 }
 
 export function drawCityIdleBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
@@ -328,11 +439,17 @@ export function drawCityIdleBadgePass(ctx: CanvasRenderingContext2D, item: CityR
   }
 
   const idleIcon = item.city.idleProduction === 'gold' ? '💰' : '🔬';
-  ctx.font = `${item.size * 0.28}px system-ui`;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'middle';
   ctx.fillStyle = '#fff';
-  ctx.fillText(idleIcon, item.screen.x - item.size * 0.48, item.screen.y - item.size * 0.42);
+  drawFittedText(
+    ctx,
+    idleIcon,
+    item.screen.x - item.size * 0.48,
+    item.screen.y - item.size * 0.42,
+    item.size * 0.28,
+    item.size * 0.28,
+  );
 }
 
 export function drawCityIntelBadgePass(ctx: CanvasRenderingContext2D, item: CityRenderItem): void {
@@ -354,10 +471,16 @@ export function drawCityIntelBadgePass(ctx: CanvasRenderingContext2D, item: City
     ctx.arc(badge.x, y, item.size * 0.14, 0, Math.PI * 2);
     ctx.fillStyle = 'rgba(20,24,30,0.86)';
     ctx.fill();
-    ctx.font = `${item.size * 0.2}px system-ui`;
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(badge.text, badge.x, y);
+    drawFittedText(
+      ctx,
+      badge.text,
+      badge.x,
+      y,
+      item.size * 0.28,
+      item.size * 0.2,
+    );
   }
 }
 

--- a/tests/renderer/city-map-presentation.test.ts
+++ b/tests/renderer/city-map-presentation.test.ts
@@ -5,7 +5,6 @@ import { foundCity } from '@/systems/city-system';
 import type { LegendaryWonderMapEntry } from '@/systems/legendary-wonder-map-presentation';
 import { getEraAdvancementTechs } from '@/systems/tech-definitions';
 import {
-  formatCityBannerLabel,
   getCityBannerTextColor,
   getCityDioramaBounds,
 } from '@/renderer/city-render-passes';
@@ -174,10 +173,6 @@ describe('city map presentation', () => {
     const bounds = getCityDioramaBounds(size);
 
     expect(bounds.width).toBeLessThanOrEqual(Math.sqrt(3) * size * 0.75);
-  });
-
-  it('truncates long names while preserving population in the owner banner', () => {
-    expect(formatCityBannerLabel('A Very Long Capital Name', 12, 10)).toBe('A Very Lo… (12)');
   });
 
   it('chooses readable banner text for light and dark civilization colors', () => {

--- a/tests/renderer/city-render-passes.test.ts
+++ b/tests/renderer/city-render-passes.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import {
+  drawCityLabelPass,
+  formatCityBannerLabel,
+  type CityRenderItem,
+} from '@/renderer/city-render-passes';
+
+class MockCtx {
+  fillTextCalls: Array<{ text: string; x: number; y: number; maxWidth?: number }> = [];
+  font = '';
+  fillStyle = '';
+  strokeStyle = '';
+  lineWidth = 0;
+  textAlign: CanvasTextAlign = 'start';
+  textBaseline: CanvasTextBaseline = 'alphabetic';
+
+  fillText(text: string, x: number, y: number, maxWidth?: number): void {
+    this.fillTextCalls.push({ text, x, y, maxWidth });
+  }
+  beginPath(): void {}
+  rect(): void {}
+  fill(): void {}
+  stroke(): void {}
+  save(): void {}
+  restore(): void {}
+  arc(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  closePath(): void {}
+}
+
+function makeItem(overrides: Partial<CityRenderItem> = {}): CityRenderItem {
+  return {
+    projection: {
+      name: 'Alexandroupolis',
+      position: { q: 0, r: 0 },
+      population: 7,
+      owner: 'player',
+      isLive: true,
+    },
+    presentation: {
+      architectureEra: 1,
+      populationTier: 'outpost',
+      visualFamily: 'generic',
+      specializations: [],
+      isCapital: false,
+      isBreakawayCapital: false,
+      primaryWonder: undefined,
+      completedWonderOverflowCount: 0,
+      visibilityMode: 'live' as const,
+    },
+    screen: { x: 100, y: 100 },
+    size: 80,
+    ownerColor: '#4488cc',
+    playerCivId: 'player',
+    isMinorCiv: false,
+    intel: { hasEmbeddedSpy: false, hasInfiltratedSpy: false },
+    landmarkEntries: [],
+    lowZoom: false,
+    reducedMotion: false,
+    nowMs: 0,
+    ...overrides,
+  };
+}
+
+describe('formatCityBannerLabel', () => {
+  it('returns name + population for short names', () => {
+    expect(formatCityBannerLabel('Rome', 3)).toBe('Rome (3)');
+  });
+
+  it('truncates names longer than 14 chars and appends ellipsis', () => {
+    const label = formatCityBannerLabel('Constantinopolis', 5);
+    expect(label).toBe('Constantinopo… (5)');
+  });
+
+  it('respects custom maxNameLength', () => {
+    const label = formatCityBannerLabel('Alexandroupolis', 4, 8);
+    expect(label).toContain('…');
+    expect(label.indexOf('…')).toBeLessThanOrEqual(8);
+  });
+});
+
+describe('drawCityLabelPass', () => {
+  it('passes maxWidth to fillText so long labels cannot overflow the banner', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const item = makeItem();
+
+    drawCityLabelPass(ctx, item);
+
+    const bannerWidth = item.size * 1.22;
+    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.find(c =>
+      c.text.startsWith('Alexandroup'),
+    );
+    expect(labelCall).toBeDefined();
+    expect(labelCall!.maxWidth).toBeCloseTo(bannerWidth * 0.92, 5);
+  });
+
+  it('passes maxWidth at small zoom sizes too', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const item = makeItem({ size: 20 });
+
+    drawCityLabelPass(ctx, item);
+
+    const bannerWidth = item.size * 1.22;
+    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.find(c =>
+      c.text.includes('('),
+    );
+    expect(labelCall).toBeDefined();
+    expect(labelCall!.maxWidth).toBeCloseTo(bannerWidth * 0.92, 5);
+  });
+
+  it('skips render when renderMode is landmark-only', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const item = makeItem({
+      projection: {
+        name: 'Rome',
+        position: { q: 0, r: 0 },
+        population: 1,
+        owner: 'player',
+        isLive: true,
+        renderMode: 'landmark-only',
+      },
+    });
+
+    drawCityLabelPass(ctx, item);
+
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(0);
+  });
+});

--- a/tests/renderer/city-render-passes.test.ts
+++ b/tests/renderer/city-render-passes.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import {
+  drawCityIconPass,
+  drawCityIdleBadgePass,
+  drawCityIntelBadgePass,
   drawCityLabelPass,
-  formatCityBannerLabel,
+  drawCityLandmarkPass,
+  drawCityProductionBadgePass,
+  drawCityStatusBadgePass,
+  fitCityBannerLabel,
   type CityRenderItem,
 } from '@/renderer/city-render-passes';
+import { getLegendaryWonderLandmarkMetadata } from '@/systems/legendary-wonder-landmark-catalog';
+import type { LegendaryWonderMapEntry } from '@/systems/legendary-wonder-map-presentation';
 
 class MockCtx {
-  fillTextCalls: Array<{ text: string; x: number; y: number; maxWidth?: number }> = [];
+  fillTextCalls: Array<{ text: string; x: number; y: number; font: string; measuredWidth: number; maxWidth?: number }> = [];
   font = '';
   fillStyle = '';
   strokeStyle = '';
@@ -15,7 +23,24 @@ class MockCtx {
   textBaseline: CanvasTextBaseline = 'alphabetic';
 
   fillText(text: string, x: number, y: number, maxWidth?: number): void {
-    this.fillTextCalls.push({ text, x, y, maxWidth });
+    this.fillTextCalls.push({
+      text,
+      x,
+      y,
+      font: this.font,
+      measuredWidth: this.measureText(text).width,
+      maxWidth,
+    });
+  }
+  measureText(text: string): TextMetrics {
+    const fontSize = Number.parseFloat(/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1] ?? '10');
+    const width = [...text].reduce((sum, character) => {
+      if (character === 'i' || character === 'l' || character === ' ') return sum + fontSize * 0.28;
+      if (character === 'W' || character === 'M') return sum + fontSize * 0.92;
+      if (character.codePointAt(0)! > 0xffff) return sum + fontSize;
+      return sum + fontSize * 0.58;
+    }, 0);
+    return { width } as TextMetrics;
   }
   beginPath(): void {}
   rect(): void {}
@@ -63,50 +88,74 @@ function makeItem(overrides: Partial<CityRenderItem> = {}): CityRenderItem {
   };
 }
 
-describe('formatCityBannerLabel', () => {
-  it('returns name + population for short names', () => {
-    expect(formatCityBannerLabel('Rome', 3)).toBe('Rome (3)');
+describe('fitCityBannerLabel', () => {
+  it('keeps the full label when its measured width fits', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    ctx.font = 'bold 12px system-ui';
+
+    expect(fitCityBannerLabel(ctx, 'Rome', 3, 100, true)).toBe('Rome (3)');
   });
 
-  it('truncates names longer than 14 chars and appends ellipsis', () => {
-    const label = formatCityBannerLabel('Constantinopolis', 5);
-    expect(label).toBe('Constantinopo… (5)');
+  it('fits by measured glyph width instead of a fixed character count', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    ctx.font = 'bold 12px system-ui';
+
+    const narrow = fitCityBannerLabel(ctx, 'iiiiiiiiiiiiiiii', 7, 80, true);
+    const wide = fitCityBannerLabel(ctx, 'WWWWWWWWWWWWWWWW', 7, 80, true);
+
+    expect(narrow).toBe('iiiiiiiiiiiiiiii (7)');
+    expect(wide.length).toBeLessThan(narrow.length);
+    expect(wide).toContain('…');
+    expect(ctx.measureText(wide).width).toBeLessThanOrEqual(80);
   });
 
-  it('respects custom maxNameLength', () => {
-    const label = formatCityBannerLabel('Alexandroupolis', 4, 8);
-    expect(label).toContain('…');
-    expect(label.indexOf('…')).toBeLessThanOrEqual(8);
+  it('reserves measured width for the complete population suffix', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    ctx.font = 'bold 12px system-ui';
+
+    const singleDigit = fitCityBannerLabel(ctx, 'Alexandroupolis', 7, 90, true);
+    const tripleDigit = fitCityBannerLabel(ctx, 'Alexandroupolis', 123, 90, true);
+
+    expect(tripleDigit.length).toBeLessThan(singleDigit.length + 2);
+    expect(tripleDigit).toMatch(/\(123\)$/);
+    expect(ctx.measureText(tripleDigit).width).toBeLessThanOrEqual(90);
+  });
+
+  it('omits population at low zoom and spends the width on the city name', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    ctx.font = 'bold 9px system-ui';
+
+    const label = fitCityBannerLabel(ctx, 'Constantinopolis', 12, 55, false);
+
+    expect(label).not.toContain('(12)');
+    expect(ctx.measureText(label).width).toBeLessThanOrEqual(55);
   });
 });
 
 describe('drawCityLabelPass', () => {
-  it('passes maxWidth to fillText so long labels cannot overflow the banner', () => {
+  it('renders a measured label that fits without Canvas horizontal compression', () => {
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
     const item = makeItem();
 
     drawCityLabelPass(ctx, item);
 
-    const bannerWidth = item.size * 1.22;
-    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.find(c =>
-      c.text.startsWith('Alexandroup'),
-    );
+    const availableWidth = item.size * 1.22 * 0.92;
+    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.at(-1);
     expect(labelCall).toBeDefined();
-    expect(labelCall!.maxWidth).toBeCloseTo(bannerWidth * 0.92, 5);
+    expect(labelCall!.maxWidth).toBeUndefined();
+    expect(labelCall!.measuredWidth).toBeLessThanOrEqual(availableWidth);
   });
 
-  it('passes maxWidth at small zoom sizes too', () => {
+  it('hides population and fits the name at low zoom', () => {
     const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
-    const item = makeItem({ size: 20 });
+    const item = makeItem({ size: 20, lowZoom: true });
 
     drawCityLabelPass(ctx, item);
 
-    const bannerWidth = item.size * 1.22;
-    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.find(c =>
-      c.text.includes('('),
-    );
+    const labelCall = (ctx as unknown as MockCtx).fillTextCalls.at(-1);
     expect(labelCall).toBeDefined();
-    expect(labelCall!.maxWidth).toBeCloseTo(bannerWidth * 0.92, 5);
+    expect(labelCall!.text).not.toContain('(7)');
+    expect(labelCall!.measuredWidth).toBeLessThanOrEqual(item.size * 1.22 * 0.92);
   });
 
   it('skips render when renderMode is landmark-only', () => {
@@ -125,5 +174,70 @@ describe('drawCityLabelPass', () => {
     drawCityLabelPass(ctx, item);
 
     expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(0);
+  });
+});
+
+describe('city icon and badge text bounds', () => {
+  it('fits minor-civ, status, production, idle, and intel glyphs to their containers', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const city = {
+      id: 'city-1',
+      owner: 'player',
+      productionQueue: ['warrior'],
+      idleProduction: null,
+      unrestLevel: 2,
+    } as CityRenderItem['city'];
+    const item = makeItem({
+      city,
+      isMinorCiv: true,
+      minorCivIcon: '🏛️',
+      intel: { hasEmbeddedSpy: true, hasInfiltratedSpy: true },
+    });
+
+    drawCityIconPass(ctx, item);
+    drawCityStatusBadgePass(ctx, item);
+    drawCityProductionBadgePass(ctx, item);
+    drawCityIntelBadgePass(ctx, item);
+
+    item.city = { ...city, productionQueue: [], idleProduction: 'gold' } as CityRenderItem['city'];
+    drawCityIdleBadgePass(ctx, item);
+
+    expect((ctx as unknown as MockCtx).fillTextCalls).toHaveLength(6);
+    for (const call of (ctx as unknown as MockCtx).fillTextCalls) {
+      expect(call.maxWidth).toBeUndefined();
+      expect(call.measuredWidth).toBeLessThanOrEqual(item.size * 0.28);
+    }
+  });
+
+  it('fits the legendary-wonder overflow count without Canvas horizontal compression', () => {
+    const ctx = new MockCtx() as unknown as CanvasRenderingContext2D;
+    const landmark: LegendaryWonderMapEntry = {
+      wonderId: 'test-wonder',
+      cityId: 'city-1',
+      coord: { q: 0, r: 0 },
+      ownerId: 'player',
+      relationship: 'owned',
+      state: 'under-construction',
+      turnCompleted: 0,
+      label: 'Test Wonder',
+      visual: {} as LegendaryWonderMapEntry['visual'],
+      metadata: getLegendaryWonderLandmarkMetadata('test-wonder'),
+      progressRatio: 0.8,
+    };
+    const item = makeItem({
+      presentation: {
+        ...makeItem().presentation,
+        primaryWonder: landmark,
+        completedWonderOverflowCount: 123,
+      },
+      landmarkEntries: [landmark],
+    });
+
+    drawCityLandmarkPass(ctx, item);
+
+    const overflowCall = (ctx as unknown as MockCtx).fillTextCalls.find(call => call.text === '+123');
+    expect(overflowCall).toBeDefined();
+    expect(overflowCall!.maxWidth).toBeUndefined();
+    expect(overflowCall!.measuredWidth).toBeLessThanOrEqual(item.size * 0.16 * 1.4);
   });
 });

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -33,6 +33,10 @@ class MockCanvasContext {
     this.fillTextCalls.push({ text, x, y, maxWidth });
     this.operations.push(`text:${text}`);
   }
+  measureText(text: string): TextMetrics {
+    const fontSize = Number.parseFloat(/(\d+(?:\.\d+)?)px/.exec(this.font)?.[1] ?? '10');
+    return { width: [...text].length * fontSize * 0.48 } as TextMetrics;
+  }
   drawImage(): void {
     this.operations.push('drawImage');
   }

--- a/tests/renderer/city-renderer.test.ts
+++ b/tests/renderer/city-renderer.test.ts
@@ -11,7 +11,7 @@ const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1
 
 class MockCanvasContext {
   operations: string[] = [];
-  fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+  fillTextCalls: Array<{ text: string; x: number; y: number; maxWidth?: number }> = [];
   fillStyle = '';
   strokeStyle = '';
   lineWidth = 0;
@@ -29,8 +29,8 @@ class MockCanvasContext {
   closePath(): void { this.operations.push('closePath'); }
   fill(): void { this.operations.push(`fill:${this.fillStyle}`); }
   stroke(): void { this.operations.push(`stroke:${this.strokeStyle}`); }
-  fillText(text: string, x: number, y: number): void {
-    this.fillTextCalls.push({ text, x, y });
+  fillText(text: string, x: number, y: number, maxWidth?: number): void {
+    this.fillTextCalls.push({ text, x, y, maxWidth });
     this.operations.push(`text:${text}`);
   }
   drawImage(): void {


### PR DESCRIPTION
## Summary

Fixes #392 by replacing fixed character truncation and Canvas `fillText(..., maxWidth)` compression with measured city-banner layout.

## Changes

- Measure the active Canvas font with `ctx.measureText()` and preserve the full city name plus population when it fits.
- Reduce the banner font to a readable floor, then truncate the name with an ellipsis based on actual available width.
- Hide population at low zoom so limited banner space is spent on city identity.
- Reserve the measured population suffix width, including multi-digit populations.
- Fit minor-civilization, status, production, idle, intel, and legendary-wonder overflow glyphs to their containers without horizontal text compression.
- Remove the fixed 14-character formatter.

## Regression coverage

- Narrow and wide glyph strings with the same character count produce different fitted labels.
- Single- and multi-digit populations remain bounded.
- Low zoom omits population and remains bounded.
- Banner rendering uses no `fillText` `maxWidth` argument and the measured result fits.
- Minor-civilization, status, production, idle, intel, and landmark-overflow text remain within their containers.

## Verification

- [x] `scripts/check-src-rule-violations.sh src/renderer/city-render-passes.ts`
- [x] `./scripts/run-with-mise.sh yarn test --run tests/renderer/city-render-passes.test.ts tests/renderer/city-map-presentation.test.ts tests/renderer/city-renderer.test.ts` - 64 passed
- [x] `./scripts/run-with-mise.sh yarn test` - 295 files, 4,349 passed, 2 skipped
- [x] `./scripts/run-with-mise.sh yarn build`
- [x] Local browser startup smoke check with no console errors

The branch is rebased onto the latest `origin/main`.
