### PR TITLE
feat(ai): issue 412 purposeful world actors

### DIFF
--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -140,7 +140,13 @@ function normalizePlan(
     requiredRoles,
     assignedUnitIds: Array.isArray(plan.assignedUnitIds)
       ? [...new Set(plan.assignedUnitIds.filter(unitId =>
-          typeof unitId === 'string' && state.units[unitId]?.owner === actorId))]
+          typeof unitId === 'string'
+          && (
+            state.units[unitId]?.owner === actorId
+            || state.barbarianCamps[actorId]
+              && state.units[unitId]?.owner === 'barbarian'
+              && state.opponentAI?.barbarianHomeCampByUnitId?.[unitId] === actorId
+          )))]
       : [],
     ...(isFiniteCoord(plan.rallyPoint) ? { rallyPoint: { ...plan.rallyPoint } } : { rallyPoint: undefined }),
   };

--- a/src/core/pirate-state.ts
+++ b/src/core/pirate-state.ts
@@ -74,6 +74,10 @@ export interface PirateIntentState {
   targetCityId?: string;
   targetUnitId?: string;
   plannedRound: number;
+  lastProgressRound?: number;
+  lastTargetDistance?: number;
+  mode?: 'engage' | 'withdraw';
+  leaderUnitId?: string;
 }
 
 export interface PirateTransitionGuards {

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -7,7 +7,11 @@ import { getCivAvailableResources } from '@/systems/resource-acquisition-system'
 import { applyCityMaturity } from '@/systems/city-maturity-system';
 import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
 import { processResearch, getTechById } from '@/systems/tech-system';
-import { processBarbarians } from '@/systems/barbarian-system';
+import {
+  processBarbarians,
+  processPurposefulBarbarians,
+  type PurposefulBarbarianProcessResult,
+} from '@/systems/barbarian-system';
 import {
   processBeasts, placeBeastLairs, recordBeastSlain, BEAST_OWNER,
   LAIR_GROWTH_INTERVAL_TURNS, LAIR_GROWTH_CAP, LAIR_GROWTH_EXPERIENCE,
@@ -80,6 +84,11 @@ import {
 import type { PirateEconomyModifiers } from '@/systems/economy-system';
 import { processPiratesForCompletedRound } from '@/systems/pirate-system';
 import { classifyOwner } from './owner-kind';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from './feature-flags';
+
+export interface ProcessTurnOptions {
+  purposefulAIEnabled?: boolean;
+}
 
 export function finalizeOpponentRoundState(state: GameState): GameState {
   const normalized = normalizeOpponentAIState(state);
@@ -98,8 +107,14 @@ export function finalizeOpponentRoundState(state: GameState): GameState {
   };
 }
 
-export function processTurn(state: GameState, bus: EventBus): GameState {
+export function processTurn(
+  state: GameState,
+  bus: EventBus,
+  options: ProcessTurnOptions = {},
+): GameState {
+  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
+  if (purposefulAIEnabled) newState = normalizeOpponentAIState(newState);
 
   bus.emit('turn:end', { turn: newState.turn, playerId: newState.currentPlayer });
 
@@ -128,7 +143,9 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
     let totalScience = 0;
     let totalGold = 0;
 
-    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
+    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId, {
+      hostileOccupationEnabled: purposefulAIEnabled,
+    });
     const npCivBonuses = getNationalProjectCivYieldBonus(newState, civId);
 
     for (const cityId of civ.cities) {
@@ -154,7 +171,9 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
       totalScience += yields.science;
       totalGold += yields.gold;
       const effectiveProduction = isCityProductionLocked(city) ? 0 : yields.production;
-      const availableResources = getCivAvailableResources(newState, civId);
+      const availableResources = getCivAvailableResources(newState, civId, {
+        hostileOccupationEnabled: purposefulAIEnabled,
+      });
       const npKeysForCiv = new Set(
         Object.keys(newState.builtNationalProjects ?? {}).filter(k => k.startsWith(`${civId}:`))
       );
@@ -571,14 +590,19 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   const cityTargets = Object.values(newState.cities)
     .filter(city => city.owner !== 'barbarian' && !city.owner.startsWith('mc-') && city.owner !== BEAST_OWNER)
     .map(city => ({ id: city.id, position: city.position, owner: city.owner }));
-  const barbResult = processBarbarians(
-    Object.values(newState.barbarianCamps),
-    newState.map,
-    playerUnits,
-    barbSeed,
-    barbarianUnits,
-    cityTargets,
-  );
+  const barbResult = purposefulAIEnabled
+    ? processPurposefulBarbarians(newState)
+    : processBarbarians(
+        Object.values(newState.barbarianCamps),
+        newState.map,
+        playerUnits,
+        barbSeed,
+        barbarianUnits,
+        cityTargets,
+      );
+  if (purposefulAIEnabled) {
+    newState.opponentAI = (barbResult as PurposefulBarbarianProcessResult).opponentAI;
+  }
   newState.barbarianCamps = {};
   for (const camp of barbResult.updatedCamps) {
     newState.barbarianCamps[camp.id] = camp;
@@ -586,8 +610,11 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
 
   // Spawn barbarian raiders
   for (const spawn of barbResult.spawnedUnits) {
-    const raider = createUnit('warrior', 'barbarian', spawn.position, newState.idCounters);
+    const raider = createUnit(spawn.unitType ?? 'warrior', 'barbarian', spawn.position, newState.idCounters);
     newState.units[raider.id] = raider;
+    if (purposefulAIEnabled && newState.opponentAI) {
+      newState.opponentAI.barbarianHomeCampByUnitId[raider.id] = spawn.campId;
+    }
     bus.emit('barbarian:spawned', { campId: spawn.campId, unitId: raider.id });
   }
 
@@ -595,9 +622,13 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   for (const order of barbResult.moveOrders) {
     const unit = newState.units[order.unitId];
     if (unit) {
-      const tile = newState.map.tiles[`${order.toCoord.q},${order.toCoord.r}`];
-      const cost = tile?.terrain === 'hills' || tile?.terrain === 'forest' ? 2 : 1;
-      newState.units[order.unitId] = moveUnit(unit, order.toCoord, cost);
+      if (purposefulAIEnabled) {
+        executeUnitMove(newState, order.unitId, order.toCoord, { actor: 'world', bus });
+      } else {
+        const tile = newState.map.tiles[`${order.toCoord.q},${order.toCoord.r}`];
+        const cost = tile?.terrain === 'hills' || tile?.terrain === 'forest' ? 2 : 1;
+        newState.units[order.unitId] = moveUnit(unit, order.toCoord, cost);
+      }
     }
   }
 
@@ -666,7 +697,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   }
 
   // --- Minor civ turn phase ---
-  newState = processMinorCivTurn(newState, bus);
+  newState = processMinorCivTurn(newState, bus, { purposefulAIEnabled });
 
   // --- Barbarian evolution check ---
   const evolution = checkCampEvolution(newState, newState.turn);
@@ -1015,7 +1046,7 @@ export function processTurn(state: GameState, bus: EventBus): GameState {
   }
 
   let pirateEconomyModifiers: PirateEconomyModifiers | undefined;
-  const pirateRound = processPiratesForCompletedRound(newState, bus);
+  const pirateRound = processPiratesForCompletedRound(newState, bus, { purposefulAIEnabled });
   newState = pirateRound.state;
   pirateEconomyModifiers = pirateRound.economyModifiers;
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -677,6 +677,17 @@ export function processTurn(
       cities: { ...newState.cities, [order.cityId]: { ...city, hp: newHp } },
     };
     bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: currentHp - newHp });
+    if (purposefulAIEnabled && newState.opponentAI) {
+      const campId = newState.opponentAI.barbarianHomeCampByUnitId[order.attackerUnitId];
+      const plan = campId ? newState.opponentAI.barbarianCamps[campId] : undefined;
+      if (plan?.target.kind === 'city' && plan.target.id === order.cityId) {
+        newState.opponentAI.barbarianCamps[campId] = {
+          ...plan,
+          phase: 'withdrawing',
+          lastProgressTurn: newState.turn,
+        };
+      }
+    }
 
     if (newHp === 0) {
       const ownerId = city.owner;

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -16,6 +16,7 @@ import {
   type PirateFactionState,
   type PirateHeadquarters,
   type PirateHistoryEntry,
+  type PirateIntentState,
   type PirateRelocationDirection,
   type PirateState,
 } from '@/core/pirate-state';
@@ -268,6 +269,50 @@ function normalizePirateIntel(value: unknown, state: GameState, factions: Pirate
   return intelByCiv;
 }
 
+function normalizePirateIntent(
+  value: unknown,
+  state: GameState,
+  faction: PirateFactionState,
+): PirateIntentState | null {
+  if (!isRecord(value)) return null;
+  if (value.kind !== 'patrol' && value.kind !== 'raid' && value.kind !== 'blockade') return null;
+  if (!Number.isFinite(value.plannedRound)) return null;
+  const targetCivId = typeof value.targetCivId === 'string' && state.civilizations[value.targetCivId]
+    ? value.targetCivId
+    : undefined;
+  const targetUnitId = typeof value.targetUnitId === 'string' && state.units[value.targetUnitId]
+    ? value.targetUnitId
+    : undefined;
+  const targetCityId = typeof value.targetCityId === 'string' && state.cities[value.targetCityId]
+    ? value.targetCityId
+    : undefined;
+  if (targetUnitId && targetCityId) return null;
+  if (value.kind !== 'patrol' && !targetUnitId && !targetCityId) return null;
+  if (targetUnitId && targetCivId && state.units[targetUnitId]?.owner !== targetCivId) return null;
+  if (targetCityId && targetCivId && state.cities[targetCityId]?.owner !== targetCivId) return null;
+  const leaderUnitId = typeof value.leaderUnitId === 'string'
+    && faction.shipIds.includes(value.leaderUnitId)
+    && state.units[value.leaderUnitId]
+    ? value.leaderUnitId
+    : undefined;
+  if ((value.mode !== 'engage' && value.mode !== 'withdraw') || !leaderUnitId) return null;
+  return {
+    kind: value.kind,
+    ...(targetCivId ? { targetCivId } : {}),
+    ...(targetUnitId ? { targetUnitId } : {}),
+    ...(targetCityId ? { targetCityId } : {}),
+    plannedRound: Math.max(0, Number(value.plannedRound)),
+    ...(Number.isFinite(value.lastProgressRound)
+      ? { lastProgressRound: Math.max(0, Number(value.lastProgressRound)) }
+      : {}),
+    ...(Number.isFinite(value.lastTargetDistance)
+      ? { lastTargetDistance: Math.max(0, Number(value.lastTargetDistance)) }
+      : {}),
+    mode: value.mode,
+    leaderUnitId,
+  };
+}
+
 export function normalizePirateState(state: GameState): PirateState {
   const raw = isRecord(state.pirates) ? (state.pirates as unknown as Record<string, unknown>) : {};
   const normalized = createEmptyPirateState();
@@ -389,6 +434,7 @@ export function normalizePirateState(state: GameState): PirateState {
           };
         }
       }
+      faction.intent = normalizePirateIntent(rawFaction.intent, state, faction);
       if (headquarters.kind === 'deep-sea-flotilla' && !state.units?.[headquarters.flagshipUnitId]) {
         if (!normalized.history.some(entry => entry.kind === 'destroyed' && entry.factionId === faction.id)) {
           normalized.history.push({

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -6,6 +6,7 @@ import { selectDefenderForAttack } from '@/systems/combat-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { isBeastConcealedFrom, canUnitAttackBeast } from '@/systems/beast-system';
 import { isAlwaysHostilePair, isPirateOwner } from '@/core/owner-kind';
+import { isMinorCivHostileToOwner } from './minor-civ-diplomacy';
 
 export type AttackTargetFailure =
   | 'missing-attacker'
@@ -54,6 +55,9 @@ function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord
 function canAttackOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
   if (targetOwner === attackerOwner) return false;
   if (isAlwaysHostilePair(attackerOwner, targetOwner)) return true;
+  if (attackerOwner.startsWith('mc-')) {
+    return isMinorCivHostileToOwner(state, attackerOwner, targetOwner);
+  }
   if (targetOwner.startsWith('mc-')) {
     return state.civilizations[attackerOwner]?.diplomacy.atWarWith.includes(targetOwner) ?? false;
   }

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -1,8 +1,28 @@
-import type { BarbarianCamp, GameMap, GameState, HexCoord, IdCounters, Unit } from '@/core/types';
+import type {
+  AIStrategicPlan,
+  BarbarianCamp,
+  GameMap,
+  GameState,
+  HexCoord,
+  IdCounters,
+  OpponentAIState,
+  ResourceType,
+  Unit,
+  UnitType,
+} from '@/core/types';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
+import { OPPONENT_CHALLENGE_PROFILES, resolveOpponentChallenge } from '@/core/opponent-challenge';
 import { canAttackByProfileOnMap } from './attack-targeting';
-import { hexKey, hexDistance, hexNeighbors, wrappedHexDistance } from './hex-utils';
+import {
+  getWrappedHexNeighbors,
+  hexKey,
+  hexDistance,
+  hexNeighbors,
+  wrappedHexDistance,
+} from './hex-utils';
 import { selectDefenderForAttack } from './combat-system';
 import { applyQuestGameplayAction, type ChainTransition } from './quest-chain-system';
+import { UNIT_DEFINITIONS } from './unit-system';
 
 // Seeded LCG — avoids Math.random() per project rules
 function lcg(seed: number): () => number {
@@ -127,10 +147,358 @@ export interface BarbarianCityAttackOrder {
 
 export interface BarbarianProcessResult {
   updatedCamps: BarbarianCamp[];
-  spawnedUnits: Array<{ campId: string; position: HexCoord }>;
+  spawnedUnits: Array<{ campId: string; position: HexCoord; unitType?: UnitType }>;
   moveOrders: BarbarianMoveOrder[];
   attackOrders: BarbarianAttackOrder[];
   cityAttackOrders: BarbarianCityAttackOrder[];
+}
+
+export const BARBARIAN_ROSTER_BY_ERA: Array<{
+  maxEra: number;
+  melee: UnitType[];
+  ranged: UnitType[];
+}> = [
+  { maxEra: 2, melee: ['warrior', 'axeman'], ranged: ['archer'] },
+  { maxEra: 4, melee: ['swordsman', 'spearman'], ranged: ['crossbowman'] },
+  { maxEra: 7, melee: ['pikeman', 'musketeer'], ranged: ['crossbowman'] },
+  { maxEra: 9, melee: ['rifleman'], ranged: ['grenadier'] },
+  { maxEra: 11, melee: ['tank', 'rifleman'], ranged: ['machine_gunner'] },
+];
+
+export function getBarbarianRosterForEra(era: number) {
+  return BARBARIAN_ROSTER_BY_ERA.find(roster => era <= roster.maxEra)
+    ?? BARBARIAN_ROSTER_BY_ERA.at(-1)!;
+}
+
+export interface PurposefulBarbarianProcessResult extends BarbarianProcessResult {
+  opponentAI: OpponentAIState;
+}
+
+const BARBARIAN_SENSE_RADIUS = 7;
+const BARBARIAN_DEFENSE_RADIUS = 4;
+
+function barbarianDistance(state: GameState, a: HexCoord, b: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(a, b, state.map.width)
+    : hexDistance(a, b);
+}
+
+function isPassableBarbarianTile(state: GameState, coord: HexCoord): boolean {
+  const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+  return Boolean(terrain && terrain !== 'ocean' && terrain !== 'coast' && terrain !== 'mountain');
+}
+
+function sensedByCamp(
+  state: GameState,
+  camp: BarbarianCamp,
+  assignedUnits: Unit[],
+  coord: HexCoord,
+): boolean {
+  return [camp.position, ...assignedUnits.map(unit => unit.position)]
+    .some(origin => barbarianDistance(state, origin, coord) <= BARBARIAN_SENSE_RADIUS);
+}
+
+function planTargetPosition(state: GameState, plan: AIStrategicPlan): HexCoord | null {
+  if (plan.target.kind === 'unit') {
+    return state.units[plan.target.id]?.position ?? null;
+  }
+  if (plan.target.kind === 'city') {
+    return state.cities[plan.target.id]?.position ?? null;
+  }
+  if (plan.target.kind === 'camp') {
+    return state.barbarianCamps[plan.target.id]?.position ?? null;
+  }
+  return plan.target.kind === 'resource' ? plan.target.position : plan.target.anchor;
+}
+
+function makeBarbarianPlan(
+  state: GameState,
+  camp: BarbarianCamp,
+  target: AIStrategicPlan['target'],
+  objective: AIStrategicPlan['objective'],
+  reason: AIStrategicPlan['reasonCodes'][number],
+  assignedUnitIds: string[],
+): AIStrategicPlan {
+  return {
+    id: `barbarian-plan:${camp.id}:${state.turn}:${objective}`,
+    actorId: camp.id,
+    objective,
+    target,
+    theaterId: `camp:${camp.id}`,
+    phase: objective === 'defend' ? 'attacking' : 'advancing',
+    reasonCodes: [reason],
+    commitment: objective === 'defend' ? 1 : 0.7,
+    createdTurn: state.turn,
+    reconsiderAfterTurn: state.turn + 2,
+    expiresAfterTurn: state.turn + 8,
+    lastProgressTurn: state.turn,
+    rallyPoint: { ...camp.position },
+    requiredRoles: { frontline: 1 },
+    assignedUnitIds,
+  };
+}
+
+function chooseStepToward(
+  state: GameState,
+  unit: Unit,
+  target: HexCoord,
+): HexCoord | null {
+  const occupied = new Set(Object.values(state.units)
+    .filter(candidate => candidate.id !== unit.id && !candidate.transportId)
+    .map(candidate => hexKey(candidate.position)));
+  const neighboringCoords = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(unit.position, state.map.width)
+    : hexNeighbors(unit.position);
+  return neighboringCoords
+    .filter(coord => isPassableBarbarianTile(state, coord) && !occupied.has(hexKey(coord)))
+    .filter(coord => barbarianDistance(state, coord, target) < barbarianDistance(state, unit.position, target))
+    .sort((a, b) =>
+      barbarianDistance(state, a, target) - barbarianDistance(state, b, target)
+      || a.q - b.q
+      || a.r - b.r)[0] ?? null;
+}
+
+function chooseBarbarianSpawnType(
+  state: GameState,
+  campId: string,
+  assignedUnits: Unit[],
+): UnitType {
+  const roster = getBarbarianRosterForEra(state.era);
+  const rangedCount = assignedUnits.filter(unit => roster.ranged.includes(unit.type)).length;
+  const canAddRanged = (rangedCount + 1) * 3 <= assignedUnits.length + 1;
+  const pool = canAddRanged ? [...roster.melee, ...roster.ranged] : roster.melee;
+  const seed = [...`${state.gameId ?? 'game'}:${state.turn}:${campId}`]
+    .reduce((value, character) => (value * 31 + character.charCodeAt(0)) >>> 0, 1);
+  return pool[seed % pool.length]!;
+}
+
+/**
+ * Pure, camp-local barbarian planner. The returned orders must be revalidated
+ * through canonical movement/combat helpers by the caller.
+ */
+export function processPurposefulBarbarians(state: GameState): PurposefulBarbarianProcessResult {
+  const opponentAI = structuredClone(state.opponentAI ?? createEmptyOpponentAIState());
+  opponentAI.barbarianCamps = Object.fromEntries(
+    Object.entries(opponentAI.barbarianCamps)
+      .filter(([campId]) => Boolean(state.barbarianCamps[campId])),
+  );
+  opponentAI.barbarianHomeCampByUnitId = Object.fromEntries(
+    Object.entries(opponentAI.barbarianHomeCampByUnitId)
+      .filter(([unitId, campId]) =>
+        state.units[unitId]?.owner === 'barbarian' && Boolean(state.barbarianCamps[campId])),
+  );
+
+  const camps = Object.values(state.barbarianCamps)
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const barbarianUnits = Object.values(state.units)
+    .filter(unit => unit.owner === 'barbarian' && !unit.transportId)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  for (const unit of barbarianUnits) {
+    if (opponentAI.barbarianHomeCampByUnitId[unit.id]) continue;
+    const nearest = camps
+      .filter(camp => barbarianDistance(state, unit.position, camp.position) <= BARBARIAN_SENSE_RADIUS)
+      .sort((a, b) =>
+        barbarianDistance(state, unit.position, a.position) - barbarianDistance(state, unit.position, b.position)
+        || a.id.localeCompare(b.id))[0];
+    if (nearest) opponentAI.barbarianHomeCampByUnitId[unit.id] = nearest.id;
+  }
+
+  const campTick = processBarbarians(camps, state.map, [], state.turn * 31337);
+  const spawnedUnits: PurposefulBarbarianProcessResult['spawnedUnits'] = [];
+  const moveOrders: BarbarianMoveOrder[] = [];
+  const attackOrders: BarbarianAttackOrder[] = [];
+  const cityAttackOrders: BarbarianCityAttackOrder[] = [];
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+
+  for (const camp of camps) {
+    const assigned = barbarianUnits.filter(unit =>
+      opponentAI.barbarianHomeCampByUnitId[unit.id] === camp.id);
+    const assignedIds = assigned.map(unit => unit.id);
+    const spawn = campTick.spawnedUnits.find(candidate => candidate.campId === camp.id);
+    if (spawn) {
+      const occupied = new Set(Object.values(state.units)
+        .filter(unit => !unit.transportId)
+        .map(unit => hexKey(unit.position)));
+      const spawnPosition = [spawn.position, ...(
+        state.map.wrapsHorizontally
+          ? getWrappedHexNeighbors(spawn.position, state.map.width)
+          : hexNeighbors(spawn.position)
+      )]
+        .filter(coord => isPassableBarbarianTile(state, coord) && !occupied.has(hexKey(coord)))
+        .sort((a, b) =>
+          barbarianDistance(state, a, camp.position) - barbarianDistance(state, b, camp.position)
+          || a.q - b.q
+          || a.r - b.r)[0];
+      if (spawnPosition) {
+        spawnedUnits.push({
+          ...spawn,
+          position: spawnPosition,
+          unitType: chooseBarbarianSpawnType(state, camp.id, assigned),
+        });
+      }
+    }
+
+    const sensedUnits = Object.values(state.units)
+      .filter(unit =>
+        unit.owner !== 'barbarian'
+        && !unit.transportId
+        && sensedByCamp(state, camp, assigned, unit.position))
+      .sort((a, b) =>
+        barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
+        || a.id.localeCompare(b.id));
+    const campThreat = sensedUnits.find(unit =>
+      UNIT_DEFINITIONS[unit.type].strength > 0
+      && barbarianDistance(state, camp.position, unit.position) <= BARBARIAN_DEFENSE_RADIUS);
+    const existing = opponentAI.barbarianCamps[camp.id];
+    const existingPosition = existing ? planTargetPosition(state, existing) : null;
+    const existingValid = Boolean(
+      existing
+      && state.turn <= existing.expiresAfterTurn
+      && existingPosition
+      && sensedByCamp(state, camp, assigned, existingPosition),
+    );
+
+    let plan: AIStrategicPlan | null = existingValid ? existing : null;
+    if (campThreat && (plan?.objective !== 'defend' || plan.target.kind !== 'unit' || plan.target.id !== campThreat.id)) {
+      plan = makeBarbarianPlan(
+        state,
+        camp,
+        { kind: 'unit', id: campThreat.id, lastKnownPosition: { ...campThreat.position } },
+        'defend',
+        'camp-defense',
+        assignedIds,
+      );
+    }
+
+    if (!plan) {
+      const raidUnit = sensedUnits
+        .filter(unit => unit.type === 'worker' || unit.type === 'caravan')
+        .sort((a, b) => {
+          const priority = (unit: Unit) => unit.type === 'caravan' ? 0 : 1;
+          return priority(a) - priority(b)
+            || barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
+            || a.id.localeCompare(b.id);
+        })[0];
+      if (raidUnit) {
+        plan = makeBarbarianPlan(
+          state,
+          camp,
+          { kind: 'unit', id: raidUnit.id, lastKnownPosition: { ...raidUnit.position } },
+          'raid',
+          'opportunistic-raid',
+          assignedIds,
+        );
+      }
+    }
+
+    if (!plan) {
+      const resource = Object.values(state.map.tiles)
+        .filter(tile =>
+          Boolean(tile.resource)
+          && tile.improvement !== 'none'
+          && tile.improvementTurnsLeft === 0
+          && tile.owner !== null
+          && tile.owner !== 'barbarian'
+          && sensedByCamp(state, camp, assigned, tile.coord))
+        .sort((a, b) =>
+          barbarianDistance(state, camp.position, a.coord) - barbarianDistance(state, camp.position, b.coord)
+          || hexKey(a.coord).localeCompare(hexKey(b.coord)))[0];
+      if (resource?.resource) {
+        plan = makeBarbarianPlan(
+          state,
+          camp,
+          { kind: 'resource', resource: resource.resource as ResourceType, position: { ...resource.coord } },
+          'raid',
+          'opportunistic-raid',
+          assignedIds,
+        );
+      }
+    }
+
+    if (!plan) {
+      const city = Object.values(state.cities)
+        .filter(city =>
+          city.owner !== 'barbarian'
+          && sensedByCamp(state, camp, assigned, city.position)
+          && (city.hp ?? 100) <= Math.max(40, camp.strength * 10))
+        .sort((a, b) =>
+          barbarianDistance(state, camp.position, a.position) - barbarianDistance(state, camp.position, b.position)
+          || a.id.localeCompare(b.id))[0];
+      if (city) {
+        plan = makeBarbarianPlan(
+          state,
+          camp,
+          { kind: 'city', id: city.id, lastKnownPosition: { ...city.position } },
+          'raid',
+          'nearby-opportunity',
+          assignedIds,
+        );
+      }
+    }
+
+    if (!plan) {
+      plan = makeBarbarianPlan(
+        state,
+        camp,
+        { kind: 'region', id: `patrol:${camp.id}`, anchor: { ...camp.position } },
+        'defend',
+        'homeland-secure',
+        assignedIds,
+      );
+      plan.phase = 'scouting';
+      plan.commitment = 0.3;
+    }
+
+    const targetPosition = planTargetPosition(state, plan);
+    const resourceTarget = plan.target.kind === 'resource' ? plan.target : null;
+    const completedResourceRaid = resourceTarget !== null
+      && plan.createdTurn < state.turn
+      && assigned.some(unit => hexKey(unit.position) === hexKey(resourceTarget.position));
+    const lostUnitTarget = plan.target.kind === 'unit' && !state.units[plan.target.id];
+    if (completedResourceRaid || lostUnitTarget) {
+      plan = {
+        ...plan,
+        phase: 'withdrawing',
+        lastProgressTurn: state.turn,
+      };
+    }
+    plan = { ...plan, assignedUnitIds: assignedIds };
+    opponentAI.barbarianCamps[camp.id] = plan;
+
+    for (const unit of assigned) {
+      if (unit.movementPointsLeft <= 0 || unit.hasActed) continue;
+      const withdrawing = plan.phase === 'withdrawing' || unit.health < profile.retreatHealthPercent;
+      const destination = withdrawing ? camp.position : targetPosition;
+      if (!destination) continue;
+      if (!withdrawing && plan.target.kind === 'unit') {
+        const defender = state.units[plan.target.id];
+        if (
+          defender
+          && canAttackByProfileOnMap(unit, defender, state.map)
+          && UNIT_DEFINITIONS[unit.type].strength >= UNIT_DEFINITIONS[defender.type].strength * 0.75
+        ) {
+          attackOrders.push({ attackerUnitId: unit.id, defenderUnitId: defender.id });
+          continue;
+        }
+      }
+      if (!withdrawing && plan.target.kind === 'city' && barbarianDistance(state, unit.position, destination) <= 1) {
+        cityAttackOrders.push({ attackerUnitId: unit.id, cityId: plan.target.id, damage: 10 });
+        continue;
+      }
+      const step = chooseStepToward(state, unit, destination);
+      if (step) moveOrders.push({ unitId: unit.id, toCoord: step });
+    }
+  }
+
+  return {
+    updatedCamps: campTick.updatedCamps,
+    spawnedUnits,
+    moveOrders,
+    attackOrders,
+    cityAttackOrders,
+    opponentAI,
+  };
 }
 
 const BARBARIAN_CHASE_RANGE = 5;

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -358,8 +358,19 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
       && existingPosition
       && sensedByCamp(state, camp, assigned, existingPosition),
     );
+    const existingRaidTargetEscaped = Boolean(
+      existing
+      && existing.objective === 'raid'
+      && existing.target.kind === 'unit'
+      && (
+        !existingPosition
+        || !sensedByCamp(state, camp, assigned, existingPosition)
+      ),
+    );
 
-    let plan: AIStrategicPlan | null = existingValid ? existing : null;
+    let plan: AIStrategicPlan | null = existingRaidTargetEscaped
+      ? { ...existing!, phase: 'withdrawing', lastProgressTurn: state.turn }
+      : existingValid ? existing! : null;
     if (campThreat && (plan?.objective !== 'defend' || plan.target.kind !== 'unit' || plan.target.id !== campThreat.id)) {
       plan = makeBarbarianPlan(
         state,

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -235,6 +235,7 @@ export function applyCombatOutcomeToState(
 
   let units = { ...state.units };
   let civilizations = { ...state.civilizations };
+  let minorCivs = { ...state.minorCivs };
   let espionage = state.espionage ? { ...state.espionage } : state.espionage;
 
   const defenderCiv = civilizations[defenderBefore.owner];
@@ -247,6 +248,17 @@ export function applyCombatOutcomeToState(
       ...defenderCiv,
       diplomacy: recordMilitaryAttack(
         defenderCiv.diplomacy,
+        attackerBefore.owner,
+        state.turn,
+      ),
+    };
+  }
+  const defenderMinor = minorCivs[defenderBefore.owner];
+  if (attackerBefore.owner !== defenderBefore.owner && defenderMinor?.diplomacy) {
+    minorCivs[defenderBefore.owner] = {
+      ...defenderMinor,
+      diplomacy: recordMilitaryAttack(
+        defenderMinor.diplomacy,
         attackerBefore.owner,
         state.turn,
       ),
@@ -307,6 +319,7 @@ export function applyCombatOutcomeToState(
       ...state,
       units,
       civilizations,
+      minorCivs,
       espionage,
   };
   const pirateEvents: PirateActionEvent[] = [];

--- a/src/systems/minor-civ-diplomacy.ts
+++ b/src/systems/minor-civ-diplomacy.ts
@@ -1,4 +1,5 @@
 import type { GameState } from '@/core/types';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
 
 export function isMinorCivAtWar(
   state: Readonly<Pick<GameState, 'civilizations' | 'minorCivs'>>,
@@ -11,4 +12,22 @@ export function isMinorCivAtWar(
     majorCiv?.diplomacy.atWarWith.includes(minorCivId)
     || minorCiv?.diplomacy.atWarWith.includes(majorCivId),
   );
+}
+
+export function isMinorCivHostileToOwner(
+  state: Readonly<Pick<GameState, 'civilizations' | 'minorCivs'>>,
+  minorCivId: string,
+  ownerId: string,
+): boolean {
+  if (minorCivId === ownerId) return false;
+  if (isAlwaysHostilePair(minorCivId, ownerId)) return true;
+  if (state.civilizations[ownerId] && isMinorCivAtWar(state, ownerId, minorCivId)) {
+    return true;
+  }
+
+  const minor = state.minorCivs[minorCivId];
+  if (!minor) return false;
+  return Object.entries(minor.chainStatusByCiv ?? {}).some(([allyId, status]) =>
+    status.status === 'allied'
+    && state.civilizations[allyId]?.diplomacy.atWarWith.includes(ownerId));
 }

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -155,7 +155,11 @@ function hashSeed(seed: string): number {
 
 // === Turn Processing ===
 
-export function processMinorCivTurn(state: GameState, bus: EventBus): GameState {
+export function processMinorCivTurn(
+  state: GameState,
+  bus: EventBus,
+  _options: { purposefulAIEnabled?: boolean } = {},
+): GameState {
   let nextState = structuredClone(state);
   for (const mcId of Object.keys(nextState.minorCivs).sort()) {
     let mc = nextState.minorCivs[mcId];

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -1,15 +1,34 @@
-import type { GameState, MinorCivArchetype, MinorCivState, HexCoord, City, Unit, UnitType } from '@/core/types';
+import type {
+  AIStrategicPlan,
+  GameState,
+  MinorCivArchetype,
+  MinorCivState,
+  HexCoord,
+  City,
+  Unit,
+  UnitType,
+} from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
+import { OPPONENT_CHALLENGE_PROFILES, resolveOpponentChallenge } from '@/core/opponent-challenge';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
 import { TECH_TREE } from './tech-definitions';
 import { createDiplomacyState, modifyRelationship } from './diplomacy-system';
 import { applyResearchBonus } from './tech-system';
-import { hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
-import { createUnit, UNIT_DEFINITIONS } from './unit-system';
+import {
+  getWrappedHexNeighbors,
+  hexDistance,
+  hexKey,
+  hexNeighbors,
+  wrappedHexDistance,
+} from './hex-utils';
+import { createUnit, resetUnitTurn, UNIT_DEFINITIONS } from './unit-system';
 import { foundCity } from './city-system';
 import { collectUsedCityNames } from './city-name-system';
 import { generateQuest } from './quest-system';
-import { isMinorCivAtWar } from './minor-civ-diplomacy';
+import { isMinorCivAtWar, isMinorCivHostileToOwner } from './minor-civ-diplomacy';
 import { resolveCombat } from './combat-system';
 import { hasDiscoveredMinorCiv } from './discovery-system';
 import { canAttackByProfileOnMap } from './attack-targeting';
@@ -20,6 +39,11 @@ import {
   isMinorCivAllianceActive,
   reconcileMinorCivQuestTurn,
 } from './quest-chain-system';
+import { executeUnitMove } from './unit-movement-system';
+import { canUnitAttackTarget } from './attack-targeting';
+import { applyCombatOutcomeToState } from './combat-reward-system';
+import { buildCombatPresentation } from './viewer-event-presentation';
+import { removeRouteForUnit } from './trade-system';
 
 const PLACEMENT_COUNTS: Record<string, [number, number]> = {
   small: [2, 4],
@@ -158,9 +182,21 @@ function hashSeed(seed: string): number {
 export function processMinorCivTurn(
   state: GameState,
   bus: EventBus,
-  _options: { purposefulAIEnabled?: boolean } = {},
+  options: { purposefulAIEnabled?: boolean } = {},
 ): GameState {
   let nextState = structuredClone(state);
+  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
+  if (purposefulAIEnabled && !nextState.opponentAI) {
+    nextState.opponentAI = createEmptyOpponentAIState();
+  }
+  if (purposefulAIEnabled) {
+    nextState.opponentAI!.minorCivs = Object.fromEntries(
+      Object.entries(nextState.opponentAI!.minorCivs).filter(([minorCivId]) => {
+        const minor = nextState.minorCivs[minorCivId];
+        return Boolean(minor && !minor.isDestroyed && nextState.cities[minor.cityId]);
+      }),
+    );
+  }
   for (const mcId of Object.keys(nextState.minorCivs).sort()) {
     let mc = nextState.minorCivs[mcId];
     if (mc.isDestroyed) continue;
@@ -168,7 +204,21 @@ export function processMinorCivTurn(
     const def = MINOR_CIV_DEFINITIONS.find(d => d.id === mc.definitionId);
     if (!def) continue;
 
-    processMovement(nextState, mc);
+    if (purposefulAIEnabled) {
+      for (const unitId of mc.units) {
+        const unit = nextState.units[unitId];
+        if (unit) nextState.units[unitId] = resetUnitTurn(unit);
+      }
+      const planned = planPurposefulMinorCivTurn(nextState, mcId);
+      if (planned.plan) {
+        nextState.opponentAI!.minorCivs[mcId] = planned.plan;
+      } else {
+        delete nextState.opponentAI!.minorCivs[mcId];
+      }
+      nextState = executePurposefulMinorCivOrders(nextState, planned, bus);
+    } else {
+      processMovement(nextState, mc);
+    }
     nextState = processQuests(nextState, mcId, def, bus);
     mc = nextState.minorCivs[mcId];
     nextState = applyAllyBonuses(nextState, mc, def);
@@ -177,6 +227,266 @@ export function processMinorCivTurn(
     emitRelationshipThresholds(nextState, nextState.minorCivs[mcId], bus);
   }
 
+  return nextState;
+}
+
+export interface PurposefulMinorCivPlanResult {
+  plan: AIStrategicPlan | null;
+  moveOrders: Array<{ unitId: string; to: HexCoord }>;
+  attackOrders: Array<{ attackerUnitId: string; defenderUnitId: string }>;
+}
+
+const MINOR_OPERATIONAL_RADIUS = 6;
+const MINOR_RESOURCE_RADIUS = 4;
+
+function minorDistance(state: GameState, a: HexCoord, b: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(a, b, state.map.width)
+    : hexDistance(a, b);
+}
+
+function makeMinorPlan(
+  state: GameState,
+  mc: MinorCivState,
+  target: AIStrategicPlan['target'],
+  objective: AIStrategicPlan['objective'],
+  reason: AIStrategicPlan['reasonCodes'][number],
+): AIStrategicPlan {
+  const city = state.cities[mc.cityId]!;
+  return {
+    id: `minor-plan:${mc.id}:${state.turn}:${objective}`,
+    actorId: mc.id,
+    objective,
+    target,
+    theaterId: `minor:${mc.id}`,
+    phase: target.kind === 'region' ? 'scouting' : 'advancing',
+    reasonCodes: [reason],
+    commitment: objective === 'defend' ? 1 : 0.7,
+    createdTurn: state.turn,
+    reconsiderAfterTurn: state.turn + 2,
+    expiresAfterTurn: state.turn + 6,
+    lastProgressTurn: state.turn,
+    rallyPoint: { ...city.position },
+    requiredRoles: { frontline: 1 },
+    assignedUnitIds: mc.units.filter(unitId => Boolean(state.units[unitId])).sort(),
+  };
+}
+
+function minorPlanPosition(state: GameState, plan: AIStrategicPlan): HexCoord | null {
+  if (plan.target.kind === 'unit') return state.units[plan.target.id]?.position ?? null;
+  if (plan.target.kind === 'city') return state.cities[plan.target.id]?.position ?? null;
+  if (plan.target.kind === 'camp') return state.barbarianCamps[plan.target.id]?.position ?? null;
+  return plan.target.kind === 'resource' ? plan.target.position : plan.target.anchor;
+}
+
+function chooseMinorStep(
+  state: GameState,
+  unit: Unit,
+  target: HexCoord,
+): HexCoord | null {
+  const occupied = new Set(Object.values(state.units)
+    .filter(candidate => candidate.id !== unit.id && !candidate.transportId)
+    .map(candidate => hexKey(candidate.position)));
+  const candidates = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(unit.position, state.map.width)
+    : hexNeighbors(unit.position);
+  return candidates
+    .filter(coord => {
+      const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+      return terrain !== undefined
+        && terrain !== 'ocean'
+        && terrain !== 'coast'
+        && terrain !== 'mountain'
+        && !occupied.has(hexKey(coord));
+    })
+    .filter(coord =>
+      minorDistance(state, coord, target) < minorDistance(state, unit.position, target))
+    .sort((a, b) =>
+      minorDistance(state, a, target) - minorDistance(state, b, target)
+      || a.q - b.q
+      || a.r - b.r)[0] ?? null;
+}
+
+function isAlliedDefenseTarget(state: GameState, mc: MinorCivState, unit: Unit): boolean {
+  return Object.entries(mc.chainStatusByCiv ?? {}).some(([allyId, status]) => {
+    if (status.status !== 'allied') return false;
+    const ally = state.civilizations[allyId];
+    if (!ally?.diplomacy.atWarWith.includes(unit.owner)) return false;
+    return ally.cities.some(cityId => {
+      const city = state.cities[cityId];
+      return city && minorDistance(state, city.position, unit.position) <= 2;
+    }) || ally.units.some(unitId => {
+      const allyUnit = state.units[unitId];
+      return allyUnit && minorDistance(state, allyUnit.position, unit.position) <= 1;
+    });
+  });
+}
+
+export function planPurposefulMinorCivTurn(
+  state: GameState,
+  minorCivId: string,
+): PurposefulMinorCivPlanResult {
+  const mc = state.minorCivs[minorCivId];
+  const city = mc ? state.cities[mc.cityId] : undefined;
+  if (!mc || mc.isDestroyed || !city) {
+    return { plan: null, moveOrders: [], attackOrders: [] };
+  }
+  const definition = MINOR_CIV_DEFINITIONS.find(candidate => candidate.id === mc.definitionId);
+  if (!definition) return { plan: null, moveOrders: [], attackOrders: [] };
+
+  const localUnits = Object.values(state.units)
+    .filter(unit =>
+      unit.owner !== mc.id
+      && !unit.transportId
+      && minorDistance(state, city.position, unit.position) <= MINOR_OPERATIONAL_RADIUS)
+    .sort((a, b) =>
+      minorDistance(state, city.position, a.position) - minorDistance(state, city.position, b.position)
+      || a.id.localeCompare(b.id));
+  const legalHostiles = localUnits.filter(unit =>
+    isMinorCivHostileToOwner(state, mc.id, unit.owner));
+  const immediateCityThreat = legalHostiles.find(unit =>
+    minorDistance(state, city.position, unit.position) <= 2);
+
+  const resourceCoords = city.ownedTiles
+    .filter(coord => {
+      const tile = state.map.tiles[hexKey(coord)];
+      return minorDistance(state, city.position, coord) <= MINOR_RESOURCE_RADIUS
+        && Boolean(tile?.resource)
+        && tile.improvement !== 'none'
+        && tile.improvementTurnsLeft === 0;
+    });
+  const resourceThreat = legalHostiles.find(unit =>
+    resourceCoords.some(coord => minorDistance(state, coord, unit.position) <= 1));
+  const alwaysHostile = definition.archetype === 'militaristic'
+    ? legalHostiles.find(unit => isAlwaysHostilePair(mc.id, unit.owner))
+    : undefined;
+  const allyThreat = legalHostiles.find(unit => isAlliedDefenseTarget(state, mc, unit));
+  const recentAggressorIds = new Set(mc.diplomacy.events
+    .filter(event => event.type === 'military_attacked' && state.turn - event.turn <= 6)
+    .map(event => event.otherCiv));
+  const retaliatoryTarget = legalHostiles.find(unit => recentAggressorIds.has(unit.owner));
+
+  const chosen = immediateCityThreat
+    ?? resourceThreat
+    ?? alwaysHostile
+    ?? allyThreat
+    ?? retaliatoryTarget;
+  let objective: AIStrategicPlan['objective'] = 'defend';
+  let reason: AIStrategicPlan['reasonCodes'][number] = 'homeland-secure';
+  if (chosen === alwaysHostile && chosen !== immediateCityThreat && chosen !== resourceThreat) {
+    objective = 'repel';
+    reason = 'nearby-opportunity';
+  } else if (chosen === allyThreat && chosen !== immediateCityThreat && chosen !== resourceThreat) {
+    objective = 'support-ally';
+    reason = 'alliance-obligation';
+  } else if (chosen === retaliatoryTarget && chosen !== immediateCityThreat && chosen !== resourceThreat) {
+    objective = 'repel';
+    reason = 'retaliate-recent-attack';
+  } else if (chosen) {
+    reason = 'urgent-defense';
+  }
+
+  const target = chosen
+    ? { kind: 'unit' as const, id: chosen.id, lastKnownPosition: { ...chosen.position } }
+    : { kind: 'region' as const, id: `patrol:${mc.id}`, anchor: { ...city.position } };
+  let plan = makeMinorPlan(state, mc, target, objective, reason);
+  const existing = state.opponentAI?.minorCivs[mc.id];
+  const existingPosition = existing ? minorPlanPosition(state, existing) : null;
+  const existingMatchesChosen = Boolean(
+    chosen
+    && existing?.target.kind === 'unit'
+    && existing.target.id === chosen.id,
+  );
+  if (
+    !immediateCityThreat
+    && existing
+    && existing.target.kind !== 'city'
+    && existingPosition
+    && state.turn <= existing.expiresAfterTurn
+    && minorDistance(state, city.position, existingPosition) <= MINOR_OPERATIONAL_RADIUS
+    && (!chosen || existingMatchesChosen)
+  ) {
+    plan = { ...existing, assignedUnitIds: plan.assignedUnitIds };
+  }
+
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+  const challengeThreshold = resolveOpponentChallenge(state) === 'explorer'
+    ? 1.15
+    : resolveOpponentChallenge(state) === 'veteran' ? 0.9 : 1;
+  const archetypeThreshold = definition.archetype === 'militaristic' ? 0.9 : 1.2;
+  const ownStrength = mc.units.reduce((total, unitId) => {
+    const unit = state.units[unitId];
+    return total + (unit ? UNIT_DEFINITIONS[unit.type].strength : 0);
+  }, 0);
+  const targetPosition = minorPlanPosition(state, plan) ?? city.position;
+  const targetUnit = plan.target.kind === 'unit' ? state.units[plan.target.id] : undefined;
+  const targetStrength = targetUnit ? UNIT_DEFINITIONS[targetUnit.type].strength : 0;
+  const leavingHome = minorDistance(state, city.position, targetPosition) > 3;
+  const requiredRatio = leavingHome ? archetypeThreshold * challengeThreshold : 0.75;
+  const authorized = targetStrength === 0 || ownStrength >= targetStrength * Math.max(0.75, requiredRatio);
+  const moveOrders: PurposefulMinorCivPlanResult['moveOrders'] = [];
+  const attackOrders: PurposefulMinorCivPlanResult['attackOrders'] = [];
+
+  for (const unitId of [...mc.units].sort()) {
+    const unit = state.units[unitId];
+    if (!unit || unit.movementPointsLeft <= 0 || unit.hasActed) continue;
+    const withdrawing = unit.health < profile.retreatHealthPercent;
+    const destination = withdrawing || !authorized ? city.position : targetPosition;
+    if (
+      !withdrawing
+      && authorized
+      && targetUnit
+      && canUnitAttackTarget(state, unit, targetUnit.position, { requireVisibility: false }).ok
+    ) {
+      attackOrders.push({ attackerUnitId: unit.id, defenderUnitId: targetUnit.id });
+      continue;
+    }
+    if (
+      hexKey(unit.position) === hexKey(destination)
+      || (!chosen && minorDistance(state, unit.position, city.position) <= 3)
+    ) continue;
+    const step = chooseMinorStep(state, unit, destination);
+    if (step) moveOrders.push({ unitId: unit.id, to: step });
+  }
+
+  if (!authorized && chosen) plan = { ...plan, phase: 'mobilizing', commitment: 0.4 };
+  return { plan, moveOrders, attackOrders };
+}
+
+function executePurposefulMinorCivOrders(
+  state: GameState,
+  planned: PurposefulMinorCivPlanResult,
+  bus: EventBus,
+): GameState {
+  let nextState = state;
+  for (const order of planned.attackOrders) {
+    const attacker = nextState.units[order.attackerUnitId];
+    const defender = nextState.units[order.defenderUnitId];
+    if (!attacker || !defender || attacker.hasActed) continue;
+    const legality = canUnitAttackTarget(nextState, attacker, defender.position, { requireVisibility: false });
+    if (!legality.ok || legality.targetType !== 'unit' || legality.targetUnitId !== defender.id) continue;
+    const seed = Math.max(1, nextState.turn * 16807 + attacker.id.length * 97 + defender.id.length);
+    const result = resolveCombat(attacker, defender, nextState.map, seed, undefined, nextState.era);
+    const presentation = buildCombatPresentation(nextState, result, attacker, defender);
+    const attackerRouteId = attacker.committedToRouteId;
+    const defenderRouteId = defender.committedToRouteId;
+    const applied = applyCombatOutcomeToState(nextState, result, seed);
+    nextState = applied.state;
+    emitMinorCivQuestTransitions(bus, applied.questTransitions, nextState);
+    if (applied.attackerDefeated && attackerRouteId) {
+      nextState = removeRouteForUnit(nextState, attacker.id, bus, 'unit-died', attackerRouteId);
+    }
+    if (applied.defenderDefeated && defenderRouteId) {
+      nextState = removeRouteForUnit(nextState, defender.id, bus, 'unit-died', defenderRouteId);
+    }
+    bus.emit('combat:resolved', { result, ...presentation });
+    for (const reward of applied.rewards) bus.emit('combat:reward-earned', { reward });
+  }
+  for (const order of planned.moveOrders) {
+    const unit = nextState.units[order.unitId];
+    if (!unit || unit.hasActed || unit.movementPointsLeft <= 0) continue;
+    executeUnitMove(nextState, order.unitId, order.to, { actor: 'world', bus });
+  }
   return nextState;
 }
 
@@ -539,6 +849,14 @@ const ERA_UNIT_MAP: Record<number, UnitType> = {
   2: 'swordsman',
   3: 'pikeman',
   4: 'musketeer',
+  5: 'rifleman',
+  6: 'rifleman',
+  7: 'rifleman',
+  8: 'tank',
+  9: 'tank',
+  10: 'tank',
+  11: 'tank',
+  12: 'tank',
 };
 
 // Pre-built for O(1) lookup in checkEraAdvancement (called every turn)

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -392,6 +392,11 @@ export function planPurposefulMinorCivTurn(
   let plan = makeMinorPlan(state, mc, target, objective, reason);
   const existing = state.opponentAI?.minorCivs[mc.id];
   const existingPosition = existing ? minorPlanPosition(state, existing) : null;
+  const existingTargetRemainsHostile = existing?.target.kind !== 'unit'
+    || Boolean(
+      state.units[existing.target.id]
+      && isMinorCivHostileToOwner(state, mc.id, state.units[existing.target.id].owner),
+    );
   const existingMatchesChosen = Boolean(
     chosen
     && existing?.target.kind === 'unit'
@@ -402,6 +407,7 @@ export function planPurposefulMinorCivTurn(
     && existing
     && existing.target.kind !== 'city'
     && existingPosition
+    && existingTargetRemainsHostile
     && state.turn <= existing.expiresAfterTurn
     && minorDistance(state, city.position, existingPosition) <= MINOR_OPERATIONAL_RADIUS
     && (!chosen || existingMatchesChosen)

--- a/src/systems/pirate-behavior.ts
+++ b/src/systems/pirate-behavior.ts
@@ -5,6 +5,10 @@ import type {
   PirateRelocationPlan,
 } from '@/core/pirate-state';
 import { PIRATE_RELOCATION_DIRECTIONS } from '@/core/pirate-state';
+import {
+  OPPONENT_CHALLENGE_PROFILES,
+  resolveOpponentChallenge,
+} from '@/core/opponent-challenge';
 import { isAlwaysHostilePair } from '@/core/owner-kind';
 import {
   getWrappedHexNeighbors,
@@ -16,7 +20,7 @@ import {
 } from './hex-utils';
 import { createRng } from './map-generator';
 import { PIRATE_PLUNDER_CAP } from './pirate-definitions';
-import { getMovementStepCost, moveUnit, UNIT_DEFINITIONS } from './unit-system';
+import { findPath, getMovementStepCost, moveUnit, UNIT_DEFINITIONS } from './unit-system';
 
 export type PirateIntent = PirateIntentState;
 
@@ -247,6 +251,166 @@ export function choosePirateIntent(state: GameState, factionId: string): PirateI
     }
   }
   return null;
+}
+
+export function getPirateFleetLeader(state: GameState, factionId: string): Unit | null {
+  const faction = state.pirates?.factions[factionId];
+  if (!faction) return null;
+  if (faction.headquarters.kind === 'deep-sea-flotilla') {
+    const flagship = state.units[faction.headquarters.flagshipUnitId];
+    if (flagship && faction.shipIds.includes(flagship.id)) return flagship;
+  }
+  return faction.shipIds
+    .map(unitId => state.units[unitId])
+    .filter((unit): unit is Unit => Boolean(unit))
+    .sort((a, b) =>
+      UNIT_DEFINITIONS[b.type].strength - UNIT_DEFINITIONS[a.type].strength
+      || a.id.localeCompare(b.id))[0] ?? null;
+}
+
+function pirateIntentTargetPosition(
+  state: GameState,
+  intent: PirateIntentState,
+): HexCoord | null {
+  if (intent.targetUnitId) return state.units[intent.targetUnitId]?.position ?? null;
+  if (intent.targetCityId) return state.cities[intent.targetCityId]?.position ?? null;
+  return null;
+}
+
+function pirateApproachPositions(
+  state: GameState,
+  target: HexCoord,
+): HexCoord[] {
+  const targetTerrain = state.map.tiles[hexKey(target)]?.terrain;
+  if (targetTerrain === 'coast' || targetTerrain === 'ocean') return [target];
+  return neighbors(state, target)
+    .filter(coord => {
+      const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+      return terrain === 'coast' || terrain === 'ocean';
+    })
+    .sort((a, b) => a.q - b.q || a.r - b.r);
+}
+
+function hasPiratePathToIntent(
+  state: GameState,
+  factionId: string,
+  intent: PirateIntentState,
+): boolean {
+  const leader = getPirateFleetLeader(state, factionId);
+  const target = pirateIntentTargetPosition(state, intent);
+  if (!leader || !target) return false;
+  return pirateApproachPositions(state, target).some(position =>
+    Boolean(findPath(leader.position, position, state.map, 'naval', { unit: leader })));
+}
+
+function headquartersDefenseIntent(
+  state: GameState,
+  factionId: string,
+): PirateIntentState | null {
+  const faction = state.pirates?.factions[factionId];
+  const leader = getPirateFleetLeader(state, factionId);
+  if (!faction || !leader) return null;
+  const headquartersPosition = faction.headquarters.kind === 'coastal-enclave'
+    ? faction.headquarters.position
+    : leader.position;
+  const threat = Object.values(state.units)
+    .filter(unit =>
+      !unit.transportId
+      && isCombatNaval(unit)
+      && isEligibleVictim(state, factionId, unit.owner)
+      && isAlwaysHostilePair(factionId, unit.owner)
+      && distance(state, headquartersPosition, unit.position) <= 2)
+    .sort((a, b) =>
+      distance(state, headquartersPosition, a.position) - distance(state, headquartersPosition, b.position)
+      || a.id.localeCompare(b.id))[0];
+  return threat ? {
+    kind: 'raid',
+    targetCivId: threat.owner,
+    targetUnitId: threat.id,
+    plannedRound: state.turn,
+    lastProgressRound: state.turn,
+    lastTargetDistance: distance(state, leader.position, threat.position),
+    mode: 'engage',
+    leaderUnitId: leader.id,
+  } : null;
+}
+
+export function shouldPirateFleetWithdraw(state: GameState, factionId: string): boolean {
+  const faction = state.pirates?.factions[factionId];
+  const leader = getPirateFleetLeader(state, factionId);
+  if (!faction || !leader) return false;
+  const ships = faction.shipIds
+    .map(unitId => state.units[unitId])
+    .filter((unit): unit is Unit => Boolean(unit));
+  if (ships.length === 0) return false;
+  const averageHealth = ships.reduce((total, unit) => total + unit.health, 0) / ships.length;
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+  const healthThreshold = Math.max(0, profile.retreatHealthPercent - (faction.contract ? 10 : 0));
+  if (averageHealth < healthThreshold) return true;
+
+  const fleetStrength = ships.reduce(
+    (total, unit) => total + UNIT_DEFINITIONS[unit.type].strength,
+    0,
+  );
+  const hostileStrength = Object.values(state.units)
+    .filter(unit =>
+      !unit.transportId
+      && isCombatNaval(unit)
+      && isEligibleVictim(state, factionId, unit.owner)
+      && isAlwaysHostilePair(factionId, unit.owner)
+      && distance(state, leader.position, unit.position) <= PIRATE_LOCAL_RISK_RADIUS)
+    .reduce((total, unit) => total + UNIT_DEFINITIONS[unit.type].strength, 0);
+  const minimumRatio = faction.contract ? 0.45 : 0.7;
+  return hostileStrength > 0 && fleetStrength < hostileStrength * minimumRatio;
+}
+
+const PIRATE_LOCAL_RISK_RADIUS = 7;
+
+function isPersistentPirateIntentValid(
+  state: GameState,
+  factionId: string,
+  intent: PirateIntentState,
+): boolean {
+  const faction = state.pirates?.factions[factionId];
+  if (!faction || intent.mode === 'withdraw') return false;
+  if (state.turn - (intent.lastProgressRound ?? intent.plannedRound) >= 3) return false;
+  if (intent.targetCivId && !isEligibleVictim(state, factionId, intent.targetCivId)) return false;
+  if (faction.contract && intent.targetCivId !== faction.contract.targetId) return false;
+  if (!pirateIntentTargetPosition(state, intent)) return false;
+  return hasPiratePathToIntent(state, factionId, intent);
+}
+
+export function choosePersistentPirateIntent(
+  state: GameState,
+  factionId: string,
+): PirateIntentState | null {
+  const faction = state.pirates?.factions[factionId];
+  const leader = getPirateFleetLeader(state, factionId);
+  if (!faction || !leader) return null;
+
+  if (shouldPirateFleetWithdraw(state, factionId)) {
+    return {
+      kind: 'patrol',
+      plannedRound: state.turn,
+      lastProgressRound: state.turn,
+      mode: 'withdraw',
+      leaderUnitId: leader.id,
+    };
+  }
+  const defense = headquartersDefenseIntent(state, factionId);
+  if (defense) return defense;
+  if (faction.intent && isPersistentPirateIntentValid(state, factionId, faction.intent)) {
+    return { ...faction.intent, leaderUnitId: leader.id, mode: 'engage' };
+  }
+  const chosen = choosePirateIntent(state, factionId);
+  const target = chosen ? pirateIntentTargetPosition(state, chosen) : null;
+  return chosen ? {
+    ...chosen,
+    lastProgressRound: state.turn,
+    lastTargetDistance: target ? distance(state, leader.position, target) : undefined,
+    mode: 'engage',
+    leaderUnitId: leader.id,
+  } : null;
 }
 
 function relocationAnchorRound(faction: NonNullable<GameState['pirates']>['factions'][string]): number {

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -2,6 +2,7 @@ import type { EventBus } from '@/core/event-bus';
 import type { CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import type { PirateFactionState } from '@/core/pirate-state';
 import { isMajorCivOwner } from '@/core/owner-kind';
+import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
 import { resolveCombat } from './combat-system';
@@ -10,8 +11,10 @@ import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDi
 import {
   applyPlannedRelocation,
   choosePirateIntent,
+  choosePersistentPirateIntent,
   derivePirateBlockades,
   derivePirateRaids,
+  getPirateFleetLeader,
   planFlotillaRelocation,
   type PirateRoundFacts,
 } from './pirate-behavior';
@@ -30,7 +33,17 @@ import {
   deliverPirateActivationWarnings,
   type PirateNotificationEvent,
 } from './pirate-notifications';
-import { createUnit, getMovementStepCost, moveUnit, resetUnitTurn, UNIT_DEFINITIONS } from './unit-system';
+import {
+  createUnit,
+  findPath,
+  getMovementStepCost,
+  moveUnit,
+  resetUnitTurn,
+  UNIT_DEFINITIONS,
+} from './unit-system';
+import { executeUnitMove } from './unit-movement-system';
+import { removeRouteForUnit } from './trade-system';
+import { emitMinorCivQuestTransitions } from './quest-chain-system';
 import {
   buildCombatPresentation,
   buildMovePresentationByViewer,
@@ -74,17 +87,33 @@ function neighbors(state: GameState, coord: HexCoord): HexCoord[] {
   return state.map.wrapsHorizontally ? getWrappedHexNeighbors(coord, state.map.width) : hexNeighbors(coord);
 }
 
-function normalizeRoundState(state: GameState): { state: GameState; events: PirateTransitionEvent[] } {
+function normalizeRoundState(
+  state: GameState,
+  purposefulAIEnabled: boolean,
+): { state: GameState; events: PirateTransitionEvent[] } {
   if (!state.pirates) return { state, events: [] };
   let nextState = state;
   const events: PirateTransitionEvent[] = [];
-  for (const faction of Object.values(state.pirates.factions)) {
+  for (const originalFaction of Object.values(state.pirates.factions)) {
+    let faction = originalFaction;
     if (faction.headquarters.kind === 'deep-sea-flotilla' && !state.units[faction.headquarters.flagshipUnitId]) {
-      const result = destroyPirateFaction(nextState, {
-        factionId: faction.id, destroyedByOwnerId: null, reason: 'missing-flagship',
-      });
-      nextState = result.state;
-      continue;
+      const replacement = purposefulAIEnabled ? getPirateFleetLeader(state, faction.id) : null;
+      if (replacement) {
+        faction = {
+          ...faction,
+          shipIds: faction.shipIds.filter(unitId => Boolean(state.units[unitId])),
+          headquarters: {
+            ...faction.headquarters,
+            flagshipUnitId: replacement.id,
+          },
+        };
+      } else {
+        const result = destroyPirateFaction(nextState, {
+          factionId: faction.id, destroyedByOwnerId: null, reason: 'missing-flagship',
+        });
+        nextState = result.state;
+        continue;
+      }
     }
     const tributeByCiv = Object.fromEntries(Object.entries(faction.tributeByCiv)
       .filter(([, record]) => record.protectedUntilRound > state.turn));
@@ -143,6 +172,7 @@ function attackTarget(
   state: GameState,
   attacker: Unit,
   targetUnitId: string | undefined,
+  bus?: EventBus,
 ): {
   state: GameState;
   result: CombatResult | null;
@@ -158,11 +188,34 @@ function attackTarget(
   const seed = Math.max(1, state.turn * 7919 + attacker.id.length * 97 + defender.id.length);
   const result = resolveCombat(attacker, defender, state.map, seed, undefined, state.era);
   const applied = applyCombatOutcomeToState(state, result, seed);
+  let appliedState = applied.state;
+  if (bus && applied.attackerDefeated && attacker.committedToRouteId) {
+    appliedState = removeRouteForUnit(
+      appliedState,
+      attacker.id,
+      bus,
+      'unit-died',
+      attacker.committedToRouteId,
+    );
+  }
+  if (bus && applied.defenderDefeated && defender.committedToRouteId) {
+    appliedState = removeRouteForUnit(
+      appliedState,
+      defender.id,
+      bus,
+      'unit-died',
+      defender.committedToRouteId,
+    );
+  }
+  if (bus) {
+    emitMinorCivQuestTransitions(bus, applied.questTransitions, appliedState);
+    for (const reward of applied.rewards) bus.emit('combat:reward-earned', { reward });
+  }
   const transportKill = !result.defenderSurvived && UNIT_DEFINITIONS[defender.type]?.cargoCapacity !== undefined
     ? { factionId: attacker.owner as `pirate-${number}`, victimCivId: defender.owner, unitId: defender.id }
     : null;
   return {
-    state: applied.state,
+    state: appliedState,
     result,
     presentation: buildCombatPresentation(state, result, attacker, defender),
     transportKill,
@@ -235,6 +288,245 @@ function processMovementAndCombat(state: GameState, relocated: Set<string>): {
         if (attack.transportKill) facts.transportKills.push(attack.transportKill);
         events.push(...attack.events);
       }
+    }
+  }
+  return { state: nextState, facts, events };
+}
+
+function purposefulTargetPosition(
+  state: GameState,
+  faction: PirateFactionState,
+): HexCoord | null {
+  if (faction.intent?.targetUnitId) {
+    return state.units[faction.intent.targetUnitId]?.position ?? null;
+  }
+  if (faction.intent?.targetCityId) {
+    return state.cities[faction.intent.targetCityId]?.position ?? null;
+  }
+  return null;
+}
+
+function waterApproachTiles(state: GameState, target: HexCoord): HexCoord[] {
+  const targetTerrain = state.map.tiles[hexKey(target)]?.terrain;
+  const adjacent = neighbors(state, target).filter(coord => {
+    const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+    return terrain === 'coast' || terrain === 'ocean';
+  });
+  return targetTerrain === 'coast' || targetTerrain === 'ocean'
+    ? [target, ...adjacent]
+    : adjacent;
+}
+
+function purposefulRetreatTarget(
+  state: GameState,
+  faction: PirateFactionState,
+  leader: Unit,
+): HexCoord | null {
+  if (faction.headquarters.kind === 'coastal-enclave') {
+    return waterApproachTiles(state, faction.headquarters.position)
+      .sort((a, b) =>
+        distance(state, leader.position, a) - distance(state, leader.position, b)
+        || a.q - b.q
+        || a.r - b.r)[0] ?? null;
+  }
+  const hostiles = Object.values(state.units).filter(unit =>
+    unit.owner !== faction.id
+    && UNIT_DEFINITIONS[unit.type]?.domain === 'naval'
+    && UNIT_DEFINITIONS[unit.type].strength > 0);
+  return neighbors(state, leader.position)
+    .filter(coord => {
+      const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+      return terrain === 'coast' || terrain === 'ocean';
+    })
+    .sort((a, b) => {
+      const safety = (coord: HexCoord) => hostiles.length === 0
+        ? 0
+        : Math.min(...hostiles.map(unit => distance(state, coord, unit.position)));
+      return safety(b) - safety(a) || a.q - b.q || a.r - b.r;
+    })[0] ?? null;
+}
+
+function choosePurposefulMoveDestination(
+  state: GameState,
+  unit: Unit,
+  desired: HexCoord,
+  leaderPosition: HexCoord | null,
+): HexCoord | null {
+  const approaches = waterApproachTiles(state, desired)
+    .map(coord => ({
+      coord,
+      path: findPath(unit.position, coord, state.map, 'naval', { unit }),
+    }))
+    .filter((entry): entry is { coord: HexCoord; path: HexCoord[] } => Boolean(entry.path))
+    .sort((a, b) =>
+      a.path.length - b.path.length
+      || a.coord.q - b.coord.q
+      || a.coord.r - b.coord.r);
+  const path = approaches[0]?.path;
+  if (!path || path.length <= 1) return null;
+  const occupied = new Set(Object.values(state.units)
+    .filter(candidate => candidate.id !== unit.id && !candidate.transportId)
+    .map(candidate => hexKey(candidate.position)));
+  let cost = 0;
+  const reachable: HexCoord[] = [];
+  for (let index = 1; index < path.length; index++) {
+    const stepCost = getMovementStepCost(unit, state.map, path[index - 1]!, path[index]!, {});
+    if (!Number.isFinite(stepCost) || cost + stepCost > unit.movementPointsLeft) break;
+    if (occupied.has(hexKey(path[index]!))) break;
+    cost += stepCost;
+    reachable.push(path[index]!);
+  }
+  if (reachable.length === 0) return null;
+  if (!leaderPosition) return reachable.at(-1)!;
+  return [...reachable]
+    .reverse()
+    .find(coord => distance(state, coord, leaderPosition) <= 2)
+    ?? reachable.sort((a, b) =>
+      distance(state, a, leaderPosition) - distance(state, b, leaderPosition)
+      || a.q - b.q
+      || a.r - b.r)[0]!;
+}
+
+function processPurposefulMovementAndCombat(
+  state: GameState,
+  relocated: Set<string>,
+  bus: EventBus,
+): {
+  state: GameState;
+  facts: PirateRoundFacts;
+  events: PirateActionEvent[];
+} {
+  let nextState = state;
+  const facts: PirateRoundFacts = {
+    movements: [],
+    attacks: [],
+    transportKills: [],
+    attackPresentations: [],
+  };
+  const events: PirateActionEvent[] = [];
+
+  for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
+    let faction = nextState.pirates?.factions[factionId];
+    if (!faction) continue;
+    const intent = choosePersistentPirateIntent(nextState, factionId);
+    faction = { ...faction, intent };
+    nextState = {
+      ...nextState,
+      pirates: {
+        ...nextState.pirates!,
+        factions: { ...nextState.pirates!.factions, [factionId]: faction },
+      },
+    };
+    const leader = getPirateFleetLeader(nextState, factionId);
+    if (!leader) continue;
+    const orderedShipIds = [
+      leader.id,
+      ...faction.shipIds.filter(unitId => unitId !== leader.id).sort(),
+    ];
+    const target = intent?.mode === 'withdraw'
+      ? purposefulRetreatTarget(nextState, faction, leader)
+      : purposefulTargetPosition(nextState, faction);
+    const beforeDistance = target ? distance(nextState, leader.position, target) : null;
+    const attacksBeforeFaction = facts.attacks.length;
+    let currentLeaderPosition = { ...leader.position };
+
+    for (const unitId of orderedShipIds) {
+      let unit = nextState.units[unitId];
+      if (!unit || relocated.has(unitId)) continue;
+      unit = resetUnitTurn(unit);
+      nextState = { ...nextState, units: { ...nextState.units, [unitId]: unit } };
+
+      let attack = intent?.mode !== 'withdraw'
+        ? attackTarget(nextState, unit, intent?.targetUnitId, bus)
+        : { state: nextState, result: null, presentation: null, transportKill: null, events: [] };
+      if (attack.result) {
+        nextState = attack.state;
+        facts.attacks.push(attack.result);
+        facts.attackPresentations!.push(attack.presentation!);
+        if (attack.transportKill) facts.transportKills.push(attack.transportKill);
+        events.push(...attack.events);
+        if (unitId === leader.id && nextState.units[unitId]) {
+          currentLeaderPosition = { ...nextState.units[unitId].position };
+        }
+        continue;
+      }
+
+      if (target) {
+        const desired = unitId === leader.id
+          ? target
+          : distance(nextState, unit.position, currentLeaderPosition) > 2
+            ? currentLeaderPosition
+            : target;
+        const destination = choosePurposefulMoveDestination(
+          nextState,
+          unit,
+          desired,
+          unitId === leader.id ? null : currentLeaderPosition,
+        );
+        if (destination) {
+          const beforeMove = nextState;
+          const move = executeUnitMove(nextState, unitId, destination, { actor: 'world' });
+          if (move.ok) {
+            facts.movements.push({
+              unitId,
+              from: move.from,
+              to: move.to,
+              path: move.path.slice(1),
+              presentationByViewer: buildMovePresentationByViewer(
+                beforeMove,
+                unit,
+                move.path,
+              ),
+            });
+            unit = nextState.units[unitId]!;
+            if (unitId === leader.id) currentLeaderPosition = { ...unit.position };
+          }
+        }
+      }
+
+      attack = intent?.mode !== 'withdraw' && nextState.units[unitId]
+        ? attackTarget(nextState, nextState.units[unitId], intent?.targetUnitId, bus)
+        : attack;
+      if (attack.result) {
+        nextState = attack.state;
+        facts.attacks.push(attack.result);
+        facts.attackPresentations!.push(attack.presentation!);
+        if (attack.transportKill) facts.transportKills.push(attack.transportKill);
+        events.push(...attack.events);
+      }
+    }
+
+    faction = nextState.pirates?.factions[factionId];
+    const currentIntent = faction?.intent;
+    const currentLeader = getPirateFleetLeader(nextState, factionId);
+    const currentTarget = faction ? purposefulTargetPosition(nextState, faction) : null;
+    if (faction && currentIntent && currentLeader) {
+      const afterDistance = currentTarget
+        ? distance(nextState, currentLeader.position, currentTarget)
+        : null;
+      const madeProgress = beforeDistance !== null
+        && afterDistance !== null
+        && (
+          afterDistance < beforeDistance
+          || afterDistance <= 2
+          || facts.attacks.length > attacksBeforeFaction
+        );
+      const updatedIntent = {
+        ...currentIntent,
+        lastTargetDistance: afterDistance ?? currentIntent.lastTargetDistance,
+        lastProgressRound: madeProgress ? state.turn : currentIntent.lastProgressRound,
+        leaderUnitId: currentLeader.id,
+      };
+      nextState = {
+        ...nextState,
+        pirates: {
+          ...nextState.pirates!,
+          factions: {
+            ...nextState.pirates!.factions,
+            [factionId]: { ...faction, intent: updatedIntent },
+          },
+        },
+      };
     }
   }
   return { state: nextState, facts, events };
@@ -370,11 +662,12 @@ function advanceStageAndReinforce(state: GameState, bus: EventBus): GameState {
 export function processPiratesForCompletedRound(
   state: GameState,
   bus: EventBus,
-  _options: { purposefulAIEnabled?: boolean } = {},
+  options: { purposefulAIEnabled?: boolean } = {},
 ): ProcessPiratesResult {
+  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
   const trace = [...PIRATE_ROUND_TRACE];
   const wasActivated = state.pirates?.activatedTurn !== null;
-  let normalized = normalizeRoundState(state);
+  let normalized = normalizeRoundState(state, purposefulAIEnabled);
   let nextState = normalized.state;
   const events: PirateTransitionEvent[] = [...normalized.events];
   const relocated = new Set<string>();
@@ -416,7 +709,9 @@ export function processPiratesForCompletedRound(
     }
     if (result.facts.relocation.status === 'moved') events.push({ type: 'relocated', factionId });
   }
-  const processed = processMovementAndCombat(nextState, relocated);
+  const processed = purposefulAIEnabled
+    ? processPurposefulMovementAndCombat(nextState, relocated, bus)
+    : processMovementAndCombat(nextState, relocated);
   nextState = processed.state;
   const facts: PirateRoundFacts = {
     movements: [...relocationFacts, ...processed.facts.movements],

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -367,7 +367,11 @@ function advanceStageAndReinforce(state: GameState, bus: EventBus): GameState {
   return nextState;
 }
 
-export function processPiratesForCompletedRound(state: GameState, bus: EventBus): ProcessPiratesResult {
+export function processPiratesForCompletedRound(
+  state: GameState,
+  bus: EventBus,
+  _options: { purposefulAIEnabled?: boolean } = {},
+): ProcessPiratesResult {
   const trace = [...PIRATE_ROUND_TRACE];
   const wasActivated = state.pirates?.activatedTurn !== null;
   let normalized = normalizeRoundState(state);

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -25,6 +25,12 @@ export function isResourceTileDeniedByHostileOccupation(
   coord: HexCoord,
 ): boolean {
   const civ = state.civilizations[civId];
+  const tile = state.map.tiles[hexKey(coord)];
+  if (
+    !tile?.resource
+    || tile.improvement === 'none'
+    || tile.improvementTurnsLeft !== 0
+  ) return false;
   return Object.values(state.units ?? {}).some(unit => {
     if (unit.transportId || unit.owner === civId || hexKey(unit.position) !== hexKey(coord)) {
       return false;

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -1,4 +1,5 @@
-import type { GameState, ResourceType, ResourceYield, PurchasedResourceEntry } from '@/core/types';
+import type { GameState, HexCoord, ResourceType, ResourceYield, PurchasedResourceEntry } from '@/core/types';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { hexKey } from './hex-utils';
 import { RESOURCE_DEFINITIONS } from './resource-definitions';
 import { isAtWar } from './diplomacy-system';
@@ -18,7 +19,30 @@ import { isAtWar } from './diplomacy-system';
  *
  * Pure function — reads state only, never mutates.
  */
-export function getCivAvailableResources(state: GameState, civId: string): Set<ResourceType> {
+export function isResourceTileDeniedByHostileOccupation(
+  state: GameState,
+  civId: string,
+  coord: HexCoord,
+): boolean {
+  const civ = state.civilizations[civId];
+  return Object.values(state.units ?? {}).some(unit => {
+    if (unit.transportId || unit.owner === civId || hexKey(unit.position) !== hexKey(coord)) {
+      return false;
+    }
+    if (isAlwaysHostilePair(civId, unit.owner)) return true;
+    return Boolean(
+      civ?.diplomacy && isAtWar(civ.diplomacy, unit.owner)
+      || state.civilizations[unit.owner]?.diplomacy
+        && isAtWar(state.civilizations[unit.owner].diplomacy, civId),
+    );
+  });
+}
+
+export function getCivAvailableResources(
+  state: GameState,
+  civId: string,
+  options: { hostileOccupationEnabled?: boolean } = {},
+): Set<ResourceType> {
   const result = new Set<ResourceType>();
   const civ = state.civilizations[civId];
   if (!civ) return result;
@@ -42,6 +66,10 @@ export function getCivAvailableResources(state: GameState, civId: string): Set<R
 
       // Tech gate — must have researched the revealing tech.
       if (!completedTechs.has(def.tech)) continue;
+      if (
+        options.hostileOccupationEnabled
+        && isResourceTileDeniedByHostileOccupation(state, civId, coord)
+      ) continue;
 
       if (key === cityKey) {
         // City-center exception: tech alone grants the resource.
@@ -71,6 +99,10 @@ export function getCivAvailableResources(state: GameState, civId: string): Set<R
     const def = resourceDefMap.get(tile.resource as ResourceType);
     if (!def) continue;
     if (!completedTechs.has(def.tech)) continue;
+    if (
+      options.hostileOccupationEnabled
+      && isResourceTileDeniedByHostileOccupation(state, civId, tile.coord)
+    ) continue;
 
     result.add(tile.resource as ResourceType);
   }
@@ -101,9 +133,10 @@ export function getCivAvailableResources(state: GameState, civId: string): Set<R
 export function getCivResourceYieldBonus(
   state: GameState,
   civId: string,
+  options: { hostileOccupationEnabled?: boolean } = {},
 ): ResourceYield {
   const bonus: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
-  const owned = getCivAvailableResources(state, civId);
+  const owned = getCivAvailableResources(state, civId, options);
 
   for (const def of RESOURCE_DEFINITIONS) {
     if (!def.effect || def.effect.type === 'happiness') continue;
@@ -127,8 +160,9 @@ export function getCivResourceYieldBonus(
 export function getCivHappinessFromResources(
   state: GameState,
   civId: string,
+  options: { hostileOccupationEnabled?: boolean } = {},
 ): number {
-  const owned = getCivAvailableResources(state, civId);
+  const owned = getCivAvailableResources(state, civId, options);
   let count = 0;
 
   for (const def of RESOURCE_DEFINITIONS) {

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -20,12 +20,17 @@ import { buildUnitOccupancy, getUnitIdsAtCoord } from '@/systems/unit-occupancy'
 import { syncTransportCargoPositions } from '@/systems/transport-system';
 import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
 
-export interface ExecuteUnitMoveOptions {
-  actor: 'player' | 'automation' | 'ai';
-  civId: string;
-  bus?: EventBus;
-  foreignCityEntryId?: string;
-}
+export type ExecuteUnitMoveOptions =
+  | {
+      actor: 'player' | 'automation' | 'ai';
+      civId: string;
+      bus?: EventBus;
+      foreignCityEntryId?: string;
+    }
+  | {
+      actor: 'world';
+      bus?: EventBus;
+    };
 
 export interface WonderDiscoveryResult {
   wonderId: string;
@@ -125,6 +130,17 @@ export function executeUnitMove(
     path: movePath,
     presentationByViewer,
   });
+
+  if (options.actor === 'world') {
+    return {
+      ok: true,
+      from,
+      to: validation.to,
+      path: movePath,
+      revealedTiles: [],
+      discoveredWonders: [],
+    };
+  }
 
   let villageOutcome: Extract<ExecuteUnitMoveResult, { ok: true }>['villageOutcome'];
   const villageAtDestination = Object.values(state.tribalVillages).find(village => hexKey(village.position) === hexKey(validation.to));
@@ -280,7 +296,7 @@ export function validateUnitMove(
     && hexKey(city.position) === hexKey(target));
   if (
     foreignCity
-    && options.foreignCityEntryId !== foreignCity.id
+    && (options.actor === 'world' || options.foreignCityEntryId !== foreignCity.id)
     && !hasAlliance(state, unit.owner, foreignCity.owner)
   ) {
     return movementFailure(
@@ -315,7 +331,8 @@ export function validateUnitMove(
       && hexKey(city.position) === hexKey(coord)
       && !hasAlliance(state, unit.owner, city.owner)
       && (
-        options.foreignCityEntryId !== city.id
+        options.actor === 'world'
+        || options.foreignCityEntryId !== city.id
         || hexKey(coord) !== hexKey(target)
       )));
   if (pathCrossesBlockedForeignCity) {
@@ -328,8 +345,12 @@ export function validateUnitMove(
     );
   }
 
-  const visibility = state.civilizations[options.civId]?.visibility;
-  const isPlayerControlledMove = options.actor !== 'automation' && options.actor !== 'ai';
+  const visibility = options.actor === 'world'
+    ? undefined
+    : state.civilizations[options.civId]?.visibility;
+  const isPlayerControlledMove = options.actor !== 'automation'
+    && options.actor !== 'ai'
+    && options.actor !== 'world';
   if (
     isPlayerControlledMove
     && visibility

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -325,6 +325,18 @@ export function validateUnitMove(
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
   const path = findPath(from, target, state.map, domain, { unit, completedTechs });
   if (!path) return movementFailure(from, target, [from], 'unreachable', 'No passable route to that tile.');
+  const pathCrossesHostileOccupant = path.slice(1, -1).some(coord =>
+    getUnitIdsAtCoord(occupancy, coord).some(id =>
+      id !== unitId && occupancy.ownersByUnitId[id] !== unit.owner));
+  if (pathCrossesHostileOccupant) {
+    return movementFailure(
+      from,
+      target,
+      path,
+      'occupied',
+      'An enemy unit is blocking the way.',
+    );
+  }
   const pathCrossesBlockedForeignCity = path.slice(1).some(coord =>
     Object.values(state.cities).some(city =>
       city.owner !== unit.owner

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -124,6 +124,35 @@ describe('opponent AI state normalization', () => {
     expect(normalized.opponentAI!.majorCivs['ai-1']).toBeUndefined();
   });
 
+  it('preserves live barbarian assignments owned through a camp mapping', () => {
+    const state = makeState();
+    const unitId = state.civilizations.player.units[0]!;
+    state.units[unitId].owner = 'barbarian';
+    state.barbarianCamps['camp-purposeful'] = {
+      id: 'camp-purposeful',
+      position: state.units[unitId].position,
+      strength: 5,
+      spawnCooldown: 3,
+    };
+    state.opponentAI!.barbarianHomeCampByUnitId[unitId] = 'camp-purposeful';
+    state.opponentAI!.barbarianCamps['camp-purposeful'] = makePlan({
+      id: 'barbarian-plan:camp-purposeful',
+      actorId: 'camp-purposeful',
+      objective: 'raid',
+      target: {
+        kind: 'resource',
+        resource: 'iron',
+        position: { q: 3, r: 3 },
+      },
+      assignedUnitIds: [unitId],
+    });
+
+    const normalized = normalizeOpponentAIState(state);
+
+    expect(normalized.opponentAI!.barbarianCamps['camp-purposeful'].assignedUnitIds)
+      .toEqual([unitId]);
+  });
+
   it('rebuilds unknown versions while retaining the campaign challenge', () => {
     const state = makeState();
     state.opponentChallenge = 'explorer';

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -240,6 +240,31 @@ describe('processPurposefulBarbarians', () => {
       ranged: ['machine_gunner'],
     });
   });
+
+  it('withdraws a surviving raider after its persisted target is removed', () => {
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 7, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const worker = createUnit('worker', 'player', { q: 9, r: 5 }, state.idCounters);
+    worker.id = 'worker';
+    state.units = { raider, worker };
+    state.civilizations.player.units = [worker.id];
+    const planned = processPurposefulBarbarians(state);
+    delete state.units.worker;
+    state.civilizations.player.units = [];
+
+    const result = processPurposefulBarbarians({
+      ...state,
+      turn: state.turn + 1,
+      opponentAI: planned.opponentAI,
+    });
+
+    expect(result.opponentAI.barbarianCamps['camp-a'].phase).toBe('withdrawing');
+    expect(result.moveOrders).toContainEqual({
+      unitId: raider.id,
+      toCoord: { q: 6, r: 5 },
+    });
+  });
 });
 
 describe('barbarian camp evolution', () => {

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -1,6 +1,8 @@
 import {
   spawnBarbarianCamp,
   processBarbarians,
+  processPurposefulBarbarians,
+  getBarbarianRosterForEra,
   destroyCamp,
   applyCampDestruction,
 } from '@/systems/barbarian-system';
@@ -147,6 +149,95 @@ describe('processBarbarians', () => {
     expect(result.attackOrders).toContainEqual({
       attackerUnitId: 'barb',
       defenderUnitId: 'player-warrior',
+    });
+  });
+});
+
+describe('processPurposefulBarbarians', () => {
+  function purposefulState() {
+    const state = createNewGame(undefined, 'purposeful-barbarians', 'small');
+    for (const tile of Object.values(state.map.tiles)) {
+      tile.terrain = 'plains';
+      tile.elevation = 'lowland';
+      tile.resource = null;
+      tile.improvement = 'none';
+      tile.improvementTurnsLeft = 0;
+    }
+    state.barbarianCamps = {
+      'camp-a': {
+        id: 'camp-a',
+        position: { q: 5, r: 5 },
+        strength: 6,
+        spawnCooldown: 4,
+      },
+    };
+    state.units = {};
+    state.cities = {};
+    state.civilizations.player.cities = [];
+    state.civilizations.player.units = [];
+    state.opponentAI = undefined;
+    return state;
+  }
+
+  it('adopts a nearby raider and prefers an exposed worker over a farther city', () => {
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const worker = createUnit('worker', 'player', { q: 7, r: 5 }, state.idCounters);
+    worker.id = 'worker';
+    state.units = { raider, worker };
+    state.civilizations.player.units = [worker.id];
+    state.cities.far = {
+      id: 'far',
+      owner: 'player',
+      position: { q: 10, r: 5 },
+      hp: 30,
+    } as never;
+    state.civilizations.player.cities = ['far'];
+
+    const first = processPurposefulBarbarians(state);
+    expect(first.opponentAI.barbarianHomeCampByUnitId.raider).toBe('camp-a');
+    expect(first.opponentAI.barbarianCamps['camp-a']).toMatchObject({
+      objective: 'raid',
+      target: { kind: 'unit', id: 'worker' },
+    });
+
+    const persisted = processPurposefulBarbarians({
+      ...state,
+      opponentAI: first.opponentAI,
+      turn: state.turn + 1,
+    });
+    expect(persisted.opponentAI.barbarianCamps['camp-a'].target).toMatchObject({
+      kind: 'unit',
+      id: 'worker',
+    });
+  });
+
+  it('preempts raids to defend a camp and never senses beyond radius seven', () => {
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 5, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const defender = createUnit('warrior', 'player', { q: 8, r: 5 }, state.idCounters);
+    defender.id = 'camp-threat';
+    const unseenWorker = createUnit('worker', 'player', { q: 14, r: 5 }, state.idCounters);
+    unseenWorker.id = 'unseen-worker';
+    state.units = { raider, defender, unseenWorker };
+    state.civilizations.player.units = [defender.id, unseenWorker.id];
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.opponentAI.barbarianCamps['camp-a']).toMatchObject({
+      objective: 'defend',
+      target: { kind: 'unit', id: 'camp-threat' },
+    });
+    expect(JSON.stringify(result.opponentAI)).not.toContain('unseen-worker');
+  });
+
+  it('uses the final roster band beyond its declared maximum era', () => {
+    expect(getBarbarianRosterForEra(12)).toEqual({
+      maxEra: 11,
+      melee: ['tank', 'rifleman'],
+      ranged: ['machine_gunner'],
     });
   });
 });

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -255,6 +255,50 @@ describe('applyCombatOutcomeToState', () => {
       .not.toContainEqual(expect.objectContaining({ type: 'military_attacked' }));
   });
 
+  it('records a recent aggressor in minor-civ diplomacy at the combat source', () => {
+    const state = makeRewardState();
+    state.units.defender.owner = 'mc-test';
+    state.civilizations['ai-1'].units = [];
+    state.minorCivs['mc-test'] = {
+      id: 'mc-test',
+      definitionId: 'sparta',
+      cityId: 'minor-city',
+      units: ['defender'],
+      diplomacy: {
+        relationships: { player: -50 },
+        treaties: [],
+        events: [],
+        atWarWith: ['player'],
+      },
+      activeQuests: {},
+      chainStatusByCiv: {},
+      questCooldownUntilByCiv: {},
+      lastNotifiedStatusByCiv: {},
+      isDestroyed: false,
+      garrisonCooldown: 0,
+      lastEraUpgrade: 1,
+    } as never;
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+
+    expect(applied.state.minorCivs['mc-test'].diplomacy.events).toContainEqual({
+      type: 'military_attacked',
+      turn: state.turn,
+      otherCiv: 'player',
+      weight: 1,
+    });
+  });
+
   it('removes the defeated unit, spends the attacker, and applies XP, healing, and gold', () => {
     const state = makeRewardState();
     const result: CombatResult = {

--- a/tests/systems/minor-civ-diplomacy.test.ts
+++ b/tests/systems/minor-civ-diplomacy.test.ts
@@ -1,8 +1,37 @@
 import { describe, it, expect } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { declareWar, makePeace } from '@/systems/diplomacy-system';
+import { isMinorCivHostileToOwner } from '@/systems/minor-civ-diplomacy';
 
 describe('minor civ war/peace bilateral updates', () => {
+  it('uses bilateral war and active ally wars for minor-civ combat legality', () => {
+    const state = createNewGame(undefined, 'mc-hostility-test', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const aiId = Object.keys(state.civilizations).find(id => id !== 'player')!;
+
+    expect(isMinorCivHostileToOwner(state, mcId, 'player')).toBe(false);
+    state.minorCivs[mcId].diplomacy = declareWar(
+      state.minorCivs[mcId].diplomacy,
+      'player',
+      state.turn,
+    );
+    expect(isMinorCivHostileToOwner(state, mcId, 'player')).toBe(true);
+
+    state.minorCivs[mcId].diplomacy = makePeace(
+      state.minorCivs[mcId].diplomacy,
+      'player',
+      state.turn,
+    );
+    state.minorCivs[mcId].chainStatusByCiv.player = {
+      chainId: 'ally-chain',
+      status: 'allied',
+      statusTurn: state.turn,
+      earnedTurn: state.turn,
+    };
+    state.civilizations.player.diplomacy.atWarWith.push(aiId);
+    expect(isMinorCivHostileToOwner(state, mcId, aiId)).toBe(true);
+  });
+
   it('declaring war on MC updates both MC and player diplomacy', () => {
     const state = createNewGame(undefined, 'mc-war-test', 'small');
     const mcEntries = Object.entries(state.minorCivs);

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -5,7 +5,7 @@ import { hexDistance, hexKey } from '@/systems/hex-utils';
 import { EventBus } from '@/core/event-bus';
 import { TECH_TREE, getEraAdvancementTechs } from '@/systems/tech-definitions';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
-import { createUnit } from '@/systems/unit-system';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -97,6 +97,92 @@ describe('minor civ placement', () => {
 });
 
 describe('minor civ turn processing', () => {
+  it('purposefully intercepts always-hostile units inside its territory', () => {
+    const state = createNewGame(undefined, 'mc-purposeful-defense', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    const garrison = state.units[mc.units[0]];
+    const targetPosition = Object.values(state.map.tiles)
+      .map(tile => tile.coord)
+      .find(coord =>
+        hexDistance(coord, city.position) === 1
+        && !['ocean', 'coast', 'mountain'].includes(state.map.tiles[hexKey(coord)].terrain))!;
+    garrison.position = { ...city.position };
+    const raider = createUnit('warrior', 'barbarian', targetPosition, state.idCounters);
+    raider.id = 'local-raider';
+    state.units[raider.id] = raider;
+    const before = structuredClone(state);
+
+    const result = processMinorCivTurn(
+      state,
+      new EventBus(),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(state).toEqual(before);
+    expect(result.opponentAI?.minorCivs[mcId]).toMatchObject({
+      objective: 'defend',
+      target: { kind: 'unit', id: raider.id },
+    });
+    expect(result.units[garrison.id]?.hasActed).toBe(true);
+  });
+
+  it('does not attack a peaceful major or target anything outside radius six', () => {
+    const state = createNewGame(undefined, 'mc-purposeful-bounds', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    const peaceful = state.units[state.civilizations.player.units[0]];
+    peaceful.position = { q: city.position.q + 1, r: city.position.r };
+    const distant = createUnit(
+      'warrior',
+      'barbarian',
+      { q: city.position.q + 8, r: city.position.r },
+      state.idCounters,
+    );
+    distant.id = 'distant-raider';
+    state.units[distant.id] = distant;
+
+    const result = processMinorCivTurn(
+      state,
+      new EventBus(),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(result.opponentAI?.minorCivs[mcId].target).toMatchObject({
+      kind: 'region',
+    });
+    expect(result.units[peaceful.id].health).toBe(peaceful.health);
+    expect(JSON.stringify(result.opponentAI?.minorCivs[mcId])).not.toContain(distant.id);
+  });
+
+  it('returns a badly damaged unit toward its city without changing combat stats', () => {
+    const state = createNewGame(undefined, 'mc-purposeful-retreat', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    const garrison = state.units[mc.units[0]];
+    const start = Object.values(state.map.tiles)
+      .map(tile => tile.coord)
+      .find(coord =>
+        hexDistance(coord, city.position) === 4
+        && !['ocean', 'coast', 'mountain'].includes(state.map.tiles[hexKey(coord)].terrain))!;
+    garrison.position = start;
+    garrison.health = 10;
+    const strengthBefore = UNIT_DEFINITIONS[garrison.type].strength;
+
+    const result = processMinorCivTurn(
+      state,
+      new EventBus(),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(hexDistance(result.units[garrison.id].position, city.position))
+      .toBeLessThan(hexDistance(start, city.position));
+    expect(UNIT_DEFINITIONS[result.units[garrison.id].type].strength).toBe(strengthBefore);
+  });
+
   it('replaces lost garrison after cooldown', () => {
     const state = createNewGame(undefined, 'mc-garrison', 'small');
     const mcId = Object.keys(state.minorCivs)[0];
@@ -336,6 +422,19 @@ describe('minor civ era upgrades', () => {
 
     processMinorCivEraUpgrade(state, mc);
     expect(state.cities[mc.cityId].population).toBe(popBefore + 1);
+  });
+
+  it('keeps the garrison modern at the current maximum era', () => {
+    const state = createNewGame(undefined, 'mc-era-twelve', 'small');
+    state.era = 12;
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    mc.lastEraUpgrade = 4;
+
+    processMinorCivEraUpgrade(state, mc);
+
+    expect(state.units[mc.units[0]].type).toBe('tank');
+    expect(mc.lastEraUpgrade).toBe(12);
   });
 });
 

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { placeMinorCivs, processMinorCivTurn, checkEraAdvancement, processMinorCivEraUpgrade, conquestMinorCiv, processGuerrilla, processScuffles, applyDiplomaticReaction } from '@/systems/minor-civ-system';
+import { placeMinorCivs, processMinorCivTurn, planPurposefulMinorCivTurn, checkEraAdvancement, processMinorCivEraUpgrade, conquestMinorCiv, processGuerrilla, processScuffles, applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { createNewGame } from '@/core/game-state';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
 import { EventBus } from '@/core/event-bus';
@@ -181,6 +181,26 @@ describe('minor civ turn processing', () => {
     expect(hexDistance(result.units[garrison.id].position, city.position))
       .toBeLessThan(hexDistance(start, city.position));
     expect(UNIT_DEFINITIONS[result.units[garrison.id].type].strength).toBe(strengthBefore);
+  });
+
+  it('abandons a persisted retaliation target after peace', () => {
+    const state = createNewGame(undefined, 'mc-purposeful-peace', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    const playerUnit = state.units[state.civilizations.player.units[0]];
+    playerUnit.position = { q: city.position.q + 3, r: city.position.r };
+    mc.diplomacy.atWarWith.push('player');
+    state.civilizations.player.diplomacy.atWarWith.push(mcId);
+    const wartime = planPurposefulMinorCivTurn(state, mcId);
+    state.opponentAI!.minorCivs[mcId] = wartime.plan!;
+
+    mc.diplomacy.atWarWith = [];
+    state.civilizations.player.diplomacy.atWarWith = [];
+    const peacetime = planPurposefulMinorCivTurn(state, mcId);
+
+    expect(peacetime.plan?.target).toMatchObject({ kind: 'region' });
+    expect(peacetime.attackOrders).toEqual([]);
   });
 
   it('replaces lost garrison after cooldown', () => {

--- a/tests/systems/pirate-behavior.test.ts
+++ b/tests/systems/pirate-behavior.test.ts
@@ -8,6 +8,9 @@ import {
   derivePirateBlockades,
   derivePirateRaids,
   getRelocationDirectionForViewer,
+  choosePersistentPirateIntent,
+  getPirateFleetLeader,
+  shouldPirateFleetWithdraw,
   isTransportEscorted,
   planFlotillaRelocation,
 } from '@/systems/pirate-behavior';
@@ -89,6 +92,102 @@ function faction(
 }
 
 describe('pirate escort and targeting', () => {
+  it('retains a valid intent and replaces it after three rounds without progress', () => {
+    const state = stateWithMap(oceanGrid());
+    addUnit(state, unit('flagship', 'pirate_frigate', 'pirate-1', { q: 1, r: 1 }));
+    addUnit(state, unit('old-target', 'transport', 'player', { q: 8, r: 8 }));
+    addUnit(state, unit('new-target', 'transport', 'ai-1', { q: 4, r: 1 }));
+    const current = faction('pirate-1', 'raiding', {
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'flagship',
+      relocation: { planned: null, lastRelocatedRound: null },
+    }, ['flagship']);
+    current.intent = {
+      kind: 'raid',
+      targetCivId: 'player',
+      targetUnitId: 'old-target',
+      plannedRound: 1,
+      lastProgressRound: 3,
+      lastTargetDistance: 10,
+    };
+    state.turn = 5;
+    state.pirates!.factions[current.id] = current;
+
+    expect(choosePersistentPirateIntent(state, current.id)).toMatchObject({
+      targetUnitId: 'old-target',
+    });
+
+    state.turn = 6;
+    expect(choosePersistentPirateIntent(state, current.id)).toMatchObject({
+      targetUnitId: 'new-target',
+    });
+  });
+
+  it('selects a stable leader and falls back to the strongest surviving hull', () => {
+    const state = stateWithMap(oceanGrid());
+    addUnit(state, unit('flagship', 'pirate_corsair', 'pirate-1', { q: 2, r: 2 }));
+    addUnit(state, unit('strong-b', 'pirate_frigate', 'pirate-1', { q: 2, r: 3 }));
+    addUnit(state, unit('strong-a', 'pirate_frigate', 'pirate-1', { q: 3, r: 2 }));
+    state.pirates!.factions['pirate-1'] = faction('pirate-1', 'raiding', {
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'flagship',
+      relocation: { planned: null, lastRelocatedRound: null },
+    }, ['flagship', 'strong-b', 'strong-a']);
+
+    expect(getPirateFleetLeader(state, 'pirate-1')?.id).toBe('flagship');
+    delete state.units.flagship;
+    expect(getPirateFleetLeader(state, 'pirate-1')?.id).toBe('strong-a');
+  });
+
+  it('withdraws for challenge health or overwhelming visible local force', () => {
+    const state = stateWithMap(oceanGrid());
+    const flagship = unit('flagship', 'pirate_frigate', 'pirate-1', { q: 2, r: 2 });
+    flagship.health = 30;
+    addUnit(state, flagship);
+    addUnit(state, unit('hostile', 'pirate_mothership', 'player', { q: 3, r: 2 }));
+    state.pirates!.factions['pirate-1'] = faction('pirate-1', 'raiding', {
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'flagship',
+      relocation: { planned: null, lastRelocatedRound: null },
+    }, ['flagship']);
+    state.opponentChallenge = 'standard';
+
+    expect(shouldPirateFleetWithdraw(state, 'pirate-1')).toBe(true);
+    flagship.health = 100;
+    expect(shouldPirateFleetWithdraw(state, 'pirate-1')).toBe(true);
+  });
+
+  it('lets a contract reduce the health threshold without attacking below 0.45x force', () => {
+    const state = stateWithMap(oceanGrid());
+    const flagship = unit('flagship', 'pirate_frigate', 'pirate-1', { q: 2, r: 2 });
+    flagship.health = 35;
+    addUnit(state, flagship);
+    const current = faction('pirate-1', 'raiding', {
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'flagship',
+      relocation: { planned: null, lastRelocatedRound: null },
+    }, ['flagship'], 5);
+    state.pirates!.factions[current.id] = current;
+    state.opponentChallenge = 'standard';
+    expect(shouldPirateFleetWithdraw(state, current.id)).toBe(true);
+
+    current.contract = {
+      employerId: 'ai-1',
+      targetId: 'player',
+      startedRound: 1,
+      expiresAfterRound: 20,
+      successfulRaidCount: 0,
+      exposed: false,
+      exposureResolvedRaidKeys: [],
+    };
+    expect(shouldPirateFleetWithdraw(state, current.id)).toBe(false);
+
+    addUnit(state, unit('hostile-a', 'pirate_mothership', 'player', { q: 3, r: 2 }));
+    addUnit(state, unit('hostile-b', 'pirate_mothership', 'player', { q: 3, r: 3 }));
+    addUnit(state, unit('hostile-c', 'pirate_mothership', 'player', { q: 2, r: 3 }));
+    expect(shouldPirateFleetWithdraw(state, current.id)).toBe(true);
+  });
+
   it('ignores targets outside the bounded naval search neighborhood', () => {
     const state = stateWithMap(oceanGrid(0, 60));
     addUnit(state, unit('pirate', 'pirate_frigate', 'pirate-1', { q: 1, r: 1 }));

--- a/tests/systems/pirate-end-to-end.test.ts
+++ b/tests/systems/pirate-end-to-end.test.ts
@@ -62,6 +62,66 @@ describe('pirate feature completion gate', () => {
 });
 
 describe('deterministic pirate campaign lifecycle', () => {
+  it('preserves validated purposeful fleet intent across save normalization', () => {
+    const state = scenarioState();
+    const flagship: Unit = {
+      id: 'flagship',
+      type: 'pirate_frigate',
+      owner: 'pirate-1',
+      position: { q: 4, r: 4 },
+      movementPointsLeft: 4,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    };
+    state.units[flagship.id] = flagship;
+    const target: Unit = {
+      ...flagship,
+      id: 'target',
+      type: 'transport',
+      owner: 'player',
+      position: { q: 6, r: 4 },
+    };
+    state.units[target.id] = target;
+    state.civilizations.player.units = [target.id];
+    state.pirates!.factions['pirate-1'] = {
+      id: 'pirate-1',
+      name: 'The Red Wake',
+      spawnedRound: 1,
+      behavior: 'raiding',
+      maritimeStage: 3,
+      notoriety: 2,
+      shipIds: [flagship.id],
+      headquarters: {
+        kind: 'deep-sea-flotilla',
+        flagshipUnitId: flagship.id,
+        relocation: { planned: null, lastRelocatedRound: null },
+      },
+      tributeByCiv: {},
+      demandByCiv: {},
+      contract: null,
+      intent: {
+        kind: 'raid',
+        targetCivId: 'player',
+        targetUnitId: target.id,
+        plannedRound: 1,
+        lastProgressRound: 1,
+        lastTargetDistance: 2,
+        mode: 'engage',
+        leaderUnitId: flagship.id,
+      },
+      transitionGuards: { emittedEventKeys: [] },
+    };
+
+    const loaded = normalizeLoadedState(JSON.parse(JSON.stringify(state)) as GameState);
+
+    expect(loaded.pirates!.factions['pirate-1'].intent).toEqual(
+      state.pirates!.factions['pirate-1'].intent,
+    );
+  });
+
   it('composes activation, spawn, save/load, tribute, contract, exposure bookkeeping, and destruction', () => {
     const state = scenarioState();
     expect(processPirateEcology(state, new EventBus(), 'before-galleys')).toBe(state);

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -60,6 +60,89 @@ function faction(headquarters: PirateFactionState['headquarters'], shipIds: stri
 }
 
 describe('completed-round pirate coordinator', () => {
+  it('moves a purposeful fleet along canonical multi-step cohesive paths and retains intent', () => {
+    const state = fixture();
+    addCity(state);
+    addUnit(state, 'leader', 'pirate_frigate', 'pirate-1', { q: 5, r: 1 });
+    addUnit(state, 'escort', 'pirate_corsair', 'pirate-1', { q: 4, r: 1 });
+    state.pirates!.factions['pirate-1'] = faction({
+      kind: 'coastal-enclave',
+      position: { q: 1, r: 1 },
+      integrity: 100,
+      maxIntegrity: 100,
+    }, ['leader', 'escort']);
+    const before = structuredClone(state);
+    const bus = new EventBus();
+    const moveEvents: Array<{ unitId: string }> = [];
+    bus.on('unit:move', event => moveEvents.push(event));
+
+    const result = processPiratesForCompletedRound(
+      state,
+      bus,
+      { purposefulAIEnabled: true },
+    );
+
+    expect(state).toEqual(before);
+    expect(result.state.pirates!.factions['pirate-1'].intent).toMatchObject({
+      targetCityId: 'port',
+      mode: 'engage',
+      leaderUnitId: 'leader',
+    });
+    expect(result.facts.movements.some(movement => movement.path.length > 1)).toBe(true);
+    expect(result.state.units.leader.movementPointsLeft).toBeLessThan(4);
+    expect(Math.max(
+      Math.abs(result.state.units.leader.position.q - result.state.units.escort.position.q),
+      Math.abs(result.state.units.leader.position.r - result.state.units.escort.position.r),
+    )).toBeLessThanOrEqual(2);
+    expect(moveEvents).toHaveLength(result.facts.movements.length);
+  });
+
+  it('repairs a missing purposeful flagship to the strongest stable surviving hull', () => {
+    const state = fixture();
+    addUnit(state, 'strong-b', 'pirate_frigate', 'pirate-1', { q: 5, r: 3 });
+    addUnit(state, 'strong-a', 'pirate_frigate', 'pirate-1', { q: 5, r: 4 });
+    state.pirates!.factions['pirate-1'] = faction({
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'missing',
+      relocation: { planned: null, lastRelocatedRound: null },
+    }, ['missing', 'strong-b', 'strong-a']);
+
+    const result = processPiratesForCompletedRound(
+      state,
+      new EventBus(),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(result.state.pirates!.factions['pirate-1']).toBeDefined();
+    expect(result.state.pirates!.factions['pirate-1'].headquarters).toMatchObject({
+      kind: 'deep-sea-flotilla',
+      flagshipUnitId: 'strong-a',
+    });
+  });
+
+  it('withdraws a damaged purposeful fleet instead of attacking', () => {
+    const state = fixture();
+    addUnit(state, 'raider', 'pirate_frigate', 'pirate-1', { q: 5, r: 3 }).health = 10;
+    addUnit(state, 'target', 'galley', 'player', { q: 5, r: 2 });
+    state.civilizations.player.units = ['target'];
+    state.pirates!.factions['pirate-1'] = faction({
+      kind: 'coastal-enclave',
+      position: { q: 1, r: 1 },
+      integrity: 100,
+      maxIntegrity: 100,
+    }, ['raider']);
+
+    const result = processPiratesForCompletedRound(
+      state,
+      new EventBus(),
+      { purposefulAIEnabled: true },
+    );
+
+    expect(result.state.pirates!.factions['pirate-1'].intent?.mode).toBe('withdraw');
+    expect(result.facts.attacks).toEqual([]);
+    expect(result.state.units.target.health).toBe(100);
+  });
+
   it('advances factions with deterministic mixed-fleet reinforcements without upgrading old ships', () => {
     const state = fixture();
     state.pirates!.nextSpawnCheckTurn = 99;

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -186,6 +186,46 @@ describe('getCivAvailableResources', () => {
     expect(isResourceTileDeniedByHostileOccupation(state, 'player', { q: 4, r: 3 })).toBe(false);
   });
 
+  it('does not deny an unimproved or city-center resource', () => {
+    const unimproved = makeState({
+      tileResource: 'silk',
+      tileImprovement: 'none',
+      completed: ['irrigation'],
+    });
+    unimproved.units = {
+      raider: {
+        id: 'raider',
+        type: 'warrior',
+        owner: 'barbarian',
+        position: { q: 4, r: 3 },
+      } as never,
+    };
+    expect(isResourceTileDeniedByHostileOccupation(
+      unimproved,
+      'player',
+      { q: 4, r: 3 },
+    )).toBe(false);
+
+    const cityCenter = makeState({
+      tileResource: 'horses',
+      tileIsCity: true,
+      completed: ['animal-husbandry'],
+    });
+    cityCenter.units = {
+      raider: {
+        id: 'raider',
+        type: 'warrior',
+        owner: 'barbarian',
+        position: { q: 3, r: 3 },
+      } as never,
+    };
+    expect(getCivAvailableResources(
+      cityCenter,
+      'player',
+      { hostileOccupationEnabled: true },
+    ).has('horses')).toBe(true);
+  });
+
   it('returns empty set for unknown civId', () => {
     const state = makeState({});
     const result = getCivAvailableResources(state, 'ghost-civ');

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
+import {
+  getCivAvailableResources,
+  isResourceTileDeniedByHostileOccupation,
+  canEstablishOutpost,
+  performEstablishOutpost,
+  canBuyResourceAccess,
+  performBuyResourceAccess,
+} from '@/systems/resource-acquisition-system';
 import type { GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
@@ -115,6 +122,70 @@ function makeState(overrides: {
 }
 
 describe('getCivAvailableResources', () => {
+  it('optionally denies an improved resource occupied by a hostile world unit', () => {
+    const state = makeState({
+      tileResource: 'silk',
+      tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0,
+      completed: ['irrigation'],
+    });
+    state.units = {
+      raider: {
+        id: 'raider',
+        type: 'warrior',
+        owner: 'barbarian',
+        position: { q: 4, r: 3 },
+      } as never,
+    };
+
+    expect(isResourceTileDeniedByHostileOccupation(state, 'player', { q: 4, r: 3 })).toBe(true);
+    expect(getCivAvailableResources(state, 'player').has('silk')).toBe(true);
+    expect(getCivAvailableResources(
+      state,
+      'player',
+      { hostileOccupationEnabled: true },
+    ).has('silk')).toBe(false);
+
+    delete state.units.raider;
+    expect(getCivAvailableResources(
+      state,
+      'player',
+      { hostileOccupationEnabled: true },
+    ).has('silk')).toBe(true);
+  });
+
+  it('does not deny resources for cargo, neutral, or friendly occupants', () => {
+    const state = makeState({
+      tileResource: 'silk',
+      tileImprovement: 'plantation',
+      tileImprovementTurnsLeft: 0,
+      completed: ['irrigation'],
+    });
+    state.units = {
+      friendly: {
+        id: 'friendly',
+        type: 'warrior',
+        owner: 'player',
+        position: { q: 4, r: 3 },
+      } as never,
+      neutral: {
+        id: 'neutral',
+        type: 'warrior',
+        owner: 'ai-1',
+        position: { q: 4, r: 3 },
+      } as never,
+      cargo: {
+        id: 'cargo',
+        type: 'warrior',
+        owner: 'barbarian',
+        position: { q: 4, r: 3 },
+        transportId: 'transport',
+      } as never,
+    };
+
+    expect(isResourceTileDeniedByHostileOccupation(state, 'player', { q: 4, r: 3 })).toBe(false);
+  });
+
   it('returns empty set for unknown civId', () => {
     const state = makeState({});
     const result = getCivAvailableResources(state, 'ghost-civ');

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -99,6 +99,65 @@ function movementState(
 }
 
 describe('unit-movement-system', () => {
+  it('moves world actors without civilization discovery consequences', () => {
+    const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    mover.id = 'world-mover';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      { ...tile({ q: 1, r: 0 }), wonder: 'grand_canyon' },
+    ]);
+    delete state.civilizations.barbarian;
+    const villageId = 'village-world';
+    state.tribalVillages[villageId] = {
+      id: villageId,
+      position: { q: 1, r: 0 },
+    } as never;
+    const beforeWonders = structuredClone(state.discoveredWonders);
+    const moves: Array<GameEvents['unit:move']> = [];
+    const contacts: Array<GameEvents['civilization:first-contact']> = [];
+    const bus = new EventBus();
+    bus.on('unit:move', event => moves.push(event));
+    bus.on('civilization:first-contact', event => contacts.push(event));
+
+    const result = executeUnitMove(
+      state,
+      mover.id,
+      { q: 1, r: 0 },
+      { actor: 'world', bus },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      revealedTiles: [],
+      discoveredWonders: [],
+    });
+    expect(state.units[mover.id].position).toEqual({ q: 1, r: 0 });
+    expect(state.tribalVillages[villageId]).toBeDefined();
+    expect(state.discoveredWonders).toEqual(beforeWonders);
+    expect(contacts).toEqual([]);
+    expect(moves).toHaveLength(1);
+  });
+
+  it('does not let world actors bypass occupancy', () => {
+    const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    mover.id = 'world-mover';
+    const blocker = createUnit('worker', 'player', { q: 1, r: 0 }, mkC());
+    blocker.id = 'blocker';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+    ], { extraUnits: [blocker] });
+    delete state.civilizations.barbarian;
+
+    expect(executeUnitMove(
+      state,
+      mover.id,
+      blocker.position,
+      { actor: 'world' },
+    )).toMatchObject({ ok: false, reason: 'occupied' });
+    expect(state.units[mover.id].position).toEqual({ q: 0, r: 0 });
+  });
+
   it('reserves foreign-city entry for an explicit canonical capture flow', () => {
     const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
     mover.id = 'mover';

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -158,6 +158,27 @@ describe('unit-movement-system', () => {
     expect(state.units[mover.id].position).toEqual({ q: 0, r: 0 });
   });
 
+  it('does not let world actors path through an occupied intermediate tile', () => {
+    const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
+    mover.id = 'world-mover';
+    mover.movementPointsLeft = 3;
+    const blocker = createUnit('worker', 'player', { q: 1, r: 0 }, mkC());
+    blocker.id = 'blocker';
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }),
+      tile({ q: 1, r: 0 }),
+      tile({ q: 2, r: 0 }),
+    ], { extraUnits: [blocker] });
+    delete state.civilizations.barbarian;
+
+    expect(executeUnitMove(
+      state,
+      mover.id,
+      { q: 2, r: 0 },
+      { actor: 'world' },
+    )).toMatchObject({ ok: false, reason: 'occupied' });
+  });
+
   it('reserves foreign-city entry for an explicit canonical capture flow', () => {
     const mover = createUnit('warrior', 'player', { q: 0, r: 0 }, mkC());
     mover.id = 'mover';


### PR DESCRIPTION
## Summary

- add rollout-gated, camp-local barbarian defense and raid plans with era-relevant rosters and hostile resource occupation
- add actor-neutral canonical world movement without civilization-only discovery side effects
- add bounded minor-civ territorial defense, ally support, lawful retaliation, and current-era garrisons
- add persistent, cohesive, risk-aware pirate fleet intents with canonical multi-step movement and save normalization
- preserve every legacy world-actor path while `PURPOSEFUL_AI_FEATURE_ENABLED` remains false

## Gameplay impact

When explicitly enabled, independent world actors now make local, deterministic plans instead of relying on global nearest-target behavior. Barbarians defend camps and raid exposed workers, caravans, and improved resources; minor civilizations defend their territory and active allies without pursuing conquest; pirate fleets retain valid targets, maintain formation, and withdraw from unfavorable fights. Combat, trade-route cleanup, quests, blockades, pirate economy, intel, notifications, SFX cues, and event-time animation facts continue through shared systems.

No player-facing UI changes are included in this slice.

## Verification

- `./scripts/run-with-mise.sh yarn test` — 334 files passed, 4,958 tests passed, 2 skipped
- `./scripts/run-wonder-regressions.sh` — 13 files passed, 318 tests passed
- targeted MR5/storage suite — 12 files passed, 268 tests passed
- `./scripts/run-with-mise.sh yarn build`
- `./scripts/run-with-mise.sh yarn build:tauri`
- `scripts/check-src-rule-violations.sh` for every changed source file
- reviewed committed and uncommitted diffs against current `origin/main`

Refs #412