### PR TITLE
feat(ai): issue 412 shared perception and strategic planning

### DIFF
--- a/src/ai/ai-decision-trace.ts
+++ b/src/ai/ai-decision-trace.ts
@@ -1,0 +1,29 @@
+export interface AIDecisionTrace {
+  actorId: string;
+  turn: number;
+  decision: 'objective' | 'tactical' | 'production' | 'research';
+  selectedId: string | null;
+  candidates: Array<{
+    id: string;
+    score: number;
+    eligible: boolean;
+    reasonCodes: string[];
+  }>;
+}
+
+export function createAIDecisionTrace(trace: AIDecisionTrace): AIDecisionTrace {
+  return {
+    actorId: trace.actorId,
+    turn: trace.turn,
+    decision: trace.decision,
+    selectedId: trace.selectedId,
+    candidates: trace.candidates
+      .map(candidate => ({
+        ...candidate,
+        reasonCodes: [...candidate.reasonCodes],
+      }))
+      .sort((left, right) =>
+        right.score - left.score || left.id.localeCompare(right.id))
+      .slice(0, 12),
+  };
+}

--- a/src/ai/ai-decision-trace.ts
+++ b/src/ai/ai-decision-trace.ts
@@ -12,18 +12,27 @@ export interface AIDecisionTrace {
 }
 
 export function createAIDecisionTrace(trace: AIDecisionTrace): AIDecisionTrace {
+  const sorted = trace.candidates
+    .map(candidate => ({
+      ...candidate,
+      reasonCodes: [...candidate.reasonCodes],
+    }))
+    .sort((left, right) =>
+      right.score - left.score || left.id.localeCompare(right.id));
+  let candidates = sorted.slice(0, 12);
+  const selected = trace.selectedId
+    ? sorted.find(candidate => candidate.id === trace.selectedId)
+    : undefined;
+  if (selected && !candidates.some(candidate => candidate.id === selected.id)) {
+    candidates = [...candidates.slice(0, 11), selected]
+      .sort((left, right) =>
+        right.score - left.score || left.id.localeCompare(right.id));
+  }
   return {
     actorId: trace.actorId,
     turn: trace.turn,
     decision: trace.decision,
     selectedId: trace.selectedId,
-    candidates: trace.candidates
-      .map(candidate => ({
-        ...candidate,
-        reasonCodes: [...candidate.reasonCodes],
-      }))
-      .sort((left, right) =>
-        right.score - left.score || left.id.localeCompare(right.id))
-      .slice(0, 12),
+    candidates,
   };
 }

--- a/src/ai/ai-diplomacy.ts
+++ b/src/ai/ai-diplomacy.ts
@@ -45,6 +45,7 @@ export function evaluateDiplomacy(
       }
     } else {
       const context = contextByCiv[civId] ?? { hasMet: false, hasBorderPressure: false };
+      if (!context.hasMet) continue;
       if (actions.includes('declare_war') && shouldDeclareWar(
         personality,
         relationship,

--- a/src/ai/ai-diplomacy.ts
+++ b/src/ai/ai-diplomacy.ts
@@ -6,6 +6,7 @@ import {
   canOfferVassalage,
 } from '@/systems/diplomacy-system';
 import { shouldDeclareWar } from './ai-personality';
+import type { MilitaryStrengthEstimate } from './ai-strength';
 
 export interface DiplomaticDecision {
   action: DiplomaticAction;
@@ -22,8 +23,8 @@ export function evaluateDiplomacy(
   diplomacy: DiplomacyState,
   completedTechs: string[],
   era: number,
-  militaryStrengths: Record<string, number>,
-  selfStrength: number,
+  militaryStrengths: Record<string, MilitaryStrengthEstimate>,
+  selfStrength: MilitaryStrengthEstimate,
   currentTurn: number,
   contextByCiv: Record<string, DiplomaticContext>,
 ): DiplomaticDecision[] {
@@ -32,9 +33,10 @@ export function evaluateDiplomacy(
   for (const civId of Object.keys(diplomacy.relationships)) {
     const actions = getAvailableActions(diplomacy, civId, completedTechs, era);
     const relationship = getRelationship(diplomacy, civId);
-    const theirStrength = militaryStrengths[civId] ?? 0;
-    const advantage = selfStrength > 0 && theirStrength > 0
-      ? selfStrength / theirStrength
+    const theirStrength = militaryStrengths[civId]?.midpoint ?? 0;
+    const ownStrength = selfStrength.midpoint;
+    const advantage = ownStrength > 0 && theirStrength > 0
+      ? ownStrength / theirStrength
       : 1;
 
     if (isAtWar(diplomacy, civId)) {
@@ -42,7 +44,7 @@ export function evaluateDiplomacy(
         decisions.push({ action: 'request_peace', targetCiv: civId });
       }
     } else {
-      const context = contextByCiv[civId] ?? { hasMet: true, hasBorderPressure: false };
+      const context = contextByCiv[civId] ?? { hasMet: false, hasBorderPressure: false };
       if (actions.includes('declare_war') && shouldDeclareWar(
         personality,
         relationship,
@@ -122,10 +124,10 @@ export function evaluateVassalage(
   personality: PersonalityTraits,
   diplomacy: DiplomacyState,
   era: number,
-  selfStrength: number,
+  selfStrength: MilitaryStrengthEstimate,
   currentCities: number,
   currentMilitary: number,
-  otherStrengths: Record<string, number>,
+  otherStrengths: Record<string, MilitaryStrengthEstimate>,
 ): DiplomaticDecision | null {
   if (!canOfferVassalage(
     currentCities, diplomacy.vassalage.peakCities,
@@ -135,15 +137,16 @@ export function evaluateVassalage(
   // Find strongest non-enemy civ
   let bestTarget: string | null = null;
   let bestStrength = 0;
-  for (const [civId, strength] of Object.entries(otherStrengths)) {
+  for (const [civId, estimate] of Object.entries(otherStrengths)) {
     if (diplomacy.atWarWith.includes(civId)) continue;
+    const strength = estimate.midpoint;
     if (strength > bestStrength) {
       bestStrength = strength;
       bestTarget = civId;
     }
   }
 
-  if (bestTarget && selfStrength < bestStrength * 0.4) {
+  if (bestTarget && selfStrength.midpoint < bestStrength * 0.4) {
     return { action: 'offer_vassalage', targetCiv: bestTarget };
   }
   return null;

--- a/src/ai/ai-objective-scoring.ts
+++ b/src/ai/ai-objective-scoring.ts
@@ -1,0 +1,285 @@
+import type {
+  AIPlanReason,
+  AIStrategicObjective,
+  AIStrategicRole,
+  AITarget,
+  GameMap,
+} from '@/core/types';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { findPath } from '@/systems/unit-system';
+import { createAIDecisionTrace, type AIDecisionTrace } from './ai-decision-trace';
+
+export interface AIObjectiveCandidate {
+  objective: AIStrategicObjective;
+  target: AITarget;
+  theaterId: string;
+  travelTurns: number;
+  strategicValue: number;
+  expectedLossRatio: number;
+  supplyDistance: number;
+  explicitDistantReasons: AIPlanReason[];
+  requiredRoles: Partial<Record<AIStrategicRole, number>>;
+}
+
+export interface AIObjectiveTravelCandidate extends Omit<AIObjectiveCandidate, 'travelTurns'> {
+  start: { q: number; r: number };
+  domain: 'land' | 'naval' | 'air';
+  movementPoints: number;
+  completedMovementTechHash: string;
+}
+
+export interface AIObjectiveChoiceContext {
+  actorId: string;
+  turn: number;
+  candidates: readonly AIObjectiveCandidate[];
+  availableRoles: Partial<Record<AIStrategicRole, number>>;
+}
+
+export interface AIObjectiveChoice {
+  plan: {
+    objective: AIStrategicObjective;
+    target: AITarget;
+    theaterId: string;
+    reasonCodes: AIPlanReason[];
+    requiredRoles: Partial<Record<AIStrategicRole, number>>;
+    score: number;
+  } | null;
+  demands: AIStrategicRole[];
+  trace: AIDecisionTrace;
+}
+
+const DISTANT_ELIGIBILITY_REASONS = new Set<AIPlanReason>([
+  'retaliate-recent-attack',
+  'continue-active-war',
+  'alliance-obligation',
+  'critical-resource',
+  'no-local-alternative',
+]);
+
+const OFFENSIVE_OBJECTIVES = new Set<AIStrategicObjective>([
+  'raid',
+  'blockade',
+  'repel',
+  'capture',
+  'support-ally',
+]);
+
+function finiteClamped(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+export function targetStableKey(target: AITarget): string {
+  switch (target.kind) {
+    case 'city':
+    case 'unit':
+    case 'camp':
+      return `${target.kind}:${target.id}`;
+    case 'resource':
+      return `resource:${target.resource}:${hexKey(target.position)}`;
+    case 'region':
+      return `region:${target.id}`;
+  }
+}
+
+function candidateId(candidate: AIObjectiveCandidate): string {
+  return `${candidate.objective}:${targetStableKey(candidate.target)}`;
+}
+
+export function scoreObjectiveCandidate(candidate: AIObjectiveCandidate): number {
+  const travelTurns = finiteClamped(candidate.travelTurns, 0, Number.MAX_SAFE_INTEGER);
+  const strategicValue = finiteClamped(candidate.strategicValue, 0, 100);
+  const expectedLossRatio = finiteClamped(candidate.expectedLossRatio, 0, 2);
+  const supplyDistance = finiteClamped(candidate.supplyDistance, 0, Number.MAX_SAFE_INTEGER);
+  const distancePenalty = 4 * travelTurns + 0.75 * travelTurns * travelTurns;
+  const lossPenalty = 35 * expectedLossRatio;
+  const supplyPenalty = 2 * supplyDistance;
+  const distantReasonBonus = candidate.explicitDistantReasons.length > 0 ? 35 : 0;
+  return strategicValue
+    + distantReasonBonus
+    - distancePenalty
+    - lossPenalty
+    - supplyPenalty;
+}
+
+export function getObjectiveApproximateDistance(
+  map: Pick<GameMap, 'width' | 'wrapsHorizontally'>,
+  start: { q: number; r: number },
+  target: { q: number; r: number },
+): number {
+  return map.wrapsHorizontally
+    ? wrappedHexDistance(start, target, map.width)
+    : hexDistance(start, target);
+}
+
+function targetPosition(target: AITarget): { q: number; r: number } {
+  switch (target.kind) {
+    case 'city':
+    case 'unit':
+    case 'camp':
+      return target.lastKnownPosition;
+    case 'resource':
+      return target.position;
+    case 'region':
+      return target.anchor;
+  }
+}
+
+export function resolveObjectiveTravelCandidates(
+  map: GameMap,
+  candidates: readonly AIObjectiveTravelCandidate[],
+  pathfinder: typeof findPath = findPath,
+): AIObjectiveCandidate[] {
+  const perObjective = new Map<AIStrategicObjective, AIObjectiveTravelCandidate[]>();
+  for (const candidate of candidates) {
+    const group = perObjective.get(candidate.objective) ?? [];
+    group.push(candidate);
+    perObjective.set(candidate.objective, group);
+  }
+
+  const approximate = [...perObjective.values()]
+    .flatMap(group => group
+      .sort((left, right) => {
+        const distanceDelta = getObjectiveApproximateDistance(
+          map,
+          left.start,
+          targetPosition(left.target),
+        ) - getObjectiveApproximateDistance(map, right.start, targetPosition(right.target));
+        return distanceDelta || targetStableKey(left.target).localeCompare(targetStableKey(right.target));
+      })
+      .slice(0, 8))
+    .sort((left, right) => {
+      const distanceDelta = getObjectiveApproximateDistance(
+        map,
+        left.start,
+        targetPosition(left.target),
+      ) - getObjectiveApproximateDistance(map, right.start, targetPosition(right.target));
+      return distanceDelta || candidateId({ ...left, travelTurns: 0 })
+        .localeCompare(candidateId({ ...right, travelTurns: 0 }));
+    })
+    .slice(0, 24);
+
+  const pathLengthByKey = new Map<string, number | null>();
+  return approximate.map(candidate => {
+    const destination = targetPosition(candidate.target);
+    const cacheKey = [
+      candidate.domain,
+      hexKey(candidate.start),
+      hexKey(destination),
+      candidate.completedMovementTechHash,
+    ].join(':');
+    if (!pathLengthByKey.has(cacheKey)) {
+      const path = pathfinder(candidate.start, destination, map, candidate.domain);
+      pathLengthByKey.set(cacheKey, path ? Math.max(0, path.length - 1) : null);
+    }
+    const pathLength = pathLengthByKey.get(cacheKey);
+    const movementPoints = Math.max(1, Math.floor(candidate.movementPoints));
+    const {
+      start: _start,
+      domain: _domain,
+      movementPoints: _movementPoints,
+      completedMovementTechHash: _completedMovementTechHash,
+      ...objective
+    } = candidate;
+    return {
+      ...objective,
+      travelTurns: pathLength === null || pathLength === undefined
+        ? Number.POSITIVE_INFINITY
+        : Math.ceil(pathLength / movementPoints),
+    };
+  });
+}
+
+function missingRoles(
+  candidate: AIObjectiveCandidate,
+  availableRoles: AIObjectiveChoiceContext['availableRoles'],
+): AIStrategicRole[] {
+  return (Object.entries(candidate.requiredRoles) as Array<[AIStrategicRole, number]>)
+    .filter(([role, count]) => (availableRoles[role] ?? 0) < count)
+    .map(([role]) => role);
+}
+
+export function choosePrimaryObjective(
+  context: AIObjectiveChoiceContext,
+): AIObjectiveChoice {
+  const demands = new Set<AIStrategicRole>();
+  const analyzed = context.candidates.map(candidate => {
+    const reasons = candidate.explicitDistantReasons
+      .filter(reason => DISTANT_ELIGIBILITY_REASONS.has(reason));
+    const missing = missingRoles(candidate, context.availableRoles);
+    for (const role of missing) demands.add(role);
+    const exactTargetKnown = !(
+      candidate.target.kind === 'region'
+      && OFFENSIVE_OBJECTIVES.has(candidate.objective)
+    );
+    if (!exactTargetKnown) demands.add('recon');
+    const pathReachable = Number.isFinite(candidate.travelTurns) && candidate.travelTurns >= 0;
+    return {
+      candidate: { ...candidate, explicitDistantReasons: reasons },
+      id: candidateId(candidate),
+      reasons,
+      baseEligible: missing.length === 0 && exactTargetKnown && pathReachable,
+    };
+  });
+
+  const pathCandidates = analyzed.filter(entry => entry.baseEligible);
+  const nearestTurns = pathCandidates.length > 0
+    ? Math.min(...pathCandidates.map(entry => entry.candidate.travelTurns))
+    : Number.POSITIVE_INFINITY;
+  const localityLimit = Number.isFinite(nearestTurns)
+    ? Math.max(nearestTurns + 3, Math.ceil(nearestTurns * 1.5))
+    : Number.NEGATIVE_INFINITY;
+
+  const ranked = analyzed.map(entry => {
+    const local = entry.candidate.travelTurns <= localityLimit;
+    const eligible = entry.baseEligible && (local || entry.reasons.length > 0);
+    return {
+      ...entry,
+      eligible,
+      score: scoreObjectiveCandidate(entry.candidate),
+    };
+  });
+
+  const selected = ranked
+    .filter(entry => entry.eligible)
+    .sort((left, right) =>
+      right.score - left.score || left.id.localeCompare(right.id))[0];
+
+  const selectedReasons = selected ? [...selected.reasons] : [];
+  if (
+    selected
+    && selectedReasons.length === 0
+    && selected.candidate.travelTurns > 6
+    && selected.candidate.travelTurns === nearestTurns
+  ) {
+    selectedReasons.push('no-local-alternative');
+  }
+
+  const trace = createAIDecisionTrace({
+    actorId: context.actorId,
+    turn: context.turn,
+    decision: 'objective',
+    selectedId: selected?.id ?? null,
+    candidates: ranked.map(entry => ({
+      id: entry.id,
+      score: entry.score,
+      eligible: entry.eligible,
+      reasonCodes: entry.reasons,
+    })),
+  });
+
+  return {
+    plan: selected
+      ? {
+          objective: selected.candidate.objective,
+          target: selected.candidate.target,
+          theaterId: selected.candidate.theaterId,
+          reasonCodes: selectedReasons,
+          requiredRoles: { ...selected.candidate.requiredRoles },
+          score: selected.score,
+        }
+      : null,
+    demands: [...demands].sort(),
+    trace,
+  };
+}

--- a/src/ai/ai-objective-scoring.ts
+++ b/src/ai/ai-objective-scoring.ts
@@ -45,6 +45,7 @@ export interface AIObjectiveChoice {
     score: number;
   } | null;
   demands: AIStrategicRole[];
+  eligibleCandidateIds: string[];
   trace: AIDecisionTrace;
 }
 
@@ -87,6 +88,9 @@ function candidateId(candidate: AIObjectiveCandidate): string {
 }
 
 export function scoreObjectiveCandidate(candidate: AIObjectiveCandidate): number {
+  if (!Number.isFinite(candidate.travelTurns) || candidate.travelTurns < 0) {
+    return -Number.MAX_VALUE;
+  }
   const travelTurns = finiteClamped(candidate.travelTurns, 0, Number.MAX_SAFE_INTEGER);
   const strategicValue = finiteClamped(candidate.strategicValue, 0, 100);
   const expectedLossRatio = finiteClamped(candidate.expectedLossRatio, 0, 2);
@@ -280,6 +284,9 @@ export function choosePrimaryObjective(
         }
       : null,
     demands: [...demands].sort(),
+    eligibleCandidateIds: ranked
+      .filter(entry => entry.eligible)
+      .map(entry => entry.id),
     trace,
   };
 }

--- a/src/ai/ai-perception.ts
+++ b/src/ai/ai-perception.ts
@@ -7,12 +7,18 @@ import type {
   Unit,
   UnitType,
 } from '@/core/types';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
-import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import {
+  isTrustedObservedLastSeenTile,
+  refreshLastSeenPresentationsForCiv,
+} from '@/systems/last-seen-presentation';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
 import { TECH_TREE } from '@/systems/tech-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { canInspectUnitForViewer } from '@/systems/viewer-intel';
+import { getVisibleUnitsForPlayer } from '@/systems/espionage-stealth';
 import { decayRememberedConfidence } from '@/systems/actor-perception';
 import {
   estimateMilitaryStrength,
@@ -75,6 +81,28 @@ function isKnownResourceType(resource: string | null): resource is ResourceType 
   return resource !== null && KNOWN_RESOURCE_TYPES.has(resource);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isRememberedUnit(value: unknown): value is {
+  id: string;
+  owner: string;
+  type: UnitType;
+  healthBand: LastSeenHealthBand;
+} {
+  if (!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.owner === 'string'
+    && typeof value.type === 'string'
+    && Object.prototype.hasOwnProperty.call(UNIT_DEFINITIONS, value.type)
+    && (
+      value.healthBand === 'healthy'
+      || value.healthBand === 'damaged'
+      || value.healthBand === 'critical'
+    );
+}
+
 function knownCivIds(state: GameState, actorId: string): string[] {
   const actor = state.civilizations[actorId];
   if (!actor) return [];
@@ -122,19 +150,24 @@ export function buildMajorCivPerception(
 
   const contacted = knownCivIds(state, actorId);
   const contactedSet = new Set(contacted);
+  const relevantOwner = (ownerId: string) =>
+    contactedSet.has(ownerId)
+    || actor.diplomacy.atWarWith.includes(ownerId)
+    || isAlwaysHostilePair(actorId, ownerId);
   const ownCities = actor.cities
     .map(id => state.cities[id])
-    .filter((city): city is City => city !== undefined)
+    .filter((city): city is City => city?.owner === actorId)
     .map(city => structuredClone(city));
   const ownUnits = actor.units
     .map(id => state.units[id])
-    .filter((unit): unit is Unit => unit !== undefined)
+    .filter((unit): unit is Unit => unit?.owner === actorId)
     .map(unit => structuredClone(unit));
 
   const unitsById = new Map<string, AIPerceivedUnit>();
-  for (const unit of Object.values(state.units)) {
+  const viewerFacingUnits = getVisibleUnitsForPlayer(state.units, state, actorId);
+  for (const unit of Object.values(viewerFacingUnits)) {
     if (
-      !contactedSet.has(unit.owner)
+      !relevantOwner(unit.owner)
       || unit.transportId
       || !canInspectUnitForViewer(state, actorId, unit.id)
       || isForestConcealedUnit(state, actorId, unit)
@@ -154,19 +187,19 @@ export function buildMajorCivPerception(
 
   const rememberedCities = new Map<string, MajorCivPerception['knownCities'][number]>();
   const rememberedResources = new Map<string, MajorCivPerception['knownResources'][number]>();
-  for (const [key, snapshot] of Object.entries(actor.visibility.lastSeen ?? {})) {
-    if (
-      snapshot.source !== 'observed'
-      || !Number.isFinite(snapshot.observedTurn)
-      || snapshot.observedTurn === undefined
-    ) {
-      continue;
-    }
+  for (const [key, value] of Object.entries(actor.visibility.lastSeen ?? {})) {
+    if (!isTrustedObservedLastSeenTile(value)) continue;
+    const snapshot = value;
     const age = state.turn - snapshot.observedTurn;
     if (age < 0 || decayRememberedConfidence(age) <= 0) continue;
-    if (getVisibility(actor.visibility, snapshot.coord) === 'visible') continue;
+    if (getVisibility(actor.visibility, snapshot.coord) !== 'fog') continue;
 
-    if (snapshot.city && contactedSet.has(snapshot.city.owner)) {
+    if (
+      isRecord(snapshot.city)
+      && typeof snapshot.city.id === 'string'
+      && typeof snapshot.city.owner === 'string'
+      && contactedSet.has(snapshot.city.owner)
+    ) {
       rememberedCities.set(snapshot.city.id, {
         id: snapshot.city.id,
         owner: snapshot.city.owner,
@@ -184,8 +217,11 @@ export function buildMajorCivPerception(
         observedTurn: snapshot.observedTurn,
       });
     }
-    for (const unit of snapshot.units ?? []) {
-      if (!contactedSet.has(unit.owner) || unitsById.has(unit.id)) continue;
+    const rememberedUnits = Array.isArray(snapshot.units)
+      ? snapshot.units.filter(isRememberedUnit)
+      : [];
+    for (const unit of rememberedUnits) {
+      if (!relevantOwner(unit.owner) || unitsById.has(unit.id)) continue;
       unitsById.set(unit.id, {
         id: unit.id,
         owner: unit.owner,
@@ -258,7 +294,11 @@ export function buildMajorCivPerception(
     knownOpponentCapabilities[civId] = {
       observedUnitTypes,
       inferredEraMin: Math.max(1, ...observedUnitTypes.map(requiredEraForUnit)),
-      inferredEraMax: Math.max(1, state.era),
+      inferredEraMax: Math.max(
+        1,
+        state.era,
+        ...observedUnitTypes.map(requiredEraForUnit),
+      ),
     };
   }
 

--- a/src/ai/ai-perception.ts
+++ b/src/ai/ai-perception.ts
@@ -1,0 +1,339 @@
+import type {
+  City,
+  GameState,
+  HexCoord,
+  LastSeenHealthBand,
+  ResourceType,
+  Unit,
+  UnitType,
+} from '@/core/types';
+import { getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
+import { hexKey } from '@/systems/hex-utils';
+import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
+import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
+import { TECH_TREE } from '@/systems/tech-system';
+import { canInspectUnitForViewer } from '@/systems/viewer-intel';
+import { decayRememberedConfidence } from '@/systems/actor-perception';
+import {
+  estimateMilitaryStrength,
+  getMedianFrontlineStrengthForEra,
+  type AIStrengthObservation,
+  type MilitaryStrengthEstimate,
+} from './ai-strength';
+
+export type AIPerceptionConfidence = 'visible' | 'remembered' | 'rumored';
+
+export interface AIPerceivedUnit {
+  id: string;
+  owner: string;
+  type: UnitType | null;
+  position: HexCoord | null;
+  lastSeenTurn: number | null;
+  confidence: AIPerceptionConfidence;
+  healthBand: LastSeenHealthBand | null;
+}
+
+export interface MajorCivPerception {
+  actorId: string;
+  turn: number;
+  ownCities: ReadonlyArray<Readonly<City>>;
+  ownUnits: ReadonlyArray<Readonly<Unit>>;
+  knownCities: Array<{
+    id: string;
+    owner: string;
+    position: HexCoord | null;
+    confidence: AIPerceptionConfidence;
+    observedTurn: number | null;
+  }>;
+  units: AIPerceivedUnit[];
+  knownCivIds: string[];
+  knownResources: Array<{
+    resource: ResourceType;
+    position: HexCoord;
+    owner: string | null;
+    confidence: 'visible' | 'remembered';
+    observedTurn: number;
+  }>;
+  knownOpponentCapabilities: Record<string, {
+    observedUnitTypes: UnitType[];
+    inferredEraMin: number;
+    inferredEraMax: number;
+  }>;
+}
+
+const HEALTH_MIDPOINTS: Record<LastSeenHealthBand, number> = {
+  healthy: 85,
+  damaged: 52,
+  critical: 17,
+};
+
+const KNOWN_RESOURCE_TYPES = new Set<string>(
+  RESOURCE_DEFINITIONS.map(definition => definition.id),
+);
+
+function isKnownResourceType(resource: string | null): resource is ResourceType {
+  return resource !== null && KNOWN_RESOURCE_TYPES.has(resource);
+}
+
+function knownCivIds(state: GameState, actorId: string): string[] {
+  const actor = state.civilizations[actorId];
+  if (!actor) return [];
+  const ids = new Set(actor.knownCivilizations ?? []);
+  for (const id of actor.diplomacy.atWarWith ?? []) ids.add(id);
+  for (const treaty of actor.diplomacy.treaties ?? []) {
+    if (treaty.civA === actorId) ids.add(treaty.civB);
+    if (treaty.civB === actorId) ids.add(treaty.civA);
+  }
+  ids.delete(actorId);
+  return [...ids]
+    .filter(id => state.civilizations[id] !== undefined)
+    .sort();
+}
+
+function copyCoord(coord: HexCoord): HexCoord {
+  return { q: coord.q, r: coord.r };
+}
+
+function healthBand(health: number): LastSeenHealthBand {
+  if (health >= 70) return 'healthy';
+  if (health >= 30) return 'damaged';
+  return 'critical';
+}
+
+function requiredEraForUnit(type: UnitType): number {
+  const unlock = TECH_TREE.find(tech => tech.unlocksUnits?.includes(type));
+  return unlock?.era ?? 1;
+}
+
+export function refreshMajorCivIntel(state: GameState, civId: string): GameState {
+  const nextState = structuredClone(state);
+  refreshLastSeenPresentationsForCiv(nextState, civId);
+  return nextState;
+}
+
+export function buildMajorCivPerception(
+  state: GameState,
+  actorId: string,
+): MajorCivPerception {
+  const actor = state.civilizations[actorId];
+  if (!actor) {
+    throw new Error(`Cannot build perception for missing civilization: ${actorId}`);
+  }
+
+  const contacted = knownCivIds(state, actorId);
+  const contactedSet = new Set(contacted);
+  const ownCities = actor.cities
+    .map(id => state.cities[id])
+    .filter((city): city is City => city !== undefined)
+    .map(city => structuredClone(city));
+  const ownUnits = actor.units
+    .map(id => state.units[id])
+    .filter((unit): unit is Unit => unit !== undefined)
+    .map(unit => structuredClone(unit));
+
+  const unitsById = new Map<string, AIPerceivedUnit>();
+  for (const unit of Object.values(state.units)) {
+    if (
+      !contactedSet.has(unit.owner)
+      || unit.transportId
+      || !canInspectUnitForViewer(state, actorId, unit.id)
+      || isForestConcealedUnit(state, actorId, unit)
+    ) {
+      continue;
+    }
+    unitsById.set(unit.id, {
+      id: unit.id,
+      owner: unit.owner,
+      type: unit.type,
+      position: copyCoord(unit.position),
+      lastSeenTurn: state.turn,
+      confidence: 'visible',
+      healthBand: healthBand(unit.health),
+    });
+  }
+
+  const rememberedCities = new Map<string, MajorCivPerception['knownCities'][number]>();
+  const rememberedResources = new Map<string, MajorCivPerception['knownResources'][number]>();
+  for (const [key, snapshot] of Object.entries(actor.visibility.lastSeen ?? {})) {
+    if (
+      snapshot.source !== 'observed'
+      || !Number.isFinite(snapshot.observedTurn)
+      || snapshot.observedTurn === undefined
+    ) {
+      continue;
+    }
+    const age = state.turn - snapshot.observedTurn;
+    if (age < 0 || decayRememberedConfidence(age) <= 0) continue;
+    if (getVisibility(actor.visibility, snapshot.coord) === 'visible') continue;
+
+    if (snapshot.city && contactedSet.has(snapshot.city.owner)) {
+      rememberedCities.set(snapshot.city.id, {
+        id: snapshot.city.id,
+        owner: snapshot.city.owner,
+        position: copyCoord(snapshot.coord),
+        confidence: 'remembered',
+        observedTurn: snapshot.observedTurn,
+      });
+    }
+    if (isKnownResourceType(snapshot.resource)) {
+      rememberedResources.set(key, {
+        resource: snapshot.resource,
+        position: copyCoord(snapshot.coord),
+        owner: snapshot.owner,
+        confidence: 'remembered',
+        observedTurn: snapshot.observedTurn,
+      });
+    }
+    for (const unit of snapshot.units ?? []) {
+      if (!contactedSet.has(unit.owner) || unitsById.has(unit.id)) continue;
+      unitsById.set(unit.id, {
+        id: unit.id,
+        owner: unit.owner,
+        type: unit.type,
+        position: copyCoord(snapshot.coord),
+        lastSeenTurn: snapshot.observedTurn,
+        confidence: 'remembered',
+        healthBand: unit.healthBand,
+      });
+    }
+  }
+
+  const knownCities = [...rememberedCities.values()];
+  for (const civId of contacted) {
+    for (const cityId of state.civilizations[civId].cities) {
+      const city = state.cities[cityId];
+      if (!city || getVisibility(actor.visibility, city.position) !== 'visible') continue;
+      const known = {
+        id: city.id,
+        owner: city.owner,
+        position: copyCoord(city.position),
+        confidence: 'visible' as const,
+        observedTurn: state.turn,
+      };
+      const index = knownCities.findIndex(candidate => candidate.id === city.id);
+      if (index >= 0) knownCities[index] = known;
+      else knownCities.push(known);
+    }
+    if (!knownCities.some(city => city.owner === civId)) {
+      knownCities.push({
+        id: `rumor:${civId}:seat`,
+        owner: civId,
+        position: null,
+        confidence: 'rumored',
+        observedTurn: null,
+      });
+    }
+  }
+  knownCities.sort((left, right) => left.id.localeCompare(right.id));
+
+  const knownResources = [...rememberedResources.values()];
+  for (const [key, tile] of Object.entries(state.map.tiles)) {
+    if (
+      !isKnownResourceType(tile.resource)
+      || getVisibility(actor.visibility, tile.coord) !== 'visible'
+    ) {
+      continue;
+    }
+    const visible = {
+      resource: tile.resource,
+      position: copyCoord(tile.coord),
+      owner: tile.owner,
+      confidence: 'visible' as const,
+      observedTurn: state.turn,
+    };
+    const index = knownResources.findIndex(resource => hexKey(resource.position) === key);
+    if (index >= 0) knownResources[index] = visible;
+    else knownResources.push(visible);
+  }
+  knownResources.sort((left, right) =>
+    hexKey(left.position).localeCompare(hexKey(right.position)));
+
+  const units = [...unitsById.values()].sort((left, right) => left.id.localeCompare(right.id));
+  const knownOpponentCapabilities: MajorCivPerception['knownOpponentCapabilities'] = {};
+  for (const civId of contacted) {
+    const observedUnitTypes = [...new Set(
+      units.filter(unit => unit.owner === civId && unit.type !== null)
+        .map(unit => unit.type!),
+    )].sort();
+    knownOpponentCapabilities[civId] = {
+      observedUnitTypes,
+      inferredEraMin: Math.max(1, ...observedUnitTypes.map(requiredEraForUnit)),
+      inferredEraMax: Math.max(1, state.era),
+    };
+  }
+
+  return {
+    actorId,
+    turn: state.turn,
+    ownCities,
+    ownUnits,
+    knownCities,
+    units,
+    knownCivIds: contacted,
+    knownResources,
+    knownOpponentCapabilities,
+  };
+}
+
+export function estimatePerceivedCivStrength(
+  perception: MajorCivPerception,
+  ownerId: string,
+  actorEra: number,
+): MilitaryStrengthEstimate {
+  const observations: AIStrengthObservation[] = ownerId === perception.actorId
+    ? perception.ownUnits.map(unit => ({
+        type: unit.type,
+        health: unit.health,
+        experience: unit.experience,
+        source: 'visible',
+        confidence: 1,
+        uncertainty: 0,
+        locallyAvailable: !unit.transportId,
+        cargoOrCaptured: Boolean(unit.transportId),
+      }))
+    : perception.units
+        .filter(unit => unit.owner === ownerId && unit.type && unit.healthBand)
+        .map(unit => {
+          const confidence = unit.confidence === 'visible'
+            ? 1
+            : decayRememberedConfidence(perception.turn - (unit.lastSeenTurn ?? perception.turn));
+          return {
+            type: unit.type!,
+            health: HEALTH_MIDPOINTS[unit.healthBand!],
+            experience: 0,
+            source: unit.confidence === 'visible' ? 'visible' : 'remembered',
+            confidence,
+            uncertainty: unit.confidence === 'visible' ? 0 : 1 - confidence,
+            locallyAvailable: true,
+            cargoOrCaptured: false,
+          };
+        });
+
+  const median = getMedianFrontlineStrengthForEra(actorEra);
+  const knownCityCount = perception.knownCities
+    .filter(city => city.owner === ownerId && city.confidence !== 'rumored')
+    .length;
+  const unknownReserveUpper = ownerId === perception.actorId
+    ? 0
+    : Math.max(0.5, knownCityCount) * median * 0.5;
+
+  return estimateMilitaryStrength(observations, { unknownReserveUpper });
+}
+
+export function buildDiplomaticStrengthEstimates(
+  perception: MajorCivPerception,
+  actorEra: number,
+): {
+  self: MilitaryStrengthEstimate;
+  others: Record<string, MilitaryStrengthEstimate>;
+} {
+  return {
+    self: estimatePerceivedCivStrength(perception, perception.actorId, actorEra),
+    others: Object.fromEntries(
+      perception.knownCivIds.map(civId => [
+        civId,
+        estimatePerceivedCivStrength(perception, civId, actorEra),
+      ]),
+    ),
+  };
+}

--- a/src/ai/ai-plan-portfolio.ts
+++ b/src/ai/ai-plan-portfolio.ts
@@ -239,14 +239,17 @@ function rankRetainedThreats(
   urgentCityIds: ReadonlySet<string>,
 ): AICityThreat[] {
   return [...context.cityThreats]
-    .filter(threat =>
-      !urgentCityIds.has(threat.cityId)
-      && context.portfolio.defensePlansByCityId[threat.cityId] !== undefined
-      && threat.threatStillValid
-      && (
-        threat.travelTurns <= 6
-        || (threat.consecutiveBeyondSixPhases ?? 0) < 2
-      ))
+    .filter(threat => {
+      const existing = context.portfolio.defensePlansByCityId[threat.cityId];
+      if (urgentCityIds.has(threat.cityId) || !existing || !threat.threatStillValid) {
+        return false;
+      }
+      if (threat.travelTurns <= 6) return true;
+      if (threat.consecutiveBeyondSixPhases !== undefined) {
+        return threat.consecutiveBeyondSixPhases < 2;
+      }
+      return context.turn - existing.lastProgressTurn < 2;
+    })
     .sort((left, right) =>
       left.travelTurns - right.travelTurns
       || right.captureRisk - left.captureRisk
@@ -292,6 +295,9 @@ export function refreshMajorCivPortfolio(
       existing
         ? {
             ...existing,
+            lastProgressTurn: threat.travelTurns <= 6
+              ? context.turn
+              : existing.lastProgressTurn,
             target: structuredClone(existing.target),
             reasonCodes: [...existing.reasonCodes],
             requiredRoles: { ...existing.requiredRoles },

--- a/src/ai/ai-plan-portfolio.ts
+++ b/src/ai/ai-plan-portfolio.ts
@@ -1,0 +1,324 @@
+import type {
+  AIPlanReason,
+  AIStrategicObjective,
+  AIStrategicPlan,
+  AIStrategicRole,
+  AITarget,
+  HexCoord,
+  MajorCivPlanPortfolio,
+} from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { targetStableKey } from './ai-objective-scoring';
+
+export interface AIPlanCandidate {
+  objective: AIStrategicObjective;
+  target: AITarget;
+  theaterId: string;
+  score: number;
+  reasonCodes: AIPlanReason[];
+  requiredRoles: Partial<Record<AIStrategicRole, number>>;
+  commitment: number;
+  targetValid: boolean;
+  reasonValid: boolean;
+  expectedLossRatio: number;
+  progress: boolean;
+}
+
+export interface AICityThreat {
+  cityId: string;
+  position: HexCoord;
+  theaterId?: string;
+  travelTurns: number;
+  alreadyAttackedTerritory: boolean;
+  captureRisk: number;
+  hostileStrength: number;
+  isCapital: boolean;
+  isLastCity: boolean;
+  threatStillValid: boolean;
+  consecutiveBeyondSixPhases?: number;
+}
+
+export interface AIModernizationFactors {
+  bestTrainableStrength: number;
+  deployedStrength: number;
+  actorEra: number;
+  globalEra: number;
+  knownRivalMaxStrength: number;
+  obsoleteUnitShare: number;
+  treasuryCanAct: boolean;
+}
+
+export interface AIPortfolioContext {
+  actorId: string;
+  turn: number;
+  actorEliminated: boolean;
+  portfolio: MajorCivPlanPortfolio;
+  candidates: readonly AIPlanCandidate[];
+  cityThreats: readonly AICityThreat[];
+  modernization: AIModernizationFactors;
+}
+
+export interface AIPortfolioRefreshResult {
+  portfolio: MajorCivPlanPortfolio;
+  unplannedDefenseCityIds: string[];
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.max(minimum, Math.min(maximum, value));
+}
+
+export function createEmptyMajorCivPortfolio(): MajorCivPlanPortfolio {
+  return {
+    primaryPlan: null,
+    defensePlansByCityId: {},
+    upgradeRoutesByUnitId: {},
+    modernizationDemand: 0,
+    researchTargetTechId: null,
+    lastPlannedTurn: -1,
+    lastExecutedTurn: -1,
+  };
+}
+
+function planMatchesCandidate(
+  plan: AIStrategicPlan,
+  candidate: AIPlanCandidate,
+): boolean {
+  return plan.objective === candidate.objective
+    && targetStableKey(plan.target) === targetStableKey(candidate.target);
+}
+
+function deterministicPlanId(
+  actorId: string,
+  objective: AIStrategicObjective,
+  target: AITarget,
+  createdTurn: number,
+): string {
+  return `ai-plan:${actorId}:${objective}:${targetStableKey(target)}:${createdTurn}`;
+}
+
+function normalizedTheater(theaterId: string | undefined, anchor: HexCoord): string {
+  const trimmed = theaterId?.trim();
+  return trimmed ? trimmed : `local:${hexKey(anchor)}`;
+}
+
+function targetAnchor(target: AITarget): HexCoord {
+  switch (target.kind) {
+    case 'city':
+    case 'unit':
+    case 'camp':
+      return target.lastKnownPosition;
+    case 'resource':
+      return target.position;
+    case 'region':
+      return target.anchor;
+  }
+}
+
+function createPlan(
+  context: Pick<AIPortfolioContext, 'actorId' | 'turn'>,
+  candidate: AIPlanCandidate,
+): AIStrategicPlan {
+  return {
+    id: deterministicPlanId(
+      context.actorId,
+      candidate.objective,
+      candidate.target,
+      context.turn,
+    ),
+    actorId: context.actorId,
+    objective: candidate.objective,
+    target: structuredClone(candidate.target),
+    theaterId: normalizedTheater(candidate.theaterId, targetAnchor(candidate.target)),
+    phase: 'mobilizing',
+    reasonCodes: [...candidate.reasonCodes],
+    commitment: clamp(candidate.commitment, 0, 1),
+    createdTurn: context.turn,
+    reconsiderAfterTurn: context.turn + 3,
+    expiresAfterTurn: context.turn + 12,
+    lastProgressTurn: context.turn,
+    requiredRoles: { ...candidate.requiredRoles },
+    assignedUnitIds: [],
+  };
+}
+
+function currentPlanIsValid(
+  plan: AIStrategicPlan,
+  candidate: AIPlanCandidate | undefined,
+  turn: number,
+): boolean {
+  if (!candidate?.targetValid || !candidate.reasonValid) return false;
+  if (candidate.expectedLossRatio > 1.5) return false;
+  if (turn > plan.expiresAfterTurn) return false;
+  const stalledPastReconsideration = turn >= plan.reconsiderAfterTurn
+    && !candidate.progress
+    && plan.lastProgressTurn < plan.reconsiderAfterTurn;
+  return !stalledPastReconsideration;
+}
+
+function selectPrimaryPlan(context: AIPortfolioContext): AIStrategicPlan | null {
+  const ranked = [...context.candidates]
+    .filter(candidate =>
+      candidate.targetValid
+      && candidate.reasonValid
+      && candidate.expectedLossRatio <= 1.5)
+    .sort((left, right) =>
+      right.score - left.score
+      || targetStableKey(left.target).localeCompare(targetStableKey(right.target)));
+  const best = ranked[0];
+  const current = context.portfolio.primaryPlan;
+  const currentCandidate = current
+    ? context.candidates.find(candidate => planMatchesCandidate(current, candidate))
+    : undefined;
+
+  if (current && currentPlanIsValid(current, currentCandidate, context.turn)) {
+    const switchingBonus = 10 + 20 * clamp(current.commitment, 0, 1);
+    if (!best || (currentCandidate?.score ?? Number.NEGATIVE_INFINITY) + switchingBonus >= best.score) {
+      return {
+        ...current,
+        lastProgressTurn: currentCandidate?.progress ? context.turn : current.lastProgressTurn,
+        commitment: clamp(current.commitment, 0, 1),
+        reasonCodes: currentCandidate ? [...currentCandidate.reasonCodes] : [...current.reasonCodes],
+        requiredRoles: currentCandidate
+          ? { ...currentCandidate.requiredRoles }
+          : { ...current.requiredRoles },
+      };
+    }
+  }
+
+  return best ? createPlan(context, best) : null;
+}
+
+function createDefensePlan(
+  context: AIPortfolioContext,
+  threat: AICityThreat,
+): AIStrategicPlan {
+  const target: AITarget = {
+    kind: 'city',
+    id: threat.cityId,
+    lastKnownPosition: { ...threat.position },
+  };
+  return {
+    id: deterministicPlanId(context.actorId, 'defend', target, context.turn),
+    actorId: context.actorId,
+    objective: 'defend',
+    target,
+    theaterId: normalizedTheater(threat.theaterId, threat.position),
+    phase: 'mobilizing',
+    reasonCodes: ['urgent-defense'],
+    commitment: 1,
+    createdTurn: context.turn,
+    reconsiderAfterTurn: context.turn + 1,
+    expiresAfterTurn: context.turn + 6,
+    lastProgressTurn: context.turn,
+    rallyPoint: { ...threat.position },
+    requiredRoles: { frontline: 1, ranged: 1 },
+    assignedUnitIds: [],
+  };
+}
+
+function rankUrgentThreats(threats: readonly AICityThreat[]): AICityThreat[] {
+  const unique = new Map<string, AICityThreat>();
+  for (const threat of threats) {
+    const existing = unique.get(threat.cityId);
+    if (
+      !existing
+      || threat.alreadyAttackedTerritory && !existing.alreadyAttackedTerritory
+      || threat.captureRisk > existing.captureRisk
+    ) {
+      unique.set(threat.cityId, threat);
+    }
+  }
+  return [...unique.values()]
+    .filter(threat =>
+      threat.threatStillValid
+      && (threat.alreadyAttackedTerritory || threat.travelTurns <= 3))
+    .sort((left, right) =>
+      Number(right.alreadyAttackedTerritory) - Number(left.alreadyAttackedTerritory)
+      || right.captureRisk - left.captureRisk
+      || Number(right.isCapital || right.isLastCity) - Number(left.isCapital || left.isLastCity)
+      || right.hostileStrength - left.hostileStrength
+      || left.cityId.localeCompare(right.cityId));
+}
+
+function rankRetainedThreats(
+  context: AIPortfolioContext,
+  urgentCityIds: ReadonlySet<string>,
+): AICityThreat[] {
+  return [...context.cityThreats]
+    .filter(threat =>
+      !urgentCityIds.has(threat.cityId)
+      && context.portfolio.defensePlansByCityId[threat.cityId] !== undefined
+      && threat.threatStillValid
+      && (
+        threat.travelTurns <= 6
+        || (threat.consecutiveBeyondSixPhases ?? 0) < 2
+      ))
+    .sort((left, right) =>
+      left.travelTurns - right.travelTurns
+      || right.captureRisk - left.captureRisk
+      || left.cityId.localeCompare(right.cityId));
+}
+
+export function calculateModernizationDemand(
+  factors: AIModernizationFactors,
+): number {
+  const trainable = Math.max(0, factors.bestTrainableStrength);
+  const deployed = Math.max(0, factors.deployedStrength);
+  const roleGap = trainable > 0 ? Math.max(0, trainable - deployed) / trainable : 0;
+  const eraGap = Math.max(0, factors.globalEra - factors.actorEra) / Math.max(1, factors.globalEra);
+  const rivalGap = factors.knownRivalMaxStrength > 0
+    ? Math.max(0, factors.knownRivalMaxStrength - deployed) / factors.knownRivalMaxStrength
+    : 0;
+  const obsoleteShare = clamp(factors.obsoleteUnitShare, 0, 1);
+  const raw = roleGap * 35 + eraGap * 20 + rivalGap * 25 + obsoleteShare * 20;
+  return Math.round(clamp(raw * (factors.treasuryCanAct ? 1 : 0.8), 0, 100));
+}
+
+export function refreshMajorCivPortfolio(
+  context: AIPortfolioContext,
+): AIPortfolioRefreshResult {
+  if (context.actorEliminated) {
+    return {
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        lastPlannedTurn: context.turn,
+      },
+      unplannedDefenseCityIds: [],
+    };
+  }
+
+  const urgentThreats = rankUrgentThreats(context.cityThreats);
+  const urgentCityIds = new Set(urgentThreats.map(threat => threat.cityId));
+  const retainedThreats = rankRetainedThreats(context, urgentCityIds);
+  const plannedThreats = [...urgentThreats, ...retainedThreats].slice(0, 4);
+  const defensePlansByCityId = Object.fromEntries(plannedThreats.map(threat => {
+    const existing = context.portfolio.defensePlansByCityId[threat.cityId];
+    return [
+      threat.cityId,
+      existing
+        ? {
+            ...existing,
+            target: structuredClone(existing.target),
+            reasonCodes: [...existing.reasonCodes],
+            requiredRoles: { ...existing.requiredRoles },
+            assignedUnitIds: [...existing.assignedUnitIds],
+          }
+        : createDefensePlan(context, threat),
+    ];
+  }));
+
+  return {
+    portfolio: {
+      ...context.portfolio,
+      primaryPlan: selectPrimaryPlan(context),
+      defensePlansByCityId,
+      upgradeRoutesByUnitId: { ...context.portfolio.upgradeRoutesByUnitId },
+      modernizationDemand: calculateModernizationDemand(context.modernization),
+      lastPlannedTurn: context.turn,
+    },
+    unplannedDefenseCityIds: urgentThreats
+      .filter(threat => !plannedThreats.some(planned => planned.cityId === threat.cityId))
+      .map(threat => threat.cityId),
+  };
+}

--- a/src/ai/ai-plan-portfolio.ts
+++ b/src/ai/ai-plan-portfolio.ts
@@ -9,6 +9,7 @@ import type {
 } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { targetStableKey } from './ai-objective-scoring';
+import { createEmptyMajorCivPlanPortfolio } from '@/core/opponent-ai-state';
 
 export interface AIPlanCandidate {
   objective: AIStrategicObjective;
@@ -69,15 +70,7 @@ function clamp(value: number, minimum: number, maximum: number): number {
 }
 
 export function createEmptyMajorCivPortfolio(): MajorCivPlanPortfolio {
-  return {
-    primaryPlan: null,
-    defensePlansByCityId: {},
-    upgradeRoutesByUnitId: {},
-    modernizationDemand: 0,
-    researchTargetTechId: null,
-    lastPlannedTurn: -1,
-    lastExecutedTurn: -1,
-  };
+  return createEmptyMajorCivPlanPortfolio();
 }
 
 function planMatchesCandidate(

--- a/src/ai/ai-prepared-turn.ts
+++ b/src/ai/ai-prepared-turn.ts
@@ -1,10 +1,20 @@
 import type { EventBus } from '@/core/event-bus';
-import type { GameState, MajorCivPlanPortfolio } from '@/core/types';
-import { hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
-import { getTrainableUnitsForCiv } from '@/systems/city-system';
-import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
+import type {
+  AIStrategicPlan,
+  GameMap,
+  GameState,
+  MajorCivPlanPortfolio,
+} from '@/core/types';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { getTrainableUnitsForCiv, TRAINABLE_UNITS } from '@/systems/city-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { isTrustedObservedLastSeenTile } from '@/systems/last-seen-presentation';
+import { resolveCivilizationEra } from '@/systems/tech-definitions';
+import { findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import {
   buildMajorCivPerception,
+  estimatePerceivedCivStrength,
   type MajorCivPerception,
 } from './ai-perception';
 import type { AIDecisionTrace } from './ai-decision-trace';
@@ -54,6 +64,45 @@ export type ExecutePreparedMajorCivPlan = (
   bus: EventBus,
 ) => ProcessMajorCivStrategicTurnResult;
 
+export interface PreparedForceDemandSeed {
+  role: AIForceDemand['role'];
+  sourceId: string;
+  priority: number;
+}
+
+export function mergePreparedForceDemands(
+  assignmentDemands: readonly AIForceDemand[],
+  additionalDemands: readonly PreparedForceDemandSeed[],
+): AIForceDemand[] {
+  const byRole = new Map(assignmentDemands.map(demand => [
+    demand.role,
+    {
+      ...demand,
+      sourcePlanIds: [...demand.sourcePlanIds],
+    },
+  ]));
+  for (const addition of additionalDemands) {
+    const existing = byRole.get(addition.role) ?? {
+      role: addition.role,
+      desired: 0,
+      assigned: 0,
+      missing: 0,
+      priority: 0,
+      sourcePlanIds: [],
+    };
+    existing.desired += 1;
+    existing.missing = Math.max(0, existing.desired - existing.assigned);
+    existing.priority = Math.max(existing.priority, addition.priority);
+    existing.sourcePlanIds = [...new Set([
+      ...existing.sourcePlanIds,
+      addition.sourceId,
+    ])].sort();
+    byRole.set(addition.role, existing);
+  }
+  return [...byRole.values()].sort((left, right) =>
+    right.priority - left.priority || left.role.localeCompare(right.role));
+}
+
 function distance(
   state: Readonly<GameState>,
   left: { q: number; r: number },
@@ -64,25 +113,77 @@ function distance(
     : hexDistance(left, right);
 }
 
+function buildKnownPathMap(
+  state: Readonly<GameState>,
+  civId: string,
+): GameMap {
+  const actor = state.civilizations[civId];
+  const knownMap = structuredClone(state.map);
+  if (!actor) {
+    knownMap.tiles = {};
+    return knownMap;
+  }
+  for (const key of Object.keys(knownMap.tiles)) {
+    const visibility = actor.visibility.tiles[key] ?? 'unexplored';
+    if (visibility === 'visible') continue;
+    const snapshot = actor.visibility.lastSeen?.[key];
+    if (visibility !== 'fog' || !isTrustedObservedLastSeenTile(snapshot)) {
+      delete knownMap.tiles[key];
+      continue;
+    }
+    knownMap.tiles[key] = {
+      coord: { ...snapshot.coord },
+      terrain: snapshot.terrain,
+      elevation: snapshot.elevation,
+      resource: snapshot.resource,
+      improvement: snapshot.improvement,
+      improvementTurnsLeft: snapshot.improvementTurnsLeft,
+      owner: snapshot.owner,
+      hasRiver: snapshot.hasRiver,
+      wonder: snapshot.wonder,
+    };
+  }
+  return knownMap;
+}
+
 function objectiveCandidates(
   state: Readonly<GameState>,
   civId: string,
   perception: MajorCivPerception,
+  knownMap: GameMap,
 ): AIObjectiveCandidate[] {
   const actor = state.civilizations[civId];
-  const anchor = perception.ownCities[0]?.position ?? perception.ownUnits[0]?.position;
-  if (!actor || !anchor) return [];
+  const operationalAnchors = perception.ownCities.length > 0
+    ? perception.ownCities.map(city => city.position)
+    : perception.ownUnits
+        .filter(unit => !unit.transportId)
+        .map(unit => unit.position);
+  if (!actor || operationalAnchors.length === 0) return [];
+  const nearestAnchor = (target: { q: number; r: number }) =>
+    [...operationalAnchors].sort((left, right) =>
+      distance(state, left, target) - distance(state, right, target)
+      || hexKey(left).localeCompare(hexKey(right)))[0];
 
   const candidates: AIObjectiveCandidate[] = [];
+  const startByCandidate = new Map<AIObjectiveCandidate, { q: number; r: number }>();
+  const actorEra = resolveCivilizationEra(actor.techState.completed);
+  const ownStrength = estimatePerceivedCivStrength(perception, civId, actorEra).midpoint;
   for (const city of perception.knownCities) {
     if (!city.position || city.owner === civId) continue;
+    const anchor = nearestAnchor(city.position);
     const travelTurns = Math.ceil(distance(state, anchor, city.position) / 2);
     const recentAttack = actor.diplomacy.events.some(event =>
       event.type === 'military_attacked'
       && event.otherCiv === city.owner
       && state.turn - event.turn <= 6);
     const activeWar = actor.diplomacy.atWarWith.includes(city.owner);
-    candidates.push({
+    if (!activeWar && !recentAttack) continue;
+    const rivalStrength = estimatePerceivedCivStrength(
+      perception,
+      city.owner,
+      actorEra,
+    ).midpoint;
+    const candidate: AIObjectiveCandidate = {
       objective: 'capture',
       target: {
         kind: 'city',
@@ -92,7 +193,7 @@ function objectiveCandidates(
       theaterId: `local:${city.position.q},${city.position.r}`,
       travelTurns,
       strategicValue: activeWar ? 75 : 45,
-      expectedLossRatio: 0.75,
+      expectedLossRatio: Math.min(2, rivalStrength / Math.max(1, ownStrength)),
       supplyDistance: travelTurns,
       explicitDistantReasons: recentAttack
         ? ['retaliate-recent-attack']
@@ -100,11 +201,19 @@ function objectiveCandidates(
           ? ['continue-active-war']
           : [],
       requiredRoles: { frontline: 1, capture: 1 },
-    });
+    };
+    candidates.push(candidate);
+    startByCandidate.set(candidate, anchor);
   }
-  for (const resource of perception.knownResources.filter(entry => entry.owner !== civId)) {
+  for (const resource of perception.knownResources.filter(entry =>
+    entry.owner === null
+    || (
+      entry.owner !== civId
+      && actor.diplomacy.atWarWith.includes(entry.owner)
+    ))) {
+    const anchor = nearestAnchor(resource.position);
     const travelTurns = Math.ceil(distance(state, anchor, resource.position) / 3);
-    candidates.push({
+    const candidate: AIObjectiveCandidate = {
       objective: 'secure-resource',
       target: {
         kind: 'resource',
@@ -118,45 +227,28 @@ function objectiveCandidates(
       supplyDistance: travelTurns,
       explicitDistantReasons: [],
       requiredRoles: { 'resource-expedition': 1 },
-    });
-  }
-  const knownMap = structuredClone(state.map);
-  for (const key of Object.keys(knownMap.tiles)) {
-    const visibility = actor.visibility.tiles[key] ?? 'unexplored';
-    if (visibility === 'visible') continue;
-    const snapshot = actor.visibility.lastSeen?.[key];
-    if (
-      visibility !== 'fog'
-      || snapshot?.source !== 'observed'
-      || !Number.isFinite(snapshot.observedTurn)
-    ) {
-      delete knownMap.tiles[key];
-      continue;
-    }
-    knownMap.tiles[key] = {
-      ...knownMap.tiles[key],
-      coord: { ...snapshot.coord },
-      terrain: snapshot.terrain,
-      elevation: snapshot.elevation,
-      resource: snapshot.resource,
-      improvement: snapshot.improvement,
-      improvementTurnsLeft: snapshot.improvementTurnsLeft,
-      owner: snapshot.owner,
-      hasRiver: snapshot.hasRiver,
-      wonder: snapshot.wonder,
     };
+    candidates.push(candidate);
+    startByCandidate.set(candidate, anchor);
   }
   const travelInputs: AIObjectiveTravelCandidate[] = candidates.map(candidate => {
     const { travelTurns: _travelTurns, ...withoutTravel } = candidate;
     return {
       ...withoutTravel,
-      start: { ...anchor },
+      start: { ...startByCandidate.get(candidate)! },
       domain: 'land',
       movementPoints: 2,
       completedMovementTechHash: [...actor.techState.completed].sort().join(','),
     };
   });
   return resolveObjectiveTravelCandidates(knownMap, travelInputs);
+}
+
+function planTargetPosition(plan: AIStrategicPlan): { q: number; r: number } {
+  if ('lastKnownPosition' in plan.target) return plan.target.lastKnownPosition;
+  return plan.target.kind === 'resource'
+    ? plan.target.position
+    : plan.target.anchor;
 }
 
 function availableRoleCounts(perception: MajorCivPerception) {
@@ -213,7 +305,7 @@ function cityThreats(
     const hostile = perception.units
       .filter(unit =>
         unit.position
-        && atWar.has(unit.owner)
+        && (atWar.has(unit.owner) || isAlwaysHostilePair(civId, unit.owner))
         && unit.type
         && hasAICombatRole(unit.type))
       .map(unit => ({
@@ -230,7 +322,8 @@ function cityThreats(
       alreadyAttackedTerritory: actor.diplomacy.events.some(event =>
         event.type === 'military_attacked'
         && event.otherCiv === hostile.unit.owner
-        && state.turn - event.turn <= 1),
+        && state.turn - event.turn <= 1
+        && hostile.turns <= 6),
       captureRisk: Math.max(0, 100 - hostile.turns * 20),
       hostileStrength: hostile.unit.type
         ? UNIT_DEFINITIONS[hostile.unit.type].strength
@@ -248,8 +341,10 @@ export function prepareMajorCivStrategicPlan(
 ): PreparedMajorCivPlan {
   const state = planningSnapshot as GameState;
   const civ = state.civilizations[civId];
+  const actorEra = resolveCivilizationEra(civ.techState.completed);
   const perception = buildMajorCivPerception(state, civId);
-  const candidates = objectiveCandidates(state, civId, perception);
+  const knownMap = buildKnownPathMap(state, civId);
+  const candidates = objectiveCandidates(state, civId, perception, knownMap);
   const choice = choosePrimaryObjective({
     actorId: civId,
     turn: state.turn,
@@ -257,26 +352,38 @@ export function prepareMajorCivStrategicPlan(
     availableRoles: availableRoleCounts(perception),
   });
   const previous = state.opponentAI?.majorCivs[civId] ?? createEmptyMajorCivPortfolio();
-  const trainable = getTrainableUnitsForCiv(civ.techState.completed, civ.civType);
+  const trainable = getTrainableUnitsForCiv(
+    civ.techState.completed,
+    civ.civType,
+    getCivAvailableResources(state, civId),
+  );
   const bestTrainableStrength = Math.max(
     0,
     ...trainable.map(entry => UNIT_DEFINITIONS[entry.type].strength),
   );
   const deployedCombat = perception.ownUnits.filter(unit => hasAICombatRole(unit.type));
+  const obsoleteTypes = new Set(
+    TRAINABLE_UNITS
+      .filter(entry =>
+        entry.obsoletedByTech
+        && civ.techState.completed.includes(entry.obsoletedByTech))
+      .map(entry => entry.type),
+  );
+  const threats = cityThreats(state, civId, perception);
   const portfolioResult = refreshMajorCivPortfolio({
     actorId: civId,
     turn: state.turn,
     actorEliminated: civ.isEliminated === true,
     portfolio: previous,
     candidates: planCandidates(candidates, choice),
-    cityThreats: cityThreats(state, civId, perception),
+    cityThreats: threats,
     modernization: {
       bestTrainableStrength,
       deployedStrength: Math.max(
         0,
         ...deployedCombat.map(unit => UNIT_DEFINITIONS[unit.type].strength),
       ),
-      actorEra: state.era,
+      actorEra,
       globalEra: state.era,
       knownRivalMaxStrength: Math.max(
         0,
@@ -284,7 +391,9 @@ export function prepareMajorCivStrategicPlan(
           .filter(unit => unit.type)
           .map(unit => UNIT_DEFINITIONS[unit.type!].strength),
       ),
-      obsoleteUnitShare: 0,
+      obsoleteUnitShare: deployedCombat.length > 0
+        ? deployedCombat.filter(unit => obsoleteTypes.has(unit.type)).length / deployedCombat.length
+        : 0,
       treasuryCanAct: civ.gold > 0,
     },
   });
@@ -301,38 +410,72 @@ export function prepareMajorCivStrategicPlan(
       experience: unit.experience,
       embarked: Boolean(unit.transportId),
       activeOtherDuty: Boolean(unit.workerTask || unit.committedToRouteId),
-      travelTurnsByPlanId: Object.fromEntries(plans.map(plan => [
-        plan.id,
-        Math.ceil(distance(
-          state,
+      travelTurnsByPlanId: Object.fromEntries(plans.map(plan => {
+        const path = findPath(
           unit.position,
-          plan.rallyPoint
-            ?? ('lastKnownPosition' in plan.target
-              ? plan.target.lastKnownPosition
-              : plan.target.kind === 'resource'
-                ? plan.target.position
-                : plan.target.anchor),
-        ) / Math.max(1, UNIT_DEFINITIONS[unit.type].movementPoints)),
-      ])),
+          plan.rallyPoint ?? planTargetPosition(plan),
+          knownMap,
+          UNIT_DEFINITIONS[unit.type].domain ?? 'land',
+          { unit, completedTechs: civ.techState.completed },
+        );
+        return [
+          plan.id,
+          path
+            ? Math.ceil(
+                Math.max(0, path.length - 1)
+                / Math.max(1, UNIT_DEFINITIONS[unit.type].movementPoints),
+              )
+            : Number.POSITIVE_INFINITY,
+        ];
+      })),
     })),
     profile: { maxPrimaryForce: 8, retreatHealthPercent: 30 },
     defenseThreatScoreByPlanId: Object.fromEntries(
       Object.values(portfolioResult.portfolio.defensePlansByCityId)
-        .map(plan => [plan.id, 100]),
+        .map(plan => {
+          const cityId = plan.target.kind === 'city' ? plan.target.id : '';
+          return [
+            plan.id,
+            threats.find(threat => threat.cityId === cityId)?.captureRisk ?? 0,
+          ];
+        }),
     ),
     eliminationDefensePlanIds: perception.ownCities.length === 1
       ? Object.values(portfolioResult.portfolio.defensePlansByCityId).map(plan => plan.id)
       : [],
-    onlyImmediateDefenderUnitIds: [],
+    onlyImmediateDefenderUnitIds: perception.ownCities.length === 1
+      && Object.keys(portfolioResult.portfolio.defensePlansByCityId).length > 0
+      && deployedCombat.length === 1
+      ? [deployedCombat[0].id]
+      : [],
     requiresEmbarkationByPlanId: {},
   });
+  const forceDemands = mergePreparedForceDemands(
+    assignments.forceDemands,
+    [
+      ...choice.demands.map(role => ({
+        role,
+        sourceId: 'objective-readiness',
+        priority: 90,
+      })),
+      ...portfolioResult.unplannedDefenseCityIds.map(cityId => ({
+        role: 'frontline' as const,
+        sourceId: `defense-overflow:${cityId}`,
+        priority: 600,
+      })),
+    ],
+  );
+  const preparedAssignments = {
+    ...assignments,
+    forceDemands,
+  };
 
   return {
     civId,
     perception,
-    portfolio: assignments.portfolio,
-    assignments,
-    forceDemands: assignments.forceDemands,
+    portfolio: preparedAssignments.portfolio,
+    assignments: preparedAssignments,
+    forceDemands,
     traces: [choice.trace],
   };
 }

--- a/src/ai/ai-prepared-turn.ts
+++ b/src/ai/ai-prepared-turn.ts
@@ -174,24 +174,31 @@ function planCandidates(
   candidates: readonly AIObjectiveCandidate[],
   choice: AIObjectiveChoice,
 ): AIPlanCandidate[] {
-  if (!choice.plan) return [];
-  const selected = candidates.find(candidate =>
-    candidate.objective === choice.plan!.objective
-    && targetStableKey(candidate.target) === targetStableKey(choice.plan!.target));
-  if (!selected) return [];
-  return [{
-    objective: selected.objective,
-    target: selected.target,
-    theaterId: selected.theaterId,
-    score: scoreObjectiveCandidate(selected),
-    reasonCodes: [...choice.plan.reasonCodes],
-    requiredRoles: { ...selected.requiredRoles },
-    commitment: 0.25,
-    targetValid: Number.isFinite(selected.travelTurns),
-    reasonValid: true,
-    expectedLossRatio: selected.expectedLossRatio,
-    progress: false,
-  }];
+  const eligibleIds = new Set(choice.eligibleCandidateIds);
+  return candidates.flatMap(candidate => {
+    const id = `${candidate.objective}:${targetStableKey(candidate.target)}`;
+    if (!eligibleIds.has(id)) return [];
+    const selected = choice.plan
+      && candidate.objective === choice.plan.objective
+      && targetStableKey(candidate.target) === targetStableKey(choice.plan.target);
+    return [{
+      objective: candidate.objective,
+      target: candidate.target,
+      theaterId: candidate.theaterId,
+      score: scoreObjectiveCandidate(candidate),
+      reasonCodes: selected
+        ? [...choice.plan!.reasonCodes]
+        : candidate.explicitDistantReasons.length > 0
+          ? [...candidate.explicitDistantReasons]
+          : ['nearby-opportunity'],
+      requiredRoles: { ...candidate.requiredRoles },
+      commitment: 0.25,
+      targetValid: Number.isFinite(candidate.travelTurns),
+      reasonValid: true,
+      expectedLossRatio: candidate.expectedLossRatio,
+      progress: false,
+    }];
+  });
 }
 
 function cityThreats(

--- a/src/ai/ai-prepared-turn.ts
+++ b/src/ai/ai-prepared-turn.ts
@@ -1,0 +1,331 @@
+import type { EventBus } from '@/core/event-bus';
+import type { GameState, MajorCivPlanPortfolio } from '@/core/types';
+import { hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
+import { getTrainableUnitsForCiv } from '@/systems/city-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import {
+  buildMajorCivPerception,
+  type MajorCivPerception,
+} from './ai-perception';
+import type { AIDecisionTrace } from './ai-decision-trace';
+import {
+  assignUnitsToPortfolio,
+  type AIForceDemand,
+  type AIUnitAssignmentResult,
+} from './ai-unit-assignment';
+import {
+  choosePrimaryObjective,
+  resolveObjectiveTravelCandidates,
+  scoreObjectiveCandidate,
+  targetStableKey,
+  type AIObjectiveCandidate,
+  type AIObjectiveChoice,
+  type AIObjectiveTravelCandidate,
+} from './ai-objective-scoring';
+import {
+  createEmptyMajorCivPortfolio,
+  refreshMajorCivPortfolio,
+  type AICityThreat,
+  type AIPlanCandidate,
+} from './ai-plan-portfolio';
+import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
+
+export interface PreparedMajorCivPlan {
+  civId: string;
+  perception: MajorCivPerception;
+  portfolio: MajorCivPlanPortfolio;
+  assignments: AIUnitAssignmentResult;
+  forceDemands: AIForceDemand[];
+  traces: AIDecisionTrace[];
+}
+
+export interface ProcessMajorCivStrategicTurnResult {
+  state: GameState;
+}
+
+export type PrepareMajorCivPlan = (
+  planningSnapshot: Readonly<GameState>,
+  civId: string,
+) => PreparedMajorCivPlan;
+
+export type ExecutePreparedMajorCivPlan = (
+  latestState: GameState,
+  prepared: PreparedMajorCivPlan,
+  bus: EventBus,
+) => ProcessMajorCivStrategicTurnResult;
+
+function distance(
+  state: Readonly<GameState>,
+  left: { q: number; r: number },
+  right: { q: number; r: number },
+): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(left, right, state.map.width)
+    : hexDistance(left, right);
+}
+
+function objectiveCandidates(
+  state: Readonly<GameState>,
+  civId: string,
+  perception: MajorCivPerception,
+): AIObjectiveCandidate[] {
+  const actor = state.civilizations[civId];
+  const anchor = perception.ownCities[0]?.position ?? perception.ownUnits[0]?.position;
+  if (!actor || !anchor) return [];
+
+  const candidates: AIObjectiveCandidate[] = [];
+  for (const city of perception.knownCities) {
+    if (!city.position || city.owner === civId) continue;
+    const travelTurns = Math.ceil(distance(state, anchor, city.position) / 2);
+    const recentAttack = actor.diplomacy.events.some(event =>
+      event.type === 'military_attacked'
+      && event.otherCiv === city.owner
+      && state.turn - event.turn <= 6);
+    const activeWar = actor.diplomacy.atWarWith.includes(city.owner);
+    candidates.push({
+      objective: 'capture',
+      target: {
+        kind: 'city',
+        id: city.id,
+        lastKnownPosition: { ...city.position },
+      },
+      theaterId: `local:${city.position.q},${city.position.r}`,
+      travelTurns,
+      strategicValue: activeWar ? 75 : 45,
+      expectedLossRatio: 0.75,
+      supplyDistance: travelTurns,
+      explicitDistantReasons: recentAttack
+        ? ['retaliate-recent-attack']
+        : activeWar
+          ? ['continue-active-war']
+          : [],
+      requiredRoles: { frontline: 1, capture: 1 },
+    });
+  }
+  for (const resource of perception.knownResources.filter(entry => entry.owner !== civId)) {
+    const travelTurns = Math.ceil(distance(state, anchor, resource.position) / 3);
+    candidates.push({
+      objective: 'secure-resource',
+      target: {
+        kind: 'resource',
+        resource: resource.resource,
+        position: { ...resource.position },
+      },
+      theaterId: `local:${resource.position.q},${resource.position.r}`,
+      travelTurns,
+      strategicValue: 55,
+      expectedLossRatio: 0,
+      supplyDistance: travelTurns,
+      explicitDistantReasons: [],
+      requiredRoles: { 'resource-expedition': 1 },
+    });
+  }
+  const knownMap = structuredClone(state.map);
+  for (const key of Object.keys(knownMap.tiles)) {
+    const visibility = actor.visibility.tiles[key] ?? 'unexplored';
+    if (visibility === 'visible') continue;
+    const snapshot = actor.visibility.lastSeen?.[key];
+    if (
+      visibility !== 'fog'
+      || snapshot?.source !== 'observed'
+      || !Number.isFinite(snapshot.observedTurn)
+    ) {
+      delete knownMap.tiles[key];
+      continue;
+    }
+    knownMap.tiles[key] = {
+      ...knownMap.tiles[key],
+      coord: { ...snapshot.coord },
+      terrain: snapshot.terrain,
+      elevation: snapshot.elevation,
+      resource: snapshot.resource,
+      improvement: snapshot.improvement,
+      improvementTurnsLeft: snapshot.improvementTurnsLeft,
+      owner: snapshot.owner,
+      hasRiver: snapshot.hasRiver,
+      wonder: snapshot.wonder,
+    };
+  }
+  const travelInputs: AIObjectiveTravelCandidate[] = candidates.map(candidate => {
+    const { travelTurns: _travelTurns, ...withoutTravel } = candidate;
+    return {
+      ...withoutTravel,
+      start: { ...anchor },
+      domain: 'land',
+      movementPoints: 2,
+      completedMovementTechHash: [...actor.techState.completed].sort().join(','),
+    };
+  });
+  return resolveObjectiveTravelCandidates(knownMap, travelInputs);
+}
+
+function availableRoleCounts(perception: MajorCivPerception) {
+  const counts: Partial<Record<ReturnType<typeof getAIStrategicRoles>[number], number>> = {};
+  for (const unit of perception.ownUnits) {
+    if (unit.transportId) continue;
+    for (const role of getAIStrategicRoles(unit.type)) {
+      counts[role] = (counts[role] ?? 0) + 1;
+    }
+  }
+  return counts;
+}
+
+function planCandidates(
+  candidates: readonly AIObjectiveCandidate[],
+  choice: AIObjectiveChoice,
+): AIPlanCandidate[] {
+  if (!choice.plan) return [];
+  const selected = candidates.find(candidate =>
+    candidate.objective === choice.plan!.objective
+    && targetStableKey(candidate.target) === targetStableKey(choice.plan!.target));
+  if (!selected) return [];
+  return [{
+    objective: selected.objective,
+    target: selected.target,
+    theaterId: selected.theaterId,
+    score: scoreObjectiveCandidate(selected),
+    reasonCodes: [...choice.plan.reasonCodes],
+    requiredRoles: { ...selected.requiredRoles },
+    commitment: 0.25,
+    targetValid: Number.isFinite(selected.travelTurns),
+    reasonValid: true,
+    expectedLossRatio: selected.expectedLossRatio,
+    progress: false,
+  }];
+}
+
+function cityThreats(
+  state: Readonly<GameState>,
+  civId: string,
+  perception: MajorCivPerception,
+): AICityThreat[] {
+  const actor = state.civilizations[civId];
+  if (!actor) return [];
+  const atWar = new Set(actor.diplomacy.atWarWith);
+  return perception.ownCities.flatMap((city, index) => {
+    const hostile = perception.units
+      .filter(unit =>
+        unit.position
+        && atWar.has(unit.owner)
+        && unit.type
+        && hasAICombatRole(unit.type))
+      .map(unit => ({
+        unit,
+        turns: Math.ceil(distance(state, city.position, unit.position!) / 2),
+      }))
+      .sort((left, right) => left.turns - right.turns)[0];
+    if (!hostile) return [];
+    return [{
+      cityId: city.id,
+      position: { ...city.position },
+      theaterId: `local:${city.position.q},${city.position.r}`,
+      travelTurns: hostile.turns,
+      alreadyAttackedTerritory: actor.diplomacy.events.some(event =>
+        event.type === 'military_attacked'
+        && event.otherCiv === hostile.unit.owner
+        && state.turn - event.turn <= 1),
+      captureRisk: Math.max(0, 100 - hostile.turns * 20),
+      hostileStrength: hostile.unit.type
+        ? UNIT_DEFINITIONS[hostile.unit.type].strength
+        : 0,
+      isCapital: index === 0,
+      isLastCity: perception.ownCities.length === 1,
+      threatStillValid: hostile.unit.confidence !== 'rumored',
+    }];
+  });
+}
+
+export function prepareMajorCivStrategicPlan(
+  planningSnapshot: Readonly<GameState>,
+  civId: string,
+): PreparedMajorCivPlan {
+  const state = planningSnapshot as GameState;
+  const civ = state.civilizations[civId];
+  const perception = buildMajorCivPerception(state, civId);
+  const candidates = objectiveCandidates(state, civId, perception);
+  const choice = choosePrimaryObjective({
+    actorId: civId,
+    turn: state.turn,
+    candidates,
+    availableRoles: availableRoleCounts(perception),
+  });
+  const previous = state.opponentAI?.majorCivs[civId] ?? createEmptyMajorCivPortfolio();
+  const trainable = getTrainableUnitsForCiv(civ.techState.completed, civ.civType);
+  const bestTrainableStrength = Math.max(
+    0,
+    ...trainable.map(entry => UNIT_DEFINITIONS[entry.type].strength),
+  );
+  const deployedCombat = perception.ownUnits.filter(unit => hasAICombatRole(unit.type));
+  const portfolioResult = refreshMajorCivPortfolio({
+    actorId: civId,
+    turn: state.turn,
+    actorEliminated: civ.isEliminated === true,
+    portfolio: previous,
+    candidates: planCandidates(candidates, choice),
+    cityThreats: cityThreats(state, civId, perception),
+    modernization: {
+      bestTrainableStrength,
+      deployedStrength: Math.max(
+        0,
+        ...deployedCombat.map(unit => UNIT_DEFINITIONS[unit.type].strength),
+      ),
+      actorEra: state.era,
+      globalEra: state.era,
+      knownRivalMaxStrength: Math.max(
+        0,
+        ...perception.units
+          .filter(unit => unit.type)
+          .map(unit => UNIT_DEFINITIONS[unit.type!].strength),
+      ),
+      obsoleteUnitShare: 0,
+      treasuryCanAct: civ.gold > 0,
+    },
+  });
+  const plans = [
+    ...Object.values(portfolioResult.portfolio.defensePlansByCityId),
+    ...(portfolioResult.portfolio.primaryPlan ? [portfolioResult.portfolio.primaryPlan] : []),
+  ];
+  const assignments = assignUnitsToPortfolio({
+    portfolio: portfolioResult.portfolio,
+    units: perception.ownUnits.map(unit => ({
+      id: unit.id,
+      type: unit.type,
+      health: unit.health,
+      experience: unit.experience,
+      embarked: Boolean(unit.transportId),
+      activeOtherDuty: Boolean(unit.workerTask || unit.committedToRouteId),
+      travelTurnsByPlanId: Object.fromEntries(plans.map(plan => [
+        plan.id,
+        Math.ceil(distance(
+          state,
+          unit.position,
+          plan.rallyPoint
+            ?? ('lastKnownPosition' in plan.target
+              ? plan.target.lastKnownPosition
+              : plan.target.kind === 'resource'
+                ? plan.target.position
+                : plan.target.anchor),
+        ) / Math.max(1, UNIT_DEFINITIONS[unit.type].movementPoints)),
+      ])),
+    })),
+    profile: { maxPrimaryForce: 8, retreatHealthPercent: 30 },
+    defenseThreatScoreByPlanId: Object.fromEntries(
+      Object.values(portfolioResult.portfolio.defensePlansByCityId)
+        .map(plan => [plan.id, 100]),
+    ),
+    eliminationDefensePlanIds: perception.ownCities.length === 1
+      ? Object.values(portfolioResult.portfolio.defensePlansByCityId).map(plan => plan.id)
+      : [],
+    onlyImmediateDefenderUnitIds: [],
+    requiresEmbarkationByPlanId: {},
+  });
+
+  return {
+    civId,
+    perception,
+    portfolio: assignments.portfolio,
+    assignments,
+    forceDemands: assignments.forceDemands,
+    traces: [choice.trace],
+  };
+}

--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -1,7 +1,18 @@
 import { processAITurn } from '@/ai/basic-ai';
 import type { EventBus } from '@/core/event-bus';
-import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
+import {
+  createEmptyMajorCivPlanPortfolio,
+  normalizeOpponentAIState,
+} from '@/core/opponent-ai-state';
 import type { GameState } from '@/core/types';
+import { refreshMajorCivIntel } from './ai-perception';
+import type {
+  ExecutePreparedMajorCivPlan,
+  PrepareMajorCivPlan,
+  PreparedMajorCivPlan,
+} from './ai-prepared-turn';
+import { prepareMajorCivStrategicPlan } from './ai-prepared-turn';
+import type { AIDecisionTrace } from './ai-decision-trace';
 
 export function getLivingNonHumanMajorIds(state: GameState): string[] {
   return Object.values(state.civilizations)
@@ -23,10 +34,83 @@ export function rotateIdsForRound(ids: readonly string[], turn: number): string[
 
 export interface ProcessNonHumanRoundOptions {
   execute?: (state: GameState, civId: string, bus: EventBus) => GameState;
+  strategicPlanningEnabled?: boolean;
+  prepare?: PrepareMajorCivPlan;
+  executePrepared?: ExecutePreparedMajorCivPlan;
 }
 
 export interface ProcessNonHumanRoundResult {
   state: GameState;
+  traces: AIDecisionTrace[];
+}
+
+function preparedTargetIsStale(
+  state: GameState,
+  prepared: PreparedMajorCivPlan,
+): boolean {
+  const plan = prepared.portfolio.primaryPlan;
+  if (!plan) return false;
+  switch (plan.target.kind) {
+    case 'city': {
+      const city = state.cities[plan.target.id];
+      return !city || (
+        plan.objective === 'capture'
+        && city.owner === prepared.civId
+      );
+    }
+    case 'unit':
+      return !Object.prototype.hasOwnProperty.call(state.units, plan.target.id);
+    case 'camp':
+      return state.barbarianCamps[plan.target.id] === undefined;
+    case 'resource':
+    case 'region':
+      return false;
+  }
+}
+
+function writePreparedPortfolios(
+  state: GameState,
+  preparedPlans: readonly PreparedMajorCivPlan[],
+): GameState {
+  const normalized = normalizeOpponentAIState(state);
+  const majorCivs = { ...normalized.opponentAI!.majorCivs };
+  for (const prepared of preparedPlans) {
+    majorCivs[prepared.civId] = structuredClone(prepared.portfolio);
+  }
+  return {
+    ...normalized,
+    opponentAI: {
+      ...normalized.opponentAI!,
+      majorCivs,
+      lastPlannedRound: normalized.turn,
+    },
+  };
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): Readonly<T> {
+  if (!value || typeof value !== 'object') return value;
+  const object = value as object;
+  if (seen.has(object)) return value;
+  seen.add(object);
+  for (const child of Object.values(object)) deepFreeze(child, seen);
+  return Object.freeze(value);
+}
+
+function withMajorPortfolio(
+  state: GameState,
+  civId: string,
+  portfolio: NonNullable<GameState['opponentAI']>['majorCivs'][string],
+): GameState {
+  return {
+    ...state,
+    opponentAI: {
+      ...state.opponentAI!,
+      majorCivs: {
+        ...state.opponentAI!.majorCivs,
+        [civId]: portfolio,
+      },
+    },
+  };
 }
 
 export function processNonHumanMajorRound(
@@ -36,10 +120,70 @@ export function processNonHumanMajorRound(
 ): ProcessNonHumanRoundResult {
   let working = normalizeOpponentAIState(state);
   if (working.opponentAI!.lastProcessedRound === working.turn) {
-    return { state: working };
+    return { state: working, traces: [] };
   }
 
-  const actorIds = rotateIdsForRound(getLivingNonHumanMajorIds(working), working.turn);
+  const stableActorIds = getLivingNonHumanMajorIds(working);
+  const actorIds = rotateIdsForRound(stableActorIds, working.turn);
+  if (options.strategicPlanningEnabled) {
+    let refreshed = working;
+    for (const civId of stableActorIds) {
+      refreshed = refreshMajorCivIntel(refreshed, civId);
+    }
+    const planningSnapshot = deepFreeze(structuredClone(refreshed));
+    const prepare = options.prepare ?? prepareMajorCivStrategicPlan;
+    const preparedPlans = stableActorIds.map(civId => prepare(planningSnapshot, civId));
+    const preparedByCiv = new Map(preparedPlans.map(prepared => [prepared.civId, prepared]));
+    const traces = preparedPlans.flatMap(prepared => prepared.traces);
+    working = writePreparedPortfolios(refreshed, preparedPlans);
+
+    const executePrepared = options.executePrepared ?? ((current: GameState) => ({ state: current }));
+    for (const civId of actorIds) {
+      const prepared = preparedByCiv.get(civId);
+      const civ = working.civilizations[civId];
+      const portfolio = working.opponentAI?.majorCivs[civId];
+      if (
+        !prepared
+        || !civ
+        || civ.isHuman
+        || civ.isEliminated
+        || portfolio?.lastExecutedTurn === working.turn
+      ) {
+        continue;
+      }
+      if (preparedTargetIsStale(working, prepared)) {
+        const stalePortfolio = portfolio ?? createEmptyMajorCivPlanPortfolio();
+        working = withMajorPortfolio(working, civId, {
+          ...stalePortfolio,
+          primaryPlan: null,
+          lastExecutedTurn: working.turn,
+        });
+        continue;
+      }
+      working = executePrepared(working, prepared, bus).state;
+      working = normalizeOpponentAIState(working);
+      const executedPortfolio = working.opponentAI!.majorCivs[civId]
+        ?? createEmptyMajorCivPlanPortfolio();
+      working = withMajorPortfolio(working, civId, {
+        ...executedPortfolio,
+        lastExecutedTurn: working.turn,
+      });
+    }
+
+    working = normalizeOpponentAIState(working);
+    return {
+      state: {
+        ...working,
+        opponentAI: {
+          ...working.opponentAI!,
+          lastPlannedRound: working.turn,
+          lastProcessedRound: working.turn,
+        },
+      },
+      traces,
+    };
+  }
+
   const execute = options.execute ?? processAITurn;
   for (const civId of actorIds) {
     const civ = working.civilizations[civId];
@@ -59,5 +203,6 @@ export function processNonHumanMajorRound(
         lastProcessedRound: working.turn,
       },
     },
+    traces: [],
   };
 }

--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -5,6 +5,7 @@ import {
   normalizeOpponentAIState,
 } from '@/core/opponent-ai-state';
 import type { GameState } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
 import { refreshMajorCivIntel } from './ai-perception';
 import type {
   ExecutePreparedMajorCivPlan,
@@ -42,30 +43,114 @@ export interface ProcessNonHumanRoundOptions {
 export interface ProcessNonHumanRoundResult {
   state: GameState;
   traces: AIDecisionTrace[];
+  planningErrors: Array<{
+    actorId: string;
+    phase: 'prepare';
+    message: string;
+  }>;
 }
 
-function preparedTargetIsStale(
+function planTargetIsStale(
   state: GameState,
-  prepared: PreparedMajorCivPlan,
+  civId: string,
+  plan: NonNullable<PreparedMajorCivPlan['portfolio']['primaryPlan']>,
 ): boolean {
-  const plan = prepared.portfolio.primaryPlan;
-  if (!plan) return false;
   switch (plan.target.kind) {
     case 'city': {
       const city = state.cities[plan.target.id];
-      return !city || (
-        plan.objective === 'capture'
-        && city.owner === prepared.civId
-      );
+      if (!city) return true;
+      if (plan.objective === 'defend') return city.owner !== civId;
+      return plan.objective === 'capture' && city.owner === civId;
     }
     case 'unit':
       return !Object.prototype.hasOwnProperty.call(state.units, plan.target.id);
     case 'camp':
       return state.barbarianCamps[plan.target.id] === undefined;
-    case 'resource':
+    case 'resource': {
+      const tile = state.map.tiles[hexKey(plan.target.position)];
+      if (!tile || tile.resource !== plan.target.resource) return true;
+      if (tile.owner === null) return false;
+      if (tile.owner === civId) return true;
+      return !state.civilizations[civId]?.diplomacy.atWarWith.includes(tile.owner);
+    }
     case 'region':
-      return false;
+      return state.map.tiles[hexKey(plan.target.anchor)] === undefined;
   }
+}
+
+function revalidatePreparedPlan(
+  state: GameState,
+  prepared: PreparedMajorCivPlan,
+): PreparedMajorCivPlan {
+  const primaryPlan = prepared.portfolio.primaryPlan
+    && !planTargetIsStale(state, prepared.civId, prepared.portfolio.primaryPlan)
+    ? prepared.portfolio.primaryPlan
+    : null;
+  const defensePlansByCityId = Object.fromEntries(
+    Object.entries(prepared.portfolio.defensePlansByCityId)
+      .filter(([, plan]) => !planTargetIsStale(state, prepared.civId, plan)),
+  );
+  const validPlanIds = new Set([
+    ...(primaryPlan ? [primaryPlan.id] : []),
+    ...Object.values(defensePlansByCityId).map(plan => plan.id),
+  ]);
+  const validUnitIds = new Set(
+    Object.values(state.units)
+      .filter(unit => unit.owner === prepared.civId)
+      .map(unit => unit.id),
+  );
+  const assignmentsByPlanId = Object.fromEntries(
+    Object.entries(prepared.assignments.assignmentsByPlanId)
+      .filter(([planId]) => validPlanIds.has(planId))
+      .map(([planId, unitIds]) => [
+        planId,
+        unitIds.filter(unitId => validUnitIds.has(unitId)),
+      ]),
+  );
+  const forceDemands = prepared.forceDemands.flatMap(demand => {
+    const sourcePlanIds = demand.sourcePlanIds.filter(sourceId => {
+      if (sourceId === 'objective-readiness') return true;
+      if (sourceId.startsWith('defense-overflow:')) {
+        const cityId = sourceId.slice('defense-overflow:'.length);
+        return state.cities[cityId]?.owner === prepared.civId;
+      }
+      return validPlanIds.has(sourceId);
+    });
+    return sourcePlanIds.length > 0 ? [{ ...demand, sourcePlanIds }] : [];
+  });
+  const portfolio = {
+    ...prepared.portfolio,
+    primaryPlan: primaryPlan
+      ? {
+          ...primaryPlan,
+          assignedUnitIds: primaryPlan.assignedUnitIds
+            .filter(unitId => validUnitIds.has(unitId)),
+        }
+      : null,
+    defensePlansByCityId: Object.fromEntries(
+      Object.entries(defensePlansByCityId).map(([cityId, plan]) => [
+        cityId,
+        {
+          ...plan,
+          assignedUnitIds: plan.assignedUnitIds
+            .filter(unitId => validUnitIds.has(unitId)),
+        },
+      ]),
+    ),
+  };
+  return {
+    ...prepared,
+    portfolio,
+    assignments: {
+      ...prepared.assignments,
+      portfolio,
+      assignmentsByPlanId,
+      recoveryUnitIds: prepared.assignments.recoveryUnitIds
+        .filter(unitId => validUnitIds.has(unitId)),
+      forceDemands,
+    },
+    forceDemands,
+  };
 }
 
 function writePreparedPortfolios(
@@ -120,7 +205,7 @@ export function processNonHumanMajorRound(
 ): ProcessNonHumanRoundResult {
   let working = normalizeOpponentAIState(state);
   if (working.opponentAI!.lastProcessedRound === working.turn) {
-    return { state: working, traces: [] };
+    return { state: working, traces: [], planningErrors: [] };
   }
 
   const stableActorIds = getLivingNonHumanMajorIds(working);
@@ -132,7 +217,25 @@ export function processNonHumanMajorRound(
     }
     const planningSnapshot = deepFreeze(structuredClone(refreshed));
     const prepare = options.prepare ?? prepareMajorCivStrategicPlan;
-    const preparedPlans = stableActorIds.map(civId => prepare(planningSnapshot, civId));
+    const preparedPlans: PreparedMajorCivPlan[] = [];
+    const planningErrors: ProcessNonHumanRoundResult['planningErrors'] = [];
+    for (const civId of stableActorIds) {
+      try {
+        const prepared = prepare(planningSnapshot, civId);
+        if (prepared.civId !== civId) {
+          throw new Error(
+            `Prepared actor mismatch: expected ${civId}, received ${prepared.civId}`,
+          );
+        }
+        preparedPlans.push(prepared);
+      } catch (error) {
+        planningErrors.push({
+          actorId: civId,
+          phase: 'prepare',
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     const preparedByCiv = new Map(preparedPlans.map(prepared => [prepared.civId, prepared]));
     const traces = preparedPlans.flatMap(prepared => prepared.traces);
     working = writePreparedPortfolios(refreshed, preparedPlans);
@@ -151,16 +254,20 @@ export function processNonHumanMajorRound(
       ) {
         continue;
       }
-      if (preparedTargetIsStale(working, prepared)) {
-        const stalePortfolio = portfolio ?? createEmptyMajorCivPlanPortfolio();
+      const revalidated = revalidatePreparedPlan(working, prepared);
+      const hadPlan = prepared.portfolio.primaryPlan !== null
+        || Object.keys(prepared.portfolio.defensePlansByCityId).length > 0;
+      const hasPlan = revalidated.portfolio.primaryPlan !== null
+        || Object.keys(revalidated.portfolio.defensePlansByCityId).length > 0;
+      if (hadPlan && !hasPlan) {
         working = withMajorPortfolio(working, civId, {
-          ...stalePortfolio,
-          primaryPlan: null,
+          ...revalidated.portfolio,
           lastExecutedTurn: working.turn,
         });
         continue;
       }
-      working = executePrepared(working, prepared, bus).state;
+      working = withMajorPortfolio(working, civId, revalidated.portfolio);
+      working = executePrepared(working, revalidated, bus).state;
       working = normalizeOpponentAIState(working);
       const executedPortfolio = working.opponentAI!.majorCivs[civId]
         ?? createEmptyMajorCivPlanPortfolio();
@@ -181,6 +288,7 @@ export function processNonHumanMajorRound(
         },
       },
       traces,
+      planningErrors,
     };
   }
 
@@ -204,5 +312,6 @@ export function processNonHumanMajorRound(
       },
     },
     traces: [],
+    planningErrors: [],
   };
 }

--- a/src/ai/ai-strength.ts
+++ b/src/ai/ai-strength.ts
@@ -1,6 +1,8 @@
 import type { UnitType } from '@/core/types';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { TECH_TREE } from '@/systems/tech-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { hasAICombatRole } from './ai-unit-roles';
+import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
 
 export interface AIStrengthObservation {
   type: UnitType;
@@ -80,4 +82,26 @@ export function estimateMilitaryStrength(
     uncertaintyUpper,
     midpoint: (uncertaintyLower + uncertaintyUpper) / 2,
   };
+}
+
+export function getMedianFrontlineStrengthForEra(era: number): number {
+  const boundedEra = Number.isFinite(era) ? Math.max(1, Math.floor(era)) : 1;
+  const strengths = TRAINABLE_UNITS
+    .filter(entry => {
+      const requiredEra = entry.techRequired
+        ? TECH_TREE.find(tech => tech.id === entry.techRequired)?.era ?? 1
+        : 1;
+      const roles = getAIStrategicRoles(entry.type);
+      return requiredEra <= boundedEra
+        && (roles.includes('frontline') || roles.includes('capture'))
+        && UNIT_DEFINITIONS[entry.type].strength > 0;
+    })
+    .map(entry => UNIT_DEFINITIONS[entry.type].strength)
+    .sort((left, right) => left - right);
+
+  if (strengths.length === 0) return 0;
+  const middle = Math.floor(strengths.length / 2);
+  return strengths.length % 2 === 0
+    ? (strengths[middle - 1] + strengths[middle]) / 2
+    : strengths[middle];
 }

--- a/src/ai/ai-strength.ts
+++ b/src/ai/ai-strength.ts
@@ -1,0 +1,83 @@
+import type { UnitType } from '@/core/types';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { hasAICombatRole } from './ai-unit-roles';
+
+export interface AIStrengthObservation {
+  type: UnitType;
+  health: number;
+  experience: number;
+  source: 'visible' | 'remembered';
+  confidence: number;
+  uncertainty: number;
+  locallyAvailable: boolean;
+  cargoOrCaptured: boolean;
+}
+
+export interface AIStrengthEstimateOptions {
+  unknownReserveUpper?: number;
+}
+
+export interface MilitaryStrengthEstimate {
+  exactVisible: number;
+  remembered: number;
+  uncertaintyLower: number;
+  uncertaintyUpper: number;
+  midpoint: number;
+}
+
+function clampUnitInterval(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function clampNonNegative(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, value);
+}
+
+function observationBaseStrength(observation: AIStrengthObservation): number {
+  const definition = UNIT_DEFINITIONS[observation.type];
+  const health = clampUnitInterval(observation.health / 100);
+  const experience = Math.min(clampNonNegative(observation.experience), 100);
+  return definition.strength * health * (1 + experience / 500);
+}
+
+export function estimateMilitaryStrength(
+  observations: readonly AIStrengthObservation[],
+  options: AIStrengthEstimateOptions = {},
+): MilitaryStrengthEstimate {
+  let exactVisible = 0;
+  let remembered = 0;
+  let rememberedUncertainty = 0;
+
+  for (const observation of observations) {
+    if (
+      observation.cargoOrCaptured
+      || !observation.locallyAvailable
+      || !hasAICombatRole(observation.type)
+    ) {
+      continue;
+    }
+
+    const base = observationBaseStrength(observation);
+    if (observation.source === 'visible') {
+      exactVisible += base;
+      continue;
+    }
+
+    remembered += base * clampUnitInterval(observation.confidence);
+    rememberedUncertainty += base * clampUnitInterval(observation.uncertainty);
+  }
+
+  const unknownReserveUpper = clampNonNegative(options.unknownReserveUpper ?? 0);
+  const uncertaintyLower = exactVisible + Math.max(0, remembered - rememberedUncertainty);
+  const uncertaintyUpper = exactVisible + remembered + rememberedUncertainty + unknownReserveUpper;
+
+  return {
+    exactVisible,
+    remembered,
+    uncertaintyLower,
+    uncertaintyUpper,
+    midpoint: (uncertaintyLower + uncertaintyUpper) / 2,
+  };
+}

--- a/src/ai/ai-unit-assignment.ts
+++ b/src/ai/ai-unit-assignment.ts
@@ -1,0 +1,280 @@
+import type {
+  AIStrategicPlan,
+  AIStrategicRole,
+  MajorCivPlanPortfolio,
+  UnitType,
+} from '@/core/types';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getAIStrategicRoles } from './ai-unit-roles';
+
+export interface AIUnitAssignmentCandidate {
+  id: string;
+  type: UnitType;
+  health: number;
+  experience: number;
+  embarked: boolean;
+  activeOtherDuty: boolean;
+  travelTurnsByPlanId: Record<string, number>;
+}
+
+export interface AIForceDemand {
+  role: AIStrategicRole;
+  desired: number;
+  assigned: number;
+  missing: number;
+  priority: number;
+  sourcePlanIds: string[];
+}
+
+export interface AIUnitAssignmentContext {
+  portfolio: MajorCivPlanPortfolio;
+  units: readonly AIUnitAssignmentCandidate[];
+  profile: {
+    maxPrimaryForce: number;
+    retreatHealthPercent: number;
+  };
+  defenseThreatScoreByPlanId: Record<string, number>;
+  eliminationDefensePlanIds: readonly string[];
+  onlyImmediateDefenderUnitIds: readonly string[];
+  requiresEmbarkationByPlanId: Record<string, boolean>;
+}
+
+export interface AIUnitAssignmentResult {
+  portfolio: MajorCivPlanPortfolio;
+  assignmentsByPlanId: Record<string, string[]>;
+  recoveryUnitIds: string[];
+  forceDemands: AIForceDemand[];
+  rejectedByUnitId: Record<string, string[]>;
+}
+
+const ROLE_ORDER: AIStrategicRole[] = [
+  'transport',
+  'frontline',
+  'capture',
+  'ranged',
+  'siege',
+  'mobile',
+  'air-combat',
+  'naval-combat',
+  'escort',
+  'recon',
+  'detection',
+  'settlement',
+  'worker',
+  'resource-expedition',
+  'trade',
+  'espionage',
+];
+
+const COMPATIBLE_ROLES: Partial<Record<AIStrategicRole, readonly AIStrategicRole[]>> = {
+  frontline: ['capture'],
+  capture: ['frontline'],
+  recon: ['mobile'],
+  mobile: ['recon'],
+  escort: ['naval-combat'],
+  'naval-combat': ['escort'],
+};
+
+function roleFit(type: UnitType, required: AIStrategicRole): number {
+  const roles = getAIStrategicRoles(type);
+  if (roles.includes(required)) return 1;
+  if (COMPATIBLE_ROLES[required]?.some(role => roles.includes(role))) return 0.7;
+  return 0;
+}
+
+function veterancyTier(experience: number): number {
+  if (experience >= 50) return 3;
+  if (experience >= 25) return 2;
+  if (experience >= 10) return 1;
+  return 0;
+}
+
+function clonePlan(plan: AIStrategicPlan, assignedUnitIds: string[]): AIStrategicPlan {
+  return {
+    ...plan,
+    target: structuredClone(plan.target),
+    reasonCodes: [...plan.reasonCodes],
+    requiredRoles: { ...plan.requiredRoles },
+    assignedUnitIds,
+  };
+}
+
+function orderedPlans(context: AIUnitAssignmentContext): AIStrategicPlan[] {
+  const eliminationIds = new Set(context.eliminationDefensePlanIds);
+  const defenses = Object.values(context.portfolio.defensePlansByCityId);
+  const elimination = defenses
+    .filter(plan => eliminationIds.has(plan.id))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const ordinaryDefense = defenses
+    .filter(plan => !eliminationIds.has(plan.id))
+    .sort((left, right) =>
+      (context.defenseThreatScoreByPlanId[right.id] ?? 0)
+      - (context.defenseThreatScoreByPlanId[left.id] ?? 0)
+      || left.id.localeCompare(right.id));
+  return [
+    ...elimination,
+    ...ordinaryDefense,
+    ...(context.portfolio.primaryPlan ? [context.portfolio.primaryPlan] : []),
+  ];
+}
+
+function planPriority(
+  plan: AIStrategicPlan,
+  context: AIUnitAssignmentContext,
+): number {
+  if (context.eliminationDefensePlanIds.includes(plan.id)) return 1000;
+  if (plan.objective === 'defend') {
+    return 500 + (context.defenseThreatScoreByPlanId[plan.id] ?? 0);
+  }
+  return 100;
+}
+
+export function assignUnitsToPortfolio(
+  context: AIUnitAssignmentContext,
+): AIUnitAssignmentResult {
+  const plans = orderedPlans(context);
+  const primaryId = context.portfolio.primaryPlan?.id;
+  const usedUnitIds = new Set<string>();
+  const immediateDefenders = new Set(context.onlyImmediateDefenderUnitIds);
+  const recoveryUnitIds = context.units
+    .filter(unit =>
+      !unit.embarked
+      && unit.health < context.profile.retreatHealthPercent
+      && !immediateDefenders.has(unit.id))
+    .map(unit => unit.id)
+    .sort();
+  const recovering = new Set(recoveryUnitIds);
+  const assignmentsByPlanId: Record<string, string[]> = Object.fromEntries(
+    plans.map(plan => [plan.id, []]),
+  );
+  const assignedSlotsByPlanId: Record<string, AIStrategicRole[]> = Object.fromEntries(
+    plans.map(plan => [plan.id, []]),
+  );
+  const rejectedByUnitId: Record<string, string[]> = {};
+
+  for (const plan of plans) {
+    let transportCapacity = 0;
+    let cargoCapacityUsed = 0;
+    const requiredEntries = (Object.entries(plan.requiredRoles) as Array<[AIStrategicRole, number]>)
+      .sort((left, right) =>
+        ROLE_ORDER.indexOf(left[0]) - ROLE_ORDER.indexOf(right[0]));
+
+    for (const [role, desired] of requiredEntries) {
+      for (let slot = 0; slot < Math.max(0, Math.floor(desired)); slot++) {
+        if (
+          plan.id === primaryId
+          && assignmentsByPlanId[plan.id].length >= context.profile.maxPrimaryForce
+        ) {
+          break;
+        }
+        if (
+          role === 'siege'
+          && !assignedSlotsByPlanId[plan.id].some(assigned =>
+            assigned === 'frontline' || assigned === 'capture')
+        ) {
+          continue;
+        }
+
+        const candidates = context.units
+          .filter(unit =>
+            !usedUnitIds.has(unit.id)
+            && !recovering.has(unit.id)
+            && !unit.embarked
+            && roleFit(unit.type, role) > 0
+            && Number.isFinite(unit.travelTurnsByPlanId[plan.id]))
+          .filter(unit => {
+            if (!context.requiresEmbarkationByPlanId[plan.id]) return true;
+            const definition = UNIT_DEFINITIONS[unit.type];
+            if (role === 'transport') return definition.cargoCapacity !== undefined;
+            if ((definition.domain ?? 'land') !== 'land') return true;
+            const cargoSize = definition.cargoSize ?? 1;
+            return cargoCapacityUsed + cargoSize <= transportCapacity;
+          })
+          .map(unit => ({
+            unit,
+            score: roleFit(unit.type, role) * 40
+              - unit.travelTurnsByPlanId[plan.id] * 5
+              + Math.max(0, Math.min(100, unit.health)) * 0.2
+              + veterancyTier(unit.experience) * 3
+              - (unit.activeOtherDuty ? 20 : 0),
+          }))
+          .sort((left, right) =>
+            right.score - left.score || left.unit.id.localeCompare(right.unit.id));
+        const selected = candidates[0]?.unit;
+        if (!selected) continue;
+
+        usedUnitIds.add(selected.id);
+        assignmentsByPlanId[plan.id].push(selected.id);
+        assignedSlotsByPlanId[plan.id].push(role);
+        const definition = UNIT_DEFINITIONS[selected.type];
+        if (role === 'transport') {
+          transportCapacity += definition.cargoCapacity ?? 0;
+        } else if (
+          context.requiresEmbarkationByPlanId[plan.id]
+          && (definition.domain ?? 'land') === 'land'
+        ) {
+          cargoCapacityUsed += definition.cargoSize ?? 1;
+        }
+      }
+    }
+  }
+
+  for (const unit of context.units) {
+    if (usedUnitIds.has(unit.id) || recovering.has(unit.id)) continue;
+    rejectedByUnitId[unit.id] = unit.embarked ? ['embarked'] : ['no-open-compatible-slot'];
+  }
+
+  const demandByRole = new Map<AIStrategicRole, AIForceDemand>();
+  for (const plan of plans) {
+    for (const [role, desiredRaw] of Object.entries(plan.requiredRoles) as Array<[AIStrategicRole, number]>) {
+      const desired = Math.max(0, Math.floor(desiredRaw));
+      const assigned = assignedSlotsByPlanId[plan.id].filter(slot => slot === role).length;
+      const existing = demandByRole.get(role) ?? {
+        role,
+        desired: 0,
+        assigned: 0,
+        missing: 0,
+        priority: 0,
+        sourcePlanIds: [],
+      };
+      existing.desired += desired;
+      existing.assigned += assigned;
+      existing.missing = existing.desired - existing.assigned;
+      existing.priority = Math.max(existing.priority, planPriority(plan, context));
+      existing.sourcePlanIds.push(plan.id);
+      demandByRole.set(role, existing);
+    }
+  }
+
+  const defensePlansByCityId = Object.fromEntries(
+    Object.entries(context.portfolio.defensePlansByCityId).map(([cityId, plan]) => [
+      cityId,
+      clonePlan(plan, assignmentsByPlanId[plan.id] ?? []),
+    ]),
+  );
+  const primaryPlan = context.portfolio.primaryPlan
+    ? clonePlan(
+        context.portfolio.primaryPlan,
+        assignmentsByPlanId[context.portfolio.primaryPlan.id] ?? [],
+      )
+    : null;
+
+  return {
+    portfolio: {
+      ...context.portfolio,
+      primaryPlan,
+      defensePlansByCityId,
+      upgradeRoutesByUnitId: { ...context.portfolio.upgradeRoutesByUnitId },
+    },
+    assignmentsByPlanId,
+    recoveryUnitIds,
+    forceDemands: [...demandByRole.values()]
+      .map(demand => ({
+        ...demand,
+        sourcePlanIds: [...new Set(demand.sourcePlanIds)].sort(),
+      }))
+      .sort((left, right) =>
+        right.priority - left.priority || left.role.localeCompare(right.role)),
+    rejectedByUnitId,
+  };
+}

--- a/src/ai/ai-unit-assignment.ts
+++ b/src/ai/ai-unit-assignment.ts
@@ -150,23 +150,31 @@ export function assignUnitsToPortfolio(
   const assignedSlotsByPlanId: Record<string, AIStrategicRole[]> = Object.fromEntries(
     plans.map(plan => [plan.id, []]),
   );
+  const desiredSlotsByPlanId: Record<string, Partial<Record<AIStrategicRole, number>>> = {};
+  const capacityBlockedPlanIds = new Set<string>();
   const rejectedByUnitId: Record<string, string[]> = {};
 
   for (const plan of plans) {
     let transportCapacity = 0;
     let cargoCapacityUsed = 0;
+    let remainingPrimarySlots = plan.id === primaryId
+      ? Math.max(0, Math.floor(context.profile.maxPrimaryForce))
+      : Number.POSITIVE_INFINITY;
     const requiredEntries = (Object.entries(plan.requiredRoles) as Array<[AIStrategicRole, number]>)
       .sort((left, right) =>
-        ROLE_ORDER.indexOf(left[0]) - ROLE_ORDER.indexOf(right[0]));
+        ROLE_ORDER.indexOf(left[0]) - ROLE_ORDER.indexOf(right[0]))
+      .map(([role, desired]) => {
+        const effectiveDesired = Math.min(
+          Math.max(0, Math.floor(desired)),
+          remainingPrimarySlots,
+        );
+        remainingPrimarySlots -= effectiveDesired;
+        return [role, effectiveDesired] as const;
+      });
+    desiredSlotsByPlanId[plan.id] = Object.fromEntries(requiredEntries);
 
     for (const [role, desired] of requiredEntries) {
-      for (let slot = 0; slot < Math.max(0, Math.floor(desired)); slot++) {
-        if (
-          plan.id === primaryId
-          && assignmentsByPlanId[plan.id].length >= context.profile.maxPrimaryForce
-        ) {
-          break;
-        }
+      for (let slot = 0; slot < desired; slot++) {
         if (
           role === 'siege'
           && !assignedSlotsByPlanId[plan.id].some(assigned =>
@@ -175,21 +183,34 @@ export function assignUnitsToPortfolio(
           continue;
         }
 
-        const candidates = context.units
+        const compatibleCandidates = context.units
           .filter(unit =>
             !usedUnitIds.has(unit.id)
             && !recovering.has(unit.id)
             && !unit.embarked
             && roleFit(unit.type, role) > 0
-            && Number.isFinite(unit.travelTurnsByPlanId[plan.id]))
-          .filter(unit => {
+            && Number.isFinite(unit.travelTurnsByPlanId[plan.id]));
+        const capacityEligibleCandidates = compatibleCandidates.filter(unit => {
             if (!context.requiresEmbarkationByPlanId[plan.id]) return true;
             const definition = UNIT_DEFINITIONS[unit.type];
             if (role === 'transport') return definition.cargoCapacity !== undefined;
             if ((definition.domain ?? 'land') !== 'land') return true;
             const cargoSize = definition.cargoSize ?? 1;
             return cargoCapacityUsed + cargoSize <= transportCapacity;
+          });
+        if (
+          capacityEligibleCandidates.length === 0
+          && compatibleCandidates.some(unit => {
+            const definition = UNIT_DEFINITIONS[unit.type];
+            return context.requiresEmbarkationByPlanId[plan.id]
+              && role !== 'transport'
+              && (definition.domain ?? 'land') === 'land'
+              && cargoCapacityUsed + (definition.cargoSize ?? 1) > transportCapacity;
           })
+        ) {
+          capacityBlockedPlanIds.add(plan.id);
+        }
+        const candidates = capacityEligibleCandidates
           .map(unit => ({
             unit,
             score: roleFit(unit.type, role) * 40
@@ -226,7 +247,7 @@ export function assignUnitsToPortfolio(
 
   const demandByRole = new Map<AIStrategicRole, AIForceDemand>();
   for (const plan of plans) {
-    for (const [role, desiredRaw] of Object.entries(plan.requiredRoles) as Array<[AIStrategicRole, number]>) {
+    for (const [role, desiredRaw] of Object.entries(desiredSlotsByPlanId[plan.id] ?? {}) as Array<[AIStrategicRole, number]>) {
       const desired = Math.max(0, Math.floor(desiredRaw));
       const assigned = assignedSlotsByPlanId[plan.id].filter(slot => slot === role).length;
       const existing = demandByRole.get(role) ?? {
@@ -244,6 +265,23 @@ export function assignUnitsToPortfolio(
       existing.sourcePlanIds.push(plan.id);
       demandByRole.set(role, existing);
     }
+  }
+  for (const planId of capacityBlockedPlanIds) {
+    const plan = plans.find(candidate => candidate.id === planId);
+    if (!plan) continue;
+    const existing = demandByRole.get('transport') ?? {
+      role: 'transport',
+      desired: 0,
+      assigned: 0,
+      missing: 0,
+      priority: 0,
+      sourcePlanIds: [],
+    };
+    existing.desired += 1;
+    existing.missing = Math.max(0, existing.desired - existing.assigned);
+    existing.priority = Math.max(existing.priority, planPriority(plan, context));
+    existing.sourcePlanIds.push(plan.id);
+    demandByRole.set('transport', existing);
   }
 
   const defensePlansByCityId = Object.fromEntries(

--- a/src/ai/ai-unit-roles.ts
+++ b/src/ai/ai-unit-roles.ts
@@ -1,0 +1,62 @@
+import type { AIStrategicRole, UnitType } from '@/core/types';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+const ROLE_OVERRIDES: Partial<Record<UnitType, readonly AIStrategicRole[]>> = {
+  scout: ['recon'],
+  observation_balloon: ['recon'],
+  caravan: ['trade'],
+  expedition: ['resource-expedition', 'recon'],
+  settler: ['settlement'],
+  worker: ['worker'],
+  spy_scout: ['espionage', 'recon'],
+  spy_informant: ['espionage'],
+  spy_agent: ['espionage'],
+  spy_operative: ['espionage'],
+  spy_hacker: ['espionage'],
+  scout_hound: ['detection', 'frontline'],
+  shadow_warden: ['detection', 'frontline'],
+  war_hound: ['detection', 'frontline', 'mobile', 'capture'],
+};
+
+const COMBAT_ROLES = new Set<AIStrategicRole>([
+  'capture',
+  'frontline',
+  'ranged',
+  'siege',
+  'mobile',
+  'air-combat',
+  'naval-combat',
+  'escort',
+]);
+
+export function getAIStrategicRoles(type: UnitType): readonly AIStrategicRole[] {
+  const override = ROLE_OVERRIDES[type];
+  if (override) return override;
+
+  const definition = UNIT_DEFINITIONS[type];
+  if (definition.domain === 'air') {
+    return definition.attackProfile ? ['air-combat', 'ranged'] : ['recon'];
+  }
+  if (definition.cargoCapacity !== undefined) {
+    return definition.strength > 0 ? ['transport', 'escort'] : ['transport'];
+  }
+  if (definition.domain === 'naval') return ['naval-combat', 'escort'];
+  if (definition.strength <= 0) return [];
+  if (
+    definition.attackProfile?.kind === 'siege'
+    || definition.attackProfile?.kind === 'bombard'
+  ) {
+    return ['siege', 'ranged'];
+  }
+  if (definition.attackProfile?.kind === 'ranged') {
+    return definition.movementPoints >= 3
+      ? ['ranged', 'mobile', 'capture']
+      : ['ranged', 'capture'];
+  }
+  if (definition.movementPoints >= 3) return ['mobile', 'capture'];
+  return ['frontline', 'capture'];
+}
+
+export function hasAICombatRole(type: UnitType): boolean {
+  return getAIStrategicRoles(type).some(role => COMBAT_ROLES.has(role));
+}

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -19,6 +19,7 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { getAttackTargets } from '@/systems/attack-targeting';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
+import { resolveCivilizationEra } from '@/systems/tech-definitions';
 import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { hasMetCivilization, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
@@ -1207,7 +1208,10 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     const {
       self: selfStrength,
       others: otherStrengths,
-    } = buildDiplomaticStrengthEstimates(perception, newState.era);
+    } = buildDiplomaticStrengthEstimates(
+      perception,
+      resolveCivilizationEra(civ.techState.completed),
+    );
     const diplomacyContext: Record<string, { hasMet: boolean; hasBorderPressure: boolean }> = {};
     for (const otherId of perception.knownCivIds) {
       const otherCities = perception.knownCities

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -79,6 +79,11 @@ import {
 } from '@/systems/pirate-actions';
 import { derivePirateBlockades } from '@/systems/pirate-behavior';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
+import {
+  buildDiplomaticStrengthEstimates,
+  buildMajorCivPerception,
+} from './ai-perception';
+import { hasAICombatRole } from './ai-unit-roles';
 
 function addAlwaysHostileOwners(
   state: GameState,
@@ -1193,37 +1198,43 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
 
   // --- Handle diplomacy ---
   if (civ.diplomacy) {
-    const selfStrength = militaryUnits.reduce((sum, u) => {
-      const def = newState.units[u.id];
-      return sum + (def?.health ?? 0);
-    }, 0);
-
-    const otherStrengths: Record<string, number> = {};
+    updateAndRefreshVisibility(newState, civId);
+    for (const contact of syncCivilizationContactsFromVisibility(newState, civId)) {
+      bus.emit('civilization:first-contact', contact);
+    }
+    civ = newState.civilizations[civId];
+    const perception = buildMajorCivPerception(newState, civId);
+    const {
+      self: selfStrength,
+      others: otherStrengths,
+    } = buildDiplomaticStrengthEstimates(perception, newState.era);
     const diplomacyContext: Record<string, { hasMet: boolean; hasBorderPressure: boolean }> = {};
-    for (const [otherId, otherCiv] of Object.entries(newState.civilizations)) {
-      if (otherId === civId) continue;
-      const otherMil = otherCiv.units
-        .map(id => newState.units[id])
-        .filter((u): u is Unit => u !== undefined && u.type === 'warrior');
-      otherStrengths[otherId] = otherMil.reduce((sum, u) => sum + u.health, 0);
-
-      const otherCities = otherCiv.cities
-        .map(id => newState.cities[id])
-        .filter((city): city is City => city !== undefined);
+    for (const otherId of perception.knownCivIds) {
+      const otherCities = perception.knownCities
+        .filter(city => city.owner === otherId && city.position !== null);
       const ownCities = civ.cities
         .map(id => newState.cities[id])
         .filter((city): city is City => city !== undefined);
       const ownUnits = civ.units
         .map(id => newState.units[id])
         .filter((unit): unit is Unit => unit !== undefined);
-      const otherUnits = otherCiv.units
-        .map(id => newState.units[id])
-        .filter((unit): unit is Unit => unit !== undefined);
+      const otherUnits = perception.units
+        .filter(unit => unit.owner === otherId && unit.position !== null);
 
       const hasBorderPressure = ownUnits.some(unit =>
-        otherCities.some(city => hexDistance(unit.position, city.position) <= 3),
+        otherCities.some(city => {
+          const distance = newState.map.wrapsHorizontally
+            ? wrappedHexDistance(unit.position, city.position!, newState.map.width)
+            : hexDistance(unit.position, city.position!);
+          return distance <= 3;
+        }),
       ) || otherUnits.some(unit =>
-        ownCities.some(city => hexDistance(unit.position, city.position) <= 3),
+        ownCities.some(city => {
+          const distance = newState.map.wrapsHorizontally
+            ? wrappedHexDistance(unit.position!, city.position, newState.map.width)
+            : hexDistance(unit.position!, city.position);
+          return distance <= 3;
+        }),
       );
 
       diplomacyContext[otherId] = {
@@ -1284,7 +1295,10 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
 
     // AI vassalage: offer vassalage if very weak
     const currentCities = civ.cities.length;
-    const currentMilitary = militaryUnits.length;
+    const currentMilitary = civ.units
+      .map(unitId => newState.units[unitId])
+      .filter((unit): unit is Unit => Boolean(unit) && !unit.transportId && hasAICombatRole(unit.type))
+      .length;
     const vassalageDecision = evaluateVassalage(
       personality, civ.diplomacy, newState.era, selfStrength,
       currentCities, currentMilitary, otherStrengths,

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -199,6 +199,18 @@ export function createEmptyOpponentAIState(): OpponentAIState {
   };
 }
 
+export function createEmptyMajorCivPlanPortfolio(): MajorCivPlanPortfolio {
+  return {
+    primaryPlan: null,
+    defensePlansByCityId: {},
+    upgradeRoutesByUnitId: {},
+    modernizationDemand: 0,
+    researchTargetTechId: null,
+    lastPlannedTurn: -1,
+    lastExecutedTurn: -1,
+  };
+}
+
 export function normalizeOpponentAIState(state: GameState): GameState {
   const source = state.opponentAI;
   if (!source || source.version !== 1) {

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -59,6 +59,7 @@ const STRATEGIC_ROLES = new Set([
   'trade',
   'espionage',
 ]);
+const MAX_PLAN_ROLE_REQUIREMENT = 32;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -113,14 +114,21 @@ function normalizePlan(
   if (isRecord(plan.requiredRoles)) {
     for (const [role, count] of Object.entries(plan.requiredRoles)) {
       if (STRATEGIC_ROLES.has(role) && Number.isFinite(count) && Number(count) > 0) {
-        requiredRoles[role as keyof typeof requiredRoles] = Math.floor(Number(count));
+        requiredRoles[role as keyof typeof requiredRoles] = Math.min(
+          MAX_PLAN_ROLE_REQUIREMENT,
+          Math.floor(Number(count)),
+        );
       }
     }
   }
 
   return {
-    ...plan,
+    id: plan.id,
+    actorId,
+    objective: plan.objective,
     target: structuredClone(plan.target),
+    theaterId: plan.theaterId,
+    phase: plan.phase,
     reasonCodes: Array.isArray(plan.reasonCodes)
       ? plan.reasonCodes.filter(reason => PLAN_REASONS.has(reason))
       : [],
@@ -131,7 +139,8 @@ function normalizePlan(
     lastProgressTurn: Math.max(0, Math.floor(plan.lastProgressTurn)),
     requiredRoles,
     assignedUnitIds: Array.isArray(plan.assignedUnitIds)
-      ? [...new Set(plan.assignedUnitIds.filter(unitId => state.units[unitId]?.owner === actorId))]
+      ? [...new Set(plan.assignedUnitIds.filter(unitId =>
+          typeof unitId === 'string' && state.units[unitId]?.owner === actorId))]
       : [],
     ...(isFiniteCoord(plan.rallyPoint) ? { rallyPoint: { ...plan.rallyPoint } } : { rallyPoint: undefined }),
   };
@@ -149,8 +158,15 @@ function normalizePortfolio(
   for (const [cityId, planValue] of Object.entries(portfolio.defensePlansByCityId ?? {})) {
     if (state.cities[cityId]?.owner !== actorId) continue;
     const plan = normalizePlan(state, actorId, planValue);
-    if (plan) defensePlansByCityId[cityId] = plan;
+    if (
+      plan?.objective === 'defend'
+      && plan.target.kind === 'city'
+      && plan.target.id === cityId
+    ) {
+      defensePlansByCityId[cityId] = plan;
+    }
   }
+  const normalizedPrimary = normalizePlan(state, actorId, portfolio.primaryPlan);
 
   const upgradeRoutesByUnitId: MajorCivPlanPortfolio['upgradeRoutesByUnitId'] = {};
   for (const [unitId, route] of Object.entries(portfolio.upgradeRoutesByUnitId ?? {})) {
@@ -169,7 +185,7 @@ function normalizePortfolio(
   }
 
   return {
-    primaryPlan: normalizePlan(state, actorId, portfolio.primaryPlan),
+    primaryPlan: normalizedPrimary?.objective === 'defend' ? null : normalizedPrimary,
     defensePlansByCityId,
     upgradeRoutesByUnitId,
     modernizationDemand: Math.max(
@@ -179,8 +195,12 @@ function normalizePortfolio(
     researchTargetTechId: typeof portfolio.researchTargetTechId === 'string'
       ? portfolio.researchTargetTechId
       : null,
-    lastPlannedTurn: Number.isFinite(portfolio.lastPlannedTurn) ? portfolio.lastPlannedTurn! : 0,
-    lastExecutedTurn: Number.isFinite(portfolio.lastExecutedTurn) ? portfolio.lastExecutedTurn! : 0,
+    lastPlannedTurn: Number.isFinite(portfolio.lastPlannedTurn)
+      ? Math.max(-1, Math.floor(portfolio.lastPlannedTurn!))
+      : -1,
+    lastExecutedTurn: Number.isFinite(portfolio.lastExecutedTurn)
+      ? Math.max(-1, Math.floor(portfolio.lastExecutedTurn!))
+      : -1,
   };
 }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -276,6 +276,15 @@ export interface LastSeenCityPresentation {
   population: number;
 }
 
+export type LastSeenHealthBand = 'healthy' | 'damaged' | 'critical';
+
+export interface LastSeenUnitPresentation {
+  id: string;
+  owner: string;
+  type: UnitType;
+  healthBand: LastSeenHealthBand;
+}
+
 export interface LastSeenTilePresentation {
   coord: HexCoord;
   terrain: TerrainType;
@@ -287,6 +296,9 @@ export interface LastSeenTilePresentation {
   hasRiver: boolean;
   wonder: string | null;
   city?: LastSeenCityPresentation;
+  observedTurn?: number;
+  source?: 'observed' | 'legacy-reconstructed';
+  units?: LastSeenUnitPresentation[];
 }
 
 // --- Units ---

--- a/src/systems/actor-perception.ts
+++ b/src/systems/actor-perception.ts
@@ -1,0 +1,33 @@
+import type { GameState, HexCoord, Unit } from '@/core/types';
+import { hexDistance, wrappedHexDistance } from './hex-utils';
+
+function distance(state: GameState, left: HexCoord, right: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(left, right, state.map.width)
+    : hexDistance(left, right);
+}
+
+export function getLocallySensedUnits(
+  state: GameState,
+  centers: readonly HexCoord[],
+  radius: number,
+  ownerFilter: (owner: string) => boolean,
+): Unit[] {
+  if (centers.length === 0 || !Number.isFinite(radius) || radius < 0) return [];
+
+  return Object.values(state.units)
+    .filter(unit => !unit.transportId && ownerFilter(unit.owner))
+    .map(unit => ({
+      unit,
+      distance: Math.min(...centers.map(center => distance(state, center, unit.position))),
+    }))
+    .filter(candidate => candidate.distance <= radius)
+    .sort((left, right) =>
+      left.distance - right.distance || left.unit.id.localeCompare(right.unit.id))
+    .map(candidate => candidate.unit);
+}
+
+export function decayRememberedConfidence(age: number): number {
+  if (!Number.isFinite(age)) return 0;
+  return Math.max(0, 1 - Math.max(0, age) / 6);
+}

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -8,6 +8,7 @@ import {
   destroyPirateFaction,
   type PirateActionEvent,
 } from '@/systems/pirate-actions';
+import { recordMilitaryAttack } from './diplomacy-system';
 
 export type VeterancyTierId = 'recruit' | 'seasoned' | 'veteran' | 'elite';
 
@@ -235,6 +236,22 @@ export function applyCombatOutcomeToState(
   let units = { ...state.units };
   let civilizations = { ...state.civilizations };
   let espionage = state.espionage ? { ...state.espionage } : state.espionage;
+
+  const defenderCiv = civilizations[defenderBefore.owner];
+  if (
+    attackerBefore.owner !== defenderBefore.owner
+    && civilizations[attackerBefore.owner]
+    && defenderCiv?.diplomacy
+  ) {
+    civilizations[defenderBefore.owner] = {
+      ...defenderCiv,
+      diplomacy: recordMilitaryAttack(
+        defenderCiv.diplomacy,
+        attackerBefore.owner,
+        state.turn,
+      ),
+    };
+  }
 
   if (result.attackerSurvived) {
     units[result.attackerId] = {

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -72,21 +72,32 @@ export function recordMilitaryAttack(
   attackerCivId: string,
   turn: number,
 ): DiplomacyState {
-  const unrelated = state.events.filter(event => event.type !== 'military_attacked');
-  const attacks = state.events
-    .filter(event => event.type === 'military_attacked')
-    .filter(event => !(event.otherCiv === attackerCivId && event.turn === turn));
-  attacks.push({
+  const withoutDuplicate = state.events.filter(event =>
+    event.type !== 'military_attacked'
+    || event.otherCiv !== attackerCivId
+    || event.turn !== turn);
+  const newAttack = {
     type: 'military_attacked',
     turn,
     otherCiv: attackerCivId,
     weight: 1,
-  });
-  attacks.sort((left, right) =>
-    left.turn - right.turn || left.otherCiv.localeCompare(right.otherCiv));
+  } as const;
+  const retainedAttacks = new Set(
+    [
+      ...withoutDuplicate.filter(event => event.type === 'military_attacked'),
+      newAttack,
+    ]
+      .sort((left, right) =>
+        left.turn - right.turn || left.otherCiv.localeCompare(right.otherCiv))
+      .slice(-12),
+  );
   return {
     ...state,
-    events: [...unrelated, ...attacks.slice(-12)],
+    events: [
+      ...withoutDuplicate.filter(event =>
+        event.type !== 'military_attacked' || retainedAttacks.has(event)),
+      ...(retainedAttacks.has(newAttack) ? [newAttack] : []),
+    ],
   };
 }
 

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -67,6 +67,29 @@ export function modifyRelationship(
   return newState;
 }
 
+export function recordMilitaryAttack(
+  state: DiplomacyState,
+  attackerCivId: string,
+  turn: number,
+): DiplomacyState {
+  const unrelated = state.events.filter(event => event.type !== 'military_attacked');
+  const attacks = state.events
+    .filter(event => event.type === 'military_attacked')
+    .filter(event => !(event.otherCiv === attackerCivId && event.turn === turn));
+  attacks.push({
+    type: 'military_attacked',
+    turn,
+    otherCiv: attackerCivId,
+    weight: 1,
+  });
+  attacks.sort((left, right) =>
+    left.turn - right.turn || left.otherCiv.localeCompare(right.otherCiv));
+  return {
+    ...state,
+    events: [...unrelated, ...attacks.slice(-12)],
+  };
+}
+
 export function isAtWar(state: DiplomacyState, civId: string): boolean {
   return state.atWarWith.includes(civId);
 }

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -1,11 +1,54 @@
-import type { GameState, HexCoord, HexTile, LastSeenTilePresentation, Unit } from '@/core/types';
-import { getVisibility, updateVisibility } from '@/systems/fog-of-war';
-import { hexKey, parseHexKey } from '@/systems/hex-utils';
+import type {
+  GameState,
+  HexCoord,
+  HexTile,
+  LastSeenHealthBand,
+  LastSeenTilePresentation,
+  LastSeenUnitPresentation,
+  Unit,
+} from '@/core/types';
+import { getVisibility, isForestConcealedUnit, updateVisibility } from '@/systems/fog-of-war';
+import { hexKey, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
+import { canInspectUnitForViewer } from './viewer-intel';
 
-export function createLastSeenTilePresentation(
+function healthBand(health: number): LastSeenHealthBand {
+  if (health >= 70) return 'healthy';
+  if (health >= 30) return 'damaged';
+  return 'critical';
+}
+
+function visibleUnitsByTile(
   state: GameState,
-  _viewerId: string,
+  viewerId: string,
+): Map<string, LastSeenUnitPresentation[]> {
+  const byTile = new Map<string, LastSeenUnitPresentation[]>();
+  for (const unit of Object.values(state.units)
+    .filter(unit => !unit.transportId)
+    .filter(unit => canInspectUnitForViewer(state, viewerId, unit.id))
+    .filter(unit => !isForestConcealedUnit(state, viewerId, unit))) {
+    const position = state.map.wrapsHorizontally
+      ? wrapHexCoord(unit.position, state.map.width)
+      : unit.position;
+    const key = hexKey(position);
+    const presentations = byTile.get(key) ?? [];
+    presentations.push({
+      id: unit.id,
+      owner: unit.owner,
+      type: unit.type,
+      healthBand: healthBand(unit.health),
+    });
+    byTile.set(key, presentations);
+  }
+  for (const presentations of byTile.values()) {
+    presentations.sort((left, right) => left.id.localeCompare(right.id));
+  }
+  return byTile;
+}
+
+function createTilePresentation(
+  state: GameState,
   tile: HexTile,
+  units: LastSeenUnitPresentation[],
 ): LastSeenTilePresentation {
   const tileKey = hexKey(tile.coord);
   const city = Object.values(state.cities).find(candidate => hexKey(candidate.position) === tileKey);
@@ -22,7 +65,22 @@ export function createLastSeenTilePresentation(
     city: city
       ? { id: city.id, name: city.name, owner: city.owner, population: city.population }
       : undefined,
+    observedTurn: state.turn,
+    source: 'observed',
+    units,
   };
+}
+
+export function createLastSeenTilePresentation(
+  state: GameState,
+  viewerId: string,
+  tile: HexTile,
+): LastSeenTilePresentation {
+  return createTilePresentation(
+    state,
+    tile,
+    visibleUnitsByTile(state, viewerId).get(hexKey(tile.coord)) ?? [],
+  );
 }
 
 export function refreshLastSeenPresentationsForCiv(state: GameState, viewerId: string): void {
@@ -30,10 +88,15 @@ export function refreshLastSeenPresentationsForCiv(state: GameState, viewerId: s
   if (!civ?.visibility) return;
 
   civ.visibility.lastSeen ??= {};
+  const unitsByTile = visibleUnitsByTile(state, viewerId);
   for (const [key, tile] of Object.entries(state.map.tiles)) {
     const coord = tile.coord ?? parseHexKey(key);
     if (getVisibility(civ.visibility, coord) !== 'visible') continue;
-    civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, viewerId, { ...tile, coord });
+    civ.visibility.lastSeen[key] = createTilePresentation(
+      state,
+      { ...tile, coord },
+      unitsByTile.get(key) ?? [],
+    );
   }
 }
 
@@ -51,7 +114,15 @@ export function reconstructLastSeenFromMap(state: GameState, civId: string): voi
     if (civ.visibility.tiles[key] !== 'fog') continue;
     if (civ.visibility.lastSeen[key]) continue;
     const coord = tile.coord ?? parseHexKey(key);
-    civ.visibility.lastSeen[key] = createLastSeenTilePresentation(state, civId, { ...tile, coord });
+    const {
+      observedTurn: _observedTurn,
+      units: _units,
+      ...presentation
+    } = createTilePresentation(state, { ...tile, coord }, []);
+    civ.visibility.lastSeen[key] = {
+      ...presentation,
+      source: 'legacy-reconstructed',
+    };
   }
 }
 

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -10,6 +10,36 @@ import type {
 import { getVisibility, isForestConcealedUnit, updateVisibility } from '@/systems/fog-of-war';
 import { hexKey, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { canInspectUnitForViewer } from './viewer-intel';
+import { getVisibleUnitsForPlayer } from './espionage-stealth';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === 'string';
+}
+
+export function isTrustedObservedLastSeenTile(
+  value: unknown,
+): value is LastSeenTilePresentation & {
+  observedTurn: number;
+  source: 'observed';
+} {
+  if (!isRecord(value) || !isRecord(value.coord)) return false;
+  return value.source === 'observed'
+    && Number.isFinite(value.observedTurn)
+    && Number.isFinite(value.coord.q)
+    && Number.isFinite(value.coord.r)
+    && typeof value.terrain === 'string'
+    && typeof value.elevation === 'string'
+    && isNullableString(value.resource)
+    && typeof value.improvement === 'string'
+    && Number.isFinite(value.improvementTurnsLeft)
+    && isNullableString(value.owner)
+    && typeof value.hasRiver === 'boolean'
+    && isNullableString(value.wonder);
+}
 
 function healthBand(health: number): LastSeenHealthBand {
   if (health >= 70) return 'healthy';
@@ -22,7 +52,8 @@ function visibleUnitsByTile(
   viewerId: string,
 ): Map<string, LastSeenUnitPresentation[]> {
   const byTile = new Map<string, LastSeenUnitPresentation[]>();
-  for (const unit of Object.values(state.units)
+  const viewerFacingUnits = getVisibleUnitsForPlayer(state.units, state, viewerId);
+  for (const unit of Object.values(viewerFacingUnits)
     .filter(unit => !unit.transportId)
     .filter(unit => canInspectUnitForViewer(state, viewerId, unit.id))
     .filter(unit => !isForestConcealedUnit(state, viewerId, unit))) {
@@ -67,7 +98,7 @@ function createTilePresentation(
       : undefined,
     observedTurn: state.turn,
     source: 'observed',
-    units,
+    ...(units.length > 0 ? { units } : {}),
   };
 }
 

--- a/tests/ai/ai-decision-trace.test.ts
+++ b/tests/ai/ai-decision-trace.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { createAIDecisionTrace } from '@/ai/ai-decision-trace';
+
+describe('AI decision traces', () => {
+  it('keeps only the top twelve candidates in deterministic score order', () => {
+    const trace = createAIDecisionTrace({
+      actorId: 'ai-1',
+      turn: 12,
+      decision: 'objective',
+      selectedId: 'candidate-14',
+      candidates: Array.from({ length: 15 }, (_, index) => ({
+        id: `candidate-${index}`,
+        score: index,
+        eligible: index % 2 === 0,
+        reasonCodes: [],
+      })),
+    });
+
+    expect(trace.candidates).toHaveLength(12);
+    expect(trace.candidates[0].id).toBe('candidate-14');
+    expect(trace.candidates.at(-1)?.id).toBe('candidate-3');
+  });
+
+  it('defensively copies transient trace candidates', () => {
+    const candidates = [{
+      id: 'candidate',
+      score: 10,
+      eligible: true,
+      reasonCodes: ['nearby'],
+    }];
+    const trace = createAIDecisionTrace({
+      actorId: 'ai-1',
+      turn: 12,
+      decision: 'objective',
+      selectedId: 'candidate',
+      candidates,
+    });
+    candidates[0].reasonCodes.push('mutated');
+
+    expect(trace.candidates[0].reasonCodes).toEqual(['nearby']);
+  });
+});

--- a/tests/ai/ai-diplomacy.test.ts
+++ b/tests/ai/ai-diplomacy.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from 'vitest';
 import { evaluateDiplomacy, evaluateMinorCivDiplomacy } from '@/ai/ai-diplomacy';
 import type { PersonalityTraits, GameState, MinorCivState, DiplomacyState } from '@/core/types';
+import type { MilitaryStrengthEstimate } from '@/ai/ai-strength';
+
+function strength(midpoint: number): MilitaryStrengthEstimate {
+  return {
+    exactVisible: midpoint,
+    remembered: 0,
+    uncertaintyLower: midpoint,
+    uncertaintyUpper: midpoint,
+    midpoint,
+  };
+}
 
 function makeDiplomacy(overrides: Partial<DiplomacyState> = {}): DiplomacyState {
   return {
@@ -102,12 +113,42 @@ describe('evaluateDiplomacy', () => {
       makeDiplomacy({ relationships: { player: -60 } }),
       [],
       1,
-      { player: 10 },
-      100,
+      { player: strength(10) },
+      strength(100),
       1,
       { player: { hasMet: false, hasBorderPressure: false } },
     );
 
     expect(decisions.find(d => d.action === 'declare_war')).toBeUndefined();
+  });
+
+  it('treats a missing perception context as unmet', () => {
+    const decisions = evaluateDiplomacy(
+      aggressivePersonality,
+      makeDiplomacy({ relationships: { player: -100 } }),
+      [],
+      4,
+      { player: strength(10) },
+      strength(100),
+      20,
+      {},
+    );
+
+    expect(decisions.find(decision => decision.action === 'declare_war')).toBeUndefined();
+  });
+
+  it('compares both civilizations through the same midpoint contract', () => {
+    const decisions = evaluateDiplomacy(
+      aggressivePersonality,
+      makeDiplomacy({ relationships: { player: -60 } }),
+      [],
+      4,
+      { player: strength(120) },
+      strength(40),
+      20,
+      { player: { hasMet: true, hasBorderPressure: true } },
+    );
+
+    expect(decisions.find(decision => decision.action === 'declare_war')).toBeUndefined();
   });
 });

--- a/tests/ai/ai-diplomacy.test.ts
+++ b/tests/ai/ai-diplomacy.test.ts
@@ -137,6 +137,21 @@ describe('evaluateDiplomacy', () => {
     expect(decisions.find(decision => decision.action === 'declare_war')).toBeUndefined();
   });
 
+  it('does not sign treaties with an unmet civilization', () => {
+    const decisions = evaluateDiplomacy(
+      diplomaticPersonality,
+      makeDiplomacy({ relationships: { player: 80 } }),
+      [],
+      4,
+      { player: strength(40) },
+      strength(40),
+      20,
+      { player: { hasMet: false, hasBorderPressure: false } },
+    );
+
+    expect(decisions).toEqual([]);
+  });
+
   it('compares both civilizations through the same midpoint contract', () => {
     const decisions = evaluateDiplomacy(
       aggressivePersonality,

--- a/tests/ai/ai-objective-scoring.test.ts
+++ b/tests/ai/ai-objective-scoring.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+import {
+  choosePrimaryObjective,
+  getObjectiveApproximateDistance,
+  resolveObjectiveTravelCandidates,
+  scoreObjectiveCandidate,
+  type AIObjectiveCandidate,
+  type AIObjectiveTravelCandidate,
+} from '@/ai/ai-objective-scoring';
+
+function candidate(
+  id: string,
+  travelTurns: number,
+  strategicValue: number,
+  overrides: Partial<AIObjectiveCandidate> = {},
+): AIObjectiveCandidate {
+  return {
+    objective: 'capture',
+    target: { kind: 'city', id, lastKnownPosition: { q: travelTurns, r: 0 } },
+    theaterId: 'region-0',
+    travelTurns,
+    strategicValue,
+    expectedLossRatio: 0,
+    supplyDistance: travelTurns,
+    explicitDistantReasons: [],
+    requiredRoles: { capture: 1 },
+    ...overrides,
+  };
+}
+
+describe('AI objective scoring', () => {
+  it('chooses a close viable city over a much richer distant capital', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [
+        candidate('close', 4, 45),
+        candidate('far-capital', 16, 100),
+      ],
+      availableRoles: { capture: 2 },
+    });
+
+    expect(result.plan?.target).toMatchObject({ kind: 'city', id: 'close' });
+    expect(result.trace.candidates.find(entry => entry.id.includes('far-capital'))?.eligible)
+      .toBe(false);
+  });
+
+  it('makes a distant aggressor eligible without bypassing transport feasibility', () => {
+    const distant = candidate('aggressor', 14, 90, {
+      explicitDistantReasons: ['retaliate-recent-attack'],
+      requiredRoles: { capture: 1, transport: 1 },
+    });
+    const local = candidate('close', 3, 30);
+
+    const withoutTransport = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [local, distant],
+      availableRoles: { capture: 2 },
+    });
+    expect(withoutTransport.plan?.target).toMatchObject({ kind: 'city', id: 'close' });
+    expect(withoutTransport.demands).toContain('transport');
+
+    const withTransport = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [local, distant],
+      availableRoles: { capture: 2, transport: 1 },
+    });
+    expect(withTransport.trace.candidates.find(entry => entry.id.includes('aggressor')))
+      .toMatchObject({ eligible: true, reasonCodes: ['retaliate-recent-attack'] });
+  });
+
+  it('prefers useful local development over unsupported distant conquest', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [
+        candidate('distant-capital', 12, 100),
+        candidate('iron', 3, 50, {
+          objective: 'secure-resource',
+          target: { kind: 'resource', resource: 'iron', position: { q: 3, r: 0 } },
+          requiredRoles: { 'resource-expedition': 1 },
+        }),
+      ],
+      availableRoles: { capture: 2, 'resource-expedition': 1 },
+    });
+
+    expect(result.plan?.objective).toBe('secure-resource');
+  });
+
+  it('allows regional expansion when there is no closer alternative', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [candidate('only-option', 12, 70)],
+      availableRoles: { capture: 1 },
+    });
+
+    expect(result.plan?.target).toMatchObject({ kind: 'city', id: 'only-option' });
+    expect(result.plan?.reasonCodes).toContain('no-local-alternative');
+  });
+
+  it('keeps an existing distant war eligible', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [
+        candidate('close', 3, 35),
+        candidate('war-target', 11, 75, {
+          explicitDistantReasons: ['continue-active-war'],
+        }),
+      ],
+      availableRoles: { capture: 2 },
+    });
+
+    expect(result.trace.candidates.find(entry => entry.id.includes('war-target')))
+      .toMatchObject({ eligible: true, reasonCodes: ['continue-active-war'] });
+  });
+
+  it('turns an offensive region rumor into a recon demand instead of an attack', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [candidate('rumor', 5, 80, {
+        target: { kind: 'region', id: 'rumored-seat', anchor: { q: 5, r: 0 } },
+      })],
+      availableRoles: { capture: 1 },
+    });
+
+    expect(result.plan).toBeNull();
+    expect(result.demands).toContain('recon');
+  });
+
+  it('excludes unreachable objectives even with a retaliation reason', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [candidate('unreachable', Number.POSITIVE_INFINITY, 100, {
+        explicitDistantReasons: ['retaliate-recent-attack'],
+      })],
+      availableRoles: { capture: 1 },
+    });
+
+    expect(result.plan).toBeNull();
+  });
+
+  it.each([
+    ['homeland-secure'],
+    ['nearby-opportunity'],
+    ['opportunistic-raid'],
+  ] as const)('does not let %s bypass locality', reason => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [
+        candidate('close', 3, 30),
+        candidate('far', 15, 100, { explicitDistantReasons: [reason] }),
+      ],
+      availableRoles: { capture: 2 },
+    });
+
+    expect(result.trace.candidates.find(entry => entry.id.includes(':far'))?.eligible).toBe(false);
+  });
+
+  it('uses wrapped horizontal distance for approximate candidate ordering', () => {
+    const map = { width: 20, height: 10, wrapsHorizontally: true };
+    expect(getObjectiveApproximateDistance(map, { q: 0, r: 0 }, { q: 19, r: 0 })).toBe(1);
+  });
+
+  it('caps canonical path queries and caches duplicate travel requests for one pass', () => {
+    const map = {
+      width: 40,
+      height: 20,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {},
+    };
+    const inputs: AIObjectiveTravelCandidate[] = Array.from({ length: 30 }, (_, index) => ({
+      ...candidate(`city-${index}`, 0, 50),
+      start: { q: 0, r: 0 },
+      domain: 'land',
+      movementPoints: 2,
+      completedMovementTechHash: 'none',
+    }));
+    inputs.push({ ...inputs[0], objective: 'raid' });
+    let queries = 0;
+
+    const resolved = resolveObjectiveTravelCandidates(map, inputs, (from, to) => {
+      queries += 1;
+      return [from, to];
+    });
+
+    expect(resolved.length).toBeLessThanOrEqual(16);
+    expect(queries).toBeLessThan(resolved.length);
+    expect(queries).toBeLessThanOrEqual(24);
+  });
+
+  it('applies the documented score formula with bounded values', () => {
+    const value = scoreObjectiveCandidate(candidate('score', 2, 80, {
+      expectedLossRatio: 0.5,
+      supplyDistance: 3,
+      explicitDistantReasons: ['critical-resource'],
+    }));
+
+    expect(value).toBeCloseTo(80 + 35 - (8 + 3) - 17.5 - 6);
+  });
+
+  it('breaks equal-score ties by stable target identity', () => {
+    const result = choosePrimaryObjective({
+      actorId: 'ai-1',
+      turn: 10,
+      candidates: [candidate('beta', 3, 50), candidate('alpha', 3, 50)],
+      availableRoles: { capture: 2 },
+    });
+
+    expect(result.plan?.target).toMatchObject({ kind: 'city', id: 'alpha' });
+  });
+});

--- a/tests/ai/ai-perception.test.ts
+++ b/tests/ai/ai-perception.test.ts
@@ -9,6 +9,11 @@ import {
 } from '@/ai/ai-perception';
 import { hexKey } from '@/systems/hex-utils';
 import { createUnit } from '@/systems/unit-system';
+import {
+  createEspionageCivState,
+  createSpyFromUnit,
+  setDisguise,
+} from '@/systems/espionage-system';
 
 const ACTOR = 'ai-1';
 const RIVAL = 'player';
@@ -92,6 +97,22 @@ describe('major-civilization perception', () => {
     expect(facts.knownCities.some(city => city.owner === RIVAL)).toBe(false);
   });
 
+  it('perceives visible always-hostile world units without diplomatic contact', () => {
+    const state = makePerceptionState();
+    const barbarian = createUnit('warrior', 'barbarian', OBSERVED, state.idCounters);
+    barbarian.id = 'visible-barbarian';
+    state.units[barbarian.id] = barbarian;
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'visible';
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+
+    expect(facts.units).toContainEqual(expect.objectContaining({
+      id: barbarian.id,
+      owner: 'barbarian',
+      confidence: 'visible',
+    }));
+  });
+
   it('represents contacted but unlocated rivals as rumors without exact coordinates', () => {
     const state = makePerceptionState();
 
@@ -128,6 +149,54 @@ describe('major-civilization perception', () => {
     expect(facts.units.find(unit => unit.id === 'legacy-unit')).toBeUndefined();
   });
 
+  it('does not treat a snapshot attached to an unexplored tile as earned memory', () => {
+    const state = makePerceptionState();
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'unexplored';
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = makeSnapshot(state, {
+      units: [{
+        id: 'unearned-tank',
+        type: 'tank',
+        owner: RIVAL,
+        healthBand: 'healthy',
+      }],
+    });
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+
+    expect(facts.units.find(unit => unit.id === 'unearned-tank')).toBeUndefined();
+  });
+
+  it('ignores malformed remembered-unit data from an untrusted save', () => {
+    const state = makePerceptionState();
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+    const snapshot = makeSnapshot(state);
+    (snapshot as unknown as { units: unknown }).units = {
+      id: 'not-an-array',
+    };
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = snapshot;
+
+    expect(() => buildMajorCivPerception(state, ACTOR)).not.toThrow();
+    expect(buildMajorCivPerception(state, ACTOR).units).toEqual([]);
+  });
+
+  it('keeps only structurally valid remembered units from save data', () => {
+    const state = makePerceptionState();
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+    const snapshot = makeSnapshot(state);
+    (snapshot as unknown as { units: unknown }).units = [
+      null,
+      { id: 7, owner: RIVAL, type: 'tank', healthBand: 'healthy' },
+      { id: 'bad-type', owner: RIVAL, type: 'teleporter', healthBand: 'healthy' },
+      { id: 'bad-health', owner: RIVAL, type: 'tank', healthBand: 'fine' },
+      { id: 'valid', owner: RIVAL, type: 'tank', healthBand: 'damaged' },
+    ];
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = snapshot;
+
+    expect(buildMajorCivPerception(state, ACTOR).units).toEqual([
+      expect.objectContaining({ id: 'valid', type: 'tank', healthBand: 'damaged' }),
+    ]);
+  });
+
   it('keeps own cities and units exact while returning defensive copies', () => {
     const state = makePerceptionState();
     const templateCity = Object.values(state.cities)[0];
@@ -146,6 +215,16 @@ describe('major-civilization perception', () => {
     expect(facts.ownCities[0]).not.toBe(ownCity);
   });
 
+  it('rejects stale cross-owner IDs from the actor roster', () => {
+    const state = makePerceptionState();
+    const rivalUnit = addRivalUnit(state, 'tank');
+    state.civilizations[ACTOR].units.push(rivalUnit.id);
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+
+    expect(facts.ownUnits.some(unit => unit.id === rivalUnit.id)).toBe(false);
+  });
+
   it('does not count a live hidden tank as exact military strength', () => {
     const state = makePerceptionState();
     addRivalUnit(state, 'tank', { q: 12, r: 4 });
@@ -156,6 +235,28 @@ describe('major-civilization perception', () => {
     expect(strength.exactVisible).toBe(0);
     expect(strength.remembered).toBe(0);
     expect(strength.uncertaintyUpper).toBeGreaterThan(0);
+  });
+
+  it('uses the viewer-facing disguise for a currently visible spy', () => {
+    const state = makePerceptionState();
+    const spyUnit = addRivalUnit(state, 'spy_scout');
+    state.civilizations[ACTOR].visibility.tiles[hexKey(spyUnit.position)] = 'visible';
+    const created = createSpyFromUnit(
+      createEspionageCivState(),
+      spyUnit.id,
+      RIVAL,
+      'spy_scout',
+      'perception-disguise',
+    );
+    state.espionage = {
+      [RIVAL]: setDisguise(created.state, spyUnit.id, 'warrior'),
+    };
+
+    const perceived = buildMajorCivPerception(state, ACTOR)
+      .units.find(unit => unit.id === spyUnit.id);
+
+    expect(perceived).toMatchObject({ owner: RIVAL, type: 'warrior' });
+    expect(perceived?.type).not.toBe('spy_scout');
   });
 
   it('counts every visible combat role symmetrically instead of filtering rivals to warriors', () => {
@@ -192,6 +293,25 @@ describe('major-civilization perception', () => {
     expect(capabilities.inferredEraMax).toBe(8);
     expect(JSON.stringify(capabilities)).not.toContain('cyber-warfare');
     expect(JSON.stringify(capabilities)).not.toContain('jet-aviation');
+  });
+
+  it('never reports an inferred maximum era below observed capability', () => {
+    const state = makePerceptionState();
+    state.era = 1;
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = makeSnapshot(state, {
+      units: [{
+        id: 'observed-jet',
+        type: 'jet_fighter',
+        owner: RIVAL,
+        healthBand: 'healthy',
+      }],
+    });
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+
+    const capabilities = buildMajorCivPerception(state, ACTOR)
+      .knownOpponentCapabilities[RIVAL];
+
+    expect(capabilities.inferredEraMax).toBeGreaterThanOrEqual(capabilities.inferredEraMin);
   });
 
   it('refreshes intel immutably and preserves a last-known position after sight is lost', () => {

--- a/tests/ai/ai-perception.test.ts
+++ b/tests/ai/ai-perception.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, LastSeenTilePresentation, UnitType } from '@/core/types';
+import {
+  buildDiplomaticStrengthEstimates,
+  buildMajorCivPerception,
+  estimatePerceivedCivStrength,
+  refreshMajorCivIntel,
+} from '@/ai/ai-perception';
+import { hexKey } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
+
+const ACTOR = 'ai-1';
+const RIVAL = 'player';
+const OBSERVED = { q: 8, r: 4 };
+
+function makeSnapshot(
+  state: GameState,
+  overrides: Partial<LastSeenTilePresentation> = {},
+): LastSeenTilePresentation {
+  const tile = state.map.tiles[hexKey(OBSERVED)];
+  return {
+    coord: { ...OBSERVED },
+    terrain: tile.terrain,
+    elevation: tile.elevation,
+    resource: tile.resource,
+    improvement: tile.improvement,
+    improvementTurnsLeft: tile.improvementTurnsLeft,
+    owner: tile.owner,
+    hasRiver: tile.hasRiver,
+    wonder: tile.wonder,
+    observedTurn: state.turn - 2,
+    source: 'observed',
+    ...overrides,
+  };
+}
+
+function makePerceptionState(): GameState {
+  const state = createNewGame(undefined, 'ai-perception', 'small');
+  state.turn = 10;
+  state.civilizations[ACTOR].knownCivilizations = [RIVAL];
+  state.civilizations[ACTOR].visibility.tiles = {};
+  state.civilizations[ACTOR].visibility.lastSeen = {};
+  state.civilizations[RIVAL].techState.completed = [];
+  return state;
+}
+
+function addRivalUnit(state: GameState, type: UnitType, position = OBSERVED) {
+  const unit = createUnit(type, RIVAL, position, state.idCounters);
+  unit.id = `${RIVAL}-${type}`;
+  state.units[unit.id] = unit;
+  if (!state.civilizations[RIVAL].units.includes(unit.id)) {
+    state.civilizations[RIVAL].units.push(unit.id);
+  }
+  return unit;
+}
+
+describe('major-civilization perception', () => {
+  it('does not expose live hidden coordinates through a remembered target', () => {
+    const state = makePerceptionState();
+    const tank = addRivalUnit(state, 'tank', { q: 12, r: 4 });
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = makeSnapshot(state, {
+      units: [{
+        id: tank.id,
+        type: 'tank',
+        owner: RIVAL,
+        healthBand: 'healthy',
+      }],
+    });
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+    const remembered = facts.units.find(unit => unit.id === tank.id);
+
+    expect(remembered).toMatchObject({
+      confidence: 'remembered',
+      position: OBSERVED,
+      lastSeenTurn: 8,
+    });
+    expect(remembered?.position).not.toEqual(tank.position);
+  });
+
+  it('omits unmet civilizations even when their live state exists', () => {
+    const state = makePerceptionState();
+    state.civilizations[ACTOR].knownCivilizations = [];
+    addRivalUnit(state, 'tank');
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+
+    expect(facts.knownCivIds).not.toContain(RIVAL);
+    expect(facts.units.some(unit => unit.owner === RIVAL)).toBe(false);
+    expect(facts.knownCities.some(city => city.owner === RIVAL)).toBe(false);
+  });
+
+  it('represents contacted but unlocated rivals as rumors without exact coordinates', () => {
+    const state = makePerceptionState();
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+    const rumor = facts.knownCities.find(city => city.owner === RIVAL);
+
+    expect(rumor).toMatchObject({
+      owner: RIVAL,
+      position: null,
+      confidence: 'rumored',
+      observedTurn: null,
+    });
+    expect(rumor?.id).not.toBe(state.civilizations[RIVAL].cities[0]);
+  });
+
+  it('expires remembered units after six rounds and ignores untrusted legacy snapshots', () => {
+    const state = makePerceptionState();
+    const tank = addRivalUnit(state, 'tank', { q: 12, r: 4 });
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = makeSnapshot(state, {
+      observedTurn: state.turn - 7,
+      units: [{ id: tank.id, type: tank.type, owner: RIVAL, healthBand: 'healthy' }],
+    });
+    state.civilizations[ACTOR].visibility.lastSeen!['7,4'] = makeSnapshot(state, {
+      coord: { q: 7, r: 4 },
+      observedTurn: undefined,
+      source: 'legacy-reconstructed',
+      units: [{ id: 'legacy-unit', type: 'warrior', owner: RIVAL, healthBand: 'healthy' }],
+    });
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+
+    expect(facts.units.find(unit => unit.id === tank.id)).toBeUndefined();
+    expect(facts.units.find(unit => unit.id === 'legacy-unit')).toBeUndefined();
+  });
+
+  it('keeps own cities and units exact while returning defensive copies', () => {
+    const state = makePerceptionState();
+    const templateCity = Object.values(state.cities)[0];
+    const ownCity = structuredClone(templateCity);
+    ownCity.id = 'ai-perception-city';
+    ownCity.owner = ACTOR;
+    state.cities[ownCity.id] = ownCity;
+    state.civilizations[ACTOR].cities.push(ownCity.id);
+
+    const facts = buildMajorCivPerception(state, ACTOR);
+    const ownUnit = facts.ownUnits[0];
+
+    expect(ownUnit).toBeDefined();
+    expect(ownUnit).not.toBe(state.units[ownUnit.id]);
+    expect(facts.ownCities[0]).toEqual(ownCity);
+    expect(facts.ownCities[0]).not.toBe(ownCity);
+  });
+
+  it('does not count a live hidden tank as exact military strength', () => {
+    const state = makePerceptionState();
+    addRivalUnit(state, 'tank', { q: 12, r: 4 });
+
+    const perception = buildMajorCivPerception(state, ACTOR);
+    const strength = estimatePerceivedCivStrength(perception, RIVAL, state.era);
+
+    expect(strength.exactVisible).toBe(0);
+    expect(strength.remembered).toBe(0);
+    expect(strength.uncertaintyUpper).toBeGreaterThan(0);
+  });
+
+  it('counts every visible combat role symmetrically instead of filtering rivals to warriors', () => {
+    const state = makePerceptionState();
+    const tank = addRivalUnit(state, 'tank');
+    state.civilizations[ACTOR].visibility.tiles[hexKey(tank.position)] = 'visible';
+    const perception = buildMajorCivPerception(state, ACTOR);
+
+    const estimates = buildDiplomaticStrengthEstimates(perception, state.era);
+
+    expect(estimates.others[RIVAL].exactVisible).toBeGreaterThan(40);
+    expect(estimates.self.midpoint).toBeGreaterThanOrEqual(0);
+  });
+
+  it('infers capabilities from observed units without exposing hidden technology', () => {
+    const state = makePerceptionState();
+    state.era = 8;
+    state.civilizations[RIVAL].techState.completed = ['cyber-warfare', 'jet-aviation'];
+    state.civilizations[ACTOR].visibility.lastSeen![hexKey(OBSERVED)] = makeSnapshot(state, {
+      units: [{
+        id: 'observed-rifle',
+        type: 'rifleman',
+        owner: RIVAL,
+        healthBand: 'healthy',
+      }],
+    });
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+
+    const capabilities = buildMajorCivPerception(state, ACTOR)
+      .knownOpponentCapabilities[RIVAL];
+
+    expect(capabilities.observedUnitTypes).toEqual(['rifleman']);
+    expect(capabilities.inferredEraMin).toBeGreaterThan(1);
+    expect(capabilities.inferredEraMax).toBe(8);
+    expect(JSON.stringify(capabilities)).not.toContain('cyber-warfare');
+    expect(JSON.stringify(capabilities)).not.toContain('jet-aviation');
+  });
+
+  it('refreshes intel immutably and preserves a last-known position after sight is lost', () => {
+    const state = makePerceptionState();
+    const tank = addRivalUnit(state, 'tank');
+    state.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'visible';
+
+    const refreshed = refreshMajorCivIntel(state, ACTOR);
+    expect(state.civilizations[ACTOR].visibility.lastSeen?.[hexKey(OBSERVED)]).toBeUndefined();
+
+    refreshed.turn += 1;
+    refreshed.civilizations[ACTOR].visibility.tiles[hexKey(OBSERVED)] = 'fog';
+    refreshed.units[tank.id].position = { q: 12, r: 4 };
+    const remembered = buildMajorCivPerception(refreshed, ACTOR)
+      .units.find(unit => unit.id === tank.id);
+
+    expect(remembered).toMatchObject({
+      position: OBSERVED,
+      confidence: 'remembered',
+      lastSeenTurn: 10,
+    });
+  });
+});

--- a/tests/ai/ai-plan-portfolio.test.ts
+++ b/tests/ai/ai-plan-portfolio.test.ts
@@ -224,6 +224,42 @@ describe('major-civilization plan portfolios', () => {
     })).portfolio.defensePlansByCityId.old).toBeUndefined();
   });
 
+  it('derives receding-defense grace from persisted progress when no counter is supplied', () => {
+    const recent = plan('defend-recent', {
+      objective: 'defend',
+      target: { kind: 'city', id: 'old', lastKnownPosition: { q: 1, r: 1 } },
+      lastProgressTurn: 9,
+    });
+    const stale = { ...recent, id: 'defend-stale', lastProgressTurn: 8 };
+    const threat: AICityThreat = {
+      cityId: 'old',
+      position: { q: 1, r: 1 },
+      theaterId: 'home',
+      travelTurns: 7,
+      alreadyAttackedTerritory: false,
+      captureRisk: 10,
+      hostileStrength: 10,
+      isCapital: false,
+      isLastCity: false,
+      threatStillValid: true,
+    };
+
+    expect(refreshMajorCivPortfolio(context({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        defensePlansByCityId: { old: recent },
+      },
+      cityThreats: [threat],
+    })).portfolio.defensePlansByCityId.old).toBeDefined();
+    expect(refreshMajorCivPortfolio(context({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        defensePlansByCityId: { old: stale },
+      },
+      cityThreats: [threat],
+    })).portfolio.defensePlansByCityId.old).toBeUndefined();
+  });
+
   it('uses deterministic plan IDs and clamps commitment', () => {
     const first = refreshMajorCivPortfolio(context({
       portfolio: createEmptyMajorCivPortfolio(),

--- a/tests/ai/ai-plan-portfolio.test.ts
+++ b/tests/ai/ai-plan-portfolio.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import type { AIStrategicPlan, MajorCivPlanPortfolio } from '@/core/types';
+import {
+  createEmptyMajorCivPortfolio,
+  refreshMajorCivPortfolio,
+  type AIPlanCandidate,
+  type AICityThreat,
+} from '@/ai/ai-plan-portfolio';
+
+function candidate(id: string, score: number, overrides: Partial<AIPlanCandidate> = {}): AIPlanCandidate {
+  return {
+    objective: 'capture',
+    target: { kind: 'city', id, lastKnownPosition: { q: 3, r: 2 } },
+    theaterId: 'region-0',
+    score,
+    reasonCodes: ['nearby-opportunity'],
+    requiredRoles: { capture: 1, frontline: 1 },
+    commitment: 0.3,
+    targetValid: true,
+    reasonValid: true,
+    expectedLossRatio: 0.5,
+    progress: false,
+    ...overrides,
+  };
+}
+
+function plan(id: string, overrides: Partial<AIStrategicPlan> = {}): AIStrategicPlan {
+  return {
+    id,
+    actorId: 'ai-1',
+    objective: 'capture',
+    target: { kind: 'city', id: 'close', lastKnownPosition: { q: 3, r: 2 } },
+    theaterId: 'region-0',
+    phase: 'advancing',
+    reasonCodes: ['nearby-opportunity'],
+    commitment: 0.7,
+    createdTurn: 5,
+    reconsiderAfterTurn: 12,
+    expiresAfterTurn: 20,
+    lastProgressTurn: 9,
+    requiredRoles: { capture: 1, frontline: 1 },
+    assignedUnitIds: [],
+    ...overrides,
+  };
+}
+
+function context(overrides: Record<string, unknown> = {}) {
+  return {
+    actorId: 'ai-1',
+    turn: 10,
+    actorEliminated: false,
+    portfolio: {
+      ...createEmptyMajorCivPortfolio(),
+      primaryPlan: plan('capture-close'),
+    },
+    candidates: [candidate('close', 40), candidate('new', 44)],
+    cityThreats: [] as AICityThreat[],
+    modernization: {
+      bestTrainableStrength: 30,
+      deployedStrength: 25,
+      actorEra: 3,
+      globalEra: 3,
+      knownRivalMaxStrength: 30,
+      obsoleteUnitShare: 0.1,
+      treasuryCanAct: true,
+    },
+    ...overrides,
+  };
+}
+
+describe('major-civilization plan portfolios', () => {
+  it('retains a progressing local campaign over a marginally higher new score', () => {
+    const result = refreshMajorCivPortfolio(context({
+      candidates: [
+        candidate('close', 40, { progress: true }),
+        candidate('new', 44),
+      ],
+    }));
+
+    expect(result.portfolio.primaryPlan?.id).toBe('capture-close');
+    expect(result.portfolio.primaryPlan?.lastProgressTurn).toBe(10);
+  });
+
+  it('switches when the new plan clears the commitment-weighted threshold', () => {
+    const result = refreshMajorCivPortfolio(context({
+      candidates: [candidate('close', 40), candidate('decisive', 70)],
+    }));
+
+    expect(result.portfolio.primaryPlan?.target).toMatchObject({ kind: 'city', id: 'decisive' });
+  });
+
+  it('abandons missing targets, stale plans, unacceptable losses, and expired reasons', () => {
+    for (const currentCandidate of [
+      candidate('close', 40, { targetValid: false }),
+      candidate('close', 40, { expectedLossRatio: 1.8 }),
+      candidate('close', 40, { reasonValid: false }),
+    ]) {
+      const result = refreshMajorCivPortfolio(context({
+        candidates: [currentCandidate, candidate('fallback', 30)],
+      }));
+      expect(result.portfolio.primaryPlan?.target).toMatchObject({ kind: 'city', id: 'fallback' });
+    }
+
+    const stale = plan('stale', {
+      reconsiderAfterTurn: 8,
+      lastProgressTurn: 6,
+    });
+    const staleResult = refreshMajorCivPortfolio(context({
+      portfolio: { ...createEmptyMajorCivPortfolio(), primaryPlan: stale },
+      candidates: [candidate('close', 40), candidate('fallback', 30)],
+    }));
+    expect(staleResult.portfolio.primaryPlan?.id).not.toBe('stale');
+  });
+
+  it('clears strategic plans for an eliminated actor', () => {
+    const result = refreshMajorCivPortfolio(context({ actorEliminated: true }));
+
+    expect(result.portfolio.primaryPlan).toBeNull();
+    expect(result.portfolio.defensePlansByCityId).toEqual({});
+  });
+
+  it('adds urgent city defense without deleting the primary plan', () => {
+    const result = refreshMajorCivPortfolio(context({
+      cityThreats: [{
+        cityId: 'capital',
+        position: { q: 2, r: 2 },
+        theaterId: 'region-home',
+        travelTurns: 2,
+        alreadyAttackedTerritory: false,
+        captureRisk: 80,
+        hostileStrength: 35,
+        isCapital: true,
+        isLastCity: false,
+        threatStillValid: true,
+      }],
+    }));
+
+    expect(result.portfolio.primaryPlan).not.toBeNull();
+    expect(Object.keys(result.portfolio.defensePlansByCityId)).toContain('capital');
+  });
+
+  it('deduplicates and caps defense plans while retaining overflow demand', () => {
+    const threats: AICityThreat[] = Array.from({ length: 6 }, (_, index) => ({
+      cityId: `city-${index}`,
+      position: { q: index, r: 0 },
+      theaterId: 'region-home',
+      travelTurns: 1,
+      alreadyAttackedTerritory: index === 5,
+      captureRisk: 50 + index,
+      hostileStrength: 20 + index,
+      isCapital: index === 4,
+      isLastCity: false,
+      threatStillValid: true,
+    }));
+    threats.push({ ...threats[0] });
+
+    const result = refreshMajorCivPortfolio(context({ cityThreats: threats }));
+
+    expect(Object.keys(result.portfolio.defensePlansByCityId)).toHaveLength(4);
+    expect(result.unplannedDefenseCityIds).toHaveLength(2);
+    expect(new Set(result.unplannedDefenseCityIds).size).toBe(2);
+  });
+
+  it('removes defense when its threat is no longer valid or urgent', () => {
+    const existing = plan('defend-old', {
+      objective: 'defend',
+      target: { kind: 'city', id: 'old', lastKnownPosition: { q: 1, r: 1 } },
+    });
+    const portfolio: MajorCivPlanPortfolio = {
+      ...createEmptyMajorCivPortfolio(),
+      primaryPlan: plan('primary'),
+      defensePlansByCityId: { old: existing },
+    };
+    const result = refreshMajorCivPortfolio(context({
+      portfolio,
+      cityThreats: [{
+        cityId: 'old',
+        position: { q: 1, r: 1 },
+        theaterId: 'home',
+        travelTurns: 7,
+        alreadyAttackedTerritory: false,
+        captureRisk: 10,
+        hostileStrength: 10,
+        isCapital: false,
+        isLastCity: false,
+        threatStillValid: false,
+      }],
+    }));
+
+    expect(result.portfolio.defensePlansByCityId).toEqual({});
+  });
+
+  it('retains a receding defense until it is beyond six turns for two planning phases', () => {
+    const existing = plan('defend-old', {
+      objective: 'defend',
+      target: { kind: 'city', id: 'old', lastKnownPosition: { q: 1, r: 1 } },
+    });
+    const portfolio: MajorCivPlanPortfolio = {
+      ...createEmptyMajorCivPortfolio(),
+      primaryPlan: plan('primary'),
+      defensePlansByCityId: { old: existing },
+    };
+    const threat: AICityThreat = {
+      cityId: 'old',
+      position: { q: 1, r: 1 },
+      theaterId: 'home',
+      travelTurns: 7,
+      alreadyAttackedTerritory: false,
+      captureRisk: 10,
+      hostileStrength: 10,
+      isCapital: false,
+      isLastCity: false,
+      threatStillValid: true,
+      consecutiveBeyondSixPhases: 1,
+    };
+
+    expect(refreshMajorCivPortfolio(context({
+      portfolio,
+      cityThreats: [threat],
+    })).portfolio.defensePlansByCityId.old).toBeDefined();
+    expect(refreshMajorCivPortfolio(context({
+      portfolio,
+      cityThreats: [{ ...threat, consecutiveBeyondSixPhases: 2 }],
+    })).portfolio.defensePlansByCityId.old).toBeUndefined();
+  });
+
+  it('uses deterministic plan IDs and clamps commitment', () => {
+    const first = refreshMajorCivPortfolio(context({
+      portfolio: createEmptyMajorCivPortfolio(),
+      candidates: [candidate('target', 50, { commitment: 3 })],
+    }));
+    const second = refreshMajorCivPortfolio(context({
+      portfolio: createEmptyMajorCivPortfolio(),
+      candidates: [candidate('target', 50, { commitment: 3 })],
+    }));
+
+    expect(first.portfolio.primaryPlan?.id).toBe(
+      'ai-plan:ai-1:capture:city:target:10',
+    );
+    expect(first.portfolio.primaryPlan).toEqual(second.portfolio.primaryPlan);
+    expect(first.portfolio.primaryPlan?.commitment).toBe(1);
+  });
+
+  it('keeps modernization bounded and non-spatial', () => {
+    const result = refreshMajorCivPortfolio(context({
+      modernization: {
+        bestTrainableStrength: 100,
+        deployedStrength: 10,
+        actorEra: 2,
+        globalEra: 5,
+        knownRivalMaxStrength: 100,
+        obsoleteUnitShare: 0.9,
+        treasuryCanAct: false,
+      },
+    }));
+
+    expect(result.portfolio.modernizationDemand).toBeGreaterThan(50);
+    expect(result.portfolio.modernizationDemand).toBeLessThanOrEqual(100);
+    expect(result.portfolio.primaryPlan?.target.kind).not.toBe('region');
+  });
+});

--- a/tests/ai/ai-prepared-turn.test.ts
+++ b/tests/ai/ai-prepared-turn.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergePreparedForceDemands,
+  prepareMajorCivStrategicPlan,
+} from '@/ai/ai-prepared-turn';
+import { createNewGame } from '@/core/game-state';
+import { getWrappedHexNeighbors, hexDistance, hexKey } from '@/systems/hex-utils';
+import { foundCity } from '@/systems/city-system';
+import { createUnit, findPath } from '@/systems/unit-system';
+
+describe('prepared major-civilization planning', () => {
+  it('preserves objective-readiness demand when no current unit can fill the role', () => {
+    const state = createNewGame(undefined, 'prepared-objective-demand', 'small');
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+    const resourceTile = Object.values(state.map.tiles)
+      .filter(tile => hexDistance(anchor, tile.coord) === 1)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    resourceTile.resource = 'iron';
+    resourceTile.owner = null;
+    civ.visibility.tiles[hexKey(resourceTile.coord)] = 'visible';
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).toBeNull();
+    expect(prepared.forceDemands).toContainEqual(expect.objectContaining({
+      role: 'resource-expedition',
+      desired: 1,
+      assigned: 0,
+      missing: 1,
+      sourcePlanIds: ['objective-readiness'],
+    }));
+  });
+
+  it('does not draft conquest against a peaceful neighbor', () => {
+    const state = createNewGame(undefined, 'prepared-peaceful-neighbor', 'small');
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+    const cityTile = Object.values(state.map.tiles)
+      .filter(tile =>
+        hexDistance(anchor, tile.coord) === 1
+        && findPath(anchor, tile.coord, state.map, 'land') !== null)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    const city = foundCity('player', cityTile.coord, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    civ.knownCivilizations = ['player'];
+    civ.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).not.toMatchObject({
+      objective: 'capture',
+      target: { kind: 'city', id: city.id },
+    });
+  });
+
+  it('does not target a peacefully owned resource for acquisition', () => {
+    const state = createNewGame(undefined, 'prepared-owned-resource', 'small');
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+    const resourceTile = Object.values(state.map.tiles)
+      .filter(tile =>
+        hexDistance(anchor, tile.coord) === 1
+        && findPath(anchor, tile.coord, state.map, 'land') !== null)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    resourceTile.resource = 'iron';
+    resourceTile.owner = 'player';
+    civ.knownCivilizations = ['player'];
+    civ.visibility.tiles = {
+      [hexKey(anchor)]: 'visible',
+      [hexKey(resourceTile.coord)]: 'visible',
+    };
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).not.toMatchObject({
+      objective: 'secure-resource',
+      target: { kind: 'resource', position: resourceTile.coord },
+    });
+    expect(prepared.forceDemands.find(demand => demand.role === 'resource-expedition'))
+      .toBeUndefined();
+  });
+
+  it('creates city defense against a visible always-hostile raider', () => {
+    const state = createNewGame(undefined, 'prepared-world-threat', 'small');
+    const civ = state.civilizations['ai-1'];
+    const settler = civ.units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler')!;
+    const city = foundCity(civ.id, settler.position, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    civ.cities.push(city.id);
+    const threatTile = Object.values(state.map.tiles)
+      .filter(tile => hexDistance(city.position, tile.coord) === 1)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    const raider = createUnit('warrior', 'barbarian', threatTile.coord, state.idCounters);
+    raider.id = 'visible-raider';
+    state.units[raider.id] = raider;
+    civ.visibility.tiles[hexKey(city.position)] = 'visible';
+    civ.visibility.tiles[hexKey(raider.position)] = 'visible';
+
+    const prepared = prepareMajorCivStrategicPlan(state, civ.id);
+
+    expect(prepared.portfolio.defensePlansByCityId[city.id]).toMatchObject({
+      objective: 'defend',
+      target: { kind: 'city', id: city.id },
+    });
+  });
+
+  it('merges overflow defense and objective readiness into actionable demand', () => {
+    const demands = mergePreparedForceDemands([], [
+      { role: 'resource-expedition', sourceId: 'objective-readiness', priority: 90 },
+      { role: 'frontline', sourceId: 'defense-overflow:city-4', priority: 600 },
+      { role: 'frontline', sourceId: 'defense-overflow:city-5', priority: 600 },
+    ]);
+
+    expect(demands).toContainEqual(expect.objectContaining({
+      role: 'resource-expedition',
+      desired: 1,
+      missing: 1,
+      sourcePlanIds: ['objective-readiness'],
+    }));
+    expect(demands).toContainEqual(expect.objectContaining({
+      role: 'frontline',
+      desired: 2,
+      missing: 2,
+      priority: 600,
+      sourcePlanIds: ['defense-overflow:city-4', 'defense-overflow:city-5'],
+    }));
+  });
+
+  it('ignores malformed observed tile snapshots when building its known path map', () => {
+    const state = createNewGame(undefined, 'prepared-malformed-intel', 'small');
+    const civ = state.civilizations['ai-1'];
+    const key = Object.keys(state.map.tiles)[0];
+    civ.visibility.tiles[key] = 'fog';
+    civ.visibility.lastSeen ??= {};
+    civ.visibility.lastSeen[key] = {
+      source: 'observed',
+      observedTurn: state.turn,
+      coord: null,
+    } as unknown as NonNullable<typeof civ.visibility.lastSeen>[string];
+
+    expect(() => prepareMajorCivStrategicPlan(state, 'ai-1')).not.toThrow();
+  });
+
+  it('penalizes an offensive objective more when the perceived defender is stronger', () => {
+    function captureScore(defenderType: 'warrior' | 'tank'): number {
+      const state = createNewGame(undefined, `prepared-strength-${defenderType}`, 'small');
+      const civ = state.civilizations['ai-1'];
+      const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+      const cityTile = Object.values(state.map.tiles)
+        .filter(tile =>
+          hexDistance(anchor, tile.coord) === 1
+          && findPath(anchor, tile.coord, state.map, 'land') !== null)
+        .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+      const city = foundCity('player', cityTile.coord, state.map, state.idCounters);
+      state.cities[city.id] = city;
+      state.civilizations.player.cities.push(city.id);
+      const defender = createUnit(defenderType, 'player', city.position, state.idCounters);
+      defender.id = `visible-${defenderType}`;
+      state.units[defender.id] = defender;
+      state.civilizations.player.units.push(defender.id);
+      civ.knownCivilizations = ['player'];
+      civ.diplomacy.atWarWith = ['player'];
+      civ.visibility.tiles = {
+        [hexKey(anchor)]: 'visible',
+        [hexKey(city.position)]: 'visible',
+      };
+
+      const trace = prepareMajorCivStrategicPlan(state, 'ai-1').traces[0];
+      return trace.candidates.find(entry => entry.id.includes(city.id))!.score;
+    }
+
+    expect(captureScore('tank')).toBeLessThan(captureScore('warrior'));
+  });
+
+  it('does not inflate unseen rival reserves from another civilization advancing the global era', () => {
+    function captureScore(globalEra: number): number {
+      const state = createNewGame(undefined, 'prepared-actor-era', 'small');
+      state.era = globalEra;
+      const civ = state.civilizations['ai-1'];
+      const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+      const cityTile = Object.values(state.map.tiles)
+        .filter(tile =>
+          hexDistance(anchor, tile.coord) === 1
+          && findPath(anchor, tile.coord, state.map, 'land') !== null)
+        .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+      const city = foundCity('player', cityTile.coord, state.map, state.idCounters);
+      state.cities[city.id] = city;
+      state.civilizations.player.cities.push(city.id);
+      civ.knownCivilizations = ['player'];
+      civ.diplomacy.atWarWith = ['player'];
+      civ.visibility.tiles = {
+        [hexKey(anchor)]: 'visible',
+        [hexKey(city.position)]: 'visible',
+      };
+
+      return prepareMajorCivStrategicPlan(state, 'ai-1').traces[0]
+        .candidates.find(entry => entry.id.includes(city.id))!.score;
+    }
+
+    expect(captureScore(10)).toBeCloseTo(captureScore(1));
+  });
+
+  it('scores from the nearest friendly city regardless of roster order', () => {
+    function captureScore(nearFirst: boolean): number {
+      const state = createNewGame(undefined, 'prepared-nearest-city', 'medium');
+      const civ = state.civilizations['ai-1'];
+      const landTiles = Object.values(state.map.tiles)
+        .filter(tile => findPath(tile.coord, tile.coord, state.map, 'land') !== null);
+      const targetTile = landTiles.find(tile =>
+        landTiles.some(candidate =>
+          hexDistance(tile.coord, candidate.coord) === 1
+          && findPath(candidate.coord, tile.coord, state.map, 'land') !== null)
+        && landTiles.some(candidate =>
+          hexDistance(tile.coord, candidate.coord) >= 7
+          && findPath(candidate.coord, tile.coord, state.map, 'land') !== null))!;
+      const nearTile = landTiles
+        .filter(tile =>
+          hexDistance(targetTile.coord, tile.coord) === 1
+          && findPath(tile.coord, targetTile.coord, state.map, 'land') !== null)
+        .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+      const farTile = landTiles
+        .filter(tile =>
+          hexDistance(targetTile.coord, tile.coord) >= 7
+          && findPath(tile.coord, targetTile.coord, state.map, 'land') !== null)
+        .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+      const nearCity = foundCity(civ.id, nearTile.coord, state.map, state.idCounters);
+      const farCity = foundCity(civ.id, farTile.coord, state.map, state.idCounters);
+      state.cities[nearCity.id] = nearCity;
+      state.cities[farCity.id] = farCity;
+      civ.cities = nearFirst
+        ? [nearCity.id, farCity.id]
+        : [farCity.id, nearCity.id];
+      const targetCity = foundCity('player', targetTile.coord, state.map, state.idCounters);
+      state.cities[targetCity.id] = targetCity;
+      state.civilizations.player.cities.push(targetCity.id);
+      civ.knownCivilizations = ['player'];
+      civ.diplomacy.atWarWith = ['player'];
+      civ.visibility.tiles = Object.fromEntries(
+        Object.keys(state.map.tiles).map(key => [key, 'visible' as const]),
+      );
+
+      return prepareMajorCivStrategicPlan(state, civ.id).traces[0]
+        .candidates.find(entry => entry.id.includes(targetCity.id))!.score;
+    }
+
+    expect(captureScore(false)).toBeCloseTo(captureScore(true));
+  });
+
+  it('does not assign a land unit with no known legal path to the plan', () => {
+    const state = createNewGame(undefined, 'prepared-unit-path', 'medium');
+    const civ = state.civilizations['ai-1'];
+    for (const tile of Object.values(state.map.tiles)) tile.resource = null;
+    for (const unitId of state.civilizations.player.units) delete state.units[unitId];
+    state.civilizations.player.units = [];
+    const warrior = civ.units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'warrior')!;
+    const candidateTiles = Object.values(state.map.tiles)
+      .filter(tile =>
+        hexDistance(tile.coord, warrior.position) >= 5
+        && findPath(tile.coord, tile.coord, state.map, 'land') !== null);
+    const targetTile = candidateTiles.find(tile =>
+      candidateTiles.some(neighbor =>
+        hexDistance(tile.coord, neighbor.coord) === 1
+        && findPath(neighbor.coord, tile.coord, state.map, 'land') !== null))!;
+    const homeTile = candidateTiles
+      .filter(tile =>
+        hexDistance(tile.coord, targetTile.coord) === 1
+        && findPath(tile.coord, targetTile.coord, state.map, 'land') !== null)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    const homeCity = foundCity(civ.id, homeTile.coord, state.map, state.idCounters);
+    state.cities[homeCity.id] = homeCity;
+    civ.cities = [homeCity.id];
+    const targetCity = foundCity('player', targetTile.coord, state.map, state.idCounters);
+    state.cities[targetCity.id] = targetCity;
+    state.civilizations.player.cities.push(targetCity.id);
+    for (const neighbor of getWrappedHexNeighbors(warrior.position, state.map.width)) {
+      const tile = state.map.tiles[hexKey(neighbor)];
+      if (tile) tile.terrain = 'ocean';
+    }
+    civ.knownCivilizations = ['player'];
+    civ.diplomacy.atWarWith = ['player'];
+    civ.visibility.tiles = Object.fromEntries(
+      Object.keys(state.map.tiles).map(key => [key, 'visible' as const]),
+    );
+
+    const prepared = prepareMajorCivStrategicPlan(state, civ.id);
+
+    expect(prepared.portfolio.primaryPlan?.target).toMatchObject({
+      kind: 'city',
+      id: targetCity.id,
+    });
+    expect(prepared.assignments.assignmentsByPlanId[prepared.portfolio.primaryPlan!.id])
+      .not.toContain(warrior.id);
+  });
+});

--- a/tests/ai/ai-round-scheduler.test.ts
+++ b/tests/ai/ai-round-scheduler.test.ts
@@ -150,6 +150,26 @@ describe('AI round scheduler', () => {
       strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
+        value.portfolio.primaryPlan = {
+          id: `plan-${civId}`,
+          actorId: civId,
+          objective: 'expand',
+          target: {
+            kind: 'region',
+            id: `region-${civId}`,
+            anchor: { q: 0, r: 0 },
+          },
+          theaterId: 'home',
+          phase: 'mobilizing',
+          reasonCodes: ['nearby-opportunity'],
+          commitment: 0.5,
+          createdTurn: state.turn,
+          reconsiderAfterTurn: state.turn + 2,
+          expiresAfterTurn: state.turn + 8,
+          lastProgressTurn: state.turn,
+          requiredRoles: { settlement: 1 },
+          assignedUnitIds: [],
+        };
         value.forceDemands = [{
           role: 'frontline',
           desired: 1,
@@ -174,7 +194,7 @@ describe('AI round scheduler', () => {
     }
   });
 
-  it('skips a prepared action when an earlier actor removes its target', () => {
+  it('drops a stale primary action while preserving valid defense work', () => {
     const state = createNewGame({
       civType: 'egypt',
       mapSize: 'medium',
@@ -189,9 +209,15 @@ describe('AI round scheduler', () => {
     const targetCity = foundCity('player', playerSettler.position, state.map, state.idCounters);
     state.cities[targetCity.id] = targetCity;
     state.civilizations.player.cities.push(targetCity.id);
-    const executed: string[] = [];
+    const aiTwoSettler = state.civilizations['ai-2'].units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler')!;
+    const defendedCity = foundCity('ai-2', aiTwoSettler.position, state.map, state.idCounters);
+    state.cities[defendedCity.id] = defendedCity;
+    state.civilizations['ai-2'].cities.push(defendedCity.id);
+    const executed: PreparedMajorCivPlan[] = [];
 
-    processNonHumanMajorRound(state, new EventBus(), {
+    const result = processNonHumanMajorRound(state, new EventBus(), {
       strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
@@ -212,11 +238,31 @@ describe('AI round scheduler', () => {
             requiredRoles: { capture: 1 },
             assignedUnitIds: [],
           };
+          value.portfolio.defensePlansByCityId[defendedCity.id] = {
+            id: 'defend-home',
+            actorId: civId,
+            objective: 'defend',
+            target: {
+              kind: 'city',
+              id: defendedCity.id,
+              lastKnownPosition: defendedCity.position,
+            },
+            theaterId: 'home',
+            phase: 'mobilizing',
+            reasonCodes: ['urgent-defense'],
+            commitment: 1,
+            createdTurn: 0,
+            reconsiderAfterTurn: 1,
+            expiresAfterTurn: 5,
+            lastProgressTurn: 0,
+            requiredRoles: { frontline: 1 },
+            assignedUnitIds: [],
+          };
         }
         return value;
       },
       executePrepared: (current, value) => {
-        executed.push(value.civId);
+        executed.push(value);
         if (value.civId === 'ai-1') {
           const next = structuredClone(current);
           delete next.cities[targetCity.id];
@@ -226,7 +272,170 @@ describe('AI round scheduler', () => {
       },
     });
 
+    expect(executed.map(value => value.civId)).toEqual(['ai-1', 'ai-2']);
+    expect(executed[1].portfolio.primaryPlan).toBeNull();
+    expect(executed[1].portfolio.defensePlansByCityId[defendedCity.id]).toBeDefined();
+    expect(result.state.opponentAI?.majorCivs['ai-2']?.primaryPlan).toBeNull();
+  });
+
+  it('removes stale defense plans before prepared execution', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Stale defense',
+      seed: 'scheduler-stale-defense',
+    });
+    state.turn = 0;
+    const aiTwoSettler = state.civilizations['ai-2'].units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler')!;
+    const defendedCity = foundCity('ai-2', aiTwoSettler.position, state.map, state.idCounters);
+    state.cities[defendedCity.id] = defendedCity;
+    state.civilizations['ai-2'].cities.push(defendedCity.id);
+    let executedAiTwo: PreparedMajorCivPlan | null = null;
+
+    const result = processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        const value = prepared(snapshot as typeof state, civId);
+        if (civId === 'ai-2') {
+          value.portfolio.primaryPlan = {
+            id: 'expand-valid',
+            actorId: civId,
+            objective: 'expand',
+            target: {
+              kind: 'region',
+              id: 'safe-region',
+              anchor: aiTwoSettler.position,
+            },
+            theaterId: 'home',
+            phase: 'mobilizing',
+            reasonCodes: ['nearby-opportunity'],
+            commitment: 0.5,
+            createdTurn: 0,
+            reconsiderAfterTurn: 2,
+            expiresAfterTurn: 8,
+            lastProgressTurn: 0,
+            requiredRoles: { settlement: 1 },
+            assignedUnitIds: [],
+          };
+          value.portfolio.defensePlansByCityId[defendedCity.id] = {
+            id: 'defend-stale',
+            actorId: civId,
+            objective: 'defend',
+            target: {
+              kind: 'city',
+              id: defendedCity.id,
+              lastKnownPosition: defendedCity.position,
+            },
+            theaterId: 'home',
+            phase: 'mobilizing',
+            reasonCodes: ['urgent-defense'],
+            commitment: 1,
+            createdTurn: 0,
+            reconsiderAfterTurn: 1,
+            expiresAfterTurn: 6,
+            lastProgressTurn: 0,
+            requiredRoles: { frontline: 1 },
+            assignedUnitIds: [],
+          };
+          value.forceDemands = [{
+            role: 'frontline',
+            desired: 2,
+            assigned: 0,
+            missing: 2,
+            priority: 600,
+            sourcePlanIds: ['defend-stale', 'expand-valid'],
+          }, {
+            role: 'recon',
+            desired: 1,
+            assigned: 0,
+            missing: 1,
+            priority: 600,
+            sourcePlanIds: ['defend-stale'],
+          }];
+          value.assignments.forceDemands = value.forceDemands;
+        }
+        return value;
+      },
+      executePrepared: (current, value) => {
+        if (value.civId === 'ai-1') {
+          const next = structuredClone(current);
+          delete next.cities[defendedCity.id];
+          return { state: next };
+        }
+        executedAiTwo = value;
+        return { state: current };
+      },
+    });
+
+    expect(executedAiTwo).not.toBeNull();
+    expect(executedAiTwo!.portfolio.defensePlansByCityId).toEqual({});
+    expect(executedAiTwo!.forceDemands).toEqual([
+      expect.objectContaining({
+        role: 'frontline',
+        sourcePlanIds: ['expand-valid'],
+      }),
+    ]);
+    expect(result.state.opponentAI?.majorCivs['ai-2']?.defensePlansByCityId).toEqual({});
+  });
+
+  it('skips a resource objective claimed peacefully after preparation', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'small',
+      opponentCount: 2,
+      gameTitle: 'Stale resource',
+      seed: 'scheduler-stale-resource',
+    });
+    state.turn = 0;
+    const targetTile = Object.values(state.map.tiles)[0];
+    targetTile.resource = 'iron';
+    targetTile.owner = null;
+    const executed: string[] = [];
+
+    const result = processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        const value = prepared(snapshot as typeof state, civId);
+        if (civId === 'ai-2') {
+          value.portfolio.primaryPlan = {
+            id: 'secure-iron',
+            actorId: civId,
+            objective: 'secure-resource',
+            target: {
+              kind: 'resource',
+              resource: 'iron',
+              position: targetTile.coord,
+            },
+            theaterId: 'resource',
+            phase: 'mobilizing',
+            reasonCodes: ['nearby-opportunity'],
+            commitment: 0.5,
+            createdTurn: 0,
+            reconsiderAfterTurn: 2,
+            expiresAfterTurn: 8,
+            lastProgressTurn: 0,
+            requiredRoles: { 'resource-expedition': 1 },
+            assignedUnitIds: [],
+          };
+        }
+        return value;
+      },
+      executePrepared: (current, value) => {
+        executed.push(value.civId);
+        if (value.civId === 'ai-1') {
+          const next = structuredClone(current);
+          next.map.tiles[`${targetTile.coord.q},${targetTile.coord.r}`].owner = 'player';
+          return { state: next };
+        }
+        return { state: current };
+      },
+    });
+
     expect(executed).toEqual(['ai-1']);
+    expect(result.state.opponentAI?.majorCivs['ai-2']?.primaryPlan).toBeNull();
   });
 
   it('keeps the existing live AI path when strategic planning is disabled', () => {
@@ -242,5 +451,65 @@ describe('AI round scheduler', () => {
 
     expect(prepare).not.toHaveBeenCalled();
     expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it('isolates a failed actor preparation and reports it without blocking peers', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'small',
+      opponentCount: 2,
+      gameTitle: 'Planner isolation',
+      seed: 'scheduler-wrong-actor',
+    });
+    const executed: string[] = [];
+
+    const result = processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => civId === 'ai-1'
+        ? {
+            ...prepared(snapshot as typeof state, civId),
+            civId: 'player',
+          }
+        : prepared(snapshot as typeof state, civId),
+      executePrepared: (current, value) => {
+        executed.push(value.civId);
+        return { state: current };
+      },
+    });
+
+    expect(executed).toEqual(['ai-2']);
+    expect(result.planningErrors).toEqual([expect.objectContaining({
+      actorId: 'ai-1',
+      phase: 'prepare',
+      message: expect.stringMatching(/prepared actor/i),
+    })]);
+  });
+
+  it('never plans or executes additional hot-seat humans', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Hot seat scheduler',
+      seed: 'scheduler-hot-seat',
+    });
+    state.civilizations['ai-2'].isHuman = true;
+    const preparedIds: string[] = [];
+    const executedIds: string[] = [];
+
+    processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        preparedIds.push(civId);
+        return prepared(snapshot as typeof state, civId);
+      },
+      executePrepared: (current, value) => {
+        executedIds.push(value.civId);
+        return { state: current };
+      },
+    });
+
+    expect(preparedIds).toEqual(['ai-1']);
+    expect(executedIds).toEqual(['ai-1']);
   });
 });

--- a/tests/ai/ai-round-scheduler.test.ts
+++ b/tests/ai/ai-round-scheduler.test.ts
@@ -6,6 +6,34 @@ import {
   processNonHumanMajorRound,
   rotateIdsForRound,
 } from '@/ai/ai-round-scheduler';
+import type { PreparedMajorCivPlan } from '@/ai/ai-prepared-turn';
+import { buildMajorCivPerception } from '@/ai/ai-perception';
+import { createEmptyMajorCivPortfolio } from '@/ai/ai-plan-portfolio';
+import { foundCity } from '@/systems/city-system';
+
+function prepared(state: ReturnType<typeof createNewGame>, civId: string): PreparedMajorCivPlan {
+  const portfolio = createEmptyMajorCivPortfolio();
+  return {
+    civId,
+    perception: buildMajorCivPerception(state, civId),
+    portfolio,
+    assignments: {
+      portfolio,
+      assignmentsByPlanId: {},
+      recoveryUnitIds: [],
+      forceDemands: [],
+      rejectedByUnitId: {},
+    },
+    forceDemands: [],
+    traces: [{
+      actorId: civId,
+      turn: state.turn,
+      decision: 'objective',
+      selectedId: null,
+      candidates: [],
+    }],
+  };
+}
 
 describe('AI round scheduler', () => {
   it('processes every living non-human civilization once in rotating order', () => {
@@ -80,5 +108,139 @@ describe('AI round scheduler', () => {
     expect(rotateIdsForRound([], 4)).toEqual([]);
     expect(rotateIdsForRound(['a', 'b', 'c'], -1)).toEqual(['c', 'a', 'b']);
     expect(rotateIdsForRound(['a', 'b', 'c'], 7)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('plans every actor from the same immutable pre-AI snapshot', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Shared snapshot',
+      seed: 'scheduler-snapshot',
+    });
+    const snapshots: Readonly<typeof state>[] = [];
+
+    const result = processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        snapshots.push(snapshot);
+        return prepared(snapshot as typeof state, civId);
+      },
+      executePrepared: current => ({ state: current }),
+    });
+
+    expect(snapshots).toHaveLength(2);
+    expect(snapshots[0]).toBe(snapshots[1]);
+    expect(snapshots[0]).not.toBe(result.state);
+    expect(result.traces).toHaveLength(2);
+    expect((result.state as typeof result.state & { traces?: unknown }).traces).toBeUndefined();
+  });
+
+  it('passes each actor its own prepared perception, assignments, and demand', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Prepared identity',
+      seed: 'scheduler-prepared-identity',
+    });
+    const seen: PreparedMajorCivPlan[] = [];
+
+    processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        const value = prepared(snapshot as typeof state, civId);
+        value.forceDemands = [{
+          role: 'frontline',
+          desired: 1,
+          assigned: 0,
+          missing: 1,
+          priority: 100,
+          sourcePlanIds: [`plan-${civId}`],
+        }];
+        return value;
+      },
+      executePrepared: (current, value) => {
+        seen.push(value);
+        return { state: current };
+      },
+    });
+
+    expect(seen.map(value => value.civId).sort()).toEqual(['ai-1', 'ai-2']);
+    for (const value of seen) {
+      expect(value.perception.actorId).toBe(value.civId);
+      expect(value.assignments.portfolio).toBe(value.portfolio);
+      expect(value.forceDemands[0].sourcePlanIds).toEqual([`plan-${value.civId}`]);
+    }
+  });
+
+  it('skips a prepared action when an earlier actor removes its target', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Stale target',
+      seed: 'scheduler-stale-target',
+    });
+    state.turn = 0;
+    const playerSettler = state.civilizations.player.units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler')!;
+    const targetCity = foundCity('player', playerSettler.position, state.map, state.idCounters);
+    state.cities[targetCity.id] = targetCity;
+    state.civilizations.player.cities.push(targetCity.id);
+    const executed: string[] = [];
+
+    processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        const value = prepared(snapshot as typeof state, civId);
+        if (civId === 'ai-2') {
+          value.portfolio.primaryPlan = {
+            id: 'capture-target',
+            actorId: civId,
+            objective: 'capture',
+            target: { kind: 'city', id: targetCity.id, lastKnownPosition: targetCity.position },
+            theaterId: 'test',
+            phase: 'attacking',
+            reasonCodes: ['nearby-opportunity'],
+            commitment: 0.5,
+            createdTurn: 0,
+            reconsiderAfterTurn: 1,
+            expiresAfterTurn: 5,
+            lastProgressTurn: 0,
+            requiredRoles: { capture: 1 },
+            assignedUnitIds: [],
+          };
+        }
+        return value;
+      },
+      executePrepared: (current, value) => {
+        executed.push(value.civId);
+        if (value.civId === 'ai-1') {
+          const next = structuredClone(current);
+          delete next.cities[targetCity.id];
+          return { state: next };
+        }
+        return { state: current };
+      },
+    });
+
+    expect(executed).toEqual(['ai-1']);
+  });
+
+  it('keeps the existing live AI path when strategic planning is disabled', () => {
+    const state = createNewGame(undefined, 'scheduler-disabled', 'small');
+    const prepare = vi.fn();
+    const execute = vi.fn(current => current);
+
+    processNonHumanMajorRound(state, new EventBus(), {
+      strategicPlanningEnabled: false,
+      prepare,
+      execute,
+    });
+
+    expect(prepare).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledOnce();
   });
 });

--- a/tests/ai/ai-strength.test.ts
+++ b/tests/ai/ai-strength.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateMilitaryStrength,
+  type AIStrengthObservation,
+} from '@/ai/ai-strength';
+
+function observation(
+  overrides: Partial<AIStrengthObservation> = {},
+): AIStrengthObservation {
+  return {
+    type: 'warrior',
+    health: 100,
+    experience: 0,
+    source: 'visible',
+    confidence: 1,
+    uncertainty: 0,
+    locallyAvailable: true,
+    cargoOrCaptured: false,
+    ...overrides,
+  };
+}
+
+describe('AI military strength estimation', () => {
+  it('applies the same formula regardless of who owns an observation', () => {
+    const own = estimateMilitaryStrength([
+      observation({ type: 'swordsman', health: 80, experience: 25 }),
+    ]);
+    const opponent = estimateMilitaryStrength([
+      observation({ type: 'swordsman', health: 80, experience: 25 }),
+    ]);
+
+    expect(own).toEqual(opponent);
+  });
+
+  it('scales visible combat strength by health and bounded experience', () => {
+    const healthy = estimateMilitaryStrength([observation()]);
+    const damagedVeteran = estimateMilitaryStrength([
+      observation({ health: 50, experience: 50 }),
+    ]);
+    const cappedVeteran = estimateMilitaryStrength([
+      observation({ experience: 500 }),
+    ]);
+
+    expect(healthy.exactVisible).toBe(10);
+    expect(damagedVeteran.exactVisible).toBeCloseTo(5.5);
+    expect(cappedVeteran.exactVisible).toBeCloseTo(12);
+  });
+
+  it('decays remembered strength with confidence and widens its uncertainty bounds', () => {
+    const estimate = estimateMilitaryStrength([
+      observation({
+        source: 'remembered',
+        confidence: 0.6,
+        uncertainty: 0.2,
+      }),
+    ]);
+
+    expect(estimate.exactVisible).toBe(0);
+    expect(estimate.remembered).toBeCloseTo(6);
+    expect(estimate.uncertaintyLower).toBeCloseTo(4);
+    expect(estimate.uncertaintyUpper).toBeCloseTo(8);
+    expect(estimate.midpoint).toBeCloseTo(6);
+  });
+
+  it('clamps malformed observation percentages without producing invalid estimates', () => {
+    const estimate = estimateMilitaryStrength([
+      observation({
+        source: 'remembered',
+        health: 140,
+        experience: -20,
+        confidence: Number.POSITIVE_INFINITY,
+        uncertainty: -3,
+      }),
+    ]);
+
+    expect(estimate).toEqual({
+      exactVisible: 0,
+      remembered: 0,
+      uncertaintyLower: 0,
+      uncertaintyUpper: 0,
+      midpoint: 0,
+    });
+  });
+
+  it('adds a bounded inferred reserve only to the upper uncertainty bound', () => {
+    const estimate = estimateMilitaryStrength(
+      [observation()],
+      { unknownReserveUpper: 8 },
+    );
+
+    expect(estimate.exactVisible).toBe(10);
+    expect(estimate.uncertaintyLower).toBe(10);
+    expect(estimate.uncertaintyUpper).toBe(18);
+    expect(estimate.midpoint).toBe(14);
+  });
+
+  it('clamps invalid unknown-reserve bounds to zero', () => {
+    expect(estimateMilitaryStrength([], { unknownReserveUpper: -10 }))
+      .toEqual(estimateMilitaryStrength([]));
+    expect(estimateMilitaryStrength([], { unknownReserveUpper: Number.NaN }))
+      .toEqual(estimateMilitaryStrength([]));
+  });
+
+  it('excludes civilians, recon-only units, cargo or captured units, and unavailable forces', () => {
+    const estimate = estimateMilitaryStrength([
+      observation({ type: 'worker' }),
+      observation({ type: 'settler' }),
+      observation({ type: 'scout' }),
+      observation({ type: 'warrior', cargoOrCaptured: true }),
+      observation({ type: 'swordsman', locallyAvailable: false }),
+      observation({ type: 'war_hound' }),
+    ]);
+
+    expect(estimate.exactVisible).toBe(12);
+    expect(estimate.midpoint).toBe(12);
+  });
+
+  it('returns a stable zero estimate for no observations', () => {
+    expect(estimateMilitaryStrength([])).toEqual({
+      exactVisible: 0,
+      remembered: 0,
+      uncertaintyLower: 0,
+      uncertaintyUpper: 0,
+      midpoint: 0,
+    });
+  });
+});

--- a/tests/ai/ai-unit-assignment.test.ts
+++ b/tests/ai/ai-unit-assignment.test.ts
@@ -228,6 +228,10 @@ describe('AI unit assignment', () => {
     expect(result.assignmentsByPlanId.overseas).toContain('cavalry');
     expect(result.assignmentsByPlanId.overseas).not.toContain('warrior');
     expect(result.forceDemands.find(demand => demand.role === 'capture')?.missing).toBe(1);
+    expect(result.forceDemands.find(demand => demand.role === 'transport')).toMatchObject({
+      assigned: 1,
+      missing: 1,
+    });
   });
 
   it('uses stable IDs to break equal assignment ties and caps the primary force', () => {
@@ -249,5 +253,10 @@ describe('AI unit assignment', () => {
     });
 
     expect(result.assignmentsByPlanId.primary).toEqual(['unit-a', 'unit-b']);
+    expect(result.forceDemands.find(demand => demand.role === 'frontline')).toMatchObject({
+      desired: 2,
+      assigned: 2,
+      missing: 0,
+    });
   });
 });

--- a/tests/ai/ai-unit-assignment.test.ts
+++ b/tests/ai/ai-unit-assignment.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import type { AIStrategicPlan, MajorCivPlanPortfolio, UnitType } from '@/core/types';
+import {
+  assignUnitsToPortfolio,
+  type AIUnitAssignmentCandidate,
+} from '@/ai/ai-unit-assignment';
+import { createEmptyMajorCivPortfolio } from '@/ai/ai-plan-portfolio';
+
+function plan(
+  id: string,
+  objective: AIStrategicPlan['objective'],
+  requiredRoles: AIStrategicPlan['requiredRoles'],
+): AIStrategicPlan {
+  return {
+    id,
+    actorId: 'ai-1',
+    objective,
+    target: { kind: 'city', id: `${id}-target`, lastKnownPosition: { q: 5, r: 0 } },
+    theaterId: 'region-0',
+    phase: 'mobilizing',
+    reasonCodes: objective === 'defend' ? ['urgent-defense'] : ['nearby-opportunity'],
+    commitment: 0.5,
+    createdTurn: 5,
+    reconsiderAfterTurn: 9,
+    expiresAfterTurn: 20,
+    lastProgressTurn: 8,
+    requiredRoles,
+    assignedUnitIds: [],
+  };
+}
+
+function unit(
+  id: string,
+  type: UnitType,
+  travel: Record<string, number>,
+  overrides: Partial<AIUnitAssignmentCandidate> = {},
+): AIUnitAssignmentCandidate {
+  return {
+    id,
+    type,
+    health: 100,
+    experience: 0,
+    embarked: false,
+    activeOtherDuty: false,
+    travelTurnsByPlanId: travel,
+    ...overrides,
+  };
+}
+
+function portfolio(): MajorCivPlanPortfolio {
+  return {
+    ...createEmptyMajorCivPortfolio(),
+    primaryPlan: plan('capture-rival', 'capture', { frontline: 1, capture: 1 }),
+    defensePlansByCityId: {
+      capital: plan('defend-capital', 'defend', { frontline: 1 }),
+    },
+  };
+}
+
+describe('AI unit assignment', () => {
+  it('never assigns one unit to two plans', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: portfolio(),
+      units: [
+        unit('near-swordsman', 'swordsman', { 'defend-capital': 1, 'capture-rival': 2 }),
+        unit('warrior', 'warrior', { 'defend-capital': 2, 'capture-rival': 1 }),
+        unit('horseman', 'horseman', { 'defend-capital': 3, 'capture-rival': 2 }),
+      ],
+      profile: { maxPrimaryForce: 3, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: { 'defend-capital': 90 },
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+    const assigned = Object.values(result.assignmentsByPlanId).flat();
+
+    expect(new Set(assigned).size).toBe(assigned.length);
+  });
+
+  it('preempts the nearest viable offensive unit for urgent defense', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: portfolio(),
+      units: [
+        unit('near-swordsman', 'swordsman', { 'defend-capital': 1, 'capture-rival': 1 }),
+        unit('far-warrior', 'warrior', { 'defend-capital': 4, 'capture-rival': 2 }),
+      ],
+      profile: { maxPrimaryForce: 3, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: { 'defend-capital': 90 },
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+
+    expect(result.assignmentsByPlanId['defend-capital']).toContain('near-swordsman');
+    expect(result.assignmentsByPlanId['capture-rival']).not.toContain('near-swordsman');
+  });
+
+  it('never fills combat requirements with support specialists', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        primaryPlan: plan('attack', 'capture', { frontline: 2 }),
+      },
+      units: [
+        unit('settler', 'settler', { attack: 0 }),
+        unit('worker', 'worker', { attack: 0 }),
+        unit('expedition', 'expedition', { attack: 0 }),
+        unit('caravan', 'caravan', { attack: 0 }),
+      ],
+      profile: { maxPrimaryForce: 4, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: {},
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+
+    expect(result.assignmentsByPlanId.attack).toEqual([]);
+    expect(result.forceDemands).toContainEqual(expect.objectContaining({
+      role: 'frontline',
+      desired: 2,
+      assigned: 0,
+      missing: 2,
+    }));
+  });
+
+  it('keeps settlement, worker, expedition, and trade demand distinct', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        primaryPlan: plan('develop', 'expand', {
+          settlement: 1,
+          worker: 1,
+          'resource-expedition': 1,
+          trade: 1,
+        }),
+      },
+      units: [
+        unit('settler', 'settler', { develop: 1 }),
+        unit('worker', 'worker', { develop: 1 }),
+        unit('expedition', 'expedition', { develop: 1 }),
+        unit('caravan', 'caravan', { develop: 1 }),
+      ],
+      profile: { maxPrimaryForce: 4, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: {},
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+
+    expect(result.assignmentsByPlanId.develop).toEqual([
+      'settler',
+      'worker',
+      'expedition',
+      'caravan',
+    ]);
+  });
+
+  it('sends damaged units to recovery unless they alone prevent immediate capture', () => {
+    const base = {
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        defensePlansByCityId: {
+          capital: plan('defend', 'defend', { frontline: 1 }),
+        },
+      },
+      units: [unit('damaged', 'warrior', { defend: 0 }, { health: 20 })],
+      profile: { maxPrimaryForce: 4, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: { defend: 100 },
+      eliminationDefensePlanIds: ['defend'],
+      requiresEmbarkationByPlanId: {},
+    };
+
+    const recovering = assignUnitsToPortfolio({
+      ...base,
+      onlyImmediateDefenderUnitIds: [],
+    });
+    const lastStand = assignUnitsToPortfolio({
+      ...base,
+      onlyImmediateDefenderUnitIds: ['damaged'],
+    });
+
+    expect(recovering.recoveryUnitIds).toContain('damaged');
+    expect(recovering.assignmentsByPlanId.defend).toEqual([]);
+    expect(lastStand.assignmentsByPlanId.defend).toContain('damaged');
+  });
+
+  it('excludes embarked cargo and protects siege with a frontline unit', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        primaryPlan: plan('siege', 'capture', { frontline: 1, siege: 1 }),
+      },
+      units: [
+        unit('embarked-warrior', 'warrior', { siege: 0 }, { embarked: true }),
+        unit('catapult', 'catapult', { siege: 1 }),
+      ],
+      profile: { maxPrimaryForce: 4, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: {},
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+
+    expect(result.assignmentsByPlanId.siege).toEqual([]);
+    expect(result.forceDemands.find(demand => demand.role === 'frontline')?.missing).toBe(1);
+    expect(result.forceDemands.find(demand => demand.role === 'siege')?.missing).toBe(1);
+  });
+
+  it('respects transport capacity and cargo size for overseas plans', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        primaryPlan: plan('overseas', 'capture', { transport: 1, capture: 2 }),
+      },
+      units: [
+        unit('transport', 'transport', { overseas: 1 }),
+        unit('cavalry', 'cavalry', { overseas: 1 }),
+        unit('warrior', 'warrior', { overseas: 1 }),
+      ],
+      profile: { maxPrimaryForce: 4, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: {},
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: { overseas: true },
+    });
+
+    expect(result.assignmentsByPlanId.overseas).toContain('transport');
+    expect(result.assignmentsByPlanId.overseas).toContain('cavalry');
+    expect(result.assignmentsByPlanId.overseas).not.toContain('warrior');
+    expect(result.forceDemands.find(demand => demand.role === 'capture')?.missing).toBe(1);
+  });
+
+  it('uses stable IDs to break equal assignment ties and caps the primary force', () => {
+    const result = assignUnitsToPortfolio({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        primaryPlan: plan('primary', 'capture', { frontline: 3 }),
+      },
+      units: [
+        unit('unit-b', 'warrior', { primary: 1 }),
+        unit('unit-a', 'warrior', { primary: 1 }),
+        unit('unit-c', 'warrior', { primary: 1 }),
+      ],
+      profile: { maxPrimaryForce: 2, retreatHealthPercent: 30 },
+      defenseThreatScoreByPlanId: {},
+      eliminationDefensePlanIds: [],
+      onlyImmediateDefenderUnitIds: [],
+      requiresEmbarkationByPlanId: {},
+    });
+
+    expect(result.assignmentsByPlanId.primary).toEqual(['unit-a', 'unit-b']);
+  });
+});

--- a/tests/ai/ai-unit-roles.test.ts
+++ b/tests/ai/ai-unit-roles.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getAIStrategicRoles } from '@/ai/ai-unit-roles';
+import type { UnitType } from '@/core/types';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+
+describe('AI strategic unit roles', () => {
+  it('classifies every trainable unit into at least one strategic role', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      expect(getAIStrategicRoles(unit.type), unit.type).not.toHaveLength(0);
+    }
+  });
+
+  it.each([
+    ['warrior', ['frontline', 'capture']],
+    ['archer', ['ranged', 'capture']],
+    ['horseman', ['mobile', 'capture']],
+    ['catapult', ['siege', 'ranged']],
+    ['galley', ['naval-combat', 'escort']],
+  ] satisfies Array<[UnitType, string[]]>)('classifies %s from canonical unit fields', (type, roles) => {
+    expect(getAIStrategicRoles(type)).toEqual(roles);
+  });
+
+  it('never treats air units as capture units', () => {
+    for (const unit of TRAINABLE_UNITS) {
+      if (['observation_balloon', 'biplane', 'jet_fighter', 'attack_helicopter'].includes(unit.type)) {
+        expect(getAIStrategicRoles(unit.type), unit.type).not.toContain('capture');
+      }
+    }
+  });
+
+  it('keeps transports out of frontline duty', () => {
+    for (const type of ['transport', 'carrack', 'galleon', 'steamship', 'troop_transport'] as UnitType[]) {
+      expect(getAIStrategicRoles(type), type).toContain('transport');
+      expect(getAIStrategicRoles(type), type).not.toContain('frontline');
+      expect(getAIStrategicRoles(type), type).not.toContain('capture');
+    }
+  });
+
+  it('assigns spies to espionage rather than conventional combat', () => {
+    for (const type of ['spy_scout', 'spy_informant', 'spy_agent', 'spy_operative', 'spy_hacker'] as UnitType[]) {
+      expect(getAIStrategicRoles(type), type).toContain('espionage');
+      expect(getAIStrategicRoles(type), type).not.toContain('frontline');
+      expect(getAIStrategicRoles(type), type).not.toContain('capture');
+    }
+  });
+
+  it('keeps civilian support purposes distinct', () => {
+    expect(getAIStrategicRoles('settler')).toEqual(['settlement']);
+    expect(getAIStrategicRoles('worker')).toEqual(['worker']);
+    expect(getAIStrategicRoles('expedition')).toEqual(['resource-expedition', 'recon']);
+    expect(getAIStrategicRoles('caravan')).toEqual(['trade']);
+  });
+
+  it('preserves the intended detection-unit specializations', () => {
+    expect(getAIStrategicRoles('scout_hound')).toEqual(['detection', 'frontline']);
+    expect(getAIStrategicRoles('shadow_warden')).toEqual(['detection', 'frontline']);
+    expect(getAIStrategicRoles('war_hound')).toEqual([
+      'detection',
+      'frontline',
+      'mobile',
+      'capture',
+    ]);
+  });
+});

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1224,6 +1224,44 @@ describe('processAITurn', () => {
     expect(result.civilizations['ai-1'].diplomacy.atWarWith).not.toContain('player');
   });
 
+  it('counts visible rival combined arms instead of only rival warriors', () => {
+    const state = createNewGame(undefined, 'ai-symmetric-visible-strength');
+    state.turn = 20;
+    state.civilizations['ai-1'].civType = 'rome';
+    state.civilizations['ai-1'].knownCivilizations = ['player'];
+    state.civilizations.player.knownCivilizations = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.relationships.player = -60;
+    state.civilizations.player.diplomacy.relationships['ai-1'] = -60;
+
+    const anchor = state.civilizations['ai-1'].units
+      .map(id => state.units[id])
+      .find(Boolean)!.position;
+    const rivalPosition = {
+      q: (anchor.q + 2) % state.map.width,
+      r: anchor.r,
+    };
+    for (const type of ['swordsman', 'swordsman'] as const) {
+      const unit = createUnit(type, 'ai-1', anchor, state.idCounters);
+      unit.id = `ai-${type}-${state.civilizations['ai-1'].units.length}`;
+      unit.movementPointsLeft = 0;
+      state.units[unit.id] = unit;
+      state.civilizations['ai-1'].units.push(unit.id);
+    }
+    for (const type of ['tank', 'jet_fighter'] as const) {
+      const unit = createUnit(type, 'player', rivalPosition, state.idCounters);
+      unit.id = `player-${type}`;
+      state.units[unit.id] = unit;
+      state.civilizations.player.units.push(unit.id);
+    }
+    for (const id of state.civilizations['ai-1'].units) {
+      if (state.units[id]) state.units[id].movementPointsLeft = 0;
+    }
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.civilizations['ai-1'].diplomacy.atWarWith).not.toContain('player');
+  });
+
   it('AI settler founds a city when possible', () => {
     const state = createNewGame(undefined, 'ai-test');
     const bus = new EventBus();

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import {
   createEmptyOpponentAIState,
+  createEmptyMajorCivPlanPortfolio,
   normalizeOpponentAIState,
 } from '@/core/opponent-ai-state';
 import type { AIStrategicPlan, GameState } from '@/core/types';
@@ -69,6 +70,21 @@ describe('opponent AI state normalization', () => {
       lastProcessedRound: null,
       lastFinalizedRound: null,
     });
+  });
+
+  it('creates compact portfolio state without transient planner data', () => {
+    const portfolio = createEmptyMajorCivPlanPortfolio();
+
+    expect(portfolio).toEqual({
+      primaryPlan: null,
+      defensePlansByCityId: {},
+      upgradeRoutesByUnitId: {},
+      modernizationDemand: 0,
+      researchTargetTechId: null,
+      lastPlannedTurn: -1,
+      lastExecutedTurn: -1,
+    });
+    expect((portfolio as typeof portfolio & { traces?: unknown }).traces).toBeUndefined();
   });
 
   it('removes dead or wrong-owner assignments without mutating the loaded object', () => {

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -150,4 +150,69 @@ describe('opponent AI state normalization', () => {
     expect(normalized.opponentAI!.majorCivs['ai-1'].upgradeRoutesByUnitId).toEqual({});
     expect(normalized.opponentAI!.migrationGraceRoundsRemaining).toBe(2);
   });
+
+  it('normalizes persisted portfolio turn markers while preserving the never-run sentinel', () => {
+    const state = makeState();
+    state.opponentAI!.majorCivs['ai-1'].lastPlannedTurn = -4.8;
+    state.opponentAI!.majorCivs['ai-1'].lastExecutedTurn = 7.9;
+
+    const portfolio = normalizeOpponentAIState(state).opponentAI!.majorCivs['ai-1'];
+
+    expect(portfolio.lastPlannedTurn).toBe(-1);
+    expect(portfolio.lastExecutedTurn).toBe(7);
+  });
+
+  it('defaults missing saved turn markers to the never-run sentinel', () => {
+    const state = makeState();
+    const saved = state.opponentAI!.majorCivs['ai-1'] as unknown as Record<string, unknown>;
+    delete saved.lastPlannedTurn;
+    delete saved.lastExecutedTurn;
+
+    const portfolio = normalizeOpponentAIState(state).opponentAI!.majorCivs['ai-1'];
+
+    expect(portfolio.lastPlannedTurn).toBe(-1);
+    expect(portfolio.lastExecutedTurn).toBe(-1);
+  });
+
+  it('bounds saved role demand and rejects mislabeled defense plans', () => {
+    const state = makeState();
+    const aiUnitId = state.civilizations['ai-1'].units[0]!;
+    const ownCity = structuredClone(Object.values(state.cities)[0]);
+    ownCity.id = 'ai-owned-city';
+    ownCity.owner = 'ai-1';
+    state.cities[ownCity.id] = ownCity;
+    state.civilizations['ai-1'].cities.push(ownCity.id);
+    state.opponentAI!.majorCivs['ai-1'].primaryPlan = makePlan({
+      requiredRoles: { frontline: Number.MAX_SAFE_INTEGER },
+      assignedUnitIds: [aiUnitId, 7 as unknown as string],
+    });
+    state.opponentAI!.majorCivs['ai-1'].defensePlansByCityId[ownCity.id] = makePlan({
+      objective: 'capture',
+      target: {
+        kind: 'city',
+        id: ownCity.id,
+        lastKnownPosition: ownCity.position,
+      },
+    });
+
+    const portfolio = normalizeOpponentAIState(state).opponentAI!.majorCivs['ai-1'];
+
+    expect(portfolio.primaryPlan?.requiredRoles.frontline).toBeLessThanOrEqual(32);
+    expect(portfolio.primaryPlan?.assignedUnitIds).toEqual([aiUnitId]);
+    expect(portfolio.defensePlansByCityId).toEqual({});
+  });
+
+  it('strips transient and unknown fields from normalized saved plans', () => {
+    const state = makeState();
+    const savedPlan = state.opponentAI!.majorCivs['ai-1'].primaryPlan as
+      AIStrategicPlan & { traces?: unknown; cachedPath?: unknown };
+    savedPlan.traces = [{ selectedId: 'private-debug-data' }];
+    savedPlan.cachedPath = [{ q: 1, r: 1 }];
+
+    const plan = normalizeOpponentAIState(state).opponentAI!.majorCivs['ai-1'].primaryPlan as
+      AIStrategicPlan & { traces?: unknown; cachedPath?: unknown };
+
+    expect(plan.traces).toBeUndefined();
+    expect(plan.cachedPath).toBeUndefined();
+  });
 });

--- a/tests/systems/actor-perception.test.ts
+++ b/tests/systems/actor-perception.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import {
+  decayRememberedConfidence,
+  getLocallySensedUnits,
+} from '@/systems/actor-perception';
+import { createUnit } from '@/systems/unit-system';
+
+describe('actor perception', () => {
+  it('uses wrapped distance and sorts sensed units by distance then id', () => {
+    const state = createNewGame(undefined, 'actor-perception-wrap', 'small');
+    state.map.wrapsHorizontally = true;
+    state.units = {};
+
+    const edge = createUnit('warrior', 'player', { q: state.map.width - 1, r: 0 }, state.idCounters);
+    edge.id = 'unit-b';
+    const sameHex = createUnit('warrior', 'player', { q: 0, r: 0 }, state.idCounters);
+    sameHex.id = 'unit-a';
+    state.units[edge.id] = edge;
+    state.units[sameHex.id] = sameHex;
+
+    expect(getLocallySensedUnits(
+      state,
+      [{ q: 0, r: 0 }],
+      1,
+      owner => owner === 'player',
+    ).map(unit => unit.id)).toEqual(['unit-a', 'unit-b']);
+  });
+
+  it('excludes transported cargo from local sensing', () => {
+    const state = createNewGame(undefined, 'actor-perception-cargo', 'small');
+    state.units = {};
+    const cargo = createUnit('warrior', 'player', { q: 0, r: 0 }, state.idCounters);
+    cargo.transportId = 'transport-1';
+    state.units[cargo.id] = cargo;
+
+    expect(getLocallySensedUnits(state, [{ q: 0, r: 0 }], 2, () => true)).toEqual([]);
+  });
+
+  it('decays remembered confidence over six rounds with bounded inputs', () => {
+    expect(decayRememberedConfidence(-2)).toBe(1);
+    expect(decayRememberedConfidence(0)).toBe(1);
+    expect(decayRememberedConfidence(3)).toBe(0.5);
+    expect(decayRememberedConfidence(6)).toBe(0);
+    expect(decayRememberedConfidence(20)).toBe(0);
+    expect(decayRememberedConfidence(Number.NaN)).toBe(0);
+  });
+});

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -204,6 +204,57 @@ function makeRewardState(): GameState {
 }
 
 describe('applyCombatOutcomeToState', () => {
+  it.each([
+    ['player', 'ai-1'],
+    ['ai-1', 'player'],
+  ])('records a %s attack in the defending major civilization history', (attackerOwner, defenderOwner) => {
+    const state = makeRewardState();
+    state.units.attacker.owner = attackerOwner;
+    state.units.defender.owner = defenderOwner;
+    state.civilizations.player.units = attackerOwner === 'player' ? ['attacker'] : ['defender'];
+    state.civilizations['ai-1'].units = attackerOwner === 'ai-1' ? ['attacker'] : ['defender'];
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.state.civilizations[defenderOwner].diplomacy.events).toContainEqual({
+      type: 'military_attacked',
+      turn: state.turn,
+      otherCiv: attackerOwner,
+      weight: 1,
+    });
+  });
+
+  it('does not create major-civilization attack history for world actors', () => {
+    const state = makeRewardState();
+    state.units.attacker.owner = 'barbarian';
+    state.civilizations.player.units = [];
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.state.civilizations['ai-1'].diplomacy.events)
+      .not.toContainEqual(expect.objectContaining({ type: 'military_attacked' }));
+  });
+
   it('removes the defeated unit, spends the attacker, and applies XP, healing, and gold', () => {
     const state = makeRewardState();
     const result: CombatResult = {

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -12,6 +12,7 @@ import {
   proposeTreaty,
   breakTreaty,
   processRelationshipDrift,
+  recordMilitaryAttack,
   decayEvents,
   getAvailableActions,
   isAtWar,
@@ -78,6 +79,40 @@ describe('diplomacy-system', () => {
       state = declareWar(state, 'ai-egypt', 5);
       expect(state.events).toHaveLength(1);
       expect(state.events[0].type).toBe('war_declared');
+    });
+  });
+
+  describe('recordMilitaryAttack', () => {
+    it('coalesces attacks from the same civilization in one turn', () => {
+      let state = createDiplomacyState(civIds, 'player');
+      state = recordMilitaryAttack(state, 'ai-egypt', 8);
+      state = recordMilitaryAttack(state, 'ai-egypt', 8);
+
+      expect(state.events.filter(event => event.type === 'military_attacked')).toEqual([{
+        type: 'military_attacked',
+        turn: 8,
+        otherCiv: 'ai-egypt',
+        weight: 1,
+      }]);
+    });
+
+    it('retains the newest twelve attacks without rewriting unrelated history', () => {
+      let state = createDiplomacyState(civIds, 'player');
+      state.events.push({ type: 'peace_made', turn: 1, otherCiv: 'ai-rome', weight: 0.5 });
+      for (let turn = 1; turn <= 14; turn++) {
+        state = recordMilitaryAttack(state, `attacker-${turn}`, turn);
+      }
+
+      expect(state.events.find(event => event.type === 'peace_made')).toEqual({
+        type: 'peace_made',
+        turn: 1,
+        otherCiv: 'ai-rome',
+        weight: 0.5,
+      });
+      const attacks = state.events.filter(event => event.type === 'military_attacked');
+      expect(attacks).toHaveLength(12);
+      expect(attacks[0].turn).toBe(3);
+      expect(attacks.at(-1)?.turn).toBe(14);
     });
   });
 

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -114,6 +114,24 @@ describe('diplomacy-system', () => {
       expect(attacks[0].turn).toBe(3);
       expect(attacks.at(-1)?.turn).toBe(14);
     });
+
+    it('preserves the relative order of unrelated diplomatic history', () => {
+      let state = createDiplomacyState(civIds, 'player');
+      state.events = [
+        { type: 'war_declared', turn: 1, otherCiv: 'ai-egypt', weight: 1 },
+        { type: 'military_attacked', turn: 2, otherCiv: 'ai-egypt', weight: 1 },
+        { type: 'peace_made', turn: 3, otherCiv: 'ai-egypt', weight: 1 },
+      ];
+
+      state = recordMilitaryAttack(state, 'ai-rome', 4);
+
+      expect(state.events.map(event => event.type)).toEqual([
+        'war_declared',
+        'military_attacked',
+        'peace_made',
+        'military_attacked',
+      ]);
+    });
   });
 
   describe('makePeace', () => {

--- a/tests/systems/last-seen-presentation.test.ts
+++ b/tests/systems/last-seen-presentation.test.ts
@@ -1,9 +1,41 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv, updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
+import {
+  createLastSeenTilePresentation,
+  isTrustedObservedLastSeenTile,
+  refreshLastSeenPresentationsForCiv,
+  updateAndRefreshVisibility,
+  reconstructLastSeenFromMap,
+} from '@/systems/last-seen-presentation';
 import { createUnit } from '@/systems/unit-system';
+import {
+  createEspionageCivState,
+  createSpyFromUnit,
+  setDisguise,
+} from '@/systems/espionage-system';
+import { hexKey } from '@/systems/hex-utils';
 
 describe('last-seen-presentation', () => {
+  it('recognizes only structurally valid observed snapshots as trusted AI intel', () => {
+    const state = createNewGame(undefined, 'trusted-last-seen', 'small');
+    const valid = createLastSeenTilePresentation(
+      state,
+      'player',
+      state.map.tiles['0,0'],
+    );
+
+    expect(isTrustedObservedLastSeenTile(valid)).toBe(true);
+    expect(isTrustedObservedLastSeenTile({
+      ...valid,
+      coord: null,
+    })).toBe(false);
+    expect(isTrustedObservedLastSeenTile({
+      ...valid,
+      source: 'legacy-reconstructed',
+      observedTurn: undefined,
+    })).toBe(false);
+  });
+
   it('captures serializable tile presentation for visible tiles', () => {
     const state = createNewGame(undefined, 'last-seen-visible', 'small');
     const tile = state.map.tiles['0,0'];
@@ -39,6 +71,7 @@ describe('last-seen-presentation', () => {
     refreshLastSeenPresentationsForCiv(state, 'player');
 
     expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('forest');
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.units).toBeUndefined();
     expect(state.civilizations.player.visibility.lastSeen?.['1,0']).toBeUndefined();
   });
 
@@ -96,6 +129,39 @@ describe('last-seen-presentation', () => {
         healthBand: 'damaged',
       }],
     });
+  });
+
+  it('stores the viewer-facing disguise instead of a spy true identity', () => {
+    const state = createNewGame(undefined, 'last-seen-disguise', 'small');
+    const coord = { q: 8, r: 4 };
+    const key = hexKey(coord);
+    state.civilizations.player.visibility.tiles = { [key]: 'visible' };
+    const spyUnit = createUnit('spy_scout', 'ai-1', coord, state.idCounters);
+    spyUnit.id = 'disguised-spy';
+    state.units[spyUnit.id] = spyUnit;
+    state.civilizations['ai-1'].units.push(spyUnit.id);
+    const created = createSpyFromUnit(
+      createEspionageCivState(),
+      spyUnit.id,
+      'ai-1',
+      'spy_scout',
+      'last-seen-disguise',
+    );
+    state.espionage = {
+      'ai-1': setDisguise(created.state, spyUnit.id, 'barbarian'),
+    };
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.[key]?.units).toContainEqual(
+      expect.objectContaining({
+        id: spyUnit.id,
+        owner: 'barbarian',
+        type: 'warrior',
+      }),
+    );
+    expect(state.civilizations.player.visibility.lastSeen?.[key]?.units)
+      .not.toContainEqual(expect.objectContaining({ type: 'spy_scout' }));
   });
 
   it('does not update fogged city presentation from live city changes', () => {

--- a/tests/systems/last-seen-presentation.test.ts
+++ b/tests/systems/last-seen-presentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { createLastSeenTilePresentation, refreshLastSeenPresentationsForCiv, updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
+import { createUnit } from '@/systems/unit-system';
 
 describe('last-seen-presentation', () => {
   it('captures serializable tile presentation for visible tiles', () => {
@@ -50,6 +51,51 @@ describe('last-seen-presentation', () => {
 
     expect(state.civilizations.player.visibility.lastSeen?.['0,0']).toBeDefined();
     expect(state.civilizations['ai-1'].visibility.lastSeen?.['0,0']).toBeUndefined();
+  });
+
+  it('records trusted, coarse unit intel without transported or concealed units', () => {
+    const state = createNewGame(undefined, 'last-seen-units', 'small');
+    state.turn = 9;
+    const coord = { q: 8, r: 4 };
+    const key = '8,4';
+    state.civilizations.player.visibility.tiles = { [key]: 'visible' };
+
+    const visible = createUnit('warrior', 'ai-1', coord, state.idCounters);
+    visible.id = 'visible-unit';
+    visible.health = 45;
+    const cargo = createUnit('warrior', 'ai-1', coord, state.idCounters);
+    cargo.id = 'cargo-unit';
+    cargo.transportId = 'transport-1';
+    const concealed = createUnit('warrior', 'ai-1', coord, state.idCounters);
+    concealed.id = 'concealed-unit';
+    state.civilizations['ai-1'].civType = 'lothlorien';
+    state.map.tiles[key].terrain = 'forest';
+    state.units = {
+      ...state.units,
+      [visible.id]: visible,
+      [cargo.id]: cargo,
+      [concealed.id]: concealed,
+    };
+
+    // Keep viewer pieces away so Lothlorien's enemy unit remains concealed.
+    const playerUnit = state.civilizations.player.units
+      .map(id => state.units[id])
+      .find(Boolean)!;
+    playerUnit.position = { q: 0, r: 0 };
+    visible.owner = 'player';
+
+    refreshLastSeenPresentationsForCiv(state, 'player');
+
+    expect(state.civilizations.player.visibility.lastSeen?.[key]).toMatchObject({
+      observedTurn: 9,
+      source: 'observed',
+      units: [{
+        id: visible.id,
+        owner: 'player',
+        type: 'warrior',
+        healthBand: 'damaged',
+      }],
+    });
   });
 
   it('does not update fogged city presentation from live city changes', () => {
@@ -141,6 +187,11 @@ describe('reconstructLastSeenFromMap', () => {
     reconstructLastSeenFromMap(state, 'player');
 
     expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.terrain).toBe('desert');
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']).toMatchObject({
+      source: 'legacy-reconstructed',
+    });
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.observedTurn).toBeUndefined();
+    expect(state.civilizations.player.visibility.lastSeen?.['0,0']?.units).toBeUndefined();
   });
 
   it('does not overwrite existing lastSeen entries or snapshot unexplored tiles', () => {


### PR DESCRIPTION
## Summary
- add typed strategic unit roles and one symmetric military-strength estimator
- derive actor-scoped visible/remembered/rumored intelligence without hidden unit, technology, cargo, disguise, or legacy-snapshot leakage
- add locality-first objective scoring, bounded traces, persistent plan portfolios, exclusive path-valid unit assignment, and aggregate force demand
- record major-civilization attacks at the canonical combat outcome boundary without reordering diplomacy history
- add a feature-gated two-phase scheduler that plans all AI actors from one immutable snapshot and revalidates stale targets, assignments, and demand

## Gameplay impact
AI diplomacy now compares combined arms consistently instead of counting all self units versus rival warriors only. The strategic planner favors nearby feasible goals from the nearest friendly city, accounts for perceived defender strength, retains and retires defense plans coherently, reacts to visible always-hostile raiders, and cannot invent transport, paths, or hidden knowledge. Tactical replacement remains disabled pending MR3; the live scheduler continues to use the existing AI turn path.

## Save and hot-seat safety
- last-seen additions are optional, structurally validated, disguise-safe, and backward-compatible
- legacy reconstructed snapshots remain available to UI but have zero AI confidence
- malformed saved plans are bounded and normalized; missing turn markers preserve the never-run sentinel
- only compact allowlisted portfolio fields and assigned unit IDs persist; perception, path caches, force working data, errors, and traces remain transient
- failed preparation is isolated to its AI actor, while other non-human actors continue
- all human civilizations remain excluded from non-human planning and execution

## UI, UX, and SFX scope
MR2 adds no player-facing planner surface or new sound. The strategic path remains feature-gated, so existing mobile/laptop UI and viewer-scoped SFX behavior are unchanged.

## Verification
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test` — 323 files, 4,695 passed, 2 skipped
- changed-source rule checks
- hook smoke tests
- GitHub CI green: security, web build, tests, web smoke, Tauri frontend, and desktop change check

Closes #412
