### PR TITLE
feat(buildings): building obsolescence — obsoletedByTech for stable, cavalry-academy, siege-workshop (#443)

### DIFF
--- a/docs/superpowers/plans/2026-07-04-building-obsolescence-implementation.md
+++ b/docs/superpowers/plans/2026-07-04-building-obsolescence-implementation.md
@@ -1,0 +1,699 @@
+# Building Obsolescence (#443) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Project override:** this repo's `CLAUDE.md` forbids subagents/parallel agents. Execute this plan with `superpowers:executing-plans` inline in the current session, not `subagent-driven-development`.
+
+**Goal:** Give `stable`, `cavalry-academy`, and `siege-workshop` an `obsoletedByTech` field so they disappear from the build queue, silently dequeue if already queued, drop to zero upkeep, and show an "(obsolete)" badge once their linked unit line fully retires — mirroring #429's unit-obsolescence behavior exactly, with no demolish mechanic.
+
+**Architecture:** One new optional field on `Building` (`src/core/types.ts`), consumed at 4 existing touch points: `getAvailableBuildings` (queue filter), `processCity`'s dequeue block (silent drop), `calculateCityBuildingMaintenance` (upkeep exemption via a new `'obsolete'` `MaintenanceReason`), and `createCityPanel`'s built-buildings render loop (badge + upkeep row text). No new files, no new systems, no AI changes (AI already only acts on `getAvailableBuildings`'s output).
+
+**Tech Stack:** TypeScript, Vitest. No UI framework — `city-panel.ts` builds an HTML string template.
+
+## Global Constraints
+
+- Spec of record: `docs/superpowers/specs/2026-07-04-building-obsolescence-design.md` — do not deviate from its scope (queue availability + upkeep + UI badge; no demolish mechanic; cosmetic only, not a mechanical fix).
+- Exactly 3 buildings get `obsoletedByTech`: `stable` → `tank-warfare`, `cavalry-academy` → `tank-warfare`, `siege-workshop` → `black-powder`. `armory`, `war-academy`, `safehouse`, `artillery_corps_hq` must NOT get the field (see spec's exclusion table).
+- `calculateCityBuildingMaintenance` must resolve the owning civ via `city.owner`, never `state.currentPlayer` (this function runs for AI cities too).
+- `game-balance.md`: not applicable to this feature (no yields added), but do not touch any wonder/national-project ceiling while in these files.
+- Every step below shows real code — no "add tests for the above" placeholders.
+
+---
+
+### Task 1: `Building.obsoletedByTech` field + assign to the 3 candidate buildings
+
+**Files:**
+- Modify: `src/core/types.ts` (`Building` interface, ~line 393-409)
+- Modify: `src/systems/city-system.ts` (`stable` at line 65, `cavalry-academy` at line 131-140, `siege-workshop` at line 173-182)
+- Test: `tests/systems/city-system.test.ts`
+
+**Interfaces:**
+- Produces: `Building.obsoletedByTech?: string` — consumed by Tasks 2, 6, 7 (`getAvailableBuildings`, `processCity`, `calculateCityBuildingMaintenance`) and Task 8 (`city-panel.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/systems/city-system.test.ts` (new `describe` block, anywhere after the existing `describe('getAvailableBuildings', ...)` block):
+
+```typescript
+describe('#443 — building obsolescence data', () => {
+  it('stable obsoletes at tank-warfare (mounted-unit line fully retires there)', () => {
+    expect(BUILDINGS.stable.obsoletedByTech).toBe('tank-warfare');
+  });
+
+  it('cavalry-academy obsoletes at tank-warfare (same mounted-unit line)', () => {
+    expect(BUILDINGS['cavalry-academy'].obsoletedByTech).toBe('tank-warfare');
+  });
+
+  it('siege-workshop obsoletes at black-powder (catapult/ballista line fully retires there)', () => {
+    expect(BUILDINGS['siege-workshop'].obsoletedByTech).toBe('black-powder');
+  });
+
+  it('armory, war-academy, safehouse, artillery_corps_hq do NOT get obsoletedByTech (melee/ranged/spy categories never fully empty; artillery_corps_hq already has its own national-project fade lifecycle)', () => {
+    expect(BUILDINGS.armory.obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS['war-academy'].obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS.safehouse.obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS.artillery_corps_hq.obsoletedByTech).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "building obsolescence data"`
+Expected: FAIL — `obsoletedByTech` is `undefined` for `stable`/`cavalry-academy`/`siege-workshop` (property doesn't exist on the type or data yet; the `toBeUndefined()` assertions on the 4 excluded buildings already pass since the field doesn't exist anywhere yet, but the first 3 fail).
+
+- [ ] **Step 3: Add the field to the type**
+
+In `src/core/types.ts`, in the `Building` interface:
+
+```typescript
+export interface Building {
+  id: string;
+  name: string;
+  category?: BuildingCategory;
+  yields: ResourceYield;
+  productionCost: number;
+  description: string;
+  techRequired?: string | null;
+  coastalRequired?: boolean;
+  pacing?: PacingMetadata;
+  resourceRequired?: ResourceType[];
+  routeCapacity?: number;   // trade route slots added to the FROM city; 0 or absent = none
+  requiresBuildings?: string[];   // chain of building IDs that must be built first
+  uniquePerEmpire?: true;         // only one instance per civ (used by national projects)
+  nationalProject?: NationalProject;  // present when this building is a national project
+  civYieldBonus?: Partial<ResourceYield>;  // empire-wide yield bonus while active
+  obsoletedByTech?: string;  // once this tech completes, building is hidden from queue, silently dequeued, upkeep-free
+}
+```
+
+- [ ] **Step 4: Set the field on the 3 buildings**
+
+In `src/systems/city-system.ts`, edit the 3 definitions in place (do not reformat surrounding entries):
+
+```typescript
+  stable: { id: 'stable', name: 'Stable', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 55, description: 'Trains mounted units', techRequired: 'horseback-riding', obsoletedByTech: 'tank-warfare' },
+```
+
+```typescript
+  'cavalry-academy': {
+    id: 'cavalry-academy', name: 'Cavalry Academy', category: 'military',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 55,
+    description: 'Mounted warfare school. Reduces cavalry unit training cost by 15% in this city.',
+    techRequired: 'horseback-riding',
+    resourceRequired: ['horses'],
+    obsoletedByTech: 'tank-warfare',
+    pacing: { band: 'power-spike', role: 'cavalry-cost-reduction', impact: 1.15, scope: 'city', snowball: 1, urgency: 1, situationality: 1.15, unlockBreadth: 1 },
+  },
+```
+
+```typescript
+  'siege-workshop': {
+    id: 'siege-workshop', name: 'Siege Workshop', category: 'military',
+    yields: { food: 0, production: 0, gold: 0, science: 0 },
+    productionCost: 90,
+    description: 'Siege engine fabrication. Reduces Catapult and Ballista training cost by 20% in this city.',
+    techRequired: 'siege-warfare',
+    resourceRequired: ['stone'],
+    obsoletedByTech: 'black-powder',
+    pacing: { band: 'infrastructure', role: 'siege-cost-reduction', impact: 1.2, scope: 'city', snowball: 1, urgency: 1, situationality: 1.2, unlockBreadth: 1 },
+  },
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "building obsolescence data"`
+Expected: PASS (4 tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/core/types.ts src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(buildings): add obsoletedByTech to stable, cavalry-academy, siege-workshop (#443)"
+```
+
+---
+
+### Task 2: Queue availability — `getAvailableBuildings` filters obsolete buildings
+
+**Files:**
+- Modify: `src/systems/city-system.ts`, `getAvailableBuildings` (currently lines 1529-1556)
+- Test: `tests/systems/city-system.test.ts`
+
+**Interfaces:**
+- Consumes: `Building.obsoletedByTech` (Task 1), `completedTechs: string[]` (already a parameter of `getAvailableBuildings`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('getAvailableBuildings', ...)` block in `tests/systems/city-system.test.ts`:
+
+```typescript
+  it('offers stable and cavalry-academy before tank-warfare completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['horseback-riding'], map);
+    expect(available.find(b => b.id === 'stable')).toBeDefined();
+    expect(available.find(b => b.id === 'cavalry-academy')).toBeDefined();
+  });
+
+  it('hides stable and cavalry-academy once tank-warfare completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['horseback-riding', 'tank-warfare'], map);
+    expect(available.find(b => b.id === 'stable')).toBeUndefined();
+    expect(available.find(b => b.id === 'cavalry-academy')).toBeUndefined();
+  });
+
+  it('hides siege-workshop once black-powder completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['siege-warfare', 'black-powder'], map);
+    expect(available.find(b => b.id === 'siege-workshop')).toBeUndefined();
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "tank-warfare completes"`
+Expected: FAIL — the "hides" tests fail because `getAvailableBuildings` does not yet check `obsoletedByTech`, so `stable`/`cavalry-academy`/`siege-workshop` are still returned.
+
+- [ ] **Step 3: Implement the filter**
+
+In `src/systems/city-system.ts`, add one condition inside `getAvailableBuildings`'s filter callback:
+
+```typescript
+export function getAvailableBuildings(
+  city: City,
+  completedTechs: string[],
+  map: GameMap,
+  availableResources?: Set<ResourceType>,
+  era?: number,
+  builtNationalProjectKeys?: Set<string>,
+  civId?: string,
+): Building[] {
+  const coastal = isCityCoastal(city, map);
+  return Object.values(BUILDINGS).filter(b => {
+    if (city.buildings.includes(b.id)) return false;
+    if (b.techRequired && !completedTechs.includes(b.techRequired)) return false;
+    if (b.obsoletedByTech && completedTechs.includes(b.obsoletedByTech)) return false;
+    if (b.coastalRequired && !coastal) return false;
+    if (availableResources !== undefined && b.resourceRequired?.length) {
+      if (!b.resourceRequired.every(r => availableResources.has(r))) return false;
+    }
+    if (b.requiresBuildings?.length) {
+      if (!b.requiresBuildings.every((req: string) => city.buildings.includes(req))) return false;
+    }
+    if (b.nationalProject) {
+      const currentEra = era ?? 1;
+      if (currentEra < b.nationalProject.homeEra || currentEra > b.nationalProject.homeEra + 1) return false;
+      if (b.uniquePerEmpire && civId && builtNationalProjectKeys?.has(`${civId}:${b.id}`)) return false;
+    }
+    return true;
+  });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "getAvailableBuildings"`
+Expected: PASS (all `getAvailableBuildings` tests, including the 3 new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(buildings): hide obsoleted buildings from the production queue (#443)"
+```
+
+---
+
+### Task 3: Data-integrity test — `obsoletedByTech` genuinely matches the retired unit line
+
+**Files:**
+- Test only: `tests/systems/city-system.test.ts`
+
+**Interfaces:**
+- Consumes: `getTrainableUnitsForCiv` (existing export), `Building.obsoletedByTech` (Task 1).
+
+This proves the 3 `obsoletedByTech` values are semantically correct (the units the description names are actually gone at that tech state), not a copy-paste guess — per the spec's testing-strategy item 2. No production code changes in this task.
+
+- [ ] **Step 1: Write the test**
+
+Add a new `describe` block to `tests/systems/city-system.test.ts`:
+
+```typescript
+describe('#443 — building obsolescence matches the retired unit line', () => {
+  it('stable ("Trains mounted units"): horseman/cavalry/knight are all gone once tank-warfare completes', () => {
+    const units = getTrainableUnitsForCiv(
+      ['horseback-riding', 'iron-forging', 'tank-warfare'],
+      undefined,
+      new Set<ResourceType>(['horses', 'iron']),
+    );
+    expect(units.some(u => u.type === 'horseman')).toBe(false);
+    expect(units.some(u => u.type === 'cavalry')).toBe(false);
+    expect(units.some(u => u.type === 'knight')).toBe(false);
+  });
+
+  it('siege-workshop ("Reduces Catapult and Ballista training cost"): both gone once black-powder completes', () => {
+    const units = getTrainableUnitsForCiv(
+      ['siege-warfare', 'black-powder'],
+      undefined,
+      new Set<ResourceType>(['stone', 'iron']),
+    );
+    expect(units.some(u => u.type === 'catapult')).toBe(false);
+    expect(units.some(u => u.type === 'ballista')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "matches the retired unit line"`
+Expected: This should already PASS if #429's unit `obsoletedByTech` chains are intact (Task 5's earlier verification confirmed `horseman`/`cavalry`/`knight` → `tank-warfare` and `catapult`/`ballista` → `black-powder` on `main`). If it fails, that means #429's unit data has regressed since this plan was written — stop and re-verify before continuing; do not adjust this test to match a regression.
+
+- [ ] **Step 3: Confirm passing (no implementation step — this task locks in an existing invariant)**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "#443"`
+Expected: PASS (all `#443` tests written so far)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/systems/city-system.test.ts
+git commit -m "test(buildings): lock in that obsoletedByTech matches the retired unit line (#443)"
+```
+
+---
+
+### Task 4: Negative regression — excluded buildings never obsolete, even with every tech completed
+
+**Files:**
+- Test only: `tests/systems/city-system.test.ts` (add `TECH_TREE` import from `@/systems/tech-definitions`)
+
+**Interfaces:**
+- Consumes: `TECH_TREE: Tech[]` from `@/systems/tech-definitions` (existing export, full merged tech roster across all eras), `getAvailableBuildings` (Task 2).
+
+- [ ] **Step 1: Write the failing-if-regressed test**
+
+Add `import { TECH_TREE } from '@/systems/tech-definitions';` to the top of `tests/systems/city-system.test.ts` alongside the other imports, then add:
+
+```typescript
+describe('#443 — excluded buildings never obsolete (negative regression)', () => {
+  it('armory, war-academy, safehouse remain available even with every tech in the game completed', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const allTechs = TECH_TREE.map(t => t.id);
+    const available = getAvailableBuildings(city, allTechs, map, new Set<ResourceType>(['copper', 'iron', 'horses', 'stone']));
+    expect(available.find(b => b.id === 'armory')).toBeDefined();
+    expect(available.find(b => b.id === 'war-academy')).toBeDefined();
+    expect(available.find(b => b.id === 'safehouse')).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes as-is**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "excluded buildings never obsolete"`
+Expected: PASS immediately — Task 1 never assigned `obsoletedByTech` to these 3 buildings, so this is a regression guard, not a red/green cycle. (If it fails, a later change accidentally added `obsoletedByTech` to one of these — fix that regression before proceeding.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/systems/city-system.test.ts
+git commit -m "test(buildings): guard armory/war-academy/safehouse against accidental obsoletedByTech (#443)"
+```
+
+---
+
+### Task 5: Soft-lock guard — no `requiresBuildings` chain depends on the 3 obsoleting buildings
+
+**Files:**
+- Test only: `tests/systems/city-system.test.ts`
+
+**Interfaces:**
+- Consumes: `BUILDINGS: Record<string, Building>` (existing export).
+
+Locks in the precondition the spec's soft-lock-risk section relies on: hiding `stable`/`cavalry-academy`/`siege-workshop` from the queue is only safe because no other building's `requiresBuildings` names them as a prerequisite. If a future building addition violates this, this test fails loudly instead of silently creating a dead-end city.
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+describe('#443 — soft-lock guard', () => {
+  it('no Building.requiresBuildings chain references stable, cavalry-academy, or siege-workshop as a prerequisite', () => {
+    const obsoletableIds = new Set(['stable', 'cavalry-academy', 'siege-workshop']);
+    const offenders: string[] = [];
+    for (const b of Object.values(BUILDINGS)) {
+      if (!b.requiresBuildings?.length) continue;
+      for (const req of b.requiresBuildings) {
+        if (obsoletableIds.has(req)) offenders.push(`${b.id} requires ${req}`);
+      }
+    }
+    expect(offenders, `hiding an obsoleted building from the queue would permanently block: ${offenders.join(', ')}`).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "soft-lock guard"`
+Expected: PASS — confirmed in the plan's pre-work (grep of `requiresBuildings` on current `main` only shows `herbalist`, `semiconductor_fab`, `cyber_defense_center`, `factory` as prerequisites).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/systems/city-system.test.ts
+git commit -m "test(buildings): guard against future requiresBuildings chains on obsoletable buildings (#443)"
+```
+
+---
+
+### Task 6: Dequeue already-queued obsolete buildings — `processCity`
+
+**Files:**
+- Modify: `src/systems/city-system.ts`, inside `processCity`'s drop-queued-items block (currently lines 1655-1679; the building branch is `if (BUILDING_IDS.has(item)) { ... }` at line 1662)
+- Test: `tests/systems/city-system.test.ts`
+
+**Interfaces:**
+- Consumes: `Building.obsoletedByTech` (Task 1), `completedTechs` (already a `processCity` parameter).
+- Produces: `CityProcessResult.droppedProductionItem` populated with the building id when dropped for this reason (field already exists on the type; this task is the first building-side writer of it for the tech-loss case).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('processCity', ...)` block in `tests/systems/city-system.test.ts`:
+
+```typescript
+  it('processCity silently dequeues a not-yet-built stable once tank-warfare completes, and reports droppedProductionItem', () => {
+    const map = generateMap(30, 30, 'obsolete-building-drop-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: [],
+      productionQueue: ['stable'],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 100, undefined, ['horseback-riding', 'tank-warfare']);
+
+    expect(result.droppedProductionItem).toBe('stable');
+    expect(result.city.productionQueue).not.toContain('stable');
+    expect(result.completedBuilding).toBeNull();
+    expect(result.city.productionProgress).toBe(0);
+  });
+
+  it('processCity does NOT dequeue a queued stable when tank-warfare has not completed', () => {
+    const map = generateMap(30, 30, 'obsolete-building-keep-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: [],
+      productionQueue: ['stable'],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 1, undefined, ['horseback-riding']);
+
+    expect(result.droppedProductionItem).toBeNull();
+    expect(result.city.productionQueue).toContain('stable');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "dequeues a not-yet-built stable"`
+Expected: FAIL — `droppedProductionItem` is `null` and `stable` is still in the queue, because the `BUILDING_IDS.has(item)` branch does not yet check `obsoletedByTech`.
+
+- [ ] **Step 3: Implement the dequeue check**
+
+In `src/systems/city-system.ts`, inside `processCity`, extend the `BUILDING_IDS.has(item)` branch (the surrounding `filtered = newQueue.filter(item => { ... })` block stays otherwise unchanged):
+
+```typescript
+      if (BUILDING_IDS.has(item)) {
+        const building = BUILDINGS[item];
+        if (building?.obsoletedByTech && completedTechs.includes(building.obsoletedByTech)) {
+          droppedProductionItem ??= item;
+          return false;
+        }
+        if (building?.resourceRequired?.length && availableResources !== undefined) {
+          if (!building.resourceRequired.every(r => availableResources!.has(r))) return false;
+        }
+        return true;
+      }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts -t "processCity"`
+Expected: PASS (all `processCity` tests, including the 2 new ones)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(buildings): silently dequeue obsoleted buildings still in production (#443)"
+```
+
+---
+
+### Task 7: Upkeep exemption — `'obsolete'` `MaintenanceReason` + `calculateCityBuildingMaintenance`
+
+**Files:**
+- Modify: `src/systems/economy-system.ts` — `MaintenanceReason` type (currently line 131) and the per-building loop inside `calculateCityBuildingMaintenance` (currently lines 329-341, inside the function starting at line 318)
+- Test: `tests/systems/economy-system.test.ts`
+
+**Interfaces:**
+- Consumes: `Building.obsoletedByTech` (Task 1), `state.civilizations[city.owner].techState.completed` (existing state shape).
+- Produces: `MaintenanceRow.reason` can now be `'obsolete'`, consumed by Task 8 (`city-panel.ts`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `describe('economy maintenance', ...)` block in `tests/systems/economy-system.test.ts`:
+
+```typescript
+  it('exempts an obsolete building from upkeep with reason "obsolete" (#443)', () => {
+    const state = makeState();
+    city(state).buildings = ['cavalry-academy'];
+    state.civilizations.player.techState.completed.push('tank-warfare');
+
+    const breakdown = calculateCityBuildingMaintenance(state, 'capital');
+    const row = breakdown.rows.find(r => r.id === 'cavalry-academy');
+
+    expect(row?.upkeep).toBe(0);
+    expect(row?.reason).toBe('obsolete');
+  });
+
+  it('charges normal upkeep for cavalry-academy before tank-warfare completes', () => {
+    const state = makeState();
+    city(state).buildings = ['cavalry-academy'];
+
+    const breakdown = calculateCityBuildingMaintenance(state, 'capital');
+    const row = breakdown.rows.find(r => r.id === 'cavalry-academy');
+
+    expect(row?.reason).not.toBe('obsolete');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/economy-system.test.ts -t "obsolete"`
+Expected: FAIL — `row?.reason` is `'free-support'` or `'paid'` (never `'obsolete'`, since that value doesn't exist yet) for the first test.
+
+- [ ] **Step 3: Add the `'obsolete'` reason to the type**
+
+In `src/systems/economy-system.ts`:
+
+```typescript
+export type MaintenanceReason = 'exempt' | 'free-support' | 'free-defender' | 'paid' | 'obsolete';
+```
+
+- [ ] **Step 4: Implement the exemption in the per-building loop**
+
+In `src/systems/economy-system.ts`, inside `calculateCityBuildingMaintenance` (the function starting at `export function calculateCityBuildingMaintenance(state: GameState, cityOrId: City | string): CityBuildingMaintenance {`), replace the per-building loop:
+
+```typescript
+  const freeSupport = getFreeBuildingSlots(city);
+  const exemptBuildings: MaintenanceRow[] = [];
+  const candidates: MaintenanceRow[] = [];
+  const owner = state.civilizations[city.owner];
+
+  for (const buildingId of city.buildings) {
+    if (!BUILDINGS[buildingId]) continue;
+    if (ECONOMY_RULES.coreFreeBuildings.has(buildingId)) {
+      exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'exempt' });
+      continue;
+    }
+    const building = BUILDINGS[buildingId];
+    if (building?.obsoletedByTech && owner?.techState.completed.includes(building.obsoletedByTech)) {
+      exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'obsolete' });
+      continue;
+    }
+    candidates.push({
+      id: buildingId,
+      label: getBuildingLabel(buildingId),
+      upkeep: getBuildingUpkeep(buildingId),
+      reason: 'paid',
+    });
+  }
+```
+
+(Only the loop body changes — `candidates.sort(...)` and everything after it in the function is unchanged. `owner` uses `city.owner`, never `state.currentPlayer`, so this stays correct for AI-owned cities.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/economy-system.test.ts -t "economy maintenance"`
+Expected: PASS (all tests in the `describe('economy maintenance', ...)` block, including the 2 new ones)
+
+- [ ] **Step 6: Run the full economy + city-system suites to check for exhaustiveness regressions**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/economy-system.test.ts tests/systems/city-system.test.ts`
+Expected: PASS — the spec's regression-safety check confirmed no exhaustive switch elsewhere consumes `MaintenanceReason`, but this step verifies nothing in these two suites broke.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/economy-system.ts tests/systems/economy-system.test.ts
+git commit -m "feat(economy): exempt obsolete buildings from upkeep via new MaintenanceReason (#443)"
+```
+
+---
+
+### Task 8: City panel UI — obsolete badge + upkeep row text
+
+**Files:**
+- Modify: `src/ui/city-panel.ts` — the built-buildings render loop (currently lines 231-253, inside `createCityPanel`)
+- Test: `tests/ui/city-panel.test.ts`
+
+**Interfaces:**
+- Consumes: `Building.obsoletedByTech` (Task 1), `state.civilizations[city.owner].techState.completed` (existing), `cityMaintenance.rows` with `reason: 'obsolete'` (Task 7, already computed at line 201 via `calculateCityBuildingMaintenance(state, city)`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block to `tests/ui/city-panel.test.ts` (after the existing `describe('city-panel unrest section — #436', ...)` block, using the same `makeWonderPanelFixture()`/`collectText()` pattern already imported at the top of the file):
+
+```typescript
+describe('city-panel obsolete-building badge — #443', () => {
+  it('shows the obsolete badge and "Obsolete — no upkeep" text for a built, now-obsolete building', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['cavalry-academy'];
+    state.civilizations[state.currentPlayer].techState.completed.push('tank-warfare');
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('obsolete');
+    expect(rendered).toContain('Obsolete — no upkeep');
+  });
+
+  it('shows neither the obsolete badge nor "Obsolete — no upkeep" for a still-relevant building', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['cavalry-academy'];
+    // tank-warfare NOT completed — cavalry-academy is still relevant
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).not.toContain('obsolete');
+    expect(rendered).not.toContain('Obsolete — no upkeep');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/ui/city-panel.test.ts -t "obsolete-building badge"`
+Expected: FAIL — the first test fails because neither the badge nor the upkeep text exists yet.
+
+- [ ] **Step 3: Implement the badge and upkeep row text**
+
+In `src/ui/city-panel.ts`, inside the built-buildings render loop (the `for (let idx = 0; idx < city.buildings.length; idx++) { ... }` block), replace the body:
+
+```typescript
+  let buildingPlaceholders = '';
+  for (let idx = 0; idx < city.buildings.length; idx++) {
+    const bid = city.buildings[idx];
+    const b = BUILDINGS[bid];
+    if (b) {
+      const row = cityMaintenance.rows.find(r => r.id === bid);
+      const upkeep = row?.upkeep ?? 0;
+      let fadingBadge = '';
+      if (b.nationalProject && b.uniquePerEmpire) {
+        const record = state.builtNationalProjects?.[`${city.owner}:${bid}`];
+        if (record) {
+          const multiplier = getNationalProjectMultiplier(state.era, record.eraBuilt);
+          if (multiplier === 0.5) {
+            fadingBadge = ' <span style="color:#f0c040;font-size:10px;" title="This institution is losing relevance and will expire next era.">⏳ (fading)</span>';
+          }
+        }
+      }
+      let obsoleteBadge = '';
+      if (b.obsoletedByTech && state.civilizations[city.owner]?.techState.completed.includes(b.obsoletedByTech)) {
+        obsoleteBadge = ' <span style="color:#e88;font-size:10px;" title="This building\'s purpose no longer applies — later technology has moved past it. No upkeep cost, but no effect either.">⚠️ (obsolete)</span>';
+      }
+      const upkeepText = row?.reason === 'obsolete'
+        ? 'Obsolete — no upkeep'
+        : upkeep > 0
+          ? `Upkeep: -${upkeep} gold/turn`
+          : 'Free support';
+      buildingPlaceholders += `<div style="background:rgba(255,255,255,0.05);border-radius:6px;padding:8px;margin-bottom:4px;font-size:12px;">
+        <strong data-text="bldg-name-${idx}"></strong>${fadingBadge}${obsoleteBadge} — <span data-text="bldg-desc-${idx}"></span>
+        <div style="font-size:11px;opacity:0.72;margin-top:3px;" data-text="bldg-upkeep-${idx}">${upkeepText}</div>
+      </div>`;
+    }
+  }
+```
+
+Note: this replaces the old `const upkeep = cityMaintenance.rows.find(row => row.id === bid)?.upkeep ?? 0;` line with `const row = cityMaintenance.rows.find(r => r.id === bid);` plus a derived `upkeep`, since the row's `reason` is now needed too, not just its `upkeep`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/ui/city-panel.test.ts -t "obsolete-building badge"`
+Expected: PASS (both new tests)
+
+- [ ] **Step 5: Run the full city-panel suite to check for regressions**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/ui/city-panel.test.ts`
+Expected: PASS — confirms the `fadingBadge`/national-project rendering and the plain "Free support"/"Upkeep: -N gold/turn" text for ordinary buildings still render correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "feat(ui): show obsolete badge and upkeep-free label on the city panel (#443)"
+```
+
+---
+
+## Final Verification (after all 8 tasks)
+
+- [ ] **Run the full build and test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: both exit 0.
+
+- [ ] **Self-review the full diff against merge-base with origin/main**
+
+```bash
+git diff "$(git merge-base HEAD origin/main)"..HEAD
+```
+
+Check for: proper testing, regressions, logic issues, data issues, quality issues — per `spec-fidelity.md`'s instruction to compare against the current merge-base, not a stale ref.
+
+- [ ] **Push and open a PR** (see task prompt Step 5 for the required PR body sections: Summary, Design rationale, Notable findings, Test plan). Do not merge — leave open for review.
+
+- [ ] **File 2 deferred follow-up issues** (see task prompt Step 6): `droppedProductionItem` notification-wiring gap, and the unit-training-cost-reduction mechanics these buildings' flavor text describes. Reference this PR and the spec doc in both.

--- a/docs/superpowers/specs/2026-07-04-building-obsolescence-design.md
+++ b/docs/superpowers/specs/2026-07-04-building-obsolescence-design.md
@@ -1,0 +1,283 @@
+# Building Obsolescence (#443) — Design
+
+## Context
+
+#429 added `obsoletedByTech` coverage for combat units — a unit stops appearing in the
+production queue once a tech that supersedes it completes, and already-trained units are
+untouched. The original issue also asked about the building equivalent (e.g. "Stable feels
+obsolete once the cavalry line fully retires"), explicitly deferred to keep #429 reviewable
+and tracked as its own follow-up, #443.
+
+## Scope
+
+Confirmed with the user before writing this spec:
+
+- **Queue availability + upkeep + a UI signal.** Once a building's obsoleting tech
+  completes: (1) it disappears from the "can build" list (mirrors #429's unit behavior
+  exactly), (2) if already queued but not yet built, it's silently dequeued, (3) if already
+  built, its upkeep drops to zero, (4) the city panel shows a badge marking it obsolete.
+- **No demolish mechanic.** There is no building-removal system in this game today and this
+  spec does not add one. Obsolete-but-built buildings simply sit in `city.buildings` forever,
+  upkeep-free, with a UI badge — exactly like a unit that's still alive after its type
+  stopped being trainable.
+- **Cosmetic, not mechanical.** Investigated whether any of the candidate buildings'
+  described effects (e.g. "Reduces cavalry unit training cost by 15%") are actually
+  implemented anywhere in the code. None are — `cavalry-academy`, `armory`, `war-academy`,
+  `siege-workshop`, and `safehouse`'s percentage cost-reduction text has zero corresponding
+  logic anywhere in the codebase; `stable`'s "Trains mounted units" is pure flavor text with
+  no `requiresBuildings` link from any unit. This spec does not implement the missing
+  mechanical effects — that's a separate, larger feature, not a #429-style follow-up fix.
+  This spec is purely about a building's *description* no longer matching reality once its
+  linked unit line is gone.
+
+## Candidate buildings
+
+Found by grepping all 139 `BUILDINGS` entries for descriptions referencing a specific unit
+type or unit category, then cross-checking against #429's retirement chains
+(`src/systems/city-system.ts`'s `TRAINABLE_UNITS`).
+
+**Get `obsoletedByTech` (their linked unit line has a real, single retirement point):**
+
+| Building | `techRequired` | `obsoletedByTech` | Why |
+|---|---|---|---|
+| `stable` | `horseback-riding` | `tank-warfare` | "Trains mounted units" — horseman/cavalry/knight all obsolete at `tank-warfare` (#429). |
+| `cavalry-academy` | `horseback-riding` | `tank-warfare` | "Reduces cavalry unit training cost" — same line, same retirement point. |
+| `siege-workshop` | `siege-warfare` | `black-powder` | "Reduces Catapult and Ballista training cost" — both obsolete at `black-powder`, replaced by Cannon (#429). |
+
+**Explicitly considered, deliberately excluded (documented in a code comment, not a test —
+see Architecture):**
+
+| Building | Why it never obsoletes |
+|---|---|
+| `armory` | "Reduces melee and ranged unit training cost" — melee/ranged is a category, not a line; some melee/ranged unit is trainable at every era (e.g. Rifleman → Machine Gunner, which is terminal). Never fully empty. |
+| `war-academy` | Same reasoning as `armory` — melee/ranged, never fully empty. |
+| `safehouse` | "Reduces spy unit training cost" — the spy chain terminates at `spy_hacker`, which never obsoletes. The category is never empty. |
+| `artillery_corps_hq` | Cannon-linked flavor text, but this building is a national project with its own existing era-based fade lifecycle (`nationalProject.homeEra`, fade multiplier) and its *real* effect is a `civYieldBonus`, not the flavor-text cannon bonus. Out of scope — don't layer a second obsolescence mechanism onto something that already has one. |
+
+**Checked for soft-lock risk:** none of `requiresBuildings`'s 4 existing chains
+(`herbalist`→apothecary-tier, `semiconductor_fab`-based era-12 chains) reference `stable`,
+`cavalry-academy`, or `siege-workshop` as a prerequisite. Safe to hide them from the queue
+without permanently blocking any other building.
+
+## Architecture
+
+### 1. `Building.obsoletedByTech` field
+
+Add to `src/core/types.ts`'s `Building` interface, matching `TrainableUnitEntry`'s existing
+field exactly:
+
+```typescript
+export interface Building {
+  // ...existing fields...
+  obsoletedByTech?: string;
+}
+```
+
+No `upgradesTo`-equivalent. Considered it (units get one per #429/#444's concurrent-PR
+convention) — rejected because buildings have no slot-based replace mechanic. A city can
+have both `stable` and `tank_depot` built simultaneously; there's no "auto-upgrade this
+building" action for a successor field to drive. Adding one would be unconsumed dead data,
+violating `end-to-end-wiring.md`'s "never compute without rendering" rule.
+
+### 2. Queue availability — `getAvailableBuildings`
+
+`src/systems/city-system.ts`. Add one condition to the existing filter, using the
+`completedTechs` parameter it already receives:
+
+```typescript
+if (b.obsoletedByTech && completedTechs.includes(b.obsoletedByTech)) return false;
+```
+
+### 3. Dequeue already-queued obsolete buildings — `processCity`
+
+`src/systems/city-system.ts`, inside the "drop queued items that are no longer available"
+block (~line 1660). Today this block checks `resourceRequired` for buildings but never
+checks tech state at all for buildings (only for units, via `trainableTypes`) — a real gap
+that predates this spec. Extend the existing per-item building branch:
+
+```typescript
+if (BUILDING_IDS.has(item)) {
+  const building = BUILDINGS[item];
+  if (building?.obsoletedByTech && completedTechs.includes(building.obsoletedByTech)) {
+    droppedProductionItem ??= item;
+    return false;
+  }
+  if (building?.resourceRequired?.length && availableResources !== undefined) {
+    if (!building.resourceRequired.every(r => availableResources!.has(r))) return false;
+  }
+  return true;
+}
+```
+
+**Note on `droppedProductionItem`:** this field is returned by `CityProcessResult` but
+**nothing anywhere currently reads it** — confirmed by grep across `src/`. This means the
+*existing* unit-dequeue path already silently drops queued items with zero player
+notification, and the *existing* resource-loss building-dequeue path does too. This is a
+real, pre-existing bug (silent destructive UI on an already-shipped feature), but it's
+strictly bigger than #443's scope (it's about notification wiring across `main.ts`, not
+about building obsolescence data). This spec populates `droppedProductionItem` correctly
+for the new obsolescence case (consistent with the unit path, no worse than the existing
+gap) and files the wiring gap as its own separate follow-up issue — same pattern as
+#429 deferring buildings to #443.
+
+### 4. Upkeep exemption — `economy-system.ts`
+
+Add a new `MaintenanceReason` value:
+
+```typescript
+export type MaintenanceReason = 'exempt' | 'free-support' | 'free-defender' | 'paid' | 'obsolete';
+```
+
+In `calculateCityBuildingMaintenance`'s per-building loop, add a check before the
+`coreFreeBuildings` candidate/paid split (no overlap exists between `coreFreeBuildings` —
+`city-center`, `herbalist`, `workshop`, `shrine`, `barracks`, `library`, `granary` — and the
+3 candidate buildings, confirmed):
+
+```typescript
+for (const buildingId of city.buildings) {
+  if (!BUILDINGS[buildingId]) continue;
+  if (ECONOMY_RULES.coreFreeBuildings.has(buildingId)) {
+    exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'exempt' });
+    continue;
+  }
+  const building = BUILDINGS[buildingId];
+  const owner = state.civilizations[city.owner];
+  if (building?.obsoletedByTech && owner?.techState.completed.includes(building.obsoletedByTech)) {
+    exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'obsolete' });
+    continue;
+  }
+  candidates.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: getBuildingUpkeep(buildingId), reason: 'paid' });
+}
+```
+
+Uses `city.owner` to resolve the civ, not `state.currentPlayer` — this function runs for
+every civ's cities (AI included), and hot-seat correctness requires resolving ownership
+per-city, never assuming "the current player."
+
+Obsolete buildings are lumped into the same `exemptBuildings` array as core-free buildings
+(distinguished only by the `reason` tag) rather than a new array, because
+`freeBuildings` (a count metric consumed elsewhere, e.g. `ai-production.ts`) sums
+`exemptBuildings.length + supportedBuildings.length` — an obsolete building genuinely is
+upkeep-free, so including it in that count is correct, even though the *reason* differs
+from a core-free building.
+
+### 5. City panel UI — `src/ui/city-panel.ts`
+
+Two changes to the existing built-buildings render loop (~line 233), which already has a
+`fadingBadge` pattern for national projects to mirror:
+
+**Badge**, as its own independent variable (not reusing `fadingBadge`, since the two
+conditions are mutually exclusive in practice but shouldn't share a variable that implies
+one meaning):
+
+```typescript
+let obsoleteBadge = '';
+if (b.obsoletedByTech && state.civilizations[city.owner]?.techState.completed.includes(b.obsoletedByTech)) {
+  obsoleteBadge = ' <span style="color:#e88;font-size:10px;" title="This building\'s purpose no longer applies — later technology has moved past it. No upkeep cost, but no effect either.">⚠️ (obsolete)</span>';
+}
+```
+
+Inserted into the template alongside `fadingBadge`:
+
+```typescript
+<strong data-text="bldg-name-${idx}"></strong>${fadingBadge}${obsoleteBadge} — <span data-text="bldg-desc-${idx}"></span>
+```
+
+**Upkeep row text** — today this branches only on `upkeep > 0` (`'Upkeep: -N gold/turn'` vs
+`'Free support'`), which would misleadingly show "Free support" for an obsolete building
+(that phrase implies a valuable free slot, not "this is now useless"). Branch on the row's
+`reason` instead:
+
+```typescript
+const row = cityMaintenance.rows.find(r => r.id === bid);
+const upkeep = row?.upkeep ?? 0;
+const upkeepText = row?.reason === 'obsolete'
+  ? 'Obsolete — no upkeep'
+  : upkeep > 0
+    ? `Upkeep: -${upkeep} gold/turn`
+    : 'Free support';
+```
+
+## AI safety check
+
+`src/ai/basic-ai.ts`'s military-building fallback (`['barracks', 'stable'].find(id => ... availableBuildings.includes(id) ...)`)
+and `src/ai/ai-personality.ts`'s `weightProductionChoice` (`MILITARY_ITEMS` includes `'stable'`)
+both only act on items already present in the `availableBuildings` list `getAvailableBuildings`
+produced. Once `stable` is filtered out there, both paths naturally stop considering it —
+no AI code changes needed; the existing `availableBuildings.includes(...)` guards are
+already correct.
+
+## Regression safety check — `MaintenanceReason`
+
+Confirmed via grep that no exhaustive switch/match anywhere outside `economy-system.ts`
+itself consumes `MaintenanceReason` (the only other `.reason ===` sites in the codebase are
+unrelated `reason` fields on different types — territory-founding blockers, claim results).
+Adding `'obsolete'` to the union is safe and cannot silently break an existing exhaustiveness
+check elsewhere.
+
+## Test fixture conventions to reuse (don't invent new ones)
+
+- **`calculateCityBuildingMaintenance` / upkeep tests** — `tests/systems/economy-system.test.ts`
+  already has the exact fixture to extend: `makeState()` (builds a real city via `foundCity`,
+  id `'capital'`, owner `'player'`) plus the `city(state)` accessor. See the existing
+  `describe('economy maintenance', ...)` block (e.g. "keeps core buildings exempt; gives one
+  free slot..." at the top of that describe) for the established assertion style
+  (`calculateCityBuildingMaintenance(state, 'capital')`, checking `.upkeep`/`.paidBuildings`/
+  `.freeBuildings`/`.rows`). Add `state.civilizations.player.techState.completed.push('tank-warfare')`
+  (or set the array directly) to simulate the obsoleting tech being done, then assert the row
+  for `'cavalry-academy'` has `reason: 'obsolete'` and `upkeep: 0`.
+- **City panel UI tests** — `tests/ui/city-panel.test.ts` already imports
+  `makeWonderPanelFixture()` and `collectText()` from `./helpers/wonder-panel-fixture` (see the
+  `city-panel unrest section — #436` describe block for the exact usage pattern:
+  `const { container, city, state } = makeWonderPanelFixture();`). **Note:** the existing
+  national-project `fadingBadge` feature has *no* test coverage in this file at all (checked —
+  zero hits for "fading" in `tests/ui/city-panel.test.ts`), so there's no existing badge test
+  to mirror structurally; write the new obsolete-badge test fresh using the same
+  `makeWonderPanelFixture()`/`collectText()` pattern the unrest-section tests already use.
+  `makeWonderPanelFixture()`'s default state has `completedTechs: ['philosophy', 'pilgrimages']`
+  — override by pushing `'tank-warfare'` onto `state.civilizations[state.currentPlayer].techState.completed`
+  after construction, and set `city.buildings = ['cavalry-academy']` before rendering.
+
+## Testing strategy
+
+No completeness test (see below for why). Instead:
+
+1. **Queue availability**: `getAvailableBuildings` offers `stable`/`cavalry-academy` before
+   `tank-warfare` completes, and does not after. Same for `siege-workshop`/`black-powder`.
+2. **Data-integrity, not completeness**: for each obsoleted building, assert that once its
+   `obsoletedByTech` tech is in `completedTechs`, the unit(s) its description names are
+   genuinely absent from `getTrainableUnitsForCiv`'s output at that same tech state. This
+   proves the `obsoletedByTech` value is semantically correct — not a copy-paste guess —
+   without claiming a completeness guarantee the data doesn't structurally support (there's
+   no crisp mechanical filter like units' `strength > 0` to detect "this building needs a
+   decision"; identifying candidates here was inherently an editorial grep-and-read pass,
+   documented in a code comment, not enforced by a test).
+3. **Dequeue**: a city with `stable` queued (not yet built, `productionProgress: 0` to avoid
+   #429's cost-math false-positive lesson) silently drops it once `tank-warfare` completes,
+   and `droppedProductionItem` is populated with `'stable'`.
+4. **Upkeep**: a city with `cavalry-academy` already built shows `upkeep === 0` and
+   `reason === 'obsolete'` (not `'exempt'` or `'free-support'`) once `tank-warfare` completes.
+5. **UI**: the city panel shows the obsolete badge and "Obsolete — no upkeep" text for an
+   already-built, now-obsolete building; shows neither for a still-relevant one.
+6. **Negative regression**: `armory`, `war-academy`, and `safehouse` remain in
+   `getAvailableBuildings`'s output even with every tech in the game completed — proving
+   they were not accidentally given `obsoletedByTech`.
+7. **Soft-lock guard**: assert no `Building.requiresBuildings` array in the full `BUILDINGS`
+   roster references `stable`, `cavalry-academy`, or `siege-workshop` — locks in the
+   precondition that made this safe, so a future building addition that violates it fails
+   loudly instead of silently creating a dead-end.
+
+## Out of scope (follow-up issues to file)
+
+- **`droppedProductionItem` notification wiring.** Confirmed dead data — no code anywhere
+  consumes it, so players get zero feedback when a queued unit *or* building silently drops
+  from production today. Pre-existing, affects units already, bigger than this spec. File
+  as its own issue, same pattern as #429→#443.
+- **Implementing the actual unit-training-cost-reduction mechanic** these buildings describe
+  (`cavalry-academy`, `armory`, `war-academy`, `siege-workshop`, `safehouse`'s percentage
+  bonuses, and `stable`'s implied unit-training gate). This spec only addresses the
+  description no longer matching reality once the linked line is gone — it does not make
+  the description true in the first place. Worth its own design discussion given the
+  balance implications (`game-balance.md`'s national-project/wonder ceilings don't directly
+  apply to a flat per-building percentage discount, but a fresh discussion should confirm
+  reasonable bounds before implementing).

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -406,6 +406,7 @@ export interface Building {
   uniquePerEmpire?: true;         // only one instance per civ (used by national projects)
   nationalProject?: NationalProject;  // present when this building is a national project
   civYieldBonus?: Partial<ResourceYield>;  // empire-wide yield bonus while active
+  obsoletedByTech?: string;  // once this tech completes, building is hidden from queue, silently dequeued, upkeep-free
 }
 
 export interface OccupiedCityState {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -62,7 +62,7 @@ export const BUILDINGS: Record<string, Building> = {
   // Military
   barracks: { id: 'barracks', name: 'Barracks', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 10, description: 'A training ground. Required by future military doctrines.', techRequired: null, pacing: { band: 'starter', role: 'military-enabler', impact: 1, scope: 'city', snowball: 1, urgency: 1.15, situationality: 1, unlockBreadth: 1.05 } },
   walls: { id: 'walls', name: 'Walls', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 60, description: 'Defends the city', techRequired: 'fortification' },
-  stable: { id: 'stable', name: 'Stable', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 55, description: 'Trains mounted units', techRequired: 'horseback-riding' },
+  stable: { id: 'stable', name: 'Stable', category: 'military', yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 55, description: 'Trains mounted units', techRequired: 'horseback-riding', obsoletedByTech: 'tank-warfare' },
 
   // Culture
   temple: { id: 'temple', name: 'Temple', category: 'culture', yields: { food: 0, production: 0, gold: 0, science: 1 }, productionCost: 45, description: 'Spiritual center', techRequired: 'philosophy' },
@@ -135,7 +135,7 @@ export const BUILDINGS: Record<string, Building> = {
     description: 'Mounted warfare school. Reduces cavalry unit training cost by 15% in this city.',
     techRequired: 'horseback-riding',
     resourceRequired: ['horses'],
-   
+    obsoletedByTech: 'tank-warfare',
     pacing: { band: 'power-spike', role: 'cavalry-cost-reduction', impact: 1.15, scope: 'city', snowball: 1, urgency: 1, situationality: 1.15, unlockBreadth: 1 },
   },
   // S4b — Strategic resource buildings (iron)
@@ -177,7 +177,7 @@ export const BUILDINGS: Record<string, Building> = {
     description: 'Siege engine fabrication. Reduces Catapult and Ballista training cost by 20% in this city.',
     techRequired: 'siege-warfare',
     resourceRequired: ['stone'],
-   
+    obsoletedByTech: 'black-powder',
     pacing: { band: 'infrastructure', role: 'siege-cost-reduction', impact: 1.2, scope: 'city', snowball: 1, urgency: 1, situationality: 1.2, unlockBreadth: 1 },
   },
   // S5 — Trade infrastructure buildings

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1539,6 +1539,7 @@ export function getAvailableBuildings(
   return Object.values(BUILDINGS).filter(b => {
     if (city.buildings.includes(b.id)) return false;
     if (b.techRequired && !completedTechs.includes(b.techRequired)) return false;
+    if (b.obsoletedByTech && completedTechs.includes(b.obsoletedByTech)) return false;
     if (b.coastalRequired && !coastal) return false;
     if (availableResources !== undefined && b.resourceRequired?.length) {
       if (!b.resourceRequired.every(r => availableResources.has(r))) return false;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1526,6 +1526,10 @@ export function isCityCoastal(city: City, map: GameMap): boolean {
   });
 }
 
+export function isBuildingObsolete(building: Building | undefined, completedTechs: string[]): boolean {
+  return !!building?.obsoletedByTech && completedTechs.includes(building.obsoletedByTech);
+}
+
 export function getAvailableBuildings(
   city: City,
   completedTechs: string[],
@@ -1539,7 +1543,7 @@ export function getAvailableBuildings(
   return Object.values(BUILDINGS).filter(b => {
     if (city.buildings.includes(b.id)) return false;
     if (b.techRequired && !completedTechs.includes(b.techRequired)) return false;
-    if (b.obsoletedByTech && completedTechs.includes(b.obsoletedByTech)) return false;
+    if (isBuildingObsolete(b, completedTechs)) return false;
     if (b.coastalRequired && !coastal) return false;
     if (availableResources !== undefined && b.resourceRequired?.length) {
       if (!b.resourceRequired.every(r => availableResources.has(r))) return false;
@@ -1662,7 +1666,7 @@ export function processCity(
       if (item.startsWith('legendary:')) return true;
       if (BUILDING_IDS.has(item)) {
         const building = BUILDINGS[item];
-        if (building?.obsoletedByTech && completedTechs.includes(building.obsoletedByTech)) {
+        if (isBuildingObsolete(building, completedTechs)) {
           droppedProductionItem ??= item;
           return false;
         }

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1662,6 +1662,10 @@ export function processCity(
       if (item.startsWith('legendary:')) return true;
       if (BUILDING_IDS.has(item)) {
         const building = BUILDINGS[item];
+        if (building?.obsoletedByTech && completedTechs.includes(building.obsoletedByTech)) {
+          droppedProductionItem ??= item;
+          return false;
+        }
         if (building?.resourceRequired?.length && availableResources !== undefined) {
           if (!building.resourceRequired.every(r => availableResources!.has(r))) return false;
         }

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -128,7 +128,7 @@ interface LegacyEconomyStatus {
   turn?: number;
 }
 
-export type MaintenanceReason = 'exempt' | 'free-support' | 'free-defender' | 'paid';
+export type MaintenanceReason = 'exempt' | 'free-support' | 'free-defender' | 'paid' | 'obsolete';
 
 export interface MaintenanceRow {
   id: string;
@@ -325,11 +325,17 @@ export function calculateCityBuildingMaintenance(state: GameState, cityOrId: Cit
   const freeSupport = getFreeBuildingSlots(city);
   const exemptBuildings: MaintenanceRow[] = [];
   const candidates: MaintenanceRow[] = [];
+  const owner = state.civilizations[city.owner];
 
   for (const buildingId of city.buildings) {
     if (!BUILDINGS[buildingId]) continue;
     if (ECONOMY_RULES.coreFreeBuildings.has(buildingId)) {
       exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'exempt' });
+      continue;
+    }
+    const building = BUILDINGS[buildingId];
+    if (building?.obsoletedByTech && owner?.techState.completed.includes(building.obsoletedByTech)) {
+      exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'obsolete' });
       continue;
     }
     candidates.push({

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -8,7 +8,7 @@ import type {
   UnitType,
 } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
-import { BUILDINGS, completeCityProductionItem, getProductionCostForItem, TRAINABLE_UNITS } from './city-system';
+import { BUILDINGS, completeCityProductionItem, getProductionCostForItem, isBuildingObsolete, TRAINABLE_UNITS } from './city-system';
 import { calculateProjectedCityYields } from './city-work-system';
 import { createSpyFromUnit, isSpyUnitType } from './espionage-system';
 import { getLegendaryWonderCityYieldBonus, getLegendaryWonderCivYieldBonus } from './legendary-wonder-system';
@@ -328,13 +328,13 @@ export function calculateCityBuildingMaintenance(state: GameState, cityOrId: Cit
   const owner = state.civilizations[city.owner];
 
   for (const buildingId of city.buildings) {
-    if (!BUILDINGS[buildingId]) continue;
+    const building = BUILDINGS[buildingId];
+    if (!building) continue;
     if (ECONOMY_RULES.coreFreeBuildings.has(buildingId)) {
       exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'exempt' });
       continue;
     }
-    const building = BUILDINGS[buildingId];
-    if (building?.obsoletedByTech && owner?.techState.completed.includes(building.obsoletedByTech)) {
+    if (isBuildingObsolete(building, owner?.techState.completed ?? [])) {
       exemptBuildings.push({ id: buildingId, label: getBuildingLabel(buildingId), upkeep: 0, reason: 'obsolete' });
       continue;
     }

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -234,7 +234,8 @@ export function createCityPanel(
     const bid = city.buildings[idx];
     const b = BUILDINGS[bid];
     if (b) {
-      const upkeep = cityMaintenance.rows.find(row => row.id === bid)?.upkeep ?? 0;
+      const row = cityMaintenance.rows.find(r => r.id === bid);
+      const upkeep = row?.upkeep ?? 0;
       let fadingBadge = '';
       if (b.nationalProject && b.uniquePerEmpire) {
         const record = state.builtNationalProjects?.[`${city.owner}:${bid}`];
@@ -245,9 +246,18 @@ export function createCityPanel(
           }
         }
       }
+      let obsoleteBadge = '';
+      if (b.obsoletedByTech && state.civilizations[city.owner]?.techState.completed.includes(b.obsoletedByTech)) {
+        obsoleteBadge = ' <span style="color:#e88;font-size:10px;" title="This building\'s purpose no longer applies — later technology has moved past it. No upkeep cost, but no effect either.">⚠️ (obsolete)</span>';
+      }
+      const upkeepText = row?.reason === 'obsolete'
+        ? 'Obsolete — no upkeep'
+        : upkeep > 0
+          ? `Upkeep: -${upkeep} gold/turn`
+          : 'Free support';
       buildingPlaceholders += `<div style="background:rgba(255,255,255,0.05);border-radius:6px;padding:8px;margin-bottom:4px;font-size:12px;">
-        <strong data-text="bldg-name-${idx}"></strong>${fadingBadge} — <span data-text="bldg-desc-${idx}"></span>
-        <div style="font-size:11px;opacity:0.72;margin-top:3px;" data-text="bldg-upkeep-${idx}">${upkeep > 0 ? `Upkeep: -${upkeep} gold/turn` : 'Free support'}</div>
+        <strong data-text="bldg-name-${idx}"></strong>${fadingBadge}${obsoleteBadge} — <span data-text="bldg-desc-${idx}"></span>
+        <div style="font-size:11px;opacity:0.72;margin-top:3px;" data-text="bldg-upkeep-${idx}">${upkeepText}</div>
       </div>`;
     }
   }

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -246,11 +246,11 @@ export function createCityPanel(
           }
         }
       }
-      let obsoleteBadge = '';
-      if (b.obsoletedByTech && state.civilizations[city.owner]?.techState.completed.includes(b.obsoletedByTech)) {
-        obsoleteBadge = ' <span style="color:#e88;font-size:10px;" title="This building\'s purpose no longer applies — later technology has moved past it. No upkeep cost, but no effect either.">⚠️ (obsolete)</span>';
-      }
-      const upkeepText = row?.reason === 'obsolete'
+      const isObsolete = row?.reason === 'obsolete';
+      const obsoleteBadge = isObsolete
+        ? ' <span style="color:#e88;font-size:10px;" title="This building\'s purpose no longer applies — later technology has moved past it. No upkeep cost, but no effect either.">⚠️ (obsolete)</span>'
+        : '';
+      const upkeepText = isObsolete
         ? 'Obsolete — no upkeep'
         : upkeep > 0
           ? `Upkeep: -${upkeep} gold/turn`

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -294,6 +294,27 @@ describe('getAvailableBuildings', () => {
   });
 });
 
+describe('#443 — building obsolescence data', () => {
+  it('stable obsoletes at tank-warfare (mounted-unit line fully retires there)', () => {
+    expect(BUILDINGS.stable.obsoletedByTech).toBe('tank-warfare');
+  });
+
+  it('cavalry-academy obsoletes at tank-warfare (same mounted-unit line)', () => {
+    expect(BUILDINGS['cavalry-academy'].obsoletedByTech).toBe('tank-warfare');
+  });
+
+  it('siege-workshop obsoletes at black-powder (catapult/ballista line fully retires there)', () => {
+    expect(BUILDINGS['siege-workshop'].obsoletedByTech).toBe('black-powder');
+  });
+
+  it('armory, war-academy, safehouse, artillery_corps_hq do NOT get obsoletedByTech (melee/ranged/spy categories never fully empty; artillery_corps_hq already has its own national-project fade lifecycle)', () => {
+    expect(BUILDINGS.armory.obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS['war-academy'].obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS.safehouse.obsoletedByTech).toBeUndefined();
+    expect(BUILDINGS.artillery_corps_hq.obsoletedByTech).toBeUndefined();
+  });
+});
+
 describe('getTrainableUnitsForCity', () => {
   function coastalGateMap(): GameMap {
     return {

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -341,6 +341,29 @@ describe('#443 — building obsolescence data', () => {
   });
 });
 
+describe('#443 — building obsolescence matches the retired unit line', () => {
+  it('stable ("Trains mounted units"): horseman/cavalry/knight are all gone once tank-warfare completes', () => {
+    const units = getTrainableUnitsForCiv(
+      ['horseback-riding', 'iron-forging', 'tank-warfare'],
+      undefined,
+      new Set<ResourceType>(['horses', 'iron']),
+    );
+    expect(units.some(u => u.type === 'horseman')).toBe(false);
+    expect(units.some(u => u.type === 'cavalry')).toBe(false);
+    expect(units.some(u => u.type === 'knight')).toBe(false);
+  });
+
+  it('siege-workshop ("Reduces Catapult and Ballista training cost"): both gone once black-powder completes', () => {
+    const units = getTrainableUnitsForCiv(
+      ['siege-warfare', 'black-powder'],
+      undefined,
+      new Set<ResourceType>(['stone', 'iron']),
+    );
+    expect(units.some(u => u.type === 'catapult')).toBe(false);
+    expect(units.some(u => u.type === 'ballista')).toBe(false);
+  });
+});
+
 describe('getTrainableUnitsForCity', () => {
   function coastalGateMap(): GameMap {
     return {

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -467,6 +467,40 @@ describe('processCity', () => {
     expect(result.city.productionProgress).toBe(5);
   });
 
+  it('processCity silently dequeues a not-yet-built stable once tank-warfare completes, and reports droppedProductionItem', () => {
+    const map = generateMap(30, 30, 'obsolete-building-drop-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: [],
+      productionQueue: ['stable'],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 100, undefined, ['horseback-riding', 'tank-warfare']);
+
+    expect(result.droppedProductionItem).toBe('stable');
+    expect(result.city.productionQueue).not.toContain('stable');
+    expect(result.completedBuilding).toBeNull();
+    expect(result.city.productionProgress).toBe(0);
+  });
+
+  it('processCity does NOT dequeue a queued stable when tank-warfare has not completed', () => {
+    const map = generateMap(30, 30, 'obsolete-building-keep-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: [],
+      productionQueue: ['stable'],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 1, undefined, ['horseback-riding']);
+
+    expect(result.droppedProductionItem).toBeNull();
+    expect(result.city.productionQueue).toContain('stable');
+  });
+
   it('processCity dequeues harbor when city is not coastal and returns droppedBuilding', () => {
     const map = generateMap(30, 30, 'coastal-test');
     const inlandTile = Object.values(map.tiles).find(t =>

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -501,6 +501,21 @@ describe('processCity', () => {
     expect(result.city.productionQueue).toContain('stable');
   });
 
+  it('processCity does NOT demolish an already-built obsolete building — it stays in city.buildings forever, upkeep-free', () => {
+    const map = generateMap(30, 30, 'obsolete-building-no-demolish-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: ['cavalry-academy'],
+      productionQueue: [],
+      productionProgress: 0,
+    };
+
+    const result = processCity(city, map, 2, 5, undefined, ['horseback-riding', 'tank-warfare']);
+
+    expect(result.city.buildings).toContain('cavalry-academy');
+  });
+
   it('processCity dequeues harbor when city is not coastal and returns droppedBuilding', () => {
     const map = generateMap(30, 30, 'coastal-test');
     const inlandTile = Object.values(map.tiles).find(t =>

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -378,6 +378,20 @@ describe('#443 — excluded buildings never obsolete (negative regression)', () 
   });
 });
 
+describe('#443 — soft-lock guard', () => {
+  it('no Building.requiresBuildings chain references stable, cavalry-academy, or siege-workshop as a prerequisite', () => {
+    const obsoletableIds = new Set(['stable', 'cavalry-academy', 'siege-workshop']);
+    const offenders: string[] = [];
+    for (const b of Object.values(BUILDINGS)) {
+      if (!b.requiresBuildings?.length) continue;
+      for (const req of b.requiresBuildings) {
+        if (obsoletableIds.has(req)) offenders.push(`${b.id} requires ${req}`);
+      }
+    }
+    expect(offenders, `hiding an obsoleted building from the queue would permanently block: ${offenders.join(', ')}`).toEqual([]);
+  });
+});
+
 describe('getTrainableUnitsForCity', () => {
   function coastalGateMap(): GameMap {
     return {

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -21,6 +21,7 @@ import type { City, GameMap, HexCoord, ResourceType, UnitType } from '@/core/typ
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS } from '@/systems/unit-system';
 import { generateMap } from '@/systems/map-generator';
 import { hexKey } from '@/systems/hex-utils';
+import { TECH_TREE } from '@/systems/tech-definitions';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -361,6 +362,19 @@ describe('#443 — building obsolescence matches the retired unit line', () => {
     );
     expect(units.some(u => u.type === 'catapult')).toBe(false);
     expect(units.some(u => u.type === 'ballista')).toBe(false);
+  });
+});
+
+describe('#443 — excluded buildings never obsolete (negative regression)', () => {
+  it('armory, war-academy, safehouse remain available even with every tech in the game completed', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const allTechs = TECH_TREE.map(t => t.id);
+    const available = getAvailableBuildings(city, allTechs, map, new Set<ResourceType>(['copper', 'iron', 'horses', 'stone']));
+    expect(available.find(b => b.id === 'armory')).toBeDefined();
+    expect(available.find(b => b.id === 'war-academy')).toBeDefined();
+    expect(available.find(b => b.id === 'safehouse')).toBeDefined();
   });
 });
 

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -292,6 +292,32 @@ describe('getAvailableBuildings', () => {
     const available = getAvailableBuildings(city, ['harbor-tech'], map);
     expect(available.find(b => b.id === 'harbor')).toBeDefined();
   });
+
+  it('offers stable and cavalry-academy before tank-warfare completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['horseback-riding'], map);
+    expect(available.find(b => b.id === 'stable')).toBeDefined();
+    expect(available.find(b => b.id === 'cavalry-academy')).toBeDefined();
+  });
+
+  it('hides stable and cavalry-academy once tank-warfare completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['horseback-riding', 'tank-warfare'], map);
+    expect(available.find(b => b.id === 'stable')).toBeUndefined();
+    expect(available.find(b => b.id === 'cavalry-academy')).toBeUndefined();
+  });
+
+  it('hides siege-workshop once black-powder completes', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC());
+    const available = getAvailableBuildings(city, ['siege-warfare', 'black-powder'], map);
+    expect(available.find(b => b.id === 'siege-workshop')).toBeUndefined();
+  });
 });
 
 describe('#443 — building obsolescence data', () => {

--- a/tests/systems/economy-system.test.ts
+++ b/tests/systems/economy-system.test.ts
@@ -88,6 +88,28 @@ describe('economy maintenance', () => {
     expect(unitBreakdown.supportUsed).toBe(4);
   });
 
+  it('exempts an obsolete building from upkeep with reason "obsolete" (#443)', () => {
+    const state = makeState();
+    city(state).buildings = ['cavalry-academy'];
+    state.civilizations.player.techState.completed.push('tank-warfare');
+
+    const breakdown = calculateCityBuildingMaintenance(state, 'capital');
+    const row = breakdown.rows.find(r => r.id === 'cavalry-academy');
+
+    expect(row?.upkeep).toBe(0);
+    expect(row?.reason).toBe('obsolete');
+  });
+
+  it('charges normal upkeep for cavalry-academy before tank-warfare completes', () => {
+    const state = makeState();
+    city(state).buildings = ['cavalry-academy'];
+
+    const breakdown = calculateCityBuildingMaintenance(state, 'capital');
+    const row = breakdown.rows.find(r => r.id === 'cavalry-academy');
+
+    expect(row?.reason).not.toBe('obsolete');
+  });
+
   it('charges upkeep for all non-exempt buildings beyond the single free slot', () => {
     const state = makeState();
     city(state).buildings = [

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -160,6 +160,40 @@ describe('city-panel unrest section — #436', () => {
   });
 });
 
+describe('city-panel obsolete-building badge — #443', () => {
+  it('shows the obsolete badge and "Obsolete — no upkeep" text for a built, now-obsolete building', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['cavalry-academy'];
+    state.civilizations[state.currentPlayer].techState.completed.push('tank-warfare');
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).toContain('obsolete');
+    expect(rendered).toContain('Obsolete — no upkeep');
+  });
+
+  it('shows neither the obsolete badge nor "Obsolete — no upkeep" for a still-relevant building', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    city.buildings = ['cavalry-academy'];
+    // tank-warfare NOT completed — cavalry-academy is still relevant
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    const rendered = collectText(panel);
+    expect(rendered).not.toContain('obsolete');
+    expect(rendered).not.toContain('Obsolete — no upkeep');
+  });
+});
+
 describe('city-panel legendary wonders', () => {
   it('renders a Legendary Wonders entry point and shows carryover in the active city', () => {
     const { container, city, state } = makeWonderPanelFixture();


### PR DESCRIPTION
## Summary
- Adds `Building.obsoletedByTech`, mirroring #429's unit-obsolescence field exactly, and sets it on the 3 buildings whose linked unit line has a single, real retirement point: `stable` and `cavalry-academy` (→ `tank-warfare`, mounted-unit line), and `siege-workshop` (→ `black-powder`, Catapult/Ballista line).
- Once the obsoleting tech completes: the building disappears from the "can build" list, silently dequeues if already queued (reported via the existing `droppedProductionItem` field), drops to zero upkeep (new `MaintenanceReason: 'obsolete'`), and shows a ⚠️ (obsolete) badge + "Obsolete — no upkeep" text in the city panel for already-built instances.
- No demolish mechanic — obsolete-but-built buildings just sit in `city.buildings` forever, upkeep-free, exactly like a unit that outlived its trainable window.
- No AI changes needed — `basic-ai.ts`'s military-building fallback and `ai-personality.ts`'s `weightProductionChoice` both only act on `getAvailableBuildings`'s output, so they automatically stop considering `stable` once it's filtered there.

## Design rationale
Full design: `docs/superpowers/specs/2026-07-04-building-obsolescence-design.md`, implementation plan: `docs/superpowers/plans/2026-07-04-building-obsolescence-implementation.md`.

**Why these 3 and not others:** grepped all 139 `BUILDINGS` entries for descriptions naming a specific unit type/category, cross-checked against #429's retirement chains. `armory`, `war-academy` ("Reduces melee and ranged unit training cost") were excluded because melee/ranged is a *category*, not a line — some melee/ranged unit is trainable at every era, so the category never empties. `safehouse` ("Reduces spy unit training cost") was excluded because the spy chain terminates at `spy_hacker`, which never obsoletes. `artillery_corps_hq` was excluded because it's a national project with its own existing era-based fade lifecycle and its real effect is a `civYieldBonus`, not the flavor-text cannon bonus — layering a second obsolescence mechanism onto it would be redundant.

**Soft-lock check:** confirmed no `Building.requiresBuildings` chain anywhere in the roster references `stable`, `cavalry-academy`, or `siege-workshop` as a prerequisite, so hiding them from the queue can't create a permanent dead-end. Locked in with a regression test (Task 5) so a future building addition that violates this fails loudly instead of silently creating a dead-end.

**Cosmetic, not mechanical:** none of these buildings' described training-cost-reduction effects are implemented anywhere in the code today (confirmed by grep) — this PR only fixes the description no longer matching reality once the linked unit line is gone. It does not implement the missing mechanic (filed as #458, see below).

## Notable findings during implementation
- Verified all of the spec's factual claims still held after main moved on: `tank-warfare`/`black-powder` tech ids, the unit-side `obsoletedByTech` chains from #429 (`horseman`/`cavalry`/`knight` → `tank-warfare`, `catapult`/`ballista` → `black-powder`), and the no-`requiresBuildings`-dependency precondition. All confirmed unchanged; no plan adjustments were needed.
- The spec's illustrative line numbers (`~1660`, `~233`) had drifted slightly (actual anchors: `getAvailableBuildings` at line 1529, the building dequeue branch at 1662, `calculateCityBuildingMaintenance`'s per-building loop at 329-341, `fadingBadge` at city-panel.ts:238) — re-read each anchor's current surrounding code before writing the plan's exact diffs, per the spec's own instruction.

## Test plan
- [x] `yarn build` exits 0
- [x] `yarn test` exits 0 (4980 passed, 2 skipped)
- [x] `getAvailableBuildings`: offers `stable`/`cavalry-academy` before `tank-warfare` completes, hides both after; same for `siege-workshop`/`black-powder`
- [x] Data-integrity: the unit(s) each building's description names are genuinely absent from `getTrainableUnitsForCiv`'s output at the same tech state (proves the `obsoletedByTech` value isn't a copy-paste guess)
- [x] Negative regression: `armory`, `war-academy`, `safehouse` remain available even with every tech in the game completed
- [x] Soft-lock guard: no `requiresBuildings` chain references any of the 3 obsoletable buildings
- [x] `processCity`: silently dequeues a queued-but-not-built `stable` once `tank-warfare` completes and reports `droppedProductionItem`; does NOT dequeue before the tech completes
- [x] `calculateCityBuildingMaintenance`: an already-built `cavalry-academy` shows `upkeep: 0` and `reason: 'obsolete'` once `tank-warfare` completes; normal upkeep beforehand
- [x] City panel UI: shows the obsolete badge and "Obsolete — no upkeep" text for a built, now-obsolete building; shows neither for a still-relevant one

## Follow-up issues filed
- #457 — `droppedProductionItem` is dead data; players get no feedback when production silently drops (pre-existing, affects units too)
- #458 — the unit-training-cost-reduction mechanics these buildings' flavor text describes are not implemented anywhere (needs its own design/balance discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)