### PR TITLE
feat(era12): Task 5 — turn-manager behaviors (cyber drain, gene therapy, air movement)

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -24,7 +24,7 @@ import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { PIRATE_OWNER, recordCombatForCiv, processThreatPressure } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
-import { hexKey } from '@/systems/hex-utils';
+import { hexKey, hexDistance } from '@/systems/hex-utils';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 import { calculateCityYields } from '@/systems/resource-system';
@@ -191,8 +191,48 @@ export function processTurn(
       );
       totalGold += result.idleGoldBonus;
       totalScience += result.idleScienceBonus;
+
+      // Cyber drain: adjacent enemy cyber_units drain 2 gold per turn
+      {
+        const enemyCyberUnits = Object.values(newState.units).filter(
+          u => u.type === 'cyber_unit' && u.owner !== civId,
+        );
+        if (enemyCyberUnits.length > 0) {
+          const cityBuildings = newState.cities[cityId]?.buildings ?? [];
+          const hasCDC = cityBuildings.includes('cyber_defense_center');
+          const hasHub = cityBuildings.includes('signals_hub');
+          const blockChance = hasCDC ? (hasHub ? 0.75 : 0.65) : 0;
+          for (const cyberUnit of enemyCyberUnits) {
+            if (hexDistance(cyberUnit.position, city.position) !== 1) continue;
+            let s = Math.abs(newState.turn * 16807 + city.id.charCodeAt(0) + cyberUnit.id.charCodeAt(0));
+            s = (s * 48271) % 2147483647;
+            const roll = s / 2147483647;
+            if (roll < blockChance) continue;
+            totalGold = Math.max(0, totalGold - 2);
+            bus.emit('city:cyber-drained', {
+              cityId, cityName: city.name,
+              drainerOwner: cyberUnit.owner, drainerUnitId: cyberUnit.id,
+              goldLost: 2,
+            });
+          }
+        }
+      }
+
       const maturityResult = applyCityMaturity(result.city, civ.techState.completed);
       newState.cities[cityId] = maturityResult.city;
+
+      // cyberMarketDisruption tick: 1 gold penalty per turn remaining, then expire
+      {
+        const disruptedCity = newState.cities[cityId];
+        if (disruptedCity?.cyberMarketDisruption && disruptedCity.cyberMarketDisruption.turnsRemaining > 0) {
+          totalGold = Math.max(0, totalGold - 1);
+          const remaining = disruptedCity.cyberMarketDisruption.turnsRemaining - 1;
+          newState.cities[cityId] = {
+            ...disruptedCity,
+            cyberMarketDisruption: remaining > 0 ? { turnsRemaining: remaining } : undefined,
+          };
+        }
+      }
       if (maturityResult.changed && maturityResult.previous !== maturityResult.current) {
         bus.emit('city:maturity-upgraded', {
           cityId,
@@ -250,6 +290,13 @@ export function processTurn(
             newUnit.movementPointsLeft += navalMoveBonus;
             newUnit.movementBonus = (newUnit.movementBonus ?? 0) + navalMoveBonus;
           }
+        }
+        if (unitDef?.domain === 'air' && civ.techState.completed.includes('private-spaceflight')) {
+          newUnit.movementPointsLeft += 1;
+          newUnit.movementBonus = (newUnit.movementBonus ?? 0) + 1;
+        }
+        if (newState.cities[cityId]?.buildings.includes('gene_therapy_clinic')) {
+          newUnit.geneTherapyReady = true;
         }
         newState.units[newUnit.id] = newUnit;
         newState.civilizations[civId].units.push(newUnit.id);
@@ -362,6 +409,17 @@ export function processTurn(
       const inFriendlyCity = cityPositionsSet.has(posKey) && (tile?.owner === civId);
       const inFriendlyTerritory = !inFriendlyCity && (tile?.owner === civId);
       newState.units[unitId] = healUnit(unit, inFriendlyCity, inFriendlyTerritory);
+    }
+
+    // Reset geneTherapyReady cooldown for units that rested a full turn in a friendly city
+    for (const unitId of civ.units) {
+      const unit = newState.units[unitId];
+      if (!unit || unit.geneTherapyReady !== false) continue;
+      const posKey = `${unit.position.q},${unit.position.r}`;
+      const tile = newState.map.tiles[posKey];
+      if (cityPositionsSet.has(posKey) && tile?.owner === civId && !unit.hasMoved && !unit.hasActed) {
+        newState.units[unitId] = { ...unit, geneTherapyReady: true };
+      }
     }
 
     // Reset unit movement

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -198,9 +198,8 @@ export function processTurn(
           u => u.type === 'cyber_unit' && u.owner !== civId,
         );
         if (enemyCyberUnits.length > 0) {
-          const cityBuildings = newState.cities[cityId]?.buildings ?? [];
-          const hasCDC = cityBuildings.includes('cyber_defense_center');
-          const hasHub = cityBuildings.includes('signals_hub');
+          const hasCDC = city.buildings.includes('cyber_defense_center');
+          const hasHub = city.buildings.includes('signals_hub');
           const blockChance = hasCDC ? (hasHub ? 0.75 : 0.65) : 0;
           for (const cyberUnit of enemyCyberUnits) {
             if (hexDistance(cyberUnit.position, city.position) !== 1) continue;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1453,6 +1453,7 @@ export interface GameEvents {
   'city:national-project-expired': { civId: string; cityId: string; buildingId: string };
   'city:national-project-dequeued': { civId: string; cityId: string; buildingId: string };
   'city:unit-trained': { cityId: string; unitType: UnitType };
+  'city:cyber-drained': { cityId: string; cityName: string; drainerOwner: string; drainerUnitId: string; goldLost: number };
   'city:grew': { cityId: string; newPopulation: number };
   'city:maturity-upgraded': { cityId: string; previous: CityMaturity; current: CityMaturity };
   'economy:treasury-strain': { civId: string; level: Exclude<TreasuryStrainLevel, 'none'>; netGoldPerTurn: number; unpaidMaintenance: number };

--- a/tests/systems/era-12.test.ts
+++ b/tests/systems/era-12.test.ts
@@ -5,7 +5,9 @@ import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { UNIT_SFX } from '@/audio/sfx-catalog';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import type { GameState, Unit } from '@/core/types';
+import { processTurn } from '@/core/turn-manager';
+import { EventBus } from '@/core/event-bus';
+import type { GameState, Unit, City } from '@/core/types';
 
 const era12Techs = TECH_TREE.filter(t => t.era === 12);
 
@@ -248,5 +250,217 @@ describe('cyber_unit capture', () => {
     expect(applied.attackerDefeated).toBe(false);
     expect(applied.state.civilizations['p1'].units).not.toContain('cu2');
     expect(applied.state.civilizations['p2'].units).toContain('cu2');
+  });
+});
+
+// ---- Task 5: turn-manager behaviors ----
+
+function makeProcessTurnState(overrides: {
+  p1Gold?: number;
+  p1Buildings?: string[];
+  p2Buildings?: string[];
+  cyberUnitPos?: { q: number; r: number };
+  p1CityPos?: { q: number; r: number };
+  p1Techs?: string[];
+  p1Units?: string[];
+  extraUnits?: Record<string, Partial<Unit>>;
+}): GameState {
+  const p1CityPos = overrides.p1CityPos ?? { q: 1, r: 0 };
+  const cyberUnitPos = overrides.cyberUnitPos ?? { q: 2, r: 0 };
+  const fullUnits: Record<string, Unit> = {
+    cu1: {
+      id: 'cu1', type: 'cyber_unit', owner: 'p2', health: 100,
+      position: cyberUnitPos,
+      movementPointsLeft: 0, hasMoved: true, hasActed: true, experience: 0, isResting: false,
+    } as Unit,
+  };
+  for (const [id, partial] of Object.entries(overrides.extraUnits ?? {})) {
+    fullUnits[id] = {
+      id, type: 'warrior', owner: 'p1', health: 100,
+      position: p1CityPos, movementPointsLeft: 1,
+      hasMoved: false, hasActed: false, experience: 0, isResting: false,
+      ...partial,
+    } as Unit;
+  }
+  return {
+    turn: 1, era: 12, currentPlayer: 'p1',
+    civilizations: {
+      p1: {
+        id: 'p1', name: 'Alpha', color: '#fff', isHuman: true, civType: 'generic',
+        units: overrides.p1Units ?? [], cities: ['city-p1'], gold: overrides.p1Gold ?? 10,
+        techState: { completed: overrides.p1Techs ?? [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} } as any,
+        diplomacy: { relationships: {}, atWarWith: ['p2'], treaties: [], events: [], treacheryScore: 0, vassalage: { isVassal: false } } as any,
+        visibility: { tiles: {} } as any, score: 0,
+      },
+      p2: {
+        id: 'p2', name: 'Beta', color: '#000', isHuman: false, civType: 'generic',
+        units: ['cu1'], cities: ['city-p2'], gold: 10,
+        techState: { completed: ['cyber-warfare'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} } as any,
+        diplomacy: { relationships: {}, atWarWith: ['p1'], treaties: [], events: [], treacheryScore: 0, vassalage: { isVassal: false } } as any,
+        visibility: { tiles: {} } as any, score: 0,
+      },
+    },
+    units: fullUnits,
+    cities: {
+      'city-p1': {
+        id: 'city-p1', name: 'Capital', owner: 'p1', position: p1CityPos,
+        buildings: overrides.p1Buildings ?? [],
+        productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 15,
+        population: 1, ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'settled',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+      } as unknown as City,
+      'city-p2': {
+        id: 'city-p2', name: 'Beta City', owner: 'p2', position: { q: 10, r: 10 },
+        buildings: overrides.p2Buildings ?? [],
+        productionQueue: [], productionProgress: 0, food: 0, foodNeeded: 15,
+        population: 1, ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'settled',
+        unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+      } as unknown as City,
+    },
+    map: {
+      tiles: {
+        '1,0': { terrain: 'plains', owner: 'p1' },
+        '2,0': { terrain: 'plains', owner: undefined },
+      },
+      width: 20, height: 20, wrapsHorizontally: false,
+    },
+    idCounters: { unit: 10, city: 10 },
+    minorCivs: {},
+    barbarianCamps: {},
+  } as unknown as GameState;
+}
+
+describe('cyber unit gold drain (Task 5)', () => {
+  it('drains 2 gold from p1 when p2 cyber_unit is adjacent (no CDC)', () => {
+    const state = makeProcessTurnState({
+      p1Gold: 100,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 2, r: 0 },
+      p1Buildings: [],
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.civilizations['p1'].gold).toBeLessThanOrEqual(100);
+  });
+
+  it('does NOT drain when cyber_unit is not adjacent (hexDistance > 1)', () => {
+    const state = makeProcessTurnState({
+      p1Gold: 0,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 5, r: 5 },
+      p1Buildings: [],
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.civilizations['p1'].gold).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('cyberMarketDisruption tick (Task 5)', () => {
+  it('decrements turnsRemaining and applies 1 gold penalty', () => {
+    const state = makeProcessTurnState({ p1Gold: 10 });
+    const stateWithDisruption = {
+      ...state,
+      cities: {
+        ...state.cities,
+        'city-p1': { ...state.cities['city-p1'], cyberMarketDisruption: { turnsRemaining: 3 } },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(stateWithDisruption, bus);
+    expect(result.cities['city-p1'].cyberMarketDisruption?.turnsRemaining).toBe(2);
+  });
+
+  it('removes cyberMarketDisruption when turnsRemaining reaches 0', () => {
+    const state = makeProcessTurnState({ p1Gold: 10 });
+    const stateWithDisruption = {
+      ...state,
+      cities: {
+        ...state.cities,
+        'city-p1': { ...state.cities['city-p1'], cyberMarketDisruption: { turnsRemaining: 1 } },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(stateWithDisruption, bus);
+    expect(result.cities['city-p1'].cyberMarketDisruption).toBeUndefined();
+  });
+});
+
+describe('gene therapy pre-charge (Task 5)', () => {
+  it('unit trained in city with gene_therapy_clinic starts geneTherapyReady:true', () => {
+    const state = makeProcessTurnState({ p1Buildings: ['gene_therapy_clinic'] });
+    const stateWithQueue = {
+      ...state,
+      cities: {
+        ...state.cities,
+        'city-p1': {
+          ...state.cities['city-p1'],
+          productionQueue: ['warrior'],
+          productionProgress: 59,
+          idleProduction: 'production',
+        },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(stateWithQueue, bus);
+    const newWarrior = Object.values(result.units).find(u => u.type === 'warrior' && u.owner === 'p1');
+    expect(newWarrior).toBeDefined();
+    expect(newWarrior!.geneTherapyReady).toBe(true);
+  });
+
+  it('unit trained without gene_therapy_clinic does NOT get geneTherapyReady', () => {
+    const state = makeProcessTurnState({ p1Buildings: [] });
+    const stateWithQueue = {
+      ...state,
+      cities: {
+        ...state.cities,
+        'city-p1': {
+          ...state.cities['city-p1'],
+          productionQueue: ['warrior'],
+          productionProgress: 59,
+          idleProduction: 'production',
+        },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(stateWithQueue, bus);
+    const newWarrior = Object.values(result.units).find(u => u.type === 'warrior' && u.owner === 'p1');
+    expect(newWarrior).toBeDefined();
+    expect(newWarrior!.geneTherapyReady).toBeUndefined();
+  });
+});
+
+describe('geneTherapyReady cooldown reset (Task 5)', () => {
+  it('unit at geneTherapyReady:false resets to true after resting in own city', () => {
+    const state = makeProcessTurnState({
+      p1Units: ['warrior1'],
+      extraUnits: {
+        warrior1: {
+          type: 'warrior', owner: 'p1',
+          position: { q: 1, r: 0 },
+          hasMoved: false, hasActed: false,
+          geneTherapyReady: false,
+        },
+      },
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.units['warrior1']?.geneTherapyReady).toBe(true);
+  });
+
+  it('unit with geneTherapyReady:undefined is not affected by the reset', () => {
+    const state = makeProcessTurnState({
+      p1Units: ['warrior2'],
+      extraUnits: {
+        warrior2: {
+          type: 'warrior', owner: 'p1',
+          position: { q: 1, r: 0 },
+          hasMoved: false, hasActed: false,
+        },
+      },
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.units['warrior2']?.geneTherapyReady).toBeUndefined();
   });
 });

--- a/tests/systems/era-12.test.ts
+++ b/tests/systems/era-12.test.ts
@@ -332,6 +332,7 @@ function makeProcessTurnState(overrides: {
 
 describe('cyber unit gold drain (Task 5)', () => {
   it('drains 2 gold from p1 when p2 cyber_unit is adjacent (no CDC)', () => {
+    // p2 cyber_unit at q=2,r=0 is hexDistance 1 from p1 city at q=1,r=0
     const state = makeProcessTurnState({
       p1Gold: 100,
       p1CityPos: { q: 1, r: 0 },
@@ -353,6 +354,20 @@ describe('cyber unit gold drain (Task 5)', () => {
     const bus = new EventBus();
     const result = processTurn(state, bus);
     expect(result.civilizations['p1'].gold).toBeGreaterThanOrEqual(0);
+  });
+
+  it('cyber_defense_center blocks drain (deterministic: roll 0.382 < blockChance 0.65)', () => {
+    // With turn=1, city.id='city-p1' (charCode 99), cyberUnit.id='cu1' (charCode 99):
+    // roll ≈ 0.382 < 0.65 → drain is blocked; gold stays at or above p1Gold
+    const state = makeProcessTurnState({
+      p1Gold: 100,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 2, r: 0 },
+      p1Buildings: ['cyber_defense_center'],
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.civilizations['p1'].gold).toBeGreaterThanOrEqual(100);
   });
 });
 
@@ -462,5 +477,24 @@ describe('geneTherapyReady cooldown reset (Task 5)', () => {
     const bus = new EventBus();
     const result = processTurn(state, bus);
     expect(result.units['warrior2']?.geneTherapyReady).toBeUndefined();
+  });
+
+  it('unit at geneTherapyReady:false does NOT reset when outside a friendly city', () => {
+    // Unit at q=5,r=5 — not at the city position (q=1,r=0) — cooldown should stay false
+    const state = makeProcessTurnState({
+      p1CityPos: { q: 1, r: 0 },
+      p1Units: ['warrior3'],
+      extraUnits: {
+        warrior3: {
+          type: 'warrior', owner: 'p1',
+          position: { q: 5, r: 5 },
+          hasMoved: false, hasActed: false,
+          geneTherapyReady: false,
+        },
+      },
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.units['warrior3']?.geneTherapyReady).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- **Cyber drain**: adjacent enemy `cyber_unit` drains 2 gold/turn from p1 cities; `cyber_defense_center` gives 65% block, `signals_hub` raises it to 75%
- **cyberMarketDisruption tick**: per-city 1 gold/turn penalty + decrement; removed when counter hits 0
- **Gene therapy pre-charge**: units trained in a city with `gene_therapy_clinic` start with `geneTherapyReady: true`
- **geneTherapyReady cooldown reset**: units explicitly on cooldown (`false`, not `undefined`) reset to `true` after resting a full turn in a friendly city
- **Air movement bonus**: air-domain units trained after `private-spaceflight` tech get +1 permanent movement

Also adds `city:cyber-drained` to `GameEvents` (required by TypeScript).

## Out of scope

Tasks 6–8: national projects (`digital_silk_road`, `national_cyber_command`, `sustainability_program`), world-wide-web wonder, passive tech effects, SFX events, `geneTherapyReady` UI badge — left for follow-up prompts.

## Why safe to merge partial

No new player-visible surfaces. All five behaviors are internal economy/state mutations that fire only when era-12 buildings, techs, or units are in play. No buttons, queue entries, or panel text were added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jBXuK84vwoV6C4o63JVpE