### PR TITLE
feat(ai): issue 412 coordinated major-civilization execution

### DIFF
--- a/src/ai/ai-hostility.ts
+++ b/src/ai/ai-hostility.ts
@@ -1,0 +1,32 @@
+import { classifyOwner, isAlwaysHostilePair } from '@/core/owner-kind';
+import type { GameState } from '@/core/types';
+import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
+
+export function isAIHostileOwner(
+  state: Readonly<GameState>,
+  actorId: string,
+  ownerId: string,
+): boolean {
+  if (ownerId === actorId) return false;
+  const ownerKind = classifyOwner(ownerId);
+  if (ownerKind === 'beast') {
+    return state.settings?.aiContestsBeasts === true;
+  }
+  if (ownerKind === 'pirate') {
+    const faction = state.pirates?.factions[ownerId];
+    if (
+      faction?.contract?.employerId === actorId
+      || (faction?.tributeByCiv[actorId]?.protectedUntilRound ?? 0)
+        > state.turn
+    ) {
+      return false;
+    }
+    return true;
+  }
+  if (ownerKind === 'minor') {
+    return isMinorCivAtWar(state, actorId, ownerId);
+  }
+  if (isAlwaysHostilePair(actorId, ownerId)) return true;
+  return state.civilizations[actorId]?.diplomacy.atWarWith
+    .includes(ownerId) ?? false;
+}

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -1,0 +1,896 @@
+import type { EventBus } from '@/core/event-bus';
+import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
+import {
+  OPPONENT_CHALLENGE_PROFILES,
+  resolveOpponentChallenge,
+} from '@/core/opponent-challenge';
+import type {
+  AIStrategicPlan,
+  CombatResult,
+  GameState,
+  Unit,
+} from '@/core/types';
+import { canUnitAttackTarget } from '@/systems/attack-targeting';
+import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
+import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { resolveCombat } from '@/systems/combat-system';
+import {
+  beginMajorCityAssault,
+  canUnitOccupyCity,
+  emitMajorCityCaptureEvents,
+  resolveMajorCityCapture,
+} from '@/systems/city-capture-system';
+import { foundCityInState } from '@/systems/city-founding-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { conquestMinorCiv } from '@/systems/minor-civ-system';
+import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
+import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
+import {
+  canEstablishOutpost,
+  performEstablishOutpost,
+} from '@/systems/resource-acquisition-system';
+import { recordCombatForCiv } from '@/systems/threat-pressure-system';
+import {
+  loadUnitOntoTransport,
+  unloadUnitFromTransport,
+} from '@/systems/transport-system';
+import { executeUnitMove } from '@/systems/unit-movement-system';
+import {
+  buildUnitOccupancy,
+  getUnitIdsAtCoord,
+  hasHostileUnitAtCoord,
+} from '@/systems/unit-occupancy';
+import { restUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
+import { applyWorkerAction } from '@/systems/worker-action-system';
+import {
+  createAIDecisionTrace,
+  type AIDecisionTrace,
+} from './ai-decision-trace';
+import type { MajorCivPerception } from './ai-perception';
+import type { PreparedMajorCivPlan } from './ai-prepared-turn';
+import {
+  chooseTacticalSequence,
+  rankUnitTacticalActions,
+  type AITacticalAction,
+  type AITacticalContext,
+} from './ai-tactics';
+import { getAIStrategicRoles } from './ai-unit-roles';
+
+export interface ProcessMajorCivStrategicTurnResult {
+  state: GameState;
+  actions: AITacticalAction[];
+  traces: AIDecisionTrace[];
+}
+
+function distance(
+  state: GameState,
+  from: { q: number; r: number },
+  to: { q: number; r: number },
+): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(from, to, state.map.width)
+    : hexDistance(from, to);
+}
+
+function targetPosition(plan: AIStrategicPlan) {
+  if ('lastKnownPosition' in plan.target) return plan.target.lastKnownPosition;
+  return plan.target.kind === 'resource'
+    ? plan.target.position
+    : plan.target.anchor;
+}
+
+function deterministicCombatSeed(
+  state: GameState,
+  attackerId: string,
+  defenderId: string,
+): number {
+  const source = [
+    state.gameId ?? 'legacy',
+    state.turn,
+    attackerId,
+    defenderId,
+  ].join(':');
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index++) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.max(1, hash >>> 0);
+}
+
+function combatContext(state: GameState, attacker: Unit, defender: Unit) {
+  const defenderKey = hexKey(defender.position);
+  return {
+    attackerBonus: resolveCivDefinition(
+      state,
+      state.civilizations[attacker.owner]?.civType ?? '',
+    )?.bonusEffect,
+    defenderBonus: resolveCivDefinition(
+      state,
+      state.civilizations[defender.owner]?.civType ?? '',
+    )?.bonusEffect,
+    defenderCityHasAntiAir: Object.values(state.cities).some(city =>
+      hexKey(city.position) === defenderKey
+      && city.buildings.includes('anti_air_battery')),
+    attackerHasAirForceCommand: Object.values(state.cities).some(city =>
+      city.owner === attacker.owner
+      && city.buildings.includes('air_force_command')),
+  };
+}
+
+function actionMatches(
+  left: AITacticalAction,
+  right: AITacticalAction,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function tacticalTrace(
+  context: AITacticalContext,
+  action: AITacticalAction,
+): AIDecisionTrace {
+  const candidates = rankUnitTacticalActions(context, action.unitId);
+  const selected = candidates.find(candidate =>
+    actionMatches(candidate.action, action));
+  return createAIDecisionTrace({
+    actorId: context.actorId,
+    turn: context.state.turn,
+    decision: 'tactical',
+    selectedId: selected?.id ?? null,
+    candidates: candidates.map(candidate => ({
+      id: candidate.id,
+      score: candidate.score,
+      eligible: true,
+      reasonCodes: candidate.mandatory ? ['mandatory'] : [],
+    })),
+  });
+}
+
+function occupyMajorCity(
+  state: GameState,
+  cityId: string,
+  attackerId: string,
+  civId: string,
+  bus: EventBus,
+  precedingCombat?: CombatResult,
+): { state: GameState; captured: boolean } {
+  const city = state.cities[cityId];
+  if (!city || !state.civilizations[city.owner]) {
+    return { state, captured: false };
+  }
+  const previousOwnerId = city.owner;
+  const assault = beginMajorCityAssault(
+    state,
+    attackerId,
+    cityId,
+    {
+      actor: 'ai',
+      civId,
+      bus,
+      precedingCombat,
+    },
+  );
+  if (!assault.ok) return { state, captured: false };
+  const capture = resolveMajorCityCapture(
+    assault.state,
+    cityId,
+    civId,
+    'occupy',
+    assault.state.turn,
+  );
+  emitMajorCityCaptureEvents(
+    state,
+    capture,
+    cityId,
+    civId,
+    previousOwnerId,
+    bus,
+  );
+  return { state: capture.state, captured: true };
+}
+
+function executeAttack(
+  state: GameState,
+  action: Extract<AITacticalAction, { kind: 'attack' }>,
+  civId: string,
+  bus: EventBus,
+): { state: GameState; followUps: AITacticalAction[] } {
+  const next = structuredClone(state);
+  const attacker = next.units[action.unitId];
+  const defender = next.units[action.targetUnitId];
+  if (!attacker || !defender || attacker.owner !== civId) {
+    return { state, followUps: [] };
+  }
+  const legality = canUnitAttackTarget(
+    next,
+    attacker,
+    defender.position,
+    { viewerId: civId, requireVisibility: true },
+  );
+  if (
+    !legality.ok
+    || legality.targetType !== 'unit'
+    || legality.targetUnitId !== defender.id
+  ) {
+    return { state, followUps: [] };
+  }
+
+  const seed = deterministicCombatSeed(next, attacker.id, defender.id);
+  const combat = resolveCombat(
+    attacker,
+    defender,
+    next.map,
+    seed,
+    combatContext(next, attacker, defender),
+    next.era,
+  );
+  const presentation = buildCombatPresentation(next, combat, attacker, defender);
+  const applied = applyCombatOutcomeToState(next, combat, seed);
+  let working = recordCombatForCiv(
+    applied.state,
+    civId,
+    defender.position,
+  );
+  emitMinorCivQuestTransitions(bus, applied.questTransitions, working);
+  bus.emit('combat:resolved', { result: combat, ...presentation });
+  for (const reward of applied.rewards) {
+    bus.emit('combat:reward-earned', { reward });
+  }
+
+  const followUps: AITacticalAction[] = [];
+  if (applied.defenderDefeated) {
+    const camp = applyCampDestructionAtTarget(
+      working,
+      civId,
+      defender.position,
+      working.turn,
+    );
+    if (camp.campId) {
+      working = camp.state;
+      emitMinorCivQuestTransitions(bus, camp.questTransitions, working);
+      bus.emit('barbarian:camp-destroyed', {
+        campId: camp.campId,
+        reward: camp.reward,
+      });
+    }
+
+    const city = Object.values(working.cities).find(candidate =>
+      hexKey(candidate.position) === hexKey(defender.position)
+      && candidate.owner !== civId);
+    const attackerAfterCombat = working.units[attacker.id];
+    const occupancy = buildUnitOccupancy(working.units);
+    if (
+      city
+      && attackerAfterCombat
+      && !hasHostileUnitAtCoord(occupancy, city.position, civId)
+      && working.civilizations[city.owner]
+    ) {
+      const capture = occupyMajorCity(
+        working,
+        city.id,
+        attacker.id,
+        civId,
+        bus,
+        combat,
+      );
+      if (capture.captured) {
+        working = capture.state;
+        followUps.push({
+          kind: 'capture-city',
+          unitId: attacker.id,
+          cityId: city.id,
+        });
+      }
+    }
+  }
+  return { state: working, followUps };
+}
+
+function executeMinorCityCapture(
+  state: GameState,
+  action: Extract<AITacticalAction, { kind: 'capture-city' }>,
+  civId: string,
+  bus: EventBus,
+): { state: GameState; succeeded: boolean } {
+  const city = state.cities[action.cityId];
+  const attacker = state.units[action.unitId];
+  if (
+    !city
+    || !city.owner.startsWith('mc-')
+    || !isMinorCivAtWar(state, civId, city.owner)
+    || !attacker
+    || attacker.owner !== civId
+    || !canUnitOccupyCity(attacker)
+    || distance(state, attacker.position, city.position) !== 1
+    || getUnitIdsAtCoord(
+      buildUnitOccupancy(state.units),
+      city.position,
+    ).length > 0
+  ) {
+    return { state, succeeded: false };
+  }
+  const next = structuredClone(state);
+  const movement = executeUnitMove(
+    next,
+    action.unitId,
+    city.position,
+    {
+      actor: 'ai',
+      civId,
+      bus,
+      foreignCityEntryId: city.id,
+    },
+  );
+  if (!movement.ok) return { state, succeeded: false };
+  const conquest = conquestMinorCiv(next, city.owner, civId);
+  if (!conquest.conquered) return { state, succeeded: false };
+  emitMinorCivQuestTransitions(bus, conquest.transitions, conquest.state);
+  bus.emit('minor-civ:destroyed', {
+    minorCivId: city.owner,
+    conquerorId: civId,
+  });
+  return { state: conquest.state, succeeded: true };
+}
+
+function executeAction(
+  state: GameState,
+  action: AITacticalAction,
+  civId: string,
+  bus: EventBus,
+): {
+  state: GameState;
+  succeeded: boolean;
+  followUps: AITacticalAction[];
+} {
+  switch (action.kind) {
+    case 'attack': {
+      const attack = executeAttack(state, action, civId, bus);
+      return {
+        state: attack.state,
+        succeeded: attack.state !== state,
+        followUps: attack.followUps,
+      };
+    }
+    case 'capture-city': {
+      const city = state.cities[action.cityId];
+      if (city?.owner.startsWith('mc-')) {
+        const capture = executeMinorCityCapture(state, action, civId, bus);
+        return { ...capture, followUps: [] };
+      }
+      const capture = occupyMajorCity(
+        state,
+        action.cityId,
+        action.unitId,
+        civId,
+        bus,
+      );
+      return {
+        state: capture.state,
+        succeeded: capture.captured,
+        followUps: [],
+      };
+    }
+    case 'move':
+    case 'withdraw': {
+      const next = structuredClone(state);
+      const movement = executeUnitMove(
+        next,
+        action.unitId,
+        action.destination,
+        { actor: 'ai', civId, bus },
+      );
+      return {
+        state: movement.ok ? next : state,
+        succeeded: movement.ok,
+        followUps: [],
+      };
+    }
+    case 'found-city':
+      try {
+        return {
+          state: foundCityInState(state, action.unitId, bus).state,
+          succeeded: true,
+          followUps: [],
+        };
+      } catch {
+        return { state, succeeded: false, followUps: [] };
+      }
+    case 'establish-outpost':
+      return canEstablishOutpost(state, action.unitId)
+        ? {
+            state: performEstablishOutpost(state, action.unitId),
+            succeeded: true,
+            followUps: [],
+          }
+        : { state, succeeded: false, followUps: [] };
+    case 'worker-action': {
+      const result = applyWorkerAction(state, action.unitId, action.action);
+      if (!result.ok) return { state, succeeded: false, followUps: [] };
+      for (const event of result.events) {
+        if (event.type === 'improvement:started') {
+          bus.emit('improvement:started', event.payload);
+        } else {
+          bus.emit('unit:destroyed', event.payload);
+        }
+      }
+      return { state: result.state, succeeded: true, followUps: [] };
+    }
+    case 'load': {
+      const result = loadUnitOntoTransport(
+        state,
+        action.unitId,
+        action.transportId,
+      );
+      return {
+        state: result.ok ? result.state : state,
+        succeeded: result.ok,
+        followUps: [],
+      };
+    }
+    case 'unload': {
+      const cargo = state.units[action.unitId];
+      if (!cargo?.transportId) {
+        return { state, succeeded: false, followUps: [] };
+      }
+      const result = unloadUnitFromTransport(
+        state,
+        cargo.transportId,
+        action.unitId,
+        action.destination,
+      );
+      return {
+        state: result.ok ? result.state : state,
+        succeeded: result.ok,
+        followUps: [],
+      };
+    }
+    case 'rest': {
+      const unit = state.units[action.unitId];
+      if (!unit || unit.owner !== civId || unit.hasActed) {
+        return { state, succeeded: false, followUps: [] };
+      }
+      return {
+        state: {
+          ...state,
+          units: {
+            ...state.units,
+            [unit.id]: restUnit(unit),
+          },
+        },
+        succeeded: true,
+        followUps: [],
+      };
+    }
+    case 'hold': {
+      const unit = state.units[action.unitId];
+      if (!unit || unit.owner !== civId) {
+        return { state, succeeded: false, followUps: [] };
+      }
+      return {
+        state: {
+          ...state,
+          units: {
+            ...state.units,
+            [unit.id]: {
+              ...unit,
+              hasActed: true,
+              movementPointsLeft: 0,
+            },
+          },
+        },
+        succeeded: true,
+        followUps: [],
+      };
+    }
+  }
+}
+
+function hasRequiredRoles(
+  state: GameState,
+  plan: AIStrategicPlan,
+  assignedUnitIds: readonly string[],
+): boolean {
+  const counts = new Map<string, number>();
+  for (const unitId of assignedUnitIds) {
+    const unit = state.units[unitId];
+    if (!unit || unit.owner !== plan.actorId) continue;
+    for (const role of getAIStrategicRoles(unit.type)) {
+      counts.set(role, (counts.get(role) ?? 0) + 1);
+    }
+  }
+  return Object.entries(plan.requiredRoles).every(([role, desired]) =>
+    (counts.get(role) ?? 0) >= (desired ?? 0));
+}
+
+function hasCaptureOrFrontline(
+  state: GameState,
+  assignedUnitIds: readonly string[],
+): boolean {
+  return assignedUnitIds.some(unitId => {
+    const unit = state.units[unitId];
+    if (!unit) return false;
+    const roles = getAIStrategicRoles(unit.type);
+    return roles.includes('capture') || roles.includes('frontline');
+  });
+}
+
+function targetStillValid(
+  state: GameState,
+  plan: AIStrategicPlan,
+): boolean {
+  switch (plan.target.kind) {
+    case 'city': {
+      const city = state.cities[plan.target.id];
+      if (!city) return false;
+      if (plan.objective === 'capture') {
+        return city.owner !== plan.actorId || plan.phase === 'consolidating';
+      }
+      if (plan.objective === 'repel') return city.owner === plan.actorId;
+      return true;
+    }
+    case 'unit':
+      return Boolean(state.units[plan.target.id]);
+    case 'camp':
+      return Boolean(state.barbarianCamps[plan.target.id]);
+    case 'resource':
+      return state.map.tiles[hexKey(plan.target.position)]?.resource
+        === plan.target.resource;
+    case 'region':
+      return Boolean(state.map.tiles[hexKey(plan.target.anchor)]);
+  }
+}
+
+function isHostileOwner(
+  state: GameState,
+  actorId: string,
+  ownerId: string,
+): boolean {
+  if (ownerId === actorId) return false;
+  if (isAlwaysHostilePair(actorId, ownerId)) return true;
+  if (ownerId.startsWith('mc-')) {
+    return isMinorCivAtWar(state, actorId, ownerId);
+  }
+  return state.civilizations[actorId]?.diplomacy.atWarWith
+    .includes(ownerId) ?? false;
+}
+
+function hasVisibleLocalCounterattack(
+  state: GameState,
+  plan: AIStrategicPlan,
+): boolean {
+  const visibility = state.civilizations[plan.actorId]?.visibility;
+  const target = targetPosition(plan);
+  return Object.values(state.units).some(unit =>
+    !unit.transportId
+    && isHostileOwner(state, plan.actorId, unit.owner)
+    && getVisibility(visibility, unit.position) === 'visible'
+    && UNIT_DEFINITIONS[unit.type].strength > 0
+    && distance(state, unit.position, target) <= 4);
+}
+
+function isOffensivePlan(plan: AIStrategicPlan): boolean {
+  return plan.objective === 'capture'
+    || plan.objective === 'raid'
+    || plan.objective === 'blockade';
+}
+
+function hasSufficientTargetConfidence(
+  state: GameState,
+  perception: MajorCivPerception,
+  plan: AIStrategicPlan,
+): boolean {
+  const target = plan.target;
+  switch (target.kind) {
+    case 'city':
+      return perception.knownCities.some(city =>
+        city.id === target.id && city.confidence !== 'rumored');
+    case 'unit':
+      return perception.units.some(unit =>
+        unit.id === target.id && unit.confidence !== 'rumored');
+    case 'resource':
+      return perception.knownResources.some(resource =>
+        resource.resource === target.resource
+        && hexKey(resource.position) === hexKey(target.position));
+    case 'camp':
+      return getVisibility(
+        state.civilizations[plan.actorId]?.visibility,
+        target.lastKnownPosition,
+      ) !== 'unexplored';
+    case 'region':
+      return getVisibility(
+        state.civilizations[plan.actorId]?.visibility,
+        target.anchor,
+      ) !== 'unexplored';
+  }
+}
+
+function shouldWithdraw(
+  state: GameState,
+  plan: AIStrategicPlan,
+  assignedUnitIds: readonly string[],
+): boolean {
+  const units = assignedUnitIds
+    .map(unitId => state.units[unitId])
+    .filter((unit): unit is Unit => Boolean(unit));
+  if (units.length === 0) return false;
+  const profile = OPPONENT_CHALLENGE_PROFILES[
+    resolveOpponentChallenge(state)
+  ];
+  const averageHealth = units.reduce((sum, unit) => sum + unit.health, 0)
+    / units.length;
+  if (averageHealth < profile.retreatHealthPercent) return true;
+
+  const target = targetPosition(plan);
+  const ownStrength = units.reduce((sum, unit) =>
+    sum + UNIT_DEFINITIONS[unit.type].strength * (unit.health / 100), 0);
+  const hostileStrength = Object.values(state.units)
+    .filter(unit =>
+      isHostileOwner(state, plan.actorId, unit.owner)
+      && !unit.transportId
+      && getVisibility(
+        state.civilizations[plan.actorId]?.visibility,
+        unit.position,
+      ) === 'visible'
+      && distance(state, unit.position, target) <= 4)
+    .reduce((sum, unit) =>
+      sum + UNIT_DEFINITIONS[unit.type].strength * (unit.health / 100), 0);
+  return hostileStrength > 0 && ownStrength / hostileStrength < 0.65;
+}
+
+function nextPlanPhase(
+  after: GameState,
+  plan: AIStrategicPlan,
+  assignedUnitIds: readonly string[],
+  actions: readonly AITacticalAction[],
+  perception: MajorCivPerception,
+): AIStrategicPlan['phase'] {
+  if (actions.some(action => action.kind === 'capture-city')) {
+    return 'consolidating';
+  }
+  if (!targetStillValid(after, plan)) {
+    if (actions.some(action => action.kind === 'attack')) {
+      return isOffensivePlan(plan) ? 'consolidating' : 'complete';
+    }
+    return 'abandoned';
+  }
+  if (shouldWithdraw(after, plan, assignedUnitIds)) return 'withdrawing';
+  if (
+    plan.phase === 'scouting'
+    && hasSufficientTargetConfidence(after, perception, plan)
+  ) {
+    return 'mobilizing';
+  }
+  if (plan.phase === 'mobilizing') {
+    const profile = OPPONENT_CHALLENGE_PROFILES[
+      resolveOpponentChallenge(after)
+    ];
+    const deadlineReached = after.turn - plan.createdTurn
+      >= profile.mobilizationRounds;
+    const migrationGrace = after.opponentAI?.migrationGraceRoundsRemaining ?? 0;
+    if (
+      migrationGrace === 0
+      && hasCaptureOrFrontline(after, assignedUnitIds)
+      && (hasRequiredRoles(after, plan, assignedUnitIds) || deadlineReached)
+    ) {
+      return 'advancing';
+    }
+  }
+  if (
+    plan.phase === 'advancing'
+    && actions.some(action => action.kind === 'attack')
+    && (
+      (after.opponentAI?.migrationGraceRoundsRemaining ?? 0) === 0
+      || !isOffensivePlan(plan)
+    )
+  ) {
+    return 'attacking';
+  }
+  if (
+    plan.phase === 'consolidating'
+    && after.turn - plan.lastProgressTurn >= 2
+    && !hasVisibleLocalCounterattack(after, plan)
+  ) {
+    return 'complete';
+  }
+  return plan.phase;
+}
+
+function actionAdvancesPlan(action: AITacticalAction): boolean {
+  return action.kind !== 'hold' && action.kind !== 'rest';
+}
+
+function executionPlan(
+  state: GameState,
+  plan: AIStrategicPlan,
+): AIStrategicPlan {
+  if (
+    (plan.phase === 'scouting' || plan.phase === 'mobilizing')
+    && plan.rallyPoint
+  ) {
+    return {
+      ...plan,
+      objective: 'expand',
+      target: {
+        kind: 'region',
+        id: `rally:${plan.id}`,
+        anchor: { ...plan.rallyPoint },
+      },
+    };
+  }
+  if (plan.phase === 'withdrawing') {
+    const nearestCity = Object.values(state.cities)
+      .filter(city => city.owner === plan.actorId)
+      .sort((left, right) =>
+        distance(state, left.position, targetPosition(plan))
+        - distance(state, right.position, targetPosition(plan))
+        || left.id.localeCompare(right.id))[0];
+    if (nearestCity) {
+      return {
+        ...plan,
+        objective: 'recover',
+        target: {
+          kind: 'region',
+          id: `withdraw:${plan.id}`,
+          anchor: { ...nearestCity.position },
+        },
+      };
+    }
+  }
+  return plan;
+}
+
+function writeUpdatedPlan(
+  state: GameState,
+  plan: AIStrategicPlan,
+): GameState {
+  const portfolio = state.opponentAI?.majorCivs[plan.actorId];
+  if (!portfolio) return state;
+  if (portfolio.primaryPlan?.id === plan.id) {
+    return {
+      ...state,
+      opponentAI: {
+        ...state.opponentAI!,
+        majorCivs: {
+          ...state.opponentAI!.majorCivs,
+          [plan.actorId]: {
+            ...portfolio,
+            primaryPlan: plan,
+          },
+        },
+      },
+    };
+  }
+  const defenseEntry = Object.entries(portfolio.defensePlansByCityId)
+    .find(([, candidate]) => candidate.id === plan.id);
+  if (!defenseEntry) return state;
+  return {
+    ...state,
+    opponentAI: {
+      ...state.opponentAI!,
+      majorCivs: {
+        ...state.opponentAI!.majorCivs,
+        [plan.actorId]: {
+          ...portfolio,
+          defensePlansByCityId: {
+            ...portfolio.defensePlansByCityId,
+            [defenseEntry[0]]: plan,
+          },
+        },
+      },
+    },
+  };
+}
+
+export function processMajorCivStrategicTurn(
+  state: GameState,
+  prepared: PreparedMajorCivPlan,
+  bus: EventBus,
+): ProcessMajorCivStrategicTurnResult {
+  const preparedPlans = [
+    ...(prepared.portfolio.primaryPlan
+      ? [prepared.portfolio.primaryPlan]
+      : []),
+    ...Object.values(prepared.portfolio.defensePlansByCityId),
+  ];
+  if (
+    prepared.civId === ''
+    || !state.civilizations[prepared.civId]
+    || preparedPlans.some(plan => plan.actorId !== prepared.civId)
+  ) {
+    return { state: structuredClone(state), actions: [], traces: [] };
+  }
+
+  let working = normalizeOpponentAIState(structuredClone(state));
+  working = {
+    ...working,
+    opponentAI: {
+      ...working.opponentAI!,
+      majorCivs: {
+        ...working.opponentAI!.majorCivs,
+        [prepared.civId]: structuredClone(prepared.portfolio),
+      },
+    },
+  };
+  const plans = [
+    ...Object.values(prepared.portfolio.defensePlansByCityId)
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    ...(prepared.portfolio.primaryPlan
+      ? [prepared.portfolio.primaryPlan]
+      : []),
+  ];
+  const appliedActions: AITacticalAction[] = [];
+  const traces: AIDecisionTrace[] = [];
+
+  for (const originalPlan of plans) {
+    const requestedUnitIds = prepared.assignments
+      .assignmentsByPlanId[originalPlan.id]
+      ?? originalPlan.assignedUnitIds;
+    const assignedUnitIds = [...new Set(requestedUnitIds)].filter(unitId =>
+      working.units[unitId]?.owner === prepared.civId);
+    if (!targetStillValid(working, originalPlan)) {
+      working = writeUpdatedPlan(working, {
+        ...originalPlan,
+        phase: 'abandoned',
+        assignedUnitIds: [...assignedUnitIds],
+      });
+      continue;
+    }
+    if (assignedUnitIds.length === 0) continue;
+    const planActionStart = appliedActions.length;
+    const tacticalPlan = executionPlan(working, originalPlan);
+    const tacticalContext: AITacticalContext = {
+      state: working,
+      actorId: prepared.civId,
+      plan: tacticalPlan,
+      assignedUnitIds,
+    };
+    const preparingOffense = isOffensivePlan(originalPlan)
+      && (
+        originalPlan.phase === 'scouting'
+        || originalPlan.phase === 'mobilizing'
+      );
+    const selectedActions = chooseTacticalSequence(tacticalContext)
+      .filter(action =>
+        !preparingOffense
+        || action.kind !== 'attack' && action.kind !== 'capture-city');
+    for (const action of selectedActions) {
+      const latestContext = {
+        ...tacticalContext,
+        state: working,
+      };
+      traces.push(tacticalTrace(latestContext, action));
+      const executed = executeAction(
+        working,
+        action,
+        prepared.civId,
+        bus,
+      );
+      if (!executed.succeeded) continue;
+      working = executed.state;
+      appliedActions.push(action, ...executed.followUps);
+    }
+    const planActions = appliedActions.slice(planActionStart);
+    const phase = nextPlanPhase(
+      working,
+      originalPlan,
+      assignedUnitIds,
+      planActions,
+      prepared.perception,
+    );
+    const madeProgress = planActions.some(actionAdvancesPlan);
+    working = writeUpdatedPlan(working, {
+      ...originalPlan,
+      phase,
+      lastProgressTurn: madeProgress
+        ? working.turn
+        : originalPlan.lastProgressTurn,
+      assignedUnitIds: [...assignedUnitIds],
+    });
+  }
+
+  return { state: working, actions: appliedActions, traces };
+}

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -1,6 +1,5 @@
 import type { EventBus } from '@/core/event-bus';
 import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
-import { isAlwaysHostilePair } from '@/core/owner-kind';
 import {
   OPPONENT_CHALLENGE_PROFILES,
   resolveOpponentChallenge,
@@ -59,6 +58,7 @@ import {
   type AITacticalContext,
 } from './ai-tactics';
 import { getAIStrategicRoles } from './ai-unit-roles';
+import { isAIHostileOwner } from './ai-hostility';
 
 export interface ProcessMajorCivStrategicTurnResult {
   state: GameState;
@@ -544,20 +544,6 @@ function targetStillValid(
   }
 }
 
-function isHostileOwner(
-  state: GameState,
-  actorId: string,
-  ownerId: string,
-): boolean {
-  if (ownerId === actorId) return false;
-  if (isAlwaysHostilePair(actorId, ownerId)) return true;
-  if (ownerId.startsWith('mc-')) {
-    return isMinorCivAtWar(state, actorId, ownerId);
-  }
-  return state.civilizations[actorId]?.diplomacy.atWarWith
-    .includes(ownerId) ?? false;
-}
-
 function hasVisibleLocalCounterattack(
   state: GameState,
   plan: AIStrategicPlan,
@@ -566,7 +552,7 @@ function hasVisibleLocalCounterattack(
   const target = targetPosition(plan);
   return Object.values(state.units).some(unit =>
     !unit.transportId
-    && isHostileOwner(state, plan.actorId, unit.owner)
+    && isAIHostileOwner(state, plan.actorId, unit.owner)
     && getVisibility(visibility, unit.position) === 'visible'
     && UNIT_DEFINITIONS[unit.type].strength > 0
     && distance(state, unit.position, target) <= 4);
@@ -629,7 +615,7 @@ function shouldWithdraw(
     sum + UNIT_DEFINITIONS[unit.type].strength * (unit.health / 100), 0);
   const hostileStrength = Object.values(state.units)
     .filter(unit =>
-      isHostileOwner(state, plan.actorId, unit.owner)
+      isAIHostileOwner(state, plan.actorId, unit.owner)
       && !unit.transportId
       && getVisibility(
         state.civilizations[plan.actorId]?.visibility,
@@ -842,21 +828,19 @@ export function processMajorCivStrategicTurn(
     if (assignedUnitIds.length === 0) continue;
     const planActionStart = appliedActions.length;
     const tacticalPlan = executionPlan(working, originalPlan);
-    const tacticalContext: AITacticalContext = {
-      state: working,
-      actorId: prepared.civId,
-      plan: tacticalPlan,
-      assignedUnitIds,
-    };
     const preparingOffense = isOffensivePlan(originalPlan)
       && (
         originalPlan.phase === 'scouting'
         || originalPlan.phase === 'mobilizing'
       );
-    const selectedActions = chooseTacticalSequence(tacticalContext)
-      .filter(action =>
-        !preparingOffense
-        || action.kind !== 'attack' && action.kind !== 'capture-city');
+    const tacticalContext: AITacticalContext = {
+      state: working,
+      actorId: prepared.civId,
+      plan: tacticalPlan,
+      assignedUnitIds,
+      allowOffensiveActions: !preparingOffense,
+    };
+    const selectedActions = chooseTacticalSequence(tacticalContext);
     for (const action of selectedActions) {
       const latestContext = {
         ...tacticalContext,

--- a/src/ai/ai-perception.ts
+++ b/src/ai/ai-perception.ts
@@ -7,7 +7,6 @@ import type {
   Unit,
   UnitType,
 } from '@/core/types';
-import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { getVisibility, isForestConcealedUnit } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
 import {
@@ -26,6 +25,7 @@ import {
   type AIStrengthObservation,
   type MilitaryStrengthEstimate,
 } from './ai-strength';
+import { isAIHostileOwner } from './ai-hostility';
 
 export type AIPerceptionConfidence = 'visible' | 'remembered' | 'rumored';
 
@@ -153,7 +153,7 @@ export function buildMajorCivPerception(
   const relevantOwner = (ownerId: string) =>
     contactedSet.has(ownerId)
     || actor.diplomacy.atWarWith.includes(ownerId)
-    || isAlwaysHostilePair(actorId, ownerId);
+    || isAIHostileOwner(state, actorId, ownerId);
   const ownCities = actor.cities
     .map(id => state.cities[id])
     .filter((city): city is City => city?.owner === actorId)

--- a/src/ai/ai-prepared-turn.ts
+++ b/src/ai/ai-prepared-turn.ts
@@ -1,5 +1,4 @@
 import type { EventBus } from '@/core/event-bus';
-import { isAlwaysHostilePair } from '@/core/owner-kind';
 import type {
   AIStrategicPlan,
   GameMap,
@@ -39,6 +38,7 @@ import {
   type AIPlanCandidate,
 } from './ai-plan-portfolio';
 import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
+import { isAIHostileOwner } from './ai-hostility';
 
 export interface PreparedMajorCivPlan {
   civId: string;
@@ -300,12 +300,11 @@ function cityThreats(
 ): AICityThreat[] {
   const actor = state.civilizations[civId];
   if (!actor) return [];
-  const atWar = new Set(actor.diplomacy.atWarWith);
   return perception.ownCities.flatMap((city, index) => {
     const hostile = perception.units
       .filter(unit =>
         unit.position
-        && (atWar.has(unit.owner) || isAlwaysHostilePair(civId, unit.owner))
+        && isAIHostileOwner(state, civId, unit.owner)
         && unit.type
         && hasAICombatRole(unit.type))
       .map(unit => ({

--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -1,5 +1,9 @@
-import { processAITurn } from '@/ai/basic-ai';
+import {
+  processAITurn,
+  processPreparedAITurn,
+} from '@/ai/basic-ai';
 import type { EventBus } from '@/core/event-bus';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import {
   createEmptyMajorCivPlanPortfolio,
   normalizeOpponentAIState,
@@ -210,7 +214,10 @@ export function processNonHumanMajorRound(
 
   const stableActorIds = getLivingNonHumanMajorIds(working);
   const actorIds = rotateIdsForRound(stableActorIds, working.turn);
-  if (options.strategicPlanningEnabled) {
+  if (
+    options.strategicPlanningEnabled
+    ?? PURPOSEFUL_AI_FEATURE_ENABLED
+  ) {
     let refreshed = working;
     for (const civId of stableActorIds) {
       refreshed = refreshMajorCivIntel(refreshed, civId);
@@ -240,7 +247,7 @@ export function processNonHumanMajorRound(
     const traces = preparedPlans.flatMap(prepared => prepared.traces);
     working = writePreparedPortfolios(refreshed, preparedPlans);
 
-    const executePrepared = options.executePrepared ?? ((current: GameState) => ({ state: current }));
+    const executePrepared = options.executePrepared ?? processPreparedAITurn;
     for (const civId of actorIds) {
       const prepared = preparedByCiv.get(civId);
       const civ = working.civilizations[civId];
@@ -255,17 +262,6 @@ export function processNonHumanMajorRound(
         continue;
       }
       const revalidated = revalidatePreparedPlan(working, prepared);
-      const hadPlan = prepared.portfolio.primaryPlan !== null
-        || Object.keys(prepared.portfolio.defensePlansByCityId).length > 0;
-      const hasPlan = revalidated.portfolio.primaryPlan !== null
-        || Object.keys(revalidated.portfolio.defensePlansByCityId).length > 0;
-      if (hadPlan && !hasPlan) {
-        working = withMajorPortfolio(working, civId, {
-          ...revalidated.portfolio,
-          lastExecutedTurn: working.turn,
-        });
-        continue;
-      }
       working = withMajorPortfolio(working, civId, revalidated.portfolio);
       working = executePrepared(working, revalidated, bus).state;
       working = normalizeOpponentAIState(working);

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -9,7 +9,6 @@ import {
   OPPONENT_CHALLENGE_PROFILES,
   resolveOpponentChallenge,
 } from '@/core/opponent-challenge';
-import { isAlwaysHostilePair } from '@/core/owner-kind';
 import {
   canAttackByProfileOnMap,
   getAttackTargets,
@@ -61,6 +60,7 @@ import {
   getWorkerChargesRemaining,
 } from '@/systems/worker-action-system';
 import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
+import { isAIHostileOwner } from './ai-hostility';
 
 export type AITacticalAction =
   | { kind: 'attack'; unitId: string; targetUnitId: string }
@@ -80,6 +80,7 @@ export interface AITacticalContext {
   actorId: string;
   plan: AIStrategicPlan;
   assignedUnitIds: readonly string[];
+  allowOffensiveActions?: boolean;
 }
 
 export interface RankedAITacticalAction {
@@ -159,7 +160,7 @@ function sortRanked(
 function hostileOwners(state: GameState, actorId: string): Set<string> {
   const atWar = new Set(state.civilizations[actorId]?.diplomacy.atWarWith ?? []);
   for (const unit of Object.values(state.units)) {
-    if (isAlwaysHostilePair(actorId, unit.owner)) atWar.add(unit.owner);
+    if (isAIHostileOwner(state, actorId, unit.owner)) atWar.add(unit.owner);
   }
   return atWar;
 }
@@ -304,6 +305,7 @@ function rankAttacks(
   context: AITacticalContext,
   unit: Unit,
 ): RankedAITacticalAction[] {
+  if (context.allowOffensiveActions === false) return [];
   const attacks: RankedAITacticalAction[] = [];
   for (const target of getAttackTargets(context.state, unit, {
     viewerId: context.actorId,
@@ -312,6 +314,9 @@ function rankAttacks(
     if (target.result.targetType !== 'unit') continue;
     const defender = context.state.units[target.result.targetUnitId];
     if (!defender) continue;
+    if (!isAIHostileOwner(context.state, context.actorId, defender.owner)) {
+      continue;
+    }
     const strengths = calculateCombatStrengths(
       unit,
       defender,
@@ -383,7 +388,8 @@ function rankCapture(
   unit: Unit,
 ): RankedAITacticalAction[] {
   if (
-    context.plan.target.kind !== 'city'
+    context.allowOffensiveActions === false
+    || context.plan.target.kind !== 'city'
     || !getAIStrategicRoles(unit.type).includes('capture')
     || unit.hasActed
     || unit.movementPointsLeft <= 0

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -1,0 +1,769 @@
+import type {
+  AIStrategicPlan,
+  GameState,
+  HexCoord,
+  Unit,
+  WorkerActionType,
+} from '@/core/types';
+import {
+  OPPONENT_CHALLENGE_PROFILES,
+  resolveOpponentChallenge,
+} from '@/core/opponent-challenge';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
+import {
+  canAttackByProfileOnMap,
+  getAttackTargets,
+  getUnitAttackProfile,
+} from '@/systems/attack-targeting';
+import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import {
+  calculateCombatStrengths,
+  resolveCombat,
+} from '@/systems/combat-system';
+import { resolveMajorCityCapture } from '@/systems/city-capture-system';
+import { collectUsedCityNames } from '@/systems/city-name-system';
+import { foundCity } from '@/systems/city-system';
+import { canFoundCityAt } from '@/systems/city-territory-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { getVisibility } from '@/systems/fog-of-war';
+import {
+  hexDistance,
+  hexKey,
+  wrappedHexDistance,
+} from '@/systems/hex-utils';
+import {
+  getAvailableWorkerActions,
+  getKnownTileResourceForWorkerAction,
+} from '@/systems/improvement-system';
+import { createRng } from '@/systems/map-generator';
+import {
+  canEstablishOutpost,
+  performEstablishOutpost,
+} from '@/systems/resource-acquisition-system';
+import {
+  canLoadUnitOntoTransport,
+  getUnloadDestinations,
+  loadUnitOntoTransport,
+  syncTransportCargoPositions,
+  unloadUnitFromTransport,
+} from '@/systems/transport-system';
+import {
+  findPath,
+  getMovementRange,
+  UNIT_DEFINITIONS,
+} from '@/systems/unit-system';
+import {
+  buildUnitOccupancy,
+  getUnitIdsAtCoord,
+} from '@/systems/unit-occupancy';
+import {
+  applyWorkerAction,
+  getWorkerChargesRemaining,
+} from '@/systems/worker-action-system';
+import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
+
+export type AITacticalAction =
+  | { kind: 'attack'; unitId: string; targetUnitId: string }
+  | { kind: 'capture-city'; unitId: string; cityId: string }
+  | { kind: 'move'; unitId: string; destination: HexCoord }
+  | { kind: 'withdraw'; unitId: string; destination: HexCoord }
+  | { kind: 'found-city'; unitId: string; destination: HexCoord }
+  | { kind: 'establish-outpost'; unitId: string }
+  | { kind: 'worker-action'; unitId: string; action: WorkerActionType }
+  | { kind: 'load'; unitId: string; transportId: string }
+  | { kind: 'unload'; unitId: string; destination: HexCoord }
+  | { kind: 'rest'; unitId: string }
+  | { kind: 'hold'; unitId: string };
+
+export interface AITacticalContext {
+  state: GameState;
+  actorId: string;
+  plan: AIStrategicPlan;
+  assignedUnitIds: readonly string[];
+}
+
+export interface RankedAITacticalAction {
+  id: string;
+  action: AITacticalAction;
+  score: number;
+  mandatory: boolean;
+}
+
+function distance(
+  state: Pick<GameState, 'map'>,
+  left: HexCoord,
+  right: HexCoord,
+): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(left, right, state.map.width)
+    : hexDistance(left, right);
+}
+
+function targetPosition(plan: AIStrategicPlan): HexCoord {
+  switch (plan.target.kind) {
+    case 'city':
+    case 'unit':
+    case 'camp':
+      return plan.target.lastKnownPosition;
+    case 'resource':
+      return plan.target.position;
+    case 'region':
+      return plan.target.anchor;
+  }
+}
+
+function actionId(action: AITacticalAction): string {
+  switch (action.kind) {
+    case 'attack':
+      return `attack:${action.unitId}:${action.targetUnitId}`;
+    case 'capture-city':
+      return `capture-city:${action.unitId}:${action.cityId}`;
+    case 'move':
+    case 'withdraw':
+    case 'found-city':
+    case 'unload':
+      return `${action.kind}:${action.unitId}:${hexKey(action.destination)}`;
+    case 'worker-action':
+      return `worker-action:${action.unitId}:${action.action}`;
+    case 'load':
+      return `load:${action.unitId}:${action.transportId}`;
+    case 'establish-outpost':
+    case 'rest':
+    case 'hold':
+      return `${action.kind}:${action.unitId}`;
+  }
+}
+
+function ranked(
+  action: AITacticalAction,
+  score: number,
+  mandatory = false,
+): RankedAITacticalAction {
+  return {
+    id: actionId(action),
+    action,
+    score: Number.isFinite(score) ? score : -Number.MAX_VALUE,
+    mandatory,
+  };
+}
+
+function sortRanked(
+  candidates: RankedAITacticalAction[],
+): RankedAITacticalAction[] {
+  return candidates.sort((left, right) =>
+    Number(right.mandatory) - Number(left.mandatory)
+    || right.score - left.score
+    || left.id.localeCompare(right.id));
+}
+
+function hostileOwners(state: GameState, actorId: string): Set<string> {
+  const atWar = new Set(state.civilizations[actorId]?.diplomacy.atWarWith ?? []);
+  for (const unit of Object.values(state.units)) {
+    if (isAlwaysHostilePair(actorId, unit.owner)) atWar.add(unit.owner);
+  }
+  return atWar;
+}
+
+function combatContext(state: GameState, attacker: Unit, defender: Unit) {
+  return {
+    attackerBonus: resolveCivDefinition(
+      state,
+      state.civilizations[attacker.owner]?.civType ?? '',
+    )?.bonusEffect,
+    defenderBonus: resolveCivDefinition(
+      state,
+      state.civilizations[defender.owner]?.civType ?? '',
+    )?.bonusEffect,
+  };
+}
+
+function visibleThreatCount(
+  context: AITacticalContext,
+  unit: Unit,
+  position: HexCoord,
+): number {
+  const visibleToActor = context.state.civilizations[context.actorId]?.visibility;
+  const hostiles = hostileOwners(context.state, context.actorId);
+  const predictedUnit = { ...unit, position };
+  return Object.values(context.state.units).filter(candidate =>
+    candidate.id !== unit.id
+    && !candidate.transportId
+    && hostiles.has(candidate.owner)
+    && getVisibility(visibleToActor, candidate.position) === 'visible'
+    && canAttackByProfileOnMap(candidate, predictedUnit, context.state.map)
+  ).length;
+}
+
+function movementRange(state: GameState, actorId: string, unit: Unit): HexCoord[] {
+  const occupancy = buildUnitOccupancy(state.units);
+  return getMovementRange(
+    unit,
+    state.map,
+    occupancy.unitIdsByHex,
+    occupancy.ownersByUnitId,
+    hostileOwners(state, actorId),
+    { completedTechs: state.civilizations[actorId]?.techState.completed ?? [] },
+  ).filter(destination =>
+    getUnitIdsAtCoord(occupancy, destination)
+      .filter(unitId => unitId !== unit.id)
+      .length === 0);
+}
+
+function isForeignCityDestination(
+  state: GameState,
+  actorId: string,
+  destination: HexCoord,
+): boolean {
+  return Object.values(state.cities).some(city =>
+    city.owner !== actorId
+    && hexKey(city.position) === hexKey(destination));
+}
+
+function supportRemainsCohesive(
+  context: AITacticalContext,
+  unit: Unit,
+  destination: HexCoord,
+): boolean {
+  const supports = context.assignedUnitIds
+    .filter(unitId => unitId !== unit.id)
+    .map(unitId => context.state.units[unitId])
+    .filter((candidate): candidate is Unit =>
+      Boolean(candidate)
+      && candidate.owner === context.actorId
+      && !candidate.transportId
+      && hasAICombatRole(candidate.type));
+  if (supports.length === 0) return true;
+  return supports.some(support => {
+    const movementPoints = Math.max(1, UNIT_DEFINITIONS[support.type].movementPoints);
+    return Math.ceil(distance(context.state, support.position, destination) / movementPoints) <= 1;
+  });
+}
+
+function rankWithdrawals(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(context.state)];
+  if (unit.health >= profile.retreatHealthPercent || unit.hasActed) return [];
+  const ownCities = Object.values(context.state.cities)
+    .filter(city => city.owner === context.actorId);
+  const isOnlyImmediateDefender = context.plan.objective === 'defend'
+    && context.plan.target.kind === 'city'
+    && ownCities.length === 1
+    && ownCities[0]?.id === context.plan.target.id
+    && context.assignedUnitIds
+      .map(unitId => context.state.units[unitId])
+      .filter((candidate): candidate is Unit =>
+        Boolean(candidate)
+        && candidate.owner === context.actorId
+        && candidate.health > 0
+        && hasAICombatRole(candidate.type))
+      .length === 1;
+  if (isOnlyImmediateDefender) return [];
+
+  const healingPositions = [
+    ...ownCities.map(city => city.position),
+    ...Object.values(context.state.map.tiles)
+      .filter(tile => tile.owner === context.actorId)
+      .map(tile => tile.coord),
+  ];
+  if (healingPositions.length === 0) {
+    return [ranked({ kind: 'rest', unitId: unit.id }, 1_100, true)];
+  }
+
+  const healingDistance = (position: HexCoord) =>
+    Math.min(...healingPositions.map(healing => distance(context.state, position, healing)));
+  const currentDistance = healingDistance(unit.position);
+  const destination = movementRange(context.state, context.actorId, unit)
+    .filter(coord =>
+      healingDistance(coord) < currentDistance
+      && !isForeignCityDestination(context.state, context.actorId, coord))
+    .sort((left, right) =>
+      healingDistance(left) - healingDistance(right)
+      || distance(context.state, unit.position, right)
+        - distance(context.state, unit.position, left)
+      || hexKey(left).localeCompare(hexKey(right)))[0];
+  return destination
+    ? [ranked({ kind: 'withdraw', unitId: unit.id, destination }, 1_100, true)]
+    : [ranked({ kind: 'rest', unitId: unit.id }, 1_100, true)];
+}
+
+function isOnlyCaptureUnit(context: AITacticalContext, unit: Unit): boolean {
+  if (!getAIStrategicRoles(unit.type).includes('capture')) return false;
+  return context.assignedUnitIds
+    .map(unitId => context.state.units[unitId])
+    .filter((candidate): candidate is Unit =>
+      Boolean(candidate)
+      && candidate.owner === context.actorId
+      && candidate.health > 0
+      && getAIStrategicRoles(candidate.type).includes('capture'))
+    .length === 1;
+}
+
+function rankAttacks(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  const attacks: RankedAITacticalAction[] = [];
+  for (const target of getAttackTargets(context.state, unit, {
+    viewerId: context.actorId,
+    requireVisibility: true,
+  })) {
+    if (target.result.targetType !== 'unit') continue;
+    const defender = context.state.units[target.result.targetUnitId];
+    if (!defender) continue;
+    const strengths = calculateCombatStrengths(
+      unit,
+      defender,
+      context.state.map,
+      combatContext(context.state, unit, defender),
+    );
+    const expectedDamageRatio = Math.min(
+      2,
+      strengths.attackerStrength / Math.max(1, strengths.defenderStrength),
+    );
+    const deathRisk = Math.min(
+      2,
+      strengths.defenderStrength / Math.max(1, strengths.attackerStrength),
+    );
+    const defenderProfile = getUnitAttackProfile(defender.type);
+    const safeRanged = target.result.range > defenderProfile.range;
+    const action: AITacticalAction = {
+      kind: 'attack',
+      unitId: unit.id,
+      targetUnitId: defender.id,
+    };
+    const preview = resolveCombat(
+      unit,
+      defender,
+      context.state.map,
+      combatSeed(context, action),
+      combatContext(context.state, unit, defender),
+      context.state.era,
+    );
+    const likelyFinish = !preview.defenderSurvived;
+    const focusFireBonus = likelyFinish ? 90 : Math.max(0, 100 - defender.health) * 0.4;
+    const planProgress = context.plan.target.kind === 'unit'
+      && context.plan.target.id === defender.id
+      ? 1
+      : distance(context.state, defender.position, targetPosition(context.plan)) <= 1
+        ? 0.5
+        : 0;
+    const rolePreservationBonus = safeRanged ? 25 : 0;
+    const blocksCaptureUnitPenalty = isOnlyCaptureUnit(context, unit) && !likelyFinish ? 45 : 0;
+    const sequencePriority = context.plan.objective === 'defend'
+      ? 1_000
+      : safeRanged
+        ? 800
+        : likelyFinish
+          ? 700
+          : 500;
+    const score = sequencePriority
+      + planProgress * 30
+      + expectedDamageRatio * 25
+      + focusFireBonus
+      + rolePreservationBonus
+      - strengths.terrainDefenseBonus * 10
+      - deathRisk * 40
+      - blocksCaptureUnitPenalty;
+    const lethalCityDefense = context.plan.objective === 'defend'
+      && distance(
+        context.state,
+        defender.position,
+        targetPosition(context.plan),
+      ) <= 1
+      && likelyFinish;
+    attacks.push(ranked(action, score, lethalCityDefense));
+  }
+  return attacks;
+}
+
+function rankCapture(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  if (
+    context.plan.target.kind !== 'city'
+    || !getAIStrategicRoles(unit.type).includes('capture')
+    || unit.hasActed
+    || unit.movementPointsLeft <= 0
+  ) {
+    return [];
+  }
+  const city = context.state.cities[context.plan.target.id];
+  if (!city || city.owner === context.actorId) return [];
+  if (getVisibility(
+    context.state.civilizations[context.actorId].visibility,
+    city.position,
+  ) !== 'visible') {
+    return [];
+  }
+  const attackTarget = getAttackTargets(context.state, unit, {
+    viewerId: context.actorId,
+    requireVisibility: true,
+  }).find(target =>
+    target.result.targetType === 'city'
+    && target.result.cityId === city.id);
+  if (!attackTarget) return [];
+  if (distance(context.state, unit.position, city.position) !== 1) return [];
+  const occupancy = buildUnitOccupancy(context.state.units);
+  if (getUnitIdsAtCoord(occupancy, city.position).some(unitId =>
+    context.state.units[unitId]?.owner !== context.actorId)) {
+    return [];
+  }
+  const reachable = movementRange(context.state, context.actorId, unit)
+    .some(coord => hexKey(coord) === hexKey(city.position));
+  return reachable
+    ? [ranked({ kind: 'capture-city', unitId: unit.id, cityId: city.id }, 600)]
+    : [];
+}
+
+function rankCivilianAndTransportActions(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  if (unit.transportId) {
+    const transport = context.state.units[unit.transportId];
+    if (!transport) return [];
+    const profile = OPPONENT_CHALLENGE_PROFILES[
+      resolveOpponentChallenge(context.state)
+    ];
+    const endangered = transport.health < profile.retreatHealthPercent
+      || visibleThreatCount(context, transport, transport.position) > 0;
+    const destinations = getUnloadDestinations(context.state, unit.transportId, unit.id)
+      .sort((left, right) =>
+        visibleThreatCount(context, unit, left)
+        - visibleThreatCount(context, unit, right)
+        || distance(context.state, left, targetPosition(context.plan))
+        - distance(context.state, right, targetPosition(context.plan))
+        || hexKey(left).localeCompare(hexKey(right)));
+    const hasSafeDestination = destinations.some(destination =>
+      visibleThreatCount(context, unit, destination) === 0);
+    return destinations.length > 0
+      ? destinations.map(destination => ranked({
+          kind: 'unload',
+          unitId: unit.id,
+          destination,
+        }, 650
+          - visibleThreatCount(context, unit, destination) * 100
+          - distance(context.state, destination, targetPosition(context.plan)),
+        endangered
+          && hasSafeDestination
+          && visibleThreatCount(context, unit, destination) === 0))
+      : [];
+  }
+
+  if (unit.type === 'settler' && !unit.hasActed && unit.movementPointsLeft > 0) {
+    return canFoundCityAt(context.state, unit.position)
+      ? [ranked({ kind: 'found-city', unitId: unit.id, destination: unit.position }, 650)]
+      : [];
+  }
+  if (
+    unit.type === 'expedition'
+    && !unit.hasActed
+    && unit.movementPointsLeft > 0
+    && canEstablishOutpost(context.state, unit.id)
+  ) {
+    return [ranked({ kind: 'establish-outpost', unitId: unit.id }, 650)];
+  }
+  if (
+    unit.type === 'worker'
+    && !unit.hasActed
+    && getWorkerChargesRemaining(unit) > 0
+  ) {
+    const tile = context.state.map.tiles[hexKey(unit.position)];
+    const completedTechs = context.state.civilizations[context.actorId]?.techState.completed ?? [];
+    const isCityTile = Object.values(context.state.cities)
+      .some(city => hexKey(city.position) === hexKey(unit.position));
+    const actions = getAvailableWorkerActions(
+      tile,
+      completedTechs,
+      context.actorId,
+      {
+        isCityTile,
+        knownResource: tile
+          ? getKnownTileResourceForWorkerAction(tile, completedTechs)
+          : null,
+      },
+    );
+    return actions.map((action, index) => ranked({
+      kind: 'worker-action',
+      unitId: unit.id,
+      action,
+    }, 620 - index));
+  }
+
+  const planNeedsTransport = (context.plan.requiredRoles.transport ?? 0) > 0
+    || findPath(
+      unit.position,
+      targetPosition(context.plan),
+      context.state.map,
+      UNIT_DEFINITIONS[unit.type].domain ?? 'land',
+      {
+        unit,
+        completedTechs: context.state.civilizations[context.actorId]?.techState.completed ?? [],
+      },
+    ) === null;
+  if (!planNeedsTransport || (UNIT_DEFINITIONS[unit.type].domain ?? 'land') !== 'land') {
+    return [];
+  }
+  return Object.values(context.state.units)
+    .filter(candidate =>
+      candidate.owner === context.actorId
+      && canLoadUnitOntoTransport(context.state, unit.id, candidate.id).ok)
+    .map(transport => ranked({
+      kind: 'load',
+      unitId: unit.id,
+      transportId: transport.id,
+    }, 550));
+}
+
+function rankMoves(
+  context: AITacticalContext,
+  unit: Unit,
+): RankedAITacticalAction[] {
+  if (unit.hasActed || unit.movementPointsLeft <= 0 || unit.transportId) return [];
+  const target = targetPosition(context.plan);
+  const currentTargetDistance = distance(context.state, unit.position, target);
+  const destinations = movementRange(context.state, context.actorId, unit)
+    .filter(destination =>
+      distance(context.state, destination, target) < currentTargetDistance
+      && supportRemainsCohesive(context, unit, destination)
+      && !isForeignCityDestination(context.state, context.actorId, destination))
+    .sort((left, right) =>
+      distance(context.state, left, target) - distance(context.state, right, target)
+      || distance(context.state, unit.position, right)
+        - distance(context.state, unit.position, left)
+      || hexKey(left).localeCompare(hexKey(right)));
+  return destinations.map(destination => {
+    const planProgress = currentTargetDistance - distance(context.state, destination, target);
+    const support = context.assignedUnitIds
+      .filter(unitId => unitId !== unit.id)
+      .map(unitId => context.state.units[unitId])
+      .filter((candidate): candidate is Unit => Boolean(candidate) && hasAICombatRole(candidate.type));
+    const cohesionBreakTurns = support.length === 0
+      ? 0
+      : Math.max(0, Math.min(...support.map(candidate =>
+          Math.ceil(
+            distance(context.state, candidate.position, destination)
+            / Math.max(1, UNIT_DEFINITIONS[candidate.type].movementPoints),
+          ))) - 1);
+    return ranked({
+      kind: 'move',
+      unitId: unit.id,
+      destination,
+    }, 300 + planProgress * 30 - cohesionBreakTurns * 15);
+  });
+}
+
+export function rankUnitTacticalActions(
+  context: AITacticalContext,
+  unitId: string,
+): RankedAITacticalAction[] {
+  const unit = context.state.units[unitId];
+  if (!unit || unit.owner !== context.actorId) {
+    return [ranked({ kind: 'hold', unitId }, -1_000)];
+  }
+  if (unit.transportId) {
+    return sortRanked([
+      ...rankCivilianAndTransportActions(context, unit),
+      ranked({ kind: 'hold', unitId }, 0),
+    ]);
+  }
+  const withdrawals = rankWithdrawals(context, unit);
+  if (withdrawals.length > 0) return sortRanked(withdrawals);
+
+  const candidates = [
+    ...rankCivilianAndTransportActions(context, unit),
+    ...rankAttacks(context, unit),
+    ...rankCapture(context, unit),
+    ...rankMoves(context, unit),
+  ];
+  if (unit.health < 100 && !unit.hasActed) {
+    candidates.push(ranked({ kind: 'rest', unitId }, 100));
+  }
+  candidates.push(ranked({ kind: 'hold', unitId }, 0));
+  return sortRanked(candidates);
+}
+
+function chooseRankedAction(
+  context: AITacticalContext,
+  unitId: string,
+): RankedAITacticalAction {
+  const actions = rankUnitTacticalActions(context, unitId);
+  const best = actions[0]!;
+  if (best.mandatory) return best;
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(context.state)];
+  const nearBest = actions.filter(action =>
+    action.score >= best.score - profile.seededMistakeScoreBand);
+  const rng = createRng([
+    context.state.gameId ?? 'legacy',
+    context.state.turn,
+    context.actorId,
+    unitId,
+    context.plan.id,
+  ].join(':'));
+  if (
+    rng() < profile.seededSuboptimalChance
+    && nearBest.length > 1
+  ) {
+    return nearBest[Math.min(nearBest.length, profile.tacticalTopK) - 1]!;
+  }
+  return best;
+}
+
+export function chooseUnitTacticalAction(
+  context: AITacticalContext,
+  unitId: string,
+): AITacticalAction {
+  return chooseRankedAction(context, unitId).action;
+}
+
+function combatSeed(context: AITacticalContext, action: AITacticalAction): number {
+  const rng = createRng([
+    context.state.gameId ?? 'legacy',
+    context.state.turn,
+    context.actorId,
+    context.plan.id,
+    actionId(action),
+  ].join(':'));
+  return Math.max(1, Math.floor(rng() * 2_147_483_646));
+}
+
+function applyPredictedAction(
+  state: GameState,
+  context: AITacticalContext,
+  action: AITacticalAction,
+): GameState {
+  const next = structuredClone(state);
+  const unit = next.units[action.unitId];
+  if (!unit) return next;
+  switch (action.kind) {
+    case 'attack': {
+      const defender = next.units[action.targetUnitId];
+      if (!defender) return next;
+      const seed = combatSeed({ ...context, state: next }, action);
+      const result = resolveCombat(
+        unit,
+        defender,
+        next.map,
+        seed,
+        combatContext(next, unit, defender),
+        next.era,
+      );
+      return applyCombatOutcomeToState(next, result, seed).state;
+    }
+    case 'move':
+    case 'withdraw':
+      next.units[unit.id] = {
+        ...unit,
+        position: { ...action.destination },
+        hasMoved: true,
+        movementPointsLeft: 0,
+      };
+      return unit.cargoUnitIds?.length
+        ? syncTransportCargoPositions(next, unit.id)
+        : next;
+    case 'capture-city': {
+      const city = next.cities[action.cityId];
+      if (!city) return next;
+      next.units[unit.id] = {
+        ...unit,
+        position: { ...city.position },
+        hasMoved: true,
+        hasActed: true,
+        movementPointsLeft: 0,
+      };
+      return resolveMajorCityCapture(
+        next,
+        city.id,
+        context.actorId,
+        'occupy',
+        next.turn,
+      ).state;
+    }
+    case 'load': {
+      const result = loadUnitOntoTransport(next, action.unitId, action.transportId);
+      return result.ok ? result.state : next;
+    }
+    case 'unload': {
+      const result = unloadUnitFromTransport(
+        next,
+        unit.transportId ?? '',
+        action.unitId,
+        action.destination,
+      );
+      return result.ok ? result.state : next;
+    }
+    case 'rest':
+      next.units[unit.id] = {
+        ...unit,
+        isResting: true,
+        hasActed: true,
+        movementPointsLeft: 0,
+      };
+      return next;
+    case 'found-city': {
+      const civ = next.civilizations[context.actorId];
+      if (!civ || !canFoundCityAt(next, action.destination)) return next;
+      const city = foundCity(
+        context.actorId,
+        action.destination,
+        next.map,
+        next.idCounters,
+        {
+          civType: civ.civType,
+          civName: civ.name,
+          usedNames: collectUsedCityNames(next),
+        },
+      );
+      next.cities[city.id] = city;
+      next.civilizations[context.actorId] = {
+        ...civ,
+        cities: [...civ.cities, city.id],
+        units: civ.units.filter(unitId => unitId !== unit.id),
+      };
+      for (const coord of city.ownedTiles) {
+        const key = hexKey(coord);
+        const tile = next.map.tiles[key];
+        if (tile) next.map.tiles[key] = { ...tile, owner: context.actorId };
+      }
+      delete next.units[unit.id];
+      return next;
+    }
+    case 'establish-outpost':
+      return performEstablishOutpost(next, unit.id);
+    case 'worker-action': {
+      const result = applyWorkerAction(next, unit.id, action.action);
+      return result.ok ? result.state : next;
+    }
+    case 'hold':
+      next.units[unit.id] = { ...unit, hasActed: true };
+      return next;
+  }
+}
+
+export function chooseTacticalSequence(
+  context: AITacticalContext,
+): AITacticalAction[] {
+  let scratch = structuredClone(context.state);
+  const remaining = new Set(
+    context.assignedUnitIds
+      .filter(unitId => scratch.units[unitId]?.owner === context.actorId),
+  );
+  const actions: AITacticalAction[] = [];
+  while (remaining.size > 0) {
+    const scratchContext = { ...context, state: scratch };
+    const selected = [...remaining]
+      .map(unitId => chooseRankedAction(scratchContext, unitId))
+      .sort((left, right) =>
+        Number(right.mandatory) - Number(left.mandatory)
+        || right.score - left.score
+        || left.id.localeCompare(right.id))[0];
+    if (!selected) break;
+    actions.push(selected.action);
+    remaining.delete(selected.action.unitId);
+    scratch = applyPredictedAction(scratch, scratchContext, selected.action);
+  }
+  return actions;
+}

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,5 +1,6 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import { getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
 import { foundCityInState } from '@/systems/city-founding-system';
@@ -34,6 +35,7 @@ import {
   offerVassalage,
   joinEmbargo,
   inviteToLeague,
+  getAvailableActions,
   resolveOpponentKind,
 } from '@/systems/diplomacy-system';
 import {
@@ -86,7 +88,13 @@ import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 import {
   buildDiplomaticStrengthEstimates,
   buildMajorCivPerception,
+  type MajorCivPerception,
 } from './ai-perception';
+import { processMajorCivStrategicTurn } from './ai-major-turn';
+import {
+  prepareMajorCivStrategicPlan,
+  type PreparedMajorCivPlan,
+} from './ai-prepared-turn';
 import { hasAICombatRole } from './ai-unit-roles';
 
 function addAlwaysHostileOwners(
@@ -507,7 +515,51 @@ function scoreLegendaryWonderOpportunity(state: GameState, civId: string, cityId
   return 100 + cityBonus + rewardBonus + techMomentum - costPenalty;
 }
 
-export function processAITurn(state: GameState, civId: string, bus: EventBus): GameState {
+export interface ProcessAITurnOptions {
+  purposefulAIEnabled?: boolean;
+}
+
+interface ProcessAITurnInternalOptions extends ProcessAITurnOptions {
+  prepared?: PreparedMajorCivPlan;
+}
+
+export function canDeclareWarForPreparedPlan(
+  state: GameState,
+  prepared: PreparedMajorCivPlan,
+  targetCivId: string,
+): boolean {
+  const plan = state.opponentAI?.majorCivs[prepared.civId]?.primaryPlan
+    ?? prepared.portfolio.primaryPlan;
+  if (
+    !plan
+    || !['capture', 'repel', 'raid'].includes(plan.objective)
+    || !['advancing', 'attacking'].includes(plan.phase)
+    || (state.opponentAI?.migrationGraceRoundsRemaining ?? 0) > 0
+    || !prepared.perception.knownCivIds.includes(targetCivId)
+  ) {
+    return false;
+  }
+  const target = plan.target;
+  if (target.kind === 'city') {
+    return prepared.perception.knownCities.some(city =>
+      city.id === target.id && city.owner === targetCivId);
+  }
+  if (target.kind === 'unit') {
+    return prepared.perception.units.some(unit =>
+      unit.id === target.id && unit.owner === targetCivId);
+  }
+  return false;
+}
+
+function processAITurnInternal(
+  state: GameState,
+  civId: string,
+  bus: EventBus,
+  options: ProcessAITurnInternalOptions = {},
+): GameState {
+  const purposefulAIEnabled = options.purposefulAIEnabled
+    ?? PURPOSEFUL_AI_FEATURE_ENABLED;
+  let preparedForTurn = options.prepared;
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
   let civ = newState.civilizations[civId];
   if (!civ) return newState;
@@ -520,7 +572,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     && !civ.diplomacy.atWarWith.includes(other.id)
   );
 
-  if (ownedBreakaway) {
+  if (ownedBreakaway && !purposefulAIEnabled) {
     newState.civilizations[civId].diplomacy = declareWar(
       civ.diplomacy,
       ownedBreakaway.id,
@@ -543,6 +595,23 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     bus.emit('wonder:legendary-lost', event);
   }
 
+  if (purposefulAIEnabled) {
+    preparedForTurn ??= prepareMajorCivStrategicPlan(
+      structuredClone(newState),
+      civId,
+    );
+    newState = processMajorCivStrategicTurn(
+      newState,
+      preparedForTurn,
+      bus,
+    ).state;
+    civ = newState.civilizations[civId];
+  }
+  const administrativePerception = purposefulAIEnabled && preparedForTurn
+    ? preparedForTurn.perception
+    : buildMajorCivPerception(newState, civId);
+
+  if (!purposefulAIEnabled) {
   // --- Handle settlers: found cities ---
   const settlers = civ.units
     .map(id => newState.units[id])
@@ -571,9 +640,11 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       civ = newState.civilizations[civId];
     }
   }
+  }
 
   const contestsBeasts = newState.settings?.aiContestsBeasts === true;
 
+  if (!purposefulAIEnabled) {
   // --- Handle transports: unload onto enemy coast, then load idle land units ---
   const transportHostileOwners = new Set<string>(['barbarian', ...(contestsBeasts ? [BEAST_OWNER] : []), ...(civ.diplomacy?.atWarWith ?? [])]);
   addAlwaysHostileOwners(newState, civId, transportHostileOwners, contestsBeasts);
@@ -632,6 +703,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       }
     }
   }
+  }
 
   newState = applyPirateAiResponse(newState, civId, bus);
   civ = newState.civilizations[civId];
@@ -643,6 +715,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     .map(id => newState.units[id])
     .filter((u): u is Unit => u !== undefined && u.type !== 'settler' && u.type !== 'worker');
 
+  if (!purposefulAIEnabled) {
   for (const unit of militaryUnits) {
     if (unit.movementPointsLeft <= 0) continue;
 
@@ -792,6 +865,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       newState.units[unit.id] = moveUnit(unit, target, 1);
     }
   }
+  }
 
   // Pursue assigned economic chain steps before discretionary spending.
   for (const minorCivId of Object.keys(newState.minorCivs).sort()) {
@@ -820,7 +894,16 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
   for (const caravan of idleCaravans) {
     // Try domestic cities first (own city), then foreign
     const ownCities = civ.cities.map(id => newState.cities[id]).filter((c): c is City => !!c);
-    const foreignCities = Object.values(newState.cities).filter(c => c.owner !== civId);
+    const knownForeignCityIds = purposefulAIEnabled
+      ? new Set(
+          administrativePerception.knownCities
+            .filter(city => city.owner !== civId && city.position !== null)
+            .map(city => city.id),
+        )
+      : null;
+    const foreignCities = Object.values(newState.cities).filter(city =>
+      city.owner !== civId
+      && (!knownForeignCityIds || knownForeignCityIds.has(city.id)));
     const assignedDestinationIds = new Set(Object.values(newState.minorCivs)
       .map(minorCiv => minorCiv.activeQuests[civId])
       .flatMap(quest => quest?.target.type === 'trade_route'
@@ -844,6 +927,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
   }
 
   // --- Handle expedition outpost establishment ---
+  if (!purposefulAIEnabled) {
   const idleExpeditions = (civ.units ?? [])
     .map(id => newState.units[id])
     .filter((u): u is Unit => !!u && u.type === 'expedition' && !u.hasActed && !u.hasMoved);
@@ -868,6 +952,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
         }
       }
     }
+  }
   }
 
   // --- Handle research (personality-driven) ---
@@ -1176,7 +1261,14 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
           return u?.type === 'expedition' && !u.hasActed;
         });
         const cityPos = city.position;
+        const knownResourceKeys = purposefulAIEnabled
+          ? new Set(
+              administrativePerception.knownResources
+                .map(resource => hexKey(resource.position)),
+            )
+          : null;
         const hasNearbyUnownedResource = hasForagingTech && Object.values(newState.map.tiles).some(tile => {
+          if (knownResourceKeys && !knownResourceKeys.has(hexKey(tile.coord))) return false;
           if (!tile.resource || tile.owner !== null || tile.improvement !== 'none') return false;
           const resDef = RESOURCE_DEFINITIONS.find(d => d.id === tile.resource);
           if (!resDef || !civ.techState.completed.includes(resDef.tech)) return false;
@@ -1202,7 +1294,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       bus.emit('civilization:first-contact', contact);
     }
     civ = newState.civilizations[civId];
-    const perception = buildMajorCivPerception(newState, civId);
+    const perception = administrativePerception;
     const {
       self: selfStrength,
       others: otherStrengths,
@@ -1245,7 +1337,7 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       };
     }
 
-    const decisions = evaluateDiplomacy(
+    let decisions = evaluateDiplomacy(
       personality,
       civ.diplomacy,
       civ.techState.completed,
@@ -1255,6 +1347,38 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       newState.turn,
       diplomacyContext,
     );
+    if (purposefulAIEnabled && preparedForTurn) {
+      const plannedWarTarget = preparedForTurn.perception.knownCivIds
+        .find(targetCivId =>
+          canDeclareWarForPreparedPlan(
+            newState,
+            preparedForTurn,
+            targetCivId,
+          ));
+      const openingRuleAllowsWar = plannedWarTarget
+        ? newState.turn > 5
+          || decisions.some(decision =>
+            decision.action === 'declare_war'
+            && decision.targetCiv === plannedWarTarget)
+        : false;
+      decisions = decisions.filter(decision =>
+        decision.action !== 'declare_war');
+      if (
+        plannedWarTarget
+        && openingRuleAllowsWar
+        && getAvailableActions(
+          civ.diplomacy,
+          plannedWarTarget,
+          civ.techState.completed,
+          newState.era,
+        ).includes('declare_war')
+      ) {
+        decisions.push({
+          action: 'declare_war',
+          targetCiv: plannedWarTarget,
+        });
+      }
+    }
 
     for (const decision of decisions) {
       const currentDiplomacy = newState.civilizations[civId]?.diplomacy;
@@ -1263,6 +1387,19 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       }
       switch (decision.action) {
         case 'declare_war':
+          if (
+            purposefulAIEnabled
+            && (
+              !preparedForTurn
+              || !canDeclareWarForPreparedPlan(
+                newState,
+                preparedForTurn,
+                decision.targetCiv,
+              )
+            )
+          ) {
+            break;
+          }
           newState.civilizations[civId].diplomacy = declareWar(
             currentDiplomacy, decision.targetCiv, newState.turn,
           );
@@ -1428,18 +1565,31 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       .filter((u): u is Unit => !!u && isSpyUnitType(u.type) && !u.hasActed);
 
     for (const spyUnit of idleSpyUnits) {
-      const candidates = Object.values(newState.cities)
-        .filter(c => c.owner !== civId)
+      const candidates = (purposefulAIEnabled
+        ? administrativePerception.knownCities.filter(city =>
+            city.owner !== civId
+            && city.position !== null
+            && city.confidence !== 'rumored')
+        : Object.values(newState.cities)
+            .filter(city => city.owner !== civId)
+            .map(city => ({
+              id: city.id,
+              owner: city.owner,
+              position: city.position,
+              confidence: 'visible' as const,
+              observedTurn: newState.turn,
+            })))
         .sort((a, b) => {
-          const da = hexDistance(spyUnit.position, a.position);
-          const db = hexDistance(spyUnit.position, b.position);
+          const da = hexDistance(spyUnit.position, a.position!);
+          const db = hexDistance(spyUnit.position, b.position!);
           if (da !== db) return da - db;
           return a.id.localeCompare(b.id);
         });
       if (candidates.length === 0) continue;
       const target = candidates[0];
-      if (spyUnit.position.q === target.position.q && spyUnit.position.r === target.position.r) continue;
-      const path = findPath(spyUnit.position, target.position, newState.map);
+      const targetPosition = target.position!;
+      if (spyUnit.position.q === targetPosition.q && spyUnit.position.r === targetPosition.r) continue;
+      const path = findPath(spyUnit.position, targetPosition, newState.map);
       if (!path || path.length < 2) continue;
       const next = path[1];
       const nextKey = `${next.q},${next.r}`;
@@ -1546,7 +1696,11 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
       }
       const target = spy.targetCivId && spy.targetCityId
         ? { civId: spy.targetCivId, cityId: spy.targetCityId }
-        : chooseAiSpyTarget(newState, civId);
+        : chooseAiSpyTarget(
+            newState,
+            civId,
+            purposefulAIEnabled ? administrativePerception : undefined,
+          );
       if (target) {
         newState.espionage![civId] = startMission(
           newState.espionage![civId],
@@ -1686,6 +1840,28 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
   return newState;
 }
 
+export function processAITurn(
+  state: GameState,
+  civId: string,
+  bus: EventBus,
+  options: ProcessAITurnOptions = {},
+): GameState {
+  return processAITurnInternal(state, civId, bus, options);
+}
+
+export function processPreparedAITurn(
+  state: GameState,
+  prepared: PreparedMajorCivPlan,
+  bus: EventBus,
+): { state: GameState } {
+  return {
+    state: processAITurnInternal(state, prepared.civId, bus, {
+      purposefulAIEnabled: true,
+      prepared,
+    }),
+  };
+}
+
 // --- AI Espionage Decision Functions ---
 
 export function shouldAiRecruitSpy(state: GameState, aiCivId: string): boolean {
@@ -1702,6 +1878,7 @@ export function shouldAiRecruitSpy(state: GameState, aiCivId: string): boolean {
 export function chooseAiSpyTarget(
   state: GameState,
   aiCivId: string,
+  perception?: MajorCivPerception,
 ): { civId: string; cityId: string; position: HexCoord } | null {
   const aiDip = state.civilizations[aiCivId]?.diplomacy;
   if (!aiDip) return null;
@@ -1709,8 +1886,14 @@ export function chooseAiSpyTarget(
   const targets: Array<{ civId: string; score: number }> = [];
   for (const [civId, relationship] of Object.entries(aiDip.relationships)) {
     if (civId === aiCivId) continue;
-    const civ = state.civilizations[civId];
-    if (!civ || civ.cities.length === 0) continue;
+    const hasKnownCity = perception
+      ? perception.knownCities.some(city =>
+          city.owner === civId
+          && city.position !== null
+          && city.confidence !== 'rumored')
+      : state.civilizations[civId]?.cities.some(cityId =>
+          Boolean(state.cities[cityId]));
+    if (!hasKnownCity) continue;
     let score = Math.abs(Math.min(0, relationship));
     if (aiDip.atWarWith.includes(civId)) score += 100;
     targets.push({ civId, score });
@@ -1720,10 +1903,23 @@ export function chooseAiSpyTarget(
   if (targets.length === 0) return null;
 
   const bestCivId = targets[0].civId;
-  const city = getCapitalCity(state, bestCivId);
+  const city = perception
+    ? perception.knownCities
+        .filter(candidate =>
+          candidate.owner === bestCivId
+          && candidate.position !== null
+          && candidate.confidence !== 'rumored')
+        .sort((left, right) =>
+          (right.observedTurn ?? -1) - (left.observedTurn ?? -1)
+          || left.id.localeCompare(right.id))[0]
+    : getCapitalCity(state, bestCivId);
   if (!city) return null;
 
-  return { civId: bestCivId, cityId: city.id, position: city.position };
+  return {
+    civId: bestCivId,
+    cityId: city.id,
+    position: city.position!,
+  };
 }
 
 export function chooseAiMission(

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,9 +1,9 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
-import { foundCity, getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
+import { getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
+import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
-import { collectUsedCityNames } from '@/systems/city-name-system';
 import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import {
   canLoadUnitOntoTransport,
@@ -36,7 +36,11 @@ import {
   inviteToLeague,
   resolveOpponentKind,
 } from '@/systems/diplomacy-system';
-import { resolveMajorCityCapture } from '@/systems/city-capture-system';
+import {
+  beginMajorCityAssault,
+  emitMajorCityCaptureEvents,
+  resolveMajorCityCapture,
+} from '@/systems/city-capture-system';
 import {
   getAvailableMissions,
   embedSpy,
@@ -54,7 +58,6 @@ import { getCityAppeaseCost } from '@/systems/faction-system';
 import {
   getEligibleLegendaryWonders,
   initializeLegendaryWonderProjectsForAllCities,
-  initializeLegendaryWonderProjectsForCity,
   loseLegendaryWonderRace,
   startLegendaryWonderBuild,
 } from '@/systems/legendary-wonder-system';
@@ -547,28 +550,25 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
 
   for (const settler of settlers) {
     const tile = newState.map.tiles[hexKey(settler.position)];
-    if (tile && canFoundCityAt(newState, settler.position)) {
-      const city = foundCity(civId, settler.position, newState.map, newState.idCounters, {
-        civType: civ.civType,
-        namingPool: civDef?.cityNames,
-        civName: civDef?.name ?? civ.name,
-        usedNames: collectUsedCityNames(newState),
-      });
-      newState.cities[city.id] = city;
-      civ.cities.push(city.id);
-      newState = initializeLegendaryWonderProjectsForCity(newState, civId, city.id);
-
-      for (const ownedCoord of city.ownedTiles) {
-        const key = hexKey(ownedCoord);
-        if (newState.map.tiles[key]) {
-          newState.map.tiles[key].owner = civId;
-        }
-      }
-
-      delete newState.units[settler.id];
-      civ.units = civ.units.filter(id => id !== settler.id);
-      bus.emit('city:founded', { city, founderId: civId });
-      city.productionQueue = ['warrior'];
+    if (
+      tile
+      && !settler.hasActed
+      && settler.movementPointsLeft > 0
+      && canFoundCityAt(newState, settler.position)
+    ) {
+      const result = foundCityInState(newState, settler.id, bus);
+      newState = result.state;
+      newState = {
+        ...newState,
+        cities: {
+          ...newState.cities,
+          [result.cityId]: {
+            ...newState.cities[result.cityId],
+            productionQueue: ['warrior'],
+          },
+        },
+      };
+      civ = newState.civilizations[civId];
     }
   }
 
@@ -708,13 +708,16 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
     );
 
     if (exposedEnemyCity) {
-      const movedAttacker = moveUnit(unit, exposedEnemyCity.position, 1);
-      newState.units[unit.id] = {
-        ...movedAttacker,
-        movementPointsLeft: 0,
-        hasMoved: true,
-      };
       const prevOwnerIdForCapture = exposedEnemyCity.owner;
+      const assault = beginMajorCityAssault(
+        newState,
+        unit.id,
+        exposedEnemyCity.id,
+        { actor: 'ai', civId, bus },
+      );
+      if (!assault.ok) continue;
+      newState = assault.state;
+      const beforeCapture = newState;
       const captureResult = resolveMajorCityCapture(
         newState,
         exposedEnemyCity.id,
@@ -723,19 +726,14 @@ export function processAITurn(state: GameState, civId: string, bus: EventBus): G
         newState.turn,
       );
       newState = captureResult.state;
-      for (const event of captureResult.territoryEvents) {
-        bus.emit('territory:tile-flipped', event);
-      }
-      // Spec 3: emit near-defeat / eliminated events (matches main.ts logic for AI path)
-      const prevOwnerPostCapture = newState.civilizations[prevOwnerIdForCapture];
-      if (prevOwnerPostCapture) {
-        const prevCityCount = prevOwnerPostCapture.cities.length;
-        if (prevCityCount === 0) {
-          bus.emit('civ:eliminated', { civId: prevOwnerIdForCapture, eliminatedBy: civId });
-        } else if (prevOwnerPostCapture.nearDefeat) {
-          bus.emit('civ:near-defeat', { civId: prevOwnerIdForCapture });
-        }
-      }
+      emitMajorCityCaptureEvents(
+        beforeCapture,
+        captureResult,
+        exposedEnemyCity.id,
+        civId,
+        prevOwnerIdForCapture,
+        bus,
+      );
       civ = newState.civilizations[civId];
       continue;
     }

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -6,6 +6,7 @@ import { getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/c
 import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { executeUnitMove } from '@/systems/unit-movement-system';
 import {
   canLoadUnitOntoTransport,
   loadUnitOntoTransport,
@@ -95,6 +96,7 @@ import {
   prepareMajorCivStrategicPlan,
   type PreparedMajorCivPlan,
 } from './ai-prepared-turn';
+import { isAIHostileOwner } from './ai-hostility';
 import { hasAICombatRole } from './ai-unit-roles';
 
 function addAlwaysHostileOwners(
@@ -301,11 +303,7 @@ function activeBlockadeFactionIds(state: GameState, civId: string): Set<string> 
 }
 
 function shouldAiAvoidPirateFaction(state: GameState, civId: string, factionId: string): boolean {
-  const faction = state.pirates?.factions[factionId];
-  return Boolean(
-    faction?.contract?.employerId === civId
-    || (faction?.tributeByCiv[civId]?.protectedUntilRound ?? 0) > state.turn,
-  );
+  return !isAIHostileOwner(state, civId, factionId);
 }
 
 function knownPirateResponseUnitIds(
@@ -541,11 +539,13 @@ export function canDeclareWarForPreparedPlan(
   }
   const target = plan.target;
   if (target.kind === 'city') {
-    return prepared.perception.knownCities.some(city =>
+    return state.cities[target.id]?.owner === targetCivId
+      && prepared.perception.knownCities.some(city =>
       city.id === target.id && city.owner === targetCivId);
   }
   if (target.kind === 'unit') {
-    return prepared.perception.units.some(unit =>
+    return state.units[target.id]?.owner === targetCivId
+      && prepared.perception.units.some(unit =>
       unit.id === target.id && unit.owner === targetCivId);
   }
   return false;
@@ -1261,22 +1261,55 @@ function processAITurnInternal(
           return u?.type === 'expedition' && !u.hasActed;
         });
         const cityPos = city.position;
-        const knownResourceKeys = purposefulAIEnabled
-          ? new Set(
-              administrativePerception.knownResources
-                .map(resource => hexKey(resource.position)),
-            )
-          : null;
-        const hasNearbyUnownedResource = hasForagingTech && Object.values(newState.map.tiles).some(tile => {
-          if (knownResourceKeys && !knownResourceKeys.has(hexKey(tile.coord))) return false;
-          if (!tile.resource || tile.owner !== null || tile.improvement !== 'none') return false;
-          const resDef = RESOURCE_DEFINITIONS.find(d => d.id === tile.resource);
-          if (!resDef || !civ.techState.completed.includes(resDef.tech)) return false;
-          const dist = newState.map.wrapsHorizontally
-            ? wrappedHexDistance(tile.coord, cityPos, newState.map.width)
-            : hexDistance(tile.coord, cityPos);
-          return dist <= 8;
-        });
+        const hasNearbyUnownedResource = hasForagingTech && (
+          purposefulAIEnabled
+            ? administrativePerception.knownResources.some(resource => {
+                if (resource.owner !== null) return false;
+                const resDef = RESOURCE_DEFINITIONS.find(
+                  definition => definition.id === resource.resource,
+                );
+                if (
+                  !resDef
+                  || !civ.techState.completed.includes(resDef.tech)
+                ) {
+                  return false;
+                }
+                const dist = newState.map.wrapsHorizontally
+                  ? wrappedHexDistance(
+                      resource.position,
+                      cityPos,
+                      newState.map.width,
+                    )
+                  : hexDistance(resource.position, cityPos);
+                return dist <= 8;
+              })
+            : Object.values(newState.map.tiles).some(tile => {
+                if (
+                  !tile.resource
+                  || tile.owner !== null
+                  || tile.improvement !== 'none'
+                ) {
+                  return false;
+                }
+                const resDef = RESOURCE_DEFINITIONS.find(
+                  definition => definition.id === tile.resource,
+                );
+                if (
+                  !resDef
+                  || !civ.techState.completed.includes(resDef.tech)
+                ) {
+                  return false;
+                }
+                const dist = newState.map.wrapsHorizontally
+                  ? wrappedHexDistance(
+                      tile.coord,
+                      cityPos,
+                      newState.map.width,
+                    )
+                  : hexDistance(tile.coord, cityPos);
+                return dist <= 8;
+              })
+        );
         if (hasForagingTech && !hasUncommittedExpedition && trainableUnits.includes('expedition') && hasNearbyUnownedResource) {
           city.productionQueue = ['expedition'];
         } else {
@@ -1562,7 +1595,11 @@ function processAITurnInternal(
     // 1) Move idle spy units toward nearest enemy city
     const idleSpyUnits = (newState.civilizations[civId].units ?? [])
       .map(id => newState.units[id])
-      .filter((u): u is Unit => !!u && isSpyUnitType(u.type) && !u.hasActed);
+      .filter((u): u is Unit =>
+        Boolean(u)
+        && isSpyUnitType(u.type)
+        && !u.hasActed
+        && u.movementPointsLeft > 0);
 
     for (const spyUnit of idleSpyUnits) {
       const candidates = (purposefulAIEnabled
@@ -1597,7 +1634,19 @@ function processAITurnInternal(
         u => u.id !== spyUnit.id && `${u.position.q},${u.position.r}` === nextKey,
       );
       if (occupied) continue;
-      newState.units[spyUnit.id] = moveUnit(spyUnit, next, 1);
+      executeUnitMove(
+        newState,
+        spyUnit.id,
+        next,
+        {
+          actor: 'ai',
+          civId,
+          bus,
+          foreignCityEntryId: hexKey(next) === hexKey(targetPosition)
+            ? target.id
+            : undefined,
+        },
+      );
     }
 
     // 2) Attempt infiltration when a spy is on an enemy city tile

--- a/src/input/city-assault-flow.ts
+++ b/src/input/city-assault-flow.ts
@@ -1,19 +1,14 @@
-import type { GameState, HexCoord } from '@/core/types';
-import { moveUnit } from '@/systems/unit-system';
+import type { EventBus } from '@/core/event-bus';
+import type { CombatResult, GameState } from '@/core/types';
 import {
-  computeRazeGold,
+  beginMajorCityAssault,
   resolveMajorCityCapture,
   type MajorCityCaptureDisposition,
   type MajorCityCaptureResult,
+  type PendingMajorCityCapture,
 } from '@/systems/city-capture-system';
 
-export interface PendingCityCaptureChoice {
-  attackerId: string;
-  cityId: string;
-  targetCoord: HexCoord;
-  occupiedPopulation: number;
-  razeGold: number;
-}
+export type PendingCityCaptureChoice = PendingMajorCityCapture;
 
 export function shouldPromptForPlayerCityCapture(
   city: { population: number },
@@ -25,35 +20,24 @@ export function beginPlayerCityAssaultChoice(
   state: GameState,
   attackerId: string,
   cityId: string,
+  bus?: EventBus,
+  precedingCombat?: CombatResult,
 ): { state: GameState; pending: PendingCityCaptureChoice } {
-  const attacker = state.units[attackerId];
-  const city = state.cities[cityId];
-  if (!attacker || !city) {
-    throw new Error('Cannot begin city assault without attacker and city');
+  const result = beginMajorCityAssault(
+    state,
+    attackerId,
+    cityId,
+    {
+      actor: 'player',
+      civId: state.currentPlayer,
+      bus,
+      precedingCombat,
+    },
+  );
+  if (!result.ok) {
+    throw new Error(`Cannot begin city assault: ${result.reason}`);
   }
-
-  const movedAttacker = {
-    ...moveUnit(attacker, city.position, 1),
-    movementPointsLeft: 0,
-    hasMoved: true,
-  };
-
-  return {
-    state: {
-      ...state,
-      units: {
-        ...state.units,
-        [attackerId]: movedAttacker,
-      },
-    },
-    pending: {
-      attackerId,
-      cityId,
-      targetCoord: city.position,
-      occupiedPopulation: Math.max(1, Math.floor(city.population / 2)),
-      razeGold: computeRazeGold(city),
-    },
-  };
+  return result;
 }
 
 export function finalizePlayerCityAssaultChoice(

--- a/src/input/foreign-city-entry-flow.ts
+++ b/src/input/foreign-city-entry-flow.ts
@@ -39,5 +39,10 @@ export function beginConfirmedForeignCityEntry(
     bus?.emit('diplomacy:war-declared', { attackerId: attackerCivId, defenderId, opponentKind: resolveOpponentKind(defenderId) });
   }
 
-  return beginPlayerCityAssaultChoice(nextState, attackerId, cityId);
+  return beginPlayerCityAssaultChoice(
+    nextState,
+    attackerId,
+    cityId,
+    bus,
+  );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,10 @@ import {
   finalizePlayerCityAssaultChoice,
   shouldPromptForPlayerCityCapture,
 } from '@/input/city-assault-flow';
-import { emitMajorCityCaptureEvents } from '@/systems/city-capture-system';
+import {
+  canUnitOccupyCity,
+  emitMajorCityCaptureEvents,
+} from '@/systems/city-capture-system';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
 import { resolveNaturalWonderAudioFocus } from '@/input/natural-wonder-audio-focus';
@@ -2292,6 +2295,8 @@ function beginPlayerCityAssault(
 ): 'pending' | 'resolved' {
   const city = gameState.cities[cityId];
   if (!city) return 'resolved';
+  const attacker = gameState.units[attackerId];
+  if (!attacker || !canUnitOccupyCity(attacker)) return 'resolved';
 
   ensurePlayerWarState(city.owner);
   const begun = beginPlayerCityAssaultChoice(

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,11 +24,11 @@ import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason, findPath } from '@/systems/unit-system';
 import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owner-kind';
-import { foundCity, BUILDINGS, getProductionDisplayName } from '@/systems/city-system';
+import { BUILDINGS, getProductionDisplayName } from '@/systems/city-system';
+import { foundCityInState } from '@/systems/city-founding-system';
 import { assignCityFocus, setCityWorkedTile } from '@/systems/city-work-system';
-import { formatCityFoundingBlockerMessage, getCityFoundingBlockers, recalculateTerritory } from '@/systems/city-territory-system';
+import { formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { enqueueCityProduction, enqueueResearch, getIdleCityIds, getRecommendedIdleCityChoice, moveQueuedId, needsResearchChoice, removeQueuedId, reorderCityProduction, setIdleProduction } from '@/systems/planning-system';
-import { collectUsedCityNames } from '@/systems/city-name-system';
 import { formatImprovementYieldLabel, getImprovementDisplayName } from '@/systems/improvement-system';
 import { createTechPanel } from '@/ui/tech-panel';
 import { createCityPanel } from '@/ui/city-panel';
@@ -129,6 +129,7 @@ import {
   finalizePlayerCityAssaultChoice,
   shouldPromptForPlayerCityCapture,
 } from '@/input/city-assault-flow';
+import { emitMajorCityCaptureEvents } from '@/systems/city-capture-system';
 import { resolveSelectedUnitTapIntent } from '@/input/selected-unit-tap-intent';
 import { resolveWonderAtlasIntent } from '@/input/wonder-atlas-intent';
 import { resolveNaturalWonderAudioFocus } from '@/input/natural-wonder-audio-focus';
@@ -173,7 +174,7 @@ import {
 } from '@/systems/transport-system';
 import { getPendingUnload, getUnloadRange, setPendingUnload, clearPendingUnload } from '@/ui/transport-ui-state';
 import { getCapitalCity } from '@/systems/capital-system';
-import type { GameEvents, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
 import {
   appendNotification,
   getNotificationsForPlayer,
@@ -898,9 +899,13 @@ function handleRejectPeaceRequest(requestId: string): void {
 
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = gameState.cities[cityId]?.name ?? 'City-State';
-  executeAnimatedUnitMove(unitId, () => executeUnitMove(gameState, unitId, target, {
-    actor: 'player', civId: gameState.currentPlayer, bus,
+  const movement = executeAnimatedUnitMove(unitId, () => executeUnitMove(gameState, unitId, target, {
+    actor: 'player',
+    civId: gameState.currentPlayer,
+    bus,
+    foreignCityEntryId: cityId,
   }));
+  if (!movement.ok) return;
   const movedUnit = gameState.units[unitId];
   if (movedUnit) gameState.units[unitId] = { ...movedUnit, movementPointsLeft: 0 };
   const conquered = conquestMinorCiv(gameState, minorCivId, gameState.currentPlayer);
@@ -1998,27 +2003,6 @@ function animateMovedUnit(unitId: string, path: HexCoord[]): void {
     const unit = gameState.units[unitId];
     if (!unit || unit.owner !== gameState.currentPlayer) return;
 
-    // Post-move: check if the unit has landed on a hostile major-civ city tile.
-    // This handles the case where canReachCityAssault returned false because the unit
-    // was beyond attack range before moving (e.g., melee at distance 2 from city).
-    // Minor civ cities (owner starts with 'mc-') are excluded — they use the
-    // assault-minor-civ intent path. Allied cities are excluded by the atWarWith check.
-    const destKey = hexKey(unit.position);
-    const cityAtDest = Object.values(gameState.cities).find(c =>
-      hexKey(c.position) === destKey
-      && c.owner !== gameState.currentPlayer
-      && !c.owner.startsWith('mc-')
-      && (gameState.civilizations[gameState.currentPlayer]?.diplomacy?.atWarWith?.includes(c.owner) ?? false),
-    );
-    if (cityAtDest) {
-      beginPlayerCityAssault(unitId, cityAtDest.id);
-      SFX.tap(); // match audio feedback of the tap-path assault (line ~2094)
-      renderLoop.setGameState(gameState);
-      updateHUD();
-      // beginPlayerCityAssault handles its own selectNextUnit call via finalizePendingCityCaptureChoice.
-      return;
-    }
-
     if ((unit.movementPointsLeft ?? 0) <= 0) {
       selectNextUnit();
     } else if (selectedUnitId === unitId) {
@@ -2186,45 +2170,27 @@ function foundCityAction(): void {
   const unit = gameState.units[selectedUnitId];
   if (!unit || unit.type !== 'settler') return;
 
-  const cp = gameState.currentPlayer;
   const blockers = getCityFoundingBlockers(gameState, unit.position);
   if (blockers.length > 0) {
     showNotification(formatCityFoundingBlockerMessage(blockers), 'warning');
     return;
   }
 
-  const civDef = currentCivDef();
-  const city = foundCity(cp, unit.position, gameState.map, gameState.idCounters, {
-    civType: currentCiv().civType,
-    namingPool: civDef?.cityNames,
-    civName: civDef?.name ?? currentCiv().name,
-    usedNames: collectUsedCityNames(gameState),
-  });
-  gameState.cities[city.id] = city;
-  currentCiv().cities.push(city.id);
-  gameState = initializeLegendaryWonderProjectsForCity(gameState, cp, city.id);
-  gameState = recalculateTerritory(gameState, {
-    reason: 'founding',
-    preserveForeignHolders: true,
-  }).state;
-
-  // Remove settler
-  delete gameState.units[selectedUnitId];
-  currentCiv().units = currentCiv().units.filter(id => id !== selectedUnitId);
+  let result;
+  try {
+    result = foundCityInState(gameState, selectedUnitId, bus);
+  } catch (error) {
+    showNotification(
+      error instanceof Error ? error.message : 'City cannot be founded here.',
+      'warning',
+    );
+    return;
+  }
+  gameState = result.state;
 
   deselectUnit();
-  const foundedCity = gameState.cities[city.id] ?? city;
-  bus.emit('city:founded', { city: foundedCity, founderId: gameState.currentPlayer });
+  const foundedCity = gameState.cities[result.cityId];
   showNotification(`${foundedCity.name} has been founded!`, 'success');
-  // Spec 3: founding a city can lift near-defeat if founder now has > 1 city
-  const founderCiv = gameState.civilizations[gameState.currentPlayer];
-  if (founderCiv?.nearDefeat) {
-    const founderCityCount = Object.values(gameState.cities).filter(c => c.owner === gameState.currentPlayer).length;
-    if (founderCityCount > 1) {
-      founderCiv.nearDefeat = false;
-      bus.emit('civ:recovered-from-near-defeat', { civId: gameState.currentPlayer });
-    }
-  }
   SFX.foundCity();
 
   // Update visibility
@@ -2277,12 +2243,6 @@ function ensurePlayerWarState(targetCivId: string): void {
   bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
 }
 
-function emitTerritoryTileFlippedEvents(events: GameEvents['territory:tile-flipped'][]): void {
-  for (const event of events) {
-    bus.emit('territory:tile-flipped', event);
-  }
-}
-
 function finalizePendingCityCaptureChoice(
   disposition: 'occupy' | 'raze',
   attackerBonus?: CivBonusEffect,
@@ -2293,14 +2253,20 @@ function finalizePendingCityCaptureChoice(
   const cityBeforeResolution = gameState.cities[pending.cityId];
   const previousOwner = cityBeforeResolution?.owner ?? '';
   const cityName = cityBeforeResolution?.name ?? pending.cityId;
-  // Capture pre-capture nearDefeat for recovery detection (Spec 3)
-  const capturingCivWasNearDefeat = gameState.civilizations[gameState.currentPlayer]?.nearDefeat ?? false;
+  const beforeCapture = gameState;
   const result = finalizePlayerCityAssaultChoice(gameState, pending, disposition, gameState.turn);
 
   pendingCityCaptureChoice = null;
   document.getElementById('city-capture-panel')?.remove();
   gameState = result.state;
-  emitTerritoryTileFlippedEvents(result.territoryEvents);
+  emitMajorCityCaptureEvents(
+    beforeCapture,
+    result,
+    pending.cityId,
+    gameState.currentPlayer,
+    previousOwner,
+    bus,
+  );
 
   if (result.outcome === 'occupied') {
     const capturingCiv = currentCiv();
@@ -2309,28 +2275,6 @@ function finalizePendingCityCaptureChoice(
       showNotification('Viking raid spoils! +30 gold', 'success');
     }
     showNotification(`We have captured ${cityName}!`, 'success');
-    bus.emit('city:captured', { cityId: pending.cityId, newOwner: gameState.currentPlayer, previousOwner });
-
-    // Spec 3: emit near-defeat / eliminated / recovered events.
-    // The nearDefeat flag is set on civilizations by resolveMajorCityCapture
-    // (in city-capture-system.ts), so we can read it directly here.
-    const prevCivAfterCapture = gameState.civilizations[previousOwner];
-    if (prevCivAfterCapture) {
-      const prevCityCount = prevCivAfterCapture.cities.length;
-      if (prevCityCount === 0) {
-        bus.emit('civ:eliminated', { civId: previousOwner, eliminatedBy: gameState.currentPlayer });
-      } else if (prevCivAfterCapture.nearDefeat) {
-        // nearDefeat was just set to true by resolveMajorCityCapture (just entered near-defeat)
-        bus.emit('civ:near-defeat', { civId: previousOwner });
-      }
-    }
-    // If the capturing civ was near-defeat before this capture and now has > 1 city, emit recovery
-    if (capturingCivWasNearDefeat) {
-      const capturingCivAfter = gameState.civilizations[gameState.currentPlayer];
-      if (capturingCivAfter && capturingCivAfter.cities.length > 1) {
-        bus.emit('civ:recovered-from-near-defeat', { civId: gameState.currentPlayer });
-      }
-    }
   } else {
     showNotification(`${cityName} was razed! +${result.goldAwarded} gold`, 'success');
   }
@@ -2344,12 +2288,19 @@ function beginPlayerCityAssault(
   attackerId: string,
   cityId: string,
   attackerBonus?: CivBonusEffect,
+  precedingCombat?: CombatResult,
 ): 'pending' | 'resolved' {
   const city = gameState.cities[cityId];
   if (!city) return 'resolved';
 
   ensurePlayerWarState(city.owner);
-  const begun = beginPlayerCityAssaultChoice(gameState, attackerId, cityId);
+  const begun = beginPlayerCityAssaultChoice(
+    gameState,
+    attackerId,
+    cityId,
+    bus,
+    precedingCombat,
+  );
   gameState = begun.state;
 
   pendingCityCaptureChoice = begun.pending;
@@ -2477,7 +2428,12 @@ function executeAttack(attackerId: string, targetKey: string): void {
           showNotification(`${conqueredCityName} has been conquered!`, 'success');
         }
         if (!cityAtTarget.owner.startsWith('mc-') && cityAtTarget.owner !== gameState.currentPlayer) {
-          const assaultStatus = beginPlayerCityAssault(attackerId, cityAtTarget.id, attackerBonus);
+          const assaultStatus = beginPlayerCityAssault(
+            attackerId,
+            cityAtTarget.id,
+            attackerBonus,
+            result,
+          );
           SFX.combat();
           renderLoop.setGameState(gameState);
           updateHUD();

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -1,4 +1,13 @@
-import type { City, GameEvents, GameState, LegendaryWonderProject } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import type {
+  City,
+  CombatResult,
+  GameEvents,
+  GameState,
+  HexCoord,
+  LegendaryWonderProject,
+} from '@/core/types';
+import { getUnitAttackProfile } from '@/systems/attack-targeting';
 import { reconquerBreakawayCity } from '@/systems/breakaway-system';
 import { BUILDINGS } from '@/systems/city-system';
 import {
@@ -7,7 +16,12 @@ import {
   type TerritoryRecalculationResult,
 } from '@/systems/city-territory-system';
 import { normalizeCityWorkAfterTerritoryChange } from '@/systems/city-work-system';
-import { modifyRelationship } from '@/systems/diplomacy-system';
+import { isAtWar, modifyRelationship } from '@/systems/diplomacy-system';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { executeUnitMove } from '@/systems/unit-movement-system';
+import { buildUnitOccupancy, getUnitIdsAtCoord } from '@/systems/unit-occupancy';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
 
 export type MajorCityCaptureDisposition = 'occupy' | 'raze';
 
@@ -16,6 +30,231 @@ export interface MajorCityCaptureResult {
   outcome: 'occupied' | 'razed';
   goldAwarded: number;
   territoryEvents: GameEvents['territory:tile-flipped'][];
+}
+
+export function emitMajorCityCaptureEvents(
+  before: GameState,
+  result: MajorCityCaptureResult,
+  cityId: string,
+  newOwnerId: string,
+  previousOwnerId: string,
+  bus: EventBus,
+): void {
+  for (const event of result.territoryEvents) {
+    bus.emit('territory:tile-flipped', event);
+  }
+  if (result.outcome === 'occupied') {
+    bus.emit('city:captured', {
+      cityId,
+      newOwner: newOwnerId,
+      previousOwner: previousOwnerId,
+    });
+  }
+
+  const previousOwnerBefore = before.civilizations[previousOwnerId];
+  const previousOwnerAfter = result.state.civilizations[previousOwnerId];
+  if (
+    previousOwnerAfter?.cities.length === 0
+    && (previousOwnerBefore?.cities.length ?? 0) > 0
+  ) {
+    bus.emit('civ:eliminated', {
+      civId: previousOwnerId,
+      eliminatedBy: newOwnerId,
+    });
+  } else if (
+    previousOwnerBefore?.nearDefeat !== true
+    && previousOwnerAfter?.nearDefeat === true
+  ) {
+    bus.emit('civ:near-defeat', { civId: previousOwnerId });
+  }
+
+  const capturingCivBefore = before.civilizations[newOwnerId];
+  const capturingCivAfter = result.state.civilizations[newOwnerId];
+  if (
+    capturingCivBefore?.nearDefeat === true
+    && capturingCivAfter?.nearDefeat !== true
+    && (capturingCivAfter?.cities.length ?? 0) > 1
+  ) {
+    bus.emit('civ:recovered-from-near-defeat', { civId: newOwnerId });
+  }
+}
+
+export interface PendingMajorCityCapture {
+  attackerId: string;
+  cityId: string;
+  targetCoord: HexCoord;
+  occupiedPopulation: number;
+  razeGold: number;
+}
+
+export type MajorCityAssaultFailureReason =
+  | 'missing-attacker'
+  | 'missing-city'
+  | 'wrong-owner'
+  | 'friendly-city'
+  | 'not-major-city'
+  | 'not-at-war'
+  | 'cannot-capture'
+  | 'not-adjacent'
+  | 'city-defended'
+  | 'illegal-movement'
+  | 'invalid-post-combat-advance';
+
+export type BeginMajorCityAssaultResult =
+  | {
+      ok: true;
+      state: GameState;
+      pending: PendingMajorCityCapture;
+    }
+  | {
+      ok: false;
+      state: GameState;
+      reason: MajorCityAssaultFailureReason;
+    };
+
+export interface BeginMajorCityAssaultOptions {
+  actor: 'player' | 'ai';
+  civId: string;
+  bus?: EventBus;
+  precedingCombat?: CombatResult;
+}
+
+function distanceForState(
+  state: GameState,
+  from: HexCoord,
+  to: HexCoord,
+): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(from, to, state.map.width)
+    : hexDistance(from, to);
+}
+
+export function canUnitOccupyCity(
+  unit: GameState['units'][string],
+): boolean {
+  const definition = UNIT_DEFINITIONS[unit.type];
+  const profile = getUnitAttackProfile(unit.type);
+  return (definition.domain ?? 'land') === 'land'
+    && definition.strength > 0
+    && profile.targets.includes('city')
+    && profile.kind !== 'siege'
+    && profile.kind !== 'bombard';
+}
+
+function assaultFailure(
+  state: GameState,
+  reason: MajorCityAssaultFailureReason,
+): BeginMajorCityAssaultResult {
+  return { ok: false, state, reason };
+}
+
+export function beginMajorCityAssault(
+  state: GameState,
+  attackerId: string,
+  cityId: string,
+  options: BeginMajorCityAssaultOptions,
+): BeginMajorCityAssaultResult {
+  const attacker = state.units[attackerId];
+  if (!attacker) return assaultFailure(state, 'missing-attacker');
+  if (attacker.owner !== options.civId) {
+    return assaultFailure(state, 'wrong-owner');
+  }
+  const city = state.cities[cityId];
+  if (!city) return assaultFailure(state, 'missing-city');
+  if (city.owner === options.civId) {
+    return assaultFailure(state, 'friendly-city');
+  }
+  if (!state.civilizations[city.owner]) {
+    return assaultFailure(state, 'not-major-city');
+  }
+  const civilization = state.civilizations[options.civId];
+  if (!civilization || !isAtWar(civilization.diplomacy, city.owner)) {
+    return assaultFailure(state, 'not-at-war');
+  }
+  if (!canUnitOccupyCity(attacker)) {
+    return assaultFailure(state, 'cannot-capture');
+  }
+  if (distanceForState(state, attacker.position, city.position) !== 1) {
+    return assaultFailure(state, 'not-adjacent');
+  }
+  const occupancy = buildUnitOccupancy(state.units);
+  if (getUnitIdsAtCoord(occupancy, city.position).length > 0) {
+    return assaultFailure(state, 'city-defended');
+  }
+
+  let nextState = structuredClone(state);
+  if (options.precedingCombat) {
+    const combat = options.precedingCombat;
+    const validAdvance = combat.attackerId === attackerId
+      && combat.attackerSurvived
+      && !combat.defenderSurvived
+      && hexKey(combat.attackerPosition) === hexKey(attacker.position)
+      && hexKey(combat.defenderPosition) === hexKey(city.position)
+      && !Object.prototype.hasOwnProperty.call(
+        state.units,
+        combat.defenderId,
+      )
+      && attacker.hasActed;
+    if (!validAdvance) {
+      return assaultFailure(state, 'invalid-post-combat-advance');
+    }
+    const from = { ...attacker.position };
+    const to = { ...city.position };
+    nextState.units[attackerId] = {
+      ...nextState.units[attackerId],
+      position: to,
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: true,
+    };
+    options.bus?.emit('unit:move', {
+      unitId: attackerId,
+      from,
+      to,
+      path: [from, to],
+      presentationByViewer: buildMovePresentationByViewer(
+        state,
+        attacker,
+        [from, to],
+      ),
+    });
+  } else {
+    if (attacker.hasActed || attacker.movementPointsLeft <= 0) {
+      return assaultFailure(state, 'illegal-movement');
+    }
+    const movement = executeUnitMove(
+      nextState,
+      attackerId,
+      city.position,
+      {
+        actor: options.actor,
+        civId: options.civId,
+        bus: options.bus,
+        foreignCityEntryId: cityId,
+      },
+    );
+    if (!movement.ok) {
+      return assaultFailure(state, 'illegal-movement');
+    }
+    nextState.units[attackerId] = {
+      ...nextState.units[attackerId],
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: true,
+    };
+  }
+
+  return {
+    ok: true,
+    state: nextState,
+    pending: {
+      attackerId,
+      cityId,
+      targetCoord: { ...city.position },
+      occupiedPopulation: Math.max(1, Math.floor(city.population / 2)),
+      razeGold: computeRazeGold(city),
+    },
+  };
 }
 
 export function computeRazeGold(city: City): number {

--- a/src/systems/city-founding-system.ts
+++ b/src/systems/city-founding-system.ts
@@ -1,0 +1,103 @@
+import type { EventBus } from '@/core/event-bus';
+import type { GameState } from '@/core/types';
+import { collectUsedCityNames } from '@/systems/city-name-system';
+import { foundCity } from '@/systems/city-system';
+import {
+  buildTerritoryTileFlippedEvents,
+  canFoundCityAt,
+  recalculateTerritory,
+} from '@/systems/city-territory-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import { initializeLegendaryWonderProjectsForCity } from '@/systems/legendary-wonder-system';
+
+export interface FoundCityInStateResult {
+  state: GameState;
+  cityId: string;
+}
+
+export function foundCityInState(
+  state: GameState,
+  settlerId: string,
+  bus: EventBus,
+): FoundCityInStateResult {
+  const settler = state.units[settlerId];
+  if (!settler) throw new Error('Settler not found');
+  if (settler.type !== 'settler') throw new Error('Unit cannot found a city');
+  if (settler.hasActed) throw new Error('Settler has already acted');
+  if (settler.movementPointsLeft <= 0) {
+    throw new Error('Settler has no movement remaining');
+  }
+  const civilization = state.civilizations[settler.owner];
+  if (!civilization) throw new Error('Settler owner not found');
+  if (!canFoundCityAt(state, settler.position)) {
+    throw new Error('City cannot be founded here');
+  }
+
+  let nextState = structuredClone(state);
+  const nextCivilization = nextState.civilizations[settler.owner];
+  const definition = resolveCivDefinition(nextState, nextCivilization.civType);
+  const city = foundCity(
+    settler.owner,
+    settler.position,
+    nextState.map,
+    nextState.idCounters,
+    {
+      civType: nextCivilization.civType,
+      namingPool: definition?.cityNames,
+      civName: definition?.name ?? nextCivilization.name,
+      usedNames: collectUsedCityNames(nextState),
+    },
+  );
+  const existingOwnedCityIds = nextCivilization.cities.filter(cityId =>
+    nextState.cities[cityId]?.owner === settler.owner);
+  const recoveredFromNearDefeat = nextCivilization.nearDefeat === true
+    && existingOwnedCityIds.length >= 1;
+  const { [settlerId]: _removed, ...remainingUnits } = nextState.units;
+  nextState = {
+    ...nextState,
+    units: remainingUnits,
+    cities: {
+      ...nextState.cities,
+      [city.id]: city,
+    },
+    civilizations: {
+      ...nextState.civilizations,
+      [settler.owner]: {
+        ...nextCivilization,
+        units: nextCivilization.units.filter(unitId => unitId !== settlerId),
+        cities: [...existingOwnedCityIds, city.id],
+        nearDefeat: recoveredFromNearDefeat
+          ? false
+          : nextCivilization.nearDefeat,
+      },
+    },
+  };
+  nextState = initializeLegendaryWonderProjectsForCity(
+    nextState,
+    settler.owner,
+    city.id,
+  );
+  const beforeTerritory = nextState;
+  const territory = recalculateTerritory(nextState, {
+    reason: 'founding',
+    preserveForeignHolders: true,
+  });
+  nextState = territory.state;
+
+  for (const event of buildTerritoryTileFlippedEvents(
+    beforeTerritory,
+    nextState,
+    territory.resolutions,
+  )) {
+    bus.emit('territory:tile-flipped', event);
+  }
+  bus.emit('city:founded', {
+    city: nextState.cities[city.id] ?? city,
+    founderId: settler.owner,
+  });
+  if (recoveredFromNearDefeat) {
+    bus.emit('civ:recovered-from-near-defeat', { civId: settler.owner });
+  }
+
+  return { state: nextState, cityId: city.id };
+}

--- a/src/systems/minor-civ-diplomacy.ts
+++ b/src/systems/minor-civ-diplomacy.ts
@@ -1,6 +1,10 @@
 import type { GameState } from '@/core/types';
 
-export function isMinorCivAtWar(state: GameState, majorCivId: string, minorCivId: string): boolean {
+export function isMinorCivAtWar(
+  state: Readonly<Pick<GameState, 'civilizations' | 'minorCivs'>>,
+  majorCivId: string,
+  minorCivId: string,
+): boolean {
   const majorCiv = state.civilizations[majorCivId];
   const minorCiv = state.minorCivs[minorCivId];
   return Boolean(

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -197,10 +197,20 @@ export function performEstablishOutpost(state: GameState, unitId: string): GameS
   };
 
   const { [unitId]: _removed, ...remainingUnits } = state.units;
+  const civilization = state.civilizations[civId];
 
   return {
     ...state,
     units: remainingUnits,
+    civilizations: civilization
+      ? {
+          ...state.civilizations,
+          [civId]: {
+            ...civilization,
+            units: civilization.units.filter(id => id !== unitId),
+          },
+        }
+      : state.civilizations,
     map: {
       ...state.map,
       tiles: {

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -24,6 +24,7 @@ export interface ExecuteUnitMoveOptions {
   actor: 'player' | 'automation' | 'ai';
   civId: string;
   bus?: EventBus;
+  foreignCityEntryId?: string;
 }
 
 export interface WonderDiscoveryResult {
@@ -221,6 +222,19 @@ function getOwnerCompletedTechs(state: GameState, owner: string): string[] {
   return state.civilizations[owner]?.techState.completed ?? [];
 }
 
+function hasAlliance(
+  state: GameState,
+  civId: string,
+  otherCivId: string,
+): boolean {
+  return state.civilizations[civId]?.diplomacy.treaties.some(treaty =>
+    treaty.type === 'alliance'
+    && (
+      treaty.civA === civId && treaty.civB === otherCivId
+      || treaty.civA === otherCivId && treaty.civB === civId
+    )) ?? false;
+}
+
 function getImpassableReason(
   unitType: string,
   terrain: string,
@@ -261,6 +275,23 @@ export function validateUnitMove(
   const tile = state.map.tiles[hexKey(target)];
   if (!tile) return movementFailure(from, target, [from], 'unknown-tile', 'Too far away to spot.');
 
+  const foreignCity = Object.values(state.cities).find(city =>
+    city.owner !== unit.owner
+    && hexKey(city.position) === hexKey(target));
+  if (
+    foreignCity
+    && options.foreignCityEntryId !== foreignCity.id
+    && !hasAlliance(state, unit.owner, foreignCity.owner)
+  ) {
+    return movementFailure(
+      from,
+      target,
+      [from, target],
+      'foreign-city',
+      'Move adjacent, then use the city assault action.',
+    );
+  }
+
   const completedTechs = getOwnerCompletedTechs(state, unit.owner);
   const targetCost = getMovementCostForUnitInContext(unit, tile.terrain, { completedTechs });
   if (targetCost === Infinity) {
@@ -278,6 +309,24 @@ export function validateUnitMove(
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
   const path = findPath(from, target, state.map, domain, { unit, completedTechs });
   if (!path) return movementFailure(from, target, [from], 'unreachable', 'No passable route to that tile.');
+  const pathCrossesBlockedForeignCity = path.slice(1).some(coord =>
+    Object.values(state.cities).some(city =>
+      city.owner !== unit.owner
+      && hexKey(city.position) === hexKey(coord)
+      && !hasAlliance(state, unit.owner, city.owner)
+      && (
+        options.foreignCityEntryId !== city.id
+        || hexKey(coord) !== hexKey(target)
+      )));
+  if (pathCrossesBlockedForeignCity) {
+    return movementFailure(
+      from,
+      target,
+      path,
+      'foreign-city',
+      'Move adjacent, then use the city assault action.',
+    );
+  }
 
   const visibility = state.civilizations[options.civId]?.visibility;
   const isPlayerControlledMove = options.actor !== 'automation' && options.actor !== 'ai';

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -630,6 +630,7 @@ export type UnitMovementBlockerCode =
   | 'requires-galleys'
   | 'requires-celestial-navigation'
   | 'occupied'
+  | 'foreign-city'
   | 'unreachable'
   | 'insufficient-movement';
 

--- a/tests/ai/ai-major-turn.test.ts
+++ b/tests/ai/ai-major-turn.test.ts
@@ -1,0 +1,815 @@
+import { describe, expect, it, vi } from 'vitest';
+import { processMajorCivStrategicTurn } from '@/ai/ai-major-turn';
+import { buildMajorCivPerception } from '@/ai/ai-perception';
+import type { PreparedMajorCivPlan } from '@/ai/ai-prepared-turn';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import { createEmptyMajorCivPlanPortfolio } from '@/core/opponent-ai-state';
+import type {
+  AIStrategicPlan,
+  GameState,
+  HexCoord,
+  Unit,
+  UnitType,
+} from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
+
+const AI = 'ai-1';
+const HUMAN = 'player';
+
+function makeState(): GameState {
+  const state = createNewGame({
+    civType: 'egypt',
+    mapSize: 'small',
+    opponentCount: 1,
+    gameTitle: 'Major turn',
+    seed: 'major-turn',
+    opponentChallenge: 'veteran',
+  });
+  state.turn = 20;
+  state.units = {};
+  state.cities = {};
+  state.barbarianCamps = {};
+  state.map.wrapsHorizontally = false;
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.terrain = 'grassland';
+    tile.elevation = 'lowland';
+    tile.owner = null;
+    tile.resource = null;
+    tile.improvement = 'none';
+    tile.improvementTurnsLeft = 0;
+  }
+  for (const civilization of Object.values(state.civilizations)) {
+    civilization.units = [];
+    civilization.cities = [];
+  }
+  state.civilizations[AI].diplomacy.atWarWith = [HUMAN];
+  state.civilizations[HUMAN].diplomacy.atWarWith = [AI];
+  state.civilizations[AI].visibility.tiles = Object.fromEntries(
+    Object.keys(state.map.tiles).map(key => [key, 'visible' as const]),
+  );
+  return state;
+}
+
+function addUnit(
+  state: GameState,
+  id: string,
+  type: UnitType,
+  owner: string,
+  position: HexCoord,
+  overrides: Partial<Unit> = {},
+): Unit {
+  const unit = {
+    ...createUnit(type, owner, position, state.idCounters),
+    id,
+    ...overrides,
+  };
+  state.units[id] = unit;
+  state.civilizations[owner]?.units.push(id);
+  return unit;
+}
+
+function addCity(
+  state: GameState,
+  id: string,
+  owner: string,
+  position: HexCoord,
+) {
+  const city = foundCity(owner, position, state.map, state.idCounters);
+  city.id = id;
+  state.cities[id] = city;
+  state.civilizations[owner]?.cities.push(id);
+  state.map.tiles[hexKey(position)].owner = owner;
+  return city;
+}
+
+function makePlan(
+  target: AIStrategicPlan['target'],
+  assignedUnitIds: string[],
+  overrides: Partial<AIStrategicPlan> = {},
+): AIStrategicPlan {
+  return {
+    id: 'major-plan',
+    actorId: AI,
+    objective: target.kind === 'city' ? 'capture' : 'expand',
+    target,
+    theaterId: 'local:test',
+    phase: 'attacking',
+    reasonCodes: ['continue-active-war'],
+    commitment: 0.7,
+    createdTurn: 18,
+    reconsiderAfterTurn: 22,
+    expiresAfterTurn: 30,
+    lastProgressTurn: 19,
+    requiredRoles: { frontline: 1 },
+    assignedUnitIds,
+    ...overrides,
+  };
+}
+
+function prepared(
+  state: GameState,
+  plan: AIStrategicPlan,
+): PreparedMajorCivPlan {
+  const portfolio = {
+    ...createEmptyMajorCivPlanPortfolio(),
+    primaryPlan: plan,
+    lastPlannedTurn: state.turn,
+  };
+  return {
+    civId: AI,
+    perception: buildMajorCivPerception(state, AI),
+    portfolio,
+    assignments: {
+      portfolio,
+      assignmentsByPlanId: { [plan.id]: [...plan.assignedUnitIds] },
+      recoveryUnitIds: [],
+      forceDemands: [],
+      rejectedByUnitId: {},
+    },
+    forceDemands: [],
+    traces: [],
+  };
+}
+
+describe('processMajorCivStrategicTurn', () => {
+  it('rejects a prepared portfolio whose primary plan belongs to another actor', () => {
+    const state = makeState();
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['attacker'],
+      { actorId: HUMAN },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.actions).toEqual([]);
+    expect(result.state).toEqual(state);
+  });
+
+  it('rallies a mobilizing force without prematurely capturing its target', () => {
+    const state = makeState();
+    addUnit(state, 'fast-unit', 'horseman', AI, { q: 0, r: 0 });
+    addUnit(state, 'support', 'warrior', AI, { q: 0, r: 1 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 6, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['fast-unit', 'support'],
+      {
+        phase: 'mobilizing',
+        rallyPoint: { q: 2, r: 0 },
+        requiredRoles: { frontline: 1, capture: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.cities[target.id].owner).toBe(HUMAN);
+    expect(result.actions.some(action => action.kind === 'move')).toBe(true);
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toMatch(/mobilizing|advancing/);
+  });
+
+  it('does not capture during mobilization when no rally point is available', () => {
+    const state = makeState();
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      {
+        phase: 'mobilizing',
+        rallyPoint: undefined,
+        requiredRoles: { capture: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.cities[target.id].owner).toBe(HUMAN);
+    expect(result.actions.some(action => action.kind === 'capture-city'))
+      .toBe(false);
+  });
+
+  it('keeps scouting when the target is known only by rumor', () => {
+    const state = makeState();
+    addUnit(state, 'scout', 'scout', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 5, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['scout'],
+      {
+        phase: 'scouting',
+        requiredRoles: { recon: 1 },
+      },
+    );
+    const preparedTurn = prepared(state, plan);
+    preparedTurn.perception.knownCities = preparedTurn.perception.knownCities
+      .map(city => city.id === target.id
+        ? { ...city, confidence: 'rumored' as const }
+        : city);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      preparedTurn,
+      new EventBus(),
+    );
+
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('scouting');
+  });
+
+  it('does not enter a new attacking phase during migration grace', () => {
+    const state = makeState();
+    if (!state.opponentAI) throw new Error('missing opponent AI state');
+    state.opponentAI.migrationGraceRoundsRemaining = 2;
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'defender', 'warrior', HUMAN, { q: 1, r: 0 }, {
+      health: 100,
+    });
+    const plan = makePlan(
+      { kind: 'unit', id: 'defender', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      {
+        objective: 'raid',
+        phase: 'advancing',
+        createdTurn: state.turn,
+        requiredRoles: { frontline: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.actions.some(action => action.kind === 'attack')).toBe(true);
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('advancing');
+  });
+
+  it('captures through canonical movement and emits capture and territory parity events', () => {
+    const state = makeState();
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    state.map.tiles[hexKey(target.position)].improvement = 'farm';
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+    const before = structuredClone(state);
+    const bus = new EventBus();
+    const captured = vi.fn();
+    const flipped = vi.fn();
+    const moved = vi.fn();
+    bus.on('city:captured', captured);
+    bus.on('territory:tile-flipped', flipped);
+    bus.on('unit:move', moved);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(state).toEqual(before);
+    expect(result.state.cities[target.id].owner).toBe(AI);
+    expect(result.state.units.captor.position).toEqual(target.position);
+    expect(captured).toHaveBeenCalledOnce();
+    expect(flipped).toHaveBeenCalled();
+    expect(moved).toHaveBeenCalledOnce();
+  });
+
+  it('applies combat rewards and camp-destruction history through canonical systems', () => {
+    const state = makeState();
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'barbarian', 'warrior', 'barbarian', { q: 1, r: 0 }, {
+      health: 1,
+    });
+    state.barbarianCamps.camp = {
+      id: 'camp',
+      position: { q: 1, r: 0 },
+      strength: 1,
+      spawnCooldown: 2,
+    };
+    const plan = makePlan(
+      { kind: 'camp', id: 'camp', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      { objective: 'repel', requiredRoles: { frontline: 1 } },
+    );
+    const bus = new EventBus();
+    const combat = vi.fn();
+    const destroyed = vi.fn();
+    bus.on('combat:resolved', combat);
+    bus.on('barbarian:camp-destroyed', destroyed);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(result.state.units.barbarian).toBeUndefined();
+    expect(result.state.barbarianCamps.camp).toBeUndefined();
+    expect(result.state.legendaryWonderHistory?.destroyedStrongholds)
+      .toContainEqual(expect.objectContaining({ civId: AI, campId: 'camp' }));
+    expect(combat).toHaveBeenCalledOnce();
+    expect(destroyed).toHaveBeenCalledOnce();
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .not.toBe('abandoned');
+  });
+
+  it('founds a city through the shared whole-state helper', () => {
+    const state = makeState();
+    addUnit(state, 'settler', 'settler', AI, { q: 2, r: 2 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 2, r: 2 } },
+      ['settler'],
+      {
+        objective: 'expand',
+        requiredRoles: { settlement: 1 },
+      },
+    );
+    const bus = new EventBus();
+    const founded = vi.fn();
+    bus.on('city:founded', founded);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(result.state.units.settler).toBeUndefined();
+    expect(Object.values(result.state.cities)
+      .some(city => city.owner === AI && hexKey(city.position) === '2,2'))
+      .toBe(true);
+    expect(founded).toHaveBeenCalledOnce();
+  });
+
+  it('does not attack or capture a peaceful major civilization', () => {
+    const state = makeState();
+    state.civilizations[AI].diplomacy.atWarWith = [];
+    state.civilizations[HUMAN].diplomacy.atWarWith = [];
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.cities[target.id].owner).toBe(HUMAN);
+    expect(result.actions.some(action =>
+      action.kind === 'attack' || action.kind === 'capture-city'))
+      .toBe(false);
+  });
+
+  it('advances and captures after the same attacker defeats the final city defender', () => {
+    const state = makeState();
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'last-defender', 'warrior', HUMAN, { q: 1, r: 0 }, {
+      health: 1,
+    });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.units['last-defender']).toBeUndefined();
+    expect(result.state.cities[target.id].owner).toBe(AI);
+    expect(result.state.units.captor.position).toEqual(target.position);
+    expect(result.actions.map(action => action.kind))
+      .toEqual(['attack', 'capture-city']);
+  });
+
+  it('executes worker improvements through the canonical worker system', () => {
+    const state = makeState();
+    addCity(state, 'home', AI, { q: 1, r: 2 });
+    addUnit(state, 'worker', 'worker', AI, { q: 2, r: 2 });
+    state.map.tiles['2,2'].owner = AI;
+    const plan = makePlan(
+      { kind: 'region', id: 'home-region', anchor: { q: 2, r: 2 } },
+      ['worker'],
+      {
+        objective: 'expand',
+        requiredRoles: { worker: 1 },
+      },
+    );
+    const bus = new EventBus();
+    const started = vi.fn();
+    bus.on('improvement:started', started);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(result.state.map.tiles['2,2'].improvement).not.toBe('none');
+    expect(result.state.units.worker.hasActed).toBe(true);
+    expect(started).toHaveBeenCalledOnce();
+  });
+
+  it('establishes a legal resource outpost and consumes the expedition', () => {
+    const state = makeState();
+    state.civilizations[AI].techState.completed.push('bronze-working');
+    state.map.tiles['2,2'].resource = 'iron';
+    addUnit(state, 'expedition', 'expedition', AI, { q: 2, r: 2 });
+    const plan = makePlan(
+      { kind: 'resource', resource: 'iron', position: { q: 2, r: 2 } },
+      ['expedition'],
+      {
+        objective: 'secure-resource',
+        requiredRoles: { 'resource-expedition': 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.map.tiles['2,2'].improvement)
+      .toBe('resource_outpost');
+    expect(result.state.units.expedition).toBeUndefined();
+    expect(result.state.civilizations[AI].units).not.toContain('expedition');
+  });
+
+  it('loads a land unit through the canonical transport helper', () => {
+    const state = makeState();
+    state.map.tiles['4,0'].terrain = 'ocean';
+    addUnit(state, 'passenger', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'transport', 'transport', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'overseas', anchor: { q: 4, r: 0 } },
+      ['passenger'],
+      {
+        objective: 'expand',
+        requiredRoles: { transport: 1, frontline: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.units.passenger.transportId).toBe('transport');
+    expect(result.state.units.transport.cargoUnitIds).toContain('passenger');
+  });
+
+  it('unloads endangered cargo through the canonical transport helper', () => {
+    const state = makeState();
+    const transport = addUnit(
+      state,
+      'transport',
+      'transport',
+      AI,
+      { q: 1, r: 1 },
+      { cargoUnitIds: ['cargo'], health: 20 },
+    );
+    addUnit(state, 'cargo', 'warrior', AI, transport.position, {
+      transportId: transport.id,
+    });
+    const plan = makePlan(
+      { kind: 'region', id: 'landing', anchor: { q: 3, r: 1 } },
+      ['cargo'],
+      {
+        objective: 'expand',
+        requiredRoles: { frontline: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.actions[0]?.kind).toBe('unload');
+    expect(result.state.units.cargo.transportId).toBeUndefined();
+    expect(result.state.units.transport.cargoUnitIds).not.toContain('cargo');
+  });
+
+  it('uses wrapped adjacency when capturing across the horizontal seam', () => {
+    const state = makeState();
+    state.map.wrapsHorizontally = true;
+    const attackerPosition = { q: state.map.width - 1, r: 0 };
+    addUnit(state, 'captor', 'swordsman', AI, attackerPosition);
+    const target = addCity(state, 'target-city', HUMAN, { q: 0, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.cities[target.id].owner).toBe(AI);
+    expect(result.state.units.captor.position).toEqual({ q: 0, r: 0 });
+  });
+
+  it('transitions a badly damaged attacking force into withdrawal', () => {
+    const state = makeState();
+    addCity(state, 'home', AI, { q: 0, r: 0 });
+    addUnit(state, 'damaged', 'swordsman', AI, { q: 2, r: 0 }, {
+      health: 10,
+    });
+    const target = addCity(state, 'target-city', HUMAN, { q: 5, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['damaged'],
+      { phase: 'attacking', requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('withdrawing');
+    expect(result.actions[0]?.kind).toMatch(/withdraw|rest/);
+  });
+
+  it('cleans up an adjacent rebel through the same canonical combat path', () => {
+    const state = makeState();
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'rebel', 'warrior', 'rebels', { q: 1, r: 0 }, {
+      health: 1,
+    });
+    const plan = makePlan(
+      { kind: 'unit', id: 'rebel', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      { objective: 'repel', requiredRoles: { frontline: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.units.rebel).toBeUndefined();
+    expect(result.actions[0]).toMatchObject({
+      kind: 'attack',
+      targetUnitId: 'rebel',
+    });
+  });
+
+  it('uses minor-civilization conquest only when canonical minor war is active', () => {
+    const state = makeState();
+    const minor = Object.values(state.minorCivs)[0];
+    if (!minor) throw new Error('missing generated minor civilization');
+    minor.isDestroyed = false;
+    minor.units = [];
+    minor.diplomacy.atWarWith = [AI];
+    state.civilizations[AI].diplomacy.atWarWith.push(minor.id);
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, minor.cityId, minor.id, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+    const bus = new EventBus();
+    const destroyed = vi.fn();
+    bus.on('minor-civ:destroyed', destroyed);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(result.state.minorCivs[minor.id].isDestroyed).toBe(true);
+    expect(result.state.cities[target.id].owner).toBe(AI);
+    expect(destroyed).toHaveBeenCalledOnce();
+  });
+
+  it('does not conquer a minor civilization when neither side records a war', () => {
+    const state = makeState();
+    const minor = Object.values(state.minorCivs)[0];
+    if (!minor) throw new Error('missing generated minor civilization');
+    minor.isDestroyed = false;
+    minor.units = [];
+    minor.diplomacy.atWarWith = [];
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const target = addCity(state, minor.cityId, minor.id, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.minorCivs[minor.id].isDestroyed).toBe(false);
+    expect(result.state.cities[target.id].owner).toBe(minor.id);
+    expect(result.actions.some(action =>
+      action.kind === 'attack' || action.kind === 'capture-city'))
+      .toBe(false);
+  });
+
+  it('abandons an invalid target without moving assigned units toward stale coordinates', () => {
+    const state = makeState();
+    const attacker = addUnit(
+      state,
+      'attacker',
+      'swordsman',
+      AI,
+      { q: 0, r: 0 },
+    );
+    const plan = makePlan(
+      { kind: 'unit', id: 'missing-target', lastKnownPosition: { q: 4, r: 0 } },
+      ['attacker'],
+      { objective: 'repel', requiredRoles: { frontline: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.actions).toEqual([]);
+    expect(result.state.units.attacker.position).toEqual(attacker.position);
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('abandoned');
+  });
+
+  it('executes urgent city defense before an unrelated primary expansion', () => {
+    const state = makeState();
+    const home = addCity(state, 'home', AI, { q: 0, r: 0 });
+    addUnit(state, 'defender', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'threat', 'warrior', HUMAN, { q: 1, r: 0 }, {
+      health: 1,
+    });
+    addUnit(state, 'settler', 'settler', AI, { q: 4, r: 4 });
+    const primary = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 4, r: 4 } },
+      ['settler'],
+      {
+        id: 'primary',
+        objective: 'expand',
+        requiredRoles: { settlement: 1 },
+      },
+    );
+    const defense = makePlan(
+      { kind: 'city', id: home.id, lastKnownPosition: home.position },
+      ['defender'],
+      {
+        id: 'defense',
+        objective: 'defend',
+        requiredRoles: { frontline: 1 },
+      },
+    );
+    const preparedTurn = prepared(state, primary);
+    preparedTurn.portfolio.defensePlansByCityId = { [home.id]: defense };
+    preparedTurn.assignments.portfolio = preparedTurn.portfolio;
+    preparedTurn.assignments.assignmentsByPlanId.defense = ['defender'];
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      preparedTurn,
+      new EventBus(),
+    );
+
+    expect(result.actions[0]).toMatchObject({
+      kind: 'attack',
+      unitId: 'defender',
+      targetUnitId: 'threat',
+    });
+  });
+
+  it('does not withdraw from a stronger nearby civilization while at peace', () => {
+    const state = makeState();
+    state.civilizations[AI].diplomacy.atWarWith = [HUMAN];
+    addUnit(state, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    addUnit(state, 'peaceful-army', 'tank', 'ai-2', { q: 2, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 5, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['attacker'],
+      { phase: 'advancing', requiredRoles: { frontline: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .not.toBe('withdrawing');
+  });
+
+  it('keeps consolidating while a visible hostile counterattack is nearby', () => {
+    const state = makeState();
+    const captured = addCity(state, 'captured-city', AI, { q: 1, r: 0 });
+    addUnit(state, 'occupier', 'swordsman', AI, { q: 1, r: 0 }, {
+      hasActed: true,
+      movementPointsLeft: 0,
+    });
+    addUnit(state, 'counterattacker', 'warrior', HUMAN, { q: 3, r: 0 });
+    const plan = makePlan(
+      {
+        kind: 'city',
+        id: captured.id,
+        lastKnownPosition: captured.position,
+      },
+      ['occupier'],
+      {
+        phase: 'consolidating',
+        lastProgressTurn: state.turn - 2,
+        requiredRoles: { frontline: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('consolidating');
+  });
+
+  it('does not count holding position as fresh consolidation progress', () => {
+    const state = makeState();
+    const captured = addCity(state, 'captured-city', AI, { q: 1, r: 0 });
+    addUnit(state, 'occupier', 'swordsman', AI, { q: 1, r: 0 }, {
+      hasActed: true,
+      movementPointsLeft: 0,
+    });
+    const plan = makePlan(
+      {
+        kind: 'city',
+        id: captured.id,
+        lastKnownPosition: captured.position,
+      },
+      ['occupier'],
+      {
+        phase: 'consolidating',
+        lastProgressTurn: state.turn - 1,
+        requiredRoles: { frontline: 1 },
+      },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.phase)
+      .toBe('consolidating');
+    expect(result.state.opponentAI?.majorCivs[AI].primaryPlan?.lastProgressTurn)
+      .toBe(state.turn - 1);
+  });
+});

--- a/tests/ai/ai-major-turn.test.ts
+++ b/tests/ai/ai-major-turn.test.ts
@@ -182,6 +182,38 @@ describe('processMajorCivStrategicTurn', () => {
       .toMatch(/mobilizing|advancing/);
   });
 
+  it('still rallies when a tempting attack is illegal during mobilization', () => {
+    const state = makeState();
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'nearby-enemy', 'warrior', HUMAN, { q: 1, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 6, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      {
+        phase: 'mobilizing',
+        rallyPoint: { q: 0, r: 2 },
+        requiredRoles: { capture: 1 },
+      },
+    );
+    const bus = new EventBus();
+    const combat = vi.fn();
+    bus.on('combat:resolved', combat);
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      bus,
+    );
+
+    expect(combat).not.toHaveBeenCalled();
+    expect(result.actions).toContainEqual(expect.objectContaining({
+      kind: 'move',
+      unitId: 'captor',
+    }));
+    expect(result.state.units.captor.position).not.toEqual({ q: 0, r: 0 });
+  });
+
   it('does not capture during mobilization when no rally point is available', () => {
     const state = makeState();
     addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });

--- a/tests/ai/ai-round-scheduler.test.ts
+++ b/tests/ai/ai-round-scheduler.test.ts
@@ -194,6 +194,52 @@ describe('AI round scheduler', () => {
     }
   });
 
+  it('executes the prepared strategic path by default when planning is enabled', () => {
+    const state = createNewGame(undefined, 'scheduler-live-strategy', 'small');
+    const settlerId = state.civilizations['ai-1'].units
+      .find(unitId => state.units[unitId]?.type === 'settler');
+    if (!settlerId) throw new Error('missing AI settler');
+    const founded = vi.fn();
+    const bus = new EventBus();
+    bus.on('city:founded', founded);
+
+    const result = processNonHumanMajorRound(state, bus, {
+      strategicPlanningEnabled: true,
+      prepare: (snapshot, civId) => {
+        const value = prepared(snapshot as typeof state, civId);
+        const settler = state.units[settlerId];
+        value.portfolio.primaryPlan = {
+          id: 'settle-home',
+          actorId: civId,
+          objective: 'expand',
+          target: {
+            kind: 'region',
+            id: 'home',
+            anchor: { ...settler.position },
+          },
+          theaterId: 'home',
+          phase: 'attacking',
+          reasonCodes: ['nearby-opportunity'],
+          commitment: 0.5,
+          createdTurn: state.turn,
+          reconsiderAfterTurn: state.turn + 2,
+          expiresAfterTurn: state.turn + 8,
+          lastProgressTurn: state.turn,
+          requiredRoles: { settlement: 1 },
+          assignedUnitIds: [settlerId],
+        };
+        value.assignments.assignmentsByPlanId = {
+          'settle-home': [settlerId],
+        };
+        return value;
+      },
+    });
+
+    expect(result.state.units[settlerId]).toBeUndefined();
+    expect(result.state.civilizations['ai-1'].cities).toHaveLength(1);
+    expect(founded).toHaveBeenCalledOnce();
+  });
+
   it('drops a stale primary action while preserving valid defense work', () => {
     const state = createNewGame({
       civType: 'egypt',
@@ -393,7 +439,10 @@ describe('AI round scheduler', () => {
     const targetTile = Object.values(state.map.tiles)[0];
     targetTile.resource = 'iron';
     targetTile.owner = null;
-    const executed: string[] = [];
+    const executed: Array<{
+      civId: string;
+      hasPrimaryPlan: boolean;
+    }> = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
       strategicPlanningEnabled: true,
@@ -424,7 +473,10 @@ describe('AI round scheduler', () => {
         return value;
       },
       executePrepared: (current, value) => {
-        executed.push(value.civId);
+        executed.push({
+          civId: value.civId,
+          hasPrimaryPlan: value.portfolio.primaryPlan !== null,
+        });
         if (value.civId === 'ai-1') {
           const next = structuredClone(current);
           next.map.tiles[`${targetTile.coord.q},${targetTile.coord.r}`].owner = 'player';
@@ -434,7 +486,10 @@ describe('AI round scheduler', () => {
       },
     });
 
-    expect(executed).toEqual(['ai-1']);
+    expect(executed).toEqual([
+      { civId: 'ai-1', hasPrimaryPlan: false },
+      { civId: 'ai-2', hasPrimaryPlan: false },
+    ]);
     expect(result.state.opponentAI?.majorCivs['ai-2']?.primaryPlan).toBeNull();
   });
 

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -1,0 +1,524 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chooseTacticalSequence,
+  chooseUnitTacticalAction,
+  rankUnitTacticalActions,
+  type AITacticalContext,
+} from '@/ai/ai-tactics';
+import { createNewGame } from '@/core/game-state';
+import type {
+  AIStrategicPlan,
+  GameState,
+  HexCoord,
+  OpponentChallenge,
+  Unit,
+  UnitType,
+} from '@/core/types';
+import { foundCity } from '@/systems/city-system';
+import { hexDistance, hexKey } from '@/systems/hex-utils';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+const AI = 'ai-1';
+const HUMAN = 'player';
+
+function makeState(challenge: OpponentChallenge = 'standard'): GameState {
+  const state = createNewGame({
+    civType: 'egypt',
+    mapSize: 'small',
+    opponentCount: 1,
+    gameTitle: 'AI tactics',
+    seed: 'ai-tactics',
+    opponentChallenge: challenge,
+  });
+  state.gameId = 'ai-tactics-game';
+  state.turn = 12;
+  state.units = {};
+  state.cities = {};
+  state.map.wrapsHorizontally = false;
+  state.map.rivers = [];
+  for (const tile of Object.values(state.map.tiles)) {
+    tile.terrain = 'grassland';
+    tile.elevation = 'lowland';
+    tile.owner = null;
+    tile.improvement = 'none';
+    tile.improvementTurnsLeft = 0;
+    tile.resource = null;
+    tile.hasRiver = false;
+  }
+  for (const civ of Object.values(state.civilizations)) {
+    civ.units = [];
+    civ.cities = [];
+  }
+  state.civilizations[AI].diplomacy.atWarWith = [HUMAN];
+  state.civilizations[HUMAN].diplomacy.atWarWith = [AI];
+  state.civilizations[AI].visibility.tiles = Object.fromEntries(
+    Object.keys(state.map.tiles).map(key => [key, 'visible' as const]),
+  );
+  return state;
+}
+
+function addUnit(
+  state: GameState,
+  id: string,
+  type: UnitType,
+  owner: string,
+  position: HexCoord,
+  overrides: Partial<Unit> = {},
+): Unit {
+  const unit = {
+    ...createUnit(type, owner, position, state.idCounters),
+    id,
+    ...overrides,
+  };
+  state.units[id] = unit;
+  state.civilizations[owner]?.units.push(id);
+  return unit;
+}
+
+function addCity(state: GameState, id: string, owner: string, position: HexCoord) {
+  const city = foundCity(owner, position, state.map, state.idCounters);
+  city.id = id;
+  state.cities[id] = city;
+  state.civilizations[owner].cities.push(id);
+  return city;
+}
+
+function makePlan(
+  target: AIStrategicPlan['target'],
+  assignedUnitIds: string[],
+  overrides: Partial<AIStrategicPlan> = {},
+): AIStrategicPlan {
+  return {
+    id: 'tactical-plan',
+    actorId: AI,
+    objective: target.kind === 'city' ? 'capture' : 'expand',
+    target,
+    theaterId: 'test-theater',
+    phase: 'attacking',
+    reasonCodes: ['continue-active-war'],
+    commitment: 0.7,
+    createdTurn: 10,
+    reconsiderAfterTurn: 15,
+    expiresAfterTurn: 25,
+    lastProgressTurn: 11,
+    requiredRoles: { frontline: 1, capture: 1 },
+    assignedUnitIds,
+    ...overrides,
+  };
+}
+
+function context(
+  state: GameState,
+  plan: AIStrategicPlan,
+): AITacticalContext {
+  return {
+    state,
+    actorId: AI,
+    plan,
+    assignedUnitIds: plan.assignedUnitIds,
+  };
+}
+
+describe('AI tactical action ranking', () => {
+  it('uses safe ranged fire before committing a capture unit', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'archer', 'archer', AI, { q: 0, r: 0 });
+    addUnit(state, 'swordsman', 'swordsman', AI, { q: 1, r: 0 });
+    addUnit(state, 'defender', 'warrior', HUMAN, { q: 2, r: 0 });
+    const city = addCity(state, 'target-city', HUMAN, { q: 3, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['archer', 'swordsman'],
+    );
+
+    const actions = chooseTacticalSequence(context(state, plan));
+
+    expect(actions[0]).toMatchObject({ kind: 'attack', unitId: 'archer' });
+    expect(actions.findIndex(action => action.unitId === 'swordsman'))
+      .toBeGreaterThan(actions.findIndex(action => action.unitId === 'archer'));
+  });
+
+  it('does not send a fast unit beyond support cohesion', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'horseman', 'horseman', AI, { q: 1, r: 0 });
+    const support = addUnit(state, 'support', 'warrior', AI, { q: 0, r: 2 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 7, r: 0 } },
+      ['horseman', 'support'],
+      { objective: 'expand' },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), 'horseman');
+
+    expect(action.kind).toBe('move');
+    const supportTurns = Math.ceil(
+      hexDistance(
+        support.position,
+        action.kind === 'move' ? action.destination : support.position,
+      )
+      / UNIT_DEFINITIONS[support.type].movementPoints,
+    );
+    expect(supportTurns).toBeLessThanOrEqual(1);
+  });
+
+  it('withdraws a damaged unit toward reachable healing', () => {
+    const state = makeState('standard');
+    const city = addCity(state, 'home', AI, { q: 0, r: 0 });
+    addUnit(state, 'damaged', 'warrior', AI, { q: 2, r: 0 }, {
+      health: 35,
+      movementPointsLeft: 1,
+    });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 7, r: 0 } },
+      ['damaged'],
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), 'damaged');
+
+    expect(action).toMatchObject({ kind: 'withdraw', unitId: 'damaged' });
+    expect(hexDistance(action.kind === 'withdraw' ? action.destination : { q: 9, r: 9 }, city.position))
+      .toBeLessThan(hexDistance({ q: 2, r: 0 }, city.position));
+  });
+
+  it('does not withdraw into a peaceful foreign city', () => {
+    const state = makeState('standard');
+    addCity(state, 'home', AI, { q: 0, r: 0 });
+    const foreign = addCity(state, 'foreign', HUMAN, { q: 1, r: 0 });
+    state.civilizations[AI].diplomacy.atWarWith = [];
+    state.civilizations[HUMAN].diplomacy.atWarWith = [];
+    addUnit(state, 'damaged', 'warrior', AI, { q: 2, r: 0 }, {
+      health: 35,
+      movementPointsLeft: 1,
+    });
+    for (const tile of Object.values(state.map.tiles)) {
+      if (
+        hexDistance(tile.coord, { q: 2, r: 0 }) === 1
+        && hexKey(tile.coord) !== hexKey(foreign.position)
+      ) {
+        tile.terrain = 'mountain';
+      }
+    }
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 7, r: 0 } },
+      ['damaged'],
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), 'damaged');
+
+    expect(
+      action.kind === 'withdraw'
+        && hexKey(action.destination) === hexKey(foreign.position),
+    ).toBe(false);
+  });
+
+  it('never attacks during peace or attacks an unseen target', () => {
+    const peaceful = makeState('veteran');
+    peaceful.civilizations[AI].diplomacy.atWarWith = [];
+    peaceful.civilizations[HUMAN].diplomacy.atWarWith = [];
+    addUnit(peaceful, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    addUnit(peaceful, 'target', 'warrior', HUMAN, { q: 1, r: 0 });
+    const peacefulPlan = makePlan(
+      { kind: 'unit', id: 'target', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      { objective: 'repel' },
+    );
+
+    expect(rankUnitTacticalActions(context(peaceful, peacefulPlan), 'attacker')
+      .some(candidate => candidate.action.kind === 'attack')).toBe(false);
+
+    const hidden = makeState('veteran');
+    addUnit(hidden, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    addUnit(hidden, 'target', 'warrior', HUMAN, { q: 1, r: 0 });
+    hidden.civilizations[AI].visibility.tiles[hexKey({ q: 1, r: 0 })] = 'fog';
+    const hiddenPlan = makePlan(
+      { kind: 'unit', id: 'target', lastKnownPosition: { q: 1, r: 0 } },
+      ['attacker'],
+      { objective: 'repel' },
+    );
+
+    expect(rankUnitTacticalActions(context(hidden, hiddenPlan), 'attacker')
+      .some(candidate => candidate.action.kind === 'attack')).toBe(false);
+  });
+
+  it('does not generate attacks outside canonical range', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    addUnit(state, 'target', 'warrior', HUMAN, { q: 3, r: 0 });
+    const plan = makePlan(
+      { kind: 'unit', id: 'target', lastKnownPosition: { q: 3, r: 0 } },
+      ['attacker'],
+      { objective: 'repel' },
+    );
+
+    expect(rankUnitTacticalActions(context(state, plan), 'attacker')
+      .some(candidate => candidate.action.kind === 'attack')).toBe(false);
+  });
+
+  it('does not choose an occupied movement destination', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'mover', 'horseman', AI, { q: 0, r: 0 });
+    addUnit(state, 'blocker', 'warrior', AI, { q: 3, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 7, r: 0 } },
+      ['mover'],
+      { objective: 'expand' },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), 'mover');
+
+    expect(action.kind).toBe('move');
+    expect(action.kind === 'move' ? action.destination : null)
+      .not.toEqual({ q: 3, r: 0 });
+  });
+
+  it('accounts for river attack penalties when otherwise equal targets exist', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 1, r: 1 });
+    addUnit(state, 'across-river', 'warrior', HUMAN, { q: 2, r: 1 });
+    addUnit(state, 'clear-target', 'warrior', HUMAN, { q: 1, r: 2 });
+    state.map.rivers = [{ from: { q: 1, r: 1 }, to: { q: 2, r: 1 } }];
+    const plan = makePlan(
+      { kind: 'region', id: 'battlefield', anchor: { q: 4, r: 4 } },
+      ['attacker'],
+      { objective: 'repel' },
+    );
+
+    expect(chooseUnitTacticalAction(context(state, plan), 'attacker'))
+      .toMatchObject({ kind: 'attack', targetUnitId: 'clear-target' });
+  });
+
+  it('keeps transported cargo from attacking or moving independently', () => {
+    const state = makeState('veteran');
+    const transport = addUnit(state, 'transport', 'transport', AI, { q: 1, r: 1 }, {
+      cargoUnitIds: ['cargo'],
+    });
+    addUnit(state, 'cargo', 'warrior', AI, transport.position, {
+      transportId: transport.id,
+    });
+    addUnit(state, 'target', 'warrior', HUMAN, { q: 2, r: 1 });
+    const plan = makePlan(
+      { kind: 'unit', id: 'target', lastKnownPosition: { q: 2, r: 1 } },
+      ['cargo'],
+      { objective: 'repel' },
+    );
+
+    const tactical = context(state, plan);
+    const action = chooseUnitTacticalAction(tactical, 'cargo');
+
+    expect(['unload', 'hold']).toContain(action.kind);
+    expect(rankUnitTacticalActions(tactical, 'cargo')
+      .some(candidate =>
+        candidate.action.kind === 'attack'
+        || candidate.action.kind === 'move'
+        || candidate.action.kind === 'withdraw')).toBe(false);
+  });
+
+  it('does not move into a peaceful foreign city outside capture legality', () => {
+    const state = makeState('veteran');
+    state.civilizations[AI].diplomacy.atWarWith = [];
+    state.civilizations[HUMAN].diplomacy.atWarWith = [];
+    addUnit(state, 'mover', 'horseman', AI, { q: 0, r: 0 });
+    const city = addCity(state, 'peaceful-city', HUMAN, { q: 3, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['mover'],
+    );
+
+    expect(rankUnitTacticalActions(context(state, plan), 'mover')
+      .some(candidate =>
+        candidate.action.kind === 'move'
+        && hexKey(candidate.action.destination) === hexKey(city.position))).toBe(false);
+  });
+
+  it('does not force the sole last-city defender to retreat', () => {
+    const state = makeState('standard');
+    const city = addCity(state, 'last-city', AI, { q: 0, r: 0 });
+    addUnit(state, 'defender', 'warrior', AI, city.position, { health: 35 });
+    addUnit(state, 'attacker', 'warrior', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['defender'],
+      { objective: 'defend', requiredRoles: { frontline: 1 } },
+    );
+
+    expect(chooseUnitTacticalAction(context(state, plan), 'defender'))
+      .toMatchObject({ kind: 'attack', targetUnitId: 'attacker' });
+  });
+
+  it('never degrades an available lethal city defense through seeded mistakes', () => {
+    const state = makeState('explorer');
+    const city = addCity(state, 'last-city', AI, { q: 0, r: 0 });
+    addUnit(state, 'defender', 'swordsman', AI, city.position);
+    addUnit(state, 'fragile', 'warrior', HUMAN, { q: 1, r: 0 }, { health: 1 });
+    addUnit(state, 'healthy', 'warrior', HUMAN, { q: 0, r: 1 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['defender'],
+      { objective: 'defend', requiredRoles: { frontline: 1 } },
+    );
+
+    const lethal = rankUnitTacticalActions(context(state, plan), 'defender')
+      .find(candidate =>
+        candidate.action.kind === 'attack'
+        && candidate.action.targetUnitId === 'fragile');
+
+    expect(lethal?.mandatory).toBe(true);
+    expect(chooseUnitTacticalAction(context(state, plan), 'defender'))
+      .toMatchObject({ kind: 'attack', targetUnitId: 'fragile' });
+  });
+
+  it('does not attack a target already predicted dead earlier in the sequence', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'archer-a', 'archer', AI, { q: 0, r: 0 });
+    addUnit(state, 'archer-b', 'archer', AI, { q: 0, r: 1 });
+    addUnit(state, 'fragile', 'warrior', HUMAN, { q: 2, r: 0 }, { health: 1 });
+    const plan = makePlan(
+      { kind: 'unit', id: 'fragile', lastKnownPosition: { q: 2, r: 0 } },
+      ['archer-a', 'archer-b'],
+      { objective: 'repel' },
+    );
+
+    const attacks = chooseTacticalSequence(context(state, plan))
+      .filter(action => action.kind === 'attack' && action.targetUnitId === 'fragile');
+
+    expect(attacks).toHaveLength(1);
+  });
+
+  it('does not capture a city without a capture-capable unit', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'catapult', 'catapult', AI, { q: 0, r: 0 });
+    const city = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['catapult'],
+    );
+
+    expect(rankUnitTacticalActions(context(state, plan), 'catapult')
+      .some(candidate => candidate.action.kind === 'capture-city')).toBe(false);
+  });
+
+  it('captures an adjacent exposed enemy city with a capture-capable unit', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    const city = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['captor'],
+    );
+
+    expect(chooseUnitTacticalAction(context(state, plan), 'captor'))
+      .toEqual({ kind: 'capture-city', unitId: 'captor', cityId: city.id });
+  });
+
+  it('does not capture a city remotely with a ranged unit', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'archer', 'archer', AI, { q: 0, r: 0 }, {
+      movementPointsLeft: 2,
+    });
+    const city = addCity(state, 'target-city', HUMAN, { q: 2, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['archer'],
+    );
+
+    expect(rankUnitTacticalActions(context(state, plan), 'archer')
+      .some(candidate => candidate.action.kind === 'capture-city')).toBe(false);
+  });
+
+  it('makes unloading endangered cargo mandatory when a safe tile exists', () => {
+    const state = makeState('explorer');
+    const transport = addUnit(state, 'transport', 'transport', AI, { q: 1, r: 1 }, {
+      cargoUnitIds: ['cargo'],
+      health: 20,
+    });
+    addUnit(state, 'cargo', 'warrior', AI, transport.position, {
+      transportId: transport.id,
+    });
+    const plan = makePlan(
+      { kind: 'region', id: 'landing', anchor: { q: 3, r: 1 } },
+      ['cargo'],
+      { objective: 'expand', requiredRoles: { frontline: 1 } },
+    );
+
+    const ranked = rankUnitTacticalActions(context(state, plan), 'cargo');
+
+    expect(ranked[0]?.action.kind).toBe('unload');
+    expect(ranked[0]?.mandatory).toBe(true);
+    expect(chooseUnitTacticalAction(context(state, plan), 'cargo'))
+      .toEqual(ranked[0]?.action);
+  });
+
+  it('keeps Explorer seeded mistakes deterministic and within legal near-best actions', () => {
+    const state = makeState('explorer');
+    addUnit(state, 'attacker', 'swordsman', AI, { q: 1, r: 1 });
+    addUnit(state, 'target-a', 'warrior', HUMAN, { q: 2, r: 1 }, { health: 90 });
+    addUnit(state, 'target-b', 'warrior', HUMAN, { q: 1, r: 2 }, { health: 100 });
+    const plan = makePlan(
+      { kind: 'unit', id: 'target-a', lastKnownPosition: { q: 2, r: 1 } },
+      ['attacker'],
+      { objective: 'repel' },
+    );
+    const tactical = context(state, plan);
+    const legalNearBest = rankUnitTacticalActions(tactical, 'attacker')
+      .filter(candidate => candidate.action.kind === 'attack')
+      .slice(0, 3)
+      .map(candidate => candidate.id);
+
+    const first = chooseUnitTacticalAction(tactical, 'attacker');
+    const second = chooseUnitTacticalAction(tactical, 'attacker');
+    const selected = rankUnitTacticalActions(tactical, 'attacker')
+      .find(candidate => JSON.stringify(candidate.action) === JSON.stringify(first));
+
+    expect(first).toEqual(second);
+    expect(selected).toBeDefined();
+    expect(legalNearBest).toContain(selected!.id);
+  });
+
+  it('moves as far as legal movement permits instead of advancing one hex', () => {
+    const state = makeState('veteran');
+    const mover = addUnit(state, 'mover', 'horseman', AI, { q: 0, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 6, r: 0 } },
+      ['mover'],
+      { objective: 'expand' },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), mover.id);
+
+    expect(action).toMatchObject({ kind: 'move' });
+    expect(action.kind === 'move' ? hexDistance(mover.position, action.destination) : 0)
+      .toBe(UNIT_DEFINITIONS.horseman.movementPoints);
+  });
+
+  it('regenerates against predicted occupancy so two units do not claim one tile', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'unit-a', 'warrior', AI, { q: 0, r: 0 });
+    addUnit(state, 'unit-b', 'warrior', AI, { q: 0, r: 1 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 4, r: 0 } },
+      ['unit-a', 'unit-b'],
+      { objective: 'expand' },
+    );
+
+    const moves = chooseTacticalSequence(context(state, plan))
+      .filter(action => action.kind === 'move');
+
+    expect(new Set(moves.map(action => hexKey(action.destination))).size).toBe(moves.length);
+  });
+
+  it('predicts city founding so nearby settlers do not found illegal duplicate cities', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'settler-a', 'settler', AI, { q: 0, r: 0 });
+    addUnit(state, 'settler-b', 'settler', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'frontier', anchor: { q: 4, r: 0 } },
+      ['settler-a', 'settler-b'],
+      { objective: 'expand', requiredRoles: { settlement: 2 } },
+    );
+
+    const foundings = chooseTacticalSequence(context(state, plan))
+      .filter(action => action.kind === 'found-city');
+
+    expect(foundings).toHaveLength(1);
+  });
+});

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -6,6 +6,7 @@ import {
   type AITacticalContext,
 } from '@/ai/ai-tactics';
 import { createNewGame } from '@/core/game-state';
+import { createEmptyPirateState } from '@/core/pirate-state';
 import type {
   AIStrategicPlan,
   GameState,
@@ -136,6 +137,89 @@ describe('AI tactical action ranking', () => {
     expect(actions[0]).toMatchObject({ kind: 'attack', unitId: 'archer' });
     expect(actions.findIndex(action => action.unitId === 'swordsman'))
       .toBeGreaterThan(actions.findIndex(action => action.unitId === 'archer'));
+  });
+
+  it('does not opportunistically attack beasts when beast contests are disabled', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });
+    addUnit(state, 'beast', 'beast_boar', 'beasts', { q: 1, r: 0 });
+    const city = addCity(state, 'target-city', HUMAN, { q: 4, r: 0 });
+    const plan = makePlan(
+      { kind: 'city', id: city.id, lastKnownPosition: city.position },
+      ['captor'],
+    );
+
+    const actions = rankUnitTacticalActions(
+      context(state, plan),
+      'captor',
+    );
+
+    expect(actions).not.toContainEqual(expect.objectContaining({
+      action: {
+        kind: 'attack',
+        unitId: 'captor',
+        targetUnitId: 'beast',
+      },
+    }));
+  });
+
+  it('does not attack a pirate faction while tribute protection is active', () => {
+    const state = makeState('veteran');
+    state.map.tiles['0,0'].terrain = 'ocean';
+    state.map.tiles['1,0'].terrain = 'ocean';
+    state.map.tiles['3,0'].terrain = 'ocean';
+    addUnit(state, 'warship', 'galley', AI, { q: 0, r: 0 });
+    addUnit(
+      state,
+      'protected-pirate',
+      'pirate_galley',
+      'pirate-1',
+      { q: 1, r: 0 },
+    );
+    state.pirates = createEmptyPirateState();
+    state.pirates.factions['pirate-1'] = {
+      id: 'pirate-1',
+      name: 'The Red Wake',
+      spawnedRound: 2,
+      behavior: 'blockading',
+      maritimeStage: 1,
+      notoriety: 1,
+      shipIds: ['protected-pirate'],
+      headquarters: {
+        kind: 'coastal-enclave',
+        position: { q: 3, r: 0 },
+        integrity: 100,
+        maxIntegrity: 100,
+      },
+      tributeByCiv: {
+        [AI]: {
+          paidRound: state.turn,
+          protectedUntilRound: state.turn + 3,
+        },
+      },
+      demandByCiv: {},
+      contract: null,
+      intent: null,
+      transitionGuards: { emittedEventKeys: [] },
+    };
+    const plan = makePlan(
+      { kind: 'region', id: 'sea-lane', anchor: { q: 3, r: 0 } },
+      ['warship'],
+      { objective: 'blockade' },
+    );
+
+    const actions = rankUnitTacticalActions(
+      context(state, plan),
+      'warship',
+    );
+
+    expect(actions).not.toContainEqual(expect.objectContaining({
+      action: {
+        kind: 'attack',
+        unitId: 'warship',
+        targetUnitId: 'protected-pirate',
+      },
+    }));
   });
 
   it('does not send a fast unit beyond support cohesion', () => {

--- a/tests/ai/basic-ai-beasts.test.ts
+++ b/tests/ai/basic-ai-beasts.test.ts
@@ -96,6 +96,33 @@ describe('AI vs beasts', () => {
     expect(state.units['beast-1']).toBeDefined();
   });
 
+  it('keeps beasts out of the feature-enabled strategic path by default', () => {
+    const state = makeBeastState({
+      aiUnitType: 'swordsman',
+      beastType: 'beast_boar',
+      beastHealth: 20,
+    });
+    state.civilizations['ai-1'].visibility.tiles = {
+      '0,0': 'visible',
+      '1,0': 'visible',
+    };
+    const combatEvents: unknown[] = [];
+    const bus = new EventBus();
+    bus.on('combat:resolved', payload => combatEvents.push(payload));
+
+    const result = processAITurn(state, 'ai-1', bus, {
+      purposefulAIEnabled: true,
+    });
+
+    expect(combatEvents).toHaveLength(0);
+    expect(result.units['beast-1']).toBeDefined();
+    expect(
+      Object.values(
+        result.opponentAI?.majorCivs['ai-1']?.defensePlansByCityId ?? {},
+      ),
+    ).toHaveLength(0);
+  });
+
   it('attacks an adjacent beast when enabled AND local strength advantage >= 1.5x', () => {
     // swordsman (str 25, health 100) vs badly wounded boar (str 18, health 20)
     // myStrength = 25; beastStrength = 18 * 0.2 = 3.6; 25 >= 3.6 * 1.5 → attack

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1161,12 +1161,20 @@ describe('processAITurn', () => {
   it('assaults and occupies an exposed enemy city', () => {
     const state = makeAdjacentExposedCityState({ population: 5 });
     const bus = new EventBus();
+    const moves: GameEvents['unit:move'][] = [];
+    bus.on('unit:move', event => moves.push(event));
 
     const result = processAITurn(state, 'ai-1', bus);
 
     expect(result.cities['city-player'].owner).toBe('ai-1');
     expect(result.cities['city-player'].population).toBe(2);
     expect(result.cities['city-player'].occupation?.turnsRemaining).toBe(10);
+    expect(moves).toHaveLength(1);
+    expect(moves[0]).toMatchObject({
+      unitId: 'ai-attacker',
+      from: { q: 0, r: 0 },
+      to: { q: 1, r: 0 },
+    });
   });
 
   it('emits territory tile-flipped events when AI captures an improved city tile', () => {
@@ -1265,12 +1273,23 @@ describe('processAITurn', () => {
   it('AI settler founds a city when possible', () => {
     const state = createNewGame(undefined, 'ai-test');
     const bus = new EventBus();
+    const founded: GameEvents['city:founded'][] = [];
+    bus.on('city:founded', event => founded.push(event));
     const newState = processAITurn(state, 'ai-1', bus);
     const aiCiv = newState.civilizations['ai-1'];
     // AI should try to found a city with its settler
     expect(aiCiv.cities.length + Object.values(newState.units).filter(
       u => u.owner === 'ai-1' && u.type === 'settler'
     ).length).toBeGreaterThanOrEqual(1);
+    expect(founded).toHaveLength(aiCiv.cities.length);
+    expect(founded[0]).toMatchObject({
+      founderId: 'ai-1',
+      city: {
+        id: aiCiv.cities[0],
+        owner: 'ai-1',
+      },
+    });
+    expect(newState.cities[aiCiv.cities[0]].productionQueue).toEqual(['warrior']);
   });
 
   it('does not found an AI city inside the shared city spacing boundary', () => {

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -9,7 +9,7 @@ import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
 import { createEmptyMajorCivPlanPortfolio } from '@/core/opponent-ai-state';
 import type { GameEvents, GameState } from '@/core/types';
-import { foundCity } from '@/systems/city-system';
+import { BUILDINGS, foundCity } from '@/systems/city-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
 import { hexKey, hexDistance } from '@/systems/hex-utils';
 import { tickLegendaryWonderProjects } from '@/systems/legendary-wonder-system';
@@ -81,6 +81,13 @@ describe('purposeful AI war gating', () => {
       .toBe(true);
     expect(canDeclareWarForPreparedPlan(state, prepared, 'ai-2'))
       .toBe(false);
+    state.cities[city.id] = {
+      ...state.cities[city.id],
+      owner: 'third-party-owner',
+    };
+    expect(canDeclareWarForPreparedPlan(state, prepared, 'player'))
+      .toBe(false);
+    state.cities[city.id] = city;
     if (!state.opponentAI) throw new Error('missing opponent AI state');
     state.opponentAI.migrationGraceRoundsRemaining = 1;
     expect(canDeclareWarForPreparedPlan(state, prepared, 'player'))
@@ -109,6 +116,117 @@ describe('purposeful AI administrative intel', () => {
     perception.knownCities = [];
 
     expect(chooseAiSpyTarget(state, aiId, perception)).toBeNull();
+  });
+
+  it('plans production from remembered resource ownership instead of hidden live changes', () => {
+    const state = createNewGame(undefined, 'purposeful-remembered-resource', 'small');
+    const aiId = 'ai-1';
+    state.turn = 10;
+    const settler = state.civilizations[aiId].units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler');
+    if (!settler) throw new Error('missing AI settler');
+    const city = foundCity(
+      aiId,
+      settler.position,
+      state.map,
+      state.idCounters,
+    );
+    state.cities[city.id] = city;
+    state.civilizations[aiId].cities = [city.id];
+    for (const unitId of state.civilizations[aiId].units) {
+      delete state.units[unitId];
+    }
+    state.civilizations[aiId].units = [];
+    state.civilizations[aiId].techState.completed = ['gathering', 'foraging'];
+    state.builtNationalProjects = Object.fromEntries(
+      Object.entries(BUILDINGS)
+        .filter(([, building]) => Boolean(building.nationalProject))
+        .map(([buildingId]) => [
+          `${aiId}:${buildingId}`,
+          { civId: aiId, cityId: city.id, eraBuilt: state.era },
+        ]),
+    );
+
+    const resourceTile = Object.values(state.map.tiles).find(tile => {
+      const distance = hexDistance(city.position, tile.coord);
+      return distance >= 2 && distance <= 8;
+    });
+    if (!resourceTile) throw new Error('missing nearby resource tile');
+    const resourceKey = hexKey(resourceTile.coord);
+    state.civilizations[aiId].visibility.tiles = {
+      [resourceKey]: 'fog',
+    };
+    state.civilizations[aiId].visibility.lastSeen = {
+      [resourceKey]: {
+        coord: { ...resourceTile.coord },
+        terrain: resourceTile.terrain,
+        elevation: resourceTile.elevation,
+        resource: 'stone',
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: null,
+        hasRiver: resourceTile.hasRiver,
+        wonder: resourceTile.wonder,
+        observedTurn: state.turn - 1,
+        source: 'observed',
+      },
+    };
+    resourceTile.resource = 'stone';
+    resourceTile.owner = 'player';
+    resourceTile.improvement = 'quarry';
+
+    expect(buildMajorCivPerception(state, aiId).knownResources)
+      .toContainEqual(expect.objectContaining({
+        resource: 'stone',
+        owner: null,
+        confidence: 'remembered',
+      }));
+
+    const result = processAITurn(state, aiId, new EventBus(), {
+      purposefulAIEnabled: true,
+    });
+
+    expect(result.cities[city.id].productionQueue[0]).toBe('expedition');
+    expect(result.civilizations[aiId].techState.currentResearch).not.toBeNull();
+  });
+
+  it('does not move an exhausted spy toward a known foreign city', () => {
+    const state = createNewGame(undefined, 'purposeful-exhausted-spy', 'small');
+    const aiId = 'ai-1';
+    const spyStart = { q: 0, r: 0 };
+    const targetTile = Object.values(state.map.tiles).find(tile =>
+      hexDistance(spyStart, tile.coord) === 2);
+    if (!targetTile) throw new Error('missing spy target tile');
+    const targetCity = foundCity(
+      'player',
+      targetTile.coord,
+      state.map,
+      state.idCounters,
+    );
+    state.cities[targetCity.id] = targetCity;
+    state.civilizations.player.cities = [targetCity.id];
+    state.civilizations[aiId].knownCivilizations = ['player'];
+    state.civilizations[aiId].visibility.tiles = {
+      [hexKey(targetCity.position)]: 'visible',
+    };
+    state.units = {
+      'exhausted-spy': {
+        ...createUnit('spy_scout', aiId, spyStart, state.idCounters),
+        id: 'exhausted-spy',
+        movementPointsLeft: 0,
+      },
+    };
+    state.civilizations[aiId].units = ['exhausted-spy'];
+    state.civilizations.player.units = [];
+    state.espionage ??= {};
+    state.espionage[aiId] = createEspionageCivState();
+
+    const result = processAITurn(state, aiId, new EventBus(), {
+      purposefulAIEnabled: true,
+    });
+
+    expect(result.units['exhausted-spy'].position).toEqual(spyStart);
   });
 });
 
@@ -1528,6 +1646,26 @@ describe('processAITurn', () => {
     expect(result.cities['city-ai'].productionProgress).toBeGreaterThan(0);
     expect(lostEvents).toEqual([
       { civId: 'ai-1', cityId: 'city-ai', wonderId: 'grand-canal', goldRefund: 10, transferableProduction: 10 },
+    ]);
+  });
+
+  it('preserves legendary-wonder administration on the feature-enabled path', () => {
+    const state = makeLegendaryWonderAiFixture();
+    const bus = new EventBus();
+    const lostEvents: Array<{ wonderId: string; cityId: string }> = [];
+    bus.on('wonder:legendary-lost', event => lostEvents.push(event));
+
+    const result = processAITurn(state, 'ai-1', bus, {
+      purposefulAIEnabled: true,
+    });
+
+    expect(result.legendaryWonderProjects!['grand-canal'].phase)
+      .toBe('lost_race');
+    expect(lostEvents).toEqual([
+      expect.objectContaining({
+        wonderId: 'grand-canal',
+        cityId: 'city-ai',
+      }),
     ]);
   });
 

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -1,6 +1,13 @@
-import { processAITurn } from '@/ai/basic-ai';
+import {
+  canDeclareWarForPreparedPlan,
+  chooseAiSpyTarget,
+  processAITurn,
+} from '@/ai/basic-ai';
+import { buildMajorCivPerception } from '@/ai/ai-perception';
+import type { PreparedMajorCivPlan } from '@/ai/ai-prepared-turn';
 import { createNewGame } from '@/core/game-state';
 import { EventBus } from '@/core/event-bus';
+import { createEmptyMajorCivPlanPortfolio } from '@/core/opponent-ai-state';
 import type { GameEvents, GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
 import { createEspionageCivState, createSpyFromUnit } from '@/systems/espionage-system';
@@ -11,6 +18,99 @@ import { getCivAvailableResources } from '@/systems/resource-acquisition-system'
 import type { ResourceType } from '@/core/types';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+describe('purposeful AI war gating', () => {
+  it('allows war only for the known primary target after mobilization', () => {
+    const state = createNewGame(undefined, 'purposeful-war-gate', 'small');
+    const aiId = 'ai-1';
+    const playerSettler = state.civilizations.player.units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler');
+    if (!playerSettler) throw new Error('missing player settler');
+    const city = foundCity(
+      'player',
+      playerSettler.position,
+      state.map,
+      state.idCounters,
+    );
+    state.cities[city.id] = city;
+    state.civilizations.player.cities = [city.id];
+    state.civilizations[aiId].knownCivilizations = ['player'];
+    state.civilizations[aiId].visibility.tiles[hexKey(city.position)] = 'visible';
+    const portfolio = createEmptyMajorCivPlanPortfolio();
+    portfolio.primaryPlan = {
+      id: 'capture-player',
+      actorId: aiId,
+      objective: 'capture',
+      target: {
+        kind: 'city',
+        id: city.id,
+        lastKnownPosition: city.position,
+      },
+      theaterId: 'player-front',
+      phase: 'mobilizing',
+      reasonCodes: ['continue-active-war'],
+      commitment: 0.8,
+      createdTurn: state.turn,
+      reconsiderAfterTurn: state.turn + 2,
+      expiresAfterTurn: state.turn + 8,
+      lastProgressTurn: state.turn,
+      requiredRoles: { capture: 1 },
+      assignedUnitIds: [],
+    };
+    const perception = buildMajorCivPerception(state, aiId);
+    const prepared: PreparedMajorCivPlan = {
+      civId: aiId,
+      perception,
+      portfolio,
+      assignments: {
+        portfolio,
+        assignmentsByPlanId: {},
+        recoveryUnitIds: [],
+        forceDemands: [],
+        rejectedByUnitId: {},
+      },
+      forceDemands: [],
+      traces: [],
+    };
+
+    expect(canDeclareWarForPreparedPlan(state, prepared, 'player'))
+      .toBe(false);
+    portfolio.primaryPlan.phase = 'advancing';
+    expect(canDeclareWarForPreparedPlan(state, prepared, 'player'))
+      .toBe(true);
+    expect(canDeclareWarForPreparedPlan(state, prepared, 'ai-2'))
+      .toBe(false);
+    if (!state.opponentAI) throw new Error('missing opponent AI state');
+    state.opponentAI.migrationGraceRoundsRemaining = 1;
+    expect(canDeclareWarForPreparedPlan(state, prepared, 'player'))
+      .toBe(false);
+  });
+});
+
+describe('purposeful AI administrative intel', () => {
+  it('does not select a live foreign city absent from prepared perception', () => {
+    const state = createNewGame(undefined, 'purposeful-hidden-spy-city', 'small');
+    const aiId = 'ai-1';
+    const playerSettler = state.civilizations.player.units
+      .map(id => state.units[id])
+      .find(unit => unit?.type === 'settler');
+    if (!playerSettler) throw new Error('missing player settler');
+    const city = foundCity(
+      'player',
+      playerSettler.position,
+      state.map,
+      state.idCounters,
+    );
+    state.cities[city.id] = city;
+    state.civilizations.player.cities = [city.id];
+    state.civilizations[aiId].knownCivilizations = ['player'];
+    const perception = buildMajorCivPerception(state, aiId);
+    perception.knownCities = [];
+
+    expect(chooseAiSpyTarget(state, aiId, perception)).toBeNull();
+  });
+});
 
 function makeAiRebelState(): GameState {
   return {

--- a/tests/input/city-assault-flow.test.ts
+++ b/tests/input/city-assault-flow.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
 import type { GameState } from '@/core/types';
 import { foundCity } from '@/systems/city-system';
@@ -39,6 +40,8 @@ function makePlayerAssaultState({ population }: { population: number }): GameSta
     ownedTiles: [{ q: 1, r: 0 }],
   };
   state.civilizations['ai-1'].cities = ['athens'];
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
 
   return state;
 }
@@ -46,16 +49,38 @@ function makePlayerAssaultState({ population }: { population: number }): GameSta
 describe('city-assault-flow', () => {
   it('begins a pending player choice by moving onto a size-2 city and finalizes occupy in place', () => {
     const state = makePlayerAssaultState({ population: 4 });
+    const bus = new EventBus();
+    const moved = vi.fn();
+    bus.on('unit:move', moved);
 
-    const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    const begun = beginPlayerCityAssaultChoice(
+      state,
+      'unit-1',
+      'athens',
+      bus,
+    );
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
 
+    expect(moved).toHaveBeenCalledOnce();
     expect(begun.pending.occupiedPopulation).toBe(2);
     expect(begun.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
     expect(begun.state.units['unit-1'].movementPointsLeft).toBe(0);
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
     expect(result.state.units['unit-1'].movementPointsLeft).toBe(0);
     expect(result.state.cities.athens.owner).toBe('player');
+  });
+
+  it('rejects a city assault when war has not been declared', () => {
+    const state = makePlayerAssaultState({ population: 4 });
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    expect(() => beginPlayerCityAssaultChoice(
+      state,
+      'unit-1',
+      'athens',
+      new EventBus(),
+    )).toThrow('Cannot begin city assault: not-at-war');
   });
 
   it('begins a pending player choice by moving onto a size-2 city and finalizes raze in place', () => {

--- a/tests/input/foreign-city-entry-flow.test.ts
+++ b/tests/input/foreign-city-entry-flow.test.ts
@@ -40,7 +40,9 @@ describe('foreign-city-entry-flow', () => {
     const state = makeForeignCityEntryState();
     const bus = new EventBus();
     const warDeclared = vi.fn();
+    const moved = vi.fn();
     bus.on('diplomacy:war-declared', warDeclared);
+    bus.on('unit:move', moved);
 
     const result = beginConfirmedForeignCityEntry(state, 'unit-1', 'athens', bus);
 
@@ -49,6 +51,7 @@ describe('foreign-city-entry-flow', () => {
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
     expect(result.pending.cityId).toBe('athens');
     expect(warDeclared).toHaveBeenCalledWith({ attackerId: 'player', defenderId: 'ai-1', opponentKind: 'major' });
+    expect(moved).toHaveBeenCalledOnce();
   });
 
   it('does not duplicate war declarations when already at war', () => {

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -65,6 +65,18 @@ describe('shared city assault wiring', () => {
     );
   });
 
+  it('does not enter capture flow when the surviving attacker cannot occupy a city', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const playerAssault = main.slice(
+      main.indexOf('function beginPlayerCityAssault('),
+      main.indexOf('function executeAttack('),
+    );
+
+    expect(playerAssault).toMatch(
+      /if \(!attacker \|\| !canUnitOccupyCity\(attacker\)\) return 'resolved';/,
+    );
+  });
+
   it('routes player and legacy AI capture transitions through the shared emitter', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     const basicAi = readFileSync(

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -3,8 +3,6 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import type { NotificationEntry } from '@/core/notification-log';
 import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
-import { hexKey } from '@/systems/hex-utils';
-import type { HexCoord } from '@/core/types';
 
 const PROJECT_ROOT = resolve(__dirname, '..');
 
@@ -30,6 +28,65 @@ describe('completed-round AI wiring', () => {
     expect(main).not.toContain('processAITurn(');
     expect(main).not.toContain("getAIPlayers(");
     expect(main).not.toContain("'ai-1'");
+  });
+});
+
+describe('shared city founding wiring', () => {
+  it('routes both the live player action and legacy AI through foundCityInState', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const basicAi = readFileSync(
+      resolve(PROJECT_ROOT, 'src/ai/basic-ai.ts'),
+      'utf8',
+    );
+    const playerFlow = main.slice(
+      main.indexOf('function foundCityAction(): void'),
+      main.indexOf('function performWorkerAction('),
+    );
+
+    expect(playerFlow).toContain(
+      'foundCityInState(gameState, selectedUnitId, bus)',
+    );
+    expect(playerFlow).not.toContain('const city = foundCity(');
+    expect(basicAi).toContain(
+      'foundCityInState(newState, settler.id, bus)',
+    );
+  });
+});
+
+describe('shared city assault wiring', () => {
+  it('passes the live event bus and exact post-combat result into canonical assault', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main).toMatch(
+      /beginPlayerCityAssaultChoice\(\s*gameState,\s*attackerId,\s*cityId,\s*bus,\s*precedingCombat,\s*\)/,
+    );
+    expect(main).toMatch(
+      /beginPlayerCityAssault\(\s*attackerId,\s*cityAtTarget\.id,\s*attackerBonus,\s*result,\s*\)/,
+    );
+  });
+
+  it('routes player and legacy AI capture transitions through the shared emitter', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const basicAi = readFileSync(
+      resolve(PROJECT_ROOT, 'src/ai/basic-ai.ts'),
+      'utf8',
+    );
+
+    expect(main).toContain('emitMajorCityCaptureEvents(');
+    expect(basicAi).toContain('emitMajorCityCaptureEvents(');
+  });
+
+  it('does not resolve minor-civilization conquest after failed movement', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const minorCaptureFlow = main.slice(
+      main.indexOf('function executeMinorCivConquest('),
+      main.indexOf('function handleGiftGold('),
+    );
+
+    expect(minorCaptureFlow).toContain(
+      'const movement = executeAnimatedUnitMove(',
+    );
+    expect(minorCaptureFlow).toMatch(/if \(!movement\.ok\) return;/);
   });
 });
 
@@ -72,64 +129,5 @@ describe('era:advanced notification', () => {
     expect(toastCalls).toHaveLength(1);
     expect(toastCalls[0]!.message).toContain('Era 3');
     expect(factionCalls).toHaveLength(0);
-  });
-});
-
-// ─── Post-move hostile city detection (#264) ─────────────────────────────────
-// Tests the detection logic added inside animateMovedUnit in main.ts.
-// Follows the pattern in tests/integration/city-hex-tap.test.ts: inline the
-// pure detection helper so there's no DOM or module-mocking overhead, but the
-// conditions are proven. If the production logic in animateMovedUnit diverges,
-// these tests will still pass — they prove correctness of the algorithm, not
-// of the wiring. The wiring is covered by the tap-intent regression tests.
-
-type SlimCity = { id: string; owner: string; position: HexCoord };
-type SlimCivs = Record<string, { diplomacy?: { atWarWith?: string[] } }>;
-
-function findHostileWarCity(
-  cities: Record<string, SlimCity>,
-  civilizations: SlimCivs,
-  position: HexCoord,
-  ownerCivId: string,
-): string | null {
-  const key = hexKey(position);
-  const entry = Object.entries(cities).find(([, city]) =>
-    hexKey(city.position) === key
-    && city.owner !== ownerCivId
-    && !city.owner.startsWith('mc-')
-    && (civilizations[ownerCivId]?.diplomacy?.atWarWith?.includes(city.owner) ?? false),
-  );
-  return entry ? entry[0] : null;
-}
-
-describe('post-move hostile city detection', () => {
-  it('detects a hostile at-war major-civ city at the unit landing position', () => {
-    const cities = { 'city-1': { id: 'city-1', owner: 'ai-1', position: { q: 3, r: 2 } } };
-    const civs: SlimCivs = { player: { diplomacy: { atWarWith: ['ai-1'] } } };
-
-    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBe('city-1');
-  });
-
-  it('does not trigger for a city the player is not at war with (allied / neutral)', () => {
-    const cities = { 'city-1': { id: 'city-1', owner: 'ai-1', position: { q: 3, r: 2 } } };
-    const civs: SlimCivs = { player: { diplomacy: { atWarWith: [] } } };
-
-    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
-  });
-
-  it('does not trigger for a minor civ city (owner starts with mc-)', () => {
-    const cities = { 'mc-abc': { id: 'mc-abc', owner: 'mc-abc', position: { q: 3, r: 2 } } };
-    const civs: SlimCivs = { player: { diplomacy: { atWarWith: ['mc-abc'] } } };
-
-    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
-  });
-
-  it('does not trigger when the mover owns the city (own-city landing)', () => {
-    // The animateMovedUnit guard `c.owner !== gameState.currentPlayer` prevents
-    // a player from assaulting their own city. Verify the algorithm excludes it.
-    const cities = { 'city-1': { id: 'city-1', owner: 'player', position: { q: 3, r: 2 } } };
-    const civs: SlimCivs = { player: { diplomacy: { atWarWith: [] } } };
-
-    expect(findHostileWarCity(cities, civs, { q: 3, r: 2 }, 'player')).toBeNull();
   });
 });

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -1,10 +1,19 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
 import type { GameEvents, GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { foundCity } from '@/systems/city-system';
+import { resolveCombat } from '@/systems/combat-system';
+import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import { createUnit } from '@/systems/unit-system';
 import { makeBreakawayFixture } from './helpers/breakaway-fixture';
-import { resolveMajorCityCapture, transferCapturedCityOwnership } from '@/systems/city-capture-system';
+import {
+  beginMajorCityAssault,
+  emitMajorCityCaptureEvents,
+  resolveMajorCityCapture,
+  transferCapturedCityOwnership,
+} from '@/systems/city-capture-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -54,6 +63,238 @@ describe('city-capture-system', () => {
       },
     };
   }
+
+  function makeMajorAssaultState(): GameState {
+    const state = makeExposedCityCaptureState({
+      population: 4,
+      buildings: [],
+    });
+    const attacker = createUnit(
+      'swordsman',
+      'player',
+      { q: 0, r: 0 },
+      state.idCounters,
+    );
+    attacker.id = 'attacker';
+    attacker.movementPointsLeft = 2;
+    state.units = { [attacker.id]: attacker };
+    state.civilizations.player.units = [attacker.id];
+    state.civilizations['ai-1'].units = [];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.map.tiles['0,0'].terrain = 'grassland';
+    state.map.tiles['1,0'].terrain = 'grassland';
+    return state;
+  }
+
+  it('begins a legal major-city assault through canonical movement without mutating input', () => {
+    const state = makeMajorAssaultState();
+    const before = structuredClone(state);
+    const bus = new EventBus();
+    const moved = vi.fn();
+    bus.on('unit:move', moved);
+
+    const result = beginMajorCityAssault(
+      state,
+      'attacker',
+      'athens',
+      { actor: 'player', civId: 'player', bus },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(state).toEqual(before);
+    expect(result.state.units.attacker.position).toEqual({ q: 1, r: 0 });
+    expect(result.state.units.attacker.movementPointsLeft).toBe(0);
+    expect(result.pending.cityId).toBe('athens');
+    expect(moved).toHaveBeenCalledOnce();
+  });
+
+  it('emits capture, territory, and elimination transitions from one shared helper', () => {
+    const state = makeMajorAssaultState();
+    const result = resolveMajorCityCapture(
+      state,
+      'athens',
+      'player',
+      'occupy',
+      state.turn,
+    );
+    const bus = new EventBus();
+    const captured = vi.fn();
+    const flipped = vi.fn();
+    const eliminated = vi.fn();
+    bus.on('city:captured', captured);
+    bus.on('territory:tile-flipped', flipped);
+    bus.on('civ:eliminated', eliminated);
+
+    emitMajorCityCaptureEvents(
+      state,
+      result,
+      'athens',
+      'player',
+      'ai-1',
+      bus,
+    );
+
+    expect(captured).toHaveBeenCalledOnce();
+    expect(flipped).toHaveBeenCalled();
+    expect(eliminated).toHaveBeenCalledWith({
+      civId: 'ai-1',
+      eliminatedBy: 'player',
+    });
+  });
+
+  it('does not re-emit near-defeat when the former owner was already there', () => {
+    const state = makeMajorAssaultState();
+    const second = foundCity(
+      'ai-1',
+      { q: 4, r: 4 },
+      state.map,
+      state.idCounters,
+    );
+    second.id = 'sparta';
+    state.cities[second.id] = second;
+    state.civilizations['ai-1'].cities.push(second.id);
+    state.civilizations['ai-1'].nearDefeat = true;
+    const result = resolveMajorCityCapture(
+      state,
+      'athens',
+      'player',
+      'occupy',
+      state.turn,
+    );
+    const bus = new EventBus();
+    const nearDefeat = vi.fn();
+    bus.on('civ:near-defeat', nearDefeat);
+
+    emitMajorCityCaptureEvents(
+      state,
+      result,
+      'athens',
+      'player',
+      'ai-1',
+      bus,
+    );
+
+    expect(nearDefeat).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: 'peace',
+      mutate: (state: GameState) => {
+        state.civilizations.player.diplomacy.atWarWith = [];
+        state.civilizations['ai-1'].diplomacy.atWarWith = [];
+      },
+      reason: 'not-at-war',
+    },
+    {
+      name: 'exhausted movement',
+      mutate: (state: GameState) => {
+        state.units.attacker.movementPointsLeft = 0;
+      },
+      reason: 'illegal-movement',
+    },
+    {
+      name: 'occupied destination',
+      mutate: (state: GameState) => {
+        const defender = createUnit(
+          'warrior',
+          'ai-1',
+          { q: 1, r: 0 },
+          state.idCounters,
+        );
+        defender.id = 'city-defender';
+        state.units[defender.id] = defender;
+        state.civilizations['ai-1'].units.push(defender.id);
+      },
+      reason: 'city-defended',
+    },
+    {
+      name: 'impassable terrain',
+      mutate: (state: GameState) => {
+        state.map.tiles['1,0'].terrain = 'coast';
+      },
+      reason: 'illegal-movement',
+    },
+    {
+      name: 'non-capturing siege unit',
+      mutate: (state: GameState) => {
+        state.units.attacker.type = 'catapult';
+      },
+      reason: 'cannot-capture',
+    },
+  ])('rejects a major-city assault during $name', ({ mutate, reason }) => {
+    const state = makeMajorAssaultState();
+    mutate(state);
+    const before = structuredClone(state);
+
+    const result = beginMajorCityAssault(
+      state,
+      'attacker',
+      'athens',
+      { actor: 'ai', civId: 'player' },
+    );
+
+    expect(result).toMatchObject({ ok: false, reason });
+    expect(state).toEqual(before);
+  });
+
+  it('allows only the exact surviving attacker to advance after defeating the final city defender', () => {
+    const state = makeMajorAssaultState();
+    const defender = createUnit(
+      'warrior',
+      'ai-1',
+      { q: 1, r: 0 },
+      state.idCounters,
+    );
+    defender.id = 'city-defender';
+    defender.health = 1;
+    state.units[defender.id] = defender;
+    state.civilizations['ai-1'].units.push(defender.id);
+    const combat = resolveCombat(
+      state.units.attacker,
+      defender,
+      state.map,
+      42,
+      undefined,
+      state.era,
+    );
+    const afterCombat = applyCombatOutcomeToState(state, combat, 42).state;
+
+    const result = beginMajorCityAssault(
+      afterCombat,
+      'attacker',
+      'athens',
+      {
+        actor: 'ai',
+        civId: 'player',
+        precedingCombat: combat,
+      },
+    );
+
+    expect(combat.attackerSurvived).toBe(true);
+    expect(combat.defenderSurvived).toBe(false);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.units.attacker.position).toEqual({ q: 1, r: 0 });
+    expect(result.state.units.attacker.hasActed).toBe(true);
+
+    const wrongAttacker = beginMajorCityAssault(
+      afterCombat,
+      'attacker',
+      'athens',
+      {
+        actor: 'ai',
+        civId: 'player',
+        precedingCombat: { ...combat, attackerId: 'somebody-else' },
+      },
+    );
+    expect(wrongAttacker).toMatchObject({
+      ok: false,
+      reason: 'invalid-post-combat-advance',
+    });
+  });
 
   it('keeps instability pressure when the former owner reconquers its own breakaway city', () => {
     const { state, cityId } = makeBreakawayFixture({ breakawayStartedTurn: 12 });

--- a/tests/systems/city-founding-system.test.ts
+++ b/tests/systems/city-founding-system.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, HexCoord } from '@/core/types';
+import { foundCityInState } from '@/systems/city-founding-system';
+import { foundCity } from '@/systems/city-system';
+import { cityDistance } from '@/systems/city-territory-system';
+import { hexKey } from '@/systems/hex-utils';
+
+function getSettlerId(state: GameState, civId: string): string {
+  const settlerId = state.civilizations[civId].units
+    .find(unitId => state.units[unitId]?.type === 'settler');
+  if (!settlerId) throw new Error(`missing settler for ${civId}`);
+  return settlerId;
+}
+
+function findDistantLand(
+  state: GameState,
+  from: HexCoord,
+  minimumDistance = 4,
+): HexCoord {
+  const tile = Object.values(state.map.tiles).find(candidate =>
+    candidate.terrain !== 'ocean'
+    && candidate.terrain !== 'coast'
+    && candidate.terrain !== 'mountain'
+    && cityDistance(candidate.coord, from, state.map) >= minimumDistance);
+  if (!tile) throw new Error('missing distant land tile');
+  return tile.coord;
+}
+
+describe('foundCityInState', () => {
+  it.each(['player', 'ai-1'])(
+    'applies the same complete founding mutation for %s',
+    civId => {
+      const state = createNewGame(undefined, `founding-parity-${civId}`, 'small');
+      const settlerId = getSettlerId(state, civId);
+      const settlerPosition = { ...state.units[settlerId].position };
+      const before = structuredClone(state);
+      const bus = new EventBus();
+      const founded = vi.fn();
+      bus.on('city:founded', founded);
+
+      const result = foundCityInState(state, settlerId, bus);
+      const city = result.state.cities[result.cityId];
+
+      expect(state).toEqual(before);
+      expect(city).toBeDefined();
+      expect(city.owner).toBe(civId);
+      expect(result.state.units[settlerId]).toBeUndefined();
+      expect(result.state.civilizations[civId].units).not.toContain(settlerId);
+      expect(result.state.civilizations[civId].cities).toContain(result.cityId);
+      expect(result.state.map.tiles[hexKey(settlerPosition)].owner).toBe(civId);
+      expect(Object.values(result.state.legendaryWonderProjects ?? {})
+        .some(project => project.cityId === result.cityId && project.ownerId === civId))
+        .toBe(true);
+      expect(founded).toHaveBeenCalledOnce();
+      expect(founded).toHaveBeenCalledWith({
+        city: result.state.cities[result.cityId],
+        founderId: civId,
+      });
+    },
+  );
+
+  it('clears near-defeat and emits recovery when founding restores a second city', () => {
+    const state = createNewGame(undefined, 'founding-recovery', 'small');
+    const civId = 'ai-1';
+    const settlerId = getSettlerId(state, civId);
+    const existingPosition = findDistantLand(
+      state,
+      state.units[settlerId].position,
+    );
+    const existing = foundCity(
+      civId,
+      existingPosition,
+      state.map,
+      state.idCounters,
+    );
+    state.cities[existing.id] = existing;
+    state.civilizations[civId].cities = [existing.id];
+    state.civilizations[civId].nearDefeat = true;
+    const bus = new EventBus();
+    const recovered = vi.fn();
+    bus.on('civ:recovered-from-near-defeat', recovered);
+
+    const result = foundCityInState(state, settlerId, bus);
+
+    expect(result.state.civilizations[civId].cities).toHaveLength(2);
+    expect(result.state.civilizations[civId].nearDefeat).toBe(false);
+    expect(recovered).toHaveBeenCalledOnce();
+    expect(recovered).toHaveBeenCalledWith({ civId });
+  });
+
+  it('does not emit recovery from a stale city roster entry', () => {
+    const state = createNewGame(undefined, 'founding-stale-roster', 'small');
+    const civId = 'ai-1';
+    const settlerId = getSettlerId(state, civId);
+    state.civilizations[civId].cities = ['missing-city'];
+    state.civilizations[civId].nearDefeat = true;
+    const bus = new EventBus();
+    const recovered = vi.fn();
+    bus.on('civ:recovered-from-near-defeat', recovered);
+
+    const result = foundCityInState(state, settlerId, bus);
+
+    expect(result.state.civilizations[civId].nearDefeat).toBe(true);
+    expect(result.state.civilizations[civId].cities).toEqual([result.cityId]);
+    expect(recovered).not.toHaveBeenCalled();
+  });
+
+  it('enforces canonical city spacing without consuming the settler', () => {
+    const state = createNewGame(undefined, 'founding-spacing', 'small');
+    const civId = 'player';
+    const settlerId = getSettlerId(state, civId);
+    const nearby = foundCity(
+      civId,
+      { ...state.units[settlerId].position },
+      state.map,
+      state.idCounters,
+    );
+    state.cities[nearby.id] = nearby;
+    state.civilizations[civId].cities = [nearby.id];
+    const before = structuredClone(state);
+
+    expect(() => foundCityInState(state, settlerId, new EventBus()))
+      .toThrow('City cannot be founded here');
+    expect(state).toEqual(before);
+  });
+
+  it('rejects an exhausted settler without mutating the input', () => {
+    const state = createNewGame(undefined, 'founding-exhausted', 'small');
+    const settlerId = getSettlerId(state, 'player');
+    state.units[settlerId].hasActed = true;
+    const before = structuredClone(state);
+
+    expect(() => foundCityInState(state, settlerId, new EventBus()))
+      .toThrow('Settler has already acted');
+    expect(state).toEqual(before);
+  });
+});

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -532,6 +532,7 @@ describe('performEstablishOutpost', () => {
     expect(tile.improvementTurnsLeft).toBe(2);
     expect(tile.owner).toBe('player');
     expect(newState.units[unitId]).toBeUndefined();
+    expect(newState.civilizations.player.units).not.toContain(unitId);
   });
 
   it('is unavailable when tile is already in civ city territory (canEstablishOutpost = false)', () => {

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -1,6 +1,7 @@
 import { EventBus } from '@/core/event-bus';
 import type { GameEvents, GameMap, GameState, HexCoord, HexTile, TerrainType, Unit } from '@/core/types';
 import { createUnit } from '@/systems/unit-system';
+import { foundCity } from '@/systems/city-system';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey } from '@/systems/hex-utils';
 import { abandonWorkerTask, executeUnitMove } from '@/systems/unit-movement-system';
@@ -98,6 +99,119 @@ function movementState(
 }
 
 describe('unit-movement-system', () => {
+  it('reserves foreign-city entry for an explicit canonical capture flow', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    const foreign = createUnit('worker', 'ai-1', { q: 7, r: 7 }, mkC());
+    foreign.id = 'foreign';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+    ], { extraUnits: [foreign] });
+    const city = foundCity(
+      'ai-1',
+      { q: 1, r: 0 },
+      state.map,
+      state.idCounters,
+    );
+    city.id = 'foreign-city';
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+
+    const ordinaryMove = executeUnitMove(
+      state,
+      'mover',
+      city.position,
+      { actor: 'player', civId: 'player' },
+    );
+
+    expect(ordinaryMove).toMatchObject({
+      ok: false,
+      reason: 'foreign-city',
+    });
+    expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
+
+    const captureMove = executeUnitMove(
+      state,
+      'mover',
+      city.position,
+      {
+        actor: 'player',
+        civId: 'player',
+        foreignCityEntryId: city.id,
+      },
+    );
+    expect(captureMove.ok).toBe(true);
+    expect(state.units.mover.position).toEqual(city.position);
+  });
+
+  it('does not path through a foreign city without an alliance', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    const foreign = createUnit('worker', 'ai-1', { q: 7, r: 7 }, mkC());
+    foreign.id = 'foreign';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+      tile({ q: 2, r: 0 }),
+    ], { extraUnits: [foreign] });
+    const city = foundCity(
+      'ai-1',
+      { q: 1, r: 0 },
+      state.map,
+      state.idCounters,
+    );
+    city.id = 'foreign-city';
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+
+    const result = executeUnitMove(
+      state,
+      'mover',
+      { q: 2, r: 0 },
+      { actor: 'player', civId: 'player' },
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: 'foreign-city' });
+    expect(state.units.mover.position).toEqual({ q: 0, r: 0 });
+  });
+
+  it('preserves peaceful allied city entry', () => {
+    const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
+    mover.id = 'mover';
+    const foreign = createUnit('worker', 'ai-1', { q: 7, r: 7 }, mkC());
+    foreign.id = 'foreign';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+    ], { extraUnits: [foreign] });
+    const city = foundCity(
+      'ai-1',
+      { q: 1, r: 0 },
+      state.map,
+      state.idCounters,
+    );
+    city.id = 'allied-city';
+    state.cities[city.id] = city;
+    state.civilizations['ai-1'].cities = [city.id];
+    state.civilizations.player.diplomacy.treaties.push({
+      type: 'alliance',
+      civA: 'player',
+      civB: 'ai-1',
+      turnsRemaining: 5,
+    });
+
+    const result = executeUnitMove(
+      state,
+      'mover',
+      city.position,
+      { actor: 'player', civId: 'player' },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(state.units.mover.position).toEqual(city.position);
+  });
+
   it('refuses to execute movement onto an occupied foreign unit tile', () => {
     const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
     mover.id = 'mover';


### PR DESCRIPTION
## Summary

- add deterministic, legality-first tactical ranking with cohesion, retreat, transport, worker, settlement, outpost, combat, and capture actions
- execute major-civilization plans through canonical movement, combat, founding, capture, resource, transport, and worker systems
- integrate the prepared strategic path into the shared AI scheduler while preserving production, research, wonders, quests, trade, diplomacy, espionage, pirate behavior, hot-seat scheduling, and save migration behavior
- keep the replacement path behind `PURPOSEFUL_AI_FEATURE_ENABLED`; live games continue using the established AI path

Part of #412.

## Gameplay impact

This completes MR3 / Tasks 14–16 of the purposeful-opponent plan. When explicitly enabled in tests, major civilizations rally before attacking, prefer legal coordinated actions, preserve capture units and support cohesion, retreat damaged forces, and resolve founding/capture consequences through the same systems as human players.

The feature flag remains off. There are no new live UI controls, renderer changes, or SFX assets in this MR. Existing movement, combat, founding, capture, and notification events remain the presentation/audio contract for the future rollout.

## Inline review fixes

The final inline review found and fixed:

- feature-enabled AI treating beasts as strategic hostiles when beast contests were disabled
- tactical attacks against tribute-protected or employer-aligned pirate factions
- mobilizing forces losing their legal rally move because attacks were filtered after scratch-state selection
- war declarations against a stale former owner after the planned city changed hands
- remembered resource planning reading hidden live ownership/improvement state
- exhausted spies moving again through the legacy direct movement helper
- non-capturing siege units entering the player capture flow after defeating a city’s final defender

AI hostility policy is now centralized, spy movement uses canonical movement validation/events, and each issue has focused regression coverage.

## Out of scope

- MR4 Tasks 17–19: strategy-aware production, research, and upgrades
- MR5 Tasks 20–22: purposeful barbarians, minor civilizations, and pirates
- MR6 Tasks 23–25: pressure governor, strategic warnings/SFX, simulations, tuning, challenge activation, and legacy-path removal

## Why this is safe to merge partial

All new strategic execution remains behind the false rollout flag. No player-visible challenge surface is activated and no incomplete action is exposed. The only shared live-path changes are canonical correctness fixes for city founding, city assault/capture, foreign-city movement validation, and expedition roster cleanup; these paths have player/AI parity regressions. UI and audio continue consuming the existing typed gameplay events.

## Verification

- `scripts/check-src-rule-violations.sh` for every changed `src/` file
- focused regression suite: 18 files, 282 tests passed
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn test`: 4,770 passed, 2 skipped
- reviewed `origin/main...HEAD` and confirmed the worktree is clean

## Screenshots

Not applicable: this MR introduces no visible UI or renderer changes.
