### PR TITLE
fix(diplomacy): block treaties and war against unmet civs (#435)

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1442,6 +1442,11 @@ function processAITurnInternal(
       if (!currentDiplomacy) {
         continue;
       }
+      // Issue #435 guard: never write treaties or war records against an unmet
+      // civ — those records count as contact evidence and mass-discover civs.
+      if (!hasMetCivilization(newState, civId, decision.targetCiv)) {
+        continue;
+      }
       switch (decision.action) {
         case 'declare_war':
           if (

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -16,6 +16,7 @@ import {
   tryReabsorbBreakaway,
 } from '@/systems/breakaway-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
+import { hasMetCivilization } from '@/systems/discovery-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 
 export function resolveOpponentKind(civId: string): 'major' | 'minor' | 'barbarian' {
@@ -352,6 +353,15 @@ export function applyDiplomaticAction(
   const actor = state.civilizations[actorId];
   const target = state.civilizations[targetCivId];
   if (!actor || !target) {
+    return state;
+  }
+
+  // Issue #435 guard: a treaty (or war record) between unmet civs becomes contact
+  // "evidence" and cascades into mass discovery on the next visibility sync.
+  const requiresContact: DiplomaticAction[] = [
+    'declare_war', 'non_aggression_pact', 'trade_agreement', 'open_borders', 'alliance',
+  ];
+  if (requiresContact.includes(action) && !hasMetCivilization(state, actorId, targetCivId)) {
     return state;
   }
 

--- a/tests/ai/basic-ai-treaty-contact-guard.test.ts
+++ b/tests/ai/basic-ai-treaty-contact-guard.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import { processAITurn } from '@/ai/basic-ai';
+
+// Issue #435 defense-in-depth: even if the decision layer regresses and emits a
+// treaty or war decision for an unmet civ (the June 2026 mass-discovery bug),
+// the execution layer in basic-ai must refuse to write it.
+vi.mock('@/ai/ai-diplomacy', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/ai/ai-diplomacy')>();
+  return {
+    ...actual,
+    evaluateDiplomacy: vi.fn(() => [
+      { action: 'trade_agreement', targetCiv: 'player' },
+      { action: 'declare_war', targetCiv: 'player' },
+    ]),
+  };
+});
+
+describe('basic-ai treaty execution contact guard', () => {
+  it('refuses rogue treaty and war decisions against a civ the actor has not met', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Rogue Decision Guard',
+      seed: 'rogue-decision-guard',
+    });
+    state.era = 3;
+    state.civilizations['ai-1'].knownCivilizations = [];
+    state.civilizations.player.knownCivilizations = [];
+    state.civilizations['ai-1'].diplomacy.relationships.player = 30;
+    state.civilizations.player.diplomacy.relationships['ai-1'] = 30;
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.civilizations['ai-1'].diplomacy.treaties).toEqual([]);
+    expect(result.civilizations.player.diplomacy.treaties).toEqual([]);
+    expect(result.civilizations['ai-1'].diplomacy.atWarWith).toEqual([]);
+    expect(result.civilizations.player.diplomacy.atWarWith).toEqual([]);
+  });
+});

--- a/tests/integration/save-load-mass-discovery.test.ts
+++ b/tests/integration/save-load-mass-discovery.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { createNewGame } from '@/core/game-state';
+import { processTurn } from '@/core/turn-manager';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { normalizeLoadedState } from '@/storage/save-manager';
+import type { GameState } from '@/core/types';
+
+// Regression test for issue #435: loading a long-played save "encountered" every civ
+// at once on the next round.
+//
+// Mechanism: relationship drift raises every non-war pair to +30 over time, met or
+// not. AI treaty decisions used to skip the contact check, so on the first round
+// where a dormant AI civ was processed (right after loading an old solo save), it
+// signed instant bilateral trade agreements with every civ — and a treaty counts as
+// contact evidence in hasMetCivilizationByCurrentEvidence, so the next visibility
+// sync recorded contact with everyone and fired a "You have encountered X" burst.
+function runRealRound(state: GameState, contactEvents: Array<{ civA: string; civB: string }>): GameState {
+  const result = runCompletedRound(state, new EventBus(), {
+    improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
+    majors: (current, eventBus) => processNonHumanMajorRound(current, eventBus).state,
+    world: (current, eventBus) => processTurn(current, eventBus),
+  });
+  if (!result.ok) throw result.state && result.error;
+  const sink = new EventBus();
+  sink.on('civilization:first-contact', contact => contactEvents.push(contact));
+  result.events.commitTo(sink);
+  return result.state;
+}
+
+function majorCivIds(state: GameState): string[] {
+  return Object.keys(state.civilizations);
+}
+
+function knownPairs(state: GameState): Set<string> {
+  const pairs = new Set<string>();
+  for (const civ of Object.values(state.civilizations)) {
+    for (const otherId of civ.knownCivilizations ?? []) {
+      pairs.add([civ.id, otherId].sort().join('|'));
+    }
+  }
+  return pairs;
+}
+
+function treatyPairs(state: GameState): Set<string> {
+  const pairs = new Set<string>();
+  for (const civ of Object.values(state.civilizations)) {
+    for (const treaty of civ.diplomacy.treaties) {
+      pairs.add([treaty.civA, treaty.civB].sort().join('|'));
+    }
+  }
+  return pairs;
+}
+
+describe('issue #435 — loading an old save must not mass-discover civilizations', () => {
+  it('does not sign treaties with or "encounter" unmet civs after a save/load round trip, even at drift-cap relationships', () => {
+    const created = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 3,
+      gameTitle: 'Issue 435 Regression',
+      seed: 'issue-435-mass-discovery',
+    });
+
+    // Simulate a ~100-turn campaign where nobody has met: relationship drift has
+    // capped every pair at +30 (processRelationshipDrift cap) and the world is in
+    // era 3, where trade agreements need no tech. This is the exact precondition
+    // from the issue screenshots (relationship 35 = 30 drift cap + 5 signing bonus).
+    created.turn = 101;
+    created.era = 3;
+    for (const civ of Object.values(created.civilizations)) {
+      for (const otherId of majorCivIds(created)) {
+        if (otherId === civ.id) continue;
+        civ.diplomacy.relationships[otherId] = 30;
+      }
+    }
+
+    const baselineKnown = knownPairs(created);
+    const baselineTreaties = treatyPairs(created);
+    expect(baselineTreaties.size).toBe(0);
+
+    // Real persistence round trip through the production load normalizer.
+    const loaded = normalizeLoadedState(JSON.parse(JSON.stringify(created)) as GameState);
+
+    // Loading alone must not mint contacts or treaties.
+    expect(knownPairs(loaded)).toEqual(baselineKnown);
+    expect(treatyPairs(loaded)).toEqual(baselineTreaties);
+
+    // Run two full production rounds (improvements → AI majors → world), matching
+    // the hot-seat report of the burst appearing "on the second turn after load".
+    const contactEvents: Array<{ civA: string; civB: string }> = [];
+    let state = runRealRound(loaded, contactEvents);
+    state = runRealRound(state, contactEvents);
+
+    // The bug signed instant bilateral treaties with every drift-capped pair.
+    // No treaty may appear between civs that had never met at load time.
+    const newTreaties = [...treatyPairs(state)].filter(pair => !baselineKnown.has(pair));
+    expect(newTreaties).toEqual([]);
+
+    // Two rounds of AI movement from far-apart medium-map starts cannot plausibly
+    // produce real contact with this seed; any new known pair means the treaty
+    // (or another non-visibility) evidence path leaked again.
+    const newKnown = [...knownPairs(state)].filter(pair => !baselineKnown.has(pair));
+    expect(newKnown).toEqual([]);
+    expect(contactEvents).toEqual([]);
+  });
+});

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -298,6 +298,70 @@ describe('diplomacy-system', () => {
       expect(rejected.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
     });
 
+    // Issue #435: treaties between unmet civs become contact "evidence" and cascade
+    // into mass discovery. applyDiplomaticAction is the shared treaty writer, so it
+    // must refuse counterpart actions between civs that have never met.
+    it('refuses to sign a treaty between civs that have never met', () => {
+      const state = createNewGame({
+        civType: 'egypt',
+        mapSize: 'medium',
+        opponentCount: 2,
+        gameTitle: 'Unmet Treaty Guard',
+        seed: 'unmet-treaty-guard',
+      });
+      state.era = 3;
+      state.civilizations['ai-1'].knownCivilizations = [];
+      state.civilizations.player.knownCivilizations = [];
+      state.civilizations['ai-1'].diplomacy.relationships.player = 30;
+      state.civilizations.player.diplomacy.relationships['ai-1'] = 30;
+
+      const result = applyDiplomaticAction(state, 'ai-1', 'player', 'trade_agreement', new EventBus());
+
+      expect(result.civilizations['ai-1'].diplomacy.treaties).toEqual([]);
+      expect(result.civilizations.player.diplomacy.treaties).toEqual([]);
+    });
+
+    it('refuses to declare war on a civ that has never been met', () => {
+      const state = createNewGame({
+        civType: 'egypt',
+        mapSize: 'medium',
+        opponentCount: 2,
+        gameTitle: 'Unmet War Guard',
+        seed: 'unmet-war-guard',
+      });
+      state.civilizations['ai-1'].knownCivilizations = [];
+      state.civilizations.player.knownCivilizations = [];
+
+      const result = applyDiplomaticAction(state, 'ai-1', 'player', 'declare_war', new EventBus());
+
+      expect(result.civilizations['ai-1'].diplomacy.atWarWith).toEqual([]);
+      expect(result.civilizations.player.diplomacy.atWarWith).toEqual([]);
+    });
+
+    it('still signs treaties between civs that have met', () => {
+      const state = createNewGame({
+        civType: 'egypt',
+        mapSize: 'medium',
+        opponentCount: 2,
+        gameTitle: 'Met Treaty Allowed',
+        seed: 'met-treaty-allowed',
+      });
+      state.era = 3;
+      state.civilizations['ai-1'].knownCivilizations = ['player'];
+      state.civilizations.player.knownCivilizations = ['ai-1'];
+      state.civilizations['ai-1'].diplomacy.relationships.player = 30;
+      state.civilizations.player.diplomacy.relationships['ai-1'] = 30;
+
+      const result = applyDiplomaticAction(state, 'ai-1', 'player', 'trade_agreement', new EventBus());
+
+      expect(result.civilizations['ai-1'].diplomacy.treaties).toContainEqual(
+        expect.objectContaining({ type: 'trade_agreement' }),
+      );
+      expect(result.civilizations.player.diplomacy.treaties).toContainEqual(
+        expect.objectContaining({ type: 'trade_agreement' }),
+      );
+    });
+
     it('applies Narnias treaty relationship bonus symmetrically when a treaty is signed', () => {
       const bus = new EventBus();
       const state = {
@@ -306,11 +370,13 @@ describe('diplomacy-system', () => {
           player: {
             id: 'player',
             civType: 'narnia',
+            knownCivilizations: ['ai-egypt'],
             diplomacy: createDiplomacyState(['player', 'ai-egypt'], 'player'),
           },
           'ai-egypt': {
             id: 'ai-egypt',
             civType: 'egypt',
+            knownCivilizations: ['player'],
             diplomacy: createDiplomacyState(['player', 'ai-egypt'], 'ai-egypt'),
           },
         },


### PR DESCRIPTION
Fixes #435 — "Regression: Loading a saved game resulted in me 'encountering' all civs"

## Root cause

Three mechanics interact:

1. **Relationship drift never checks contact.** `processRelationshipDrift` raises every non-war civ pair by +1/turn toward a cap of +30, met or not (relationships are seeded for all pairs at game creation). By turn ~100 of a solo campaign, every unmet pair sits at the +30 cap.
2. **AI treaty decisions never checked contact.** Before `4f59c559`, `evaluateDiplomacy` signed a trade agreement with any civ at relationship > 10 (era 3 unlocks trade agreements with no tech) — the `hasMet` flag was only consulted for war declarations, and the missing-context fallback was `hasMet: true`. Treaties are written bilaterally and instantly, including onto the human's diplomacy state.
3. **A treaty is contact evidence.** `hasMetCivilizationByCurrentEvidence` treats any shared treaty as proof of contact, so the next visibility sync records contact with every treaty partner and fires `civilization:first-contact` for each.

The detonator was `20c3eb77` ("process every opponent each round", June 28): solo games previously hard-coded `['ai-1']`, so ai-2…ai-N had never run AI diplomacy. Loading a 100-turn solo save under the new build activated all of them on the first round — each signed instant trade agreements with everyone at the drift cap, and the following sync burst out "You have encountered X" for every civ. This exactly matches the issue screenshots: every "new" civ shows a trade agreement at relationship 35 (30 drift cap + 5 signing bonus), and the burst lands at T102 after "Game loaded! Turn 101".

The decision-layer gate added in `4f59c559` (`if (!context.hasMet) continue;`) already stops the cascade — which is why post-June-29 repro attempts with clean fixtures kept passing. Those fixtures also used relationship 0, below the >10 signing threshold, so they could never have triggered the bug's precondition.

## What this PR adds

- **End-to-end regression** (`tests/integration/save-load-mass-discovery.test.ts`): drives the real load pipeline (`normalizeLoadedState`) plus two production rounds (`processImprovementTurns` → `processNonHumanMajorRound` → `processTurn`) from a drift-capped, unmet, era-3 state and asserts no treaties, no contact records, and no first-contact events appear. Verified to fail against the pre-gate June 28 behavior (reverting the one-line gate produces treaties for all six civ pairs) and pass on current main.
- **Defense-in-depth in the shared treaty writer** (`applyDiplomaticAction`): refuses `declare_war` / `non_aggression_pact` / `trade_agreement` / `open_borders` / `alliance` between civs that have never met. War/peace between met civs is unaffected (war itself is contact evidence).
- **Defense-in-depth in the AI execution loop** (`basic-ai.ts`): skips any diplomacy decision targeting an unmet civ, so a future decision-layer regression cannot write the poisoning records again. Covered by a mocked rogue-decision test.

## Note on already-poisoned saves

Campaigns saved while the June 28 build was live retain the bogus trade agreements and contact records. Those two records are indistinguishable from a legitimately met pair after the fact, so this PR does not attempt retroactive save surgery — it prevents the records from being minted. Affected campaigns will keep showing all civs as met; new and healthy old saves are unaffected (verified by the E2E test's load round trip).

## Verification

- `yarn test`: 333 files / 4867 tests pass
- `yarn build`: clean
- Regression test red on pre-gate code, green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXVuawwbG5LrsqKGmjuNqz