### PR TITLE
feat(era12): Task 4 — geneTherapyReady, cyber_unit capture, stealth targeting

### DIFF
--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -117,6 +117,15 @@ export function canUnitAttackTarget(
     if (!canUnitAttackBeast(attacker, targetUnit[1]).allowed) return { ok: false, reason: 'unsupported-target' };
     if (!canAttackOwner(state, attacker.owner, targetUnit[1].owner)) return { ok: false, reason: 'not-hostile' };
     if (!profile.targets.includes('unit')) return { ok: false, reason: 'unsupported-target' };
+    // Stealth bomber: cannot be targeted by ranged attacks unless an enemy signals_hub is within 2 hexes
+    if (targetUnit[1].type === 'stealth_bomber' && profile.range > 1) {
+      const hubNearby = Object.values(state.cities).some(city => {
+        if (city.owner === targetUnit[1].owner) return false;
+        if (!city.buildings.includes('signals_hub')) return false;
+        return hexDistance(city.position, targetUnit[1].position) <= 2;
+      });
+      if (!hubNearby) return { ok: false, reason: 'unsupported-target' };
+    }
     return { ok: true, targetType: 'unit', targetUnitId: targetUnit[0], coord, range };
   }
 

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -265,6 +265,9 @@ export function applyCombatOutcomeToState(
     };
   }
 
+  let attackerActuallyDefeated = !result.attackerSurvived;
+  let defenderActuallyDefeated = !result.defenderSurvived;
+
   if (result.attackerSurvived) {
     units[result.attackerId] = {
       ...attackerBefore,
@@ -273,6 +276,32 @@ export function applyCombatOutcomeToState(
       hasMoved: true,
       hasActed: true,
     };
+  } else if (attackerBefore.geneTherapyReady === true) {
+    // Gene therapy: survive lethal hit at 1 HP, enter cooldown
+    units[result.attackerId] = {
+      ...attackerBefore,
+      health: 1,
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: true,
+      geneTherapyReady: false,
+    };
+    attackerActuallyDefeated = false;
+  } else if (attackerBefore.type === 'cyber_unit') {
+    // Cyber unit: capture (transfer ownership) instead of destroy
+    units[result.attackerId] = { ...attackerBefore, owner: defenderBefore.owner };
+    civilizations = {
+      ...civilizations,
+      [attackerBefore.owner]: {
+        ...civilizations[attackerBefore.owner],
+        units: (civilizations[attackerBefore.owner]?.units ?? []).filter(id => id !== result.attackerId),
+      },
+      [defenderBefore.owner]: {
+        ...civilizations[defenderBefore.owner],
+        units: [...(civilizations[defenderBefore.owner]?.units ?? []), result.attackerId],
+      },
+    };
+    attackerActuallyDefeated = false;
   } else {
     const removed = removeUnitFromCopies(units, civilizations, espionage, result.attackerId);
     units = removed.units;
@@ -285,6 +314,32 @@ export function applyCombatOutcomeToState(
       ...defenderBefore,
       health: Math.max(1, defenderBefore.health - result.defenderDamage),
     };
+  } else if (defenderBefore.geneTherapyReady === true) {
+    // Gene therapy: survive lethal hit at 1 HP, enter cooldown
+    units[result.defenderId] = {
+      ...defenderBefore,
+      health: 1,
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: true,
+      geneTherapyReady: false,
+    };
+    defenderActuallyDefeated = false;
+  } else if (defenderBefore.type === 'cyber_unit') {
+    // Cyber unit: capture (transfer ownership) instead of destroy
+    units[result.defenderId] = { ...defenderBefore, owner: attackerBefore.owner };
+    civilizations = {
+      ...civilizations,
+      [defenderBefore.owner]: {
+        ...civilizations[defenderBefore.owner],
+        units: (civilizations[defenderBefore.owner]?.units ?? []).filter(id => id !== result.defenderId),
+      },
+      [attackerBefore.owner]: {
+        ...civilizations[attackerBefore.owner],
+        units: [...(civilizations[attackerBefore.owner]?.units ?? []), result.defenderId],
+      },
+    };
+    defenderActuallyDefeated = false;
   } else {
     const removed = removeUnitFromCopies(units, civilizations, espionage, result.defenderId);
     units = removed.units;
@@ -328,7 +383,7 @@ export function applyCombatOutcomeToState(
     nextState = breakPirateTributeOnAttack(nextState, defenderFaction.id, attackerBefore.owner);
   }
   const questTransitions: ChainTransition[] = [];
-  if (!result.defenderSurvived) {
+  if (defenderActuallyDefeated) {
     const progress = applyQuestGameplayAction(nextState, {
       type: 'unit_defeated', actorCivId: attackerBefore.owner, defeatedOwnerId: defenderBefore.owner,
       unitId: defenderBefore.id, position: defenderBefore.position, turn: state.turn,
@@ -336,7 +391,7 @@ export function applyCombatOutcomeToState(
     nextState = progress.state;
     questTransitions.push(...progress.transitions);
   }
-  if (!result.attackerSurvived) {
+  if (attackerActuallyDefeated) {
     const progress = applyQuestGameplayAction(nextState, {
       type: 'unit_defeated', actorCivId: defenderBefore.owner, defeatedOwnerId: attackerBefore.owner,
       unitId: attackerBefore.id, position: attackerBefore.position, turn: state.turn,
@@ -346,7 +401,7 @@ export function applyCombatOutcomeToState(
   }
 
   if (
-    !result.defenderSurvived
+    defenderActuallyDefeated
     && defenderFaction?.headquarters.kind === 'deep-sea-flotilla'
     && defenderFaction.headquarters.flagshipUnitId === defenderBefore.id
   ) {
@@ -361,7 +416,7 @@ export function applyCombatOutcomeToState(
   }
   const attackerFaction = state.pirates?.factions[attackerBefore.owner];
   if (
-    !result.attackerSurvived
+    attackerActuallyDefeated
     && attackerFaction?.headquarters.kind === 'deep-sea-flotilla'
     && attackerFaction.headquarters.flagshipUnitId === attackerBefore.id
   ) {
@@ -378,8 +433,8 @@ export function applyCombatOutcomeToState(
   return {
     state: nextState,
     rewards,
-    attackerDefeated: !result.attackerSurvived,
-    defenderDefeated: !result.defenderSurvived,
+    attackerDefeated: attackerActuallyDefeated,
+    defenderDefeated: defenderActuallyDefeated,
     questTransitions,
     pirateEvents,
   };

--- a/tests/systems/era-12.test.ts
+++ b/tests/systems/era-12.test.ts
@@ -4,6 +4,8 @@ import { ERA_NAMES } from '@/ui/tech-panel';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { UNIT_SFX } from '@/audio/sfx-catalog';
+import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
+import type { GameState, Unit } from '@/core/types';
 
 const era12Techs = TECH_TREE.filter(t => t.era === 12);
 
@@ -118,5 +120,133 @@ describe('ERA_NAMES', () => {
     for (const era of [8, 9, 10, 11]) {
       expect(ERA_NAMES[era], `ERA_NAMES[${era}] missing`).toBeDefined();
     }
+  });
+});
+
+// --- Combat behavior tests (Task 4) ---
+
+function makeCombatState(units: Record<string, Partial<Unit>>, civUnits: Record<string, string[]>): GameState {
+  const civilizations: GameState['civilizations'] = {};
+  for (const [civId, unitIds] of Object.entries(civUnits)) {
+    civilizations[civId] = {
+      id: civId, name: civId, color: civId === 'p1' ? '#fff' : '#000',
+      isHuman: civId === 'p1', civType: 'generic',
+      units: unitIds, cities: [], gold: 100,
+      techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} } as any,
+      diplomacy: { relationships: {}, atWarWith: [civId === 'p1' ? 'p2' : 'p1'], treaties: [], events: [], treacheryScore: 0, vassalage: { isVassal: false } } as any,
+      visibility: { tiles: {} } as any, score: 0,
+    };
+  }
+  const fullUnits: Record<string, Unit> = {};
+  for (const [id, partial] of Object.entries(units)) {
+    fullUnits[id] = {
+      id, type: 'warrior', owner: 'p1', health: 100,
+      position: { q: 0, r: 0 }, movementPointsLeft: 1,
+      hasMoved: false, hasActed: false, experience: 0, isResting: false,
+      ...partial,
+    } as Unit;
+  }
+  return {
+    turn: 1, era: 12, currentPlayer: 'p1', civilizations,
+    units: fullUnits, cities: {},
+    map: { tiles: {}, width: 10, height: 10, wrapsHorizontally: false },
+    idCounters: { unit: 0, city: 0 },
+  } as unknown as GameState;
+}
+
+describe('geneTherapyReady — combat survival', () => {
+  it('unit with geneTherapyReady:true survives lethal hit at 1 HP and sets flag false', () => {
+    const state = makeCombatState(
+      { a1: { owner: 'p1', health: 80, position: { q: 0, r: 0 }, geneTherapyReady: true },
+        d1: { owner: 'p2', health: 100, position: { q: 1, r: 0 } } },
+      { p1: ['a1'], p2: ['d1'] },
+    );
+    const result = {
+      attackerId: 'a1', defenderId: 'd1',
+      attackerDamage: 80, defenderDamage: 30,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+    const applied = applyCombatOutcomeToState(state, result, 42);
+    expect(applied.state.units['a1']).toBeDefined();
+    expect(applied.state.units['a1'].health).toBe(1);
+    expect(applied.state.units['a1'].geneTherapyReady).toBe(false);
+    expect(applied.attackerDefeated).toBe(false);
+  });
+
+  it('unit with geneTherapyReady:false is eliminated normally', () => {
+    const state = makeCombatState(
+      { a2: { owner: 'p1', health: 80, position: { q: 0, r: 0 }, geneTherapyReady: false },
+        d2: { owner: 'p2', health: 100, position: { q: 1, r: 0 } } },
+      { p1: ['a2'], p2: ['d2'] },
+    );
+    const result = {
+      attackerId: 'a2', defenderId: 'd2',
+      attackerDamage: 80, defenderDamage: 30,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+    const applied = applyCombatOutcomeToState(state, result, 42);
+    expect(applied.state.units['a2']).toBeUndefined();
+    expect(applied.attackerDefeated).toBe(true);
+  });
+
+  it('geneTherapyReady:undefined does NOT save the unit', () => {
+    const state = makeCombatState(
+      { a3: { owner: 'p1', health: 80, position: { q: 0, r: 0 } },
+        d3: { owner: 'p2', health: 100, position: { q: 1, r: 0 } } },
+      { p1: ['a3'], p2: ['d3'] },
+    );
+    const result = {
+      attackerId: 'a3', defenderId: 'd3',
+      attackerDamage: 80, defenderDamage: 30,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+    const applied = applyCombatOutcomeToState(state, result, 42);
+    expect(applied.state.units['a3']).toBeUndefined();
+    expect(applied.attackerDefeated).toBe(true);
+  });
+});
+
+describe('cyber_unit capture', () => {
+  it('cyber_unit defender is captured (ownership transferred) not destroyed', () => {
+    const state = makeCombatState(
+      { cu1: { type: 'cyber_unit', owner: 'p1', health: 100, position: { q: 0, r: 0 } },
+        w1:  { type: 'warrior',    owner: 'p2', health: 100, position: { q: 1, r: 0 } } },
+      { p1: ['cu1'], p2: ['w1'] },
+    );
+    const result = {
+      attackerId: 'w1', defenderId: 'cu1',
+      attackerDamage: 0, defenderDamage: 100,
+      attackerSurvived: true, defenderSurvived: false,
+      attackerPosition: { q: 1, r: 0 }, defenderPosition: { q: 0, r: 0 },
+    };
+    const applied = applyCombatOutcomeToState(state, result, 42);
+    expect(applied.state.units['cu1']).toBeDefined();
+    expect(applied.state.units['cu1'].owner).toBe('p2');
+    expect(applied.defenderDefeated).toBe(false);
+    expect(applied.state.civilizations['p1'].units).not.toContain('cu1');
+    expect(applied.state.civilizations['p2'].units).toContain('cu1');
+  });
+
+  it('cyber_unit attacker is captured (ownership transferred) not destroyed', () => {
+    const state = makeCombatState(
+      { cu2: { type: 'cyber_unit', owner: 'p1', health: 100, position: { q: 0, r: 0 } },
+        w2:  { type: 'warrior',    owner: 'p2', health: 100, position: { q: 1, r: 0 } } },
+      { p1: ['cu2'], p2: ['w2'] },
+    );
+    const result = {
+      attackerId: 'cu2', defenderId: 'w2',
+      attackerDamage: 100, defenderDamage: 0,
+      attackerSurvived: false, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+    };
+    const applied = applyCombatOutcomeToState(state, result, 42);
+    expect(applied.state.units['cu2']).toBeDefined();
+    expect(applied.state.units['cu2'].owner).toBe('p2');
+    expect(applied.attackerDefeated).toBe(false);
+    expect(applied.state.civilizations['p1'].units).not.toContain('cu2');
+    expect(applied.state.civilizations['p2'].units).toContain('cu2');
   });
 });


### PR DESCRIPTION
## Summary

- **geneTherapyReady survive-at-1HP**: Units with `geneTherapyReady: true` intercept a lethal hit, survive at 1 HP with `movementPointsLeft: 0`, and reset the flag to `false` (cooldown). Works for both attacker and defender positions.
- **cyber_unit capture**: When a `cyber_unit` is defeated in combat, it is transferred to the victor's ownership rather than destroyed. Civ unit rosters are updated bilaterally. Quest and pirate faction logic correctly skips captured units (they aren't "defeated").
- **stealth_bomber ranged immunity**: `canUnitAttackTarget` rejects ranged attacks against a `stealth_bomber` unless the attacker's civ has a `signals_hub` building within 2 hexes of the bomber. Melee attacks are unaffected.

## Out of scope

- Task 5: turn-manager behaviors (gene therapy pre-charge on training, cooldown reset, private-spaceflight air movement, cyber drain, cyberMarketDisruption tick)
- Task 6: national projects (digital_silk_road, national_cyber_command, sustainability_program) + world-wide-web wonder + game-balance.md allowlist
- Task 7: passive tech effects (nanomaterials, transhumanism, quantum-computing cost, etc.)
- Task 8: SFX events (cyber drain, gene therapy survive) + geneTherapyReady UI badge

## Why this is safe to merge partial

No new player-visible surfaces are introduced. All three behaviors are pure combat-logic changes that activate only when era-12 units (`cyber_unit`, `stealth_bomber`) are present in game state. The production queue entries for these units already exist from Task 3; the new combat behaviors simply change what happens when those units participate in combat. No buttons, UI panels, or queue entries are added or changed — there is no dead-end UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jBXuK84vwoV6C4o63JVpE