### PR TITLE
tooling: parallelize tsc+vitest in pre-push hook; fix cacheDir for worktrees

### DIFF
--- a/.claude/hooks/require-green-before-push.sh
+++ b/.claude/hooks/require-green-before-push.sh
@@ -62,54 +62,85 @@ fi
 IN_WORKTREE=0
 [ "$PROJECT_DIR" != "$MAIN_WORKTREE" ] && IN_WORKTREE=1
 
-BUILD_LOG=$(mktemp)
-TEST_LOG=$(mktemp)
-trap 'rm -f "$BUILD_LOG" "$TEST_LOG"' EXIT
+# Shared temp files; individual branches add more as needed.
+INSTALL_LOG=$(mktemp)
+trap 'rm -f "$INSTALL_LOG"' EXIT
 
 # Ensure dependencies are installed before building/testing
-(cd "$MAIN_WORKTREE" && "$RUN" yarn install --immutable) >"$BUILD_LOG" 2>&1 || true
+(cd "$MAIN_WORKTREE" && "$RUN" yarn install --immutable) >"$INSTALL_LOG" 2>&1 || true
 
-# Type-check: when in a worktree, run tsc against that worktree's tsconfig so
-# we gate the feature branch's types, not the main branch's.  On the main tree
-# run the full build (tsc + vite bundle) as before.
-build_failed=0
 if [ "$IN_WORKTREE" -eq 1 ]; then
+  # Worktree gate: run tsc and vitest in parallel — they don't depend on each other.
+  # This cuts wall-clock time from ~40s (sequential) to ~25s (vitest-dominated).
+  # The vitest transform cache is shared via node_modules/.vite/vitest in the main
+  # worktree (set in vite.config.ts cacheDir), so repeated runs are faster still.
+  TSC_LOG=$(mktemp)
+  VITEST_LOG=$(mktemp)
+  trap 'rm -f "$INSTALL_LOG" "$TSC_LOG" "$VITEST_LOG"' EXIT
+
   (cd "$MAIN_WORKTREE" && "$RUN" yarn tsc --project "$PROJECT_DIR/tsconfig.json" --noEmit) \
-    >>"$BUILD_LOG" 2>&1 || build_failed=1
-else
-  (cd "$MAIN_WORKTREE" && "$RUN" yarn build) >>"$BUILD_LOG" 2>&1 || build_failed=1
-fi
+    >"$TSC_LOG" 2>&1 &
+  TSC_PID=$!
 
-if [ "$build_failed" -ne 0 ]; then
-  {
-    echo "ERROR: type-check failed — fix type/build errors before pushing."
-    echo "--- last 30 lines of build output ---"
-    tail -n 30 "$BUILD_LOG"
-  } >&2
-  exit 2
-fi
-
-# Tests: when in a worktree, run vitest with --root pointing at the worktree so
-# test files and @/ aliases resolve against the feature branch's source, not main.
-# Hook smoke tests run from the worktree too (they find their sibling scripts via
-# relative paths from tests/hooks/).  On the main tree, run the combined yarn test
-# script as before.
-tests_failed=0
-if [ "$IN_WORKTREE" -eq 1 ]; then
   (cd "$MAIN_WORKTREE" && "$RUN" yarn vitest run --root "$PROJECT_DIR") \
-    >"$TEST_LOG" 2>&1 || tests_failed=1
-  bash "$PROJECT_DIR/tests/hooks/run.sh" >>"$TEST_LOG" 2>&1 || tests_failed=1
-else
-  (cd "$MAIN_WORKTREE" && "$RUN" yarn test) >"$TEST_LOG" 2>&1 || tests_failed=1
-fi
+    >"$VITEST_LOG" 2>&1 &
+  VITEST_PID=$!
 
-if [ "$tests_failed" -ne 0 ]; then
-  {
-    echo "ERROR: tests failed — fix failing tests before pushing."
-    echo "--- last 30 lines of test output ---"
-    tail -n 30 "$TEST_LOG"
-  } >&2
-  exit 2
+  wait "$TSC_PID"; tsc_exit=$?
+  wait "$VITEST_PID"; vitest_exit=$?
+
+  # Shell hook smoke tests are fast (~5s); run after vitest completes so their
+  # output appends cleanly to the same log without interleaving.
+  shell_exit=0
+  bash "$PROJECT_DIR/tests/hooks/run.sh" >>"$VITEST_LOG" 2>&1 || shell_exit=1
+
+  if [ "$tsc_exit" -ne 0 ]; then
+    {
+      echo "ERROR: type-check failed — fix type/build errors before pushing."
+      echo "--- last 20 lines of tsc output ---"
+      tail -n 20 "$TSC_LOG"
+    } >&2
+    exit 2
+  fi
+
+  if [ "$vitest_exit" -ne 0 ] || [ "$shell_exit" -ne 0 ]; then
+    {
+      echo "ERROR: tests failed — fix failing tests before pushing."
+      echo "--- last 30 lines of test output ---"
+      tail -n 30 "$VITEST_LOG"
+    } >&2
+    exit 2
+  fi
+
+else
+  # Main tree: full build (tsc + vite bundle) then tests, sequential as before.
+  BUILD_LOG=$(mktemp)
+  TEST_LOG=$(mktemp)
+  trap 'rm -f "$INSTALL_LOG" "$BUILD_LOG" "$TEST_LOG"' EXIT
+
+  build_failed=0
+  (cd "$MAIN_WORKTREE" && "$RUN" yarn build) >"$BUILD_LOG" 2>&1 || build_failed=1
+
+  if [ "$build_failed" -ne 0 ]; then
+    {
+      echo "ERROR: type-check failed — fix type/build errors before pushing."
+      echo "--- last 30 lines of build output ---"
+      tail -n 30 "$BUILD_LOG"
+    } >&2
+    exit 2
+  fi
+
+  tests_failed=0
+  (cd "$MAIN_WORKTREE" && "$RUN" yarn test) >"$TEST_LOG" 2>&1 || tests_failed=1
+
+  if [ "$tests_failed" -ne 0 ]; then
+    {
+      echo "ERROR: tests failed — fix failing tests before pushing."
+      echo "--- last 30 lines of test output ---"
+      tail -n 30 "$TEST_LOG"
+    } >&2
+    exit 2
+  fi
 fi
 
 exit 0

--- a/.claude/rules/hooks-and-tooling.md
+++ b/.claude/rules/hooks-and-tooling.md
@@ -39,3 +39,39 @@ paths:
 - [ ] Returns exit 2 on the deny path with a clear stderr message
 - [ ] Has matching `tests/hooks/<name>.test.sh` covering pass and block paths
 - [ ] Registered in `.claude/settings.json` under the correct `matcher` for the tool it cares about
+
+## Pre-push gate: what it runs and how long it takes
+
+`require-green-before-push.sh` fires only for `git push`, `gh pr create`, and `gh pr merge` — not for `git commit`.
+
+**From a worktree** (the common case for all Claude sessions):
+- `yarn install --immutable` — serial, ~3s
+- `tsc` + `vitest run --root <worktree>` — **parallel**, wall-clock ~25s (vitest dominates)
+- Shell hook smoke tests — serial after vitest, ~5s
+- **Total: ~35–45 seconds**
+
+**From the main tree:**
+- `yarn build` (tsc + vite bundle) then `yarn test` — sequential, ~50s total
+
+**Set Bash tool timeout to match the command, not the hook:**
+- `git commit` — **30 000 ms**. No hook runs tests; the commit itself takes < 1s.
+- `git push` / `gh pr create` / `gh pr merge` — **120 000 ms**. The hook runs tsc + vitest.
+- A 360 000 ms timeout on `git commit` papers over the wrong symptom. Match the timeout to what the command actually does.
+
+## Vitest cache config
+
+`cacheDir` in `vite.config.ts` is pinned to `node_modules/.vite/vitest` in the main worktree. Without this, `vitest --root /worktree/path` looked for Vite's dependency optimizer cache inside the worktree where `node_modules/` doesn't exist.
+
+**What this fixes:** Vite's dependency pre-bundling cache is shared across all worktrees.
+
+**What this does NOT change:** esbuild TypeScript transforms (~17s cumulative / ~2–3s wall-clock). That time is proportional to suite size (~300 files × 8 workers) and is inherent to every run. The ~26s floor is the cost of running the suite, not a cache miss.
+
+## Worktree setup: trust mise before the first push
+
+Every new worktree has its own `mise.toml`. The `run-with-mise-worktree.test.sh` smoke test will fail with `mise ERROR Config files ... are not trusted` until you run:
+
+```bash
+mise trust /path/to/worktree/mise.toml
+```
+
+Run this immediately after creating a worktree, before the first push attempt. The `EnterWorktree` tool does not do this automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ Civilization-building strategy game. TypeScript + Canvas 2D + Vite.
 1. Check if already in a worktree (`git worktree list`).
 2. If not, create one via `EnterWorktree` tool BEFORE writing any code.
 3. Never write code on `main` or on a feature branch in the main working tree — always use a worktree.
+4. After creating a new worktree, run `mise trust <worktree-path>/mise.toml` before the first push — otherwise the `run-with-mise-worktree.test.sh` smoke test will block the push.
 
 This is enforced by the user and is not optional.
 
@@ -23,6 +24,11 @@ This is enforced by the user and is not optional.
 - `bash scripts/run-with-mise.sh yarn build` — Production build
 - `bash scripts/run-with-mise.sh yarn test` — Run vitest + hook smoke tests. DOES NOT type-check — `yarn build` is the only path that runs `tsc`. Before any `git push`, `gh pr create`, or `gh pr merge`, run `yarn build` and `yarn test` and confirm both exit 0. The `require-green-before-push` hook enforces this, but catching it locally is faster.
 - `bash scripts/run-with-mise.sh yarn test:watch` — Run tests in watch mode
+
+**Bash tool timeout guidance** — set `timeout` to match what the command actually does:
+- `git commit` → **30 000 ms** (commit itself < 1s; no hook runs tests on commit)
+- `git push` / `gh pr create` / `gh pr merge` → **120 000 ms** (pre-push hook runs tsc + vitest in parallel, ~35–45s from a worktree)
+- Using a 360 000 ms timeout for commits papers over the root cause; the correct fix is matching the timeout to the command's expected duration.
 
 ## Rules Index
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,13 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'node',
       exclude: ['**/node_modules/**', '**/.worktrees/**', '**/.claude/worktrees/**', 'tests/e2e/**'],
+      // Pin Vite's dependency optimizer cache to the main worktree's node_modules so
+      // secondary worktrees (which have no node_modules/) can find it. Without this,
+      // `vitest --root /worktree/path` looks for the cache inside the worktree and
+      // falls back to re-optimizing deps on every run. Note: esbuild's TypeScript
+      // transform time (~17s cumulative) is inherent to 300+ test files and 8 workers
+      // and is NOT reduced by this cache — that time is fixed by the suite size.
+      cacheDir: resolve(__dirname, 'node_modules/.vite/vitest'),
     },
   };
 });


### PR DESCRIPTION
## Summary

- **Parallelizes tsc and vitest** in the worktree branch of `require-green-before-push.sh` (background jobs + `wait`), cutting wall-clock time from ~40s to ~25s and making the 120 000ms Bash timeout comfortable
- **Pins `cacheDir`** in `vite.config.ts` to the main worktree's `node_modules/.vite/vitest` so Vite's dep optimizer cache is shared across all secondary worktrees (which have no `node_modules/`)
- **Updates `hooks-and-tooling.md`** with: pre-push gate timing breakdown, correct Bash tool timeout guidance (30s commit vs 120s push), vitest cache clarification, and `mise trust` requirement for new worktrees
- **Updates `CLAUDE.md`** with: Bash timeout guidance in the Commands section, and `mise trust` step in the Worktree Policy

## Root cause (recap)

The pre-push hook ran tsc (~15s) then vitest (~25s) sequentially = ~40s total. Using a 120s Bash timeout for `git commit` was papering over this. The real fix is parallelization, which brings the worktree gate under 30s wall-clock.

The 17s cumulative transform time shown in vitest output is inherent to ~300 test files × 8 workers (esbuild per-file, not a cache miss). The `cacheDir` fix addresses dep optimizer caching, not transforms.

## Test plan

- [x] `bash tests/hooks/require-green-before-push.test.sh` exits 0
- [x] `yarn build` exits 0
- [x] `yarn test` exits 0 (26s, unchanged)
- [x] `vite.config.ts` changes verified: `cacheDir` dir created at `node_modules/.vite/vitest/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LtMoD5NjH19wCwpM4wuq2h