### PR TITLE
feat(ai): issue 412 foundation, scheduling, and hot-seat privacy

### DIFF
--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -1,0 +1,63 @@
+import { processAITurn } from '@/ai/basic-ai';
+import type { EventBus } from '@/core/event-bus';
+import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
+import type { GameState } from '@/core/types';
+
+export function getLivingNonHumanMajorIds(state: GameState): string[] {
+  return Object.values(state.civilizations)
+    .filter(civ => {
+      if (civ.isHuman || civ.isEliminated === true) return false;
+      const hasLiveCity = civ.cities.some(id => state.cities[id]?.owner === civ.id);
+      const hasLiveUnit = civ.units.some(id => state.units[id]?.owner === civ.id);
+      return hasLiveCity || hasLiveUnit;
+    })
+    .map(civ => civ.id)
+    .sort();
+}
+
+export function rotateIdsForRound(ids: readonly string[], turn: number): string[] {
+  if (ids.length === 0) return [];
+  const start = ((turn % ids.length) + ids.length) % ids.length;
+  return [...ids.slice(start), ...ids.slice(0, start)];
+}
+
+export interface ProcessNonHumanRoundOptions {
+  execute?: (state: GameState, civId: string, bus: EventBus) => GameState;
+}
+
+export interface ProcessNonHumanRoundResult {
+  state: GameState;
+}
+
+export function processNonHumanMajorRound(
+  state: GameState,
+  bus: EventBus,
+  options: ProcessNonHumanRoundOptions = {},
+): ProcessNonHumanRoundResult {
+  let working = normalizeOpponentAIState(state);
+  if (working.opponentAI!.lastProcessedRound === working.turn) {
+    return { state: working };
+  }
+
+  const actorIds = rotateIdsForRound(getLivingNonHumanMajorIds(working), working.turn);
+  const execute = options.execute ?? processAITurn;
+  for (const civId of actorIds) {
+    const civ = working.civilizations[civId];
+    if (!civ || civ.isHuman || civ.isEliminated) continue;
+    const hasLiveAsset = civ.cities.some(id => working.cities[id]?.owner === civId)
+      || civ.units.some(id => working.units[id]?.owner === civId);
+    if (!hasLiveAsset) continue;
+    working = execute(working, civId, bus);
+  }
+
+  working = normalizeOpponentAIState(working);
+  return {
+    state: {
+      ...working,
+      opponentAI: {
+        ...working.opponentAI!,
+        lastProcessedRound: working.turn,
+      },
+    },
+  };
+}

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -78,6 +78,7 @@ import {
   payPirateTribute,
 } from '@/systems/pirate-actions';
 import { derivePirateBlockades } from '@/systems/pirate-behavior';
+import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 
 function addAlwaysHostileOwners(
   state: GameState,
@@ -376,10 +377,11 @@ export function applyPirateAiResponse(state: GameState, civId: string, bus: Even
     if (adjacentPirate) {
       const seed = Math.max(1, nextState.turn * 16807 + warship.id.length * 97 + adjacentPirate.id.length);
       const combat = resolveCombat(warship, adjacentPirate, nextState.map, seed, undefined, nextState.era);
+      const combatPresentation = buildCombatPresentation(nextState, combat, warship, adjacentPirate);
       const applied = applyCombatOutcomeToState(nextState, combat, seed);
       nextState = applied.state;
       emitMinorCivQuestTransitions(bus, applied.questTransitions, nextState);
-      bus.emit('combat:resolved', { result: combat });
+      bus.emit('combat:resolved', { result: combat, ...combatPresentation });
       for (const reward of applied.rewards) bus.emit('combat:reward-earned', { reward });
       continue;
     }
@@ -665,6 +667,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
             { attackerBonus, defenderBonus },
             newState.era,
           );
+          const combatPresentation = buildCombatPresentation(newState, result, unit, occupant);
           const applied = applyCombatOutcomeToState(newState, result, seed);
           newState = applied.state;
           emitMinorCivQuestTransitions(bus, applied.questTransitions, newState);
@@ -679,7 +682,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
               }
             }
           }
-          bus.emit('combat:resolved', { result });
+          bus.emit('combat:resolved', { result, ...combatPresentation });
           for (const reward of applied.rewards) {
             bus.emit('combat:reward-earned', { reward });
           }

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -86,7 +86,7 @@ export class AudioSystem {
     this.wireEvents(bus, isPresentationSuppressed);
     this.sfxDirector.start(state.units, bus, getState, isPresentationSuppressed);
     this.pirateAudioDirector.start(bus);
-    routeSfxComponents(this.mixer, this.loader);
+    routeSfxComponents(this.mixer, this.loader, isPresentationSuppressed);
     this.armIosResume();
 
     void this.preloadForEra(state.era, this.currentCivType);

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -32,6 +32,7 @@ export class AudioSystem {
   private started = false;
   private iosResumeListeners: Array<() => void> = [];
   private gestureResumeHandler: (() => void) | null = null;
+  private isPresentationSuppressed: () => boolean = () => false;
 
   constructor(private readonly ctx: AudioContext) {
     this.loader = new AudioLoader(ctx);
@@ -53,6 +54,7 @@ export class AudioSystem {
       this.loader,
       path => this.director.playStingerWithDuck(path),
       () => this.stateProvider!(),
+      () => this.isPresentationSuppressed(),
     );
   }
 
@@ -66,6 +68,7 @@ export class AudioSystem {
     this.started = true;
     this.currentPlayerId = state.currentPlayer;
     this.stateProvider = getState;
+    this.isPresentationSuppressed = isPresentationSuppressed;
 
     // Snapshot civType lookup — civ identities are fixed for a game's lifetime
     for (const [id, civ] of Object.entries(state.civilizations ?? {})) {
@@ -194,6 +197,7 @@ export class AudioSystem {
     this.currentCivType = '';
     this.civTypeById = {};
     this.stateProvider = null;
+    this.isPresentationSuppressed = () => false;
     this.started = false;
   }
 

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -33,6 +33,7 @@ export class AudioSystem {
   private iosResumeListeners: Array<() => void> = [];
   private gestureResumeHandler: (() => void) | null = null;
   private isPresentationSuppressed: () => boolean = () => false;
+  private loopLoadRequestId = 0;
 
   constructor(private readonly ctx: AudioContext) {
     this.loader = new AudioLoader(ctx);
@@ -64,32 +65,23 @@ export class AudioSystem {
     getState: () => GameState = () => state,
     isPresentationSuppressed: () => boolean = () => false,
   ): void {
-    if (this.started) return;
-    this.started = true;
-    this.currentPlayerId = state.currentPlayer;
-    this.stateProvider = getState;
-    this.isPresentationSuppressed = isPresentationSuppressed;
-
-    // Snapshot civType lookup — civ identities are fixed for a game's lifetime
-    for (const [id, civ] of Object.entries(state.civilizations ?? {})) {
-      this.civTypeById[id] = (civ as { civType: string }).civType;
+    if (this.started) {
+      this.rebindCampaign(state, getState, isPresentationSuppressed);
+      return;
     }
-    this.currentCivType = this.civTypeById[this.currentPlayerId] ?? this.currentPlayerId;
+    this.started = true;
+    this.bindCampaignState(state, getState, isPresentationSuppressed);
+    this.applySettings(state);
 
-    const settings = state.settings;
-    this.mixer.setMusicEnabled(settings.musicEnabled);
-    this.mixer.setSfxEnabled(settings.soundEnabled);
-    this.mixer.setMusicVolume(settings.musicVolume);
-    this.mixer.setSfxVolume(settings.sfxVolume);
-    this.mixer.setVoiceEnabled(settings.voiceEnabled ?? true);
-    this.mixer.setVoiceVolume(settings.voiceVolume ?? 1.0);
-    this.mixer.setStingerEnabled(settings.stingerEnabled ?? true);
-    this.mixer.setStingerVolume(settings.stingerVolume ?? 1.0);
-
-    this.wireEvents(bus, isPresentationSuppressed);
-    this.sfxDirector.start(state.units, bus, getState, isPresentationSuppressed);
+    this.wireEvents(bus);
+    this.sfxDirector.start(
+      state.units,
+      bus,
+      getState,
+      () => this.isPresentationSuppressed(),
+    );
     this.pirateAudioDirector.start(bus);
-    routeSfxComponents(this.mixer, this.loader, isPresentationSuppressed);
+    routeSfxComponents(this.mixer, this.loader, () => this.isPresentationSuppressed());
     this.armIosResume();
 
     void this.preloadForEra(state.era, this.currentCivType);
@@ -198,17 +190,81 @@ export class AudioSystem {
     this.civTypeById = {};
     this.stateProvider = null;
     this.isPresentationSuppressed = () => false;
+    this.loopLoadRequestId += 1;
     this.started = false;
   }
 
-  private wireEvents(sourceBus: EventBus, isPresentationSuppressed: () => boolean): void {
+  private bindCampaignState(
+    state: GameState,
+    getState: () => GameState,
+    isPresentationSuppressed: () => boolean,
+  ): void {
+    this.currentPlayerId = state.currentPlayer;
+    this.stateProvider = getState;
+    this.isPresentationSuppressed = isPresentationSuppressed;
+    this.civTypeById = {};
+    for (const [id, civ] of Object.entries(state.civilizations ?? {})) {
+      this.civTypeById[id] = civ.civType;
+    }
+    this.currentCivType = this.civTypeById[this.currentPlayerId] ?? this.currentPlayerId;
+  }
+
+  private applySettings(state: GameState): void {
+    const settings = state.settings;
+    this.mixer.setMusicEnabled(settings.musicEnabled);
+    this.mixer.setSfxEnabled(settings.soundEnabled);
+    this.mixer.setMusicVolume(settings.musicVolume);
+    this.mixer.setSfxVolume(settings.sfxVolume);
+    this.mixer.setVoiceEnabled(settings.voiceEnabled ?? true);
+    this.mixer.setVoiceVolume(settings.voiceVolume ?? 1.0);
+    this.mixer.setStingerEnabled(settings.stingerEnabled ?? true);
+    this.mixer.setStingerVolume(settings.stingerVolume ?? 1.0);
+  }
+
+  private rebindCampaign(
+    state: GameState,
+    getState: () => GameState,
+    isPresentationSuppressed: () => boolean,
+  ): void {
+    this.bindCampaignState(state, getState, isPresentationSuppressed);
+    this.applySettings(state);
+    this.sfxDirector.replaceUnits(
+      state.units,
+      getState,
+      () => this.isPresentationSuppressed(),
+    );
+    this.naturalWonderDirector.stopAmbient('player-changed');
+    this.pirateAudioDirector.stopAmbience('player-changed');
+    this.voiceDirector.stop();
+    this.voiceDirector.setVoicePack(this.currentCivType);
+    void this.preloadVoicePack(this.currentCivType);
+
+    const civ = state.civilizations[this.currentPlayerId];
+    this.warCount = civ?.diplomacy?.atWarWith?.length ?? 0;
+    const unrestCityCount = Object.values(state.cities ?? {})
+      .filter(city => city.owner === this.currentPlayerId && city.unrestLevel > 0)
+      .length;
+    this.director.handlePlayerChanged({
+      civId: this.currentPlayerId,
+      civType: this.currentCivType,
+      era: state.era,
+      atWar: this.warCount > 0,
+      unrestCityCount,
+      nearDefeat: civ?.nearDefeat ?? false,
+      inBeastTerritory: false,
+    });
+    void this.preloadForEra(state.era, this.currentCivType);
+  }
+
+  private wireEvents(sourceBus: EventBus): void {
+    const isSuppressed = (): boolean => this.isPresentationSuppressed();
     const bus = {
       on<K extends keyof GameEvents>(
         event: K,
         listener: (payload: GameEvents[K]) => void,
       ): () => void {
         return sourceBus.on(event, payload => {
-          if (!isPresentationSuppressed()) listener(payload);
+          if (!isSuppressed()) listener(payload);
         });
       },
     } as EventBus;
@@ -242,21 +298,28 @@ export class AudioSystem {
       }),
 
       bus.on('currentPlayer:changed-after-handoff', p => {
+        const currentState = this.stateProvider?.();
+        const era = p.era ?? currentState?.era ?? 1;
         this.currentPlayerId = p.civId;
-        this.currentCivType = this.civTypeById[p.civId] ?? p.civId;
+        this.currentCivType = p.civType
+          ?? this.civTypeById[p.civId]
+          ?? currentState?.civilizations[p.civId]?.civType
+          ?? p.civId;
         // Reset warCount to exact count from payload so remainingWars stays precise
         this.warCount = p.atWarCount;
         this.naturalWonderDirector.stopAmbient('player-changed');
         this.director.handlePlayerChanged({
           civId: this.currentPlayerId,
           civType: this.currentCivType,
+          era,
           atWar: p.atWarCount > 0,
           unrestCityCount: p.unrestCityCount,
           nearDefeat: p.nearDefeat,
           inBeastTerritory: p.inBeastTerritory,
         });
-        // Swap in the new civ's accent track; era + adaptive buses keep their current sources
-        void this.reloadAccent(this.currentCivType);
+        // Hidden round processing may have advanced the era. Rewire all loop buses
+        // from the authoritative handoff snapshot without replaying the era stinger.
+        void this.preloadForEra(era, this.currentCivType);
         // Spec 3: hot-seat voice privacy — stop any in-progress voice line from outgoing player
         this.voiceDirector.stop();
         this.voiceDirector.setVoicePack(this.currentCivType);
@@ -413,13 +476,6 @@ export class AudioSystem {
     }
   }
 
-  private async reloadAccent(civType: string): Promise<void> {
-    const family = getFamilyForCiv(civType);
-    const accentEntry = ACCENT[family];
-    const buffer = await this.loader.get(accentEntry.file);
-    this.mixer.setBusSource('accent', buffer, true, accentEntry.loop, 500);
-  }
-
   private preloadSfx(): Promise<void> {
     return this.loader.preload(allSfxEntries().map(e => e.file));
   }
@@ -438,6 +494,7 @@ export class AudioSystem {
   }
 
   private async preloadForEra(era: number, civType: string): Promise<void> {
+    const requestId = ++this.loopLoadRequestId;
     const eraId = resolveEra(era);
     const family = getFamilyForCiv(civType);
 
@@ -450,6 +507,7 @@ export class AudioSystem {
       this.loader.get(warEntry.file),
       this.loader.get(accentEntry.file),
     ]);
+    if (requestId !== this.loopLoadRequestId) return;
 
     // Wire all three loop buses — the snapshot (peace/at-war/silent) controls which
     // are audible; the adaptive (war) bus runs silently in peace and fades up on war.

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -13,6 +13,7 @@ import { allSfxEntries } from './sfx-catalog';
 import { SfxDirector } from './sfx-director';
 import { routeSfxComponents } from './sfx';
 import { PirateAudioDirector, type PirateAmbientStopReason } from './pirate-audio-director';
+import type { GameEvents } from '@/core/types';
 
 export class AudioSystem {
   private loader: AudioLoader;
@@ -55,7 +56,12 @@ export class AudioSystem {
     );
   }
 
-  start(state: GameState, bus: EventBus, getState: () => GameState = () => state): void {
+  start(
+    state: GameState,
+    bus: EventBus,
+    getState: () => GameState = () => state,
+    isPresentationSuppressed: () => boolean = () => false,
+  ): void {
     if (this.started) return;
     this.started = true;
     this.currentPlayerId = state.currentPlayer;
@@ -77,8 +83,8 @@ export class AudioSystem {
     this.mixer.setStingerEnabled(settings.stingerEnabled ?? true);
     this.mixer.setStingerVolume(settings.stingerVolume ?? 1.0);
 
-    this.wireEvents(bus);
-    this.sfxDirector.start(state.units, bus, getState);
+    this.wireEvents(bus, isPresentationSuppressed);
+    this.sfxDirector.start(state.units, bus, getState, isPresentationSuppressed);
     this.pirateAudioDirector.start(bus);
     routeSfxComponents(this.mixer, this.loader);
     this.armIosResume();
@@ -191,7 +197,17 @@ export class AudioSystem {
     this.started = false;
   }
 
-  private wireEvents(bus: EventBus): void {
+  private wireEvents(sourceBus: EventBus, isPresentationSuppressed: () => boolean): void {
+    const bus = {
+      on<K extends keyof GameEvents>(
+        event: K,
+        listener: (payload: GameEvents[K]) => void,
+      ): () => void {
+        return sourceBus.on(event, payload => {
+          if (!isPresentationSuppressed()) listener(payload);
+        });
+      },
+    } as EventBus;
     this.unsubscribers.push(
       bus.on('era:advanced', p => {
         void this.preloadForEra(p.era, this.currentCivType);

--- a/src/audio/music-director.ts
+++ b/src/audio/music-director.ts
@@ -25,6 +25,7 @@ export interface CityFoundedPayload {
 export interface PlayerChangedPayload {
   civId: string;   // civ ID (e.g. 'player', 'cpu-1') — used to filter mid-game events
   civType: string; // civ type (e.g. 'rome') — used for accent/era track selection
+  era: number;
   atWar: boolean;
   unrestCityCount: number;
   nearDefeat: boolean;
@@ -102,10 +103,14 @@ export class MusicDirector {
     if (entry) {
       const captured = entry;
       const snapshotAtDispatch = snapshot;
+      const eraAtDispatch = era;
       void this.loader.get(captured.file).then(buf => {
         // Stale-check: if the snapshot changed while the load was in flight, skip the source swap.
         // This prevents the wrong adaptive layer from being set after a rapid state transition.
-        if (this.resolveSnapshot() !== snapshotAtDispatch) return;
+        if (
+          this.resolveSnapshot() !== snapshotAtDispatch
+          || resolveEra(this.currentEra) !== eraAtDispatch
+        ) return;
         this.mixer.setBusSource('adaptive', buf, true, captured.loop, ADAPTIVE_CROSSFADE_MS);
       });
     } else {
@@ -193,6 +198,7 @@ export class MusicDirector {
 
   handlePlayerChanged(p: PlayerChangedPayload): void {
     this.currentCivId = p.civId;
+    this.currentEra = p.era;
     // Reset all flags from the authoritative payload — prevents hot-seat drift
     this.atWar = p.atWar;
     this.unrestCityCount = p.unrestCityCount;

--- a/src/audio/pirate-audio-director.ts
+++ b/src/audio/pirate-audio-director.ts
@@ -20,6 +20,7 @@ export class PirateAudioDirector {
     private readonly loader: Pick<AudioLoader, 'get'>,
     private readonly playStinger: (path: string) => Promise<void>,
     private readonly getState: () => GameState,
+    private readonly isPresentationSuppressed: () => boolean = () => false,
   ) {}
 
   start(bus: EventBus): void {
@@ -27,12 +28,12 @@ export class PirateAudioDirector {
     this.unsubscribers.push(
       bus.on('pirate:audio-cue', event => {
         const state = this.getState();
-        if (!this.enabled || !event.viewerIds.includes(state.currentPlayer)) return;
+        if (this.isPresentationSuppressed() || !this.enabled || !event.viewerIds.includes(state.currentPlayer)) return;
         void this.playStinger(PIRATE_STRATEGIC_SFX[event.cue].file).catch(() => {});
       }),
       bus.on('pirate:headquarters-destroyed', event => {
         const state = this.getState();
-        if (!this.enabled || !event.viewerIds.includes(state.currentPlayer)) return;
+        if (this.isPresentationSuppressed() || !this.enabled || !event.viewerIds.includes(state.currentPlayer)) return;
         void this.playStinger(PIRATE_HEADQUARTERS_SFX.collapse.file).catch(() => {});
       }),
       bus.on('currentPlayer:changed-after-handoff', () => this.stopAmbience('player-changed')),
@@ -41,7 +42,7 @@ export class PirateAudioDirector {
   }
 
   async startHeadquartersAmbience(factionId: string): Promise<boolean> {
-    if (!this.enabled) return this.rejectAmbience();
+    if (this.isPresentationSuppressed() || !this.enabled) return this.rejectAmbience();
     const state = this.getState();
     const faction = state.pirates?.factions[factionId];
     if (!faction || faction.headquarters.kind !== 'coastal-enclave') return this.rejectAmbience();
@@ -56,7 +57,7 @@ export class PirateAudioDirector {
     } catch {
       return this.rejectAmbience();
     }
-    if (requestId !== this.requestId || !this.enabled) return false;
+    if (requestId !== this.requestId || this.isPresentationSuppressed() || !this.enabled) return false;
     this.mixer.setAmbienceLoop(buffer, PIRATE_HEADQUARTERS_SFX.ambience.loop, 350, 0.28);
     this.activeFactionId = factionId;
     return true;

--- a/src/audio/sfx-director.ts
+++ b/src/audio/sfx-director.ts
@@ -60,6 +60,24 @@ export class SfxDirector {
     this.started = false;
   }
 
+  replaceUnits(
+    units: Record<string, Unit>,
+    getState?: () => GameState,
+    isPresentationSuppressed?: () => boolean,
+  ): void {
+    for (const id of this.pendingTimeouts) clearTimeout(id);
+    this.pendingTimeouts = [];
+    this.unitTypeCache.clear();
+    this.deathPlayed.clear();
+    for (const [id, unit] of Object.entries(units)) {
+      this.unitTypeCache.set(id, unit.type);
+    }
+    if (getState) this.getState = getState;
+    if (isPresentationSuppressed) {
+      this.isPresentationSuppressed = isPresentationSuppressed;
+    }
+  }
+
   private canPresentTo(viewerIds?: string[]): boolean {
     if (this.isPresentationSuppressed()) return false;
     if (!viewerIds) return true;
@@ -149,8 +167,9 @@ export class SfxDirector {
     if (!unitType) return;
     const viewerId = this.getState?.().currentPlayer;
     const presentation = viewerId ? presentationByViewer?.[viewerId] : undefined;
-    const visibleSegments = presentation?.visibleSegments
-      ?? (path.some(coord => this.isVisible(coord)) ? [path] : []);
+    const visibleSegments = presentationByViewer
+      ? (presentation?.visibleSegments ?? [])
+      : (path.some(coord => this.isVisible(coord)) ? [path] : []);
     if (visibleSegments.length === 0) return;
     const viewerIds = viewerId ? [viewerId] : undefined;
 

--- a/src/audio/sfx-director.ts
+++ b/src/audio/sfx-director.ts
@@ -13,25 +13,37 @@ export class SfxDirector {
   private unsubscribers: Array<() => void> = [];
   private started = false;
   private getState: (() => GameState) | null = null;
+  private isPresentationSuppressed: () => boolean = () => false;
 
   constructor(
     private readonly mixer: AudioMixer,
     private readonly loader: AudioLoader,
   ) {}
 
-  start(units: Record<string, Unit>, bus: EventBus, getState?: () => GameState): void {
+  start(
+    units: Record<string, Unit>,
+    bus: EventBus,
+    getState?: () => GameState,
+    isPresentationSuppressed: () => boolean = () => false,
+  ): void {
     if (this.started) return;
     this.started = true;
     for (const [id, unit] of Object.entries(units)) {
       this.unitTypeCache.set(id, unit.type);
     }
     this.getState = getState ?? null;
+    this.isPresentationSuppressed = isPresentationSuppressed;
     this.unsubscribers.push(
       bus.on('unit:created', p => {
         this.unitTypeCache.set(p.unit.id, p.unit.type);
       }),
-      bus.on('combat:resolved', p => this.handleCombatResolved(p.result)),
-      bus.on('unit:move', p => this.handleUnitMove(p.unitId, p.to, p.path)),
+      bus.on('combat:resolved', p => this.handleCombatResolved(
+        p.result,
+        p.visibleToViewerIds,
+        p.attackerType,
+        p.defenderType,
+      )),
+      bus.on('unit:move', p => this.handleUnitMove(p.unitId, p.path, p.presentationByViewer)),
       bus.on('unit:destroyed', p => this.handleUnitDestroyed(p.unitId, p.position)),
     );
   }
@@ -44,16 +56,30 @@ export class SfxDirector {
     this.unitTypeCache.clear();
     this.deathPlayed.clear();
     this.getState = null;
+    this.isPresentationSuppressed = () => false;
     this.started = false;
   }
 
-  private playFile(path: string): void {
-    void this.loader.get(path).then(buf => void this.mixer.playOneShot('sfx', buf));
+  private canPresentTo(viewerIds?: string[]): boolean {
+    if (this.isPresentationSuppressed()) return false;
+    if (!viewerIds) return true;
+    const state = this.getState?.();
+    if (!state) return true;
+    const viewerId = state.currentPlayer;
+    return Boolean(viewerId && viewerIds.includes(viewerId));
   }
 
-  private scheduleFile(path: string, delayMs: number): void {
+  private playFile(path: string, viewerIds?: string[]): void {
+    if (!this.canPresentTo(viewerIds)) return;
+    void this.loader.get(path).then(buf => {
+      if (this.canPresentTo(viewerIds)) void this.mixer.playOneShot('sfx', buf);
+    });
+  }
+
+  private scheduleFile(path: string, delayMs: number, viewerIds?: string[]): void {
+    if (!this.canPresentTo(viewerIds)) return;
     const id = setTimeout(() => {
-      this.playFile(path);
+      if (this.canPresentTo(viewerIds)) this.playFile(path, viewerIds);
       const index = this.pendingTimeouts.indexOf(id);
       if (index !== -1) this.pendingTimeouts.splice(index, 1);
     }, delayMs);
@@ -67,16 +93,27 @@ export class SfxDirector {
     return Boolean(visibility && getVisibility(visibility, coord) === 'visible');
   }
 
-  private handleCombatResolved(result: CombatResult): void {
-    if (!this.isVisible(result.attackerPosition) && !this.isVisible(result.defenderPosition)) return;
-    const attackerType = this.unitTypeCache.get(result.attackerId);
-    const defenderType = this.unitTypeCache.get(result.defenderId);
+  private handleCombatResolved(
+    result: CombatResult,
+    visibleToViewerIds?: string[],
+    eventAttackerType?: UnitType,
+    eventDefenderType?: UnitType,
+  ): void {
+    const currentViewer = this.getState?.().currentPlayer;
+    const viewerIds = visibleToViewerIds ?? (
+      this.isVisible(result.attackerPosition) || this.isVisible(result.defenderPosition)
+        ? (currentViewer ? [currentViewer] : undefined)
+        : []
+    );
+    if (!this.canPresentTo(viewerIds)) return;
+    const attackerType = eventAttackerType ?? this.unitTypeCache.get(result.attackerId);
+    const defenderType = eventDefenderType ?? this.unitTypeCache.get(result.defenderId);
 
     if (attackerType) {
       const sfx = UNIT_SFX[attackerType];
       // Priority: ranged-loose (ranged), siege-fire (siege), attack-swing (melee)
       const sound = sfx?.['ranged-loose'] ?? sfx?.['siege-fire'] ?? sfx?.['attack-swing'];
-      if (sound) this.playFile(sound.file);
+      if (sound) this.playFile(sound.file, viewerIds);
     }
 
     if (defenderType) {
@@ -85,33 +122,46 @@ export class SfxDirector {
       // Priority: attack-impact (melee), ranged-impact (ranged), siege-impact (siege)
       const impact = sfx?.['attack-impact'] ?? sfx?.['ranged-impact'] ?? sfx?.['siege-impact'];
       if (impact) {
-        if (pirateAttacker) this.scheduleFile(impact.file, 140);
-        else this.playFile(impact.file);
+        if (pirateAttacker) this.scheduleFile(impact.file, 140, viewerIds);
+        else this.playFile(impact.file, viewerIds);
       }
     }
 
     if (!result.attackerSurvived && attackerType) {
       const death = UNIT_SFX[attackerType]?.death;
-      if (death) this.playFile(death.file);
+      if (death) this.playFile(death.file, viewerIds);
       this.deathPlayed.add(result.attackerId);
     }
 
     if (!result.defenderSurvived && defenderType) {
       const death = UNIT_SFX[defenderType]?.death;
-      if (death) this.playFile(death.file);
+      if (death) this.playFile(death.file, viewerIds);
       this.deathPlayed.add(result.defenderId);
     }
   }
 
-  private handleUnitMove(unitId: string, _to: HexCoord, path: HexCoord[]): void {
+  private handleUnitMove(
+    unitId: string,
+    path: HexCoord[],
+    presentationByViewer?: Record<string, { unit: Unit; visibleSegments: HexCoord[][] }>,
+  ): void {
     const unitType = this.unitTypeCache.get(unitId);
-    if (!unitType || !path.some(coord => this.isVisible(coord))) return;
+    if (!unitType) return;
+    const viewerId = this.getState?.().currentPlayer;
+    const presentation = viewerId ? presentationByViewer?.[viewerId] : undefined;
+    const visibleSegments = presentation?.visibleSegments
+      ?? (path.some(coord => this.isVisible(coord)) ? [path] : []);
+    if (visibleSegments.length === 0) return;
+    const viewerIds = viewerId ? [viewerId] : undefined;
 
-    const stepCount = path.length - 1;
+    const stepCount = visibleSegments.reduce(
+      (total, segment) => total + Math.max(0, segment.length - 1),
+      0,
+    );
     if (stepCount <= 0) return;
 
     if (unitType.startsWith('pirate_')) {
-      this.scheduleFile(PIRATE_MOVEMENT_SFX[unitType as PirateUnitType].file, 0);
+      this.scheduleFile(PIRATE_MOVEMENT_SFX[unitType as PirateUnitType].file, 0, viewerIds);
       return;
     }
     const sfx = MOVEMENT_SFX[getLocomotionClass(unitType)];
@@ -120,7 +170,7 @@ export class SfxDirector {
 
     for (let i = 0; i < stepCount; i++) {
       const id = setTimeout(() => {
-        this.playFile(sfx.file);
+        this.playFile(sfx.file, viewerIds);
         const idx = this.pendingTimeouts.indexOf(id);
         if (idx !== -1) this.pendingTimeouts.splice(idx, 1);
       }, i * interval);

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -6,6 +6,7 @@ let audioContext: AudioContext | null = null;
 let sfxDestination: AudioNode | null = null;
 let _mixer: AudioMixer | null = null;
 let _loader: AudioLoader | null = null;
+let _isPresentationSuppressed: () => boolean = () => false;
 
 export function routeSfxThrough(node: AudioNode): void {
   sfxDestination = node;
@@ -16,9 +17,14 @@ export function routeSfxThrough(node: AudioNode): void {
  * Wire OGG-backed load/unload sounds. Call from AudioSystem.start() after
  * the mixer and loader are initialised so real files play instead of oscillator fallbacks.
  */
-export function routeSfxComponents(mixer: AudioMixer, loader: AudioLoader): void {
+export function routeSfxComponents(
+  mixer: AudioMixer,
+  loader: AudioLoader,
+  isPresentationSuppressed: () => boolean = () => false,
+): void {
   _mixer = mixer;
   _loader = loader;
+  _isPresentationSuppressed = isPresentationSuppressed;
 }
 
 function getContext(): AudioContext {
@@ -29,6 +35,7 @@ function getContext(): AudioContext {
 }
 
 function playTone(frequency: number, duration: number, volume: number, type: OscillatorType = 'sine'): void {
+  if (_isPresentationSuppressed()) return;
   try {
     const ctx = getContext();
     const osc = ctx.createOscillator();
@@ -85,18 +92,24 @@ export const SFX = {
     setTimeout(() => playTone(349, 0.25, 0.15), 300);
   },
   transportLoad: () => {
+    if (_isPresentationSuppressed()) return;
     if (_loader && _mixer) {
       void _loader.get(TRANSPORT_SFX.load.file)
-        .then(buf => _mixer!.playOneShot('sfx', buf));
+        .then(buf => {
+          if (!_isPresentationSuppressed()) return _mixer!.playOneShot('sfx', buf);
+        });
     } else {
       playTone(330, 0.08, 0.12, 'triangle');
       setTimeout(() => playTone(440, 0.1, 0.12, 'triangle'), 80);
     }
   },
   transportUnload: () => {
+    if (_isPresentationSuppressed()) return;
     if (_loader && _mixer) {
       void _loader.get(TRANSPORT_SFX.unload.file)
-        .then(buf => _mixer!.playOneShot('sfx', buf));
+        .then(buf => {
+          if (!_isPresentationSuppressed()) return _mixer!.playOneShot('sfx', buf);
+        });
     } else {
       playTone(440, 0.08, 0.12, 'triangle');
       setTimeout(() => playTone(330, 0.1, 0.12, 'triangle'), 80);
@@ -104,6 +117,7 @@ export const SFX = {
   },
 
   seaHorn: () => {
+    if (_isPresentationSuppressed()) return;
     try {
       const ctx = getContext();
       const now = ctx.currentTime;
@@ -124,6 +138,7 @@ export const SFX = {
   },
 
   piratePlunder: () => {
+    if (_isPresentationSuppressed()) return;
     try {
       const ctx = getContext();
       const now = ctx.currentTime;
@@ -161,6 +176,7 @@ export const SFX = {
   },
 
   pirateDestroyed: () => {
+    if (_isPresentationSuppressed()) return;
     try {
       const ctx = getContext();
       const now = ctx.currentTime;
@@ -179,6 +195,7 @@ export const SFX = {
   },
 
   barbarianResurgence: () => {
+    if (_isPresentationSuppressed()) return;
     try {
       const ctx = getContext();
       const now = ctx.currentTime;

--- a/src/core/completed-round-handoff.ts
+++ b/src/core/completed-round-handoff.ts
@@ -1,0 +1,69 @@
+import type { EventBus } from '@/core/event-bus';
+import type { CompletedRoundResult } from '@/core/completed-round-orchestrator';
+import type { GameState } from '@/core/types';
+
+export type CompletedRoundHandoffResult =
+  | { status: 'ready'; state: GameState }
+  | { status: 'simulation-failed'; state: GameState; error: unknown }
+  | { status: 'persistence-failed'; state: GameState; error: unknown };
+
+export interface CompletedRoundHandoffTransactionOptions {
+  initialState: GameState;
+  runCompletedRound: (state: GameState) => CompletedRoundResult;
+  prepareCompletedState: (state: GameState) => GameState;
+  eventTarget: EventBus;
+  adoptState: (state: GameState) => void;
+  persistState: (state: GameState) => Promise<void>;
+  onCommitErrors?: (errors: readonly unknown[]) => void;
+}
+
+export interface CompletedRoundHandoffTransaction {
+  runCompletedRoundSimulation(): Promise<CompletedRoundHandoffResult>;
+  persistCompletedRoundHandoff(): Promise<CompletedRoundHandoffResult>;
+}
+
+export function createCompletedRoundHandoffTransaction(
+  options: CompletedRoundHandoffTransactionOptions,
+): CompletedRoundHandoffTransaction {
+  let completedState: GameState | null = null;
+
+  const persistCompletedRoundHandoff = async (): Promise<CompletedRoundHandoffResult> => {
+    if (!completedState) {
+      return {
+        status: 'simulation-failed',
+        state: options.initialState,
+        error: new Error('Completed-round simulation has not succeeded.'),
+      };
+    }
+    try {
+      await options.persistState(completedState);
+      return { status: 'ready', state: completedState };
+    } catch (error) {
+      return { status: 'persistence-failed', state: completedState, error };
+    }
+  };
+
+  const runCompletedRoundSimulation = async (): Promise<CompletedRoundHandoffResult> => {
+    if (completedState) return persistCompletedRoundHandoff();
+
+    const result = options.runCompletedRound(options.initialState);
+    if (!result.ok) {
+      return {
+        status: 'simulation-failed',
+        state: options.initialState,
+        error: result.error,
+      };
+    }
+
+    completedState = options.prepareCompletedState(result.state);
+    options.adoptState(completedState);
+    const commitErrors = result.events.commitTo(options.eventTarget);
+    options.onCommitErrors?.(commitErrors);
+    return persistCompletedRoundHandoff();
+  };
+
+  return {
+    runCompletedRoundSimulation,
+    persistCompletedRoundHandoff,
+  };
+}

--- a/src/core/completed-round-orchestrator.ts
+++ b/src/core/completed-round-orchestrator.ts
@@ -1,0 +1,40 @@
+import type { EventBus } from '@/core/event-bus';
+import { GameEventBuffer } from '@/core/game-event-buffer';
+import type { GameState } from '@/core/types';
+
+export interface CompletedRoundPhases {
+  improvements: (state: GameState, bus: EventBus) => GameState;
+  majors: (state: GameState, bus: EventBus) => GameState;
+  world: (state: GameState, bus: EventBus) => GameState;
+  postprocess?: (
+    beforeRound: Readonly<GameState>,
+    state: GameState,
+    bus: EventBus,
+  ) => GameState;
+}
+
+export type CompletedRoundResult =
+  | { ok: true; state: GameState; events: GameEventBuffer }
+  | { ok: false; state: GameState; error: unknown };
+
+export function runCompletedRound(
+  state: GameState,
+  _bus: EventBus,
+  phases: CompletedRoundPhases,
+): CompletedRoundResult {
+  const beforeRound = structuredClone(state);
+  const events = new GameEventBuffer();
+  try {
+    let working = structuredClone(state);
+    working = phases.improvements(working, events);
+    working = phases.majors(working, events);
+    working = phases.world(working, events);
+    if (phases.postprocess) {
+      working = phases.postprocess(beforeRound, working, events);
+    }
+    return { ok: true, state: working, events };
+  } catch (error) {
+    events.discard();
+    return { ok: false, state, error };
+  }
+}

--- a/src/core/feature-flags.ts
+++ b/src/core/feature-flags.ts
@@ -1,0 +1,1 @@
+export const PURPOSEFUL_AI_FEATURE_ENABLED = false;

--- a/src/core/game-event-buffer.ts
+++ b/src/core/game-event-buffer.ts
@@ -1,0 +1,38 @@
+import { EventBus } from '@/core/event-bus';
+import type { GameEvents } from '@/core/types';
+
+interface BufferedGameEvent<K extends keyof GameEvents = keyof GameEvents> {
+  type: K;
+  payload: GameEvents[K];
+}
+
+export class GameEventBuffer extends EventBus {
+  private events: BufferedGameEvent[] = [];
+  private consumed = false;
+
+  override emit<K extends keyof GameEvents>(event: K, data: GameEvents[K]): void {
+    if (this.consumed) return;
+    this.events.push({ type: event, payload: structuredClone(data) } as BufferedGameEvent);
+  }
+
+  commitTo(target: EventBus): readonly unknown[] {
+    if (this.consumed) return [];
+    this.consumed = true;
+    const errors: unknown[] = [];
+    for (const event of this.events) {
+      try {
+        target.emit(event.type, event.payload);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.events = [];
+    return errors;
+  }
+
+  discard(): void {
+    if (this.consumed) return;
+    this.consumed = true;
+    this.events = [];
+  }
+}

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -1,4 +1,4 @@
-import type { GameState, Civilization, Unit, HotSeatConfig, GameSettings, SoloSetupConfig, MapScript, GameMap, HexCoord } from './types';
+import type { GameState, Civilization, Unit, HotSeatConfig, GameSettings, SoloSetupConfig, MapScript, GameMap, HexCoord, OpponentChallenge } from './types';
 import { generateMap, findStartPositions, createRng, guaranteeStartResources } from '@/systems/map-generator';
 import { loadGeoMap } from '@/systems/geo-map-loader';
 import { EARTH_TILES, EARTH_START_POSITIONS, EARTH_RIVERS } from '@/systems/earth-map-data';
@@ -23,6 +23,7 @@ import { placeBeastLairs } from '@/systems/beast-system';
 import { placeMinorCivs } from '@/systems/minor-civ-system';
 import { initializeEspionage } from '@/systems/espionage-system';
 import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { createEmptyOpponentAIState } from './opponent-ai-state';
 
 function hashSeed(s: string): number {
   let h = 0;
@@ -96,6 +97,7 @@ function normalizeSoloSetupConfig(
       settingsOverrides: arg1.settingsOverrides,
       customCivilizations: arg1.customCivilizations,
       mapScript: arg1.mapScript,
+      opponentChallenge: arg1.opponentChallenge,
     };
   }
 
@@ -270,6 +272,8 @@ export function createNewGame(
     era: 1,
     gameId: createGameId(gameSeed),
     gameTitle: resolvedGameTitle,
+    opponentChallenge: config.opponentChallenge ?? 'standard',
+    opponentAI: createEmptyOpponentAIState(),
     civilizations,
     map,
     units,
@@ -314,7 +318,12 @@ export function createNewGame(
   return state;
 }
 
-export function createHotSeatGame(config: HotSeatConfig, seed?: string, gameTitle?: string): GameState {
+export function createHotSeatGame(
+  config: HotSeatConfig,
+  seed?: string,
+  gameTitle?: string,
+  opponentChallenge: OpponentChallenge = 'standard',
+): GameState {
   const idCounters = emptyIdCounters();
 
   const gameSeed = seed ?? `hotseat-${Date.now()}`;
@@ -421,6 +430,8 @@ export function createHotSeatGame(config: HotSeatConfig, seed?: string, gameTitl
     era: 1,
     gameId: createGameId(gameSeed),
     gameTitle: resolvedGameTitle,
+    opponentChallenge,
+    opponentAI: createEmptyOpponentAIState(),
     civilizations,
     map,
     units,

--- a/src/core/hotseat-events.ts
+++ b/src/core/hotseat-events.ts
@@ -32,8 +32,11 @@ export function getEventsForPlayer(
 export function clearEventsForPlayer(
   pending: Record<string, GameEvent[]>,
   civId: string,
-): void {
-  pending[civId] = [];
+): Record<string, GameEvent[]> {
+  return {
+    ...pending,
+    [civId]: [],
+  };
 }
 
 export interface TurnSummary {
@@ -44,7 +47,6 @@ export interface TurnSummary {
   units: number;
   currentResearch: string | null;
   researchProgress: number;
-  sciencePerTurn: number;
   atWarWith: string[];
   allies: string[];
   events: GameEvent[];
@@ -69,7 +71,6 @@ export function generateSummary(
     units: civ?.units.length ?? 0,
     currentResearch: civ?.techState.currentResearch ?? null,
     researchProgress: civ?.techState.researchProgress ?? 0,
-    sciencePerTurn: 0, // calculated at render time from city yields
     atWarWith: civ?.diplomacy?.atWarWith ?? [],
     allies,
     events: pending[civId] ?? [],

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -16,6 +16,53 @@ const PLAN_PHASES = new Set([
   'complete',
   'abandoned',
 ]);
+const PLAN_OBJECTIVES = new Set([
+  'defend',
+  'recover',
+  'expand',
+  'secure-resource',
+  'raid',
+  'blockade',
+  'repel',
+  'capture',
+  'support-ally',
+]);
+const PLAN_REASONS = new Set([
+  'urgent-defense',
+  'nearby-opportunity',
+  'retaliate-recent-attack',
+  'continue-active-war',
+  'alliance-obligation',
+  'critical-resource',
+  'no-local-alternative',
+  'homeland-secure',
+  'recover-damaged-force',
+  'modernization-gap',
+  'camp-defense',
+  'opportunistic-raid',
+]);
+const STRATEGIC_ROLES = new Set([
+  'capture',
+  'frontline',
+  'ranged',
+  'siege',
+  'mobile',
+  'air-combat',
+  'naval-combat',
+  'transport',
+  'escort',
+  'recon',
+  'detection',
+  'settlement',
+  'worker',
+  'resource-expedition',
+  'trade',
+  'espionage',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
 
 function isFiniteCoord(value: unknown): value is { q: number; r: number } {
   if (!value || typeof value !== 'object') return false;
@@ -44,26 +91,45 @@ function normalizePlan(
   actorId: string,
   value: unknown,
 ): AIStrategicPlan | null {
-  if (!value || typeof value !== 'object') return null;
-  const plan = value as AIStrategicPlan;
+  if (!isRecord(value)) return null;
+  const plan = value as unknown as AIStrategicPlan;
   if (
     typeof plan.id !== 'string'
+    || plan.id.length === 0
     || plan.actorId !== actorId
-    || typeof plan.objective !== 'string'
+    || !PLAN_OBJECTIVES.has(plan.objective)
     || !isTarget(plan.target)
     || !PLAN_PHASES.has(plan.phase)
+    || typeof plan.theaterId !== 'string'
+    || !Number.isFinite(plan.createdTurn)
+    || !Number.isFinite(plan.reconsiderAfterTurn)
+    || !Number.isFinite(plan.expiresAfterTurn)
+    || !Number.isFinite(plan.lastProgressTurn)
   ) {
     return null;
+  }
+
+  const requiredRoles: AIStrategicPlan['requiredRoles'] = {};
+  if (isRecord(plan.requiredRoles)) {
+    for (const [role, count] of Object.entries(plan.requiredRoles)) {
+      if (STRATEGIC_ROLES.has(role) && Number.isFinite(count) && Number(count) > 0) {
+        requiredRoles[role as keyof typeof requiredRoles] = Math.floor(Number(count));
+      }
+    }
   }
 
   return {
     ...plan,
     target: structuredClone(plan.target),
-    reasonCodes: Array.isArray(plan.reasonCodes) ? [...plan.reasonCodes] : [],
+    reasonCodes: Array.isArray(plan.reasonCodes)
+      ? plan.reasonCodes.filter(reason => PLAN_REASONS.has(reason))
+      : [],
     commitment: Math.max(0, Math.min(1, Number.isFinite(plan.commitment) ? plan.commitment : 0)),
-    requiredRoles: plan.requiredRoles && typeof plan.requiredRoles === 'object'
-      ? { ...plan.requiredRoles }
-      : {},
+    createdTurn: Math.max(0, Math.floor(plan.createdTurn)),
+    reconsiderAfterTurn: Math.max(0, Math.floor(plan.reconsiderAfterTurn)),
+    expiresAfterTurn: Math.max(0, Math.floor(plan.expiresAfterTurn)),
+    lastProgressTurn: Math.max(0, Math.floor(plan.lastProgressTurn)),
+    requiredRoles,
     assignedUnitIds: Array.isArray(plan.assignedUnitIds)
       ? [...new Set(plan.assignedUnitIds.filter(unitId => state.units[unitId]?.owner === actorId))]
       : [],
@@ -88,13 +154,17 @@ function normalizePortfolio(
 
   const upgradeRoutesByUnitId: MajorCivPlanPortfolio['upgradeRoutesByUnitId'] = {};
   for (const [unitId, route] of Object.entries(portfolio.upgradeRoutesByUnitId ?? {})) {
+    if (!isRecord(route) || typeof route.cityId !== 'string') continue;
     const city = state.cities[route.cityId];
     if (
       state.units[unitId]?.owner === actorId
       && city?.owner === actorId
       && Number.isFinite(route.createdTurn)
     ) {
-      upgradeRoutesByUnitId[unitId] = { cityId: route.cityId, createdTurn: route.createdTurn };
+      upgradeRoutesByUnitId[unitId] = {
+        cityId: String(route.cityId),
+        createdTurn: Math.max(0, Math.floor(Number(route.createdTurn))),
+      };
     }
   }
 
@@ -136,11 +206,14 @@ export function normalizeOpponentAIState(state: GameState): GameState {
   }
 
   const opponentAI = createEmptyOpponentAIState();
-  opponentAI.migrationGraceRoundsRemaining = Math.max(
-    0,
-    Number.isFinite(source.migrationGraceRoundsRemaining)
-      ? Math.floor(source.migrationGraceRoundsRemaining)
-      : 0,
+  opponentAI.migrationGraceRoundsRemaining = Math.min(
+    2,
+    Math.max(
+      0,
+      Number.isFinite(source.migrationGraceRoundsRemaining)
+        ? Math.floor(source.migrationGraceRoundsRemaining)
+        : 0,
+    ),
   );
   opponentAI.lastPlannedRound = Number.isFinite(source.lastPlannedRound)
     ? source.lastPlannedRound

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -1,0 +1,200 @@
+import type {
+  AIStrategicPlan,
+  AITarget,
+  GameState,
+  MajorCivPlanPortfolio,
+  OpponentAIState,
+} from './types';
+
+const PLAN_PHASES = new Set([
+  'scouting',
+  'mobilizing',
+  'advancing',
+  'attacking',
+  'consolidating',
+  'withdrawing',
+  'complete',
+  'abandoned',
+]);
+
+function isFiniteCoord(value: unknown): value is { q: number; r: number } {
+  if (!value || typeof value !== 'object') return false;
+  const coord = value as { q?: unknown; r?: unknown };
+  return Number.isFinite(coord.q) && Number.isFinite(coord.r);
+}
+
+function isTarget(value: unknown): value is AITarget {
+  if (!value || typeof value !== 'object') return false;
+  const target = value as Record<string, unknown>;
+  if (target.kind === 'resource') {
+    return typeof target.resource === 'string' && isFiniteCoord(target.position);
+  }
+  if (target.kind === 'region') {
+    return typeof target.id === 'string' && isFiniteCoord(target.anchor);
+  }
+  return (
+    (target.kind === 'city' || target.kind === 'unit' || target.kind === 'camp')
+    && typeof target.id === 'string'
+    && isFiniteCoord(target.lastKnownPosition)
+  );
+}
+
+function normalizePlan(
+  state: GameState,
+  actorId: string,
+  value: unknown,
+): AIStrategicPlan | null {
+  if (!value || typeof value !== 'object') return null;
+  const plan = value as AIStrategicPlan;
+  if (
+    typeof plan.id !== 'string'
+    || plan.actorId !== actorId
+    || typeof plan.objective !== 'string'
+    || !isTarget(plan.target)
+    || !PLAN_PHASES.has(plan.phase)
+  ) {
+    return null;
+  }
+
+  return {
+    ...plan,
+    target: structuredClone(plan.target),
+    reasonCodes: Array.isArray(plan.reasonCodes) ? [...plan.reasonCodes] : [],
+    commitment: Math.max(0, Math.min(1, Number.isFinite(plan.commitment) ? plan.commitment : 0)),
+    requiredRoles: plan.requiredRoles && typeof plan.requiredRoles === 'object'
+      ? { ...plan.requiredRoles }
+      : {},
+    assignedUnitIds: Array.isArray(plan.assignedUnitIds)
+      ? [...new Set(plan.assignedUnitIds.filter(unitId => state.units[unitId]?.owner === actorId))]
+      : [],
+    ...(isFiniteCoord(plan.rallyPoint) ? { rallyPoint: { ...plan.rallyPoint } } : { rallyPoint: undefined }),
+  };
+}
+
+function normalizePortfolio(
+  state: GameState,
+  actorId: string,
+  value: unknown,
+): MajorCivPlanPortfolio {
+  const portfolio = value && typeof value === 'object'
+    ? value as Partial<MajorCivPlanPortfolio>
+    : {};
+  const defensePlansByCityId: Record<string, AIStrategicPlan> = {};
+  for (const [cityId, planValue] of Object.entries(portfolio.defensePlansByCityId ?? {})) {
+    if (state.cities[cityId]?.owner !== actorId) continue;
+    const plan = normalizePlan(state, actorId, planValue);
+    if (plan) defensePlansByCityId[cityId] = plan;
+  }
+
+  const upgradeRoutesByUnitId: MajorCivPlanPortfolio['upgradeRoutesByUnitId'] = {};
+  for (const [unitId, route] of Object.entries(portfolio.upgradeRoutesByUnitId ?? {})) {
+    const city = state.cities[route.cityId];
+    if (
+      state.units[unitId]?.owner === actorId
+      && city?.owner === actorId
+      && Number.isFinite(route.createdTurn)
+    ) {
+      upgradeRoutesByUnitId[unitId] = { cityId: route.cityId, createdTurn: route.createdTurn };
+    }
+  }
+
+  return {
+    primaryPlan: normalizePlan(state, actorId, portfolio.primaryPlan),
+    defensePlansByCityId,
+    upgradeRoutesByUnitId,
+    modernizationDemand: Math.max(
+      0,
+      Math.min(100, Number.isFinite(portfolio.modernizationDemand) ? portfolio.modernizationDemand! : 0),
+    ),
+    researchTargetTechId: typeof portfolio.researchTargetTechId === 'string'
+      ? portfolio.researchTargetTechId
+      : null,
+    lastPlannedTurn: Number.isFinite(portfolio.lastPlannedTurn) ? portfolio.lastPlannedTurn! : 0,
+    lastExecutedTurn: Number.isFinite(portfolio.lastExecutedTurn) ? portfolio.lastExecutedTurn! : 0,
+  };
+}
+
+export function createEmptyOpponentAIState(): OpponentAIState {
+  return {
+    version: 1,
+    migrationGraceRoundsRemaining: 0,
+    majorCivs: {},
+    barbarianCamps: {},
+    barbarianHomeCampByUnitId: {},
+    minorCivs: {},
+    pressureByHuman: {},
+    lastPlannedRound: null,
+    lastProcessedRound: null,
+    lastFinalizedRound: null,
+  };
+}
+
+export function normalizeOpponentAIState(state: GameState): GameState {
+  const source = state.opponentAI;
+  if (!source || source.version !== 1) {
+    return { ...state, opponentAI: createEmptyOpponentAIState() };
+  }
+
+  const opponentAI = createEmptyOpponentAIState();
+  opponentAI.migrationGraceRoundsRemaining = Math.max(
+    0,
+    Number.isFinite(source.migrationGraceRoundsRemaining)
+      ? Math.floor(source.migrationGraceRoundsRemaining)
+      : 0,
+  );
+  opponentAI.lastPlannedRound = Number.isFinite(source.lastPlannedRound)
+    ? source.lastPlannedRound
+    : null;
+  opponentAI.lastProcessedRound = Number.isFinite(source.lastProcessedRound)
+    ? source.lastProcessedRound
+    : null;
+  opponentAI.lastFinalizedRound = Number.isFinite(source.lastFinalizedRound)
+    ? source.lastFinalizedRound
+    : null;
+
+  for (const [actorId, value] of Object.entries(source.majorCivs ?? {})) {
+    const civ = state.civilizations[actorId];
+    if (!civ || civ.isHuman || civ.isEliminated) continue;
+    opponentAI.majorCivs[actorId] = normalizePortfolio(state, actorId, value);
+  }
+
+  for (const [campId, value] of Object.entries(source.barbarianCamps ?? {})) {
+    if (!state.barbarianCamps[campId]) continue;
+    const plan = normalizePlan(state, campId, value);
+    if (plan) opponentAI.barbarianCamps[campId] = plan;
+  }
+
+  for (const [unitId, campId] of Object.entries(source.barbarianHomeCampByUnitId ?? {})) {
+    if (state.units[unitId]?.owner === 'barbarian' && state.barbarianCamps[campId]) {
+      opponentAI.barbarianHomeCampByUnitId[unitId] = campId;
+    }
+  }
+
+  for (const [minorId, value] of Object.entries(source.minorCivs ?? {})) {
+    if (!state.minorCivs[minorId] || state.minorCivs[minorId].isDestroyed) continue;
+    const plan = normalizePlan(state, minorId, value);
+    if (plan) opponentAI.minorCivs[minorId] = plan;
+  }
+
+  for (const [humanId, ledger] of Object.entries(source.pressureByHuman ?? {})) {
+    const civ = state.civilizations[humanId];
+    if (!civ?.isHuman || !ledger || typeof ledger !== 'object') continue;
+    opponentAI.pressureByHuman[humanId] = {
+      activeIndependentThreatIds: Array.isArray(ledger.activeIndependentThreatIds)
+        ? [...new Set(ledger.activeIndependentThreatIds.filter(id => typeof id === 'string'))]
+        : [],
+      recoveryUntilTurn: Number.isFinite(ledger.recoveryUntilTurn) ? ledger.recoveryUntilTurn : 0,
+      lastResolvedThreatTurn: Number.isFinite(ledger.lastResolvedThreatTurn)
+        ? ledger.lastResolvedThreatTurn
+        : null,
+      lastWarningTurnByKey: ledger.lastWarningTurnByKey && typeof ledger.lastWarningTurnByKey === 'object'
+        ? { ...ledger.lastWarningTurnByKey }
+        : {},
+      lastStrategicAudioTurn: Number.isFinite(ledger.lastStrategicAudioTurn)
+        ? ledger.lastStrategicAudioTurn
+        : null,
+    };
+  }
+
+  return { ...state, opponentAI };
+}

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -1,0 +1,86 @@
+import type { GameState, OpponentChallenge } from './types';
+
+export interface OpponentChallengeProfile {
+  mobilizationRounds: number;
+  maxPrimaryForce: number;
+  retreatHealthPercent: number;
+  tacticalTopK: number;
+  seededSuboptimalChance: number;
+  seededMistakeScoreBand: number;
+  maxIndependentCrisesPerHuman: number;
+  recoveryRounds: number;
+  planReconsiderRounds: number;
+}
+
+export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChallengeProfile> = {
+  explorer: {
+    mobilizationRounds: 2,
+    maxPrimaryForce: 4,
+    retreatHealthPercent: 55,
+    tacticalTopK: 3,
+    seededSuboptimalChance: 0.3,
+    seededMistakeScoreBand: 12,
+    maxIndependentCrisesPerHuman: 1,
+    recoveryRounds: 3,
+    planReconsiderRounds: 3,
+  },
+  standard: {
+    mobilizationRounds: 1,
+    maxPrimaryForce: 6,
+    retreatHealthPercent: 40,
+    tacticalTopK: 2,
+    seededSuboptimalChance: 0.1,
+    seededMistakeScoreBand: 8,
+    maxIndependentCrisesPerHuman: 2,
+    recoveryRounds: 2,
+    planReconsiderRounds: 2,
+  },
+  veteran: {
+    mobilizationRounds: 0,
+    maxPrimaryForce: 8,
+    retreatHealthPercent: 25,
+    tacticalTopK: 1,
+    seededSuboptimalChance: 0,
+    seededMistakeScoreBand: 0,
+    maxIndependentCrisesPerHuman: 3,
+    recoveryRounds: 1,
+    planReconsiderRounds: 1,
+  },
+};
+
+export function isOpponentChallenge(value: unknown): value is OpponentChallenge {
+  return value === 'explorer' || value === 'standard' || value === 'veteran';
+}
+
+export function resolveOpponentChallenge(
+  state: Pick<GameState, 'opponentChallenge'>,
+): OpponentChallenge {
+  return isOpponentChallenge(state.opponentChallenge) ? state.opponentChallenge : 'standard';
+}
+
+export function setPendingOpponentChallenge(
+  state: GameState,
+  challenge: OpponentChallenge,
+): GameState {
+  if (challenge === resolveOpponentChallenge(state)) {
+    if (state.pendingOpponentChallenge === undefined) return state;
+    const { pendingOpponentChallenge: _removed, ...withoutPending } = state;
+    return withoutPending;
+  }
+  return state.pendingOpponentChallenge === challenge
+    ? state
+    : { ...state, pendingOpponentChallenge: challenge };
+}
+
+export function applyPendingOpponentChallenge(state: GameState): GameState {
+  if (state.pendingOpponentChallenge === undefined) return state;
+  if (!isOpponentChallenge(state.pendingOpponentChallenge)) {
+    const { pendingOpponentChallenge: _removed, ...withoutPending } = state;
+    return withoutPending;
+  }
+  return {
+    ...state,
+    opponentChallenge: state.pendingOpponentChallenge,
+    pendingOpponentChallenge: undefined,
+  };
+}

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -56,6 +56,8 @@ import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyProductionBonus } from '@/systems/city-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
+import { applyPendingOpponentChallenge } from '@/core/opponent-challenge';
+import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
@@ -78,6 +80,23 @@ import {
 import type { PirateEconomyModifiers } from '@/systems/economy-system';
 import { processPiratesForCompletedRound } from '@/systems/pirate-system';
 import { classifyOwner } from './owner-kind';
+
+export function finalizeOpponentRoundState(state: GameState): GameState {
+  const normalized = normalizeOpponentAIState(state);
+  if (normalized.opponentAI!.lastFinalizedRound === normalized.turn) return state;
+  const withChallenge = applyPendingOpponentChallenge(normalized);
+  return {
+    ...withChallenge,
+    opponentAI: {
+      ...withChallenge.opponentAI!,
+      migrationGraceRoundsRemaining: Math.max(
+        0,
+        withChallenge.opponentAI!.migrationGraceRoundsRemaining - 1,
+      ),
+      lastFinalizedRound: state.turn,
+    },
+  };
+}
 
 export function processTurn(state: GameState, bus: EventBus): GameState {
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
@@ -1091,6 +1110,8 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     newState = applyEconomyTurn(newState, civId, grossGoldByCiv[civId] ?? 0, pirateEconomyModifiers);
     emitEconomyStrainIfNeeded(previousEconomyStatusByCiv[civId], newState.economyStatusByCiv![civId], bus, civId);
   }
+
+  newState = finalizeOpponentRoundState(newState);
 
   // --- Advance turn ---
   newState.turn += 1;

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -22,6 +22,7 @@ import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { hexKey } from '@/systems/hex-utils';
 import { executeUnitMove } from '@/systems/unit-movement-system';
+import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 import { calculateCityYields } from '@/systems/resource-system';
 import { getCivResourceYieldBonus } from '@/systems/resource-acquisition-system';
 import type { HexCoord } from './types';
@@ -594,6 +595,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     const defenderRouteId = defender.committedToRouteId;
     const defenderPosBarbarian = { ...defender.position };
     const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
+    const combatPresentation = buildCombatPresentation(newState, result, attacker, defender);
     const applied = applyCombatOutcomeToState(newState, result, combatSeed);
     newState = applied.state;
     if (newState.civilizations[defender.owner]?.isHuman) {
@@ -607,7 +609,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     if (applied.defenderDefeated && defenderRouteId) {
       newState = removeRouteForUnit(newState, result.defenderId, bus, 'unit-died', defenderRouteId);
     }
-    bus.emit('combat:resolved', { result });
+    bus.emit('combat:resolved', { result, ...combatPresentation });
     for (const reward of applied.rewards) {
       bus.emit('combat:reward-earned', { reward });
     }
@@ -765,6 +767,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       const combatSeed = beastSeed ^ order.attackerUnitId.charCodeAt(0);
       const defenderPosBeast = { ...defender.position };
       const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
+      const combatPresentation = buildCombatPresentation(newState, result, attacker, defender);
       const applied = applyCombatOutcomeToState(newState, result, combatSeed);
       newState = applied.state;
       if (newState.civilizations[defender.owner]?.isHuman) {
@@ -778,7 +781,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
         if (slain) bus.emit('beast:slain', slain);
       }
       // If the intruder died, no hoard — the beast attacked, not the player
-      bus.emit('combat:resolved', { result });
+      bus.emit('combat:resolved', { result, ...combatPresentation });
       for (const reward of applied.rewards) {
         bus.emit('combat:reward-earned', { reward });
       }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1441,6 +1441,8 @@ export interface GameEvents {
     visibleToViewerIds: string[];
     attackerType: UnitType;
     defenderType: UnitType;
+    attackerOwnerId: string;
+    defenderOwnerId: string;
   };
   'combat:reward-earned': { reward: CombatRewardNotification };
   'tech:completed': { civId: string; techId: string };
@@ -1480,6 +1482,8 @@ export interface GameEvents {
   'era:advanced': { era: number };
   'currentPlayer:changed-after-handoff': {
     civId: string;
+    civType: string;
+    era: number;
     atWarCount: number;    // exact war count so AudioSystem can track remainingWars precisely
     unrestCityCount: number;
     nearDefeat: boolean;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1018,6 +1018,7 @@ export interface SoloSetupConfig {
   mapSize: 'small' | 'medium' | 'large';
   opponentCount: number;
   gameTitle: string;
+  opponentChallenge?: OpponentChallenge;
   settingsOverrides?: Partial<GameSettings>;
   seed?: string;
   customCivilizations?: CustomCivDefinition[];
@@ -1028,6 +1029,120 @@ export interface GameEvent {
   type: string;
   message: string;
   turn: number;
+}
+
+export type OpponentChallenge = 'explorer' | 'standard' | 'veteran';
+
+export type AIStrategicRole =
+  | 'capture'
+  | 'frontline'
+  | 'ranged'
+  | 'siege'
+  | 'mobile'
+  | 'air-combat'
+  | 'naval-combat'
+  | 'transport'
+  | 'escort'
+  | 'recon'
+  | 'detection'
+  | 'settlement'
+  | 'worker'
+  | 'resource-expedition'
+  | 'trade'
+  | 'espionage';
+
+export type AIStrategicObjective =
+  | 'defend'
+  | 'recover'
+  | 'expand'
+  | 'secure-resource'
+  | 'raid'
+  | 'blockade'
+  | 'repel'
+  | 'capture'
+  | 'support-ally';
+
+export type AIPlanReason =
+  | 'urgent-defense'
+  | 'nearby-opportunity'
+  | 'retaliate-recent-attack'
+  | 'continue-active-war'
+  | 'alliance-obligation'
+  | 'critical-resource'
+  | 'no-local-alternative'
+  | 'homeland-secure'
+  | 'recover-damaged-force'
+  | 'modernization-gap'
+  | 'camp-defense'
+  | 'opportunistic-raid';
+
+export type AIPlanPhase =
+  | 'scouting'
+  | 'mobilizing'
+  | 'advancing'
+  | 'attacking'
+  | 'consolidating'
+  | 'withdrawing'
+  | 'complete'
+  | 'abandoned';
+
+export type AITarget =
+  | { kind: 'city'; id: string; lastKnownPosition: HexCoord }
+  | { kind: 'unit'; id: string; lastKnownPosition: HexCoord }
+  | { kind: 'resource'; resource: ResourceType; position: HexCoord }
+  | { kind: 'camp'; id: string; lastKnownPosition: HexCoord }
+  | { kind: 'region'; id: string; anchor: HexCoord };
+
+export interface AIStrategicPlan {
+  id: string;
+  actorId: string;
+  objective: AIStrategicObjective;
+  target: AITarget;
+  theaterId: string;
+  phase: AIPlanPhase;
+  reasonCodes: AIPlanReason[];
+  commitment: number;
+  createdTurn: number;
+  reconsiderAfterTurn: number;
+  expiresAfterTurn: number;
+  lastProgressTurn: number;
+  rallyPoint?: HexCoord;
+  requiredRoles: Partial<Record<AIStrategicRole, number>>;
+  assignedUnitIds: string[];
+}
+
+export interface MajorCivPlanPortfolio {
+  primaryPlan: AIStrategicPlan | null;
+  defensePlansByCityId: Record<string, AIStrategicPlan>;
+  upgradeRoutesByUnitId: Record<string, {
+    cityId: string;
+    createdTurn: number;
+  }>;
+  modernizationDemand: number;
+  researchTargetTechId: string | null;
+  lastPlannedTurn: number;
+  lastExecutedTurn: number;
+}
+
+export interface HumanPressureLedger {
+  activeIndependentThreatIds: string[];
+  recoveryUntilTurn: number;
+  lastResolvedThreatTurn: number | null;
+  lastWarningTurnByKey: Record<string, number>;
+  lastStrategicAudioTurn: number | null;
+}
+
+export interface OpponentAIState {
+  version: 1;
+  migrationGraceRoundsRemaining: number;
+  majorCivs: Record<string, MajorCivPlanPortfolio>;
+  barbarianCamps: Record<string, AIStrategicPlan>;
+  barbarianHomeCampByUnitId: Record<string, string>;
+  minorCivs: Record<string, AIStrategicPlan>;
+  pressureByHuman: Record<string, HumanPressureLedger>;
+  lastPlannedRound: number | null;
+  lastProcessedRound: number | null;
+  lastFinalizedRound: number | null;
 }
 
 // --- Trade & Resources ---
@@ -1206,6 +1321,9 @@ export interface GameState {
   era: number;
   gameId?: string;
   gameTitle?: string;
+  opponentChallenge?: OpponentChallenge;
+  pendingOpponentChallenge?: OpponentChallenge;
+  opponentAI?: OpponentAIState;
   civilizations: Record<string, Civilization>;
   map: GameMap;
   units: Record<string, Unit>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1386,7 +1386,16 @@ export interface GameSettings {
 export interface GameEvents {
   'turn:start': { turn: number; playerId: string };
   'turn:end': { turn: number; playerId: string };
-  'unit:move': { unitId: string; from: HexCoord; to: HexCoord; path: HexCoord[] };
+  'unit:move': {
+    unitId: string;
+    from: HexCoord;
+    to: HexCoord;
+    path: HexCoord[];
+    presentationByViewer: Record<string, {
+      unit: Unit;
+      visibleSegments: HexCoord[][];
+    }>;
+  };
   'unit:created': { unit: Unit };
   'unit:destroyed': { unitId: string; position: HexCoord };
   'pirate:faction-spawned': {
@@ -1427,7 +1436,12 @@ export interface GameEvents {
   'city:grew': { cityId: string; newPopulation: number };
   'city:maturity-upgraded': { cityId: string; previous: CityMaturity; current: CityMaturity };
   'economy:treasury-strain': { civId: string; level: Exclude<TreasuryStrainLevel, 'none'>; netGoldPerTurn: number; unpaidMaintenance: number };
-  'combat:resolved': { result: CombatResult };
+  'combat:resolved': {
+    result: CombatResult;
+    visibleToViewerIds: string[];
+    attackerType: UnitType;
+    defenderType: UnitType;
+  };
   'combat:reward-earned': { reward: CombatRewardNotification };
   'tech:completed': { civId: string; techId: string };
   'tech:started': { civId: string; techId: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3171,6 +3171,7 @@ function releaseHandoffToViewer(nextSlotId: string): void {
   scanBeastSightings();
   maybeShowPendingHoardChoice();
   roundPresentationGate.resume();
+  audio.setMasterVolume(currentMasterVolume);
   setBlockingOverlay(null);
   const nextCiv = gameState.civilizations[nextSlotId];
   const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
@@ -3194,6 +3195,7 @@ async function beginHotSeatHandoff(
   closePirateWatersPanels(uiLayer);
   renderLoop.setSelectedPirateFactionId(null);
   audio.stopPirateAmbience('player-changed');
+  audio.setMasterVolume(0);
   setBlockingOverlay('turn-handoff');
   roundPresentationGate.suppress();
   const controller = showTurnHandoff(
@@ -3944,6 +3946,7 @@ function enterCampaign(
     return;
   }
 
+  audio.setMasterVolume(0);
   const player = gameState.hotSeat.players.find(candidate => candidate.slotId === gameState.currentPlayer);
   setBlockingOverlay('turn-handoff');
   roundPresentationGate.suppress();
@@ -3969,6 +3972,16 @@ function enterCampaign(
         roundPresentationGate.resume();
         setBlockingOverlay(null);
         startGame();
+        const viewerCiv = gameState.civilizations[viewerId];
+        const viewerCities = Object.values(gameState.cities).filter(city => city.owner === viewerId);
+        bus.emit('currentPlayer:changed-after-handoff', {
+          civId: viewerId,
+          atWarCount: viewerCiv?.diplomacy?.atWarWith?.length ?? 0,
+          unrestCityCount: viewerCities.filter(city => city.unrestLevel > 0).length,
+          nearDefeat: viewerCiv?.nearDefeat ?? false,
+          inBeastTerritory: isCivUnitInBeastTerritory(gameState, viewerId),
+        });
+        audio.setMasterVolume(currentMasterVolume);
         showNotification(message, 'info');
       },
     },
@@ -4337,6 +4350,7 @@ function startGame(): void {
     () => gameState,
     () => roundPresentationGate.isSuppressed(),
   );
+  audio.setMasterVolume(currentMasterVolume);
   routeSfxThrough(audio.getSfxRoutingNode());
 
   // Prevent zoom-out duplication: ensure the camera cannot zoom past one full

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,6 @@ import {
   formatEconomyTreasuryStrainMessage,
   routeBarbarianSpawned,
   routeCombatRewardEarned,
-  routeCombatResolved,
   routeEconomyTreasuryStrain,
   routeEraAdvanced,
   routeFactionTransition,
@@ -221,7 +220,9 @@ import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
 import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { createCompletedRoundHandoffTransaction } from '@/core/completed-round-handoff';
 import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { handleCombatResolvedEvent } from '@/ui/combat-resolved-presentation';
 
 // --- App State ---
 let gameState: GameState;
@@ -3164,6 +3165,20 @@ function runCurrentCompletedRound(state: GameState) {
   });
 }
 
+function emitCurrentPlayerAudioSnapshot(civId: string): void {
+  const civ = gameState.civilizations[civId];
+  const cities = Object.values(gameState.cities).filter(city => city.owner === civId);
+  bus.emit('currentPlayer:changed-after-handoff', {
+    civId,
+    civType: civ?.civType ?? civId,
+    era: gameState.era,
+    atWarCount: civ?.diplomacy?.atWarWith?.length ?? 0,
+    unrestCityCount: cities.filter(city => city.unrestLevel > 0).length,
+    nearDefeat: civ?.nearDefeat ?? false,
+    inBeastTerritory: isCivUnitInBeastTerritory(gameState, civId),
+  });
+}
+
 function releaseHandoffToViewer(nextSlotId: string): void {
   centerOnCurrentPlayer();
   renderLoop.setGameState(gameState);
@@ -3173,15 +3188,7 @@ function releaseHandoffToViewer(nextSlotId: string): void {
   roundPresentationGate.resume();
   audio.setMasterVolume(currentMasterVolume);
   setBlockingOverlay(null);
-  const nextCiv = gameState.civilizations[nextSlotId];
-  const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
-  bus.emit('currentPlayer:changed-after-handoff', {
-    civId: nextSlotId,
-    atWarCount: nextCiv?.diplomacy?.atWarWith?.length ?? 0,
-    unrestCityCount: nextCivCities.filter(c => c.unrestLevel > 0).length,
-    nearDefeat: nextCiv?.nearDefeat ?? false,
-    inBeastTerritory: isCivUnitInBeastTerritory(gameState, nextSlotId),
-  });
+  emitCurrentPlayerAudioSnapshot(nextSlotId);
   handleVictoryIfNeeded();
 }
 
@@ -3230,11 +3237,71 @@ async function beginHotSeatHandoff(
     window.location.reload();
   };
 
-  const persistCompletedHandoff = async (): Promise<void> => {
+  const persistIntermediateHandoff = async (): Promise<void> => {
     try {
       await autoSave(gameState);
       controller.setReady(gameState);
     } catch {
+      controller.setError(
+        'The turn handoff could not be saved. Retry saving before opening the next turn.',
+        {
+          onRetry: () => void persistIntermediateHandoff(),
+          onReturnToSaves: returnToSaves,
+        },
+      );
+    }
+  };
+
+  if (!completesRound) {
+    gameState = { ...preSimulationState, currentPlayer: nextSlotId };
+    void persistIntermediateHandoff();
+    return;
+  }
+
+  const transaction = createCompletedRoundHandoffTransaction({
+    initialState: preSimulationState,
+    runCompletedRound: runCurrentCompletedRound,
+    prepareCompletedState: state => ({ ...state, currentPlayer: nextSlotId }),
+    eventTarget: bus,
+    adoptState: state => {
+      gameState = state;
+    },
+    persistState: autoSave,
+    onCommitErrors: errors => {
+      if (errors.length > 0) {
+        console.error('[handoff] Buffered presentation events failed to dispatch.', errors);
+      }
+    },
+  });
+
+  const persistCompletedHandoff = async (): Promise<void> => {
+    const outcome = await transaction.persistCompletedRoundHandoff();
+    if (outcome.status === 'ready') {
+      controller.setReady(outcome.state);
+      return;
+    }
+    controller.setError(
+      'The round finished, but the handoff could not be saved. Retry saving before opening the next turn.',
+      {
+        onRetry: () => void persistCompletedHandoff(),
+        onReturnToSaves: returnToSaves,
+      },
+    );
+  };
+
+  const simulate = async (): Promise<void> => {
+    const outcome = await transaction.runCompletedRoundSimulation();
+    if (outcome.status === 'simulation-failed') {
+      controller.setError(
+        'The round could not be completed. Your turn is unchanged and was not autosaved.',
+        {
+          onRetry: () => void simulate(),
+          onReturnToSaves: returnToSaves,
+        },
+      );
+      return;
+    }
+    if (outcome.status === 'persistence-failed') {
       controller.setError(
         'The round finished, but the handoff could not be saved. Retry saving before opening the next turn.',
         {
@@ -3242,32 +3309,11 @@ async function beginHotSeatHandoff(
           onReturnToSaves: returnToSaves,
         },
       );
-    }
-  };
-
-  const simulate = (): void => {
-    if (!completesRound) {
-      gameState = { ...preSimulationState, currentPlayer: nextSlotId };
-      void persistCompletedHandoff();
       return;
     }
-    const result = runCurrentCompletedRound(preSimulationState);
-    if (!result.ok) {
-      gameState = preSimulationState;
-      controller.setError(
-        'The round could not be completed. Your turn is unchanged and was not autosaved.',
-        {
-          onRetry: simulate,
-          onReturnToSaves: returnToSaves,
-        },
-      );
-      return;
-    }
-    gameState = { ...result.state, currentPlayer: nextSlotId };
-    result.events.commitTo(bus);
-    void persistCompletedHandoff();
+    controller.setReady(outcome.state);
   };
-  simulate();
+  void simulate();
 }
 
 async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<void> {
@@ -3654,13 +3700,12 @@ bus.on('advisor:message', ({ advisor, message, icon }) => {
 // its visibility covers any raider from a given camp.
 const notifiedBarbarianCampsPerCiv = new Map<string, Set<string>>();
 
-bus.on('combat:resolved', ({ result, visibleToViewerIds }) => {
-  if (
-    roundPresentationGate.isSuppressed()
-    || !visibleToViewerIds.includes(gameState.currentPlayer)
-  ) return;
-  renderLoop.applyCombatVisual(result);
-  routeCombatResolved(gameState, result, appendToCivLog);
+bus.on('combat:resolved', event => {
+  handleCombatResolvedEvent(gameState, event, {
+    isPresentationSuppressed: () => roundPresentationGate.isSuppressed(),
+    applyVisual: result => renderLoop.applyCombatVisual(result),
+    appendNotification: appendToCivLog,
+  });
 });
 
 bus.on('combat:reward-earned', ({ reward }) => {
@@ -3972,15 +4017,6 @@ function enterCampaign(
         roundPresentationGate.resume();
         setBlockingOverlay(null);
         startGame();
-        const viewerCiv = gameState.civilizations[viewerId];
-        const viewerCities = Object.values(gameState.cities).filter(city => city.owner === viewerId);
-        bus.emit('currentPlayer:changed-after-handoff', {
-          civId: viewerId,
-          atWarCount: viewerCiv?.diplomacy?.atWarWith?.length ?? 0,
-          unrestCityCount: viewerCities.filter(city => city.unrestLevel > 0).length,
-          nearDefeat: viewerCiv?.nearDefeat ?? false,
-          inBeastTerritory: isCivUnitInBeastTerritory(gameState, viewerId),
-        });
         audio.setMasterVolume(currentMasterVolume);
         showNotification(message, 'info');
       },
@@ -4352,6 +4388,7 @@ function startGame(): void {
   );
   audio.setMasterVolume(currentMasterVolume);
   routeSfxThrough(audio.getSfxRoutingNode());
+  emitCurrentPlayerAudioSnapshot(gameState.currentPlayer);
 
   // Prevent zoom-out duplication: ensure the camera cannot zoom past one full
   // map-width. hexToPixel({q: width, r:0}).x equals the wrapSpan used in

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,11 @@ import '@/assets/roc-animations.css';
 import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
-import { resolveOpponentChallenge, setPendingOpponentChallenge } from '@/core/opponent-challenge';
+import {
+  applyPendingOpponentChallenge,
+  resolveOpponentChallenge,
+  setPendingOpponentChallenge,
+} from '@/core/opponent-challenge';
 import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { processTurn } from '@/core/turn-manager';
 import { processAITurn } from '@/ai/basic-ai';
@@ -42,7 +46,7 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
-import { applyWorkerAction, clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
+import { applyWorkerAction } from '@/systems/worker-action-system';
 import { isVisible, getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { recordBeastSlain, isBeastConcealedFrom, applyHoardChoice, getHoardChoicePreview, canUnitAttackBeast, getBeastTrophyGoldPerTurn, isCivUnitInBeastTerritory } from '@/systems/beast-system';
@@ -114,7 +118,7 @@ import { getAvailableTechs } from '@/systems/tech-system';
 import { getNextPlayer, getAIPlayers, isRoundComplete } from '@/core/turn-cycling';
 import { showTurnHandoff } from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
-import { collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
+import { clearEventsForPlayer, collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
@@ -132,6 +136,7 @@ import {
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
 import { resolveNaturalWonderAudioFocus } from '@/input/natural-wonder-audio-focus';
+import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 import { handleFriendlyUnitStackTap } from '@/input/unit-stack-selection';
 import {
   initializeLegendaryWonderProjectsForCity,
@@ -218,6 +223,9 @@ import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { performMinorCivFestival, performMinorCivGift, setMinorCivWarState } from '@/systems/minor-civ-actions';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
 
 // --- App State ---
 let gameState: GameState;
@@ -268,6 +276,7 @@ function currentCivDef() {
 const bus = new EventBus();
 const audioCtx = new AudioContext();
 const audio = new AudioSystem(audioCtx);
+const roundPresentationGate = new RoundPresentationGate();
 // Master volume is not persisted (no GameSettings field) — tracked in memory only
 // so the pause menu slider shows the correct current value on re-open.
 let currentMasterVolume = 1.0;
@@ -586,6 +595,7 @@ function enqueueToast(
   type: NotificationEntry['type'],
   target?: NotificationEntry['target'],
 ): void {
+  if (roundPresentationGate.isSuppressed()) return;
   notificationQueue.push({ message, type, target });
   if (!isShowingNotification) displayNextNotification();
 }
@@ -2402,7 +2412,10 @@ function executeAttack(attackerId: string, targetKey: string): void {
     { attackerBonus, defenderBonus, defenderCityHasAntiAir, attackerHasAirForceCommand },
     gameState.era,
   );
-  bus.emit('combat:resolved', { result });
+  bus.emit('combat:resolved', {
+    result,
+    ...buildCombatPresentation(gameState, result, attacker, defender),
+  });
 
   const applied = applyCombatOutcomeToState(gameState, result, seed);
   gameState = applied.state;
@@ -3108,15 +3121,22 @@ function handleVictoryIfNeeded(): boolean {
   return true;
 }
 
-type AIMoveRecord = { unit: Unit; path: HexCoord[] };
+type AIMoveRecord = {
+  unit: Unit;
+  viewerId: string;
+  visibleSegments: HexCoord[][];
+};
 
 function captureAIMoves(fn: () => void): AIMoveRecord[] {
   const moves: AIMoveRecord[] = [];
-  const unsub = bus.on('unit:move', ({ unitId, from, path }) => {
-    // executeUnitMove mutates state.units before emitting, so the unit is already
-    // at `to` when this fires. Override position: from so animation starts correctly.
-    const unit = gameState.units[unitId];
-    if (unit) moves.push({ unit: { ...unit, position: from }, path });
+  const unsub = bus.on('unit:move', ({ presentationByViewer }) => {
+    for (const [viewerId, presentation] of Object.entries(presentationByViewer)) {
+      moves.push({
+        unit: structuredClone(presentation.unit),
+        viewerId,
+        visibleSegments: structuredClone(presentation.visibleSegments),
+      });
+    }
   });
   fn();
   unsub();
@@ -3124,16 +3144,156 @@ function captureAIMoves(fn: () => void): AIMoveRecord[] {
 }
 
 async function replayAIMoves(moves: AIMoveRecord[]): Promise<void> {
-  const playerVis = gameState.civilizations[gameState.currentPlayer]?.visibility;
+  if (roundPresentationGate.isSuppressed()) return;
   const visibleMoves = moves
-    .filter(({ path }) => {
-      const dest = path[path.length - 1];
-      return dest && playerVis && getVisibility(playerVis, dest) !== 'unexplored';
-    })
+    .filter(move => move.viewerId === gameState.currentPlayer)
     .slice(0, 6);
-  for (const { unit, path } of visibleMoves) {
-    await new Promise<void>(resolve => renderLoop.animateUnitMove(unit, path, resolve));
+  for (const { unit, visibleSegments } of visibleMoves) {
+    for (const path of visibleSegments.filter(segment => segment.length >= 2)) {
+      if (roundPresentationGate.isSuppressed() || gameState.currentPlayer !== visibleMoves[0]?.viewerId) return;
+      await new Promise<void>(resolve => renderLoop.animateUnitMove(
+        { ...unit, position: path[0]! },
+        path,
+        resolve,
+      ));
+    }
   }
+}
+
+function finalizeCompletedRoundState(state: GameState): GameState {
+  let next = applyPendingOpponentChallenge(state);
+  if ((next.opponentAI?.migrationGraceRoundsRemaining ?? 0) > 0) {
+    next = {
+      ...next,
+      opponentAI: {
+        ...next.opponentAI!,
+        migrationGraceRoundsRemaining: next.opponentAI!.migrationGraceRoundsRemaining - 1,
+      },
+    };
+  }
+  return next;
+}
+
+function runCurrentCompletedRound(state: GameState, hotSeat: NonNullable<GameState['hotSeat']> | undefined) {
+  return runCompletedRound(state, bus, {
+    improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
+    majors: (current, eventBus) => {
+      let next = current;
+      const aiIds = hotSeat ? getAIPlayers(hotSeat).map(player => player.slotId) : ['ai-1'];
+      for (const aiId of aiIds) {
+        if (next.civilizations[aiId] && !next.civilizations[aiId].isEliminated) {
+          next = processAITurn(next, aiId, eventBus);
+        }
+      }
+      return next;
+    },
+    world: (current, eventBus) => processTurn(current, eventBus),
+    postprocess: (_before, current) => finalizeCompletedRoundState(current),
+  });
+}
+
+function releaseHandoffToViewer(nextSlotId: string): void {
+  centerOnCurrentPlayer();
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  scanBeastSightings();
+  maybeShowPendingHoardChoice();
+  roundPresentationGate.resume();
+  setBlockingOverlay(null);
+  const nextCiv = gameState.civilizations[nextSlotId];
+  const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
+  bus.emit('currentPlayer:changed-after-handoff', {
+    civId: nextSlotId,
+    atWarCount: nextCiv?.diplomacy?.atWarWith?.length ?? 0,
+    unrestCityCount: nextCivCities.filter(c => c.unrestLevel > 0).length,
+    nearDefeat: nextCiv?.nearDefeat ?? false,
+    inBeastTerritory: isCivUnitInBeastTerritory(gameState, nextSlotId),
+  });
+  handleVictoryIfNeeded();
+}
+
+async function beginHotSeatHandoff(
+  hotSeat: NonNullable<GameState['hotSeat']>,
+  completesRound: boolean,
+): Promise<void> {
+  const preSimulationState = gameState;
+  const nextSlotId = getNextPlayer(hotSeat, preSimulationState.currentPlayer);
+  const nextPlayer = hotSeat.players.find(player => player.slotId === nextSlotId);
+  closePirateWatersPanels(uiLayer);
+  renderLoop.setSelectedPirateFactionId(null);
+  audio.stopPirateAmbience('player-changed');
+  setBlockingOverlay('turn-handoff');
+  roundPresentationGate.suppress();
+  const controller = showTurnHandoff(
+    uiLayer,
+    preSimulationState,
+    nextSlotId,
+    nextPlayer?.name ?? 'Player',
+    {
+      initiallyReady: false,
+      preparingLabel: 'Preparing next turn…',
+      onReady: async () => {
+        gameState = {
+          ...gameState,
+          pendingEvents: clearEventsForPlayer(gameState.pendingEvents ?? {}, nextSlotId),
+        };
+        let acknowledgementFailed = false;
+        try {
+          await autoSave(gameState);
+        } catch {
+          acknowledgementFailed = true;
+        }
+        releaseHandoffToViewer(nextSlotId);
+        if (acknowledgementFailed) {
+          showNotification('Turn opened, but its summary may repeat after reload.', 'warning');
+        }
+      },
+    },
+  );
+
+  const returnToSaves = (): void => {
+    roundPresentationGate.resume();
+    window.location.reload();
+  };
+
+  const persistCompletedHandoff = async (): Promise<void> => {
+    try {
+      await autoSave(gameState);
+      controller.setReady(gameState);
+    } catch {
+      controller.setError(
+        'The round finished, but the handoff could not be saved. Retry saving before opening the next turn.',
+        {
+          onRetry: () => void persistCompletedHandoff(),
+          onReturnToSaves: returnToSaves,
+        },
+      );
+    }
+  };
+
+  const simulate = (): void => {
+    if (!completesRound) {
+      gameState = { ...preSimulationState, currentPlayer: nextSlotId };
+      void persistCompletedHandoff();
+      return;
+    }
+    const result = runCurrentCompletedRound(preSimulationState, hotSeat);
+    if (!result.ok) {
+      gameState = preSimulationState;
+      controller.setError(
+        'The round could not be completed. Your turn is unchanged and was not autosaved.',
+        {
+          onRetry: simulate,
+          onReturnToSaves: returnToSaves,
+        },
+      );
+      return;
+    }
+    gameState = { ...result.state, currentPlayer: nextSlotId };
+    result.events.commitTo(bus);
+    void persistCompletedHandoff();
+  };
+  simulate();
 }
 
 async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<void> {
@@ -3154,77 +3314,20 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
     const hotSeat = gameState.hotSeat;
 
     if (hotSeat) {
-      // --- Hot Seat Mode ---
-      if (isRoundComplete(hotSeat, gameState.currentPlayer)) {
-        // Last human player finished — process improvements, AI, and round end
-        processImprovements();
-
-        const hotSeatAIMoves: AIMoveRecord[] = [];
-        for (const ai of getAIPlayers(hotSeat)) {
-          hotSeatAIMoves.push(...captureAIMoves(() => {
-            gameState = processAITurn(gameState, ai.slotId, bus);
-          }));
-        }
-
-        const hotSeatRoundMoves = captureAIMoves(() => {
-          gameState = processTurn(gameState, bus);
-        });
-
-        if (handleVictoryIfNeeded()) return;
-
-        renderLoop.setGameState(gameState);
-        await replayAIMoves([...hotSeatAIMoves, ...hotSeatRoundMoves]);
-
-      }
-
-      // Advance to next human player
-      const nextSlotId = getNextPlayer(hotSeat, gameState.currentPlayer);
-      gameState.currentPlayer = nextSlotId;
-      const nextPlayer = hotSeat.players.find(p => p.slotId === nextSlotId);
-
-      await autoSave(gameState);
-
-      // Show handoff screen
-      closePirateWatersPanels(uiLayer);
-      renderLoop.setSelectedPirateFactionId(null);
-      audio.stopPirateAmbience('player-changed');
-      setBlockingOverlay('turn-handoff');
-      showTurnHandoff(uiLayer, gameState, nextSlotId, nextPlayer?.name ?? 'Player', {
-        onReady: () => {
-          setBlockingOverlay(null);
-          centerOnCurrentPlayer();
-          renderLoop.setGameState(gameState);
-          updateHUD();
-          // Scan for beast sightings at turn start (units may have gained vision from prior turns)
-          scanBeastSightings();
-          maybeShowPendingHoardChoice();
-          // Compute audio-state snapshot for the incoming player (Spec 3 hot-seat drift fix)
-          const nextCiv = gameState.civilizations[nextSlotId];
-          const nextCivCities = Object.values(gameState.cities).filter(c => c.owner === nextSlotId);
-          bus.emit('currentPlayer:changed-after-handoff', {
-            civId: nextSlotId,
-            atWarCount: nextCiv?.diplomacy?.atWarWith?.length ?? 0,
-            unrestCityCount: nextCivCities.filter(c => c.unrestLevel > 0).length,
-            nearDefeat: nextCiv?.nearDefeat ?? false,
-            inBeastTerritory: isCivUnitInBeastTerritory(gameState, nextSlotId),
-          });
-        },
-      });
+      await beginHotSeatHandoff(hotSeat, isRoundComplete(hotSeat, gameState.currentPlayer));
     } else {
       // --- Solo Mode ---
-      processImprovements();
-
-      const soloAIMoves = captureAIMoves(() => {
-        gameState = processAITurn(gameState, 'ai-1', bus);
-      });
-      const soloRoundMoves = captureAIMoves(() => {
-        gameState = processTurn(gameState, bus);
+      const result = runCurrentCompletedRound(gameState, undefined);
+      if (!result.ok) throw result.error;
+      gameState = result.state;
+      const soloMoves = captureAIMoves(() => {
+        result.events.commitTo(bus);
       });
 
       if (handleVictoryIfNeeded()) return;
 
       renderLoop.setGameState(gameState);
-      await replayAIMoves([...soloAIMoves, ...soloRoundMoves]);
+      await replayAIMoves(soloMoves);
       updateHUD();
 
       showNotification(`Turn ${gameState.turn}`, 'info');
@@ -3236,27 +3339,6 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
   } catch (err) {
     console.error('endTurn error:', err);
     showNotification('Error processing turn!', 'warning');
-  }
-}
-
-function processImprovements(): void {
-  for (const tile of Object.values(gameState.map.tiles)) {
-    if (tile.improvementTurnsLeft > 0) {
-      tile.improvementTurnsLeft--;
-      if (tile.improvementTurnsLeft === 0) {
-        bus.emit('improvement:completed', { coord: tile.coord, type: tile.improvement });
-        gameState = clearCompletedWorkerTasksForImprovement(gameState, tile.coord);
-        if (tile.improvementOwner) {
-          appendToCivLog(
-            tile.improvementOwner,
-            `${getImprovementDisplayName(tile.improvement)} completed!`,
-            'success',
-            { kind: 'map', coord: { ...tile.coord }, label: getImprovementDisplayName(tile.improvement) },
-          );
-          tile.improvementOwner = undefined;
-        }
-      }
-    }
   }
 }
 
@@ -3598,7 +3680,11 @@ bus.on('advisor:message', ({ advisor, message, icon }) => {
 // its visibility covers any raider from a given camp.
 const notifiedBarbarianCampsPerCiv = new Map<string, Set<string>>();
 
-bus.on('combat:resolved', ({ result }) => {
+bus.on('combat:resolved', ({ result, visibleToViewerIds }) => {
+  if (
+    roundPresentationGate.isSuppressed()
+    || !visibleToViewerIds.includes(gameState.currentPlayer)
+  ) return;
   renderLoop.applyCombatVisual(result);
   routeCombatResolved(gameState, result, appendToCivLog);
 });
@@ -3872,15 +3958,72 @@ async function init(): Promise<void> {
   await showStartSavePanel();
 }
 
-async function showStartSavePanel(): Promise<void> {
-  const enterCampaign = (state: GameState, message: string): void => {
-    document.getElementById('save-panel')?.remove();
-    gameState = state;
-    migrateLegacySave();
+function enterCampaign(
+  state: GameState,
+  message: string,
+  persistBeforeReady: boolean = false,
+): void {
+  document.getElementById('save-panel')?.remove();
+  gameState = state;
+  migrateLegacySave();
+  if (!gameState.hotSeat) {
     startGame();
     showNotification(message, 'info');
-  };
+    return;
+  }
 
+  const player = gameState.hotSeat.players.find(candidate => candidate.slotId === gameState.currentPlayer);
+  setBlockingOverlay('turn-handoff');
+  roundPresentationGate.suppress();
+  const controller = showTurnHandoff(
+    uiLayer,
+    gameState,
+    gameState.currentPlayer,
+    player?.name ?? 'Player',
+    {
+      initiallyReady: !persistBeforeReady,
+      preparingLabel: 'Saving campaign…',
+      onReady: async () => {
+        const viewerId = gameState.currentPlayer;
+        gameState = {
+          ...gameState,
+          pendingEvents: clearEventsForPlayer(gameState.pendingEvents ?? {}, viewerId),
+        };
+        try {
+          await autoSave(gameState);
+        } catch {
+          // Entry persistence already succeeded; acknowledgement may safely retry later.
+        }
+        roundPresentationGate.resume();
+        setBlockingOverlay(null);
+        startGame();
+        showNotification(message, 'info');
+      },
+    },
+  );
+
+  if (!persistBeforeReady) return;
+  const persist = async (): Promise<void> => {
+    try {
+      await autoSave(gameState);
+      controller.setReady(gameState);
+    } catch {
+      controller.setError(
+        'The campaign could not be saved. Retry before opening the first turn.',
+        {
+          onRetry: () => void persist(),
+          onReturnToSaves: () => {
+            roundPresentationGate.resume();
+            window.location.reload();
+          },
+        },
+      );
+    }
+  };
+  void persist();
+}
+
+async function showStartSavePanel(): Promise<void> {
   await createSavePanel(uiLayer, {
     onNewGame: () => {
       showGameModeSelection();
@@ -4113,8 +4256,11 @@ function showGameModeSelection(): void {
           if (persistedSettings?.councilTalkLevel) {
             gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
           }
-          startGame();
-          showNotification(`Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`, 'info');
+          enterCampaign(
+            gameState,
+            `Hot seat game started! ${config.players.filter(p => p.isHuman).length} players`,
+            true,
+          );
         },
         onCustomCivilizationsChanged: (customCivilizations) => {
           updatePersistedCustomCivilizations(customCivilizations);
@@ -4213,7 +4359,12 @@ function startGame(): void {
     inputInitialized = true;
   }
 
-  audio.start(gameState, bus, () => gameState);
+  audio.start(
+    gameState,
+    bus,
+    () => gameState,
+    () => roundPresentationGate.isSuppressed(),
+  );
   routeSfxThrough(audio.getSfxRoutingNode());
 
   // Prevent zoom-out duplication: ensure the camera cannot zoom past one full

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
 import { resolveOpponentChallenge, setPendingOpponentChallenge } from '@/core/opponent-challenge';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { processTurn } from '@/core/turn-manager';
 import { processAITurn } from '@/ai/basic-ai';
 import { RenderLoop } from '@/renderer/render-loop';
@@ -51,7 +52,15 @@ import { recordBeastSightings, getBestiaryEntriesForPlayer } from '@/systems/bea
 import { showBeastSightingBanner } from '@/ui/beast-sighting-banner';
 import { showBeastSlayCeremony } from '@/ui/beast-slay-ceremony';
 import { createBestiaryPanel } from '@/ui/bestiary-panel';
-import { autoSave, loadAutoSave, saveGame, loadGame, listSaves, loadSettings, normalizeLoadedState, saveSettings } from '@/storage/save-manager';
+import {
+  autoSave,
+  loadMostRecentAutoSaveEntry,
+  loadSaveEntry,
+  loadSettings,
+  rewriteLoadedSaveEntry,
+  saveGame,
+  saveSettings,
+} from '@/storage/save-manager';
 import { AudioSystem } from '@/audio/audio-system';
 import { SFX, routeSfxThrough } from '@/audio/sfx';
 import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
@@ -193,6 +202,8 @@ import { confirmBusyWorkerMove } from '@/input/worker-movement-flow';
 import { createTerritoryInspectionPanel } from '@/ui/territory-inspection-panel';
 import { fortifyUnitInState, unfortifyUnitInState } from '@/systems/unit-lifecycle-system';
 import { showPauseMenu } from '@/ui/pause-menu-panel';
+import { beginCampaignEntry } from '@/ui/campaign-entry-flow';
+import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { calculateCivEconomy, formatGoldHudText, rushBuyActiveProduction } from '@/systems/economy-system';
 import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
@@ -3858,34 +3869,67 @@ async function init(): Promise<void> {
   createUI();
   persistedSettings = await loadSettings();
 
-  // Show save panel on start
+  await showStartSavePanel();
+}
+
+async function showStartSavePanel(): Promise<void> {
+  const enterCampaign = (state: GameState, message: string): void => {
+    document.getElementById('save-panel')?.remove();
+    gameState = state;
+    migrateLegacySave();
+    startGame();
+    showNotification(message, 'info');
+  };
+
   await createSavePanel(uiLayer, {
     onNewGame: () => {
       showGameModeSelection();
     },
-    onContinue: async () => {
-      const saved = await loadAutoSave();
-      if (saved) {
-        gameState = saved;
-        migrateLegacySave();
-        startGame();
-        showNotification(`Welcome back! Turn ${gameState.turn}`, 'info');
-      }
+    onContinue: async invoker => {
+      const loaded = await loadMostRecentAutoSaveEntry();
+      if (!loaded) throw new Error('Autosave no longer exists.');
+      await beginCampaignEntry(
+        { kind: 'stored', loaded },
+        invoker,
+        {
+          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
+          persistStoredChoice: rewriteLoadedSaveEntry,
+          persistImport: autoSave,
+          showChallengePrompt: showLegacyOpponentChallengePrompt,
+          onReady: state => enterCampaign(state, `Welcome back! Turn ${state.turn}`),
+        },
+      );
     },
-    onLoadSlot: async (slotId) => {
-      const saved = await loadGame(slotId);
-      if (saved) {
-        gameState = saved;
-        migrateLegacySave();
-        startGame();
-        showNotification(`Game loaded! Turn ${gameState.turn}`, 'info');
-      }
+    onLoadEntry: async (source, invoker) => {
+      const loaded = await loadSaveEntry(source);
+      if (!loaded) throw new Error('Save no longer exists.');
+      await beginCampaignEntry(
+        { kind: 'stored', loaded },
+        invoker,
+        {
+          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
+          persistStoredChoice: rewriteLoadedSaveEntry,
+          persistImport: autoSave,
+          showChallengePrompt: showLegacyOpponentChallengePrompt,
+          onReady: state => enterCampaign(state, `Game loaded! Turn ${state.turn}`),
+        },
+      );
     },
-    onImportSave: (state) => {
-      gameState = normalizeLoadedState(state);
-      migrateLegacySave();
-      startGame();
-      showNotification(`Save imported! Turn ${gameState.turn}`, 'info');
+    onImportSave: async (state, invoker) => {
+      await beginCampaignEntry(
+        { kind: 'import', state },
+        invoker,
+        {
+          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
+          persistStoredChoice: rewriteLoadedSaveEntry,
+          persistImport: autoSave,
+          showChallengePrompt: showLegacyOpponentChallengePrompt,
+          onReady: readyState => enterCampaign(
+            readyState,
+            `Save imported! Turn ${readyState.turn}`,
+          ),
+        },
+      );
     },
   });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import '@/assets/roc-animations.css';
 import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
+import { resolveOpponentChallenge, setPendingOpponentChallenge } from '@/core/opponent-challenge';
 import { processTurn } from '@/core/turn-manager';
 import { processAITurn } from '@/ai/basic-ai';
 import { RenderLoop } from '@/renderer/render-loop';
@@ -369,6 +370,11 @@ function createUI(): void {
         onNewGame: () => showGameModeSelection(),
         autoSave: () => autoSave(gameState),
         onOpenBestiary: () => openBestiary(),
+        opponentChallenge: resolveOpponentChallenge(gameState),
+        pendingOpponentChallenge: gameState.pendingOpponentChallenge,
+        onOpponentChallengeChange: (challenge) => {
+          gameState = setPendingOpponentChallenge(gameState, challenge);
+        },
         // Spec 3: per-channel audio settings
         audioSettings: {
           masterVolume:   currentMasterVolume,   // tracked in memory across menu reopens
@@ -4037,6 +4043,8 @@ function showGameModeSelection(): void {
             // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
             settingsOverrides: { ...getPersistedSettingsOverrides(), ...config.settingsOverrides },
             customCivilizations: config.customCivilizations,
+            mapScript: config.mapScript,
+            opponentChallenge: config.opponentChallenge,
           });
           if (persistedSettings?.councilTalkLevel) {
             gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
@@ -4056,8 +4064,8 @@ function showGameModeSelection(): void {
       const savedCustomCivilizations = currentSettings.customCivilizations ?? [];
       modePanel.remove();
       showHotSeatSetup(uiLayer, {
-        onComplete: (config) => {
-          gameState = createHotSeatGame(config, undefined, title);
+        onComplete: (config, opponentChallenge) => {
+          gameState = createHotSeatGame(config, undefined, title, opponentChallenge ?? 'standard');
           if (persistedSettings?.councilTalkLevel) {
             gameState.settings.councilTalkLevel = persistedSettings.councilTalkLevel;
           }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,14 +9,10 @@ import '@/assets/roc-animations.css';
 import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
-import {
-  applyPendingOpponentChallenge,
-  resolveOpponentChallenge,
-  setPendingOpponentChallenge,
-} from '@/core/opponent-challenge';
+import { resolveOpponentChallenge, setPendingOpponentChallenge } from '@/core/opponent-challenge';
 import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { processTurn } from '@/core/turn-manager';
-import { processAITurn } from '@/ai/basic-ai';
+import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
 import { RenderLoop } from '@/renderer/render-loop';
 import { initSprites } from '@/renderer/sprites/sprite-loader';
 import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
@@ -115,7 +111,7 @@ import { visitVillage } from '@/systems/village-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs } from '@/systems/tech-system';
-import { getNextPlayer, getAIPlayers, isRoundComplete } from '@/core/turn-cycling';
+import { getNextPlayer, isRoundComplete } from '@/core/turn-cycling';
 import { showTurnHandoff } from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
 import { clearEventsForPlayer, collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
@@ -3160,35 +3156,11 @@ async function replayAIMoves(moves: AIMoveRecord[]): Promise<void> {
   }
 }
 
-function finalizeCompletedRoundState(state: GameState): GameState {
-  let next = applyPendingOpponentChallenge(state);
-  if ((next.opponentAI?.migrationGraceRoundsRemaining ?? 0) > 0) {
-    next = {
-      ...next,
-      opponentAI: {
-        ...next.opponentAI!,
-        migrationGraceRoundsRemaining: next.opponentAI!.migrationGraceRoundsRemaining - 1,
-      },
-    };
-  }
-  return next;
-}
-
-function runCurrentCompletedRound(state: GameState, hotSeat: NonNullable<GameState['hotSeat']> | undefined) {
+function runCurrentCompletedRound(state: GameState) {
   return runCompletedRound(state, bus, {
     improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
-    majors: (current, eventBus) => {
-      let next = current;
-      const aiIds = hotSeat ? getAIPlayers(hotSeat).map(player => player.slotId) : ['ai-1'];
-      for (const aiId of aiIds) {
-        if (next.civilizations[aiId] && !next.civilizations[aiId].isEliminated) {
-          next = processAITurn(next, aiId, eventBus);
-        }
-      }
-      return next;
-    },
+    majors: (current, eventBus) => processNonHumanMajorRound(current, eventBus).state,
     world: (current, eventBus) => processTurn(current, eventBus),
-    postprocess: (_before, current) => finalizeCompletedRoundState(current),
   });
 }
 
@@ -3277,7 +3249,7 @@ async function beginHotSeatHandoff(
       void persistCompletedHandoff();
       return;
     }
-    const result = runCurrentCompletedRound(preSimulationState, hotSeat);
+    const result = runCurrentCompletedRound(preSimulationState);
     if (!result.ok) {
       gameState = preSimulationState;
       controller.setError(
@@ -3317,7 +3289,7 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       await beginHotSeatHandoff(hotSeat, isRoundComplete(hotSeat, gameState.currentPlayer));
     } else {
       // --- Solo Mode ---
-      const result = runCurrentCompletedRound(gameState, undefined);
+      const result = runCurrentCompletedRound(gameState);
       if (!result.ok) throw result.error;
       gameState = result.state;
       const soloMoves = captureAIMoves(() => {

--- a/src/presentation/round-presentation-gate.ts
+++ b/src/presentation/round-presentation-gate.ts
@@ -1,0 +1,19 @@
+export class RoundPresentationGate {
+  private depth = 0;
+
+  suppress(): void {
+    this.depth += 1;
+  }
+
+  resume(): void {
+    this.depth = Math.max(0, this.depth - 1);
+  }
+
+  isSuppressed(): boolean {
+    return this.depth > 0;
+  }
+
+  get suppressionDepth(): number {
+    return this.depth;
+  }
+}

--- a/src/storage/save-file-transfer.ts
+++ b/src/storage/save-file-transfer.ts
@@ -12,18 +12,30 @@ export type SaveFileImportResult =
   | { status: 'error'; message: string };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function isGameStateShape(value: unknown): value is GameState {
-  return isRecord(value)
-    && typeof value.turn === 'number'
-    && typeof value.currentPlayer === 'string'
-    && isRecord(value.civilizations)
-    && isRecord(value.cities)
-    && isRecord(value.units)
-    && isRecord(value.map)
-    && Array.isArray(value.map.tiles);
+  if (
+    !isRecord(value)
+    || !Number.isFinite(value.turn)
+    || typeof value.currentPlayer !== 'string'
+    || !isRecord(value.civilizations)
+    || !isRecord(value.cities)
+    || !isRecord(value.units)
+    || !isRecord(value.map)
+  ) {
+    return false;
+  }
+  if (
+    !Number.isFinite(value.map.width)
+    || !Number.isFinite(value.map.height)
+    || typeof value.map.wrapsHorizontally !== 'boolean'
+    || !isRecord(value.map.tiles)
+  ) {
+    return false;
+  }
+  return isRecord(value.civilizations[value.currentPlayer]);
 }
 
 export function serializeSaveFile(state: GameState): string {

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -1042,8 +1042,15 @@ export async function loadSaveEntry(source: SaveEntrySource): Promise<LoadedSave
 export async function loadMostRecentAutoSaveEntry(): Promise<LoadedSaveEntry | undefined> {
   const newestMeta = await getMostRecentAutosaveMeta();
   if (newestMeta) {
+    const loaded = await loadSaveEntry({ id: newestMeta.id, kind: 'autosave' });
+    if (!loaded) {
+      const legacyState = await loadLegacyAutoSave();
+      return legacyState
+        ? { state: legacyState, source: { id: LEGACY_AUTO_SAVE_KEY, kind: 'autosave' } }
+        : undefined;
+    }
     await retireLegacyAutosaveIfRealAutosavesExist();
-    return loadSaveEntry({ id: newestMeta.id, kind: 'autosave' });
+    return loaded;
   }
 
   const state = await loadLegacyAutoSave();

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -1,4 +1,4 @@
-import { QUEST_TYPES, type City, type CityFocus, type CityMaturity, type GameState, type QuestTarget, type SaveSlotMeta } from '@/core/types';
+import { QUEST_TYPES, type City, type CityFocus, type CityMaturity, type GameState, type OpponentChallenge, type QuestTarget, type SaveSlotMeta } from '@/core/types';
 import { drawNextCityName } from '@/systems/city-name-system';
 import { isCityCoastal, BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from '@/systems/city-maturity-system';
@@ -24,6 +24,8 @@ import { dbGet, dbPut, dbDelete, dbGetAllKeys } from './db';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
 import { getPirateStageDefinition, PIRATE_NOTORIETY, PIRATE_PRESSURE } from '@/systems/pirate-definitions';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { isOpponentChallenge } from '@/core/opponent-challenge';
+import { createEmptyOpponentAIState, normalizeOpponentAIState } from '@/core/opponent-ai-state';
 
 const SAVE_PREFIX = 'save:';
 const META_PREFIX = 'meta:';
@@ -721,9 +723,15 @@ export function normalizeLoadedState(state: GameState): NormalizedGameState {
   normalizedCityState.pirates = normalizePirateState(normalizedCityState);
   normalizedCityState.notificationLog = normalizeNotificationLog(normalizedCityState.notificationLog);
   normalizedCityState.idCounters = normalizeIdCounters(normalizedCityState);
+  if (!isOpponentChallenge(normalizedCityState.opponentChallenge)) {
+    delete normalizedCityState.opponentChallenge;
+  }
+  if (!isOpponentChallenge(normalizedCityState.pendingOpponentChallenge)) {
+    delete normalizedCityState.pendingOpponentChallenge;
+  }
   if (!normalizedCityState.map?.tiles) {
     normalizedCityState.pendingDiplomacyRequests ??= [];
-    return normalizedCityState as NormalizedGameState;
+    return normalizeOpponentAIState(normalizedCityState) as NormalizedGameState;
   }
   const territoryNormalized = recalculateTerritory(normalizedCityState, {
     reason: 'load',
@@ -744,7 +752,7 @@ export function normalizeLoadedState(state: GameState): NormalizedGameState {
       }
     }
   }
-  return normalized as NormalizedGameState;
+  return normalizeOpponentAIState(normalized) as NormalizedGameState;
 }
 
 export const normalizeLoadedStateForTest = normalizeLoadedState;
@@ -889,6 +897,16 @@ function getSaveStorageKey(id: string, kind: 'manual' | 'autosave'): string {
   return kind === 'autosave' ? id : `${SAVE_PREFIX}${id}`;
 }
 
+export interface SaveEntrySource {
+  id: string;
+  kind: 'manual' | 'autosave';
+}
+
+export interface LoadedSaveEntry {
+  state: NormalizedGameState;
+  source: SaveEntrySource;
+}
+
 function getMetaStorageKey(id: string): string {
   return `${META_PREFIX}${id}`;
 }
@@ -910,7 +928,7 @@ async function listPersistedMetas(): Promise<SaveSlotMeta[]> {
   return metas.sort(compareSaveMeta);
 }
 
-async function loadLegacyAutoSave(): Promise<GameState | undefined> {
+async function loadLegacyAutoSave(): Promise<NormalizedGameState | undefined> {
   const idbSave = await dbGet<GameState>(LEGACY_AUTO_SAVE_KEY);
   if (idbSave) {
     return normalizeLoadedState(idbSave);
@@ -1009,18 +1027,59 @@ export async function autoSave(state: GameState): Promise<void> {
   await syncLocalStorageBackup(resolved);
 }
 
+export async function loadSaveEntry(source: SaveEntrySource): Promise<LoadedSaveEntry | undefined> {
+  if (source.kind === 'autosave' && source.id === LEGACY_AUTO_SAVE_KEY) {
+    const state = await loadLegacyAutoSave();
+    return state ? { state, source: { ...source } } : undefined;
+  }
+
+  const state = await dbGet<GameState>(getSaveStorageKey(source.id, source.kind));
+  return state
+    ? { state: normalizeLoadedState(state), source: { ...source } }
+    : undefined;
+}
+
+export async function loadMostRecentAutoSaveEntry(): Promise<LoadedSaveEntry | undefined> {
+  const newestMeta = await getMostRecentAutosaveMeta();
+  if (newestMeta) {
+    await retireLegacyAutosaveIfRealAutosavesExist();
+    return loadSaveEntry({ id: newestMeta.id, kind: 'autosave' });
+  }
+
+  const state = await loadLegacyAutoSave();
+  return state
+    ? { state, source: { id: LEGACY_AUTO_SAVE_KEY, kind: 'autosave' } }
+    : undefined;
+}
+
+export async function rewriteLoadedSaveEntry(
+  source: SaveEntrySource,
+  state: GameState,
+): Promise<void> {
+  const resolved = normalizeLoadedState(structuredClone(state));
+
+  if (source.kind === 'autosave' && source.id === LEGACY_AUTO_SAVE_KEY) {
+    await dbPut(LEGACY_AUTO_SAVE_KEY, resolved);
+    await syncLocalStorageBackup(resolved);
+    return;
+  }
+
+  const storageKey = getSaveStorageKey(source.id, source.kind);
+  if (!await dbGet<GameState>(storageKey)) {
+    throw new Error('Save entry no longer exists.');
+  }
+
+  await dbPut(storageKey, resolved);
+  if (source.kind === 'autosave') {
+    const newestMeta = await getMostRecentAutosaveMeta();
+    if (newestMeta?.id === source.id) {
+      await syncLocalStorageBackup(resolved);
+    }
+  }
+}
+
 export async function loadMostRecentAutoSave(): Promise<GameState | undefined> {
-  const retiredLegacy = await retireLegacyAutosaveIfRealAutosavesExist();
-  const persistedAutoSave = await loadMostRecentPersistedAutosave();
-  if (persistedAutoSave) {
-    return persistedAutoSave;
-  }
-
-  if (retiredLegacy) {
-    return undefined;
-  }
-
-  return loadLegacyAutoSave();
+  return (await loadMostRecentAutoSaveEntry())?.state;
 }
 
 export async function loadAutoSave(): Promise<GameState | undefined> {
@@ -1071,6 +1130,20 @@ export async function loadGame(slotId: string): Promise<GameState | undefined> {
 
   const save = await dbGet<GameState>(getSaveStorageKey(slotId, 'manual'));
   return save ? normalizeLoadedState(save) : undefined;
+}
+
+export function initializeLegacyOpponentChallenge(
+  state: GameState,
+  challenge: OpponentChallenge,
+): NormalizedGameState {
+  const migrated = structuredClone(state) as NormalizedGameState;
+  migrated.opponentChallenge = challenge;
+  delete migrated.pendingOpponentChallenge;
+  migrated.opponentAI = {
+    ...createEmptyOpponentAIState(),
+    migrationGraceRoundsRemaining: 2,
+  };
+  return migrated;
 }
 
 export async function deleteSaveEntry(entryId: string, kind: 'manual' | 'autosave'): Promise<void> {

--- a/src/systems/improvement-turn-system.ts
+++ b/src/systems/improvement-turn-system.ts
@@ -1,0 +1,37 @@
+import type { EventBus } from '@/core/event-bus';
+import { appendNotification } from '@/core/notification-log';
+import type { GameState } from '@/core/types';
+import { getImprovementDisplayName } from '@/systems/improvement-system';
+import { clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
+
+export function processImprovementTurns(state: GameState, bus: EventBus): GameState {
+  let next = structuredClone(state);
+  for (const [key, tile] of Object.entries(next.map.tiles)) {
+    if (tile.improvementTurnsLeft <= 0) continue;
+    tile.improvementTurnsLeft -= 1;
+    if (tile.improvementTurnsLeft > 0) continue;
+
+    const owner = tile.improvementOwner;
+    const label = getImprovementDisplayName(tile.improvement);
+    bus.emit('improvement:completed', {
+      coord: { ...tile.coord },
+      type: tile.improvement,
+    });
+    next = clearCompletedWorkerTasksForImprovement(next, tile.coord);
+    const completedTile = next.map.tiles[key]!;
+    if (owner) {
+      appendNotification(next, owner, {
+        message: `${label} completed!`,
+        type: 'success',
+        turn: next.turn,
+        target: {
+          kind: 'map',
+          coord: { ...completedTile.coord },
+          label,
+        },
+      });
+      completedTile.improvementOwner = undefined;
+    }
+  }
+  return next;
+}

--- a/src/systems/pirate-behavior.ts
+++ b/src/systems/pirate-behavior.ts
@@ -1,4 +1,4 @@
-import type { CombatResult, GameState, HexCoord, Unit } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import type {
   PirateFactionId,
   PirateIntentState,
@@ -30,6 +30,11 @@ export interface PirateRoundFacts {
   movements: PirateMovementFact[];
   attacks: CombatResult[];
   transportKills: PirateTransportKillFact[];
+  attackPresentations?: Array<{
+    visibleToViewerIds: string[];
+    attackerType: UnitType;
+    defenderType: UnitType;
+  }>;
 }
 
 export interface PirateRaid {
@@ -51,6 +56,10 @@ export interface PirateMovementFact {
   from: HexCoord;
   to: HexCoord;
   path: HexCoord[];
+  presentationByViewer?: Record<string, {
+    unit: Unit;
+    visibleSegments: HexCoord[][];
+  }>;
 }
 
 export interface PirateMutationResult {

--- a/src/systems/pirate-behavior.ts
+++ b/src/systems/pirate-behavior.ts
@@ -34,6 +34,8 @@ export interface PirateRoundFacts {
     visibleToViewerIds: string[];
     attackerType: UnitType;
     defenderType: UnitType;
+    attackerOwnerId: string;
+    defenderOwnerId: string;
   }>;
 }
 

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -31,6 +31,10 @@ import {
   type PirateNotificationEvent,
 } from './pirate-notifications';
 import { createUnit, getMovementStepCost, moveUnit, resetUnitTurn, UNIT_DEFINITIONS } from './unit-system';
+import {
+  buildCombatPresentation,
+  buildMovePresentationByViewer,
+} from './viewer-event-presentation';
 
 export const PIRATE_ROUND_TRACE = [
   'normalize',
@@ -139,11 +143,17 @@ function attackTarget(
   state: GameState,
   attacker: Unit,
   targetUnitId: string | undefined,
-): { state: GameState; result: CombatResult | null; transportKill: PirateRoundFacts['transportKills'][number] | null; events: PirateActionEvent[] } {
+): {
+  state: GameState;
+  result: CombatResult | null;
+  presentation: NonNullable<PirateRoundFacts['attackPresentations']>[number] | null;
+  transportKill: PirateRoundFacts['transportKills'][number] | null;
+  events: PirateActionEvent[];
+} {
   const defender = targetUnitId ? state.units[targetUnitId] : undefined;
-  if (!defender || !isMajorCivOwner(defender.owner)) return { state, result: null, transportKill: null, events: [] };
+  if (!defender || !isMajorCivOwner(defender.owner)) return { state, result: null, presentation: null, transportKill: null, events: [] };
   if (!canUnitAttackTarget(state, attacker, defender.position, { requireVisibility: false }).ok) {
-    return { state, result: null, transportKill: null, events: [] };
+    return { state, result: null, presentation: null, transportKill: null, events: [] };
   }
   const seed = Math.max(1, state.turn * 7919 + attacker.id.length * 97 + defender.id.length);
   const result = resolveCombat(attacker, defender, state.map, seed, undefined, state.era);
@@ -151,7 +161,13 @@ function attackTarget(
   const transportKill = !result.defenderSurvived && UNIT_DEFINITIONS[defender.type]?.cargoCapacity !== undefined
     ? { factionId: attacker.owner as `pirate-${number}`, victimCivId: defender.owner, unitId: defender.id }
     : null;
-  return { state: applied.state, result, transportKill, events: applied.pirateEvents };
+  return {
+    state: applied.state,
+    result,
+    presentation: buildCombatPresentation(state, result, attacker, defender),
+    transportKill,
+    events: applied.pirateEvents,
+  };
 }
 
 function processMovementAndCombat(state: GameState, relocated: Set<string>): {
@@ -160,7 +176,12 @@ function processMovementAndCombat(state: GameState, relocated: Set<string>): {
   events: PirateActionEvent[];
 } {
   let nextState = state;
-  const facts: PirateRoundFacts = { movements: [], attacks: [], transportKills: [] };
+  const facts: PirateRoundFacts = {
+    movements: [],
+    attacks: [],
+    transportKills: [],
+    attackPresentations: [],
+  };
   const events: PirateActionEvent[] = [];
   for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
     let faction = nextState.pirates?.factions[factionId];
@@ -181,21 +202,36 @@ function processMovementAndCombat(state: GameState, relocated: Set<string>): {
       if (attack.result) {
         nextState = attack.state;
         facts.attacks.push(attack.result);
+        facts.attackPresentations!.push(attack.presentation!);
         if (attack.transportKill) facts.transportKills.push(attack.transportKill);
         events.push(...attack.events);
         continue;
       }
       if (target) {
         const from = unit.position;
+        const beforeMove = nextState;
         const moved = moveOneStepToward(nextState, unit, target);
         nextState = moved.state;
-        if (moved.path.length > 0) facts.movements.push({ unitId, from, to: moved.path.at(-1)!, path: moved.path });
+        if (moved.path.length > 0) {
+          facts.movements.push({
+            unitId,
+            from,
+            to: moved.path.at(-1)!,
+            path: moved.path,
+            presentationByViewer: buildMovePresentationByViewer(
+              beforeMove,
+              unit,
+              [from, ...moved.path],
+            ),
+          });
+        }
       }
       unit = nextState.units[unitId];
       attack = unit ? attackTarget(nextState, unit, intent?.targetUnitId) : attack;
       if (attack.result) {
         nextState = attack.state;
         facts.attacks.push(attack.result);
+        facts.attackPresentations!.push(attack.presentation!);
         if (attack.transportKill) facts.transportKills.push(attack.transportKill);
         events.push(...attack.events);
       }
@@ -357,11 +393,22 @@ export function processPiratesForCompletedRound(state: GameState, bus: EventBus)
         };
       }
     }
+    const beforeRelocation = nextState;
     const result = applyPlannedRelocation(nextState, factionId);
     nextState = result.state;
     for (const movement of result.facts.movements) {
       relocated.add(movement.unitId);
-      relocationFacts.push(movement);
+      const unit = beforeRelocation.units[movement.unitId];
+      relocationFacts.push({
+        ...movement,
+        ...(unit ? {
+          presentationByViewer: buildMovePresentationByViewer(
+            beforeRelocation,
+            unit,
+            [movement.from, ...movement.path],
+          ),
+        } : { presentationByViewer: {} }),
+      });
     }
     if (result.facts.relocation.status === 'moved') events.push({ type: 'relocated', factionId });
   }
@@ -371,6 +418,7 @@ export function processPiratesForCompletedRound(state: GameState, bus: EventBus)
     movements: [...relocationFacts, ...processed.facts.movements],
     attacks: processed.facts.attacks,
     transportKills: processed.facts.transportKills,
+    attackPresentations: processed.facts.attackPresentations,
   };
   events.push(...processed.events.map(event => ({ type: event.type, factionId: event.factionId })));
   const raids = derivePirateRaids(nextState, facts);
@@ -436,10 +484,13 @@ export function processPiratesForCompletedRound(state: GameState, bus: EventBus)
     bus.emit('unit:move', {
       ...movement,
       path: [movement.from, ...movement.path],
+      presentationByViewer: movement.presentationByViewer ?? {},
     });
   }
-  for (const result of facts.attacks) {
-    bus.emit('combat:resolved', { result });
+  for (const [index, result] of facts.attacks.entries()) {
+    const presentation = facts.attackPresentations?.[index];
+    if (!presentation) continue;
+    bus.emit('combat:resolved', { result, ...presentation });
   }
   return { state: nextState, economyModifiers, events, facts, trace };
 }

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -18,6 +18,7 @@ import { isAtWar } from '@/systems/diplomacy-system';
 import { removeRouteForUnit } from '@/systems/trade-system';
 import { buildUnitOccupancy, getUnitIdsAtCoord } from '@/systems/unit-occupancy';
 import { syncTransportCargoPositions } from '@/systems/transport-system';
+import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
 
 export interface ExecuteUnitMoveOptions {
   actor: 'player' | 'automation' | 'ai';
@@ -106,6 +107,8 @@ export function executeUnitMove(
 
   const unit = state.units[unitId]!;
   const from = { ...unit.position };
+  const movePath = validation.path;
+  const presentationByViewer = buildMovePresentationByViewer(state, unit, movePath);
   state.units = {
     ...state.units,
     [unitId]: moveUnit(unit, validation.to, validation.cost),
@@ -114,8 +117,13 @@ export function executeUnitMove(
     const synced = syncTransportCargoPositions(state, unitId);
     state.units = synced.units;
   }
-  const movePath = validation.path;
-  options.bus?.emit('unit:move', { unitId, from, to: validation.to, path: movePath });
+  options.bus?.emit('unit:move', {
+    unitId,
+    from,
+    to: validation.to,
+    path: movePath,
+    presentationByViewer,
+  });
 
   let villageOutcome: Extract<ExecuteUnitMoveResult, { ok: true }>['villageOutcome'];
   const villageAtDestination = Object.values(state.tribalVillages).find(village => hexKey(village.position) === hexKey(validation.to));
@@ -390,7 +398,17 @@ export function advanceRouteRunners(state: GameState, bus?: EventBus): GameState
         [caravan.id]: { ...newState.units[caravan.id]!, position: nextStep },
       },
     };
-    bus?.emit('unit:move', { unitId: caravan.id, from, to: nextStep, path: [from, nextStep] });
+    bus?.emit('unit:move', {
+      unitId: caravan.id,
+      from,
+      to: nextStep,
+      path: [from, nextStep],
+      presentationByViewer: buildMovePresentationByViewer(
+        newState,
+        { ...caravan, position: from },
+        [from, nextStep],
+      ),
+    });
 
     if (nextStep.q === targetCity.position.q && nextStep.r === targetCity.position.r) {
       const movedCaravan = newState.units[caravan.id];

--- a/src/systems/viewer-event-presentation.ts
+++ b/src/systems/viewer-event-presentation.ts
@@ -73,6 +73,8 @@ export function buildCombatPresentation(
   visibleToViewerIds: string[];
   attackerType: Unit['type'];
   defenderType: Unit['type'];
+  attackerOwnerId: string;
+  defenderOwnerId: string;
 } {
   return {
     visibleToViewerIds: getLivingHumanViewerIds(state).filter(viewerId =>
@@ -81,5 +83,7 @@ export function buildCombatPresentation(
     ),
     attackerType: attacker.type,
     defenderType: defender.type,
+    attackerOwnerId: attacker.owner,
+    defenderOwnerId: defender.owner,
   };
 }

--- a/src/systems/viewer-event-presentation.ts
+++ b/src/systems/viewer-event-presentation.ts
@@ -1,0 +1,85 @@
+import type { CombatResult, GameState, HexCoord, Unit } from '@/core/types';
+import { isBeastConcealedFrom } from '@/systems/beast-system';
+import { getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
+
+export interface ViewerMovePresentation {
+  unit: Unit;
+  visibleSegments: HexCoord[][];
+}
+
+export function getLivingHumanViewerIds(state: GameState): string[] {
+  const configured = state.hotSeat?.players
+    .filter(player => player.isHuman)
+    .map(player => player.slotId);
+  const candidates = configured?.length
+    ? configured
+    : Object.values(state.civilizations).filter(civ => civ.isHuman).map(civ => civ.id);
+  return [...new Set(candidates)]
+    .filter(civId => state.civilizations[civId] && !state.civilizations[civId].isEliminated)
+    .sort();
+}
+
+function isUnitVisibleAt(
+  state: GameState,
+  viewerId: string,
+  unit: Unit,
+  position: HexCoord,
+): boolean {
+  if (unit.owner === viewerId) return true;
+  const visibility = state.civilizations[viewerId]?.visibility;
+  if (!visibility || getVisibility(visibility, position) !== 'visible') return false;
+  const snapshot = { ...unit, position: { ...position } };
+  if (isForestConcealedUnit(state, viewerId, snapshot)) return false;
+  const viewerUnits = state.civilizations[viewerId].units
+    .map(id => state.units[id])
+    .filter((candidate): candidate is Unit => Boolean(candidate) && !candidate.transportId);
+  return !isBeastConcealedFrom(snapshot, state.map, viewerUnits);
+}
+
+export function buildMovePresentationByViewer(
+  state: GameState,
+  unit: Unit,
+  path: HexCoord[],
+): Record<string, ViewerMovePresentation> {
+  const result: Record<string, ViewerMovePresentation> = {};
+  for (const viewerId of getLivingHumanViewerIds(state)) {
+    const segments: HexCoord[][] = [];
+    let current: HexCoord[] = [];
+    for (const coord of path) {
+      if (isUnitVisibleAt(state, viewerId, unit, coord)) {
+        current.push({ ...coord });
+      } else if (current.length > 0) {
+        segments.push(current);
+        current = [];
+      }
+    }
+    if (current.length > 0) segments.push(current);
+    if (segments.length > 0) {
+      result[viewerId] = {
+        unit: structuredClone(unit),
+        visibleSegments: segments,
+      };
+    }
+  }
+  return result;
+}
+
+export function buildCombatPresentation(
+  state: GameState,
+  result: CombatResult,
+  attacker: Unit,
+  defender: Unit,
+): {
+  visibleToViewerIds: string[];
+  attackerType: Unit['type'];
+  defenderType: Unit['type'];
+} {
+  return {
+    visibleToViewerIds: getLivingHumanViewerIds(state).filter(viewerId =>
+      isUnitVisibleAt(state, viewerId, attacker, result.attackerPosition)
+      || isUnitVisibleAt(state, viewerId, defender, result.defenderPosition),
+    ),
+    attackerType: attacker.type,
+    defenderType: defender.type,
+  };
+}

--- a/src/ui/campaign-entry-flow.ts
+++ b/src/ui/campaign-entry-flow.ts
@@ -1,0 +1,67 @@
+import type { GameState } from '@/core/types';
+import { isOpponentChallenge } from '@/core/opponent-challenge';
+import {
+  autoSave,
+  initializeLegacyOpponentChallenge,
+  normalizeLoadedState,
+  rewriteLoadedSaveEntry,
+  type LoadedSaveEntry,
+} from '@/storage/save-manager';
+import {
+  showLegacyOpponentChallengePrompt,
+} from '@/ui/legacy-opponent-challenge-prompt';
+
+export type CampaignEntryCandidate =
+  | { kind: 'stored'; loaded: LoadedSaveEntry }
+  | { kind: 'import'; state: GameState };
+
+export interface CampaignEntryDependencies {
+  purposefulAIEnabled: boolean;
+  persistStoredChoice: typeof rewriteLoadedSaveEntry;
+  persistImport: typeof autoSave;
+  showChallengePrompt: typeof showLegacyOpponentChallengePrompt;
+  onReady: (state: GameState) => void;
+}
+
+export function beginCampaignEntry(
+  candidate: CampaignEntryCandidate,
+  invoker: HTMLButtonElement,
+  dependencies: CampaignEntryDependencies,
+): Promise<'entered' | 'cancelled'> {
+  const rawState = candidate.kind === 'stored' ? candidate.loaded.state : candidate.state;
+  const normalized = normalizeLoadedState(structuredClone(rawState));
+
+  const enter = async (state: GameState): Promise<'entered'> => {
+    if (candidate.kind === 'import') {
+      await dependencies.persistImport(state);
+    }
+    dependencies.onReady(state);
+    return 'entered';
+  };
+
+  if (!dependencies.purposefulAIEnabled || isOpponentChallenge(normalized.opponentChallenge)) {
+    return enter(normalized);
+  }
+
+  return new Promise<'entered' | 'cancelled'>(resolve => {
+    const savePanel = invoker.closest<HTMLElement>('#save-panel');
+    const promptContainer = savePanel?.parentElement ?? document.body;
+    dependencies.showChallengePrompt(promptContainer, {
+      hotSeat: Boolean(normalized.hotSeat),
+      returnFocusTo: invoker,
+      onCancel: () => {
+        resolve('cancelled');
+      },
+      onContinue: async challenge => {
+        const migrated = initializeLegacyOpponentChallenge(normalized, challenge);
+        if (candidate.kind === 'stored') {
+          await dependencies.persistStoredChoice(candidate.loaded.source, migrated);
+        } else {
+          await dependencies.persistImport(migrated);
+        }
+        dependencies.onReady(migrated);
+        resolve('entered');
+      },
+    });
+  });
+}

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -1,5 +1,6 @@
-import type { BeastsMode, CustomCivDefinition, SoloSetupConfig, MapScript } from '@/core/types';
+import type { BeastsMode, CustomCivDefinition, SoloSetupConfig, MapScript, OpponentChallenge } from '@/core/types';
 import { MAP_DIMENSIONS } from '@/core/game-state';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { createCivSelectPanel } from '@/ui/civ-select';
 import { createCustomCivPanel } from '@/ui/custom-civ-panel';
 import { getPlayableCivDefinitions } from '@/systems/civ-registry';
@@ -8,6 +9,7 @@ import { createDefaultSettings } from '@/core/game-state';
 import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
 import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
+import { createOpponentChallengeSelector } from '@/ui/opponent-challenge-selector';
 
 export interface CampaignSetupCallbacks {
   onStartSolo: (config: SoloSetupConfig) => void;
@@ -18,6 +20,7 @@ export interface CampaignSetupCallbacks {
 
 export interface CampaignSetupOptions {
   initialCustomCivilizations?: CustomCivDefinition[];
+  purposefulAIEnabled?: boolean;
 }
 
 function createLabeledSelect(labelText: string, id: string): { wrapper: HTMLDivElement; select: HTMLSelectElement } {
@@ -63,6 +66,7 @@ function syncChoiceButtonState(button: HTMLButtonElement, selected: boolean): vo
 
 export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSetupCallbacks, options?: CampaignSetupOptions): HTMLElement {
   container.querySelector('#campaign-setup')?.remove();
+  const purposefulAIEnabled = options?.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const shell = createSetupShell({
     panelId: 'campaign-setup',
@@ -326,6 +330,23 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     syncMapSizeCards();
   });
 
+  let selectedOpponentChallenge: OpponentChallenge = 'standard';
+  if (purposefulAIEnabled) {
+    const challengeSection = createSetupSection({
+      title: 'Opponent Challenge',
+      description: 'Choose how computer rivals and roaming threats plan and coordinate.',
+    });
+    challengeSection.section.dataset.opponentChallengeSection = '';
+    hero.appendChild(challengeSection.section);
+    challengeSection.content.appendChild(createOpponentChallengeSelector({
+      selected: selectedOpponentChallenge,
+      mode: 'new-game',
+      onSelect: challenge => {
+        selectedOpponentChallenge = challenge;
+      },
+    }));
+  }
+
   // Legendary Beasts mode section
   let beastsModeSelected: BeastsMode = 'wild';
 
@@ -479,6 +500,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       gameTitle,
       customCivilizations,
       mapScript: mapScriptSelect.value as MapScript,
+      ...(purposefulAIEnabled ? { opponentChallenge: selectedOpponentChallenge } : {}),
       settingsOverrides: { beastsMode: beastsModeSelected },
     });
   });

--- a/src/ui/combat-resolved-presentation.ts
+++ b/src/ui/combat-resolved-presentation.ts
@@ -1,0 +1,25 @@
+import type { GameEvents, GameState } from '@/core/types';
+import {
+  routeCombatResolved,
+  type NotificationSink,
+} from '@/ui/notification-routing';
+
+export interface CombatResolvedPresentationDependencies {
+  isPresentationSuppressed: () => boolean;
+  applyVisual: (result: GameEvents['combat:resolved']['result']) => void;
+  appendNotification: NotificationSink;
+}
+
+export function handleCombatResolvedEvent(
+  state: GameState,
+  event: GameEvents['combat:resolved'],
+  dependencies: CombatResolvedPresentationDependencies,
+): void {
+  if (
+    !dependencies.isPresentationSuppressed()
+    && event.visibleToViewerIds.includes(state.currentPlayer)
+  ) {
+    dependencies.applyVisual(event.result);
+  }
+  routeCombatResolved(state, event.result, dependencies.appendNotification, event);
+}

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -1,20 +1,24 @@
-import type { CustomCivDefinition, HotSeatConfig, HotSeatPlayer, MapScript } from '@/core/types';
+import type { CustomCivDefinition, HotSeatConfig, HotSeatPlayer, MapScript, OpponentChallenge } from '@/core/types';
 import { MAP_DIMENSIONS } from '@/core/game-state';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { createCivSelectPanel } from './civ-select';
 import { createCustomCivPanel } from './custom-civ-panel';
 import { createDefaultSettings } from '@/core/game-state';
 import { getPlayableCivDefinitions } from '@/systems/civ-registry';
 import { buildCustomCivId, customCivDefinitionsEqual, mergeCustomCivDefinitions } from '@/systems/custom-civ-system';
 import { loadSettings, saveSettings } from '@/storage/save-manager';
+import { createOpponentChallengeSelector } from '@/ui/opponent-challenge-selector';
+import { createGameButton } from '@/ui/ui-kit';
 
-interface HotSeatSetupCallbacks {
-  onComplete: (config: HotSeatConfig) => void;
+export interface HotSeatSetupCallbacks {
+  onComplete: (config: HotSeatConfig, opponentChallenge?: OpponentChallenge) => void;
   onCancel: () => void;
   onCustomCivilizationsChanged?: (customCivilizations: CustomCivDefinition[]) => void;
 }
 
-interface HotSeatSetupOptions {
+export interface HotSeatSetupOptions {
   initialCustomCivilizations?: CustomCivDefinition[];
+  purposefulAIEnabled?: boolean;
 }
 
 export function showHotSeatSetup(
@@ -24,6 +28,7 @@ export function showHotSeatSetup(
 ): void {
   const existing = document.getElementById('hotseat-setup');
   if (existing) existing.remove();
+  const purposefulAIEnabled = options?.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const panel = document.createElement('div');
   panel.id = 'hotseat-setup';
@@ -31,6 +36,7 @@ export function showHotSeatSetup(
 
   let selectedMapSize: 'small' | 'medium' | 'large' | null = null;
   let selectedMapScript: MapScript = 'earth';
+  let selectedOpponentChallenge: OpponentChallenge = 'standard';
   let playerCount = 0;
   const players: HotSeatPlayer[] = [];
   const chosenCivs: string[] = [];
@@ -213,10 +219,56 @@ export function showHotSeatSetup(
     nextBtn.id = 'hs-map-type-next';
     nextBtn.style.cssText = 'padding:10px 24px;min-height:44px;background:rgba(232,193,112,0.3);border:2px solid #e8c170;border-radius:8px;color:#e8c170;cursor:pointer;font-size:14px;font-weight:bold;';
     nextBtn.textContent = 'Next';
-    nextBtn.addEventListener('click', () => showPlayerCountStage());
+    nextBtn.addEventListener('click', () => {
+      if (purposefulAIEnabled) {
+        showOpponentChallengeStage();
+      } else {
+        showPlayerCountStage();
+      }
+    });
 
     nav.appendChild(backBtn);
     nav.appendChild(nextBtn);
+    panel.appendChild(nav);
+  }
+
+  function showOpponentChallengeStage() {
+    panel.replaceChildren();
+
+    const title = document.createElement('h1');
+    title.textContent = 'Choose Opponent Challenge';
+    title.style.cssText = 'font-size:22px;color:#e8c170;margin:24px 0 8px;text-align:center;';
+    panel.appendChild(title);
+
+    const subtitle = document.createElement('p');
+    subtitle.textContent = 'Choose together before private player setup begins.';
+    subtitle.style.cssText = 'font-size:13px;opacity:0.72;margin:0 0 20px;text-align:center;';
+    panel.appendChild(subtitle);
+
+    const selector = createOpponentChallengeSelector({
+      selected: selectedOpponentChallenge,
+      mode: 'new-game',
+      onSelect: challenge => {
+        selectedOpponentChallenge = challenge;
+      },
+    });
+    selector.style.maxWidth = '840px';
+    panel.appendChild(selector);
+
+    const fairness = document.createElement('p');
+    fairness.textContent = 'This choice applies to computer-controlled opponents for everyone in this campaign.';
+    fairness.style.cssText = 'font-size:12px;opacity:0.78;margin:14px 0 0;text-align:center;line-height:1.45;';
+    panel.appendChild(fairness);
+
+    const nav = document.createElement('div');
+    nav.style.cssText = 'margin-top:20px;display:flex;gap:12px;';
+    const backButton = createGameButton('Back', 'ghost');
+    backButton.id = 'hs-challenge-back';
+    backButton.addEventListener('click', () => showMapTypeStage());
+    const nextButton = createGameButton('Next', 'primary');
+    nextButton.id = 'hs-challenge-next';
+    nextButton.addEventListener('click', () => showPlayerCountStage());
+    nav.append(backButton, nextButton);
     panel.appendChild(nav);
   }
 
@@ -409,6 +461,10 @@ export function showHotSeatSetup(
     };
 
     panel.remove();
-    callbacks.onComplete(config);
+    if (purposefulAIEnabled) {
+      callbacks.onComplete(config, selectedOpponentChallenge);
+    } else {
+      callbacks.onComplete(config);
+    }
   }
 }

--- a/src/ui/legacy-opponent-challenge-prompt.ts
+++ b/src/ui/legacy-opponent-challenge-prompt.ts
@@ -1,0 +1,203 @@
+import type { OpponentChallenge } from '@/core/types';
+import { createOpponentChallengeSelector } from '@/ui/opponent-challenge-selector';
+import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
+
+export interface LegacyOpponentChallengePromptOptions {
+  hotSeat: boolean;
+  returnFocusTo?: HTMLElement;
+  onContinue: (challenge: OpponentChallenge) => Promise<void>;
+  onCancel: () => void;
+}
+
+function appendParagraph(parent: HTMLElement, text: string): HTMLParagraphElement {
+  const paragraph = document.createElement('p');
+  paragraph.textContent = text;
+  paragraph.style.cssText = 'margin:0;color:rgba(244,241,232,0.82);line-height:1.45;';
+  parent.appendChild(paragraph);
+  return paragraph;
+}
+
+function getFocusableElements(panel: HTMLElement): HTMLElement[] {
+  return Array.from(panel.querySelectorAll<HTMLElement>(
+    'button:not(:disabled), [href], input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+  ));
+}
+
+export function showLegacyOpponentChallengePrompt(
+  container: HTMLElement,
+  options: LegacyOpponentChallengePromptOptions,
+): HTMLElement {
+  container.querySelector('#legacy-opponent-challenge-prompt')?.remove();
+
+  const panel = document.createElement('div');
+  panel.id = 'legacy-opponent-challenge-prompt';
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-modal', 'true');
+  panel.setAttribute('aria-labelledby', 'legacy-opponent-challenge-title');
+  panel.setAttribute('aria-describedby', 'legacy-opponent-challenge-description');
+  panel.style.cssText = [
+    'position:fixed',
+    'inset:0',
+    'z-index:1000',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'box-sizing:border-box',
+    'background:rgba(7,9,16,0.88)',
+    'padding:max(12px, env(safe-area-inset-top)) max(12px, env(safe-area-inset-right)) max(12px, env(safe-area-inset-bottom)) max(12px, env(safe-area-inset-left))',
+  ].join(';');
+
+  const dialog = document.createElement('div');
+  dialog.dataset.legacyChallengeDialog = '';
+  dialog.style.cssText = [
+    'box-sizing:border-box',
+    'width:min(960px, 100%)',
+    'max-height:min(90dvh, 720px)',
+    'overflow-y:auto',
+    'overscroll-behavior:contain',
+    'border:1px solid rgba(232,193,112,0.45)',
+    'border-radius:14px',
+    'background:#141827',
+    'color:#f4f1e8',
+    'box-shadow:0 24px 64px rgba(0,0,0,0.55)',
+    'padding:16px',
+  ].join(';');
+  panel.appendChild(dialog);
+
+  const safeAreaStyle = document.createElement('style');
+  safeAreaStyle.textContent = [
+    '#legacy-opponent-challenge-prompt [data-legacy-challenge-dialog] {',
+    '  padding: max(16px, env(safe-area-inset-top))',
+    '    max(16px, env(safe-area-inset-right))',
+    '    max(16px, env(safe-area-inset-bottom))',
+    '    max(16px, env(safe-area-inset-left));',
+    '}',
+  ].join('\n');
+  dialog.appendChild(safeAreaStyle);
+
+  const title = document.createElement('h2');
+  title.id = 'legacy-opponent-challenge-title';
+  title.tabIndex = -1;
+  title.textContent = 'Choose Opponent Challenge';
+  title.style.cssText = 'margin:0 0 8px;font-size:clamp(1.35rem,4vw,2rem);';
+  dialog.appendChild(title);
+
+  const description = appendParagraph(
+    dialog,
+    'This campaign was created before opponent difficulty was added. Choose how computer rivals and roaming threats should behave.',
+  );
+  description.id = 'legacy-opponent-challenge-description';
+  description.style.marginBottom = '16px';
+
+  let selected: OpponentChallenge | null = null;
+  const selector = createOpponentChallengeSelector({
+    selected: null,
+    mode: 'migration',
+    onSelect: challenge => {
+      selected = challenge;
+      setButtonDisabled(continueButton, false);
+      alert.replaceChildren();
+    },
+  });
+  dialog.appendChild(selector);
+
+  const fairness = document.createElement('div');
+  fairness.style.cssText = 'display:grid;gap:6px;margin-top:16px;';
+  appendParagraph(fairness, 'Combat rules and bonuses remain the same.');
+  if (options.hotSeat) {
+    appendParagraph(
+      fairness,
+      'This choice applies to computer-controlled opponents for everyone in this campaign.',
+    );
+  }
+  dialog.appendChild(fairness);
+
+  const alert = document.createElement('p');
+  alert.setAttribute('role', 'alert');
+  alert.style.cssText = 'min-height:1.4em;margin:12px 0 0;color:#ffb4ab;font-weight:600;';
+  dialog.appendChild(alert);
+
+  const actions = document.createElement('div');
+  actions.style.cssText = 'display:flex;flex-wrap:wrap;justify-content:flex-end;gap:10px;margin-top:12px;';
+  const cancelButton = createGameButton('Cancel', 'ghost');
+  cancelButton.dataset.action = 'cancel';
+  const continueButton = createGameButton('Continue Campaign', 'primary', { disabled: true });
+  continueButton.dataset.action = 'continue';
+  actions.append(cancelButton, continueButton);
+  dialog.appendChild(actions);
+
+  let busy = false;
+  let closed = false;
+
+  const restoreFocus = (): void => {
+    if (options.returnFocusTo?.isConnected) options.returnFocusTo.focus();
+  };
+
+  const close = (notifyCancel: boolean): void => {
+    if (closed) return;
+    closed = true;
+    panel.remove();
+    restoreFocus();
+    if (notifyCancel) options.onCancel();
+  };
+
+  const setBusy = (nextBusy: boolean): void => {
+    busy = nextBusy;
+    panel.setAttribute('aria-busy', String(nextBusy));
+    for (const button of selector.querySelectorAll<HTMLButtonElement>('[data-challenge]')) {
+      setButtonDisabled(button, nextBusy);
+    }
+    setButtonDisabled(cancelButton, nextBusy);
+    setButtonDisabled(continueButton, nextBusy || selected === null);
+    continueButton.textContent = nextBusy ? 'Saving…' : 'Continue Campaign';
+  };
+
+  cancelButton.addEventListener('click', () => {
+    if (!busy) close(true);
+  });
+  continueButton.addEventListener('click', async () => {
+    if (busy || selected === null) return;
+    alert.replaceChildren();
+    setBusy(true);
+    try {
+      await options.onContinue(selected);
+      close(false);
+    } catch {
+      if (closed) return;
+      setBusy(false);
+      alert.textContent = 'Could not save your choice. Check available storage and try again.';
+      continueButton.focus();
+    }
+  });
+
+  panel.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      if (!busy) close(true);
+      return;
+    }
+    if (event.key !== 'Tab') return;
+
+    const focusable = getFocusableElements(panel);
+    if (focusable.length === 0) {
+      event.preventDefault();
+      title.focus();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && (active === first || active === title || !panel.contains(active))) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+
+  container.appendChild(panel);
+  title.focus();
+  return panel;
+}

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -246,19 +246,26 @@ export function routeCombatResolved(
   state: GameState,
   result: CombatResult,
   sink: NotificationSink,
+  facts?: Pick<
+    GameEvents['combat:resolved'],
+    'attackerOwnerId' | 'defenderOwnerId' | 'defenderType'
+  >,
 ): void {
   const defender = state.units[result.defenderId];
-  if (!defender) return;
   const attacker = state.units[result.attackerId];
-  const attackerOwner = attacker?.owner ?? 'Unknown';
+  const defenderOwner = facts?.defenderOwnerId ?? defender?.owner;
+  if (!defenderOwner) return;
+  const attackerOwner = facts?.attackerOwnerId ?? attacker?.owner ?? 'Unknown';
   const attackerLabel = attackerOwner === 'barbarian'
     ? 'Barbarians'
     : (state.civilizations[attackerOwner]?.name ?? attackerOwner);
-  const defenderType = UNIT_DEFINITIONS[defender.type]?.name ?? defender.type;
+  const defenderTypeId = facts?.defenderType ?? defender?.type;
+  if (!defenderTypeId) return;
+  const defenderType = UNIT_DEFINITIONS[defenderTypeId]?.name ?? defenderTypeId;
   const msg = result.defenderSurvived
     ? `${defenderType} was attacked by ${attackerLabel} (${result.defenderDamage} damage taken)`
     : `${defenderType} was destroyed by ${attackerLabel}!`;
-  sink(defender.owner, msg, 'warning');
+  sink(defenderOwner, msg, 'warning');
 }
 
 export function routeCombatRewardEarned(

--- a/src/ui/opponent-challenge-selector.ts
+++ b/src/ui/opponent-challenge-selector.ts
@@ -1,0 +1,126 @@
+import type { OpponentChallenge } from '@/core/types';
+import { createGameButton } from '@/ui/ui-kit';
+
+export const OPPONENT_CHALLENGE_COPY = {
+  explorer: {
+    label: 'Explorer',
+    description: 'Clear warnings, smaller attacks, and more time to recover.',
+  },
+  standard: {
+    label: 'Standard',
+    badge: 'Recommended',
+    description: 'Purposeful rivals, coordinated attacks, and fair breathing room.',
+  },
+  veteran: {
+    label: 'Veteran',
+    description: 'Faster plans, stronger coordination, and fewer tactical mistakes.',
+  },
+} as const;
+
+const CHALLENGES: OpponentChallenge[] = ['explorer', 'standard', 'veteran'];
+
+export interface OpponentChallengeSelectorOptions {
+  selected: OpponentChallenge | null;
+  onSelect: (challenge: OpponentChallenge) => void;
+  mode: 'new-game' | 'migration' | 'settings';
+}
+
+function appendText(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
+}
+
+export function createOpponentChallengeSelector(
+  options: OpponentChallengeSelectorOptions,
+): HTMLElement {
+  const selector = document.createElement('div');
+  selector.className = 'opponent-challenge-grid';
+  selector.dataset.opponentChallengeSelector = options.mode;
+  selector.setAttribute('role', 'group');
+  selector.setAttribute('aria-label', 'Opponent challenge');
+  selector.style.cssText = [
+    'display:grid',
+    'grid-template-columns:minmax(0, 1fr)',
+    'gap:12px',
+    'width:100%',
+    'min-width:0',
+  ].join(';');
+
+  const responsiveStyle = document.createElement('style');
+  responsiveStyle.textContent = [
+    '@media (min-width: 720px) {',
+    '  .opponent-challenge-grid { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }',
+    '}',
+  ].join('\n');
+  selector.appendChild(responsiveStyle);
+
+  let selected = options.selected ?? (options.mode === 'new-game' ? 'standard' : null);
+  const buttons = new Map<OpponentChallenge, HTMLButtonElement>();
+
+  const refreshSelection = (): void => {
+    for (const [challenge, button] of buttons) {
+      const isSelected = challenge === selected;
+      button.setAttribute('aria-pressed', String(isSelected));
+      button.style.borderColor = isSelected ? '#e8c170' : 'rgba(232,193,112,0.45)';
+      button.style.background = isSelected
+        ? 'rgba(232,193,112,0.18)'
+        : 'rgba(255,255,255,0.08)';
+      button.style.boxShadow = isSelected ? '0 0 0 2px rgba(232,193,112,0.22)' : 'none';
+    }
+  };
+
+  for (const challenge of CHALLENGES) {
+    const copy = OPPONENT_CHALLENGE_COPY[challenge];
+    const button = createGameButton('', 'secondary');
+    button.dataset.challenge = challenge;
+    button.setAttribute('aria-pressed', 'false');
+    button.style.cssText += [
+      'display:flex',
+      'flex-direction:column',
+      'align-items:flex-start',
+      'justify-content:flex-start',
+      'gap:6px',
+      'width:100%',
+      'min-height:44px',
+      'height:auto',
+      'padding:14px',
+      'text-align:left',
+      'white-space:normal',
+    ].join(';');
+
+    const heading = document.createElement('span');
+    heading.style.cssText = 'display:flex;flex-wrap:wrap;align-items:center;gap:8px;font-weight:700;';
+    appendText(heading, 'span', copy.label);
+    if ('badge' in copy) {
+      const badge = appendText(heading, 'span', copy.badge);
+      badge.style.cssText = [
+        'border-radius:999px',
+        'background:#e8c170',
+        'color:#1f1a12',
+        'padding:2px 7px',
+        'font-size:0.72rem',
+        'font-weight:700',
+      ].join(';');
+    }
+    button.appendChild(heading);
+
+    const description = appendText(button, 'span', copy.description);
+    description.style.cssText = 'color:rgba(244,241,232,0.82);font-size:0.9rem;line-height:1.35;';
+    button.addEventListener('click', () => {
+      selected = challenge;
+      refreshSelection();
+      options.onSelect(challenge);
+    });
+    buttons.set(challenge, button);
+    selector.appendChild(button);
+  }
+
+  refreshSelection();
+  return selector;
+}

--- a/src/ui/pause-menu-panel.ts
+++ b/src/ui/pause-menu-panel.ts
@@ -1,5 +1,11 @@
 import { createSavePanel } from '@/ui/save-panel';
 import { createGameButton } from '@/ui/ui-kit';
+import type { OpponentChallenge } from '@/core/types';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
+import {
+  OPPONENT_CHALLENGE_COPY,
+  createOpponentChallengeSelector,
+} from '@/ui/opponent-challenge-selector';
 
 export interface AudioSettingsSnapshot {
   masterVolume: number;
@@ -24,6 +30,18 @@ export interface PauseMenuCallbacks {
   // Spec 3: per-channel audio settings
   audioSettings: AudioSettingsSnapshot;
   onAudioSettingChange: (key: keyof AudioSettingsSnapshot, value: number | boolean) => void;
+  opponentChallenge: OpponentChallenge;
+  pendingOpponentChallenge?: OpponentChallenge;
+  onOpponentChallengeChange: (challenge: OpponentChallenge) => void;
+}
+
+export interface PauseMenuOptions {
+  purposefulAIEnabled?: boolean;
+}
+
+interface PauseMenuViewState {
+  announcement?: string;
+  focusChallenge?: OpponentChallenge;
 }
 
 function buildHeader(turn: number, civName: string): HTMLElement {
@@ -154,11 +172,71 @@ function buildAudioSettings(callbacks: PauseMenuCallbacks): HTMLElement {
   return section;
 }
 
+function buildOpponentChallengeSettings(
+  callbacks: PauseMenuCallbacks,
+  announcement: string,
+  onSelect: (challenge: OpponentChallenge) => void,
+): HTMLElement {
+  const section = document.createElement('section');
+  section.dataset.opponentChallengeSettings = '';
+  section.style.cssText = [
+    'border-top:1px solid rgba(255,255,255,0.1)',
+    'padding-top:12px',
+    'margin-top:12px',
+  ].join(';');
+
+  const heading = document.createElement('p');
+  heading.textContent = 'Opponent Challenge';
+  heading.style.cssText = [
+    'margin:0 0 8px',
+    'font-size:11px',
+    'text-transform:uppercase',
+    'letter-spacing:0.08em',
+    'opacity:0.65',
+  ].join(';');
+  section.appendChild(heading);
+
+  const active = document.createElement('p');
+  active.dataset.challengeActive = callbacks.opponentChallenge;
+  active.textContent = `${OPPONENT_CHALLENGE_COPY[callbacks.opponentChallenge].label} active`;
+  active.style.cssText = 'margin:0 0 4px;font-size:13px;font-weight:700;color:#e8c170;';
+  section.appendChild(active);
+
+  if (callbacks.pendingOpponentChallenge) {
+    const pending = document.createElement('p');
+    pending.dataset.challengePending = callbacks.pendingOpponentChallenge;
+    pending.textContent = `${OPPONENT_CHALLENGE_COPY[callbacks.pendingOpponentChallenge].label} next round`;
+    pending.style.cssText = 'margin:0 0 10px;font-size:12px;color:rgba(244,241,232,0.78);';
+    section.appendChild(pending);
+  }
+
+  section.appendChild(createOpponentChallengeSelector({
+    selected: callbacks.pendingOpponentChallenge ?? callbacks.opponentChallenge,
+    mode: 'settings',
+    onSelect,
+  }));
+
+  const status = document.createElement('p');
+  status.setAttribute('role', 'status');
+  status.setAttribute('aria-live', 'polite');
+  status.textContent = announcement;
+  status.style.cssText = 'min-height:1.3em;margin:8px 0 0;font-size:12px;color:#d9c58b;';
+  section.appendChild(status);
+  return section;
+}
+
+interface PauseMenuMainViewOptions {
+  purposefulAIEnabled: boolean;
+  announcement: string;
+  onOpponentChallengeSelect: (challenge: OpponentChallenge) => void;
+}
+
 function buildMainView(
   panel: HTMLElement,
   body: HTMLElement,
   container: HTMLElement,
   callbacks: PauseMenuCallbacks,
+  options: PauseMenuMainViewOptions,
 ): void {
   body.textContent = '';
 
@@ -198,8 +276,16 @@ function buildMainView(
 
   const newGameBtn = createGameButton('New Game…', 'secondary');
   newGameBtn.style.width = '100%';
-  newGameBtn.addEventListener('click', () => buildConfirmView(panel, body, container, callbacks));
+  newGameBtn.addEventListener('click', () => buildConfirmView(panel, body, container, callbacks, options));
   body.appendChild(newGameBtn);
+
+  if (options.purposefulAIEnabled) {
+    body.appendChild(buildOpponentChallengeSettings(
+      callbacks,
+      options.announcement,
+      options.onOpponentChallengeSelect,
+    ));
+  }
 
   // Spec 3: per-channel audio settings at bottom of pause menu
   body.appendChild(buildAudioSettings(callbacks));
@@ -210,6 +296,7 @@ function buildConfirmView(
   body: HTMLElement,
   container: HTMLElement,
   callbacks: PauseMenuCallbacks,
+  options: PauseMenuMainViewOptions,
 ): void {
   body.textContent = '';
 
@@ -245,12 +332,18 @@ function buildConfirmView(
 
   const cancelBtn = createGameButton('Cancel', 'ghost');
   cancelBtn.style.width = '100%';
-  cancelBtn.addEventListener('click', () => buildMainView(panel, body, container, callbacks));
+  cancelBtn.addEventListener('click', () => buildMainView(panel, body, container, callbacks, options));
   body.appendChild(cancelBtn);
 }
 
-export function showPauseMenu(container: HTMLElement, callbacks: PauseMenuCallbacks): HTMLElement {
+function renderPauseMenu(
+  container: HTMLElement,
+  callbacks: PauseMenuCallbacks,
+  options: PauseMenuOptions,
+  viewState: PauseMenuViewState,
+): HTMLElement {
   document.getElementById('pause-menu')?.remove();
+  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const overlay = document.createElement('div');
   overlay.id = 'pause-menu';
@@ -270,7 +363,9 @@ export function showPauseMenu(container: HTMLElement, callbacks: PauseMenuCallba
     border: '1px solid rgba(255,255,255,0.2)',
     borderRadius: '12px',
     padding: '20px',
-    width: '280px',
+    width: purposefulAIEnabled ? 'min(760px, calc(100vw - 32px))' : '280px',
+    maxHeight: 'min(90dvh, 760px)',
+    overflowY: 'auto',
     color: '#f4f1e8',
   });
 
@@ -281,7 +376,41 @@ export function showPauseMenu(container: HTMLElement, callbacks: PauseMenuCallba
   overlay.appendChild(panel);
   container.appendChild(overlay);
 
-  buildMainView(overlay, body, container, callbacks);
+  buildMainView(overlay, body, container, callbacks, {
+    purposefulAIEnabled,
+    announcement: viewState.announcement ?? '',
+    onOpponentChallengeSelect: challenge => {
+      callbacks.onOpponentChallengeChange(challenge);
+      const pendingOpponentChallenge = challenge === callbacks.opponentChallenge
+        ? undefined
+        : challenge;
+      renderPauseMenu(
+        container,
+        { ...callbacks, pendingOpponentChallenge },
+        options,
+        {
+          announcement: pendingOpponentChallenge
+            ? `${OPPONENT_CHALLENGE_COPY[challenge].label} will apply next round`
+            : `${OPPONENT_CHALLENGE_COPY[challenge].label} remains active`,
+          focusChallenge: challenge,
+        },
+      );
+    },
+  });
+
+  if (viewState.focusChallenge) {
+    overlay.querySelector<HTMLButtonElement>(
+      `[data-challenge="${viewState.focusChallenge}"]`,
+    )?.focus();
+  }
 
   return overlay;
+}
+
+export function showPauseMenu(
+  container: HTMLElement,
+  callbacks: PauseMenuCallbacks,
+  options: PauseMenuOptions = {},
+): HTMLElement {
+  return renderPauseMenu(container, callbacks, options, {});
 }

--- a/src/ui/pause-menu-panel.ts
+++ b/src/ui/pause-menu-panel.ts
@@ -256,7 +256,7 @@ function buildMainView(
     void createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
       onSaveToSlot: async (slotId, name) => {
         await callbacks.onSave(slotId, name);
         document.getElementById('save-panel')?.remove();

--- a/src/ui/save-panel.ts
+++ b/src/ui/save-panel.ts
@@ -1,14 +1,21 @@
 import type { SaveSlotMeta, GameState } from '@/core/types';
-import { listSaves, listSaveEpics, deleteSaveEntry, hasAutoSave, type SaveEpic } from '@/storage/save-manager';
+import {
+  listSaves,
+  listSaveEpics,
+  deleteSaveEntry,
+  hasAutoSave,
+  type SaveEntrySource,
+  type SaveEpic,
+} from '@/storage/save-manager';
 import { getSaveFileAdapter } from '@/platform/save-file-adapter';
 import { exportMostRecentAutoSave, importSaveFromFile } from '@/storage/save-file-transfer';
 
-interface SavePanelCallbacks {
+export interface SavePanelCallbacks {
   onNewGame: () => void;
-  onContinue: () => void;
-  onLoadSlot: (slotId: string) => void;
-  onSaveToSlot?: (slotId: string, name: string) => void;
-  onImportSave?: (state: GameState) => void;
+  onContinue: (invoker: HTMLButtonElement) => Promise<void> | void;
+  onLoadEntry: (source: SaveEntrySource, invoker: HTMLButtonElement) => Promise<void> | void;
+  onSaveToSlot?: (slotId: string, name: string) => Promise<void> | void;
+  onImportSave?: (state: GameState, invoker: HTMLButtonElement) => Promise<void> | void;
 }
 
 export async function createSavePanel(
@@ -108,6 +115,27 @@ export async function createSavePanel(
       status.textContent = message;
     }
   };
+  const runStartAction = async (
+    invoker: HTMLButtonElement,
+    action: () => Promise<void> | void,
+  ): Promise<void> => {
+    if (invoker.disabled) return;
+    invoker.disabled = true;
+    invoker.setAttribute('aria-busy', 'true');
+    setStatus('');
+    try {
+      await action();
+    } catch {
+      if (panel.isConnected) {
+        setStatus('Could not load this campaign. Please try again.');
+      }
+    } finally {
+      if (invoker.isConnected) {
+        invoker.disabled = false;
+        invoker.removeAttribute('aria-busy');
+      }
+    }
+  };
 
   // Bind events
   panel.querySelector('#btn-new-game')?.addEventListener('click', () => {
@@ -115,9 +143,9 @@ export async function createSavePanel(
     callbacks.onNewGame();
   });
 
-  panel.querySelector('#btn-continue')?.addEventListener('click', () => {
-    panel.remove();
-    callbacks.onContinue();
+  panel.querySelector<HTMLButtonElement>('#btn-continue')?.addEventListener('click', event => {
+    const invoker = event.currentTarget as HTMLButtonElement;
+    void runStartAction(invoker, () => callbacks.onContinue(invoker));
   });
 
   // Save to new slot
@@ -140,19 +168,20 @@ export async function createSavePanel(
   });
 
   // Import save
-  panel.querySelector('#btn-import-save')?.addEventListener('click', async () => {
-    setStatus('');
-    const adapter = await getSaveFileAdapter();
-    const result = await importSaveFromFile(adapter);
-    if (result.status === 'cancelled') {
-      return;
-    }
-    if (result.status === 'error') {
-      setStatus(result.message);
-      return;
-    }
-    panel.remove();
-    callbacks.onImportSave?.(result.state);
+  panel.querySelector<HTMLButtonElement>('#btn-import-save')?.addEventListener('click', event => {
+    const invoker = event.currentTarget as HTMLButtonElement;
+    void runStartAction(invoker, async () => {
+      const adapter = await getSaveFileAdapter();
+      const result = await importSaveFromFile(adapter);
+      if (result.status === 'cancelled') {
+        return;
+      }
+      if (result.status === 'error') {
+        setStatus(result.message);
+        return;
+      }
+      await callbacks.onImportSave?.(result.state, invoker);
+    });
   });
 
   panel.addEventListener('click', async event => {
@@ -176,12 +205,10 @@ export async function createSavePanel(
     }
 
     if (role === 'load-slot' && slotId && slotKind) {
-      panel.remove();
-      if (slotKind === 'autosave' && slotId === 'autosave') {
-        callbacks.onContinue();
-        return;
-      }
-      callbacks.onLoadSlot(slotId);
+      await runStartAction(
+        target,
+        () => callbacks.onLoadEntry({ id: slotId, kind: slotKind }, target),
+      );
       return;
     }
 

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -1,9 +1,32 @@
 import type { GameState } from '@/core/types';
-import { generateSummary, clearEventsForPlayer } from '@/core/hotseat-events';
+import { generateSummary, type TurnSummary } from '@/core/hotseat-events';
 import { resolveCivDefinition } from '@/systems/civ-registry';
+import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
 
-interface HandoffCallbacks {
-  onReady: () => void;
+export interface TurnHandoffOptions {
+  initiallyReady: boolean;
+  preparingLabel?: 'Preparing next turn…' | 'Saving campaign…';
+  onReady: (summary: TurnSummary) => Promise<void> | void;
+}
+
+export interface TurnHandoffController {
+  setReady(state: GameState): void;
+  setError(
+    message: string,
+    callbacks: { onRetry: () => void; onReturnToSaves: () => void },
+  ): void;
+  remove(): void;
+}
+
+function appendText(
+  parent: HTMLElement,
+  tagName: keyof HTMLElementTagNameMap,
+  text: string,
+): HTMLElement {
+  const element = document.createElement(tagName);
+  element.textContent = text;
+  parent.appendChild(element);
+  return element;
 }
 
 export function showTurnHandoff(
@@ -11,107 +34,234 @@ export function showTurnHandoff(
   state: GameState,
   nextCivId: string,
   playerName: string,
-  callbacks: HandoffCallbacks,
-): void {
-  const existing = document.getElementById('turn-handoff');
-  if (existing) existing.remove();
+  options: TurnHandoffOptions,
+): TurnHandoffController {
+  document.getElementById('turn-handoff')?.remove();
 
+  let currentState = state;
+  let ready = options.initiallyReady;
+  let removed = false;
   const civ = state.civilizations[nextCivId];
   const civDef = resolveCivDefinition(state, civ?.civType ?? '');
   const color = civ?.color ?? civDef?.color ?? '#e8c170';
+  const accessibilityRoot = container.closest<HTMLElement>('#game-shell') ?? container;
+  const previousAriaHidden = accessibilityRoot.getAttribute('aria-hidden');
+  const previousInert = Boolean(accessibilityRoot.inert);
+  accessibilityRoot.inert = true;
+  accessibilityRoot.setAttribute('aria-hidden', 'true');
 
   const overlay = document.createElement('div');
   overlay.id = 'turn-handoff';
-  overlay.style.cssText = `position:absolute;top:0;left:0;right:0;bottom:0;background:rgba(10,10,30,0.98);z-index:70;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:24px;`;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.setAttribute('aria-labelledby', 'turn-handoff-title');
+  overlay.style.cssText = [
+    'position:fixed',
+    'inset:0',
+    'box-sizing:border-box',
+    'background:#0a0a1e',
+    'z-index:1001',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'overflow:hidden',
+    'padding:16px',
+  ].join(';');
 
-  // Phase 1: Pass the device — use data-text placeholders, never interpolate playerName into HTML
-  overlay.innerHTML = `
-    <div style="text-align:center;">
-      <div style="width:60px;height:60px;border-radius:50%;background:${color};margin:0 auto 16px;display:flex;align-items:center;justify-content:center;font-size:24px;">&#x1f464;</div>
-      <h2 style="font-size:20px;margin:0 0 8px;color:#e8c170;">Pass to</h2>
-      <h1 style="font-size:28px;margin:0 0 24px;color:${color};" data-text="player-name-phase1"></h1>
-      <button id="handoff-confirm" style="padding:14px 32px;border-radius:10px;background:${color};border:none;color:#1a1a2e;font-weight:bold;font-size:16px;cursor:pointer;"><span data-text="handoff-btn-label"></span></button>
-    </div>
-  `;
+  const safeAreaStyle = document.createElement('style');
+  safeAreaStyle.textContent = [
+    '#turn-handoff {',
+    '  padding: max(16px, env(safe-area-inset-top))',
+    '    max(16px, env(safe-area-inset-right))',
+    '    max(16px, env(safe-area-inset-bottom))',
+    '    max(16px, env(safe-area-inset-left));',
+    '}',
+  ].join('\n');
+  overlay.appendChild(safeAreaStyle);
 
-  // Inject dynamic text via textContent (safe — playerName is user-entered, XSS risk)
-  const setTextIn = (el: HTMLElement, sel: string, text: string) => {
-    const target = el.querySelector(`[data-text="${sel}"]`);
-    if (target) target.textContent = text;
+  const card = document.createElement('div');
+  card.dataset.handoffCard = '';
+  card.style.cssText = [
+    'box-sizing:border-box',
+    'width:100%',
+    'max-width:520px',
+    'max-height:min(90dvh, 720px)',
+    'overflow-y:auto',
+    'overflow-x:hidden',
+    'overscroll-behavior:contain',
+    'border:1px solid rgba(255,255,255,0.14)',
+    'border-radius:16px',
+    'background:#15182a',
+    'color:#f4f1e8',
+    'padding:clamp(16px, 4vw, 28px)',
+    'text-align:center',
+    'overflow-wrap:anywhere',
+  ].join(';');
+  overlay.appendChild(card);
+
+  const restoreAccessibility = (): void => {
+    accessibilityRoot.inert = previousInert;
+    if (previousAriaHidden === null) accessibilityRoot.removeAttribute('aria-hidden');
+    else accessibilityRoot.setAttribute('aria-hidden', previousAriaHidden);
   };
 
-  setTextIn(overlay, 'player-name-phase1', playerName);
-  setTextIn(overlay, 'handoff-btn-label', `I'm ${playerName}`);
+  const remove = (): void => {
+    if (removed) return;
+    removed = true;
+    overlay.remove();
+    restoreAccessibility();
+  };
 
-  container.appendChild(overlay);
-
-  document.getElementById('handoff-confirm')?.addEventListener('click', () => {
-    // Phase 2: Summary card
-    const summary = generateSummary(state, nextCivId);
-
-    const warNames = summary.atWarWith.map(id => state.civilizations[id]?.name ?? id);
-    const allyNames = summary.allies.map(id => state.civilizations[id]?.name ?? id);
-    const hasEvents = summary.events.length > 0;
-
-    let eventRowsHtml = '';
-    if (hasEvents) {
-      eventRowsHtml = summary.events.map((e, idx) => `<div style="font-size:12px;padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.1);">&bull; <span data-text="event-msg-${idx}"></span></div>`).join('');
-    } else {
-      eventRowsHtml = '<div style="font-size:12px;opacity:0.5;">Nothing notable happened.</div>';
+  const trapFocus = (event: KeyboardEvent): void => {
+    if (event.key !== 'Tab') return;
+    const focusable = Array.from(
+      overlay.querySelectorAll<HTMLElement>('button:not(:disabled), [tabindex]:not([tabindex="-1"])'),
+    );
+    if (focusable.length === 0) return;
+    const first = focusable[0]!;
+    const last = focusable.at(-1)!;
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
     }
+  };
+  overlay.addEventListener('keydown', trapFocus);
 
-    overlay.innerHTML = `
-      <div style="max-width:360px;width:100%;text-align:center;">
-        <h2 style="font-size:18px;color:${color};margin:0 0 4px;" data-text="summary-player-name"></h2>
-        <div style="font-size:13px;opacity:0.6;margin-bottom:16px;">Turn <span data-text="summary-turn"></span> &middot; Era <span data-text="summary-era"></span></div>
-        <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:16px;">
-          <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px;"><div style="font-size:18px;">&#x1f4b0;</div><div style="font-size:14px;" data-text="summary-gold"></div><div style="font-size:10px;opacity:0.5;">Gold</div></div>
-          <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px;"><div style="font-size:18px;">&#x1f3db;&#xfe0f;</div><div style="font-size:14px;" data-text="summary-cities"></div><div style="font-size:10px;opacity:0.5;">Cities</div></div>
-          <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px;"><div style="font-size:18px;">&#x2694;&#xfe0f;</div><div style="font-size:14px;" data-text="summary-units"></div><div style="font-size:10px;opacity:0.5;">Units</div></div>
-          <div style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px;"><div style="font-size:18px;">&#x1f52c;</div><div style="font-size:14px;" data-text="summary-research"></div><div style="font-size:10px;opacity:0.5;">Research</div></div>
-        </div>
-        <div style="text-align:left;margin-bottom:12px;">
-          <div style="font-size:12px;margin-bottom:4px;">&#x2694;&#xfe0f; At war: <span data-text="summary-war-list"></span></div>
-          <div style="font-size:12px;">&#x1f91d; Allies: <span data-text="summary-ally-list"></span></div>
-        </div>
-        <div style="text-align:left;background:rgba(255,255,255,0.04);border-radius:8px;padding:10px;margin-bottom:16px;">
-          <div style="font-size:13px;color:#e8c170;margin-bottom:6px;">Since your last turn:</div>
-          ${eventRowsHtml}
-        </div>
-        <button id="handoff-start" style="padding:14px 32px;border-radius:10px;background:${color};border:none;color:#1a1a2e;font-weight:bold;font-size:16px;cursor:pointer;">Start Turn</button>
-      </div>
-    `;
+  let confirmButton: HTMLButtonElement;
 
-    // Inject all dynamic text via textContent (XSS-safe)
-    const setText = (sel: string, text: string) => {
-      const el = overlay.querySelector(`[data-text="${sel}"]`);
-      if (el) el.textContent = text;
-    };
-
-    setText('summary-player-name', playerName);
-    setText('summary-turn', String(summary.turn));
-    setText('summary-era', String(summary.era));
-    setText('summary-gold', String(summary.gold));
-    setText('summary-cities', String(summary.cities));
-    setText('summary-units', String(summary.units));
-    setText('summary-research', summary.currentResearch ?? 'None');
-    setText('summary-war-list', warNames.length > 0 ? warNames.join(', ') : 'None');
-    setText('summary-ally-list', allyNames.length > 0 ? allyNames.join(', ') : 'None');
-
-    if (hasEvents) {
-      summary.events.forEach((e, idx) => {
-        setText(`event-msg-${idx}`, e.message);
-      });
-    }
-
-    // Clear pending events for this player
-    if (state.pendingEvents) {
-      clearEventsForPlayer(state.pendingEvents, nextCivId);
-    }
-
-    document.getElementById('handoff-start')?.addEventListener('click', () => {
-      overlay.remove();
-      callbacks.onReady();
+  const renderPassTo = (): void => {
+    card.replaceChildren();
+    const avatar = appendText(card, 'div', '👤');
+    avatar.style.cssText = `width:60px;height:60px;border-radius:50%;background:${color};margin:0 auto 16px;display:flex;align-items:center;justify-content:center;font-size:24px;`;
+    const title = appendText(card, 'h2', 'Pass to');
+    title.id = 'turn-handoff-title';
+    title.tabIndex = -1;
+    title.style.cssText = 'font-size:20px;margin:0 0 8px;color:#e8c170;';
+    const name = appendText(card, 'h1', playerName);
+    name.style.cssText = `font-size:clamp(22px, 7vw, 30px);margin:0 0 24px;color:${color};`;
+    confirmButton = createGameButton(
+      ready ? `I'm ${playerName}` : (options.preparingLabel ?? 'Preparing next turn…'),
+      'primary',
+      { disabled: !ready },
+    );
+    confirmButton.id = 'handoff-confirm';
+    confirmButton.style.width = '100%';
+    confirmButton.addEventListener('click', () => {
+      if (ready) renderSummary();
     });
-  });
+    card.appendChild(confirmButton);
+    if (ready) confirmButton.focus();
+    else title.focus();
+  };
+
+  const renderSummary = (): void => {
+    const summary = generateSummary(currentState, nextCivId);
+    const summaryCiv = currentState.civilizations[nextCivId];
+    const warNames = summary.atWarWith.map(id => currentState.civilizations[id]?.name ?? id);
+    const allyNames = summary.allies.map(id => currentState.civilizations[id]?.name ?? id);
+    card.replaceChildren();
+
+    const title = appendText(card, 'h2', playerName);
+    title.id = 'turn-handoff-title';
+    title.style.cssText = `font-size:20px;color:${color};margin:0 0 4px;`;
+    appendText(card, 'p', `Turn ${summary.turn} · Era ${summary.era}`)
+      .style.cssText = 'font-size:13px;opacity:0.7;margin:0 0 16px;';
+
+    const facts = document.createElement('div');
+    facts.style.cssText = 'display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px;margin-bottom:16px;text-align:left;';
+    for (const [label, value] of [
+      ['Gold', String(summary.gold)],
+      ['Cities', String(summary.cities)],
+      ['Units', String(summary.units)],
+      ['Research', summary.currentResearch ?? 'None'],
+    ]) {
+      const fact = document.createElement('div');
+      fact.style.cssText = 'min-width:0;background:rgba(255,255,255,0.06);border-radius:8px;padding:10px;';
+      appendText(fact, 'strong', value).style.cssText = 'display:block;';
+      appendText(fact, 'span', label).style.cssText = 'font-size:11px;opacity:0.65;';
+      facts.appendChild(fact);
+    }
+    card.appendChild(facts);
+
+    const diplomacy = document.createElement('div');
+    diplomacy.style.cssText = 'text-align:left;margin-bottom:12px;font-size:12px;';
+    appendText(diplomacy, 'p', `⚔️ At war: ${warNames.join(', ') || 'None'}`).style.margin = '0 0 4px';
+    appendText(diplomacy, 'p', `🤝 Allies: ${allyNames.join(', ') || 'None'}`).style.margin = '0';
+    card.appendChild(diplomacy);
+
+    const events = document.createElement('div');
+    events.dataset.handoffSummaryEvents = '';
+    events.style.cssText = 'text-align:left;background:rgba(255,255,255,0.04);border-radius:8px;padding:10px;margin-bottom:16px;';
+    appendText(events, 'strong', 'Since your last turn:').style.cssText = 'display:block;color:#e8c170;margin-bottom:6px;';
+    if (summary.events.length === 0) {
+      appendText(events, 'p', 'Nothing notable happened.').style.cssText = 'font-size:12px;opacity:0.6;margin:0;';
+    } else {
+      for (const event of summary.events) {
+        appendText(events, 'p', `• ${event.message}`).style.cssText = 'font-size:12px;margin:0;padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.1);';
+      }
+    }
+    card.appendChild(events);
+
+    const start = createGameButton('Start Turn', 'primary');
+    start.id = 'handoff-start';
+    start.style.width = '100%';
+    start.addEventListener('click', async () => {
+      if (start.disabled) return;
+      setButtonDisabled(start, true);
+      start.textContent = 'Opening turn…';
+      await options.onReady(summary);
+      remove();
+    });
+    card.appendChild(start);
+    start.focus();
+
+    if (!summaryCiv) setButtonDisabled(start, true);
+  };
+
+  const setError: TurnHandoffController['setError'] = (message, callbacks) => {
+    ready = false;
+    card.replaceChildren();
+    const title = appendText(card, 'h2', 'Handoff paused');
+    title.id = 'turn-handoff-title';
+    title.tabIndex = -1;
+    title.style.cssText = 'margin:0 0 8px;color:#e8c170;';
+    appendText(card, 'p', message).style.cssText = 'margin:0 0 16px;line-height:1.45;';
+    const actions = document.createElement('div');
+    actions.style.cssText = 'display:flex;flex-wrap:wrap;gap:10px;';
+    const retry = createGameButton('Retry', 'primary');
+    retry.dataset.action = 'retry-handoff';
+    retry.addEventListener('click', callbacks.onRetry);
+    const returnButton = createGameButton('Return to Saves', 'ghost');
+    returnButton.dataset.action = 'return-to-saves';
+    returnButton.addEventListener('click', () => {
+      remove();
+      callbacks.onReturnToSaves();
+    });
+    actions.append(retry, returnButton);
+    card.appendChild(actions);
+    retry.focus();
+  };
+
+  const mount = container.ownerDocument.body ?? container;
+  mount.appendChild(overlay);
+  renderPassTo();
+
+  return {
+    setReady(updatedState) {
+      currentState = updatedState;
+      ready = true;
+      if (confirmButton?.isConnected) {
+        confirmButton.textContent = `I'm ${playerName}`;
+        setButtonDisabled(confirmButton, false);
+        confirmButton.focus();
+      } else {
+        renderPassTo();
+      }
+    },
+    setError,
+    remove,
+  };
 }

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -121,7 +121,11 @@ export function showTurnHandoff(
     const focusable = Array.from(
       overlay.querySelectorAll<HTMLElement>('button:not(:disabled), [tabindex]:not([tabindex="-1"])'),
     );
-    if (focusable.length === 0) return;
+    if (focusable.length === 0) {
+      event.preventDefault();
+      overlay.querySelector<HTMLElement>('#turn-handoff-title')?.focus();
+      return;
+    }
     const first = focusable[0]!;
     const last = focusable.at(-1)!;
     if (event.shiftKey && document.activeElement === first) {
@@ -209,6 +213,12 @@ export function showTurnHandoff(
     }
     card.appendChild(events);
 
+    const openError = document.createElement('p');
+    openError.setAttribute('role', 'alert');
+    openError.hidden = true;
+    openError.style.cssText = 'margin:0 0 8px;color:#ffb4ab;font-size:12px;font-weight:600;';
+    card.appendChild(openError);
+
     const start = createGameButton('Start Turn', 'primary');
     start.id = 'handoff-start';
     start.style.width = '100%';
@@ -216,8 +226,18 @@ export function showTurnHandoff(
       if (start.disabled) return;
       setButtonDisabled(start, true);
       start.textContent = 'Opening turn…';
-      await options.onReady(summary);
-      remove();
+      openError.replaceChildren();
+      openError.hidden = true;
+      try {
+        await options.onReady(summary);
+        remove();
+      } catch {
+        openError.textContent = 'Could not open the turn. Please try again.';
+        openError.hidden = false;
+        start.textContent = 'Try Again';
+        setButtonDisabled(start, false);
+        start.focus();
+      }
     });
     card.appendChild(start);
     start.focus();

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -18,6 +18,8 @@ export interface TurnHandoffController {
   remove(): void;
 }
 
+let activeHandoffController: TurnHandoffController | null = null;
+
 function appendText(
   parent: HTMLElement,
   tagName: keyof HTMLElementTagNameMap,
@@ -36,11 +38,12 @@ export function showTurnHandoff(
   playerName: string,
   options: TurnHandoffOptions,
 ): TurnHandoffController {
-  document.getElementById('turn-handoff')?.remove();
+  activeHandoffController?.remove();
 
   let currentState = state;
   let ready = options.initiallyReady;
   let removed = false;
+  let controller: TurnHandoffController;
   const civ = state.civilizations[nextCivId];
   const civDef = resolveCivDefinition(state, civ?.civType ?? '');
   const color = civ?.color ?? civDef?.color ?? '#e8c170';
@@ -110,6 +113,7 @@ export function showTurnHandoff(
     removed = true;
     overlay.remove();
     restoreAccessibility();
+    if (activeHandoffController === controller) activeHandoffController = null;
   };
 
   const trapFocus = (event: KeyboardEvent): void => {
@@ -231,12 +235,24 @@ export function showTurnHandoff(
     appendText(card, 'p', message).style.cssText = 'margin:0 0 16px;line-height:1.45;';
     const actions = document.createElement('div');
     actions.style.cssText = 'display:flex;flex-wrap:wrap;gap:10px;';
+    let actionStarted = false;
     const retry = createGameButton('Retry', 'primary');
     retry.dataset.action = 'retry-handoff';
-    retry.addEventListener('click', callbacks.onRetry);
+    retry.addEventListener('click', () => {
+      if (actionStarted) return;
+      actionStarted = true;
+      setButtonDisabled(retry, true);
+      setButtonDisabled(returnButton, true);
+      retry.textContent = 'Retrying…';
+      callbacks.onRetry();
+    });
     const returnButton = createGameButton('Return to Saves', 'ghost');
     returnButton.dataset.action = 'return-to-saves';
     returnButton.addEventListener('click', () => {
+      if (actionStarted) return;
+      actionStarted = true;
+      setButtonDisabled(retry, true);
+      setButtonDisabled(returnButton, true);
       remove();
       callbacks.onReturnToSaves();
     });
@@ -249,7 +265,7 @@ export function showTurnHandoff(
   mount.appendChild(overlay);
   renderPassTo();
 
-  return {
+  controller = {
     setReady(updatedState) {
       currentState = updatedState;
       ready = true;
@@ -264,4 +280,6 @@ export function showTurnHandoff(
     setError,
     remove,
   };
+  activeHandoffController = controller;
+  return controller;
 }

--- a/tests/ai/ai-round-scheduler.test.ts
+++ b/tests/ai/ai-round-scheduler.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import {
+  getLivingNonHumanMajorIds,
+  processNonHumanMajorRound,
+  rotateIdsForRound,
+} from '@/ai/ai-round-scheduler';
+
+describe('AI round scheduler', () => {
+  it('processes every living non-human civilization once in rotating order', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 3,
+      gameTitle: 'Scheduler',
+      seed: 'scheduler-order',
+    });
+    state.turn = 1;
+    const seen: string[] = [];
+
+    const result = processNonHumanMajorRound(state, new EventBus(), {
+      execute: (current, civId) => {
+        seen.push(civId);
+        return current;
+      },
+    });
+
+    expect(seen).toEqual(['ai-2', 'ai-3', 'ai-1']);
+    expect(result.state.opponentAI?.lastProcessedRound).toBe(1);
+    processNonHumanMajorRound(result.state, new EventBus(), {
+      execute: (current, civId) => {
+        seen.push(civId);
+        return current;
+      },
+    });
+    expect(seen).toHaveLength(3);
+  });
+
+  it('excludes humans, eliminated AI, and inert empty records but includes cityless settlers', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 3,
+      gameTitle: 'Eligibility',
+      seed: 'scheduler-eligibility',
+    });
+    state.civilizations['ai-1'].isEliminated = true;
+    state.civilizations['ai-2'].cities = [];
+    expect(state.civilizations['ai-2'].units.some(id => state.units[id]?.owner === 'ai-2')).toBe(true);
+    state.civilizations['ai-3'].cities = [];
+    state.civilizations['ai-3'].units = [];
+    for (const [unitId, unit] of Object.entries(state.units)) {
+      if (unit.owner === 'ai-3') delete state.units[unitId];
+    }
+
+    expect(getLivingNonHumanMajorIds(state)).toEqual(['ai-2']);
+  });
+
+  it('freezes the actor list so AI records added during execution wait until next round', () => {
+    const state = createNewGame(undefined, 'scheduler-frozen', 'small');
+    const execute = vi.fn((current, civId: string) => {
+      if (civId === 'ai-1') {
+        current.civilizations['ai-new'] = {
+          ...structuredClone(current.civilizations['ai-1']),
+          id: 'ai-new',
+          name: 'Late Arrival',
+        };
+      }
+      return current;
+    });
+
+    processNonHumanMajorRound(state, new EventBus(), { execute });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalledWith(expect.anything(), 'ai-new', expect.anything());
+  });
+
+  it('handles zero actors and negative or large rotation rounds deterministically', () => {
+    expect(rotateIdsForRound([], 4)).toEqual([]);
+    expect(rotateIdsForRound(['a', 'b', 'c'], -1)).toEqual(['c', 'a', 'b']);
+    expect(rotateIdsForRound(['a', 'b', 'c'], 7)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -3,6 +3,8 @@ import { MockAudioContext } from '../helpers/mock-audio-context';
 import { AudioSystem } from '../../src/audio/audio-system';
 import type { EventBus } from '../../src/core/event-bus';
 import type { GameState } from '../../src/core/types';
+import { ACCENT, ERA_BASE, WAR_LAYER, resolveEra } from '../../src/audio/audio-catalog';
+import { getFamilyForCiv } from '../../src/audio/civ-audio-family';
 
 // Flush microtask queue so async loader/stinger chains complete
 const flushPromises = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0));
@@ -210,8 +212,72 @@ describe('AudioSystem integration', () => {
     busHelper.emit('currentPlayer:changed-after-handoff', { civId: 'egypt' });
     await flushPromises();
     const startsAfter = ctx.transcript.filter(e => e.op === 'start').length;
-    // accent bus source restarted for egypt
-    expect(startsAfter - startsBefore).toBe(1);
+    // The authoritative handoff snapshot rewires era, adaptive, and accent buses.
+    expect(startsAfter - startsBefore).toBe(3);
+  });
+
+  it('synchronizes the incoming viewer to an era reached during hidden processing', async () => {
+    system.start(makeState({ currentPlayer: 'rome', era: 1 }), busHelper.bus);
+    await flushPromises();
+    vi.mocked(fetch).mockClear();
+
+    busHelper.emit('currentPlayer:changed-after-handoff', {
+      civId: 'egypt',
+      civType: 'egypt',
+      era: 4,
+      atWarCount: 0,
+      unrestCityCount: 0,
+      nearDefeat: false,
+      inBeastTerritory: false,
+    });
+    await flushPromises();
+
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining(ERA_BASE[resolveEra(4)].file));
+  });
+
+  it('rebinds audio state when a new campaign starts in the same app session', async () => {
+    system.start(makeState({ currentPlayer: 'rome', era: 1 }), busHelper.bus);
+    await flushPromises();
+    vi.mocked(fetch).mockClear();
+
+    system.start(makeState({ currentPlayer: 'egypt', era: 4 }), busHelper.bus);
+    await flushPromises();
+
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining(ERA_BASE[resolveEra(4)].file));
+  });
+
+  it('ignores stale loop loads from the previous campaign', async () => {
+    const internals = system as unknown as {
+      loader: { get: (path: string) => Promise<AudioBuffer> };
+      mixer: { setBusSource: (...args: unknown[]) => void };
+    };
+    const loopPaths = new Set([
+      ERA_BASE[resolveEra(1)].file,
+      WAR_LAYER[resolveEra(1)].file,
+      ACCENT[getFamilyForCiv('rome')].file,
+      ERA_BASE[resolveEra(4)].file,
+      WAR_LAYER[resolveEra(4)].file,
+      ACCENT[getFamilyForCiv('egypt')].file,
+    ]);
+    const pending: Array<{ path: string; resolve: (buffer: AudioBuffer) => void }> = [];
+    internals.loader.get = vi.fn((path: string) => {
+      if (!loopPaths.has(path)) return Promise.resolve({} as AudioBuffer);
+      return new Promise<AudioBuffer>(resolve => pending.push({ path, resolve }));
+    });
+    const setBusSource = vi.spyOn(internals.mixer, 'setBusSource');
+
+    system.start(makeState({ currentPlayer: 'rome', era: 1 }), busHelper.bus);
+    const firstCampaignRequests = pending.splice(0);
+    system.start(makeState({ currentPlayer: 'egypt', era: 4 }), busHelper.bus);
+    const secondCampaignRequests = pending.splice(0);
+
+    for (const request of secondCampaignRequests) request.resolve({} as AudioBuffer);
+    await flushPromises();
+    setBusSource.mockClear();
+    for (const request of firstCampaignRequests) request.resolve({} as AudioBuffer);
+    await flushPromises();
+
+    expect(setBusSource).not.toHaveBeenCalled();
   });
 
   // warCount clamping

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -91,6 +91,18 @@ describe('AudioSystem integration', () => {
     expect(ctx.transcript.some(e => e.op === 'linearRampToValueAtTime')).toBe(true);
   });
 
+  it('suppresses immediate audio event presentation while the round gate is active', () => {
+    system.start(makeState(), busHelper.bus, undefined, () => true);
+    const before = ctx.transcript.length;
+    busHelper.emit('diplomacy:war-declared', {
+      attackerId: 'rome',
+      defenderId: 'egypt',
+      opponentKind: 'major',
+    });
+
+    expect(ctx.transcript.length).toBe(before);
+  });
+
   // Flow E: peace signed (last war)
   it('Flow E: peace:made with warCount=1 transitions to peace', () => {
     system.start(makeState(), busHelper.bus);

--- a/tests/audio/music-director.test.ts
+++ b/tests/audio/music-director.test.ts
@@ -158,9 +158,50 @@ describe('MusicDirector', () => {
   it('reloads current music context without changing snapshot', () => {
     director.handleEraAdvanced({ era: 1, civType: 'rome' });
     vi.mocked(mixer.setSnapshot).mockClear();
-    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
+    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', era: 1, atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
     // Snapshot re-applied to reload the correct accent track for the new civ
     expect(mixer.setSnapshot).toHaveBeenCalledWith('peace', expect.any(Number));
+  });
+
+  it('does not let an old-era adaptive load overwrite the incoming handoff era', async () => {
+    const requests: Array<{ resolve: (buffer: AudioBuffer) => void }> = [];
+    vi.mocked(loader.get).mockImplementation(() => new Promise<AudioBuffer>(resolve => {
+      requests.push({ resolve });
+    }));
+    director.handlePlayerChanged({
+      civId: 'rome',
+      civType: 'rome',
+      era: 1,
+      atWar: true,
+      unrestCityCount: 0,
+      nearDefeat: false,
+      inBeastTerritory: false,
+    });
+    const oldEraRequest = requests[0]!;
+    director.handlePlayerChanged({
+      civId: 'egypt',
+      civType: 'egypt',
+      era: 4,
+      atWar: true,
+      unrestCityCount: 0,
+      nearDefeat: false,
+      inBeastTerritory: false,
+    });
+    const newEraRequest = requests[1]!;
+
+    oldEraRequest.resolve({} as AudioBuffer);
+    await flushPromises();
+    expect(mixer.setBusSource).not.toHaveBeenCalled();
+
+    newEraRequest.resolve(fakeBuffer);
+    await flushPromises();
+    expect(mixer.setBusSource).toHaveBeenCalledWith(
+      'adaptive',
+      fakeBuffer,
+      true,
+      expect.anything(),
+      expect.any(Number),
+    );
   });
 
   // --- handleGameEnded ---
@@ -256,7 +297,7 @@ import {
 // catch comparisons that accidentally use one where the other is required.
 function makeDirectorWithPlayer(civType: string, atWar = false, unrestCityCount = 0, nearDefeat = false): MusicDirector {
   const d = new MusicDirector(makeMixer(), makeLoader());
-  d.handlePlayerChanged({ civId: `civ-${civType}`, civType, atWar, unrestCityCount, nearDefeat, inBeastTerritory: false });
+  d.handlePlayerChanged({ civId: `civ-${civType}`, civType, era: 1, atWar, unrestCityCount, nearDefeat, inBeastTerritory: false });
   return d;
 }
 
@@ -287,17 +328,17 @@ describe('resolveSnapshot — priority chain (Spec 3)', () => {
   });
   it('beastTerritory alone → beast-territory', () => {
     const d = new MusicDirector(makeMixer(), makeLoader());
-    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: true });
+    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', era: 1, atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: true });
     expect(d.resolveSnapshot()).toBe('beast-territory');
   });
   it('beastTerritory + atWar → at-war (atWar wins over beastTerritory)', () => {
     const d = new MusicDirector(makeMixer(), makeLoader());
-    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', atWar: true, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: true });
+    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', era: 1, atWar: true, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: true });
     expect(d.resolveSnapshot()).toBe('at-war');
   });
   it('beastTerritory + inUnrest → unrest (inUnrest wins over beastTerritory)', () => {
     const d = new MusicDirector(makeMixer(), makeLoader());
-    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', atWar: false, unrestCityCount: 2, nearDefeat: false, inBeastTerritory: true });
+    d.handlePlayerChanged({ civId: civId('rome'), civType: 'rome', era: 1, atWar: false, unrestCityCount: 2, nearDefeat: false, inBeastTerritory: true });
     expect(d.resolveSnapshot()).toBe('unrest');
   });
   it('all flags false → peace', () => {
@@ -356,24 +397,24 @@ describe('handlePlayerChanged — hot-seat drift reset (Spec 3)', () => {
   });
 
   it('handoff with atWar:true resets to at-war', () => {
-    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', atWar: true, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
+    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', era: 1, atWar: true, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
     expect(director.resolveSnapshot()).toBe('at-war');
   });
 
   it('handoff with nearDefeat:true resets to brink-of-defeat', () => {
-    director.handlePlayerChanged({ civId: civId('viking'), civType: 'viking', atWar: false, unrestCityCount: 0, nearDefeat: true, inBeastTerritory: false });
+    director.handlePlayerChanged({ civId: civId('viking'), civType: 'viking', era: 1, atWar: false, unrestCityCount: 0, nearDefeat: true, inBeastTerritory: false });
     expect(director.resolveSnapshot()).toBe('brink-of-defeat');
   });
 
   it('handoff clears prior unrest for incoming player at peace', () => {
     director.handleUnrestStarted({ owner: civId('rome') });
     director.handleUnrestStarted({ owner: civId('rome') });
-    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
+    director.handlePlayerChanged({ civId: civId('egypt'), civType: 'egypt', era: 1, atWar: false, unrestCityCount: 0, nearDefeat: false, inBeastTerritory: false });
     expect(director.resolveSnapshot()).toBe('peace');
   });
 
   it('handoff with unrestCityCount:2 resolves to unrest', () => {
-    director.handlePlayerChanged({ civId: civId('aztec'), civType: 'aztec', atWar: false, unrestCityCount: 2, nearDefeat: false, inBeastTerritory: false });
+    director.handlePlayerChanged({ civId: civId('aztec'), civType: 'aztec', era: 1, atWar: false, unrestCityCount: 2, nearDefeat: false, inBeastTerritory: false });
     expect(director.resolveSnapshot()).toBe('unrest');
   });
 });

--- a/tests/audio/pirate-audio-director.test.ts
+++ b/tests/audio/pirate-audio-director.test.ts
@@ -64,6 +64,37 @@ describe('PirateAudioDirector', () => {
     expect(playStinger).toHaveBeenCalledWith(PIRATE_STRATEGIC_SFX.blockade.file);
   });
 
+  it('suppresses strategic cues and async ambience completion during handoff', async () => {
+    let suppressed = true;
+    let resolveBuffer!: (buffer: AudioBuffer) => void;
+    loader.get = vi.fn(() => new Promise<AudioBuffer>(resolve => {
+      resolveBuffer = resolve;
+    }));
+    const director = new PirateAudioDirector(
+      mixer,
+      loader,
+      playStinger,
+      () => state,
+      () => suppressed,
+    );
+    director.start(bus.bus);
+
+    bus.emit('pirate:audio-cue', {
+      cue: 'raid',
+      factionId: 'pirate-1',
+      viewerIds: ['player'],
+    });
+    expect(playStinger).not.toHaveBeenCalled();
+    expect(await director.startHeadquartersAmbience('pirate-1')).toBe(false);
+
+    suppressed = false;
+    const pending = director.startHeadquartersAmbience('pirate-1');
+    suppressed = true;
+    resolveBuffer({} as AudioBuffer);
+    await expect(pending).resolves.toBe(false);
+    expect(mixer.setAmbienceLoop).not.toHaveBeenCalled();
+  });
+
   it('starts enclave ambience only for a currently visible focused headquarters', async () => {
     const director = new PirateAudioDirector(mixer, loader, playStinger, () => state);
 

--- a/tests/audio/sfx-director.test.ts
+++ b/tests/audio/sfx-director.test.ts
@@ -135,6 +135,85 @@ describe('SfxDirector', () => {
     }
   });
 
+  it('does not fall back to final fog when the event-time viewer was omitted', async () => {
+    vi.useFakeTimers();
+    try {
+      const units = { u1: makeUnit('u1', 'warrior') };
+      director.start(units, busHelper.bus, stateProvider(units, 'visible'));
+
+      busHelper.emit('unit:move', {
+        unitId: 'u1',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+        presentationByViewer: {},
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mixer.playOneShot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rebinds the viewer state when a new campaign replaces the active units', async () => {
+    vi.useFakeTimers();
+    try {
+      const oldUnits = { old: makeUnit('old', 'warrior') };
+      const newUnits = { fresh: makeUnit('fresh', 'archer') };
+      const newState = stateProvider(newUnits)();
+      newState.currentPlayer = 'new-player';
+      director.start(oldUnits, busHelper.bus, stateProvider(oldUnits));
+      director.replaceUnits(newUnits, () => newState);
+
+      busHelper.emit('unit:move', {
+        unitId: 'fresh',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+        presentationByViewer: {
+          'new-player': {
+            unit: newUnits.fresh,
+            visibleSegments: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+          },
+        },
+      });
+      await vi.runAllTimersAsync();
+
+      expect(mixer.playOneShot).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('cancels delayed movement sounds from the previous campaign on rebind', async () => {
+    vi.useFakeTimers();
+    try {
+      const oldUnits = { old: makeUnit('old', 'warrior') };
+      const nextUnits = { fresh: makeUnit('fresh', 'archer') };
+      director.start(oldUnits, busHelper.bus, stateProvider(oldUnits));
+      busHelper.emit('unit:move', {
+        unitId: 'old',
+        from: { q: 0, r: 0 },
+        to: { q: 3, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 3, r: 0 }],
+        presentationByViewer: {
+          player: {
+            unit: oldUnits.old,
+            visibleSegments: [[{ q: 0, r: 0 }, { q: 1, r: 0 }, { q: 3, r: 0 }]],
+          },
+        },
+      });
+
+      director.replaceUnits(nextUnits, stateProvider(nextUnits));
+      await vi.runAllTimersAsync();
+
+      expect(mixer.playOneShot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('melee attacker plays attack-swing buffer', async () => {
     const units = { a1: makeUnit('a1', 'warrior'), d1: makeUnit('d1', 'swordsman') };
     director.start(units, busHelper.bus);

--- a/tests/audio/sfx-director.test.ts
+++ b/tests/audio/sfx-director.test.ts
@@ -83,6 +83,58 @@ describe('SfxDirector', () => {
 
   // === Combat ===
 
+  it('suppresses immediate and delayed SFX while presentation is gated', async () => {
+    vi.useFakeTimers();
+    try {
+      let suppressed = true;
+      const units = { u1: makeUnit('u1', 'warrior') };
+      director.start(units, busHelper.bus, stateProvider(units), () => suppressed);
+      busHelper.emit('unit:move', {
+        unitId: 'u1',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+        presentationByViewer: {
+          player: {
+            unit: units.u1,
+            visibleSegments: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+          },
+        },
+      });
+      await vi.runAllTimersAsync();
+      expect(mixer.playOneShot).not.toHaveBeenCalled();
+      suppressed = false;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses event-time viewers and rechecks current identity before delayed playback', async () => {
+    vi.useFakeTimers();
+    try {
+      const units = { u1: makeUnit('u1', 'warrior') };
+      const state = stateProvider(units)();
+      director.start(units, busHelper.bus, () => state);
+      busHelper.emit('unit:move', {
+        unitId: 'u1',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+        presentationByViewer: {
+          player: {
+            unit: units.u1,
+            visibleSegments: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+          },
+        },
+      });
+      state.currentPlayer = 'other';
+      await vi.runAllTimersAsync();
+      expect(mixer.playOneShot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('melee attacker plays attack-swing buffer', async () => {
     const units = { a1: makeUnit('a1', 'warrior'), d1: makeUnit('d1', 'swordsman') };
     director.start(units, busHelper.bus);

--- a/tests/audio/sfx-routing.test.ts
+++ b/tests/audio/sfx-routing.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AudioLoader } from '@/audio/audio-loader';
+import type { AudioMixer } from '@/audio/audio-mixer';
+import { routeSfxComponents, SFX } from '@/audio/sfx';
+
+describe('legacy SFX presentation routing', () => {
+  it('blocks OGG-backed cues before load and rechecks suppression after decode', async () => {
+    let suppressed = true;
+    let resolveBuffer!: (buffer: AudioBuffer) => void;
+    const loader = {
+      get: vi.fn(() => new Promise<AudioBuffer>(resolve => {
+        resolveBuffer = resolve;
+      })),
+    } as unknown as AudioLoader;
+    const mixer = {
+      playOneShot: vi.fn(),
+    } as unknown as AudioMixer;
+    routeSfxComponents(mixer, loader, () => suppressed);
+
+    SFX.transportLoad();
+    expect(loader.get).not.toHaveBeenCalled();
+
+    suppressed = false;
+    SFX.transportLoad();
+    expect(loader.get).toHaveBeenCalledOnce();
+    suppressed = true;
+    resolveBuffer({} as AudioBuffer);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mixer.playOneShot).not.toHaveBeenCalled();
+  });
+});

--- a/tests/core/completed-round-handoff.test.ts
+++ b/tests/core/completed-round-handoff.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { GameEventBuffer } from '@/core/game-event-buffer';
+import { createNewGame } from '@/core/game-state';
+import { createCompletedRoundHandoffTransaction } from '@/core/completed-round-handoff';
+
+describe('completed-round handoff transaction', () => {
+  it('reruns simulation from the original state after a phase failure', async () => {
+    const initial = createNewGame(undefined, 'handoff-phase-retry', 'small');
+    const events = new GameEventBuffer();
+    const runCompletedRound = vi.fn()
+      .mockReturnValueOnce({ ok: false, state: initial, error: new Error('phase failed') })
+      .mockReturnValueOnce({
+        ok: true,
+        state: { ...initial, turn: initial.turn + 1 },
+        events,
+      });
+    const adoptState = vi.fn();
+    const persistState = vi.fn(async () => {});
+    const transaction = createCompletedRoundHandoffTransaction({
+      initialState: initial,
+      runCompletedRound,
+      prepareCompletedState: state => ({ ...state, currentPlayer: 'player' }),
+      eventTarget: new EventBus(),
+      adoptState,
+      persistState,
+    });
+
+    await expect(transaction.runCompletedRoundSimulation())
+      .resolves.toMatchObject({ status: 'simulation-failed', state: initial });
+    await expect(transaction.runCompletedRoundSimulation())
+      .resolves.toMatchObject({ status: 'ready', state: { turn: initial.turn + 1 } });
+
+    expect(runCompletedRound).toHaveBeenCalledTimes(2);
+    expect(runCompletedRound).toHaveBeenNthCalledWith(1, initial);
+    expect(runCompletedRound).toHaveBeenNthCalledWith(2, initial);
+    expect(adoptState).toHaveBeenCalledTimes(1);
+    expect(persistState).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries only persistence after successful simulation and commits events once', async () => {
+    const initial = createNewGame(undefined, 'handoff-save-retry', 'small');
+    const eventTarget = new EventBus();
+    const delivered = vi.fn();
+    eventTarget.on('turn:end', delivered);
+    const events = new GameEventBuffer();
+    events.emit('turn:end', { turn: initial.turn, playerId: initial.currentPlayer });
+    const runCompletedRound = vi.fn(() => ({
+      ok: true as const,
+      state: { ...initial, turn: initial.turn + 1 },
+      events,
+    }));
+    const persistState = vi.fn()
+      .mockRejectedValueOnce(new Error('storage unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const order: string[] = [];
+    const transaction = createCompletedRoundHandoffTransaction({
+      initialState: initial,
+      runCompletedRound,
+      prepareCompletedState: state => ({ ...state, currentPlayer: 'player' }),
+      eventTarget,
+      adoptState: () => order.push('adopt'),
+      persistState: async state => {
+        order.push('persist');
+        await persistState(state);
+      },
+      onCommitErrors: errors => {
+        expect(errors).toEqual([]);
+        order.push('commit');
+      },
+    });
+
+    await expect(transaction.runCompletedRoundSimulation())
+      .resolves.toMatchObject({ status: 'persistence-failed', state: { turn: initial.turn + 1 } });
+    await expect(transaction.persistCompletedRoundHandoff())
+      .resolves.toMatchObject({ status: 'ready', state: { turn: initial.turn + 1 } });
+
+    expect(runCompletedRound).toHaveBeenCalledOnce();
+    expect(delivered).toHaveBeenCalledOnce();
+    expect(persistState).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(['adopt', 'commit', 'persist', 'persist']);
+  });
+});

--- a/tests/core/completed-round-orchestrator.test.ts
+++ b/tests/core/completed-round-orchestrator.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+
+describe('runCompletedRound', () => {
+  it('threads immutable completed-round phases in canonical order', () => {
+    const state = createNewGame(undefined, 'round-order', 'small');
+    const trace: string[] = [];
+    const result = runCompletedRound(state, new EventBus(), {
+      improvements: (current, bus) => {
+        trace.push('improvements');
+        bus.emit('turn:start', { turn: current.turn, playerId: 'player' });
+        return { ...current, gameTitle: 'improved' };
+      },
+      majors: current => {
+        trace.push('ai');
+        return { ...current, gameTitle: `${current.gameTitle}-ai` };
+      },
+      world: current => {
+        trace.push('world');
+        return { ...current, turn: current.turn + 1 };
+      },
+      postprocess: (before, current) => {
+        trace.push(`post:${before.turn}`);
+        return current;
+      },
+    });
+
+    expect(trace).toEqual(['improvements', 'ai', 'world', 'post:1']);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.state.turn).toBe(2);
+      expect(result.state.gameTitle).toBe('improved-ai');
+    }
+    expect(state.turn).toBe(1);
+    expect(state.gameTitle).not.toBe('improved-ai');
+  });
+
+  it.each(['improvements', 'majors', 'world'] as const)(
+    'restores the untouched input and discards events when %s throws',
+    failingPhase => {
+      const state = createNewGame(undefined, `round-failure-${failingPhase}`, 'small');
+      const phases = {
+        improvements: (current: typeof state, bus: EventBus) => {
+          bus.emit('turn:start', { turn: current.turn, playerId: 'player' });
+          if (failingPhase === 'improvements') throw new Error('failed');
+          return { ...current, turn: 20 };
+        },
+        majors: (current: typeof state) => {
+          if (failingPhase === 'majors') throw new Error('failed');
+          return { ...current, turn: 30 };
+        },
+        world: (current: typeof state) => {
+          if (failingPhase === 'world') throw new Error('failed');
+          return { ...current, turn: 40 };
+        },
+      };
+
+      const result = runCompletedRound(state, new EventBus(), phases);
+
+      expect(result.ok).toBe(false);
+      expect(result.state).toBe(state);
+      expect(result.state.turn).toBe(1);
+    },
+  );
+});

--- a/tests/core/game-event-buffer.test.ts
+++ b/tests/core/game-event-buffer.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { GameEventBuffer } from '@/core/game-event-buffer';
+
+describe('GameEventBuffer', () => {
+  it('retains events until one idempotent commit', () => {
+    const target = new EventBus();
+    const listener = vi.fn();
+    target.on('turn:start', listener);
+    const buffer = new GameEventBuffer();
+    buffer.emit('turn:start', { turn: 4, playerId: 'player' });
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(buffer.commitTo(target)).toEqual([]);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(buffer.commitTo(target)).toEqual([]);
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('discard prevents forwarding and commit continues after one event dispatch fails', () => {
+    const target = new EventBus();
+    const later = vi.fn();
+    target.on('turn:start', () => {
+      throw new Error('broken presentation');
+    });
+    target.on('turn:end', later);
+    const buffer = new GameEventBuffer();
+    buffer.emit('turn:start', { turn: 4, playerId: 'player' });
+    buffer.emit('turn:end', { turn: 4, playerId: 'player' });
+
+    expect(buffer.commitTo(target)).toHaveLength(1);
+    expect(later).toHaveBeenCalledOnce();
+
+    const discarded = new GameEventBuffer();
+    discarded.emit('turn:end', { turn: 5, playerId: 'player' });
+    discarded.discard();
+    expect(discarded.commitTo(target)).toEqual([]);
+    expect(later).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/core/game-state.test.ts
+++ b/tests/core/game-state.test.ts
@@ -175,6 +175,32 @@ describe('createNewGame', () => {
     expect(Object.keys(state.civilizations)).toHaveLength(4);
   });
 
+  it('stores Standard opponent challenge for new solo campaigns', () => {
+    const state = createNewGame({
+      civType: 'rome',
+      seed: 'challenge-standard',
+      mapSize: 'small',
+      opponentCount: 1,
+      gameTitle: 'Standard Challenge',
+    });
+
+    expect(state.opponentChallenge).toBe('standard');
+    expect(state.opponentAI?.version).toBe(1);
+  });
+
+  it('stores an explicitly selected solo challenge', () => {
+    const state = createNewGame({
+      civType: 'rome',
+      seed: 'challenge-explorer',
+      mapSize: 'small',
+      opponentCount: 1,
+      gameTitle: 'Explorer Challenge',
+      opponentChallenge: 'explorer',
+    });
+
+    expect(state.opponentChallenge).toBe('explorer');
+  });
+
   it('can seed a new campaign from persisted app settings without re-listing defaults', () => {
     const state = createNewGame({
       civType: 'rome',
@@ -330,6 +356,14 @@ describe('createHotSeatGame', () => {
     const state = createHotSeatGame(config, 'hs-title', 'Friends Campaign');
     expect(state.gameTitle).toBe('Friends Campaign');
     expect(state.gameId).toMatch(/^game-/);
+  });
+
+  it('stores hot-seat challenge only at campaign level', () => {
+    const state = createHotSeatGame(config, 'hs-challenge', 'Friends Campaign', 'veteran');
+
+    expect(state.opponentChallenge).toBe('veteran');
+    expect(state.opponentAI?.version).toBe(1);
+    expect(state.hotSeat).not.toHaveProperty('opponentChallenge');
   });
 
   it('initializes pending diplomacy requests for hot seat games', () => {

--- a/tests/core/hotseat-events.test.ts
+++ b/tests/core/hotseat-events.test.ts
@@ -25,9 +25,10 @@ describe('hotseat-events', () => {
       'player-1': [{ type: 'test', message: 'hi', turn: 1 }],
       'player-2': [{ type: 'test', message: 'yo', turn: 1 }],
     };
-    clearEventsForPlayer(pending, 'player-1');
-    expect(pending['player-1']).toHaveLength(0);
-    expect(pending['player-2']).toHaveLength(1);
+    const next = clearEventsForPlayer(pending, 'player-1');
+    expect(next['player-1']).toHaveLength(0);
+    expect(next['player-2']).toEqual(pending['player-2']);
+    expect(pending['player-1']).toHaveLength(1);
   });
 
   it('generateSummary produces summary from game state', () => {

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import {
+  createEmptyOpponentAIState,
+  normalizeOpponentAIState,
+} from '@/core/opponent-ai-state';
+import type { AIStrategicPlan, GameState } from '@/core/types';
+
+function makePlan(overrides: Partial<AIStrategicPlan> = {}): AIStrategicPlan {
+  return {
+    id: 'ai-plan:ai-1:capture:city:foreign-city:1',
+    actorId: 'ai-1',
+    objective: 'capture',
+    target: {
+      kind: 'city',
+      id: 'foreign-city',
+      lastKnownPosition: { q: 8, r: 4 },
+    },
+    theaterId: 'region:8:4',
+    phase: 'mobilizing',
+    reasonCodes: ['nearby-opportunity'],
+    commitment: 0.5,
+    createdTurn: 1,
+    reconsiderAfterTurn: 3,
+    expiresAfterTurn: 8,
+    lastProgressTurn: 1,
+    requiredRoles: { capture: 1 },
+    assignedUnitIds: [],
+    ...overrides,
+  };
+}
+
+function makeState(): GameState {
+  const state = createNewGame({
+    civType: 'rome',
+    mapSize: 'small',
+    opponentCount: 1,
+    gameTitle: 'Normalization',
+    seed: 'opponent-ai-normalization',
+  });
+  const aiUnitIds = state.civilizations['ai-1'].units;
+  state.opponentAI = createEmptyOpponentAIState();
+  state.opponentAI.majorCivs['ai-1'] = {
+    primaryPlan: makePlan({ assignedUnitIds: [aiUnitIds[0]!, 'missing', state.civilizations.player.units[0]!] }),
+    defensePlansByCityId: {},
+    upgradeRoutesByUnitId: {
+      [aiUnitIds[1]!]: { cityId: 'missing-city', createdTurn: 1 },
+      missing: { cityId: 'missing-city', createdTurn: 1 },
+    },
+    modernizationDemand: 0,
+    researchTargetTechId: null,
+    lastPlannedTurn: 1,
+    lastExecutedTurn: 0,
+  };
+  return state;
+}
+
+describe('opponent AI state normalization', () => {
+  it('creates a serializable empty versioned state', () => {
+    expect(createEmptyOpponentAIState()).toEqual({
+      version: 1,
+      migrationGraceRoundsRemaining: 0,
+      majorCivs: {},
+      barbarianCamps: {},
+      barbarianHomeCampByUnitId: {},
+      minorCivs: {},
+      pressureByHuman: {},
+      lastPlannedRound: null,
+      lastProcessedRound: null,
+      lastFinalizedRound: null,
+    });
+  });
+
+  it('removes dead or wrong-owner assignments without mutating the loaded object', () => {
+    const legacy = makeState();
+    const snapshot = structuredClone(legacy);
+
+    const normalized = normalizeOpponentAIState(legacy);
+
+    expect(normalized.opponentAI!.majorCivs['ai-1'].primaryPlan!.assignedUnitIds)
+      .toEqual([legacy.civilizations['ai-1'].units[0]]);
+    expect(normalized.opponentAI!.majorCivs['ai-1'].upgradeRoutesByUnitId).toEqual({});
+    expect(legacy).toEqual(snapshot);
+    expect(normalizeOpponentAIState(normalized)).toEqual(normalized);
+  });
+
+  it('keeps a remembered foreign target when the live city is absent', () => {
+    const state = makeState();
+
+    const normalized = normalizeOpponentAIState(state);
+
+    expect(normalized.opponentAI!.majorCivs['ai-1'].primaryPlan?.target)
+      .toEqual(expect.objectContaining({ kind: 'city', id: 'foreign-city' }));
+  });
+
+  it('removes stale barbarian home mappings and eliminated actor portfolios', () => {
+    const state = makeState();
+    const aiUnitId = state.civilizations['ai-1'].units[0]!;
+    state.opponentAI!.barbarianHomeCampByUnitId = {
+      missing: 'missing-camp',
+      [aiUnitId]: 'missing-camp',
+    };
+    state.civilizations['ai-1'].isEliminated = true;
+
+    const normalized = normalizeOpponentAIState(state);
+
+    expect(normalized.opponentAI!.barbarianHomeCampByUnitId).toEqual({});
+    expect(normalized.opponentAI!.majorCivs['ai-1']).toBeUndefined();
+  });
+
+  it('rebuilds unknown versions while retaining the campaign challenge', () => {
+    const state = makeState();
+    state.opponentChallenge = 'explorer';
+    state.opponentAI = { ...state.opponentAI!, version: 999 as 1 };
+
+    const normalized = normalizeOpponentAIState(state);
+
+    expect(normalized.opponentChallenge).toBe('explorer');
+    expect(normalized.opponentAI).toEqual(createEmptyOpponentAIState());
+  });
+});

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -118,4 +118,20 @@ describe('opponent AI state normalization', () => {
     expect(normalized.opponentChallenge).toBe('explorer');
     expect(normalized.opponentAI).toEqual(createEmptyOpponentAIState());
   });
+
+  it('rejects malformed plan enums and unsafe upgrade-route records', () => {
+    const state = makeState();
+    state.opponentAI!.majorCivs['ai-1'].primaryPlan = makePlan({
+      objective: 'teleport' as AIStrategicPlan['objective'],
+    });
+    (state.opponentAI!.majorCivs['ai-1'].upgradeRoutesByUnitId as Record<string, unknown>)
+      .broken = null;
+    state.opponentAI!.migrationGraceRoundsRemaining = 999;
+
+    expect(() => normalizeOpponentAIState(state)).not.toThrow();
+    const normalized = normalizeOpponentAIState(state);
+    expect(normalized.opponentAI!.majorCivs['ai-1'].primaryPlan).toBeNull();
+    expect(normalized.opponentAI!.majorCivs['ai-1'].upgradeRoutesByUnitId).toEqual({});
+    expect(normalized.opponentAI!.migrationGraceRoundsRemaining).toBe(2);
+  });
 });

--- a/tests/core/opponent-challenge.test.ts
+++ b/tests/core/opponent-challenge.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import {
+  applyPendingOpponentChallenge,
+  isOpponentChallenge,
+  OPPONENT_CHALLENGE_PROFILES,
+  resolveOpponentChallenge,
+  setPendingOpponentChallenge,
+} from '@/core/opponent-challenge';
+
+describe('opponent challenge', () => {
+  it('recognizes only supported campaign challenge values', () => {
+    expect(isOpponentChallenge('explorer')).toBe(true);
+    expect(isOpponentChallenge('standard')).toBe(true);
+    expect(isOpponentChallenge('veteran')).toBe(true);
+    expect(isOpponentChallenge('hard')).toBe(false);
+    expect(isOpponentChallenge(undefined)).toBe(false);
+  });
+
+  it('resolves absent or malformed legacy values without writing a default', () => {
+    const legacy = createNewGame(undefined, 'challenge-resolve');
+    delete legacy.opponentChallenge;
+
+    expect(resolveOpponentChallenge(legacy)).toBe('standard');
+    expect(legacy.opponentChallenge).toBeUndefined();
+    expect(resolveOpponentChallenge({ opponentChallenge: 'invalid' as never })).toBe('standard');
+  });
+
+  it('applies a pending challenge once at the round boundary', () => {
+    const state = createNewGame({
+      civType: 'rome',
+      mapSize: 'small',
+      opponentCount: 1,
+      gameTitle: 'Challenge',
+      opponentChallenge: 'veteran',
+      seed: 'pending-challenge',
+    });
+    const pending = setPendingOpponentChallenge(state, 'explorer');
+    const applied = applyPendingOpponentChallenge(pending);
+
+    expect(pending.opponentChallenge).toBe('veteran');
+    expect(pending.pendingOpponentChallenge).toBe('explorer');
+    expect(applied.opponentChallenge).toBe('explorer');
+    expect(applied.pendingOpponentChallenge).toBeUndefined();
+    expect(applyPendingOpponentChallenge(applied)).toBe(applied);
+  });
+
+  it('selecting the active challenge cancels an existing pending change', () => {
+    const state = createNewGame({
+      civType: 'rome',
+      mapSize: 'small',
+      opponentCount: 1,
+      gameTitle: 'Challenge',
+      opponentChallenge: 'standard',
+      seed: 'cancel-pending-challenge',
+    });
+    state.pendingOpponentChallenge = 'veteran';
+
+    const cancelled = setPendingOpponentChallenge(state, 'standard');
+
+    expect(cancelled.opponentChallenge).toBe('standard');
+    expect(cancelled.pendingOpponentChallenge).toBeUndefined();
+  });
+
+  it('drops malformed pending values instead of making them active', () => {
+    const state = createNewGame(undefined, 'malformed-pending');
+    state.pendingOpponentChallenge = 'impossible' as never;
+
+    const normalized = applyPendingOpponentChallenge(state);
+
+    expect(normalized.opponentChallenge).toBe('standard');
+    expect(normalized.pendingOpponentChallenge).toBeUndefined();
+  });
+
+  it('changes behavior parameters without combat or economy bonuses', () => {
+    expect(OPPONENT_CHALLENGE_PROFILES.explorer.maxPrimaryForce)
+      .toBeLessThan(OPPONENT_CHALLENGE_PROFILES.veteran.maxPrimaryForce);
+    expect(OPPONENT_CHALLENGE_PROFILES.explorer.seededSuboptimalChance)
+      .toBeGreaterThan(OPPONENT_CHALLENGE_PROFILES.veteran.seededSuboptimalChance);
+    for (const profile of Object.values(OPPONENT_CHALLENGE_PROFILES)) {
+      expect(profile).not.toHaveProperty('combatBonus');
+      expect(profile).not.toHaveProperty('productionBonus');
+      expect(profile).not.toHaveProperty('researchBonus');
+      expect(profile).not.toHaveProperty('visionBonus');
+    }
+  });
+});

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1,4 +1,4 @@
-import { processTurn } from '@/core/turn-manager';
+import { finalizeOpponentRoundState, processTurn } from '@/core/turn-manager';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import type { CustomCivDefinition, GameState, HexCoord, Unit, UnitType } from '@/core/types';
@@ -883,6 +883,24 @@ describe('processTurn', () => {
     const remaining = result.marketplace?.purchasedResources ?? [];
     expect(remaining.some(e => e.resource === 'silk')).toBe(false); // expired → removed
     expect(remaining.some(e => e.resource === 'wine')).toBe(true);  // active → kept
+  });
+});
+
+describe('opponent round finalization', () => {
+  it('applies pending challenge and decrements migration grace once per completed round', () => {
+    const state = createNewGame(undefined, 'opponent-finalize', 'small');
+    state.pendingOpponentChallenge = 'explorer';
+    state.opponentAI!.migrationGraceRoundsRemaining = 2;
+
+    const first = finalizeOpponentRoundState(state);
+    const duplicate = finalizeOpponentRoundState(first);
+    const nextRound = finalizeOpponentRoundState({ ...first, turn: first.turn + 1 });
+
+    expect(first.opponentChallenge).toBe('explorer');
+    expect(first.pendingOpponentChallenge).toBeUndefined();
+    expect(first.opponentAI?.migrationGraceRoundsRemaining).toBe(1);
+    expect(duplicate).toBe(first);
+    expect(nextRound.opponentAI?.migrationGraceRoundsRemaining).toBe(0);
   });
 });
 

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -1,8 +1,26 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { NotificationEntry } from '@/core/notification-log';
 import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
 import { hexKey } from '@/systems/hex-utils';
 import type { HexCoord } from '@/core/types';
+
+const PROJECT_ROOT = resolve(__dirname, '..');
+
+describe('campaign entry wiring', () => {
+  it('routes Continue, exact save rows, and imports through the shared entry gate', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main).toContain('async function showStartSavePanel()');
+    expect(main).toContain('loadMostRecentAutoSaveEntry()');
+    expect(main).toContain('loadSaveEntry(source)');
+    expect(main).toContain("{ kind: 'import', state }");
+    expect(main.match(/await beginCampaignEntry\(/g)).toHaveLength(3);
+    expect(main).not.toContain('loadAutoSave()');
+    expect(main).not.toContain('loadGame(slotId)');
+  });
+});
 
 function makeSink() {
   const calls: Array<{ civId: string; message: string; type: string }> = [];

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -22,6 +22,17 @@ describe('campaign entry wiring', () => {
   });
 });
 
+describe('completed-round AI wiring', () => {
+  it('uses one shared non-human scheduler for solo and hot-seat completed rounds', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main.match(/processNonHumanMajorRound\(current, eventBus\)/g)).toHaveLength(1);
+    expect(main).not.toContain('processAITurn(');
+    expect(main).not.toContain("getAIPlayers(");
+    expect(main).not.toContain("'ai-1'");
+  });
+});
+
 function makeSink() {
   const calls: Array<{ civId: string; message: string; type: string }> = [];
   const sink: NotificationSink = (civId, message, type) => calls.push({ civId, message, type });

--- a/tests/presentation/round-presentation-gate.test.ts
+++ b/tests/presentation/round-presentation-gate.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
+
+describe('RoundPresentationGate', () => {
+  it('requires every nested suppression to resume before presentation is released', () => {
+    const gate = new RoundPresentationGate();
+    gate.suppress();
+    gate.suppress();
+    gate.resume();
+    expect(gate.isSuppressed()).toBe(true);
+    expect(gate.suppressionDepth).toBe(1);
+    gate.resume();
+    gate.resume();
+    expect(gate.isSuppressed()).toBe(false);
+    expect(gate.suppressionDepth).toBe(0);
+  });
+});

--- a/tests/storage/opponent-challenge-migration.test.ts
+++ b/tests/storage/opponent-challenge-migration.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { initializeLegacyOpponentChallenge } from '@/storage/save-manager';
+
+describe('legacy opponent challenge migration', () => {
+  it('initializes the selected challenge and exactly two grace rounds', () => {
+    const legacy = createNewGame(undefined, 'legacy-challenge-grace', 'small');
+    delete legacy.opponentChallenge;
+
+    const migrated = initializeLegacyOpponentChallenge(legacy, 'explorer');
+
+    expect(migrated.opponentChallenge).toBe('explorer');
+    expect(migrated.pendingOpponentChallenge).toBeUndefined();
+    expect(migrated.opponentAI?.migrationGraceRoundsRemaining).toBe(2);
+  });
+
+  it('preserves research, queues, units, cities, wars, resources, and save identity', () => {
+    const legacy = createNewGame(undefined, 'legacy-challenge-content', 'small');
+    delete legacy.opponentChallenge;
+    legacy.civilizations.player.techState.completed = ['fire'];
+    legacy.civilizations.player.techState.currentResearch = 'writing';
+    legacy.civilizations.player.techState.researchProgress = 9;
+    legacy.civilizations.player.techState.researchQueue = ['wheel'];
+    legacy.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    const before = {
+      gameId: legacy.gameId,
+      gameTitle: legacy.gameTitle,
+      tech: structuredClone(legacy.civilizations.player.techState),
+      units: structuredClone(legacy.units),
+      cities: structuredClone(legacy.cities),
+      wars: [...legacy.civilizations.player.diplomacy.atWarWith],
+      resources: Object.fromEntries(
+        Object.entries(legacy.map.tiles).map(([key, tile]) => [key, tile.resource]),
+      ),
+    };
+
+    const migrated = initializeLegacyOpponentChallenge(legacy, 'veteran');
+
+    expect(migrated.gameId).toBe(before.gameId);
+    expect(migrated.gameTitle).toBe(before.gameTitle);
+    expect(migrated.civilizations.player.techState).toEqual(before.tech);
+    expect(migrated.units).toEqual(before.units);
+    expect(migrated.cities).toEqual(before.cities);
+    expect(migrated.civilizations.player.diplomacy.atWarWith).toEqual(before.wars);
+    expect(Object.fromEntries(
+      Object.entries(migrated.map.tiles).map(([key, tile]) => [key, tile.resource]),
+    )).toEqual(before.resources);
+  });
+});

--- a/tests/storage/save-file-transfer.test.ts
+++ b/tests/storage/save-file-transfer.test.ts
@@ -24,7 +24,17 @@ function makeState(turn: number = 7): any {
     },
     cities: {},
     units: {},
-    map: { width: 1, height: 1, tiles: [], wrapsHorizontally: false },
+    map: {
+      width: 1,
+      height: 1,
+      tiles: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'grassland',
+        },
+      },
+      wrapsHorizontally: false,
+    },
   };
 }
 
@@ -55,6 +65,15 @@ describe('save-file-transfer', () => {
     }
   });
 
+  it('parses a real generated game save', async () => {
+    const { createNewGame } = await import('@/core/game-state');
+    const state = createNewGame(undefined, 'real-save-shape', 'small');
+
+    const parsed = parseSaveFile(serializeSaveFile(state));
+
+    expect(parsed.status).toBe('success');
+  });
+
   it('rejects invalid JSON with a clear error', () => {
     expect(parseSaveFile('{not-json')).toEqual({
       status: 'error',
@@ -78,6 +97,29 @@ describe('save-file-transfer', () => {
       status: 'error',
       message: 'Invalid save file: missing required game state fields.',
     });
+  });
+
+  it('rejects legacy array-shaped map tiles', () => {
+    const state = makeState();
+    state.map.tiles = [];
+
+    expect(parseSaveFile(JSON.stringify(state)).status).toBe('error');
+  });
+
+  it('rejects non-finite turns and malformed map dimensions', () => {
+    const infiniteTurn = makeState(Number.POSITIVE_INFINITY);
+    const missingDimensions = makeState();
+    delete missingDimensions.map.width;
+
+    expect(parseSaveFile(JSON.stringify(infiniteTurn)).status).toBe('error');
+    expect(parseSaveFile(JSON.stringify(missingDimensions)).status).toBe('error');
+  });
+
+  it('rejects a current player missing from civilizations', () => {
+    const state = makeState();
+    state.currentPlayer = 'missing';
+
+    expect(parseSaveFile(JSON.stringify(state)).status).toBe('error');
   });
 
   it('exports the most recent autosave through the injected adapter', async () => {

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -13,7 +13,21 @@ vi.mock('@/storage/db', () => ({
 }));
 
 import { createDefaultSettings, createNewGame } from '@/core/game-state';
-import { autoSave, deleteSaveEntry, listSaveEpics, listSaves, loadGame, loadMostRecentAutoSave, loadSettings, normalizeLoadedStateForTest, saveGame, saveSettings } from '@/storage/save-manager';
+import {
+  autoSave,
+  deleteSaveEntry,
+  listSaveEpics,
+  listSaves,
+  loadGame,
+  loadMostRecentAutoSave,
+  loadMostRecentAutoSaveEntry,
+  loadSaveEntry,
+  loadSettings,
+  normalizeLoadedStateForTest,
+  rewriteLoadedSaveEntry,
+  saveGame,
+  saveSettings,
+} from '@/storage/save-manager';
 import { appendNotification } from '@/core/notification-log';
 import type { CustomCivDefinition } from '@/core/types';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
@@ -70,6 +84,82 @@ describe('save-manager autosave listing', () => {
     const autoLoaded = await loadMostRecentAutoSave();
     expect(autoLoaded?.pirates).toEqual(state.pirates);
     expect(autoLoaded?.notificationLog).toEqual(state.notificationLog);
+  });
+
+  it('loads and rewrites an exact manual source without changing metadata', async () => {
+    const state = createNewGame(undefined, 'source-aware-manual', 'small');
+    delete state.opponentChallenge;
+    await saveGame('slot-legacy', 'Old Campaign', state);
+    const source = { id: 'slot-legacy', kind: 'manual' } as const;
+    const beforeMeta = structuredClone(dbState.get('meta:slot-legacy'));
+
+    const loaded = await loadSaveEntry(source);
+    expect(loaded?.source).toEqual(source);
+    expect(loaded?.state.opponentChallenge).toBeUndefined();
+
+    await rewriteLoadedSaveEntry(source, {
+      ...loaded!.state,
+      opponentChallenge: 'explorer',
+    });
+
+    expect(dbState.get('meta:slot-legacy')).toEqual(beforeMeta);
+    expect((await loadSaveEntry(source))?.state.opponentChallenge).toBe('explorer');
+  });
+
+  it('rejects rewriting a normal source that disappeared after loading', async () => {
+    const state = createNewGame(undefined, 'source-disappears', 'small');
+    await saveGame('gone', 'Gone', state);
+    const source = { id: 'gone', kind: 'manual' } as const;
+    const loaded = await loadSaveEntry(source);
+    dbState.delete('save:gone');
+
+    await expect(rewriteLoadedSaveEntry(source, loaded!.state))
+      .rejects.toThrow('Save entry no longer exists');
+    expect(dbState.has('save:gone')).toBe(false);
+  });
+
+  it('returns the concrete newest autosave source for Continue', async () => {
+    const state = createNewGame(undefined, 'source-aware-auto', 'small');
+    state.gameId = 'game-source-aware';
+    state.turn = 7;
+    await autoSave(state);
+
+    const loaded = await loadMostRecentAutoSaveEntry();
+
+    expect(loaded?.source).toEqual({
+      id: 'autosave:game-source-aware:7',
+      kind: 'autosave',
+    });
+  });
+
+  it('rewrites the legacy autosave payload and localStorage backup', async () => {
+    const state = createNewGame(undefined, 'source-aware-legacy', 'small');
+    delete state.opponentChallenge;
+    dbState.set('autosave', state);
+    localStorage.setItem('conquestoria-autosave', JSON.stringify(state));
+
+    const loaded = await loadMostRecentAutoSaveEntry();
+    expect(loaded?.source).toEqual({ id: 'autosave', kind: 'autosave' });
+
+    await rewriteLoadedSaveEntry(loaded!.source, {
+      ...loaded!.state,
+      opponentChallenge: 'standard',
+    });
+
+    expect((dbState.get('autosave') as GameState).opponentChallenge).toBe('standard');
+    expect(JSON.parse(localStorage.getItem('conquestoria-autosave')!).opponentChallenge)
+      .toBe('standard');
+  });
+
+  it('loads a localStorage-only legacy autosave with explicit source identity', async () => {
+    const state = createNewGame(undefined, 'local-only-legacy', 'small');
+    delete state.opponentChallenge;
+    localStorage.setItem('conquestoria-autosave', JSON.stringify(state));
+
+    const loaded = await loadMostRecentAutoSaveEntry();
+
+    expect(loaded?.source).toEqual({ id: 'autosave', kind: 'autosave' });
+    expect(loaded?.state.opponentChallenge).toBeUndefined();
   });
 
   it('normalizes malformed persisted notification IDs without duplicating them', () => {

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -31,6 +31,7 @@ import {
 import { appendNotification } from '@/core/notification-log';
 import type { CustomCivDefinition } from '@/core/types';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
+import { dbGet } from '@/storage/db';
 
 const customCiv: CustomCivDefinition = {
   id: 'custom-sunfolk',
@@ -130,6 +131,42 @@ describe('save-manager autosave listing', () => {
       id: 'autosave:game-source-aware:7',
       kind: 'autosave',
     });
+  });
+
+  it('loads the concrete Continue payload before retiring the legacy fallback', async () => {
+    const concrete = createNewGame(undefined, 'concurrent-concrete', 'small');
+    concrete.gameId = 'concurrent';
+    concrete.turn = 7;
+    await autoSave(concrete);
+    const legacy = createNewGame(undefined, 'concurrent-legacy', 'small');
+    dbState.set('autosave', legacy);
+    localStorage.setItem('conquestoria-autosave', JSON.stringify(legacy));
+
+    const originalDbGet = vi.mocked(dbGet).getMockImplementation()!;
+    let concreteReads = 0;
+    vi.mocked(dbGet).mockImplementation(async key => {
+      if (key === 'autosave:concurrent:7') {
+        concreteReads += 1;
+        if (concreteReads === 3) {
+          dbState.delete(key);
+          return undefined;
+        }
+      }
+      return dbState.get(key);
+    });
+
+    try {
+      const loaded = await loadMostRecentAutoSaveEntry();
+
+      expect(loaded?.source).toEqual({
+        id: 'autosave:concurrent:7',
+        kind: 'autosave',
+      });
+      expect(loaded?.state.gameId).toBe('concurrent');
+      expect(dbState.has('autosave')).toBe(true);
+    } finally {
+      vi.mocked(dbGet).mockImplementation(originalDbGet);
+    }
   });
 
   it('rewrites the legacy autosave payload and localStorage backup', async () => {

--- a/tests/systems/improvement-turn-system.test.ts
+++ b/tests/systems/improvement-turn-system.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { hexKey } from '@/systems/hex-utils';
+
+describe('processImprovementTurns', () => {
+  it('completes improvements immutably, clears worker work, logs, and emits once', () => {
+    const state = createNewGame(undefined, 'improvement-round', 'small');
+    const worker = Object.values(state.units)[0]!;
+    worker.type = 'worker';
+    const tile = state.map.tiles[hexKey(worker.position)]!;
+    tile.improvement = 'farm';
+    tile.improvementTurnsLeft = 1;
+    tile.improvementOwner = 'player';
+    worker.workerTask = { action: 'farm', coord: { ...tile.coord } };
+    const before = structuredClone(state);
+    const bus = new EventBus();
+    const completed = vi.fn();
+    bus.on('improvement:completed', completed);
+
+    const next = processImprovementTurns(state, bus);
+
+    expect(next).not.toBe(state);
+    expect(state).toEqual(before);
+    expect(next.map.tiles[hexKey(tile.coord)]?.improvementTurnsLeft).toBe(0);
+    expect(next.map.tiles[hexKey(tile.coord)]?.improvementOwner).toBeUndefined();
+    expect(next.units[worker.id]?.workerTask).toBeUndefined();
+    expect(next.notificationLog?.player.at(-1)?.message).toBe('Farm completed!');
+    expect(completed).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/systems/viewer-event-presentation.test.ts
+++ b/tests/systems/viewer-event-presentation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
+
+describe('viewer event presentation', () => {
+  it('captures only event-time contiguous visible movement segments', () => {
+    const state = createNewGame(undefined, 'viewer-segments', 'small');
+    const unit = Object.values(state.units).find(candidate => candidate.owner !== 'player')!;
+    const path = [
+      { q: 0, r: 0 },
+      { q: 1, r: 0 },
+      { q: 2, r: 0 },
+      { q: 3, r: 0 },
+      { q: 4, r: 0 },
+    ];
+    state.civilizations.player.visibility.tiles = {
+      '0,0': 'visible',
+      '1,0': 'visible',
+      '2,0': 'fog',
+      '3,0': 'visible',
+      '4,0': 'visible',
+    };
+
+    const presentation = buildMovePresentationByViewer(state, unit, path);
+
+    expect(presentation.player.visibleSegments).toEqual([
+      [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+      [{ q: 3, r: 0 }, { q: 4, r: 0 }],
+    ]);
+  });
+
+  it('omits a viewer with no event-time visible segment even if fog changes later', () => {
+    const state = createNewGame(undefined, 'viewer-hidden', 'small');
+    const unit = Object.values(state.units).find(candidate => candidate.owner !== 'player')!;
+    const path = [{ q: 0, r: 0 }, { q: 1, r: 0 }];
+    state.civilizations.player.visibility.tiles = { '0,0': 'fog', '1,0': 'fog' };
+    const presentation = buildMovePresentationByViewer(state, unit, path);
+    state.civilizations.player.visibility.tiles['0,0'] = 'visible';
+    state.civilizations.player.visibility.tiles['1,0'] = 'visible';
+
+    expect(presentation.player).toBeUndefined();
+  });
+});

--- a/tests/ui/campaign-entry-flow.test.ts
+++ b/tests/ui/campaign-entry-flow.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { beginCampaignEntry, type CampaignEntryDependencies } from '@/ui/campaign-entry-flow';
+import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
+import { normalizeLoadedState } from '@/storage/save-manager';
+
+function makeState(seed: string, challenge: 'explorer' | 'standard' | 'veteran' | null = 'standard') {
+  const state = createNewGame(undefined, seed, 'small');
+  if (challenge === null) delete state.opponentChallenge;
+  else state.opponentChallenge = challenge;
+  return state;
+}
+
+function makeInvoker(): HTMLButtonElement {
+  const savePanel = document.createElement('div');
+  savePanel.id = 'save-panel';
+  const button = document.createElement('button');
+  button.dataset.slotId = 'slot-legacy';
+  savePanel.appendChild(button);
+  document.body.appendChild(savePanel);
+  button.focus();
+  return button;
+}
+
+function makeDependencies(
+  overrides: Partial<CampaignEntryDependencies> = {},
+): CampaignEntryDependencies {
+  return {
+    purposefulAIEnabled: true,
+    persistStoredChoice: vi.fn(async () => {}),
+    persistImport: vi.fn(async () => {}),
+    showChallengePrompt: showLegacyOpponentChallengePrompt,
+    onReady: vi.fn(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('campaign entry flow', () => {
+  it('enters a modern stored campaign without rewriting it', async () => {
+    const state = makeState('modern-stored');
+    const dependencies = makeDependencies();
+
+    const result = await beginCampaignEntry({
+      kind: 'stored',
+      loaded: {
+        state: normalizeLoadedState(state),
+        source: { id: 'slot-modern', kind: 'manual' },
+      },
+    }, makeInvoker(), dependencies);
+
+    expect(result).toBe('entered');
+    expect(dependencies.persistStoredChoice).not.toHaveBeenCalled();
+    expect(dependencies.onReady).toHaveBeenCalledWith(expect.objectContaining({
+      opponentChallenge: 'standard',
+    }));
+  });
+
+  it('does not start a legacy campaign until exact-source persistence succeeds', async () => {
+    const state = makeState('legacy-retry', null);
+    const persistStoredChoice = vi.fn()
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce(undefined);
+    const onReady = vi.fn();
+    const entry = beginCampaignEntry({
+      kind: 'stored',
+      loaded: {
+        state: normalizeLoadedState(state),
+        source: { id: 'slot-legacy', kind: 'manual' },
+      },
+    }, makeInvoker(), makeDependencies({ persistStoredChoice, onReady }));
+
+    document.querySelector<HTMLButtonElement>('[data-challenge="standard"]')!.click();
+    document.querySelector<HTMLButtonElement>('[data-action="continue"]')!.click();
+    await vi.waitFor(() => expect(document.body.textContent).toContain('Could not save your choice'));
+    expect(onReady).not.toHaveBeenCalled();
+    expect(persistStoredChoice).toHaveBeenCalledWith(
+      { id: 'slot-legacy', kind: 'manual' },
+      expect.objectContaining({
+        opponentChallenge: 'standard',
+        opponentAI: expect.objectContaining({ migrationGraceRoundsRemaining: 2 }),
+      }),
+    );
+
+    document.querySelector<HTMLButtonElement>('[data-action="continue"]')!.click();
+    await expect(entry).resolves.toBe('entered');
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels without persisting or entering and restores invoking focus', async () => {
+    const invoker = makeInvoker();
+    const dependencies = makeDependencies();
+    const entry = beginCampaignEntry({
+      kind: 'stored',
+      loaded: {
+        state: normalizeLoadedState(makeState('legacy-cancel', null)),
+        source: { id: 'slot-legacy', kind: 'manual' },
+      },
+    }, invoker, dependencies);
+
+    document.querySelector<HTMLButtonElement>('[data-action="cancel"]')!.click();
+
+    await expect(entry).resolves.toBe('cancelled');
+    expect(dependencies.persistStoredChoice).not.toHaveBeenCalled();
+    expect(dependencies.onReady).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(invoker);
+    expect(document.querySelector('#save-panel')).not.toBeNull();
+  });
+
+  it('autosaves a valid imported campaign before entering it', async () => {
+    const callOrder: string[] = [];
+    const persistImport = vi.fn(async () => {
+      callOrder.push('persist');
+    });
+    const onReady = vi.fn(() => {
+      callOrder.push('ready');
+    });
+
+    const result = await beginCampaignEntry(
+      { kind: 'import', state: makeState('modern-import') },
+      makeInvoker(),
+      makeDependencies({ persistImport, onReady }),
+    );
+
+    expect(result).toBe('entered');
+    expect(callOrder).toEqual(['persist', 'ready']);
+  });
+
+  it('prompts and autosaves a legacy or invalid imported campaign before entry', async () => {
+    for (const invalidValue of [undefined, 'impossible'] as const) {
+      document.body.replaceChildren();
+      const state = makeState(`legacy-import-${String(invalidValue)}`, null);
+      if (invalidValue) (state as any).opponentChallenge = invalidValue;
+      const dependencies = makeDependencies();
+      const entry = beginCampaignEntry(
+        { kind: 'import', state },
+        makeInvoker(),
+        dependencies,
+      );
+
+      document.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();
+      document.querySelector<HTMLButtonElement>('[data-action="continue"]')!.click();
+
+      await expect(entry).resolves.toBe('entered');
+      expect(dependencies.persistImport).toHaveBeenCalledWith(expect.objectContaining({
+        opponentChallenge: 'explorer',
+      }));
+      expect(dependencies.onReady).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('bypasses the prompt while the rollout flag is false', async () => {
+    const showChallengePrompt = vi.fn(showLegacyOpponentChallengePrompt);
+    const dependencies = makeDependencies({
+      purposefulAIEnabled: false,
+      showChallengePrompt,
+    });
+
+    const result = await beginCampaignEntry({
+      kind: 'stored',
+      loaded: {
+        state: normalizeLoadedState(makeState('disabled-legacy', null)),
+        source: { id: 'slot-legacy', kind: 'manual' },
+      },
+    }, makeInvoker(), dependencies);
+
+    expect(result).toBe('entered');
+    expect(showChallengePrompt).not.toHaveBeenCalled();
+    expect(dependencies.persistStoredChoice).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -102,6 +102,35 @@ describe('campaign-setup', () => {
     expect(startButton.dataset.ready).toBe('true');
   });
 
+  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+    showCampaignSetup(document.body, {
+      onStartSolo: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
+  });
+
+  it('passes the selected challenge from enabled solo setup', () => {
+    const onStartSolo = vi.fn();
+    const panel = showCampaignSetup(
+      document.body,
+      { onStartSolo, onCancel: vi.fn() },
+      { purposefulAIEnabled: true },
+    );
+
+    panel.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();
+    clickButtonWithText('Choose civilization');
+    (document.querySelector('.civ-card') as HTMLElement)
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    (document.querySelector('#civ-start') as HTMLButtonElement).click();
+    clickButtonWithText('Start Campaign');
+
+    expect(onStartSolo).toHaveBeenCalledWith(expect.objectContaining({
+      opponentChallenge: 'explorer',
+    }));
+  });
+
   it('updates the visible map-size and opponent cards together, preserving valid counts and snapping invalid ones', () => {
     showCampaignSetup(document.body, {
       onStartSolo: () => {},

--- a/tests/ui/combat-resolved-presentation.test.ts
+++ b/tests/ui/combat-resolved-presentation.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { GameEvents, GameState } from '@/core/types';
+import { handleCombatResolvedEvent } from '@/ui/combat-resolved-presentation';
+
+function makeState(): GameState {
+  return {
+    currentPlayer: 'defender',
+    turn: 4,
+    civilizations: {
+      attacker: { id: 'attacker', name: 'Rome' },
+      defender: { id: 'defender', name: 'Egypt' },
+    },
+    units: {},
+  } as unknown as GameState;
+}
+
+function makeEvent(): GameEvents['combat:resolved'] {
+  return {
+    result: {
+      attackerId: 'attacker-unit',
+      defenderId: 'destroyed-unit',
+      attackerDamage: 5,
+      defenderDamage: 100,
+      attackerSurvived: true,
+      defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    },
+    visibleToViewerIds: ['defender'],
+    attackerType: 'warrior',
+    defenderType: 'archer',
+    attackerOwnerId: 'attacker',
+    defenderOwnerId: 'defender',
+  };
+}
+
+describe('combat resolved presentation', () => {
+  it('keeps the defender report while suppressing hidden-round visuals', () => {
+    const applyVisual = vi.fn();
+    const appendNotification = vi.fn();
+
+    handleCombatResolvedEvent(makeState(), makeEvent(), {
+      isPresentationSuppressed: () => true,
+      applyVisual,
+      appendNotification,
+    });
+
+    expect(applyVisual).not.toHaveBeenCalled();
+    expect(appendNotification).toHaveBeenCalledWith(
+      'defender',
+      'Archer was destroyed by Rome!',
+      'warning',
+    );
+  });
+});

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -84,6 +84,45 @@ beforeEach(() => {
 });
 
 describe('hotseat-setup', () => {
+  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+    showHotSeatSetup(document.body, {
+      onComplete: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    click('[data-size="small"]');
+    advanceThroughMapType();
+
+    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
+    expect(document.body.textContent).toContain('How Many Players?');
+  });
+
+  it('chooses challenge as a group before private hot-seat setup and returns it separately', () => {
+    const onComplete = vi.fn();
+    showHotSeatSetup(
+      document.body,
+      { onComplete, onCancel: vi.fn() },
+      { purposefulAIEnabled: true },
+    );
+
+    click('[data-size="small"]');
+    click('#hs-map-type-next');
+    expect(document.body.textContent).toContain('Choose Opponent Challenge');
+    expect(document.body.textContent).not.toContain('Player Names');
+    click('[data-challenge="explorer"]');
+    click('#hs-challenge-next');
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    chooseCiv('egypt');
+    click('#hs-civ-ready');
+    chooseCiv('rome');
+
+    expect(onComplete).toHaveBeenCalledWith(
+      expect.not.objectContaining({ opponentChallenge: expect.anything() }),
+      'explorer',
+    );
+  });
+
   it('explains that supported map sizes use balanced starts before player-count selection', () => {
     showHotSeatSetup(
       document.body,

--- a/tests/ui/legacy-opponent-challenge-prompt.test.ts
+++ b/tests/ui/legacy-opponent-challenge-prompt.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
+
+describe('legacy opponent challenge prompt', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('requires an explicit legacy choice and preserves selection across retry', async () => {
+    const onContinue = vi.fn()
+      .mockRejectedValueOnce(new Error('disk unavailable'))
+      .mockResolvedValueOnce(undefined);
+    const panel = showLegacyOpponentChallengePrompt(document.body, {
+      hotSeat: true,
+      onContinue,
+      onCancel: vi.fn(),
+    });
+    const continueButton = panel.querySelector<HTMLButtonElement>('[data-action="continue"]')!;
+
+    expect(continueButton.disabled).toBe(true);
+    panel.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();
+    expect(continueButton.disabled).toBe(false);
+    continueButton.click();
+    expect(panel.getAttribute('aria-busy')).toBe('true');
+    expect(continueButton.textContent).toBe('Saving…');
+    await vi.waitFor(() => expect(panel.textContent).toContain('Could not save your choice'));
+    expect(panel.querySelector('[data-challenge="explorer"]')?.getAttribute('aria-pressed')).toBe('true');
+    continueButton.click();
+    await vi.waitFor(() => expect(onContinue).toHaveBeenCalledTimes(2));
+    expect(onContinue).toHaveBeenNthCalledWith(1, 'explorer');
+    expect(onContinue).toHaveBeenNthCalledWith(2, 'explorer');
+  });
+
+  it('renders a labelled, scroll-safe dialog with the hot-seat fairness sentence', () => {
+    const panel = showLegacyOpponentChallengePrompt(document.body, {
+      hotSeat: true,
+      onContinue: vi.fn(),
+      onCancel: vi.fn(),
+    });
+    const dialog = panel.querySelector<HTMLElement>('[data-legacy-challenge-dialog]')!;
+
+    expect(panel.getAttribute('role')).toBe('dialog');
+    expect(panel.getAttribute('aria-modal')).toBe('true');
+    expect(panel.getAttribute('aria-labelledby')).toBe('legacy-opponent-challenge-title');
+    expect(document.activeElement).toBe(panel.querySelector('#legacy-opponent-challenge-title'));
+    expect(panel.textContent).toContain('Choose Opponent Challenge');
+    expect(panel.textContent).toContain(
+      'This campaign was created before opponent difficulty was added. Choose how computer rivals and roaming threats should behave.',
+    );
+    expect(panel.textContent).toContain('Combat rules and bonuses remain the same.');
+    expect(panel.textContent).toContain(
+      'This choice applies to computer-controlled opponents for everyone in this campaign.',
+    );
+    expect(dialog.style.maxHeight).toBe('min(90dvh, 720px)');
+    expect(dialog.style.overflowY).toBe('auto');
+    expect(dialog.style.padding).toBe('16px');
+    expect(dialog.querySelector('style')?.textContent).toContain('safe-area-inset');
+  });
+
+  it('omits the hot-seat sentence for solo saves', () => {
+    const panel = showLegacyOpponentChallengePrompt(document.body, {
+      hotSeat: false,
+      onContinue: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    expect(panel.textContent).not.toContain('for everyone in this campaign');
+  });
+
+  it('traps keyboard focus and Escape cancels once and restores invoking-row focus', () => {
+    const invokingRow = document.createElement('button');
+    invokingRow.textContent = 'Load old save';
+    document.body.appendChild(invokingRow);
+    invokingRow.focus();
+    const onCancel = vi.fn();
+    const panel = showLegacyOpponentChallengePrompt(document.body, {
+      hotSeat: false,
+      returnFocusTo: invokingRow,
+      onContinue: vi.fn(),
+      onCancel,
+    });
+    const focusable = Array.from(panel.querySelectorAll<HTMLButtonElement>('button:not(:disabled)'));
+    const first = focusable[0]!;
+    const last = focusable.at(-1)!;
+
+    last.focus();
+    last.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.activeElement).toBe(first);
+
+    first.focus();
+    first.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(document.activeElement).toBe(last);
+
+    panel.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    }));
+    panel.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(invokingRow);
+    expect(panel.isConnected).toBe(false);
+  });
+
+  it('renders all player-visible strings as text rather than markup', () => {
+    const panel = showLegacyOpponentChallengePrompt(document.body, {
+      hotSeat: false,
+      onContinue: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    expect(panel.querySelector('script')).toBeNull();
+    expect(panel.querySelectorAll('[data-challenge]')).toHaveLength(3);
+    for (const card of panel.querySelectorAll<HTMLButtonElement>('[data-challenge]')) {
+      expect(card.querySelector('img,iframe,object')).toBeNull();
+    }
+  });
+});

--- a/tests/ui/opponent-challenge-selector.test.ts
+++ b/tests/ui/opponent-challenge-selector.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  OPPONENT_CHALLENGE_COPY,
+  createOpponentChallengeSelector,
+} from '@/ui/opponent-challenge-selector';
+
+describe('opponent challenge selector', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('renders the approved shared copy and marks Standard as recommended', () => {
+    const selector = createOpponentChallengeSelector({
+      selected: 'standard',
+      onSelect: vi.fn(),
+      mode: 'new-game',
+    });
+    document.body.appendChild(selector);
+
+    expect(OPPONENT_CHALLENGE_COPY).toEqual({
+      explorer: {
+        label: 'Explorer',
+        description: 'Clear warnings, smaller attacks, and more time to recover.',
+      },
+      standard: {
+        label: 'Standard',
+        badge: 'Recommended',
+        description: 'Purposeful rivals, coordinated attacks, and fair breathing room.',
+      },
+      veteran: {
+        label: 'Veteran',
+        description: 'Faster plans, stronger coordination, and fewer tactical mistakes.',
+      },
+    });
+    expect(selector.textContent).toContain('Standard');
+    expect(selector.textContent).toContain('Recommended');
+    for (const copy of Object.values(OPPONENT_CHALLENGE_COPY)) {
+      expect(selector.textContent).toContain(copy.label);
+      expect(selector.textContent).toContain(copy.description);
+    }
+  });
+
+  it('defaults new campaigns to Standard but leaves migration unselected', () => {
+    const newGame = createOpponentChallengeSelector({
+      selected: null,
+      onSelect: vi.fn(),
+      mode: 'new-game',
+    });
+    const migration = createOpponentChallengeSelector({
+      selected: null,
+      onSelect: vi.fn(),
+      mode: 'migration',
+    });
+
+    expect(newGame.querySelector('[data-challenge="standard"]')?.getAttribute('aria-pressed'))
+      .toBe('true');
+    expect(migration.querySelector('[aria-pressed="true"]')).toBeNull();
+  });
+
+  it('updates the visible selection immediately and reports the chosen value', () => {
+    const onSelect = vi.fn();
+    const selector = createOpponentChallengeSelector({
+      selected: 'standard',
+      onSelect,
+      mode: 'settings',
+    });
+    const explorer = selector.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!;
+
+    explorer.click();
+
+    expect(onSelect).toHaveBeenCalledWith('explorer');
+    expect(explorer.getAttribute('aria-pressed')).toBe('true');
+    expect(selector.querySelector('[data-challenge="standard"]')?.getAttribute('aria-pressed'))
+      .toBe('false');
+  });
+
+  it('uses touch-sized buttons and responsive one-to-three-column layout', () => {
+    const selector = createOpponentChallengeSelector({
+      selected: 'standard',
+      onSelect: vi.fn(),
+      mode: 'new-game',
+    });
+
+    expect(selector.style.gridTemplateColumns).toBe('minmax(0, 1fr)');
+    expect(selector.querySelector('style')?.textContent).toContain('@media (min-width: 720px)');
+    expect(selector.querySelector('style')?.textContent).toContain('repeat(3, minmax(0, 1fr))');
+    for (const card of selector.querySelectorAll<HTMLButtonElement>('[data-challenge]')) {
+      expect(card.style.minHeight).toBe('44px');
+      expect(card.style.height).not.toMatch(/^\d/);
+      expect(card.style.background).not.toBe('');
+      expect(card.style.color).not.toBe('');
+    }
+  });
+});

--- a/tests/ui/pause-menu-panel.test.ts
+++ b/tests/ui/pause-menu-panel.test.ts
@@ -18,6 +18,9 @@ function makeCallbacks(overrides: Partial<Parameters<typeof showPauseMenu>[1]> =
     onNewGame: vi.fn(),
     autoSave: vi.fn(async () => {}),
     onOpenBestiary: vi.fn(),
+    opponentChallenge: 'standard',
+    pendingOpponentChallenge: undefined,
+    onOpponentChallengeChange: vi.fn(),
     audioSettings: { ...DEFAULT_TEST_AUDIO },
     onAudioSettingChange: vi.fn(),
     ...overrides,
@@ -35,6 +38,49 @@ beforeEach(() => {
 });
 
 describe('pause-menu-panel', () => {
+  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+    showPauseMenu(document.body, makeCallbacks());
+
+    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
+  });
+
+  it('shows active and pending challenge without claiming pending is active', () => {
+    const panel = showPauseMenu(
+      document.body,
+      makeCallbacks({
+        opponentChallenge: 'standard',
+        pendingOpponentChallenge: 'explorer',
+      }),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(panel.textContent).toContain('Standard active');
+    expect(panel.textContent).toContain('Explorer next round');
+    expect(panel.textContent).not.toContain('Explorer active');
+  });
+
+  it('rerenders pending challenge immediately, announces it, and restores card focus', () => {
+    const onOpponentChallengeChange = vi.fn();
+    showPauseMenu(
+      document.body,
+      makeCallbacks({
+        opponentChallenge: 'standard',
+        onOpponentChallengeChange,
+      }),
+      { purposefulAIEnabled: true },
+    );
+
+    document.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();
+
+    expect(onOpponentChallengeChange).toHaveBeenCalledWith('explorer');
+    expect(document.body.textContent).toContain('Standard active');
+    expect(document.body.textContent).toContain('Explorer next round');
+    expect(document.querySelector('[role="status"]')?.textContent)
+      .toContain('Explorer will apply next round');
+    expect(document.activeElement)
+      .toBe(document.querySelector('[data-challenge="explorer"]'));
+  });
+
   it('renders with correct turn number and civ name in header', () => {
     showPauseMenu(document.body, makeCallbacks());
     expect(document.body.textContent).toContain('Turn 14');

--- a/tests/ui/save-panel.test.ts
+++ b/tests/ui/save-panel.test.ts
@@ -87,7 +87,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     expect(document.querySelectorAll('#save-panel [data-save-epic-card="true"]')).toHaveLength(1);
@@ -124,7 +124,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
       onSaveToSlot: () => {},
     }, 'save');
 
@@ -160,7 +160,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     (document.querySelector('[data-role="open-epic"]') as HTMLButtonElement).click();
@@ -172,7 +172,7 @@ describe('save-panel', () => {
   it('loads the clicked autosave row instead of routing through continue', async () => {
     const container = mountContainer();
     const onContinue = vi.fn();
-    const onLoadSlot = vi.fn();
+    const onLoadEntry = vi.fn();
     mocks.hasAutoSave.mockResolvedValue(true);
     mocks.listSaveEpics.mockResolvedValue([
       {
@@ -199,14 +199,91 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue,
-      onLoadSlot,
+      onLoadEntry,
     });
 
     (document.querySelector('[data-role="open-epic"]') as HTMLButtonElement).click();
     (document.querySelector('[data-role="load-slot"]') as HTMLButtonElement).click();
 
-    expect(onLoadSlot).toHaveBeenCalledWith('autosave:game-1:9');
+    const invoker = document.querySelector<HTMLButtonElement>(
+      '[data-role="load-slot"][data-slot-id="autosave:game-1:9"]',
+    )!;
+    expect(onLoadEntry).toHaveBeenCalledWith(
+      { id: 'autosave:game-1:9', kind: 'autosave' },
+      invoker,
+    );
     expect(onContinue).not.toHaveBeenCalled();
+  });
+
+  it('passes the Continue invoker and keeps the panel mounted until entry completes', async () => {
+    const container = mountContainer();
+    let finish!: () => void;
+    const onContinue = vi.fn(() => new Promise<void>(resolve => {
+      finish = resolve;
+    }));
+    mocks.hasAutoSave.mockResolvedValue(true);
+    mocks.listSaveEpics.mockResolvedValue([]);
+
+    await createSavePanel(container, {
+      onNewGame: vi.fn(),
+      onContinue,
+      onLoadEntry: vi.fn(),
+    });
+    const invoker = document.querySelector<HTMLButtonElement>('#btn-continue')!;
+    invoker.click();
+
+    expect(onContinue).toHaveBeenCalledWith(invoker);
+    expect(invoker.disabled).toBe(true);
+    expect(document.querySelector('#save-panel')).not.toBeNull();
+
+    finish();
+    await vi.waitFor(() => expect(invoker.disabled).toBe(false));
+  });
+
+  it('keeps the panel mounted and passes exact source plus invoker while a row load is pending', async () => {
+    const container = mountContainer();
+    let finish!: () => void;
+    const onLoadEntry = vi.fn(() => new Promise<void>(resolve => {
+      finish = resolve;
+    }));
+    mocks.hasAutoSave.mockResolvedValue(true);
+    mocks.listSaveEpics.mockResolvedValue([{
+      gameId: 'game-1',
+      title: 'Desert Run',
+      latestTurn: 9,
+      latestPlayed: '2026-04-08T12:00:00.000Z',
+      gameMode: 'solo',
+      saves: [{
+        id: 'autosave:game-1:9',
+        name: 'Autosave Turn 9',
+        civType: 'egypt',
+        turn: 9,
+        lastPlayed: '2026-04-08T12:00:00.000Z',
+        kind: 'autosave',
+        gameMode: 'solo',
+        gameTitle: 'Desert Run',
+      }],
+    }]);
+
+    await createSavePanel(container, {
+      onNewGame: vi.fn(),
+      onContinue: vi.fn(),
+      onLoadEntry,
+    });
+    (document.querySelector('[data-role="open-epic"]') as HTMLButtonElement).click();
+    const invoker = document.querySelector<HTMLButtonElement>('[data-role="load-slot"]')!;
+    invoker.click();
+
+    expect(onLoadEntry).toHaveBeenCalledWith(
+      { id: 'autosave:game-1:9', kind: 'autosave' },
+      invoker,
+    );
+    expect(document.querySelector('#save-panel')).not.toBeNull();
+    expect(invoker.disabled).toBe(true);
+    expect(invoker.getAttribute('aria-busy')).toBe('true');
+
+    finish();
+    await vi.waitFor(() => expect(invoker.disabled).toBe(false));
   });
 
   it('rerenders the list after deleting one row and keeps the remaining rows visible', async () => {
@@ -269,7 +346,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     (document.querySelector('[data-role="open-epic"]') as HTMLButtonElement).click();
@@ -310,7 +387,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     expect(document.getElementById('evil-save')).toBeNull();
@@ -353,7 +430,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     expect(document.getElementById('evil-player')).toBeNull();
@@ -369,7 +446,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     (document.querySelector('#btn-export-save') as HTMLButtonElement).click();
@@ -388,7 +465,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     (document.querySelector('#btn-import-save') as HTMLButtonElement).click();
@@ -410,7 +487,7 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
     });
 
     (document.querySelector('#btn-import-save') as HTMLButtonElement).click();
@@ -420,7 +497,7 @@ describe('save-panel', () => {
     expect(document.body.textContent).toContain('Invalid save file: missing required game state fields.');
   });
 
-  it('imports a valid save through the shared callback and closes the panel', async () => {
+  it('passes a valid import and invoker to the shared callback without preemptively closing', async () => {
     const container = mountContainer();
     const onImportSave = vi.fn();
     const importedState = {
@@ -435,15 +512,18 @@ describe('save-panel', () => {
     await createSavePanel(container, {
       onNewGame: () => {},
       onContinue: () => {},
-      onLoadSlot: () => {},
+      onLoadEntry: () => {},
       onImportSave,
     });
 
     (document.querySelector('#btn-import-save') as HTMLButtonElement).click();
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect(onImportSave).toHaveBeenCalledWith(importedState);
-    expect(document.querySelector('#save-panel')).toBeNull();
+    expect(onImportSave).toHaveBeenCalledWith(
+      importedState,
+      document.querySelector('#btn-import-save'),
+    );
+    expect(document.querySelector('#save-panel')).not.toBeNull();
   });
 
   it('shows epics first and opens a turn list for the selected epic', async () => {
@@ -472,9 +552,9 @@ describe('save-panel', () => {
         ],
       },
     ]);
-    const onLoadSlot = vi.fn();
+    const onLoadEntry = vi.fn();
 
-    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadSlot });
+    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadEntry });
 
     expect(document.body.textContent).toContain('Daddy Alex');
     expect(document.body.textContent).toContain('Tiny Epic');
@@ -489,7 +569,7 @@ describe('save-panel', () => {
 
   it('loads an exact save id from the opened epic detail', async () => {
     const container = mountContainer();
-    const onLoadSlot = vi.fn();
+    const onLoadEntry = vi.fn();
     mocks.hasAutoSave.mockResolvedValue(true);
     mocks.listSaveEpics.mockResolvedValue([
       {
@@ -504,11 +584,14 @@ describe('save-panel', () => {
       },
     ]);
 
-    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadSlot });
+    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadEntry });
     (document.querySelector('[data-role="open-epic"][data-game-id="game-a"]') as HTMLButtonElement).click();
     (document.querySelector('[data-role="load-slot"][data-slot-id="autosave:game-a:9"]') as HTMLButtonElement).click();
 
-    expect(onLoadSlot).toHaveBeenCalledWith('autosave:game-a:9');
+    expect(onLoadEntry).toHaveBeenCalledWith(
+      { id: 'autosave:game-a:9', kind: 'autosave' },
+      expect.any(HTMLButtonElement),
+    );
   });
 
   it('returns from an epic detail to the campaign list', async () => {
@@ -523,7 +606,7 @@ describe('save-panel', () => {
       ] },
     ]);
 
-    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadSlot: vi.fn() });
+    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadEntry: vi.fn() });
     (document.querySelector('[data-role="open-epic"][data-game-id="game-a"]') as HTMLButtonElement).click();
     expect(document.body.textContent).toContain('Back to campaigns');
 
@@ -550,7 +633,7 @@ describe('save-panel', () => {
         ] },
       ]);
 
-    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadSlot: vi.fn() });
+    await createSavePanel(container, { onNewGame: vi.fn(), onContinue: vi.fn(), onLoadEntry: vi.fn() });
     (document.querySelector('[data-role="open-epic"][data-game-id="game-a"]') as HTMLButtonElement).click();
     (document.querySelector('[data-role="delete-slot"][data-slot-id="autosave:game-a:9"]') as HTMLButtonElement).click();
     await new Promise(resolve => setTimeout(resolve, 0));

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -54,6 +54,47 @@ describe('turn handoff', () => {
     expect(shell.hasAttribute('aria-hidden')).toBe(false);
   });
 
+  it('keeps keyboard focus inside the opaque handoff while no action is enabled', () => {
+    const { state, layer } = makeFixture();
+    showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: false,
+      onReady: vi.fn(),
+    });
+    const title = document.querySelector<HTMLElement>('#turn-handoff-title')!;
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    document.querySelector<HTMLElement>('#turn-handoff')!.dispatchEvent(new KeyboardEvent('keydown', {
+      key: 'Tab',
+      bubbles: true,
+      cancelable: true,
+    }));
+
+    expect(document.activeElement).toBe(title);
+  });
+
+  it('recovers when opening the turn rejects instead of leaving a dead-end button', async () => {
+    const { state, layer } = makeFixture();
+    const onReady = vi.fn().mockRejectedValueOnce(new Error('temporary failure'));
+    showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: true,
+      onReady,
+    });
+    document.querySelector<HTMLButtonElement>('#handoff-confirm')!.click();
+    expect(document.querySelector<HTMLElement>('[role="alert"]')?.hidden).toBe(true);
+    document.querySelector<HTMLButtonElement>('#handoff-start')!.click();
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[role="alert"]')?.textContent)
+        .toContain('Could not open the turn');
+    });
+    const retry = document.querySelector<HTMLButtonElement>('#handoff-start')!;
+    expect(retry.disabled).toBe(false);
+    expect(retry.textContent).toBe('Try Again');
+    expect(document.querySelector('#turn-handoff')).not.toBeNull();
+  });
+
   it('keeps errors opaque and exposes retry and return controls', () => {
     const { state, layer } = makeFixture();
     const onRetry = vi.fn();

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createHotSeatGame } from '@/core/game-state';
+import { showTurnHandoff } from '@/ui/turn-handoff';
+
+function makeFixture() {
+  const state = createHotSeatGame({
+    playerCount: 2,
+    mapSize: 'small',
+    players: [
+      { name: 'Alice', slotId: 'player-1', civType: 'egypt', isHuman: true },
+      { name: 'Bob the Very Patient Cartographer', slotId: 'player-2', civType: 'rome', isHuman: true },
+    ],
+  }, 'handoff-fixture');
+  const shell = document.createElement('div');
+  shell.id = 'game-shell';
+  const layer = document.createElement('div');
+  shell.appendChild(layer);
+  document.body.appendChild(shell);
+  return { state, shell, layer };
+}
+
+afterEach(() => document.body.replaceChildren());
+
+describe('turn handoff', () => {
+  it('is opaque and blocked until setReady supplies the completed state', async () => {
+    const { state, shell, layer } = makeFixture();
+    const onReady = vi.fn();
+    const controller = showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: false,
+      preparingLabel: 'Preparing next turn…',
+      onReady,
+    });
+    const confirm = document.querySelector<HTMLButtonElement>('#handoff-confirm')!;
+
+    expect(confirm.disabled).toBe(true);
+    expect(confirm.textContent).toBe('Preparing next turn…');
+    expect(document.querySelector<HTMLElement>('#turn-handoff')?.style.backgroundColor).toBe('rgb(10, 10, 30)');
+    expect(shell.inert).toBe(true);
+    expect(shell.getAttribute('aria-hidden')).toBe('true');
+
+    const updated = structuredClone(state);
+    updated.turn = 9;
+    updated.civilizations['player-2'].gold = 321;
+    controller.setReady(updated);
+    confirm.click();
+    expect(document.body.textContent).toContain('Turn 9');
+    expect(document.body.textContent).toContain('321');
+
+    document.querySelector<HTMLButtonElement>('#handoff-start')!.click();
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalledWith(expect.objectContaining({ turn: 9 })));
+    expect(shell.inert).toBe(false);
+    expect(shell.hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  it('keeps errors opaque and exposes retry and return controls', () => {
+    const { state, layer } = makeFixture();
+    const onRetry = vi.fn();
+    const onReturnToSaves = vi.fn();
+    const controller = showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: false,
+      onReady: vi.fn(),
+    });
+
+    controller.setError('The round could not be completed.', { onRetry, onReturnToSaves });
+    document.querySelector<HTMLButtonElement>('[data-action="retry-handoff"]')!.click();
+    expect(onRetry).toHaveBeenCalledOnce();
+    document.querySelector<HTMLButtonElement>('[data-action="return-to-saves"]')!.click();
+    expect(onReturnToSaves).toHaveBeenCalledOnce();
+    expect(document.querySelector('#turn-handoff')).toBeNull();
+  });
+
+  it('uses bounded scrollable layout and touch-sized controls for phone and laptop viewports', () => {
+    const { state, layer } = makeFixture();
+    showTurnHandoff(layer, state, 'player-2', 'Bob the Very Patient Cartographer', {
+      initiallyReady: true,
+      onReady: vi.fn(),
+    });
+    const card = document.querySelector<HTMLElement>('[data-handoff-card]')!;
+    const confirm = document.querySelector<HTMLButtonElement>('#handoff-confirm')!;
+
+    expect(card.style.width).toBe('100%');
+    expect(card.style.maxWidth).toBe('520px');
+    expect(card.style.maxHeight).toBe('min(90dvh, 720px)');
+    expect(card.style.overflowY).toBe('auto');
+    expect(card.style.overflowX).toBe('hidden');
+    expect(confirm.style.minHeight).toBe('44px');
+    expect(document.querySelector('#turn-handoff style')?.textContent).toContain('safe-area-inset');
+  });
+});

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -64,11 +64,32 @@ describe('turn handoff', () => {
     });
 
     controller.setError('The round could not be completed.', { onRetry, onReturnToSaves });
-    document.querySelector<HTMLButtonElement>('[data-action="retry-handoff"]')!.click();
+    const retry = document.querySelector<HTMLButtonElement>('[data-action="retry-handoff"]')!;
+    retry.click();
+    retry.click();
     expect(onRetry).toHaveBeenCalledOnce();
+    expect(onReturnToSaves).not.toHaveBeenCalled();
+    controller.setError('Still unavailable.', { onRetry, onReturnToSaves });
     document.querySelector<HTMLButtonElement>('[data-action="return-to-saves"]')!.click();
     expect(onReturnToSaves).toHaveBeenCalledOnce();
     expect(document.querySelector('#turn-handoff')).toBeNull();
+  });
+
+  it('reopening removes the prior controller and restores accessibility after the new handoff', () => {
+    const { state, shell, layer } = makeFixture();
+    showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: true,
+      onReady: vi.fn(),
+    });
+    const second = showTurnHandoff(layer, state, 'player-1', 'Alice', {
+      initiallyReady: true,
+      onReady: vi.fn(),
+    });
+
+    expect(document.querySelectorAll('#turn-handoff')).toHaveLength(1);
+    second.remove();
+    expect(shell.inert).toBe(false);
+    expect(shell.hasAttribute('aria-hidden')).toBe(false);
   });
 
   it('uses bounded scrollable layout and touch-sized controls for phone and laptop viewports', () => {


### PR DESCRIPTION
## Summary

Part of #412.

- adds serializable campaign challenge and versioned opponent-AI state foundations
- preserves exact manual/autosave source identity for old-save migration and validates real imported save shapes
- adds shared accessible challenge cards and a retry-safe required legacy prompt, kept hidden behind the rollout flag
- makes every hot-seat campaign entry and completed round private behind an opaque, accessible identity handoff
- buffers completed-round events transactionally, rolls back failed phases, and retries failed persistence without rerunning AI/world logic
- snapshots event-time viewer visibility for movement/combat replay and SFX
- schedules every living non-human major civilization exactly once per completed round in deterministic rotating order

## Inline review follow-up

- extracts completed-round handoff retry orchestration so phase and persistence failures are independently regression-tested
- preserves defender combat reports while suppressing only hidden-round visuals
- prevents movement SFX from falling back to final fog when event-time visibility omitted the current viewer
- rebinds audio across campaigns, synchronizes hidden era changes at Ready, and rejects stale asynchronous loop loads
- loads a concrete Continue payload before retiring the legacy autosave fallback
- keeps keyboard focus inside preparing handoffs and recovers cleanly if opening a turn rejects
- rejects malformed opponent-AI plan data and caps migration grace at the designed two rounds

## Gameplay impact

The live MR1 changes fix multi-opponent scheduling and hot-seat privacy. Challenge controls remain hidden until the later AI behavior, pressure, warning, and balance slices make their descriptions true.

## Why this is safe to merge partial

Existing AI behavior remains authoritative; this slice only invokes that behavior for every configured living AI through one shared scheduler. Challenge UI is feature-gated off. Save migration does not silently choose a challenge while the flag is off, and exact-source rewrites preserve save metadata. Completed-round state and presentation events now commit transactionally, with hot-seat visuals and audio suppressed until the incoming player confirms identity.

## Out of scope

- strategic objective selection and locality scoring
- coordinated major-civilization tactics
- strategy-aware production, upgrades, and research
- barbarian, minor-civilization, and pirate behavior upgrades
- pressure governor, strategic warnings, and final SFX presentation
- challenge launch, simulation matrix, and balance tuning

## Verification

- `./scripts/run-with-mise.sh yarn test` — 314 files, 4586 passed, 2 skipped
- `./scripts/run-with-mise.sh yarn build`
- changed-source rule checks for every touched `src/` area
- focused storage, setup, load-gate, handoff, audio, movement/combat visibility, round transaction, and AI scheduler regressions

## Visual QA

The challenge surfaces are intentionally hidden in this MR. Responsive DOM/style regressions cover the visible hot-seat handoff at phone and laptop dimensions, including safe-area padding, scrolling, focus trapping, touch targets, busy/error states, and accessibility restoration.
