### PR TITLE
feat(era12): Task 2 — 12 buildings, trainedFromBuilding filter

### DIFF
--- a/src/renderer/sprites/buildings.tsx
+++ b/src/renderer/sprites/buildings.tsx
@@ -2966,3 +2966,245 @@ export function StrategicAirCommandSprite({ palette, svgOnly = false }: Building
     </BuildingFrame>
   );
 }
+
+/* === ERA 12 BUILDINGS (placeholder art) === */
+
+export function AutomatedPortSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Automated Port" category="economy" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="16" y="96" width="160" height="40" rx="2" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1.2" />
+      {/* crane arm */}
+      <rect x="32" y="56" width="6" height="40" rx="1" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1" />
+      <rect x="32" y="56" width="60" height="5" rx="1" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1" />
+      <line x1="86" y1="61" x2="86" y2="92" stroke={P.metal.iron} strokeWidth="1.2" />
+      {/* shipping container */}
+      <rect x="70" y="92" width="36" height="20" rx="2" fill={palette.bright} stroke={P.ink.line} strokeWidth="1" />
+      <line x1="88" y1="92" x2="88" y2="112" stroke={P.ink.line} strokeWidth="0.8" />
+      {/* water */}
+      <rect x="16" y="136" width="160" height="8" rx="2" fill="#3a7abf" opacity="0.5" />
+      <Banner x={140} y={30} palette={palette} scale={0.6} />
+    </BuildingFrame>
+  );
+}
+
+export function BiotechLabSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Biotech Lab" category="science" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="24" y="72" width="144" height="64" rx="3" fill="#e8f0e8" stroke={P.ink.line} strokeWidth="1.2" />
+      <rect x="24" y="72" width="144" height="14" rx="3" fill={palette.dark} stroke={P.ink.line} strokeWidth="1" />
+      {/* DNA helix suggestion */}
+      <path d="M72,96 Q84,108 72,120" fill="none" stroke="#22aa44" strokeWidth="2" />
+      <path d="M96,96 Q84,108 96,120" fill="none" stroke="#2244aa" strokeWidth="2" />
+      <line x1="78" y1="102" x2="90" y2="102" stroke={P.ink.line} strokeWidth="1" />
+      <line x1="78" y1="114" x2="90" y2="114" stroke={P.ink.line} strokeWidth="1" />
+      {/* flask */}
+      <path d="M116,96 L110,126 L130,126 L124,96 Z" fill="#aaddaa" stroke="#22aa44" strokeWidth="1.2" />
+      <line x1="112" y1="104" x2="128" y2="104" stroke="#22aa44" strokeWidth="0.8" />
+      <Banner x={30} y={20} palette={palette} scale={0.7} />
+    </BuildingFrame>
+  );
+}
+
+export function BroadcastTowerSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Broadcast Tower" category="espionage" svgOnly={svgOnly}>
+      <BuildingPlinth w={80} />
+      {/* tower mast */}
+      <rect x="90" y="32" width="12" height="104" rx="2" fill={P.metal.steel} stroke={P.ink.line} strokeWidth="1" />
+      {/* crossbars */}
+      <line x1="64" y1="60" x2="128" y2="60" stroke={P.metal.iron} strokeWidth="2" />
+      <line x1="72" y1="76" x2="120" y2="76" stroke={P.metal.iron} strokeWidth="1.5" />
+      <line x1="80" y1="92" x2="112" y2="92" stroke={P.metal.iron} strokeWidth="1.2" />
+      {/* signal arcs */}
+      <path d="M40,64 Q96,20 152,64" fill="none" stroke={palette.bright} strokeWidth="1.5" opacity="0.7" strokeDasharray="4 3" />
+      <path d="M52,72 Q96,36 140,72" fill="none" stroke={palette.bright} strokeWidth="1.2" opacity="0.5" strokeDasharray="3 3" />
+      {/* base building */}
+      <rect x="52" y="116" width="88" height="20" rx="2" fill={P.stone.mid} stroke={P.ink.line} strokeWidth="1" />
+      <Banner x={24} y={80} palette={palette} scale={0.6} />
+    </BuildingFrame>
+  );
+}
+
+export function CyberDefenseCenterSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Cyber Defense Center" category="espionage" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="20" y="76" width="152" height="60" rx="3" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1.3" />
+      {/* server racks */}
+      <rect x="32" y="86" width="28" height="42" rx="2" fill="#111122" stroke={P.metal.steel} strokeWidth="1" />
+      <rect x="36" y="90" width="20" height="6" rx="1" fill="#002244" stroke="none" />
+      <rect x="36" y="100" width="20" height="6" rx="1" fill="#002244" stroke="none" />
+      <rect x="36" y="110" width="20" height="6" rx="1" fill="#002244" stroke="none" />
+      <circle cx="52" cy="93" r="2" fill="#00ff88" />
+      <circle cx="52" cy="103" r="2" fill="#00ff88" />
+      <circle cx="52" cy="113" r="2" fill="#ffaa00" />
+      {/* shield icon */}
+      <path d="M96,88 L120,88 L120,112 L108,124 L96,112 Z" fill={palette.mid} stroke={palette.bright} strokeWidth="1.5" />
+      <path d="M104,96 L112,104 M104,104 L112,96" stroke={palette.bright} strokeWidth="2" />
+      <Banner x={138} y={30} palette={palette} scale={0.65} />
+    </BuildingFrame>
+  );
+}
+
+export function DataCenterSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Data Center" category="science" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="16" y="72" width="160" height="64" rx="3" fill="#181830" stroke={P.metal.steel} strokeWidth="1.4" />
+      {/* rack rows */}
+      <rect x="24" y="80" width="32" height="48" rx="2" fill="#0a0a20" stroke={P.metal.steel} strokeWidth="0.8" />
+      <rect x="62" y="80" width="32" height="48" rx="2" fill="#0a0a20" stroke={P.metal.steel} strokeWidth="0.8" />
+      <rect x="100" y="80" width="32" height="48" rx="2" fill="#0a0a20" stroke={P.metal.steel} strokeWidth="0.8" />
+      <rect x="138" y="80" width="32" height="48" rx="2" fill="#0a0a20" stroke={P.metal.steel} strokeWidth="0.8" />
+      {/* status LEDs */}
+      <circle cx="48" cy="88" r="2" fill="#00aaff" />
+      <circle cx="48" cy="96" r="2" fill="#00aaff" />
+      <circle cx="86" cy="88" r="2" fill="#00ff44" />
+      <circle cx="86" cy="96" r="2" fill="#ffaa00" />
+      {/* cooling units */}
+      <rect x="16" y="136" width="160" height="8" rx="2" fill={P.stone.mid} stroke={P.ink.line} strokeWidth="0.8" />
+      <Banner x={30} y={20} palette={palette} scale={0.65} />
+    </BuildingFrame>
+  );
+}
+
+export function FintechHubSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Fintech Hub" category="economy" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      {/* glass office tower */}
+      <rect x="56" y="44" width="80" height="92" rx="3" fill="#b8d4e8" stroke={P.ink.line} strokeWidth="1.2" />
+      {/* window grid */}
+      <line x1="76" y1="44" x2="76" y2="136" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      <line x1="96" y1="44" x2="96" y2="136" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      <line x1="116" y1="44" x2="116" y2="136" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      <line x1="56" y1="64" x2="136" y2="64" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      <line x1="56" y1="84" x2="136" y2="84" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      <line x1="56" y1="104" x2="136" y2="104" stroke={P.stone.dark} strokeWidth="0.8" opacity="0.4" />
+      {/* currency symbol */}
+      <text x="86" y="118" fontSize="18" fill={P.metal.gold} textAnchor="middle" fontWeight="bold">$</text>
+      <Banner x={24} y={50} palette={palette} scale={0.65} />
+    </BuildingFrame>
+  );
+}
+
+export function GeneTherapyClinicSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Gene Therapy Clinic" category="science" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="24" y="76" width="144" height="60" rx="3" fill="#f0f4f0" stroke={P.ink.line} strokeWidth="1.2" />
+      <rect x="24" y="76" width="144" height="14" rx="3" fill={palette.dark} stroke={P.ink.line} strokeWidth="1" />
+      {/* cross symbol */}
+      <rect x="90" y="56" width="12" height="34" rx="2" fill="#dd2222" />
+      <rect x="82" y="64" width="28" height="12" rx="2" fill="#dd2222" />
+      {/* gene spiral */}
+      <path d="M52,92 Q60,100 52,112" fill="none" stroke="#44aa44" strokeWidth="2" />
+      <path d="M68,92 Q60,100 68,112" fill="none" stroke="#2244cc" strokeWidth="2" />
+      <line x1="55" y1="97" x2="65" y2="97" stroke={P.ink.line} strokeWidth="1" />
+      <line x1="55" y1="107" x2="65" y2="107" stroke={P.ink.line} strokeWidth="1" />
+      <Banner x={150} y={30} palette={palette} scale={0.6} />
+    </BuildingFrame>
+  );
+}
+
+export function PrecisionFarmSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Precision Farm" category="food" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      {/* tractor */}
+      <rect x="32" y="100" width="56" height="32" rx="3" fill={palette.mid} stroke={P.ink.line} strokeWidth="1.2" />
+      <circle cx="50" cy="132" r="10" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1.2" />
+      <circle cx="50" cy="132" r="5" fill={P.stone.mid} />
+      <circle cx="78" cy="132" r="7" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1" />
+      <circle cx="78" cy="132" r="3" fill={P.stone.mid} />
+      {/* GPS antenna on tractor */}
+      <line x1="66" y1="100" x2="66" y2="88" stroke={P.metal.steel} strokeWidth="1.5" />
+      <circle cx="66" cy="86" r="3" fill={palette.bright} stroke={P.ink.line} strokeWidth="0.8" />
+      {/* crop rows */}
+      <line x1="100" y1="96" x2="170" y2="96" stroke="#44aa22" strokeWidth="2" strokeDasharray="5 4" />
+      <line x1="100" y1="108" x2="170" y2="108" stroke="#44aa22" strokeWidth="2" strokeDasharray="5 4" />
+      <line x1="100" y1="120" x2="170" y2="120" stroke="#44aa22" strokeWidth="2" strokeDasharray="5 4" />
+      <Banner x={130} y={44} palette={palette} scale={0.65} />
+    </BuildingFrame>
+  );
+}
+
+export function SignalsHubSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Signals Hub" category="espionage" svgOnly={svgOnly}>
+      <BuildingPlinth w={120} />
+      {/* dish */}
+      <path d="M48,80 Q96,52 144,80" fill="none" stroke={P.metal.steel} strokeWidth="4" />
+      <line x1="96" y1="52" x2="96" y2="80" stroke={P.metal.steel} strokeWidth="2.5" />
+      <circle cx="96" cy="50" r="5" fill={palette.bright} stroke={P.ink.line} strokeWidth="1" />
+      {/* support pole */}
+      <rect x="90" y="80" width="12" height="56" rx="2" fill={P.metal.iron} stroke={P.ink.line} strokeWidth="1" />
+      {/* signal rings */}
+      <path d="M30,48 Q96,10 162,48" fill="none" stroke={palette.bright} strokeWidth="1.2" opacity="0.6" strokeDasharray="4 3" />
+      <path d="M46,60 Q96,28 146,60" fill="none" stroke={palette.bright} strokeWidth="1" opacity="0.4" strokeDasharray="3 3" />
+      <Banner x={24} y={84} palette={palette} scale={0.6} />
+    </BuildingFrame>
+  );
+}
+
+export function SmartGridSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Smart Grid" category="production" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      {/* power station */}
+      <rect x="20" y="84" width="80" height="52" rx="3" fill={P.stone.mid} stroke={P.ink.line} strokeWidth="1.2" />
+      {/* transformer */}
+      <rect x="110" y="92" width="36" height="40" rx="2" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1" />
+      <circle cx="128" cy="108" r="10" fill="none" stroke={P.metal.gold} strokeWidth="2" />
+      {/* power lines */}
+      <line x1="40" y1="84" x2="40" y2="64" stroke={P.metal.iron} strokeWidth="1.5" />
+      <line x1="60" y1="84" x2="60" y2="64" stroke={P.metal.iron} strokeWidth="1.5" />
+      <line x1="20" y1="66" x2="100" y2="66" stroke={P.metal.iron} strokeWidth="1.5" />
+      {/* lightning bolt */}
+      <path d="M86,54 L78,70 L84,70 L76,88 L92,68 L86,68 Z" fill="#ffdd00" stroke={P.ink.line} strokeWidth="0.8" />
+      <Banner x={146} y={44} palette={palette} scale={0.65} />
+    </BuildingFrame>
+  );
+}
+
+export function StealthAirbaseSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Stealth Airbase" category="military" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      {/* reinforced hangar */}
+      <rect x="16" y="80" width="160" height="56" rx="4" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1.4" />
+      <path d="M16,80 Q96,56 176,80" fill={palette.dark} stroke={P.ink.line} strokeWidth="1.2" />
+      {/* stealth aircraft silhouette — flying wing shape */}
+      <path d="M60,108 L96,94 L132,108 L110,112 L82,112 Z" fill={P.stone.dark} stroke={P.ink.line} strokeWidth="1" />
+      <path d="M82,112 L96,100 L110,112" fill={palette.mid} stroke={P.ink.line} strokeWidth="0.8" />
+      {/* runway marking */}
+      <line x1="88" y1="122" x2="104" y2="122" stroke="#ffdd00" strokeWidth="1.5" strokeDasharray="4 3" />
+      {/* control tower */}
+      <rect x="148" y="60" width="14" height="76" rx="2" fill={P.stone.mid} stroke={P.ink.line} strokeWidth="0.8" />
+      <rect x="144" y="56" width="22" height="10" rx="2" fill={palette.bright} stroke={P.ink.line} strokeWidth="0.7" />
+      <Banner x={30} y={18} palette={palette} scale={0.7} />
+    </BuildingFrame>
+  );
+}
+
+export function TelemedicineHubSprite({ palette, svgOnly = false }: BuildingSpriteProps): string {
+  return (
+    <BuildingFrame label="Telemedicine Hub" category="food" svgOnly={svgOnly}>
+      <BuildingPlinth w={148} />
+      <rect x="24" y="76" width="144" height="60" rx="3" fill="#f0f0f8" stroke={P.ink.line} strokeWidth="1.2" />
+      <rect x="24" y="76" width="144" height="14" rx="3" fill={palette.dark} stroke={P.ink.line} strokeWidth="1" />
+      {/* medical cross */}
+      <rect x="56" y="52" width="10" height="28" rx="2" fill="#dd2222" />
+      <rect x="48" y="60" width="26" height="10" rx="2" fill="#dd2222" />
+      {/* screen showing patient */}
+      <rect x="80" y="96" width="60" height="34" rx="3" fill="#112244" stroke={P.metal.steel} strokeWidth="1" />
+      <ellipse cx="110" cy="104" rx="12" ry="10" fill="#aabbcc" stroke={P.stone.mid} strokeWidth="0.8" />
+      {/* transmission arc */}
+      <path d="M36,88 Q42,80 48,88" fill="none" stroke={palette.bright} strokeWidth="1.5" opacity="0.8" />
+      <path d="M28,92 Q42,76 56,92" fill="none" stroke={palette.bright} strokeWidth="1.2" opacity="0.5" />
+      <Banner x={150} y={30} palette={palette} scale={0.6} />
+    </BuildingFrame>
+  );
+}

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -49,6 +49,10 @@ import {
   EnvironmentalAgencySprite, SpaceCenterSprite, AgriculturalStationSprite, TransplantHospitalSprite,
   ContainerPortSprite, ResearchNetworkSprite, SurveillanceAgencySprite,
   ArmsControlTreatySprite, GreenRevolutionProgramSprite, StrategicAirCommandSprite,
+  // era 12
+  AutomatedPortSprite, BiotechLabSprite, BroadcastTowerSprite, CyberDefenseCenterSprite,
+  DataCenterSprite, FintechHubSprite, GeneTherapyClinicSprite, PrecisionFarmSprite,
+  SignalsHubSprite, SmartGridSprite, StealthAirbaseSprite, TelemedicineHubSprite,
 } from './buildings';
 import {
   PyramidsSprite, ColosseumSprite, GreatLibrarySprite, LighthouseSprite, WrightFlyerSprite,
@@ -398,6 +402,19 @@ export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = 
   arms_control_treaty:            ArmsControlTreatySprite,
   green_revolution_program:       GreenRevolutionProgramSprite,
   strategic_air_command:          StrategicAirCommandSprite,
+  // era 12 buildings
+  automated_port:                 AutomatedPortSprite,
+  biotech_lab:                    BiotechLabSprite,
+  broadcast_tower:                BroadcastTowerSprite,
+  cyber_defense_center:           CyberDefenseCenterSprite,
+  data_center:                    DataCenterSprite,
+  fintech_hub:                    FintechHubSprite,
+  gene_therapy_clinic:            GeneTherapyClinicSprite,
+  precision_farm:                 PrecisionFarmSprite,
+  signals_hub:                    SignalsHubSprite,
+  smart_grid:                     SmartGridSprite,
+  stealth_airbase:                StealthAirbaseSprite,
+  telemedicine_hub:               TelemedicineHubSprite,
 };
 
 export const PIRATE_HEADQUARTERS_SPRITE_CATALOG: Record<PirateHeadquartersSpriteId, LandmarkSpriteComponent> = {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1382,7 +1382,7 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   biotech_lab: '🧬',
   broadcast_tower: '📺',
   cyber_defense_center: '🛡️',
-  data_center: '💻',
+  data_center: '🖥️',
   fintech_hub: '💳',
   gene_therapy_clinic: '🧪',
   precision_farm: '🌾',
@@ -1683,6 +1683,10 @@ export function processCity(
     }
     const headUnit = TRAINABLE_UNITS.find(unit => unit.type === newQueue[0]);
     if (headUnit?.coastalRequired && !isCityCoastal(city, map)) {
+      droppedUnit = newQueue.shift() as UnitType;
+      droppedProductionItem = droppedUnit;
+      newProgress = 0;
+    } else if (headUnit?.trainedFromBuilding && !(city.buildings ?? []).includes(headUnit.trainedFromBuilding)) {
       droppedUnit = newQueue.shift() as UnitType;
       droppedProductionItem = droppedUnit;
       newProgress = 0;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -934,6 +934,108 @@ export const BUILDINGS: Record<string, Building> = {
     uniquePerEmpire: true, nationalProject: { homeEra: 11 },
     civYieldBonus: { production: 6 },
   },
+
+  // === ERA 12 BUILDINGS ===
+
+  automated_port: {
+    id: 'automated_port', name: 'Automated Port', category: 'economy',
+    yields: { food: 0, production: 0, gold: 2, science: 0 },
+    productionCost: 200,
+    description: 'Autonomous logistics eliminates maintenance costs for all trade routes. Coastal cities only.',
+    techRequired: 'autonomous-shipping',
+    coastalRequired: true,
+  },
+
+  biotech_lab: {
+    id: 'biotech_lab', name: 'Biotech Lab', category: 'science',
+    yields: { food: 3, production: 0, gold: 0, science: 2 },
+    productionCost: 190,
+    description: 'Genetic engineering breakthroughs boost food yield. Cities generate +1 food per 3 science per turn (from Genomics tech).',
+    techRequired: 'genomics',
+  },
+
+  broadcast_tower: {
+    id: 'broadcast_tower', name: 'Broadcast Tower', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 3, science: 0 },
+    productionCost: 170,
+    description: 'EM broadcast infrastructure supporting digital communications. Generates gold from digital commerce.',
+    techRequired: 'social-media',
+  },
+
+  cyber_defense_center: {
+    id: 'cyber_defense_center', name: 'Cyber Defense Center', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 2 },
+    productionCost: 200,
+    description: 'Probabilistically blocks cyber unit gold drain (65%), spy Market Manipulation (60%), and mass-surveillance exposure (70%). Block chances +10% with a co-located Signals Hub.',
+    techRequired: 'internet',
+  },
+
+  data_center: {
+    id: 'data_center', name: 'Data Center', category: 'science',
+    yields: { food: 0, production: 0, gold: 0, science: 3 },
+    productionCost: 200,
+    description: 'High-performance computing cluster. Requires a Semiconductor Fab.',
+    techRequired: 'quantum-computing',
+    requiresBuildings: ['semiconductor_fab'],
+  },
+
+  fintech_hub: {
+    id: 'fintech_hub', name: 'Fintech Hub', category: 'economy',
+    yields: { food: 0, production: 0, gold: 2, science: 0 },
+    productionCost: 180,
+    description: 'Digital payment infrastructure. With Digital Economy tech, the host city gains +1 gold per active trade route.',
+    techRequired: 'digital-economy',
+  },
+
+  gene_therapy_clinic: {
+    id: 'gene_therapy_clinic', name: 'Gene Therapy Clinic', category: 'science',
+    yields: { food: 0, production: 0, gold: 0, science: 2 },
+    productionCost: 220,
+    description: 'Units trained here start with gene therapy pre-charged — they survive one lethal hit at 1 HP before requiring rest.',
+    techRequired: 'gene-therapy',
+  },
+
+  precision_farm: {
+    id: 'precision_farm', name: 'Precision Farm', category: 'food',
+    yields: { food: 2, production: 0, gold: 0, science: 0 },
+    productionCost: 160,
+    description: "GPS-guided equipment. With Precision Agriculture tech, farm improvements in this city's borders also yield +1 production.",
+    techRequired: 'precision-agriculture',
+  },
+
+  signals_hub: {
+    id: 'signals_hub', name: 'Signals Hub', category: 'espionage',
+    yields: { food: 0, production: 0, gold: 0, science: 2 },
+    productionCost: 200,
+    description: 'Raises all CDC block chances in this city by +10%. Makes stealth bombers within 2 hexes targetable by ranged attacks. Requires a Cyber Defense Center.',
+    techRequired: 'cyber-intelligence',
+    requiresBuildings: ['cyber_defense_center'],
+  },
+
+  smart_grid: {
+    id: 'smart_grid', name: 'Smart Grid', category: 'production',
+    yields: { food: 0, production: 2, gold: 0, science: 1 },
+    productionCost: 200,
+    description: 'Intelligent power distribution. Requires a factory and a semiconductor fab.',
+    techRequired: 'smart-cities',
+    requiresBuildings: ['factory', 'semiconductor_fab'],
+  },
+
+  stealth_airbase: {
+    id: 'stealth_airbase', name: 'Stealth Airbase', category: 'military',
+    yields: { food: 0, production: 2, gold: 0, science: 0 },
+    productionCost: 220,
+    description: 'The only facility capable of training Stealth Bombers. Requires Stealth Technology research.',
+    techRequired: 'stealth-technology',
+  },
+
+  telemedicine_hub: {
+    id: 'telemedicine_hub', name: 'Telemedicine Hub', category: 'food',
+    yields: { food: 2, production: 0, gold: 0, science: 0 },
+    productionCost: 180,
+    description: 'Remote medical care. With Telemedicine tech, friendly units within 3 hexes of this city heal +1 extra HP per turn.',
+    techRequired: 'telemedicine',
+  },
 };
 
 export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pacing'] }> = [
@@ -977,6 +1079,8 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
   // Era 11 units
   { type: 'attack_helicopter', name: 'Attack Helicopter', cost: 230, techRequired: 'helicopter-warfare', pacing: { band: 'marquee', role: 'air-assault', impact: 1.55, scope: 'military', snowball: 1.4, urgency: 1.2, situationality: 1.3, unlockBreadth: 1 } },
   { type: 'missile_submarine', name: 'Missile Submarine', cost: 250, techRequired: 'nuclear-submarines', coastalRequired: true, pacing: { band: 'marquee', role: 'naval-deterrent', impact: 1.6, scope: 'military', snowball: 1.5, urgency: 1.2, situationality: 1.5, unlockBreadth: 1 } },
+  // Era 12 units (stats are placeholders — Task 3 will update to spec values)
+  { type: 'stealth_bomber', name: 'Stealth Bomber', cost: 320, techRequired: 'stealth-technology', trainedFromBuilding: 'stealth_airbase', pacing: { band: 'marquee', role: 'stealth-strike', impact: 1.7, scope: 'military', snowball: 1.5, urgency: 1.3, situationality: 1.5, unlockBreadth: 1 } },
   { type: 'spy_scout', name: 'Scout Agent', cost: 30, techRequired: 'espionage-scouting', obsoletedByTech: 'espionage-informants', pacing: { band: 'power-spike', role: 'first-spy-unit', impact: 1.15, scope: 'military', snowball: 1.1, urgency: 1.1, situationality: 1.1, unlockBreadth: 1.1 } },
   { type: 'spy_informant', name: 'Informant', cost: 50, techRequired: 'espionage-informants', obsoletedByTech: 'spy-networks', pacing: { band: 'power-spike', role: 'spy-capability-breakpoint', impact: 1.15, scope: 'military', snowball: 1.1, urgency: 1.05, situationality: 1.1, unlockBreadth: 1.1 } },
   { type: 'spy_agent', name: 'Field Agent', cost: 70, techRequired: 'spy-networks', obsoletedByTech: 'cryptography', pacing: { band: 'power-spike', role: 'spy-capability-breakpoint', impact: 1.2, scope: 'military', snowball: 1.1, urgency: 1, situationality: 1.1, unlockBreadth: 1.1 } },
@@ -1273,6 +1377,21 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   // era 11 units
   attack_helicopter: '🚁',
   missile_submarine: '🌊',
+  // Era 12 buildings
+  automated_port: '⚓',
+  biotech_lab: '🧬',
+  broadcast_tower: '📺',
+  cyber_defense_center: '🛡️',
+  data_center: '💻',
+  fintech_hub: '💳',
+  gene_therapy_clinic: '🧪',
+  precision_farm: '🌾',
+  signals_hub: '📡',
+  smart_grid: '⚡',
+  stealth_airbase: '✈️',
+  telemedicine_hub: '🏥',
+  // Era 12 units
+  stealth_bomber: '🛩️',
 };
 
 export const PRODUCTION_ICON_FALLBACK = '🏗️';
@@ -1325,7 +1444,8 @@ export function getTrainableUnitsForCity(
 ): TrainableUnitEntry[] {
   const coastal = isCityCoastal(city, map);
   return getTrainableUnitsForCiv(completedTechs, civType, availableResources)
-    .filter(unit => !unit.coastalRequired || coastal);
+    .filter(unit => !unit.coastalRequired || coastal)
+    .filter(unit => !unit.trainedFromBuilding || (city.buildings ?? []).includes(unit.trainedFromBuilding));
 }
 
 export function getDetectionUnitTypeForCiv(civType?: string): UnitType {

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -324,6 +324,26 @@ describe('getTrainableUnitsForCity', () => {
     expect(inlandTypes).not.toContain('trireme');
     expect(inlandTypes).not.toContain('transport');
   });
+
+  it('stealth_bomber is not offered by cities without a stealth_airbase', () => {
+    const cityWithoutAirbase = {
+      id: 'c1', buildings: [], ownedTiles: [], grid: [[null]],
+      food: 0, foodNeeded: 10, population: 1,
+      productionQueue: [], productionProgress: 0,
+      focus: 'balanced', maturity: 'city',
+      unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      position: { q: 0, r: 0 },
+    } as any;
+    const cityWithAirbase = { ...cityWithoutAirbase, buildings: ['stealth_airbase'] };
+    const map = { tiles: {}, width: 10, height: 10, wrap: false } as any;
+    const techs = ['stealth-technology'];
+
+    const offeredWithout = getTrainableUnitsForCity(cityWithoutAirbase, techs, map).map(u => u.type);
+    const offeredWith = getTrainableUnitsForCity(cityWithAirbase, techs, map).map(u => u.type);
+
+    expect(offeredWithout).not.toContain('stealth_bomber');
+    expect(offeredWith).toContain('stealth_bomber');
+  });
 });
 
 describe('processCity', () => {
@@ -683,6 +703,18 @@ describe('PRODUCTION_ICONS coverage', () => {
     for (const [id, icon] of Object.entries(PRODUCTION_ICONS)) {
       expect(typeof icon, `icon for "${id}" must be string`).toBe('string');
       expect(icon.length, `icon for "${id}" must be non-empty`).toBeGreaterThan(0);
+    }
+  });
+
+  it('all era-12 buildings have BUILDINGS and PRODUCTION_ICONS entries', () => {
+    const era12BuildingIds = [
+      'cyber_defense_center', 'signals_hub', 'stealth_airbase', 'data_center',
+      'biotech_lab', 'broadcast_tower', 'precision_farm', 'gene_therapy_clinic',
+      'telemedicine_hub', 'automated_port', 'smart_grid', 'fintech_hub',
+    ];
+    for (const id of era12BuildingIds) {
+      expect(BUILDINGS[id], `BUILDINGS['${id}'] missing`).toBeDefined();
+      expect(PRODUCTION_ICONS[id], `PRODUCTION_ICONS['${id}'] missing`).toBeDefined();
     }
   });
 });

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -408,6 +408,41 @@ describe('processCity', () => {
     expect(result.city.productionProgress).toBe(0);
   });
 
+  it('processCity drops stealth_bomber from queue head when city lacks stealth_airbase', () => {
+    const map = generateMap(30, 30, 'building-gate-drop-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: [],
+      productionQueue: ['stealth_bomber'],
+      productionProgress: 50,
+    };
+
+    const result = processCity(city, map, 2, 100, undefined, ['stealth-technology']);
+
+    expect(result.droppedUnit).toBe('stealth_bomber');
+    expect(result.droppedProductionItem).toBe('stealth_bomber');
+    expect(result.city.productionQueue).not.toContain('stealth_bomber');
+    expect(result.completedUnit).toBeNull();
+    expect(result.city.productionProgress).toBe(0);
+  });
+
+  it('processCity does NOT drop stealth_bomber when city has stealth_airbase', () => {
+    const map = generateMap(30, 30, 'building-gate-keep-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: ['stealth_airbase'],
+      productionQueue: ['stealth_bomber'],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 1, undefined, ['stealth-technology']);
+
+    expect(result.droppedUnit).toBeNull();
+    expect(result.city.productionQueue).toContain('stealth_bomber');
+  });
+
   it('processCity records unavailable resource-gated units without reporting them as coastal drops', () => {
     const map = generateMap(30, 30, 'resource-unit-drop-test');
     const city = { ...foundCity('p1', { q: 2, r: 2 }, map, mkC()), productionQueue: ['swordsman'], productionProgress: 40 };

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -148,8 +148,8 @@ describe('hostile-only unit definitions', () => {
       .sort();
   }
 
-  // era-12 units are defined in UNIT_DEFINITIONS but wired into TRAINABLE_UNITS in Task 3
-  const ERA_12_PENDING_TRAINABLE: Set<string> = new Set(['cyber_unit', 'stealth_bomber']);
+  // era-12 units: stealth_bomber is in TRAINABLE_UNITS (Task 2); cyber_unit wired in Task 3
+  const ERA_12_PENDING_TRAINABLE: Set<string> = new Set(['cyber_unit']);
 
   it('permits only explicit beast and pirate zero-cost units outside city training', () => {
     const trainableTypes = new Set([


### PR DESCRIPTION
## Summary

- Adds 12 era-12 buildings to \`BUILDINGS\` with yields, costs, tech requirements, and chain prereqs (\`requiresBuildings\`)
- Adds matching \`PRODUCTION_ICONS\` entries for all 12
- Adds \`trainedFromBuilding\` filter to \`getTrainableUnitsForCity\` so \`stealth_bomber\` only appears in the production queue of cities that have a \`stealth_airbase\`
- Adds 12 placeholder building sprites (buildings.tsx + sprite-catalog.ts) to satisfy the sprite-catalog coverage test
- Adds a minimal \`stealth_bomber\` TRAINABLE_UNITS entry (placeholder stats; Task 3 will update to spec values) to enable the filter test; removes it from \`ERA_12_PENDING_TRAINABLE\`
- Adjusts \`signals_hub\` (220→200), \`smart_grid\` (210→200), and \`stealth_airbase\` (240→220) production costs to stay within pacing audit target windows

## Building list

| ID | Name | Category | Tech |
|---|---|---|---|
| \`cyber_defense_center\` | Cyber Defense Center | espionage | internet |
| \`signals_hub\` | Signals Hub | espionage | cyber-intelligence |
| \`stealth_airbase\` | Stealth Airbase | military | stealth-technology |
| \`data_center\` | Data Center | science | quantum-computing |
| \`biotech_lab\` | Biotech Lab | science | genomics |
| \`broadcast_tower\` | Broadcast Tower | espionage | social-media |
| \`precision_farm\` | Precision Farm | food | precision-agriculture |
| \`gene_therapy_clinic\` | Gene Therapy Clinic | science | gene-therapy |
| \`telemedicine_hub\` | Telemedicine Hub | food | telemedicine |
| \`automated_port\` | Automated Port | economy | autonomous-shipping |
| \`smart_grid\` | Smart Grid | production | smart-cities |
| \`fintech_hub\` | Fintech Hub | economy | digital-economy |

## Out of scope

- Task 3: \`cyber_unit\` TRAINABLE_UNITS wiring + both units' full stats, UNIT_SFX, AI
- Task 4: Combat behaviors (geneTherapyReady, stealth targeting, cyber capture)
- Tasks 5–8: turn-manager, national projects, passive tech effects, SFX/UI

## Why this is safe to merge partial

Buildings are not yet reachable (era-12 techs cannot be unlocked in active games). The \`trainedFromBuilding\` filter is additive — no existing units are affected since the only unit using it (\`stealth_bomber\`) is not yet wired into AI or turn processing. The placeholder \`stealth_bomber\` TRAINABLE_UNITS entry only appears in cities with \`stealth_airbase\`; since \`stealth_airbase\` requires \`stealth-technology\` (era 12, unreachable), no player can queue it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jBXuK84vwoV6C4o63JVpE