### PR TITLE
feat(ai): launch purposeful opponent challenge

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "tauri:check:mac-artifacts": "node scripts/check-tauri-macos-artifacts.mjs",
     "setup:hooks": "sh scripts/setup-git-hooks.sh",
     "test": "vitest run && bash tests/hooks/run.sh",
+    "test:ai-playability": "bash scripts/run-ai-playability-regressions.sh",
     "test:hooks": "bash tests/hooks/run.sh",
     "test:web-smoke": "playwright test",
     "test:watch": "vitest",

--- a/scripts/run-ai-playability-regressions.sh
+++ b/scripts/run-ai-playability-regressions.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+./scripts/run-with-mise.sh node ./scripts/run-with-timeout.mjs 300 ai-playability -- \
+  ./scripts/run-with-mise.sh yarn test --run \
+  tests/simulation/ai-playability.test.ts \
+  --testTimeout=120000 \
+  --hookTimeout=120000

--- a/src/ai/ai-plan-portfolio.ts
+++ b/src/ai/ai-plan-portfolio.ts
@@ -290,9 +290,10 @@ export function refreshMajorCivPortfolio(
   const plannedThreats = [...urgentThreats, ...retainedThreats].slice(0, 4);
   const defensePlansByCityId = Object.fromEntries(plannedThreats.map(threat => {
     const existing = context.portfolio.defensePlansByCityId[threat.cityId];
+    const retainExisting = existing && context.turn <= existing.expiresAfterTurn;
     return [
       threat.cityId,
-      existing
+      retainExisting
         ? {
             ...existing,
             lastProgressTurn: threat.travelTurns <= 6

--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -1,9 +1,5 @@
-import {
-  processAITurn,
-  processPreparedAITurn,
-} from '@/ai/basic-ai';
+import { processPreparedAITurn } from '@/ai/basic-ai';
 import type { EventBus } from '@/core/event-bus';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import {
   createEmptyMajorCivPlanPortfolio,
   normalizeOpponentAIState,
@@ -38,8 +34,6 @@ export function rotateIdsForRound(ids: readonly string[], turn: number): string[
 }
 
 export interface ProcessNonHumanRoundOptions {
-  execute?: (state: GameState, civId: string, bus: EventBus) => GameState;
-  strategicPlanningEnabled?: boolean;
   prepare?: PrepareMajorCivPlan;
   executePrepared?: ExecutePreparedMajorCivPlan;
 }
@@ -214,88 +208,59 @@ export function processNonHumanMajorRound(
 
   const stableActorIds = getLivingNonHumanMajorIds(working);
   const actorIds = rotateIdsForRound(stableActorIds, working.turn);
-  if (
-    options.strategicPlanningEnabled
-    ?? PURPOSEFUL_AI_FEATURE_ENABLED
-  ) {
-    let refreshed = working;
-    for (const civId of stableActorIds) {
-      refreshed = refreshMajorCivIntel(refreshed, civId);
-    }
-    const planningSnapshot = deepFreeze(structuredClone(refreshed));
-    const prepare = options.prepare ?? prepareMajorCivStrategicPlan;
-    const preparedPlans: PreparedMajorCivPlan[] = [];
-    const planningErrors: ProcessNonHumanRoundResult['planningErrors'] = [];
-    for (const civId of stableActorIds) {
-      try {
-        const prepared = prepare(planningSnapshot, civId);
-        if (prepared.civId !== civId) {
-          throw new Error(
-            `Prepared actor mismatch: expected ${civId}, received ${prepared.civId}`,
-          );
-        }
-        preparedPlans.push(prepared);
-      } catch (error) {
-        planningErrors.push({
-          actorId: civId,
-          phase: 'prepare',
-          message: error instanceof Error ? error.message : String(error),
-        });
+  let refreshed = working;
+  for (const civId of stableActorIds) {
+    refreshed = refreshMajorCivIntel(refreshed, civId);
+  }
+  const planningSnapshot = deepFreeze(structuredClone(refreshed));
+  const prepare = options.prepare ?? prepareMajorCivStrategicPlan;
+  const preparedPlans: PreparedMajorCivPlan[] = [];
+  const planningErrors: ProcessNonHumanRoundResult['planningErrors'] = [];
+  for (const civId of stableActorIds) {
+    try {
+      const prepared = prepare(planningSnapshot, civId);
+      if (prepared.civId !== civId) {
+        throw new Error(
+          `Prepared actor mismatch: expected ${civId}, received ${prepared.civId}`,
+        );
       }
-    }
-    const preparedByCiv = new Map(preparedPlans.map(prepared => [prepared.civId, prepared]));
-    const traces = preparedPlans.flatMap(prepared => prepared.traces);
-    working = writePreparedPortfolios(refreshed, preparedPlans);
-
-    const executePrepared = options.executePrepared ?? processPreparedAITurn;
-    for (const civId of actorIds) {
-      const prepared = preparedByCiv.get(civId);
-      const civ = working.civilizations[civId];
-      const portfolio = working.opponentAI?.majorCivs[civId];
-      if (
-        !prepared
-        || !civ
-        || civ.isHuman
-        || civ.isEliminated
-        || portfolio?.lastExecutedTurn === working.turn
-      ) {
-        continue;
-      }
-      const revalidated = revalidatePreparedPlan(working, prepared);
-      working = withMajorPortfolio(working, civId, revalidated.portfolio);
-      working = executePrepared(working, revalidated, bus).state;
-      working = normalizeOpponentAIState(working);
-      const executedPortfolio = working.opponentAI!.majorCivs[civId]
-        ?? createEmptyMajorCivPlanPortfolio();
-      working = withMajorPortfolio(working, civId, {
-        ...executedPortfolio,
-        lastExecutedTurn: working.turn,
+      preparedPlans.push(prepared);
+    } catch (error) {
+      planningErrors.push({
+        actorId: civId,
+        phase: 'prepare',
+        message: error instanceof Error ? error.message : String(error),
       });
     }
-
-    working = normalizeOpponentAIState(working);
-    return {
-      state: {
-        ...working,
-        opponentAI: {
-          ...working.opponentAI!,
-          lastPlannedRound: working.turn,
-          lastProcessedRound: working.turn,
-        },
-      },
-      traces,
-      planningErrors,
-    };
   }
+  const preparedByCiv = new Map(preparedPlans.map(prepared => [prepared.civId, prepared]));
+  const traces = preparedPlans.flatMap(prepared => prepared.traces);
+  working = writePreparedPortfolios(refreshed, preparedPlans);
 
-  const execute = options.execute ?? processAITurn;
+  const executePrepared = options.executePrepared ?? processPreparedAITurn;
   for (const civId of actorIds) {
+    const prepared = preparedByCiv.get(civId);
     const civ = working.civilizations[civId];
-    if (!civ || civ.isHuman || civ.isEliminated) continue;
-    const hasLiveAsset = civ.cities.some(id => working.cities[id]?.owner === civId)
-      || civ.units.some(id => working.units[id]?.owner === civId);
-    if (!hasLiveAsset) continue;
-    working = execute(working, civId, bus);
+    const portfolio = working.opponentAI?.majorCivs[civId];
+    if (
+      !prepared
+      || !civ
+      || civ.isHuman
+      || civ.isEliminated
+      || portfolio?.lastExecutedTurn === working.turn
+    ) {
+      continue;
+    }
+    const revalidated = revalidatePreparedPlan(working, prepared);
+    working = withMajorPortfolio(working, civId, revalidated.portfolio);
+    working = executePrepared(working, revalidated, bus).state;
+    working = normalizeOpponentAIState(working);
+    const executedPortfolio = working.opponentAI!.majorCivs[civId]
+      ?? createEmptyMajorCivPlanPortfolio();
+    working = withMajorPortfolio(working, civId, {
+      ...executedPortfolio,
+      lastExecutedTurn: working.turn,
+    });
   }
 
   working = normalizeOpponentAIState(working);
@@ -304,10 +269,11 @@ export function processNonHumanMajorRound(
       ...working,
       opponentAI: {
         ...working.opponentAI!,
+        lastPlannedRound: working.turn,
         lastProcessedRound: working.turn,
       },
     },
-    traces: [],
-    planningErrors: [],
+    traces,
+    planningErrors,
   };
 }

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,7 +1,7 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
-import { getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
+import { getDetectionUnitTypeForCiv } from '@/systems/city-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
 import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -17,7 +17,6 @@ import {
 } from '@/systems/transport-system';
 import { resolveCombat } from '@/systems/combat-system';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import { getAttackTargets } from '@/systems/attack-targeting';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
 import { resolveCivilizationEra } from '@/systems/tech-definitions';
@@ -25,7 +24,7 @@ import { updateAndRefreshVisibility } from '@/systems/last-seen-presentation';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { hasMetCivilization, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 
-import { chooseTech, chooseProduction } from './ai-strategy';
+import { chooseProduction } from './ai-strategy';
 import { evaluateDiplomacy, evaluateMinorCivDiplomacy, evaluateVassalage, evaluateEmbargoResponse, evaluateLeagueResponse } from './ai-diplomacy';
 import {
   declareWar,
@@ -38,11 +37,6 @@ import {
   getAvailableActions,
   resolveOpponentKind,
 } from '@/systems/diplomacy-system';
-import {
-  beginMajorCityAssault,
-  emitMajorCityCaptureEvents,
-  resolveMajorCityCapture,
-} from '@/systems/city-capture-system';
 import {
   getAvailableMissions,
   embedSpy,
@@ -71,7 +65,7 @@ import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { BEAST_OWNER, isBeastUnit, canUnitAttackBeast } from '@/systems/beast-system';
 import { applyDiplomaticReaction } from '@/systems/minor-civ-system';
 import { getCivAvailableResources, canEstablishOutpost, performEstablishOutpost } from '@/systems/resource-acquisition-system';
-import { canEstablishRoute, getRouteCapacity, RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+import { canEstablishRoute, RESOURCE_DEFINITIONS } from '@/systems/trade-system';
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { performMinorCivFestival, performMinorCivGift } from '@/systems/minor-civ-actions';
@@ -756,320 +750,30 @@ function processAITurnInternal(
     }
   }
 
-  // Computed once before the city loop — civUnits reflects already-trained units,
-  // which is stable within the loop (production-queued items aren't in units[] yet).
-  const civUnitsForAir = (civ.units ?? []).map(id => newState.units[id]).filter(Boolean);
-  const hasBalloon = civUnitsForAir.some(u => u?.type === 'observation_balloon');
-  const hasBiplane = civUnitsForAir.some(u => u?.type === 'biplane');
-  const hasJetFighter = civUnitsForAir.some(u => u?.type === 'jet_fighter');
-  const hasAttackHelicopter = civUnitsForAir.some(u => u?.type === 'attack_helicopter');
-  const hasCarrier = (civ.units ?? []).some(id => newState.units[id]?.type === 'carrier');
-  const hasMissileSubmarine = (civ.units ?? []).some(id => newState.units[id]?.type === 'missile_submarine');
-  let hasQueuedCarrierThisTurn = false;
-  let hasQueuedAttackHelicopterThisTurn = false;
-  let hasQueuedMissileSubThisTurn = false;
-  const hasAirSuperiorityTech = civ.techState.completed.includes('air-superiority');
-  const hasJetAviationTech = civ.techState.completed.includes('jet-aviation');
-  const hasHelicopterWarfareTech = civ.techState.completed.includes('helicopter-warfare');
-  const hasNuclearSubsTech = civ.techState.completed.includes('nuclear-submarines');
-
   for (const cityId of civ.cities) {
     const city = newState.cities[cityId];
-    if (city && city.productionQueue.length === 0) {
-      const activeWonderBuilds = Object.values(newState.cities).filter(candidate =>
-        candidate.owner === civId && candidate.productionQueue[0]?.startsWith('legendary:'),
-      ).length;
-      if (activeWonderBuilds < 2) {
-        const wonderCandidates = getEligibleLegendaryWonders(newState, civId, cityId)
-          .filter(wonderId =>
-            Object.values(newState.legendaryWonderProjects ?? {}).some(project =>
-              project.ownerId === civId
-              && project.cityId === cityId
-              && project.wonderId === wonderId
-              && project.phase === 'ready_to_build',
-            ),
-          )
-          .sort((left, right) =>
-            scoreLegendaryWonderOpportunity(newState, civId, cityId, right)
-            - scoreLegendaryWonderOpportunity(newState, civId, cityId, left),
-          );
+    if (!city || city.productionQueue.length > 0) continue;
+    const activeWonderBuilds = Object.values(newState.cities).filter(candidate =>
+      candidate.owner === civId && candidate.productionQueue[0]?.startsWith('legendary:'),
+    ).length;
+    if (activeWonderBuilds >= 2) continue;
 
-        if (wonderCandidates.length > 0) {
-          newState = startLegendaryWonderBuild(newState, civId, cityId, wonderCandidates[0], bus);
-          continue;
-        }
-      }
+    const wonderCandidates = getEligibleLegendaryWonders(newState, civId, cityId)
+      .filter(wonderId =>
+        Object.values(newState.legendaryWonderProjects ?? {}).some(project =>
+          project.ownerId === civId
+          && project.cityId === cityId
+          && project.wonderId === wonderId
+          && project.phase === 'ready_to_build',
+        ),
+      )
+      .sort((left, right) =>
+        scoreLegendaryWonderOpportunity(newState, civId, cityId, right)
+        - scoreLegendaryWonderOpportunity(newState, civId, cityId, left),
+      );
 
-      continue;
-
-      const civAvailableResources = getCivAvailableResources(newState, civId);
-      const trainableUnits = getTrainableUnitsForCiv(
-        civ.techState.completed,
-        civ.civType,
-        civAvailableResources,
-      ).map(u => u.type as string);
-      const aiNPKeys = getReservedNationalProjectKeys(newState, civId);
-      const availableBuildingsList = getAvailableBuildings(
-        city,
-        civ.techState.completed,
-        newState.map,
-        civAvailableResources,
-        newState.era,
-        aiNPKeys,
-        civId,
-      ).map(b => b.id);
-      const derivedItems = [...trainableUnits, ...availableBuildingsList];
-
-      // National project priority: queue matching NP if city is idle and personality aligns
-      const availableNPs = getAvailableBuildings(
-        city,
-        civ.techState.completed,
-        newState.map,
-        civAvailableResources,
-        newState.era,
-        aiNPKeys,
-        civId,
-      ).filter(b => b.nationalProject);
-      if (availableNPs.length > 0) {
-        const primaryTrait = resolveCivDefinition(newState, civ.civType ?? '')?.personality?.traits?.[0];
-        const bestNP = availableNPs.find(np => {
-          if (primaryTrait === 'aggressive' && (np.civYieldBonus?.production ?? 0) > 0) return true;
-          if (primaryTrait === 'trader' && (np.civYieldBonus?.gold ?? 0) > 0) return true;
-          return false;
-        }) ?? availableNPs[0];
-        if (bestNP) {
-          newState = {
-            ...newState,
-            cities: { ...newState.cities, [cityId]: { ...city, productionQueue: [bestNP.id] } },
-          };
-          continue;
-        }
-      }
-
-      // Prioritise caravan training when conditions are met
-      const hasTradeTech = civ.techState.completed.includes('trade-routes');
-      const hasRouteCapacity = civ.cities.some(cid => {
-        const c = newState.cities[cid];
-        if (!c) return false;
-        const usedSlots = (newState.marketplace?.tradeRoutes ?? []).filter(r => r.fromCityId === cid).length;
-        return getRouteCapacity(newState, cid) > usedSlots;
-      });
-      const hasUncommittedCaravan = (civ.units ?? []).some(id => {
-        const u = newState.units[id];
-        return u?.type === 'caravan' && !u.committedToRouteId;
-      });
-      // Prioritise cannon as soon as black-powder is researched and civ has none
-      const hasCannon = (civ.units ?? []).some(id => newState.units[id]?.type === 'cannon');
-      if (civ.techState.completed.includes('black-powder') && !hasCannon && trainableUnits.includes('cannon')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['cannon'] } },
-        };
-        continue;
-      }
-      // Prioritise grenadier when grenade-warfare is researched and civ has none
-      const hasGrenadier = (civ.units ?? []).some(id => newState.units[id]?.type === 'grenadier');
-      if (civ.techState.completed.includes('grenade-warfare') && !hasGrenadier && trainableUnits.includes('grenadier')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['grenadier'] } },
-        };
-        continue;
-      }
-      // Prioritise rifleman when rifled-infantry is researched and civ has none
-      const hasRifleman = (civ.units ?? []).some(id => newState.units[id]?.type === 'rifleman');
-      if (civ.techState.completed.includes('rifled-infantry') && !hasRifleman && trainableUnits.includes('rifleman')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['rifleman'] } },
-        };
-        continue;
-      }
-      // Prioritise ironclad when ironclad-warships is researched and civ has no ironclad (coastal cities only)
-      const hasIronclad = (civ.units ?? []).some(id => newState.units[id]?.type === 'ironclad');
-      if (civ.techState.completed.includes('ironclad-warships') && !hasIronclad && trainableUnits.includes('ironclad')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['ironclad'] } },
-        };
-        continue;
-      }
-      // Prioritise machine_gunner when mass-firepower is researched and civ has none
-      const hasMachineGunner = (civ.units ?? []).some(id => newState.units[id]?.type === 'machine_gunner');
-      if (civ.techState.completed.includes('mass-firepower') && !hasMachineGunner && trainableUnits.includes('machine_gunner')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['machine_gunner'] } },
-        };
-        continue;
-      }
-      // Prioritise pre_dreadnought when naval-armor is researched and civ has none (coastal cities only)
-      const hasPreDreadnought = (civ.units ?? []).some(id => newState.units[id]?.type === 'pre_dreadnought');
-      if (civ.techState.completed.includes('naval-armor') && !hasPreDreadnought && trainableUnits.includes('pre_dreadnought')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['pre_dreadnought'] } },
-        };
-        continue;
-      }
-      // Prioritise tank when tank-warfare is researched and civ has none
-      const hasTank = (civ.units ?? []).some(id => newState.units[id]?.type === 'tank');
-      if (civ.techState.completed.includes('tank-warfare') && !hasTank && trainableUnits.includes('tank')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['tank'] } },
-        };
-        continue;
-      }
-      // Prioritise submarine when submarine-warfare is researched and civ has none (coastal cities only)
-      const hasSubmarine = (civ.units ?? []).some(id => newState.units[id]?.type === 'submarine');
-      if (civ.techState.completed.includes('submarine-warfare') && !hasSubmarine && trainableUnits.includes('submarine')) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['submarine'] } },
-        };
-        continue;
-      }
-      // Build anti_air_battery when air-superiority is unlocked (city not already protected)
-      if (
-        hasAirSuperiorityTech &&
-        !city.buildings.includes('anti_air_battery') &&
-        !city.productionQueue.includes('anti_air_battery')
-      ) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['anti_air_battery'] } },
-        };
-        continue;
-      }
-      // Queue one observation balloon per civ — pure recon, no multiples needed early
-      if (
-        civ.techState.completed.includes('balloon-corps') &&
-        !hasBalloon &&
-        trainableUnits.includes('observation_balloon') &&
-        city.productionQueue.length === 0
-      ) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['observation_balloon'] } },
-        };
-        continue;
-      }
-      // Queue one biplane per civ when air-superiority is researched
-      if (
-        hasAirSuperiorityTech &&
-        !hasBiplane &&
-        trainableUnits.includes('biplane') &&
-        city.productionQueue.length === 0
-      ) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['biplane'] } },
-        };
-        continue;
-      }
-      // Queue one jet_fighter per civ when jet-aviation is researched
-      if (
-        hasJetAviationTech &&
-        !hasJetFighter &&
-        trainableUnits.includes('jet_fighter') &&
-        city.productionQueue.length === 0
-      ) {
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['jet_fighter'] } },
-        };
-        continue;
-      }
-      // Queue one carrier per civ when carrier-warfare is researched
-      if (
-        civ.techState.completed.includes('carrier-warfare') &&
-        !hasCarrier && !hasQueuedCarrierThisTurn &&
-        trainableUnits.includes('carrier') &&
-        city.productionQueue.length === 0
-      ) {
-        hasQueuedCarrierThisTurn = true;
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['carrier'] } },
-        };
-        continue;
-      }
-      // Queue one attack_helicopter per civ when helicopter-warfare is researched
-      if (
-        hasHelicopterWarfareTech &&
-        !hasAttackHelicopter && !hasQueuedAttackHelicopterThisTurn &&
-        trainableUnits.includes('attack_helicopter') &&
-        city.productionQueue.length === 0
-      ) {
-        hasQueuedAttackHelicopterThisTurn = true;
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['attack_helicopter'] } },
-        };
-        continue;
-      }
-      // Queue one missile_submarine per civ when nuclear-submarines is researched (coastal only)
-      if (
-        hasNuclearSubsTech &&
-        !hasMissileSubmarine && !hasQueuedMissileSubThisTurn &&
-        trainableUnits.includes('missile_submarine') &&
-        city.productionQueue.length === 0
-      ) {
-        hasQueuedMissileSubThisTurn = true;
-        newState = {
-          ...newState,
-          cities: { ...newState.cities, [cityId]: { ...city, productionQueue: ['missile_submarine'] } },
-        };
-        continue;
-      }
-      // cyber_unit and stealth_bomber are handled by the catalog-driven ai-production.ts path
-      // (purposefulAI only) — no one-off legacy branch added per end-to-end-wiring rule.
-      if (hasTradeTech && hasRouteCapacity && !hasUncommittedCaravan && trainableUnits.includes('caravan')) {
-        city.productionQueue = ['caravan'];
-      } else {
-        // Train Expedition when: foraging tech, an unowned resource tile within
-        // 8 hex distance exists, and civ has no uncommitted expedition unit.
-        const hasForagingTech = civ.techState.completed.includes('foraging');
-        const hasUncommittedExpedition = (civ.units ?? []).some(id => {
-          const u = newState.units[id];
-          return u?.type === 'expedition' && !u.hasActed;
-        });
-        const cityPos = city.position;
-        const hasNearbyUnownedResource = hasForagingTech && (
-          administrativePerception.knownResources.some(resource => {
-                if (resource.owner !== null) return false;
-                const resDef = RESOURCE_DEFINITIONS.find(
-                  definition => definition.id === resource.resource,
-                );
-                if (
-                  !resDef
-                  || !civ.techState.completed.includes(resDef.tech)
-                ) {
-                  return false;
-                }
-                const dist = newState.map.wrapsHorizontally
-                  ? wrappedHexDistance(
-                      resource.position,
-                      cityPos,
-                      newState.map.width,
-                    )
-                  : hexDistance(resource.position, cityPos);
-                return dist <= 8;
-              })
-        );
-        if (hasForagingTech && !hasUncommittedExpedition && trainableUnits.includes('expedition') && hasNearbyUnownedResource) {
-          city.productionQueue = ['expedition'];
-        } else {
-          const chosen = chooseProduction(
-            personality,
-            derivedItems.length > 0 ? derivedItems : ['warrior'],
-            false,
-            civ.cities.length,
-          );
-          city.productionQueue = [chosen];
-        }
-      }
+    if (wonderCandidates.length > 0) {
+      newState = startLegendaryWonderBuild(newState, civId, cityId, wonderCandidates[0], bus);
     }
   }
   newState = applyAIProduction(

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1,6 +1,5 @@
 import type { GameState, Unit, HexCoord, PersonalityTraits, SpyMissionType, City, UnitType } from '@/core/types';
 import { EventBus } from '@/core/event-bus';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import { getTrainableUnitsForCiv, getDetectionUnitTypeForCiv } from '@/systems/city-system';
 import { foundCityInState } from '@/systems/city-founding-system';
@@ -514,11 +513,7 @@ function scoreLegendaryWonderOpportunity(state: GameState, civId: string, cityId
   return 100 + cityBonus + rewardBonus + techMomentum - costPenalty;
 }
 
-export interface ProcessAITurnOptions {
-  purposefulAIEnabled?: boolean;
-}
-
-interface ProcessAITurnInternalOptions extends ProcessAITurnOptions {
+interface ProcessAITurnInternalOptions {
   prepared?: PreparedMajorCivPlan;
 }
 
@@ -558,8 +553,6 @@ function processAITurnInternal(
   bus: EventBus,
   options: ProcessAITurnInternalOptions = {},
 ): GameState {
-  const purposefulAIEnabled = options.purposefulAIEnabled
-    ?? PURPOSEFUL_AI_FEATURE_ENABLED;
   let preparedForTurn = options.prepared;
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
   let civ = newState.civilizations[civId];
@@ -567,28 +560,6 @@ function processAITurnInternal(
 
   const personality = getPersonality(newState, civ.civType ?? 'generic');
   const civDef = resolveCivDefinition(newState, civ.civType ?? '');
-  const ownedBreakaway = Object.values(newState.civilizations).find(other =>
-    other.breakaway?.originOwnerId === civId
-    && other.breakaway.status === 'secession'
-    && !civ.diplomacy.atWarWith.includes(other.id)
-  );
-
-  if (ownedBreakaway && !purposefulAIEnabled) {
-    newState.civilizations[civId].diplomacy = declareWar(
-      civ.diplomacy,
-      ownedBreakaway.id,
-      newState.turn,
-      false,
-    );
-    newState.civilizations[ownedBreakaway.id].diplomacy = declareWar(
-      ownedBreakaway.diplomacy,
-      civId,
-      newState.turn,
-      false,
-    );
-    bus.emit('diplomacy:war-declared', { attackerId: civId, defenderId: ownedBreakaway.id, opponentKind: resolveOpponentKind(ownedBreakaway.id) });
-  }
-
   const abandonment = abandonLostLegendaryWonderRace(newState, civId);
   newState = abandonment.state;
   civ = newState.civilizations[civId];
@@ -596,277 +567,102 @@ function processAITurnInternal(
     bus.emit('wonder:legendary-lost', event);
   }
 
-  if (purposefulAIEnabled) {
-    preparedForTurn ??= prepareMajorCivStrategicPlan(
-      structuredClone(newState),
-      civId,
-    );
-    newState = processMajorCivStrategicTurn(
-      newState,
-      preparedForTurn,
-      bus,
-    ).state;
-    civ = newState.civilizations[civId];
-  }
-  const administrativePerception = purposefulAIEnabled && preparedForTurn
-    ? preparedForTurn.perception
-    : buildMajorCivPerception(newState, civId);
+  preparedForTurn ??= prepareMajorCivStrategicPlan(
+    structuredClone(newState),
+    civId,
+  );
 
-  if (!purposefulAIEnabled) {
-  // --- Handle settlers: found cities ---
+  // Strategic movement is plan-driven, while settlement remains a shared
+  // administrative action using the canonical mutation helper.
   const settlers = civ.units
     .map(id => newState.units[id])
-    .filter((u): u is Unit => u !== undefined && u.type === 'settler');
-
+    .filter((unit): unit is Unit => unit?.type === 'settler');
   for (const settler of settlers) {
-    const tile = newState.map.tiles[hexKey(settler.position)];
     if (
-      tile
-      && !settler.hasActed
+      !settler.hasActed
       && settler.movementPointsLeft > 0
       && canFoundCityAt(newState, settler.position)
     ) {
-      const result = foundCityInState(newState, settler.id, bus);
-      newState = result.state;
-      newState = {
-        ...newState,
-        cities: {
-          ...newState.cities,
-          [result.cityId]: {
-            ...newState.cities[result.cityId],
-            productionQueue: ['warrior'],
-          },
-        },
-      };
+      newState = foundCityInState(newState, settler.id, bus).state;
       civ = newState.civilizations[civId];
     }
   }
+
+  // Cargo handling is administrative rather than a competing strategic
+  // chase path, so retain the canonical all-cargo load/unload behavior.
+  const transportHostileOwners = new Set<string>([
+    'barbarian',
+    ...(newState.settings?.aiContestsBeasts === true ? [BEAST_OWNER] : []),
+    ...(civ.diplomacy?.atWarWith ?? []),
+  ]);
+  addAlwaysHostileOwners(
+    newState,
+    civId,
+    transportHostileOwners,
+    newState.settings?.aiContestsBeasts === true,
+  );
+  for (const [minorCivId, minor] of Object.entries(newState.minorCivs)) {
+    if (minor.diplomacy?.atWarWith?.includes(civId)) {
+      transportHostileOwners.add(minorCivId);
+    }
   }
-
-  const contestsBeasts = newState.settings?.aiContestsBeasts === true;
-
-  if (!purposefulAIEnabled) {
-  // --- Handle transports: unload onto enemy coast, then load idle land units ---
-  const transportHostileOwners = new Set<string>(['barbarian', ...(contestsBeasts ? [BEAST_OWNER] : []), ...(civ.diplomacy?.atWarWith ?? [])]);
-  addAlwaysHostileOwners(newState, civId, transportHostileOwners, contestsBeasts);
-  for (const [mcId, mc] of Object.entries(newState.minorCivs)) {
-    if (mc.diplomacy?.atWarWith?.includes(civId)) transportHostileOwners.add(mcId);
-  }
-
   const idleTransports = civ.units
     .map(id => newState.units[id])
-    .filter((u): u is Unit => !!u && (UNIT_DEFINITIONS[u.type]?.domain ?? 'land') === 'naval' && UNIT_DEFINITIONS[u.type]?.cargoCapacity !== undefined);
-
+    .filter((unit): unit is Unit =>
+      Boolean(unit)
+      && UNIT_DEFINITIONS[unit.type]?.domain === 'naval'
+      && UNIT_DEFINITIONS[unit.type]?.cargoCapacity !== undefined);
   for (const transport of idleTransports) {
-    // 1. Unload all eligible cargo onto adjacent enemy-owned tiles
-    const cargo = getTransportCargo(newState, transport.id);
-    let didUnload = false;
-    for (const cargoUnit of cargo) {
-      // Refresh from newState: a previous iteration may have updated action state
-      const freshCargo = newState.units[cargoUnit.id];
-      if (!freshCargo || freshCargo.hasActed || freshCargo.movementPointsLeft <= 0) continue;
-      const destinations = getUnloadDestinations(newState, transport.id, freshCargo.id);
-      const enemyDest = destinations.find(dest => {
-        const tile = newState.map.tiles[hexKey(dest)];
-        return tile && tile.owner && transportHostileOwners.has(tile.owner);
-      });
-      if (enemyDest) {
-        const result = unloadUnitFromTransport(newState, transport.id, freshCargo.id, enemyDest);
-        if (result.ok) {
-          newState = result.state;
-          civ = newState.civilizations[civId];
-          didUnload = true;
-          // Don't break — unload all eligible cargo in one turn
-        }
+    let unloaded = false;
+    for (const cargo of getTransportCargo(newState, transport.id)) {
+      const current = newState.units[cargo.id];
+      if (!current || current.hasActed || current.movementPointsLeft <= 0) continue;
+      const destination = getUnloadDestinations(newState, transport.id, current.id)
+        .find(coord => {
+          const owner = newState.map.tiles[hexKey(coord)]?.owner;
+          return owner !== null && owner !== undefined && transportHostileOwners.has(owner);
+        });
+      if (!destination) continue;
+      const result = unloadUnitFromTransport(newState, transport.id, current.id, destination);
+      if (result.ok) {
+        newState = result.state;
+        civ = newState.civilizations[civId];
+        unloaded = true;
       }
     }
-    if (didUnload) continue;
-
-    // 2. Load all adjacent idle land units up to capacity
-    const loadCandidates = civ.units
+    if (unloaded) continue;
+    for (const candidate of civ.units
       .map(id => newState.units[id])
-      .filter((u): u is Unit =>
-        !!u && !u.transportId && !u.hasActed && u.movementPointsLeft > 0
-        && (UNIT_DEFINITIONS[u.type]?.domain ?? 'land') === 'land',
-      );
-    for (const candidate of loadCandidates) {
-      // Re-check capacity each iteration: multi-slot units (cavalry, catapult) may fill the hold
-      const used = getTransportCargoUsed(newState, transport.id);
-      const cap = getTransportCapacity(newState.units[transport.id]!);
-      if (used >= cap) break;
+      .filter((unit): unit is Unit =>
+        Boolean(unit)
+        && !unit.transportId
+        && !unit.hasActed
+        && unit.movementPointsLeft > 0
+        && (UNIT_DEFINITIONS[unit.type]?.domain ?? 'land') === 'land')) {
+      if (getTransportCargoUsed(newState, transport.id)
+        >= getTransportCapacity(newState.units[transport.id]!)) break;
       const check = canLoadUnitOntoTransport(newState, candidate.id, transport.id);
-      if (check.ok) {
-        const result = loadUnitOntoTransport(newState, candidate.id, transport.id);
-        if (result.ok) {
-          newState = result.state;
-          civ = newState.civilizations[civId];
-        }
+      if (!check.ok) continue;
+      const result = loadUnitOntoTransport(newState, candidate.id, transport.id);
+      if (result.ok) {
+        newState = result.state;
+        civ = newState.civilizations[civId];
       }
     }
   }
-  }
+
+  newState = processMajorCivStrategicTurn(
+    newState,
+    preparedForTurn,
+    bus,
+  ).state;
+  civ = newState.civilizations[civId];
+  const administrativePerception = preparedForTurn.perception;
 
   newState = applyPirateAiResponse(newState, civId, bus);
   civ = newState.civilizations[civId];
   const piratePresentation = getPirateWatersPresentation(newState, civId);
   const knownPirateUnitIds = knownPirateResponseUnitIds(newState, civId, piratePresentation.factions);
-
-  // --- Handle military units: explore or attack ---
-  const militaryUnits = civ.units
-    .map(id => newState.units[id])
-    .filter((u): u is Unit => u !== undefined && u.type !== 'settler' && u.type !== 'worker');
-
-  if (!purposefulAIEnabled) {
-  for (const unit of militaryUnits) {
-    if (unit.movementPointsLeft <= 0) continue;
-
-    let attacked = false;
-    const attackTargets = getAttackTargets(newState, unit, { requireVisibility: false });
-    for (const target of attackTargets) {
-      if (target.result.targetType === 'unit') {
-        const occupant = newState.units[target.result.targetUnitId];
-        if (occupant) {
-          if (classifyOwner(occupant.owner) === 'pirate' && !knownPirateUnitIds.has(occupant.id)) continue;
-          if (classifyOwner(occupant.owner) === 'pirate' && !isFavorablePirateFight(unit, occupant)) continue;
-          // Beast guard: only engage beasts when enabled AND the fight is clearly winnable
-          if (isBeastUnit(occupant)) {
-            if (!contestsBeasts) continue;
-            if (!canUnitAttackBeast(unit, occupant).allowed) continue;
-            const myStrength = UNIT_DEFINITIONS[unit.type].strength * (unit.health / 100);
-            const beastStrength = UNIT_DEFINITIONS[occupant.type].strength * (occupant.health / 100);
-            if (myStrength < beastStrength * 1.5) continue;
-          }
-          const seed = newState.turn * 16807 + unit.id.charCodeAt(0);
-          const attackerBonus = resolveCivDefinition(newState, civ.civType ?? '')?.bonusEffect;
-          const defenderBonus = resolveCivDefinition(newState, newState.civilizations[occupant.owner]?.civType ?? '')?.bonusEffect;
-          const result = resolveCombat(
-            unit,
-            occupant,
-            newState.map,
-            seed,
-            { attackerBonus, defenderBonus },
-            newState.era,
-          );
-          const combatPresentation = buildCombatPresentation(newState, result, unit, occupant);
-          const applied = applyCombatOutcomeToState(newState, result, seed);
-          newState = applied.state;
-          emitMinorCivQuestTransitions(bus, applied.questTransitions, newState);
-          civ = newState.civilizations[civId];
-          if (applied.defenderDefeated) {
-            const destroyedCamp = applyCampDestructionAtTarget(newState, civId, occupant.position, newState.turn);
-            if (destroyedCamp.campId) {
-              newState = destroyedCamp.state;
-              emitMinorCivQuestTransitions(bus, destroyedCamp.questTransitions, newState);
-              for (const mcId of Object.keys(newState.minorCivs)) {
-                applyDiplomaticReaction(newState, 'camp_destroyed_nearby', civId, mcId);
-              }
-            }
-          }
-          bus.emit('combat:resolved', { result, ...combatPresentation });
-          for (const reward of applied.rewards) {
-            bus.emit('combat:reward-earned', { reward });
-          }
-          attacked = true;
-          break;
-        }
-      }
-    }
-
-    if (attacked) continue;
-
-    const exposedEnemyCity = Object.values(newState.cities).find(city =>
-      city.owner !== civId
-      && !city.owner.startsWith('mc-')
-      && (civ.diplomacy?.atWarWith.includes(city.owner) ?? false)
-      && hexDistance(unit.position, city.position) === 1,
-    );
-
-    if (exposedEnemyCity) {
-      const prevOwnerIdForCapture = exposedEnemyCity.owner;
-      const assault = beginMajorCityAssault(
-        newState,
-        unit.id,
-        exposedEnemyCity.id,
-        { actor: 'ai', civId, bus },
-      );
-      if (!assault.ok) continue;
-      newState = assault.state;
-      const beforeCapture = newState;
-      const captureResult = resolveMajorCityCapture(
-        newState,
-        exposedEnemyCity.id,
-        civId,
-        'occupy',
-        newState.turn,
-      );
-      newState = captureResult.state;
-      emitMajorCityCaptureEvents(
-        beforeCapture,
-        captureResult,
-        exposedEnemyCity.id,
-        civId,
-        prevOwnerIdForCapture,
-        bus,
-      );
-      civ = newState.civilizations[civId];
-      continue;
-    }
-
-    // Explore: move toward unexplored territory
-    const occupancy = buildUnitOccupancy(newState.units);
-    const aiHostileOwners = new Set<string>(['barbarian', ...(contestsBeasts ? [BEAST_OWNER] : []), ...(civ.diplomacy?.atWarWith ?? [])]);
-    addAlwaysHostileOwners(newState, civId, aiHostileOwners, contestsBeasts);
-    for (const [mcId, mc] of Object.entries(newState.minorCivs)) {
-      if (mc.diplomacy?.atWarWith?.includes(civId)) {
-        aiHostileOwners.add(mcId);
-      }
-    }
-    const range = getMovementRange(
-      unit,
-      newState.map,
-      occupancy.unitIdsByHex,
-      occupancy.ownersByUnitId,
-      aiHostileOwners,
-      { completedTechs: civ.techState.completed },
-    );
-    if (range.length > 0) {
-      const unitDef = UNIT_DEFINITIONS[unit.type];
-      const isWarship = (unitDef?.domain ?? 'land') === 'naval' && (unitDef?.strength ?? 0) > 0;
-      if (isWarship) {
-        const enemyNaval = Object.values(newState.units).filter(u => {
-          if (u.owner === civId || !aiHostileOwners.has(u.owner)) return false;
-          if (classifyOwner(u.owner) === 'pirate' && !knownPirateUnitIds.has(u.id)) return false;
-          return (UNIT_DEFINITIONS[u.type]?.domain ?? 'land') === 'naval';
-        });
-        if (enemyNaval.length > 0) {
-          let bestCoord = range[0];
-          let bestDist = Infinity;
-          for (const coord of range) {
-            const minDist = Math.min(...enemyNaval.map(e =>
-              newState.map.wrapsHorizontally
-                ? wrappedHexDistance(e.position, coord, newState.map.width)
-                : hexDistance(e.position, coord),
-            ));
-            if (minDist < bestDist) {
-              bestDist = minDist;
-              bestCoord = coord;
-            }
-          }
-          newState.units[unit.id] = moveUnit(unit, bestCoord, 1);
-          continue;
-        }
-      }
-
-      const unexplored = range.filter(
-        coord => civ.visibility.tiles[hexKey(coord)] !== 'visible',
-      );
-      const candidates = unexplored.length > 0 ? unexplored : range;
-      const moveSeed = newState.turn * 16807 + unit.id.charCodeAt(0);
-      const target = candidates[moveSeed % candidates.length];
-      newState.units[unit.id] = moveUnit(unit, target, 1);
-    }
-  }
-  }
 
   // Pursue assigned economic chain steps before discretionary spending.
   for (const minorCivId of Object.keys(newState.minorCivs).sort()) {
@@ -895,13 +691,11 @@ function processAITurnInternal(
   for (const caravan of idleCaravans) {
     // Try domestic cities first (own city), then foreign
     const ownCities = civ.cities.map(id => newState.cities[id]).filter((c): c is City => !!c);
-    const knownForeignCityIds = purposefulAIEnabled
-      ? new Set(
-          administrativePerception.knownCities
-            .filter(city => city.owner !== civId && city.position !== null)
-            .map(city => city.id),
-        )
-      : null;
+    const knownForeignCityIds = new Set(
+      administrativePerception.knownCities
+        .filter(city => city.owner !== civId && city.position !== null)
+        .map(city => city.id),
+    );
     const foreignCities = Object.values(newState.cities).filter(city =>
       city.owner !== civId
       && (!knownForeignCityIds || knownForeignCityIds.has(city.id)));
@@ -927,59 +721,32 @@ function processAITurnInternal(
     }
   }
 
-  // --- Handle expedition outpost establishment ---
-  if (!purposefulAIEnabled) {
-  const idleExpeditions = (civ.units ?? [])
+  for (const expedition of civ.units
     .map(id => newState.units[id])
-    .filter((u): u is Unit => !!u && u.type === 'expedition' && !u.hasActed && !u.hasMoved);
-
-  for (const exp of idleExpeditions) {
-    if (canEstablishOutpost(newState, exp.id)) {
-      newState = performEstablishOutpost(newState, exp.id);
+    .filter((unit): unit is Unit =>
+      unit?.type === 'expedition' && !unit.hasActed && !unit.hasMoved)) {
+    if (canEstablishOutpost(newState, expedition.id)) {
+      newState = performEstablishOutpost(newState, expedition.id);
       civ = newState.civilizations[civId];
-      continue;
     }
-    // Move toward nearest unowned resource tile the civ has tech for
-    const nearest = findNearestResourceTile(newState, exp, civId);
-    if (nearest) {
-      const path = findPath(exp.position, nearest, newState.map);
-      if (path && path.length >= 2) {
-        const next = path[1];
-        const occupied = Object.values(newState.units).some(
-          u => u.id !== exp.id && hexKey(u.position) === hexKey(next),
-        );
-        if (!occupied) {
-          newState.units[exp.id] = moveUnit(exp, next, 1);
-        }
-      }
-    }
-  }
   }
 
+  // --- Handle expedition outpost establishment ---
   // --- Handle research (personality-driven) ---
-  if (purposefulAIEnabled && preparedForTurn) {
-    const research = applyAIResearch(
-      newState,
-      civId,
-      preparedForTurn,
-      personality,
-    );
-    newState = research.state;
-    civ = newState.civilizations[civId];
-    if (research.startedTechId) {
-      bus.emit('tech:started', { civId, techId: research.startedTechId });
-    }
-  } else if (!civ.techState.currentResearch) {
-    const available = getAvailableTechs(civ.techState);
-    if (available.length > 0) {
-      const chosen = chooseTech(personality, available);
-      newState.civilizations[civId].techState = startResearch(civ.techState, chosen.id);
-      bus.emit('tech:started', { civId, techId: chosen.id });
-    }
+  civ.techState.researchQueue ??= [];
+  const research = applyAIResearch(
+    newState,
+    civId,
+    preparedForTurn,
+    personality,
+  );
+  newState = research.state;
+  civ = newState.civilizations[civId];
+  if (research.startedTechId) {
+    bus.emit('tech:started', { civId, techId: research.startedTechId });
   }
 
   // --- Handle city production (personality-driven) ---
-  const isUnderThreat = militaryUnits.length < civ.cities.length;
   for (const cityId of civ.cities) {
     const city = newState.cities[cityId];
     if (!city || city.unrestLevel === 0) continue;
@@ -1033,7 +800,7 @@ function processAITurnInternal(
         }
       }
 
-      if (purposefulAIEnabled) continue;
+      continue;
 
       const civAvailableResources = getCivAvailableResources(newState, civId);
       const trainableUnits = getTrainableUnitsForCiv(
@@ -1270,8 +1037,7 @@ function processAITurnInternal(
         });
         const cityPos = city.position;
         const hasNearbyUnownedResource = hasForagingTech && (
-          purposefulAIEnabled
-            ? administrativePerception.knownResources.some(resource => {
+          administrativePerception.knownResources.some(resource => {
                 if (resource.owner !== null) return false;
                 const resDef = RESOURCE_DEFINITIONS.find(
                   definition => definition.id === resource.resource,
@@ -1291,51 +1057,28 @@ function processAITurnInternal(
                   : hexDistance(resource.position, cityPos);
                 return dist <= 8;
               })
-            : Object.values(newState.map.tiles).some(tile => {
-                if (
-                  !tile.resource
-                  || tile.owner !== null
-                  || tile.improvement !== 'none'
-                ) {
-                  return false;
-                }
-                const resDef = RESOURCE_DEFINITIONS.find(
-                  definition => definition.id === tile.resource,
-                );
-                if (
-                  !resDef
-                  || !civ.techState.completed.includes(resDef.tech)
-                ) {
-                  return false;
-                }
-                const dist = newState.map.wrapsHorizontally
-                  ? wrappedHexDistance(
-                      tile.coord,
-                      cityPos,
-                      newState.map.width,
-                    )
-                  : hexDistance(tile.coord, cityPos);
-                return dist <= 8;
-              })
         );
         if (hasForagingTech && !hasUncommittedExpedition && trainableUnits.includes('expedition') && hasNearbyUnownedResource) {
           city.productionQueue = ['expedition'];
         } else {
-          const chosen = chooseProduction(personality, derivedItems.length > 0 ? derivedItems : ['warrior'], isUnderThreat, civ.cities.length);
+          const chosen = chooseProduction(
+            personality,
+            derivedItems.length > 0 ? derivedItems : ['warrior'],
+            false,
+            civ.cities.length,
+          );
           city.productionQueue = [chosen];
         }
       }
     }
   }
-  if (purposefulAIEnabled && preparedForTurn) {
-    newState = applyAIProduction(
-      newState,
-      civId,
-      preparedForTurn.forceDemands,
-      personality,
-    );
-    civ = newState.civilizations[civId];
-  }
+  newState = applyAIProduction(
+    newState,
+    civId,
+    preparedForTurn.forceDemands,
+    personality,
+  );
+  civ = newState.civilizations[civId];
 
   // --- Handle diplomacy ---
   if (civ.diplomacy) {
@@ -1397,7 +1140,7 @@ function processAITurnInternal(
       newState.turn,
       diplomacyContext,
     );
-    if (purposefulAIEnabled && preparedForTurn) {
+    {
       const plannedWarTarget = preparedForTurn.perception.knownCivIds
         .find(targetCivId =>
           canDeclareWarForPreparedPlan(
@@ -1442,17 +1185,11 @@ function processAITurnInternal(
       }
       switch (decision.action) {
         case 'declare_war':
-          if (
-            purposefulAIEnabled
-            && (
-              !preparedForTurn
-              || !canDeclareWarForPreparedPlan(
-                newState,
-                preparedForTurn,
-                decision.targetCiv,
-              )
-            )
-          ) {
+          if (!canDeclareWarForPreparedPlan(
+            newState,
+            preparedForTurn,
+            decision.targetCiv,
+          )) {
             break;
           }
           newState.civilizations[civId].diplomacy = declareWar(
@@ -1551,45 +1288,6 @@ function processAITurnInternal(
     }
   }
 
-  // AI espionage decisions — queue spy units in cities (physical-spy model)
-  if (!purposefulAIEnabled && shouldAiRecruitSpy(newState, civId)) {
-    const espState = newState.espionage?.[civId];
-    if (espState) {
-      const activeSpies = Object.values(espState.spies).filter(s => s.status !== 'captured').length;
-      if (activeSpies < espState.maxSpies) {
-        const availableSpyTypes = getTrainableUnitsForCiv(civ.techState.completed, civ.civType)
-          .filter(u => isSpyUnitType(u.type));
-        if (availableSpyTypes.length > 0) {
-          const bestType = availableSpyTypes[availableSpyTypes.length - 1];
-          for (const cityId of civ.cities) {
-            const city = newState.cities[cityId];
-            if (city && city.productionQueue.length === 0) {
-              newState.cities[cityId] = { ...city, productionQueue: [bestType.type] };
-              break;
-            }
-          }
-        }
-      }
-    }
-  }
-
-  // Queue detection unit when lookouts tech researched and no detection unit already queued/deployed
-  if (!purposefulAIEnabled && civ.techState.completed.includes('lookouts')) {
-    const detectionType = getDetectionUnitTypeForCiv(civ.civType);
-    const hasDetectionUnit = Object.values(newState.units).some(
-      u => u.owner === civId && !!UNIT_DEFINITIONS[u.type]?.spyDetectionChance,
-    );
-    if (!hasDetectionUnit) {
-      for (const cityId of civ.cities) {
-        const city = newState.cities[cityId];
-        if (city && city.productionQueue.length === 0) {
-          newState.cities[cityId] = { ...city, productionQueue: [detectionType] };
-          break;
-        }
-      }
-    }
-  }
-
   if (shouldAiStationDefensiveSpy(newState, civId)) {
     const capital = getCapitalCity(newState, civId);
     const espState = newState.espionage?.[civId];
@@ -1624,20 +1322,11 @@ function processAITurnInternal(
         && u.movementPointsLeft > 0);
 
     for (const spyUnit of idleSpyUnits) {
-      const candidates = (purposefulAIEnabled
-        ? administrativePerception.knownCities.filter(city =>
-            city.owner !== civId
-            && city.position !== null
-            && city.confidence !== 'rumored')
-        : Object.values(newState.cities)
-            .filter(city => city.owner !== civId)
-            .map(city => ({
-              id: city.id,
-              owner: city.owner,
-              position: city.position,
-              confidence: 'visible' as const,
-              observedTurn: newState.turn,
-            })))
+      const candidates = administrativePerception.knownCities
+        .filter(city =>
+          city.owner !== civId
+          && city.position !== null
+          && city.confidence !== 'rumored')
         .sort((a, b) => {
           const da = hexDistance(spyUnit.position, a.position!);
           const db = hexDistance(spyUnit.position, b.position!);
@@ -1770,7 +1459,7 @@ function processAITurnInternal(
         : chooseAiSpyTarget(
             newState,
             civId,
-            purposefulAIEnabled ? administrativePerception : undefined,
+            administrativePerception,
           );
       if (target) {
         newState.espionage![civId] = startMission(
@@ -1915,9 +1604,8 @@ export function processAITurn(
   state: GameState,
   civId: string,
   bus: EventBus,
-  options: ProcessAITurnOptions = {},
 ): GameState {
-  return processAITurnInternal(state, civId, bus, options);
+  return processAITurnInternal(state, civId, bus);
 }
 
 export function processPreparedAITurn(
@@ -1927,7 +1615,6 @@ export function processPreparedAITurn(
 ): { state: GameState } {
   return {
     state: processAITurnInternal(state, prepared.civId, bus, {
-      purposefulAIEnabled: true,
       prepared,
     }),
   };

--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -34,6 +34,7 @@ export class AudioSystem {
   private gestureResumeHandler: (() => void) | null = null;
   private isPresentationSuppressed: () => boolean = () => false;
   private loopLoadRequestId = 0;
+  private strategicWarningAudioKeys = new Set<string>();
 
   constructor(private readonly ctx: AudioContext) {
     this.loader = new AudioLoader(ctx);
@@ -191,6 +192,7 @@ export class AudioSystem {
     this.stateProvider = null;
     this.isPresentationSuppressed = () => false;
     this.loopLoadRequestId += 1;
+    this.strategicWarningAudioKeys.clear();
     this.started = false;
   }
 
@@ -226,6 +228,7 @@ export class AudioSystem {
     getState: () => GameState,
     isPresentationSuppressed: () => boolean,
   ): void {
+    this.strategicWarningAudioKeys.clear();
     this.bindCampaignState(state, getState, isPresentationSuppressed);
     this.applySettings(state);
     this.sfxDirector.replaceUnits(
@@ -269,6 +272,17 @@ export class AudioSystem {
       },
     } as EventBus;
     this.unsubscribers.push(
+      bus.on('ai:strategic-warning', warning => {
+        if (!warning.playAudio) return;
+        const turn = this.stateProvider?.().turn;
+        if (!Number.isFinite(turn)) return;
+        this.playStrategicWarning(warning.viewerId, turn!);
+      }),
+
+      bus.on('ai:strategic-warning-audio', event => {
+        this.playStrategicWarning(event.viewerId, event.turn);
+      }),
+
       bus.on('era:advanced', p => {
         void this.preloadForEra(p.era, this.currentCivType);
         this.director.handleEraAdvanced({ era: p.era, civType: this.currentCivType });
@@ -436,6 +450,38 @@ export class AudioSystem {
       bus.on('civ:recovered-from-near-defeat', p => {
         this.director.handleRecoveredFromNearDefeat({ civId: p.civId });
       }),
+    );
+  }
+
+  private canPlayStrategicWarning(viewerId: string): boolean {
+    const state = this.stateProvider?.();
+    if (!state || viewerId !== this.currentPlayerId || state.currentPlayer !== viewerId) {
+      return false;
+    }
+    if (this.isPresentationSuppressed()) return false;
+    if (
+      !state.settings.soundEnabled
+      || state.settings.stingerEnabled === false
+      || (state.settings.stingerVolume ?? 1) <= 0
+    ) {
+      return false;
+    }
+    if (this.ctx.state !== 'running') return false;
+    if (typeof document !== 'undefined') {
+      if (document.hidden || document.visibilityState === 'hidden') return false;
+    }
+    return true;
+  }
+
+  private playStrategicWarning(viewerId: string, turn: number): void {
+    const key = `${viewerId}:${turn}`;
+    if (this.strategicWarningAudioKeys.has(key)) return;
+    if (!this.canPlayStrategicWarning(viewerId)) return;
+    this.strategicWarningAudioKeys.add(key);
+    const era = this.stateProvider?.().era ?? 1;
+    this.director.handleStrategicWarning(
+      era,
+      () => this.canPlayStrategicWarning(viewerId),
     );
   }
 

--- a/src/audio/music-director.ts
+++ b/src/audio/music-director.ts
@@ -132,6 +132,17 @@ export class MusicDirector {
       .then(() => this.playStingerWithDuck(STINGER.eraAdvance[resolveEra(p.era)].file));
   }
 
+  handleStrategicWarning(
+    era: number,
+    canPlay: () => boolean = () => true,
+  ): void {
+    this.currentEra = era;
+    this.currentStingerPromise = this.playStingerWithDuck(
+      STINGER.eraTransitionCue[resolveEra(era)].file,
+      canPlay,
+    );
+  }
+
   handleWarDeclared(_p: WarDeclaredPayload): void {
     this.atWar = true;
     this.applySnapshot(CROSSFADE_MS);
@@ -223,9 +234,17 @@ export class MusicDirector {
     return this.currentStingerPromise;
   }
 
-  async playStingerWithDuck(path: string): Promise<void> {
+  async playStingerWithDuck(
+    path: string,
+    canPlay: () => boolean = () => true,
+  ): Promise<void> {
+    if (!canPlay()) return;
     this.mixer.setSnapshot('stinger-duck', STINGER_DUCK_FADE_MS);
     const buffer = await this.loader.get(path);
+    if (!canPlay()) {
+      this.mixer.setSnapshot(this.resolveSnapshot(), STINGER_RESTORE_MS);
+      return;
+    }
     await this.mixer.playOneShot('stinger', buffer);
     this.mixer.setSnapshot(this.resolveSnapshot(), STINGER_RESTORE_MS);
   }

--- a/src/core/feature-flags.ts
+++ b/src/core/feature-flags.ts
@@ -1,1 +1,0 @@
-export const PURPOSEFUL_AI_FEATURE_ENABLED = false;

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -71,6 +71,15 @@ function isFiniteCoord(value: unknown): value is { q: number; r: number } {
   return Number.isFinite(coord.q) && Number.isFinite(coord.r);
 }
 
+function isIndependentThreatId(threatId: unknown): threatId is string {
+  if (typeof threatId !== 'string') return false;
+  return (
+    threatId.startsWith('barbarian:')
+    || threatId.startsWith('pirate:')
+    || threatId.startsWith('beast:')
+  ) && threatId.split(':')[1]!.length > 0;
+}
+
 function isTarget(value: unknown): value is AITarget {
   if (!value || typeof value !== 'object') return false;
   const target = value as Record<string, unknown>;
@@ -287,22 +296,31 @@ export function normalizeOpponentAIState(state: GameState): GameState {
     if (plan) opponentAI.minorCivs[minorId] = plan;
   }
 
-  for (const [humanId, ledger] of Object.entries(source.pressureByHuman ?? {})) {
-    const civ = state.civilizations[humanId];
-    if (!civ?.isHuman || !ledger || typeof ledger !== 'object') continue;
+  const livingHumanIds = Object.values(state.civilizations)
+    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .map(civ => civ.id)
+    .sort();
+  for (const humanId of livingHumanIds) {
+    const ledger = source.pressureByHuman?.[humanId];
     opponentAI.pressureByHuman[humanId] = {
-      activeIndependentThreatIds: Array.isArray(ledger.activeIndependentThreatIds)
-        ? [...new Set(ledger.activeIndependentThreatIds.filter(id => typeof id === 'string'))]
+      activeIndependentThreatIds: Array.isArray(ledger?.activeIndependentThreatIds)
+        ? [...new Set(ledger.activeIndependentThreatIds
+            .filter(id => isIndependentThreatId(id)))]
+            .sort()
         : [],
-      recoveryUntilTurn: Number.isFinite(ledger.recoveryUntilTurn) ? ledger.recoveryUntilTurn : 0,
-      lastResolvedThreatTurn: Number.isFinite(ledger.lastResolvedThreatTurn)
-        ? ledger.lastResolvedThreatTurn
+      recoveryUntilTurn: Number.isFinite(ledger?.recoveryUntilTurn)
+        ? Math.max(0, Math.floor(ledger!.recoveryUntilTurn))
+        : 0,
+      lastResolvedThreatTurn: Number.isFinite(ledger?.lastResolvedThreatTurn)
+        ? Math.max(0, Math.floor(ledger!.lastResolvedThreatTurn!))
         : null,
-      lastWarningTurnByKey: ledger.lastWarningTurnByKey && typeof ledger.lastWarningTurnByKey === 'object'
-        ? { ...ledger.lastWarningTurnByKey }
-        : {},
-      lastStrategicAudioTurn: Number.isFinite(ledger.lastStrategicAudioTurn)
-        ? ledger.lastStrategicAudioTurn
+      lastWarningTurnByKey: Object.fromEntries(
+        Object.entries(ledger?.lastWarningTurnByKey ?? {})
+          .filter((entry): entry is [string, number] => Number.isFinite(entry[1]))
+          .map(([key, turn]) => [key, Math.max(0, Math.floor(turn))]),
+      ),
+      lastStrategicAudioTurn: Number.isFinite(ledger?.lastStrategicAudioTurn)
+        ? Math.max(0, Math.floor(ledger!.lastStrategicAudioTurn!))
         : null,
     };
   }

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -21,7 +21,12 @@ import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { resolveCombat } from '@/systems/combat-system';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import { PIRATE_OWNER, recordCombatForCiv, processThreatPressure } from '@/systems/threat-pressure-system';
+import {
+  PIRATE_OWNER,
+  processIndependentThreatPressureForHumans,
+  recordCombatForCiv,
+  processThreatPressure,
+} from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
 import { hexKey, hexDistance } from '@/systems/hex-utils';
@@ -907,9 +912,11 @@ export function processTurn(
   }
 
   // --- Threat pressure (spawn phase: land resurgence + pirate spawn) ---
-  newState = processThreatPressure(newState, newState.currentPlayer, bus, {
-    includeLegacyPirates: false,
-  });
+  newState = purposefulAIEnabled
+    ? processIndependentThreatPressureForHumans(newState, bus)
+    : processThreatPressure(newState, newState.currentPlayer, bus, {
+        includeLegacyPirates: false,
+      });
 
   // --- Process espionage ---
   newState = processEspionageTurn(newState, bus);

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -1,16 +1,14 @@
 import type { AdvisorType, GameState } from './types';
 import { EventBus } from './event-bus';
 import { checkDominationVictory } from '@/systems/victory-system';
-import { resetUnitTurn, createUnit, healUnit, moveUnit, findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { resetUnitTurn, createUnit, healUnit, findPath, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { processCity, TRAINABLE_UNITS, BUILDINGS } from '@/systems/city-system';
 import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
 import { applyCityMaturity } from '@/systems/city-maturity-system';
 import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
 import { processResearch, getTechById } from '@/systems/tech-system';
 import {
-  processBarbarians,
   processPurposefulBarbarians,
-  type PurposefulBarbarianProcessResult,
 } from '@/systems/barbarian-system';
 import {
   processBeasts, placeBeastLairs, recordBeastSlain, BEAST_OWNER,
@@ -25,7 +23,6 @@ import {
   PIRATE_OWNER,
   processIndependentThreatPressureForHumans,
   recordCombatForCiv,
-  processThreatPressure,
 } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
@@ -89,11 +86,6 @@ import {
 import type { PirateEconomyModifiers } from '@/systems/economy-system';
 import { processPiratesForCompletedRound } from '@/systems/pirate-system';
 import { classifyOwner } from './owner-kind';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from './feature-flags';
-
-export interface ProcessTurnOptions {
-  purposefulAIEnabled?: boolean;
-}
 
 export function finalizeOpponentRoundState(state: GameState): GameState {
   const normalized = normalizeOpponentAIState(state);
@@ -115,11 +107,9 @@ export function finalizeOpponentRoundState(state: GameState): GameState {
 export function processTurn(
   state: GameState,
   bus: EventBus,
-  options: ProcessTurnOptions = {},
 ): GameState {
-  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
   let newState = initializeLegendaryWonderProjectsForAllCities(structuredClone(state));
-  if (purposefulAIEnabled) newState = normalizeOpponentAIState(newState);
+  newState = normalizeOpponentAIState(newState);
 
   bus.emit('turn:end', { turn: newState.turn, playerId: newState.currentPlayer });
 
@@ -148,9 +138,7 @@ export function processTurn(
     let totalScience = 0;
     let totalGold = 0;
 
-    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId, {
-      hostileOccupationEnabled: purposefulAIEnabled,
-    });
+    const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
     const npCivBonuses = getNationalProjectCivYieldBonus(newState, civId);
 
     for (const cityId of civ.cities) {
@@ -176,9 +164,7 @@ export function processTurn(
       totalScience += yields.science;
       totalGold += yields.gold;
       const effectiveProduction = isCityProductionLocked(city) ? 0 : yields.production;
-      const availableResources = getCivAvailableResources(newState, civId, {
-        hostileOccupationEnabled: purposefulAIEnabled,
-      });
+      const availableResources = getCivAvailableResources(newState, civId);
       const npKeysForCiv = new Set(
         Object.keys(newState.builtNationalProjects ?? {}).filter(k => k.startsWith(`${civId}:`))
       );
@@ -643,28 +629,9 @@ export function processTurn(
       newState.units[unitId] = resetUnitTurn(unit);
     }
   }
-  const playerUnits = Object.values(newState.units).filter(unit => {
-    const kind = classifyOwner(unit.owner);
-    return kind !== 'barbarian' && kind !== 'beast' && kind !== 'minor';
-  });
-  const barbarianUnits = Object.values(newState.units).filter(u => u.owner === 'barbarian');
   const barbSeed = newState.turn * 31337 + Object.keys(newState.barbarianCamps).length;
-  const cityTargets = Object.values(newState.cities)
-    .filter(city => city.owner !== 'barbarian' && !city.owner.startsWith('mc-') && city.owner !== BEAST_OWNER)
-    .map(city => ({ id: city.id, position: city.position, owner: city.owner }));
-  const barbResult = purposefulAIEnabled
-    ? processPurposefulBarbarians(newState)
-    : processBarbarians(
-        Object.values(newState.barbarianCamps),
-        newState.map,
-        playerUnits,
-        barbSeed,
-        barbarianUnits,
-        cityTargets,
-      );
-  if (purposefulAIEnabled) {
-    newState.opponentAI = (barbResult as PurposefulBarbarianProcessResult).opponentAI;
-  }
+  const barbResult = processPurposefulBarbarians(newState);
+  newState.opponentAI = barbResult.opponentAI;
   newState.barbarianCamps = {};
   for (const camp of barbResult.updatedCamps) {
     newState.barbarianCamps[camp.id] = camp;
@@ -674,7 +641,7 @@ export function processTurn(
   for (const spawn of barbResult.spawnedUnits) {
     const raider = createUnit(spawn.unitType ?? 'warrior', 'barbarian', spawn.position, newState.idCounters);
     newState.units[raider.id] = raider;
-    if (purposefulAIEnabled && newState.opponentAI) {
+    if (newState.opponentAI) {
       newState.opponentAI.barbarianHomeCampByUnitId[raider.id] = spawn.campId;
     }
     bus.emit('barbarian:spawned', { campId: spawn.campId, unitId: raider.id });
@@ -684,13 +651,7 @@ export function processTurn(
   for (const order of barbResult.moveOrders) {
     const unit = newState.units[order.unitId];
     if (unit) {
-      if (purposefulAIEnabled) {
-        executeUnitMove(newState, order.unitId, order.toCoord, { actor: 'world', bus });
-      } else {
-        const tile = newState.map.tiles[`${order.toCoord.q},${order.toCoord.r}`];
-        const cost = tile?.terrain === 'hills' || tile?.terrain === 'forest' ? 2 : 1;
-        newState.units[order.unitId] = moveUnit(unit, order.toCoord, cost);
-      }
+      executeUnitMove(newState, order.unitId, order.toCoord, { actor: 'world', bus });
     }
   }
 
@@ -739,7 +700,7 @@ export function processTurn(
       cities: { ...newState.cities, [order.cityId]: { ...city, hp: newHp } },
     };
     bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: currentHp - newHp });
-    if (purposefulAIEnabled && newState.opponentAI) {
+    if (newState.opponentAI) {
       const campId = newState.opponentAI.barbarianHomeCampByUnitId[order.attackerUnitId];
       const plan = campId ? newState.opponentAI.barbarianCamps[campId] : undefined;
       if (plan?.target.kind === 'city' && plan.target.id === order.cityId) {
@@ -770,7 +731,7 @@ export function processTurn(
   }
 
   // --- Minor civ turn phase ---
-  newState = processMinorCivTurn(newState, bus, { purposefulAIEnabled });
+  newState = processMinorCivTurn(newState, bus);
 
   // --- Barbarian evolution check ---
   const evolution = checkCampEvolution(newState, newState.turn);
@@ -912,11 +873,7 @@ export function processTurn(
   }
 
   // --- Threat pressure (spawn phase: land resurgence + pirate spawn) ---
-  newState = purposefulAIEnabled
-    ? processIndependentThreatPressureForHumans(newState, bus)
-    : processThreatPressure(newState, newState.currentPlayer, bus, {
-        includeLegacyPirates: false,
-      });
+  newState = processIndependentThreatPressureForHumans(newState, bus);
 
   // --- Process espionage ---
   newState = processEspionageTurn(newState, bus);
@@ -1121,7 +1078,7 @@ export function processTurn(
   }
 
   let pirateEconomyModifiers: PirateEconomyModifiers | undefined;
-  const pirateRound = processPiratesForCompletedRound(newState, bus, { purposefulAIEnabled });
+  const pirateRound = processPiratesForCompletedRound(newState, bus);
   newState = pirateRound.state;
   pirateEconomyModifiers = pirateRound.economyModifiers;
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1049,6 +1049,7 @@ export interface GameEvent {
   type: string;
   message: string;
   turn: number;
+  target?: { kind: 'map'; coord: HexCoord; label: string };
 }
 
 export type OpponentChallenge = 'explorer' | 'standard' | 'veteran';
@@ -1431,6 +1432,30 @@ export interface GameEvents {
     viewerIds: string[];
   };
   'pirate:headquarters-destroyed': { factionId: string; viewerIds: string[] };
+  'ai:strategic-warning': {
+    viewerId: string;
+    actorId: string;
+    actorName: string;
+    warningKey: string;
+    kind:
+      | 'mobilizing'
+      | 'raid'
+      | 'blockade'
+      | 'resource-denied'
+      | 'resource-restored'
+      | 'withdrawing'
+      | 'recovery';
+    evidence: 'visible' | 'remembered' | 'earned-intel';
+    targetLabel?: string;
+    regionLabel?: string;
+    resource?: ResourceType;
+    target?: { kind: 'map'; coord: HexCoord; label: string };
+    playAudio: boolean;
+  };
+  'ai:strategic-warning-audio': {
+    viewerId: string;
+    turn: number;
+  };
   'city:founded': { city: City; founderId: string };
   'city:captured': { cityId: string; newOwner: string; previousOwner: string };
   'diplomacy:vassalage-offered': { fromCivId: string; toCivId: string };

--- a/src/main.ts
+++ b/src/main.ts
@@ -112,9 +112,12 @@ import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs } from '@/systems/tech-system';
 import { getNextPlayer, isRoundComplete } from '@/core/turn-cycling';
-import { showTurnHandoff } from '@/ui/turn-handoff';
+import {
+  acknowledgeTurnHandoffSummary,
+  showTurnHandoff,
+} from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
-import { clearEventsForPlayer, collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
+import { collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
@@ -200,6 +203,8 @@ import {
   routePeaceRequested,
   routeTerritoryTileFlipped,
   routeWarDeclared,
+  queueStrategicWarningPendingEvent,
+  routeStrategicWarning,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
@@ -231,6 +236,7 @@ import { runCompletedRound } from '@/core/completed-round-orchestrator';
 import { createCompletedRoundHandoffTransaction } from '@/core/completed-round-handoff';
 import { processImprovementTurns } from '@/systems/improvement-turn-system';
 import { handleCombatResolvedEvent } from '@/ui/combat-resolved-presentation';
+import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-system';
 
 // --- App State ---
 let gameState: GameState;
@@ -3134,6 +3140,10 @@ function runCurrentCompletedRound(state: GameState) {
     improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
     majors: (current, eventBus) => processNonHumanMajorRound(current, eventBus).state,
     world: (current, eventBus) => processTurn(current, eventBus),
+    postprocess: (beforeRound, current, eventBus) =>
+      applyStrategicWarningTransitions(beforeRound, current, eventBus, {
+        purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
+      }),
   });
 }
 
@@ -3185,11 +3195,13 @@ async function beginHotSeatHandoff(
     {
       initiallyReady: false,
       preparingLabel: 'Preparing next turn…',
-      onReady: async () => {
-        gameState = {
-          ...gameState,
-          pendingEvents: clearEventsForPlayer(gameState.pendingEvents ?? {}, nextSlotId),
-        };
+      onReady: async summary => {
+        const acknowledgement = acknowledgeTurnHandoffSummary(
+          gameState,
+          nextSlotId,
+          summary,
+        );
+        gameState = acknowledgement.state;
         let acknowledgementFailed = false;
         try {
           await autoSave(gameState);
@@ -3197,6 +3209,12 @@ async function beginHotSeatHandoff(
           acknowledgementFailed = true;
         }
         releaseHandoffToViewer(nextSlotId);
+        if (acknowledgement.playStrategicWarningAudio) {
+          bus.emit('ai:strategic-warning-audio', {
+            viewerId: nextSlotId,
+            turn: summary.turn,
+          });
+        }
         if (acknowledgementFailed) {
           showNotification('Turn opened, but its summary may repeat after reload.', 'warning');
         }
@@ -3805,6 +3823,13 @@ bus.on('beast:sighted', ({ beastId, civId }) => {
 
 registerMinorCivNotificationListeners(bus, () => gameState, { appendToCivLog });
 
+bus.on('ai:strategic-warning', event => {
+  routeStrategicWarning(event, appendToCivLog);
+  if (gameState.hotSeat) {
+    queueStrategicWarningPendingEvent(gameState, event);
+  }
+});
+
 function appendFactionNotice(civId: string, message: string, type: NotificationEntry['type']): void {
   appendToCivLog(civId, message, type);
   if (gameState.pendingEvents) {
@@ -3975,12 +4000,14 @@ function enterCampaign(
     {
       initiallyReady: !persistBeforeReady,
       preparingLabel: 'Saving campaign…',
-      onReady: async () => {
+      onReady: async summary => {
         const viewerId = gameState.currentPlayer;
-        gameState = {
-          ...gameState,
-          pendingEvents: clearEventsForPlayer(gameState.pendingEvents ?? {}, viewerId),
-        };
+        const acknowledgement = acknowledgeTurnHandoffSummary(
+          gameState,
+          viewerId,
+          summary,
+        );
+        gameState = acknowledgement.state;
         try {
           await autoSave(gameState);
         } catch {
@@ -3990,6 +4017,12 @@ function enterCampaign(
         setBlockingOverlay(null);
         startGame();
         audio.setMasterVolume(currentMasterVolume);
+        if (acknowledgement.playStrategicWarningAudio) {
+          bus.emit('ai:strategic-warning-audio', {
+            viewerId,
+            turn: summary.turn,
+          });
+        }
         showNotification(message, 'info');
       },
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import '@/assets/dragon-animations.css';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame, createHotSeatGame, createDefaultSettings } from '@/core/game-state';
 import { resolveOpponentChallenge, setPendingOpponentChallenge } from '@/core/opponent-challenge';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { processTurn } from '@/core/turn-manager';
 import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
 import { RenderLoop } from '@/renderer/render-loop';
@@ -3141,9 +3140,7 @@ function runCurrentCompletedRound(state: GameState) {
     majors: (current, eventBus) => processNonHumanMajorRound(current, eventBus).state,
     world: (current, eventBus) => processTurn(current, eventBus),
     postprocess: (beforeRound, current, eventBus) =>
-      applyStrategicWarningTransitions(beforeRound, current, eventBus, {
-        purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
-      }),
+      applyStrategicWarningTransitions(beforeRound, current, eventBus),
   });
 }
 
@@ -4061,7 +4058,6 @@ async function showStartSavePanel(): Promise<void> {
         { kind: 'stored', loaded },
         invoker,
         {
-          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
           persistStoredChoice: rewriteLoadedSaveEntry,
           persistImport: autoSave,
           showChallengePrompt: showLegacyOpponentChallengePrompt,
@@ -4076,7 +4072,6 @@ async function showStartSavePanel(): Promise<void> {
         { kind: 'stored', loaded },
         invoker,
         {
-          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
           persistStoredChoice: rewriteLoadedSaveEntry,
           persistImport: autoSave,
           showChallengePrompt: showLegacyOpponentChallengePrompt,
@@ -4089,7 +4084,6 @@ async function showStartSavePanel(): Promise<void> {
         { kind: 'import', state },
         invoker,
         {
-          purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED,
           persistStoredChoice: rewriteLoadedSaveEntry,
           persistImport: autoSave,
           showChallengePrompt: showLegacyOpponentChallengePrompt,

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -11,7 +11,6 @@ import type {
 import type { EventBus } from '@/core/event-bus';
 import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
 import { OPPONENT_CHALLENGE_PROFILES, resolveOpponentChallenge } from '@/core/opponent-challenge';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
 import { TECH_TREE } from './tech-definitions';
@@ -182,21 +181,17 @@ function hashSeed(seed: string): number {
 export function processMinorCivTurn(
   state: GameState,
   bus: EventBus,
-  options: { purposefulAIEnabled?: boolean } = {},
 ): GameState {
   let nextState = structuredClone(state);
-  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
-  if (purposefulAIEnabled && !nextState.opponentAI) {
+  if (!nextState.opponentAI) {
     nextState.opponentAI = createEmptyOpponentAIState();
   }
-  if (purposefulAIEnabled) {
-    nextState.opponentAI!.minorCivs = Object.fromEntries(
-      Object.entries(nextState.opponentAI!.minorCivs).filter(([minorCivId]) => {
-        const minor = nextState.minorCivs[minorCivId];
-        return Boolean(minor && !minor.isDestroyed && nextState.cities[minor.cityId]);
-      }),
-    );
-  }
+  nextState.opponentAI!.minorCivs = Object.fromEntries(
+    Object.entries(nextState.opponentAI!.minorCivs).filter(([minorCivId]) => {
+      const minor = nextState.minorCivs[minorCivId];
+      return Boolean(minor && !minor.isDestroyed && nextState.cities[minor.cityId]);
+    }),
+  );
   for (const mcId of Object.keys(nextState.minorCivs).sort()) {
     let mc = nextState.minorCivs[mcId];
     if (mc.isDestroyed) continue;
@@ -204,21 +199,17 @@ export function processMinorCivTurn(
     const def = MINOR_CIV_DEFINITIONS.find(d => d.id === mc.definitionId);
     if (!def) continue;
 
-    if (purposefulAIEnabled) {
-      for (const unitId of mc.units) {
-        const unit = nextState.units[unitId];
-        if (unit) nextState.units[unitId] = resetUnitTurn(unit);
-      }
-      const planned = planPurposefulMinorCivTurn(nextState, mcId);
-      if (planned.plan) {
-        nextState.opponentAI!.minorCivs[mcId] = planned.plan;
-      } else {
-        delete nextState.opponentAI!.minorCivs[mcId];
-      }
-      nextState = executePurposefulMinorCivOrders(nextState, planned, bus);
-    } else {
-      processMovement(nextState, mc);
+    for (const unitId of mc.units) {
+      const unit = nextState.units[unitId];
+      if (unit) nextState.units[unitId] = resetUnitTurn(unit);
     }
+    const planned = planPurposefulMinorCivTurn(nextState, mcId);
+    if (planned.plan) {
+      nextState.opponentAI!.minorCivs[mcId] = planned.plan;
+    } else {
+      delete nextState.opponentAI!.minorCivs[mcId];
+    }
+    nextState = executePurposefulMinorCivOrders(nextState, planned, bus);
     nextState = processQuests(nextState, mcId, def, bus);
     mc = nextState.minorCivs[mcId];
     nextState = applyAllyBonuses(nextState, mc, def);

--- a/src/systems/pirate-ecology.ts
+++ b/src/systems/pirate-ecology.ts
@@ -18,6 +18,11 @@ import {
   wrapHexCoord,
   wrappedHexDistance,
 } from './hex-utils';
+import {
+  deriveHumansMateriallyAffectedByPosition,
+  reserveIndependentThreatForHumans,
+  type IndependentThreatSpawnPolicy,
+} from './threat-pressure-system';
 import { calculateProjectedCityYields } from './city-work-system';
 import { resolveCivDefinition } from './civ-registry';
 import { createRng } from './map-generator';
@@ -456,7 +461,12 @@ function hasPirateActivationTech(state: GameState): boolean {
   return Object.values(state.civilizations).some(civ => civ.techState.completed.includes('galleys'));
 }
 
-export function processPirateEcology(state: GameState, bus: EventBus, seed: string): GameState {
+export function processPirateEcology(
+  state: GameState,
+  bus: EventBus,
+  seed: string,
+  options: { spawnPolicy?: IndependentThreatSpawnPolicy } = {},
+): GameState {
   if (!hasPirateActivationTech(state)) return state;
   const pirates = state.pirates ?? createEmptyPirateState();
   if (pirates.activatedTurn === null) {
@@ -491,7 +501,31 @@ export function processPirateEcology(state: GameState, bus: EventBus, seed: stri
   if (pressureValue < PIRATE_PRESSURE.threshold) return nextState;
   const plan = choosePirateSpawn(nextState, `${seed}:${state.turn}`);
   if (!plan) return nextState;
+  const pendingFactionId = `pirate-${nextState.idCounters.nextPirateFactionId ?? 1}`;
+  const affectedHumanIds = deriveHumansMateriallyAffectedByPosition(
+    nextState,
+    plan.position,
+    20,
+  );
+  if (
+    affectedHumanIds.length > 0
+    && options.spawnPolicy
+    && !options.spawnPolicy.canStart(nextState, {
+      threatId: `pirate:${pendingFactionId}`,
+      position: { ...plan.position },
+      affectedHumanIds,
+    })
+  ) {
+    return nextState;
+  }
   nextState = spawnPirateFaction(nextState, plan, bus, `${seed}:${state.turn}`);
+  if (options.spawnPolicy && affectedHumanIds.length > 0) {
+    nextState = reserveIndependentThreatForHumans(
+      nextState,
+      `pirate:${pendingFactionId}`,
+      affectedHumanIds,
+    );
+  }
   return {
     ...nextState,
     pirates: {

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -2,7 +2,6 @@ import type { EventBus } from '@/core/event-bus';
 import type { CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import type { PirateFactionState } from '@/core/pirate-state';
 import { isMajorCivOwner } from '@/core/owner-kind';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
 import { resolveCombat } from './combat-system';
@@ -95,7 +94,6 @@ function neighbors(state: GameState, coord: HexCoord): HexCoord[] {
 
 function normalizeRoundState(
   state: GameState,
-  purposefulAIEnabled: boolean,
 ): { state: GameState; events: PirateTransitionEvent[] } {
   if (!state.pirates) return { state, events: [] };
   let nextState = state;
@@ -103,7 +101,7 @@ function normalizeRoundState(
   for (const originalFaction of Object.values(state.pirates.factions)) {
     let faction = originalFaction;
     if (faction.headquarters.kind === 'deep-sea-flotilla' && !state.units[faction.headquarters.flagshipUnitId]) {
-      const replacement = purposefulAIEnabled ? getPirateFleetLeader(state, faction.id) : null;
+      const replacement = getPirateFleetLeader(state, faction.id);
       if (replacement) {
         faction = {
           ...faction,
@@ -693,19 +691,17 @@ export function processPiratesForCompletedRound(
   state: GameState,
   bus: EventBus,
   options: {
-    purposefulAIEnabled?: boolean;
     spawnPolicy?: IndependentThreatSpawnPolicy;
   } = {},
 ): ProcessPiratesResult {
-  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
-  const spawnPolicy = options.spawnPolicy ?? (purposefulAIEnabled ? {
+  const spawnPolicy = options.spawnPolicy ?? {
     canStart: (candidateState: GameState, candidate: IndependentThreatSpawnCandidate) =>
       candidate.affectedHumanIds.every(humanId =>
         canStartIndependentThreat(candidateState, humanId, candidate.threatId).allowed),
-  } : undefined);
+  };
   const trace = [...PIRATE_ROUND_TRACE];
   const wasActivated = state.pirates?.activatedTurn !== null;
-  let normalized = normalizeRoundState(state, purposefulAIEnabled);
+  let normalized = normalizeRoundState(state);
   let nextState = normalized.state;
   const events: PirateTransitionEvent[] = [...normalized.events];
   const relocated = new Set<string>();
@@ -747,9 +743,12 @@ export function processPiratesForCompletedRound(
     }
     if (result.facts.relocation.status === 'moved') events.push({ type: 'relocated', factionId });
   }
-  const processed = purposefulAIEnabled
-    ? processPurposefulMovementAndCombat(nextState, relocated, bus, spawnPolicy)
-    : processMovementAndCombat(nextState, relocated);
+  const processed = processPurposefulMovementAndCombat(
+    nextState,
+    relocated,
+    bus,
+    spawnPolicy,
+  );
   nextState = processed.state;
   const facts: PirateRoundFacts = {
     movements: [...relocationFacts, ...processed.facts.movements],

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -27,6 +27,12 @@ import {
   PIRATE_NOTORIETY,
 } from './pirate-definitions';
 import { getPirateMaritimeStage, processPirateEcology } from './pirate-ecology';
+import {
+  canStartIndependentThreat,
+  reserveIndependentThreatForHumans,
+  type IndependentThreatSpawnCandidate,
+  type IndependentThreatSpawnPolicy,
+} from './threat-pressure-system';
 import { refreshPirateIntel } from './pirate-presentation';
 import {
   applyPirateNotifications,
@@ -391,6 +397,7 @@ function processPurposefulMovementAndCombat(
   state: GameState,
   relocated: Set<string>,
   bus: EventBus,
+  spawnPolicy?: IndependentThreatSpawnPolicy,
 ): {
   state: GameState;
   facts: PirateRoundFacts;
@@ -408,7 +415,30 @@ function processPurposefulMovementAndCombat(
   for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
     let faction = nextState.pirates?.factions[factionId];
     if (!faction) continue;
-    const intent = choosePersistentPirateIntent(nextState, factionId);
+    let intent = choosePersistentPirateIntent(nextState, factionId);
+    const targetCivId = intent?.targetCivId;
+    if (targetCivId && nextState.civilizations[targetCivId]?.isHuman) {
+      const leader = getPirateFleetLeader(nextState, factionId);
+      const targetPosition = intent?.targetCityId
+        ? nextState.cities[intent.targetCityId]?.position
+        : intent?.targetUnitId
+          ? nextState.units[intent.targetUnitId]?.position
+          : leader?.position;
+      const candidate: IndependentThreatSpawnCandidate = {
+        threatId: `pirate:${factionId}`,
+        position: targetPosition ? { ...targetPosition } : { q: 0, r: 0 },
+        affectedHumanIds: [targetCivId],
+      };
+      if (spawnPolicy && !spawnPolicy.canStart(nextState, candidate)) {
+        intent = null;
+      } else {
+        nextState = reserveIndependentThreatForHumans(
+          nextState,
+          candidate.threatId,
+          candidate.affectedHumanIds,
+        );
+      }
+    }
     faction = { ...faction, intent };
     nextState = {
       ...nextState,
@@ -662,9 +692,17 @@ function advanceStageAndReinforce(state: GameState, bus: EventBus): GameState {
 export function processPiratesForCompletedRound(
   state: GameState,
   bus: EventBus,
-  options: { purposefulAIEnabled?: boolean } = {},
+  options: {
+    purposefulAIEnabled?: boolean;
+    spawnPolicy?: IndependentThreatSpawnPolicy;
+  } = {},
 ): ProcessPiratesResult {
   const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
+  const spawnPolicy = options.spawnPolicy ?? (purposefulAIEnabled ? {
+    canStart: (candidateState: GameState, candidate: IndependentThreatSpawnCandidate) =>
+      candidate.affectedHumanIds.every(humanId =>
+        canStartIndependentThreat(candidateState, humanId, candidate.threatId).allowed),
+  } : undefined);
   const trace = [...PIRATE_ROUND_TRACE];
   const wasActivated = state.pirates?.activatedTurn !== null;
   let normalized = normalizeRoundState(state, purposefulAIEnabled);
@@ -710,7 +748,7 @@ export function processPiratesForCompletedRound(
     if (result.facts.relocation.status === 'moved') events.push({ type: 'relocated', factionId });
   }
   const processed = purposefulAIEnabled
-    ? processPurposefulMovementAndCombat(nextState, relocated, bus)
+    ? processPurposefulMovementAndCombat(nextState, relocated, bus, spawnPolicy)
     : processMovementAndCombat(nextState, relocated);
   nextState = processed.state;
   const facts: PirateRoundFacts = {
@@ -738,7 +776,12 @@ export function processPiratesForCompletedRound(
   nextState = advanced.state;
   events.push(...advanced.events);
   nextState = advanceStageAndReinforce(nextState, bus);
-  nextState = processPirateEcology(nextState, bus, state.gameId ?? 'pirates');
+  nextState = processPirateEcology(
+    nextState,
+    bus,
+    state.gameId ?? 'pirates',
+    { spawnPolicy },
+  );
   if (!wasActivated && nextState.pirates?.activatedTurn !== null) events.push({ type: 'activated', factionId: '' });
   const previousIntel = state.pirates?.intelByCiv ?? {};
   for (const viewerId of Object.keys(nextState.civilizations)) {

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -47,7 +47,6 @@ export function isResourceTileDeniedByHostileOccupation(
 export function getCivAvailableResources(
   state: GameState,
   civId: string,
-  options: { hostileOccupationEnabled?: boolean } = {},
 ): Set<ResourceType> {
   const result = new Set<ResourceType>();
   const civ = state.civilizations[civId];
@@ -72,10 +71,7 @@ export function getCivAvailableResources(
 
       // Tech gate — must have researched the revealing tech.
       if (!completedTechs.has(def.tech)) continue;
-      if (
-        options.hostileOccupationEnabled
-        && isResourceTileDeniedByHostileOccupation(state, civId, coord)
-      ) continue;
+      if (isResourceTileDeniedByHostileOccupation(state, civId, coord)) continue;
 
       if (key === cityKey) {
         // City-center exception: tech alone grants the resource.
@@ -105,10 +101,7 @@ export function getCivAvailableResources(
     const def = resourceDefMap.get(tile.resource as ResourceType);
     if (!def) continue;
     if (!completedTechs.has(def.tech)) continue;
-    if (
-      options.hostileOccupationEnabled
-      && isResourceTileDeniedByHostileOccupation(state, civId, tile.coord)
-    ) continue;
+    if (isResourceTileDeniedByHostileOccupation(state, civId, tile.coord)) continue;
 
     result.add(tile.resource as ResourceType);
   }
@@ -139,10 +132,9 @@ export function getCivAvailableResources(
 export function getCivResourceYieldBonus(
   state: GameState,
   civId: string,
-  options: { hostileOccupationEnabled?: boolean } = {},
 ): ResourceYield {
   const bonus: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
-  const owned = getCivAvailableResources(state, civId, options);
+  const owned = getCivAvailableResources(state, civId);
 
   for (const def of RESOURCE_DEFINITIONS) {
     if (!def.effect || def.effect.type === 'happiness') continue;
@@ -166,9 +158,8 @@ export function getCivResourceYieldBonus(
 export function getCivHappinessFromResources(
   state: GameState,
   civId: string,
-  options: { hostileOccupationEnabled?: boolean } = {},
 ): number {
-  const owned = getCivAvailableResources(state, civId, options);
+  const owned = getCivAvailableResources(state, civId);
   let count = 0;
 
   for (const def of RESOURCE_DEFINITIONS) {

--- a/src/systems/strategic-warning-system.ts
+++ b/src/systems/strategic-warning-system.ts
@@ -1,0 +1,411 @@
+import type {
+  AIStrategicPlan,
+  GameEvents,
+  GameState,
+  HexCoord,
+  HumanPressureLedger,
+  ResourceType,
+} from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey } from '@/systems/hex-utils';
+import { isTrustedObservedLastSeenTile } from '@/systems/last-seen-presentation';
+import {
+  getCivAvailableResources,
+  isResourceTileDeniedByHostileOccupation,
+} from '@/systems/resource-acquisition-system';
+
+export interface StrategicWarningOptions {
+  purposefulAIEnabled?: boolean;
+}
+
+type StrategicWarning = GameEvents['ai:strategic-warning'];
+
+function emptyLedger(): HumanPressureLedger {
+  return {
+    activeIndependentThreatIds: [],
+    recoveryUntilTurn: 0,
+    lastResolvedThreatTurn: null,
+    lastWarningTurnByKey: {},
+    lastStrategicAudioTurn: null,
+  };
+}
+
+function isVisible(state: GameState, viewerId: string, coord: HexCoord): boolean {
+  const visibility = state.civilizations[viewerId]?.visibility;
+  return Boolean(visibility && getVisibility(visibility, coord) === 'visible');
+}
+
+function trustedLastSeenAt(state: GameState, viewerId: string, coord: HexCoord) {
+  const presentation = state.civilizations[viewerId]?.visibility.lastSeen?.[hexKey(coord)];
+  return isTrustedObservedLastSeenTile(presentation) ? presentation : null;
+}
+
+function regionLabel(state: GameState, coord: HexCoord): string {
+  const horizontal = coord.q < state.map.width / 3
+    ? 'western'
+    : coord.q > state.map.width * 2 / 3 ? 'eastern' : '';
+  const vertical = coord.r < state.map.height / 3
+    ? 'northern'
+    : coord.r > state.map.height * 2 / 3 ? 'southern' : '';
+  return `${vertical || horizontal || 'outer'}${vertical && horizontal ? `-${horizontal}` : ''} marches`;
+}
+
+function planEvidence(
+  state: GameState,
+  viewerId: string,
+  plan: AIStrategicPlan,
+): { evidence: 'visible' | 'remembered'; coord: HexCoord } | null {
+  const assigned = plan.assignedUnitIds
+    .map(unitId => state.units[unitId])
+    .filter(unit => Boolean(unit));
+  const visible = assigned
+    .filter(unit => isVisible(state, viewerId, unit.position))
+    .sort((left, right) => left!.id.localeCompare(right!.id))[0];
+  if (visible) return { evidence: 'visible', coord: { ...visible.position } };
+
+  const remembered = Object.values(
+    state.civilizations[viewerId]?.visibility.lastSeen ?? {},
+  )
+    .filter(isTrustedObservedLastSeenTile)
+    .filter(tile => tile.units?.some(unit =>
+      unit.owner === plan.actorId && plan.assignedUnitIds.includes(unit.id)))
+    .sort((left, right) =>
+      right.observedTurn - left.observedTurn
+      || hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+  return remembered
+    ? { evidence: 'remembered', coord: { ...remembered.coord } }
+    : null;
+}
+
+function safePlanTarget(
+  state: GameState,
+  viewerId: string,
+  plan: AIStrategicPlan,
+): Pick<StrategicWarning, 'targetLabel' | 'target'> {
+  if (plan.target.kind !== 'city') return {};
+  const city = state.cities[plan.target.id];
+  if (
+    city
+    && (
+      city.owner === viewerId
+      || isVisible(state, viewerId, city.position)
+    )
+  ) {
+    return {
+      targetLabel: city.name,
+      target: { kind: 'map', coord: { ...city.position }, label: city.name },
+    };
+  }
+  const remembered = trustedLastSeenAt(state, viewerId, plan.target.lastKnownPosition);
+  if (remembered?.city?.id === plan.target.id) {
+    return {
+      targetLabel: remembered.city.name,
+      target: {
+        kind: 'map',
+        coord: { ...remembered.coord },
+        label: remembered.city.name,
+      },
+    };
+  }
+  return {};
+}
+
+function targetIdentity(warning: Omit<StrategicWarning, 'warningKey' | 'playAudio'>): string {
+  if (warning.target) return hexKey(warning.target.coord);
+  if (warning.resource) return warning.resource;
+  return warning.regionLabel ?? 'regional';
+}
+
+function withKey(
+  warning: Omit<StrategicWarning, 'warningKey' | 'playAudio'>,
+): StrategicWarning {
+  return {
+    ...warning,
+    warningKey: [
+      warning.viewerId,
+      warning.actorId,
+      warning.kind,
+      targetIdentity(warning),
+    ].join(':'),
+    playAudio: false,
+  };
+}
+
+function samePlanTransition(
+  before: AIStrategicPlan | null | undefined,
+  after: AIStrategicPlan,
+  phase: AIStrategicPlan['phase'],
+): boolean {
+  return before?.id === after.id && before.phase === phase;
+}
+
+function deriveMajorWarnings(
+  before: GameState,
+  after: GameState,
+  viewerId: string,
+): StrategicWarning[] {
+  const warnings: StrategicWarning[] = [];
+  for (const actorId of Object.keys(after.opponentAI?.majorCivs ?? {}).sort()) {
+    const actor = after.civilizations[actorId];
+    if (!actor || actor.isHuman || actor.isEliminated) continue;
+    const plan = after.opponentAI!.majorCivs[actorId].primaryPlan;
+    if (!plan) continue;
+    const beforePlan = before.opponentAI?.majorCivs[actorId]?.primaryPlan;
+    const kind = plan.phase === 'mobilizing'
+      ? 'mobilizing'
+      : plan.phase === 'withdrawing' ? 'withdrawing' : null;
+    if (!kind || samePlanTransition(beforePlan, plan, plan.phase)) continue;
+    const evidence = planEvidence(after, viewerId, plan);
+    if (!evidence) continue;
+    const target = evidence.evidence === 'visible'
+      ? safePlanTarget(after, viewerId, plan)
+      : {};
+    warnings.push(withKey({
+      viewerId,
+      actorId,
+      actorName: actor.name,
+      kind,
+      evidence: evidence.evidence,
+      regionLabel: regionLabel(after, evidence.coord),
+      ...target,
+    }));
+  }
+  return warnings;
+}
+
+function derivePirateWarnings(
+  before: GameState,
+  after: GameState,
+  viewerId: string,
+): StrategicWarning[] {
+  const warnings: StrategicWarning[] = [];
+  const beforeIntel = before.pirates?.intelByCiv[viewerId] ?? {};
+  const afterIntel = after.pirates?.intelByCiv[viewerId] ?? {};
+  for (const factionId of Object.keys(afterIntel).sort()) {
+    const intel = afterIntel[factionId];
+    const previous = beforeIntel[factionId];
+    const kind = intel.knownBehavior === 'blockading'
+      ? 'blockade'
+      : intel.knownBehavior === 'raiding' ? 'raid' : null;
+    if (!kind || previous?.knownBehavior === intel.knownBehavior) continue;
+    const target = intel.lastKnownHeadquarters && intel.level !== 'rumor'
+      ? {
+          target: {
+            kind: 'map' as const,
+            coord: { ...intel.lastKnownHeadquarters.position },
+            label: 'Last known pirate waters',
+          },
+        }
+      : {};
+    warnings.push(withKey({
+      viewerId,
+      actorId: factionId,
+      actorName: 'Pirates',
+      kind,
+      evidence: 'earned-intel',
+      ...target,
+    }));
+  }
+  return warnings;
+}
+
+function deriveBarbarianWarnings(
+  before: GameState,
+  after: GameState,
+  viewerId: string,
+): StrategicWarning[] {
+  const warnings: StrategicWarning[] = [];
+  for (const campId of Object.keys(after.opponentAI?.barbarianCamps ?? {}).sort()) {
+    const plan = after.opponentAI!.barbarianCamps[campId];
+    const previous = before.opponentAI?.barbarianCamps[campId];
+    if (
+      plan.objective !== 'raid'
+      || previous?.id === plan.id && previous.phase === plan.phase
+    ) continue;
+    const coord = plan.target.kind === 'resource'
+      ? plan.target.position
+      : plan.target.kind === 'city' || plan.target.kind === 'unit'
+        ? plan.target.lastKnownPosition
+        : null;
+    if (!coord) continue;
+    const camp = after.barbarianCamps[campId];
+    const assignedUnits = plan.assignedUnitIds
+      .map(unitId => after.units[unitId])
+      .filter(unit => unit?.owner === 'barbarian');
+    const visibleThreat = [
+      ...(camp ? [camp.position] : []),
+      ...assignedUnits.map(unit => unit!.position),
+    ].some(position => isVisible(after, viewerId, position));
+    const rememberedThreat = Object.values(
+      after.civilizations[viewerId]?.visibility.lastSeen ?? {},
+    )
+      .filter(isTrustedObservedLastSeenTile)
+      .some(tile => tile.units?.some(unit =>
+        unit.owner === 'barbarian'
+        && plan.assignedUnitIds.includes(unit.id)));
+    if (!visibleThreat && !rememberedThreat) continue;
+    const targetIsSafe = after.map.tiles[hexKey(coord)]?.owner === viewerId
+      || isVisible(after, viewerId, coord)
+      || Boolean(trustedLastSeenAt(after, viewerId, coord));
+    if (!targetIsSafe) continue;
+    const resource = plan.target.kind === 'resource'
+      ? plan.target.resource
+      : undefined;
+    const label = resource ? `${resource} outpost` : 'raider target';
+    warnings.push(withKey({
+      viewerId,
+      actorId: `barbarian:${campId}`,
+      actorName: 'Raiders',
+      kind: 'raid',
+      evidence: visibleThreat ? 'visible' : 'remembered',
+      ...(resource ? { resource } : {}),
+      targetLabel: label,
+      target: { kind: 'map', coord: { ...coord }, label },
+    }));
+  }
+  return warnings;
+}
+
+function resourceTiles(state: GameState, viewerId: string, resource: ResourceType) {
+  return Object.values(state.map.tiles)
+    .filter(tile =>
+      tile.owner === viewerId
+      && tile.resource === resource
+      && tile.improvement !== 'none'
+      && tile.improvementTurnsLeft === 0)
+    .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)));
+}
+
+function deriveResourceWarnings(
+  before: GameState,
+  after: GameState,
+  viewerId: string,
+): StrategicWarning[] {
+  const beforeResources = getCivAvailableResources(before, viewerId, {
+    hostileOccupationEnabled: true,
+  });
+  const afterResources = getCivAvailableResources(after, viewerId, {
+    hostileOccupationEnabled: true,
+  });
+  const allResources = [...new Set([...beforeResources, ...afterResources])].sort();
+  const warnings: StrategicWarning[] = [];
+  for (const resource of allResources) {
+    const denied = beforeResources.has(resource) && !afterResources.has(resource);
+    const restored = !beforeResources.has(resource) && afterResources.has(resource);
+    if (!denied && !restored) continue;
+    const tiles = resourceTiles(denied ? after : before, viewerId, resource);
+    const tile = tiles.find(candidate => denied
+      ? isResourceTileDeniedByHostileOccupation(after, viewerId, candidate.coord)
+      : isResourceTileDeniedByHostileOccupation(before, viewerId, candidate.coord)
+        && !isResourceTileDeniedByHostileOccupation(after, viewerId, candidate.coord));
+    if (!tile) continue;
+    const label = `${resource} outpost`;
+    warnings.push(withKey({
+      viewerId,
+      actorId: 'hostile-occupation',
+      actorName: 'Hostile raiders',
+      kind: denied ? 'resource-denied' : 'resource-restored',
+      evidence: 'visible',
+      resource,
+      regionLabel: `${regionLabel(after, tile.coord).replace(' marches', '')} outpost`,
+      targetLabel: label,
+      target: { kind: 'map', coord: { ...tile.coord }, label },
+    }));
+  }
+  return warnings;
+}
+
+function deriveRecoveryWarning(
+  before: GameState,
+  after: GameState,
+  viewerId: string,
+): StrategicWarning[] {
+  const previous = before.opponentAI?.pressureByHuman[viewerId];
+  const current = after.opponentAI?.pressureByHuman[viewerId];
+  if (
+    !previous
+    || !current
+    || current.lastResolvedThreatTurn !== after.turn
+    || previous.activeIndependentThreatIds.every(id =>
+      current.activeIndependentThreatIds.includes(id))
+  ) return [];
+  return [withKey({
+    viewerId,
+    actorId: 'independent-threats',
+    actorName: 'Raiders',
+    kind: 'recovery',
+    evidence: 'earned-intel',
+  })];
+}
+
+export function deriveStrategicWarningTransitions(
+  beforeRound: Readonly<GameState>,
+  finalState: GameState,
+  viewerId: string,
+  options: StrategicWarningOptions = {},
+): StrategicWarning[] {
+  if (!options.purposefulAIEnabled) return [];
+  const viewer = finalState.civilizations[viewerId];
+  if (!viewer?.isHuman || viewer.isEliminated) return [];
+  const ledger = finalState.opponentAI?.pressureByHuman[viewerId] ?? emptyLedger();
+  const warnings = [
+    ...deriveMajorWarnings(beforeRound as GameState, finalState, viewerId),
+    ...derivePirateWarnings(beforeRound as GameState, finalState, viewerId),
+    ...deriveBarbarianWarnings(beforeRound as GameState, finalState, viewerId),
+    ...deriveResourceWarnings(beforeRound as GameState, finalState, viewerId),
+    ...deriveRecoveryWarning(beforeRound as GameState, finalState, viewerId),
+  ]
+    .filter(warning => ledger.lastWarningTurnByKey[warning.warningKey] !== finalState.turn)
+    .sort((left, right) =>
+      left.actorId.localeCompare(right.actorId)
+      || left.kind.localeCompare(right.kind)
+      || left.warningKey.localeCompare(right.warningKey));
+  let audioAssigned = ledger.lastStrategicAudioTurn === finalState.turn;
+  return warnings.map(warning => {
+    const playAudio = !audioAssigned;
+    audioAssigned = true;
+    return { ...warning, playAudio };
+  });
+}
+
+export function applyStrategicWarningTransitions(
+  beforeRound: Readonly<GameState>,
+  finalState: GameState,
+  bus: EventBus,
+  options: StrategicWarningOptions = {},
+): GameState {
+  if (!options.purposefulAIEnabled) return finalState;
+  const opponentAI = structuredClone(
+    finalState.opponentAI ?? createEmptyOpponentAIState(),
+  );
+  const warnings: StrategicWarning[] = [];
+  for (const viewerId of Object.values(finalState.civilizations)
+    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .map(civ => civ.id)
+    .sort()) {
+    const viewerWarnings = deriveStrategicWarningTransitions(
+      beforeRound,
+      finalState,
+      viewerId,
+      options,
+    );
+    if (viewerWarnings.length === 0) continue;
+    const ledger = opponentAI.pressureByHuman[viewerId] ?? emptyLedger();
+    opponentAI.pressureByHuman[viewerId] = {
+      ...ledger,
+      lastWarningTurnByKey: {
+        ...ledger.lastWarningTurnByKey,
+        ...Object.fromEntries(viewerWarnings.map(warning => [
+          warning.warningKey,
+          finalState.turn,
+        ])),
+      },
+    };
+    warnings.push(...viewerWarnings);
+  }
+  const nextState = { ...finalState, opponentAI };
+  for (const warning of warnings) bus.emit('ai:strategic-warning', warning);
+  return nextState;
+}

--- a/src/systems/strategic-warning-system.ts
+++ b/src/systems/strategic-warning-system.ts
@@ -16,10 +16,6 @@ import {
   isResourceTileDeniedByHostileOccupation,
 } from '@/systems/resource-acquisition-system';
 
-export interface StrategicWarningOptions {
-  purposefulAIEnabled?: boolean;
-}
-
 type StrategicWarning = GameEvents['ai:strategic-warning'];
 
 function emptyLedger(): HumanPressureLedger {
@@ -283,12 +279,8 @@ function deriveResourceWarnings(
   after: GameState,
   viewerId: string,
 ): StrategicWarning[] {
-  const beforeResources = getCivAvailableResources(before, viewerId, {
-    hostileOccupationEnabled: true,
-  });
-  const afterResources = getCivAvailableResources(after, viewerId, {
-    hostileOccupationEnabled: true,
-  });
+  const beforeResources = getCivAvailableResources(before, viewerId);
+  const afterResources = getCivAvailableResources(after, viewerId);
   const allResources = [...new Set([...beforeResources, ...afterResources])].sort();
   const warnings: StrategicWarning[] = [];
   for (const resource of allResources) {
@@ -344,9 +336,7 @@ export function deriveStrategicWarningTransitions(
   beforeRound: Readonly<GameState>,
   finalState: GameState,
   viewerId: string,
-  options: StrategicWarningOptions = {},
 ): StrategicWarning[] {
-  if (!options.purposefulAIEnabled) return [];
   const viewer = finalState.civilizations[viewerId];
   if (!viewer?.isHuman || viewer.isEliminated) return [];
   const ledger = finalState.opponentAI?.pressureByHuman[viewerId] ?? emptyLedger();
@@ -374,9 +364,7 @@ export function applyStrategicWarningTransitions(
   beforeRound: Readonly<GameState>,
   finalState: GameState,
   bus: EventBus,
-  options: StrategicWarningOptions = {},
 ): GameState {
-  if (!options.purposefulAIEnabled) return finalState;
   const opponentAI = structuredClone(
     finalState.opponentAI ?? createEmptyOpponentAIState(),
   );
@@ -389,7 +377,6 @@ export function applyStrategicWarningTransitions(
       beforeRound,
       finalState,
       viewerId,
-      options,
     );
     if (viewerWarnings.length === 0) continue;
     const ledger = opponentAI.pressureByHuman[viewerId] ?? emptyLedger();

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -1,11 +1,324 @@
-import type { BarbarianCamp, City, PirateFleet, GameState, GameMap, HexCoord } from '@/core/types';
+import type {
+  AIStrategicPlan,
+  BarbarianCamp,
+  City,
+  PirateFleet,
+  GameState,
+  GameMap,
+  HexCoord,
+  HumanPressureLedger,
+} from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
-import { hexKey, hexNeighbors, hexDistance } from './hex-utils';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
+import {
+  OPPONENT_CHALLENGE_PROFILES,
+  resolveOpponentChallenge,
+} from '@/core/opponent-challenge';
+import { BEAST_DEFINITIONS } from './beast-definitions';
+import { hexKey, hexNeighbors, hexDistance, wrappedHexDistance } from './hex-utils';
 import { createUnit } from './unit-system';
 
 export const PIRATE_OWNER = 'pirate';
 
 const NON_VIABLE_TERRAIN = new Set(['ocean', 'coast', 'mountain', 'snow']);
+const BARBARIAN_OPERATIONAL_RADIUS = 7;
+
+export interface IndependentThreatDecision {
+  allowed: boolean;
+  reason: 'allowed' | 'migration-grace' | 'recovery' | 'pressure-cap';
+  activeCount: number;
+  cap: number;
+}
+
+export interface IndependentThreatSpawnCandidate {
+  threatId: string;
+  position: HexCoord;
+  affectedHumanIds: string[];
+}
+
+export interface IndependentThreatSpawnPolicy {
+  canStart(state: GameState, candidate: IndependentThreatSpawnCandidate): boolean;
+}
+
+function emptyPressureLedger(): HumanPressureLedger {
+  return {
+    activeIndependentThreatIds: [],
+    recoveryUntilTurn: 0,
+    lastResolvedThreatTurn: null,
+    lastWarningTurnByKey: {},
+    lastStrategicAudioTurn: null,
+  };
+}
+
+function threatDistance(state: GameState, a: HexCoord, b: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(a, b, state.map.width)
+    : hexDistance(a, b);
+}
+
+function humanAssetPositions(state: GameState, humanId: string): HexCoord[] {
+  return [
+    ...Object.values(state.cities)
+      .filter(city => city.owner === humanId)
+      .map(city => city.position),
+    ...Object.values(state.units)
+      .filter(unit => unit.owner === humanId && !unit.transportId)
+      .map(unit => unit.position),
+    ...Object.values(state.map.tiles)
+      .filter(tile =>
+        tile.owner === humanId
+        && tile.resource !== null
+        && tile.improvement !== 'none'
+        && tile.improvementTurnsLeft === 0)
+      .map(tile => tile.coord),
+  ];
+}
+
+export function deriveHumansMateriallyAffectedByPosition(
+  state: GameState,
+  position: HexCoord,
+  radius: number,
+): string[] {
+  return Object.values(state.civilizations)
+    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .filter(civ =>
+      humanAssetPositions(state, civ.id)
+        .some(asset => threatDistance(state, position, asset) <= radius))
+    .map(civ => civ.id)
+    .sort();
+}
+
+function planTargetOwner(state: GameState, plan: AIStrategicPlan): string | null {
+  if (plan.target.kind === 'city') return state.cities[plan.target.id]?.owner ?? null;
+  if (plan.target.kind === 'unit') return state.units[plan.target.id]?.owner ?? null;
+  if (plan.target.kind === 'resource') {
+    return state.map.tiles[hexKey(plan.target.position)]?.owner ?? null;
+  }
+  return null;
+}
+
+function barbarianMateriallyAffectsHuman(
+  state: GameState,
+  campId: string,
+  humanId: string,
+): boolean {
+  const plan = state.opponentAI?.barbarianCamps[campId];
+  if (plan && planTargetOwner(state, plan) === humanId) return true;
+  if (!plan) return false;
+  const assets = humanAssetPositions(state, humanId);
+  return plan.assignedUnitIds.some(unitId => {
+    const unit = state.units[unitId];
+    return unit?.owner === 'barbarian'
+      && assets.some(position =>
+        threatDistance(state, unit.position, position) <= BARBARIAN_OPERATIONAL_RADIUS);
+  });
+}
+
+function pirateMateriallyAffectsHuman(
+  state: GameState,
+  factionId: string,
+  humanId: string,
+): boolean {
+  const faction = state.pirates?.factions[factionId];
+  if (!faction) return false;
+  if (faction.contract?.targetId === humanId) return true;
+  if (faction.intent?.targetCivId === humanId) return true;
+  if (
+    faction.intent?.targetCityId
+    && state.cities[faction.intent.targetCityId]?.owner === humanId
+  ) return true;
+  if (
+    faction.intent?.targetUnitId
+    && state.units[faction.intent.targetUnitId]?.owner === humanId
+  ) return true;
+  return Object.values(state.pirateFleets ?? {})
+    .some(fleet => fleet.targetCivId === humanId && fleet.id === factionId);
+}
+
+function beastMateriallyAffectsHuman(
+  state: GameState,
+  lairId: string,
+  humanId: string,
+): boolean {
+  const lair = state.beasts?.lairs[lairId];
+  if (!lair || lair.status !== 'awake') return false;
+  const radius = BEAST_DEFINITIONS[lair.beastId].leashRadius;
+  const origins = [
+    lair.position,
+    ...lair.unitIds.flatMap(unitId => {
+      const unit = state.units[unitId];
+      return unit ? [unit.position] : [];
+    }),
+  ];
+  return humanAssetPositions(state, humanId)
+    .some(asset => origins.some(origin => threatDistance(state, origin, asset) <= radius));
+}
+
+function isIndependentThreatLive(state: GameState, threatId: string): boolean {
+  if (threatId.startsWith('barbarian:')) {
+    return Boolean(state.barbarianCamps[threatId.slice('barbarian:'.length)]);
+  }
+  if (threatId.startsWith('pirate:')) {
+    return Boolean(state.pirates?.factions[threatId.slice('pirate:'.length)]);
+  }
+  if (threatId.startsWith('beast:')) {
+    return state.beasts?.lairs[threatId.slice('beast:'.length)]?.status === 'awake';
+  }
+  return false;
+}
+
+export function deriveActiveIndependentThreatIds(
+  state: GameState,
+  humanId: string,
+): string[] {
+  const human = state.civilizations[humanId];
+  if (!human?.isHuman || human.isEliminated) return [];
+  const active = new Set<string>();
+  for (const campId of Object.keys(state.barbarianCamps).sort()) {
+    if (barbarianMateriallyAffectsHuman(state, campId, humanId)) {
+      active.add(`barbarian:${campId}`);
+    }
+  }
+  for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
+    if (pirateMateriallyAffectsHuman(state, factionId, humanId)) {
+      active.add(`pirate:${factionId}`);
+    }
+  }
+  for (const lairId of Object.keys(state.beasts?.lairs ?? {}).sort()) {
+    if (beastMateriallyAffectsHuman(state, lairId, humanId)) {
+      active.add(`beast:${lairId}`);
+    }
+  }
+  for (
+    const threatId of state.opponentAI?.pressureByHuman[humanId]
+      ?.activeIndependentThreatIds ?? []
+  ) {
+    if (isIndependentThreatLive(state, threatId)) active.add(threatId);
+  }
+  return [...active].sort();
+}
+
+export function canStartIndependentThreat(
+  state: GameState,
+  humanId: string,
+  threatId: string,
+): IndependentThreatDecision {
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+  const ledger = state.opponentAI?.pressureByHuman[humanId] ?? emptyPressureLedger();
+  const activeCount = ledger.activeIndependentThreatIds.length;
+  const base = { activeCount, cap: profile.maxIndependentCrisesPerHuman };
+  if (ledger.activeIndependentThreatIds.includes(threatId)) {
+    return { ...base, allowed: true, reason: 'allowed' };
+  }
+  if ((state.opponentAI?.migrationGraceRoundsRemaining ?? 0) > 0) {
+    return { ...base, allowed: false, reason: 'migration-grace' };
+  }
+  if (state.turn < ledger.recoveryUntilTurn) {
+    return { ...base, allowed: false, reason: 'recovery' };
+  }
+  if (activeCount >= profile.maxIndependentCrisesPerHuman) {
+    return { ...base, allowed: false, reason: 'pressure-cap' };
+  }
+  return { ...base, allowed: true, reason: 'allowed' };
+}
+
+export function reserveIndependentThreatForHumans(
+  state: GameState,
+  threatId: string,
+  humanIds: string[],
+): GameState {
+  if (!state.opponentAI) return state;
+  const pressureByHuman = { ...state.opponentAI.pressureByHuman };
+  let changed = false;
+  for (const humanId of [...new Set(humanIds)].sort()) {
+    const civ = state.civilizations[humanId];
+    if (!civ?.isHuman || civ.isEliminated) continue;
+    const ledger = pressureByHuman[humanId] ?? emptyPressureLedger();
+    if (ledger.activeIndependentThreatIds.includes(threatId)) continue;
+    changed = true;
+    pressureByHuman[humanId] = {
+      ...ledger,
+      activeIndependentThreatIds: [
+        ...ledger.activeIndependentThreatIds,
+        threatId,
+      ].sort(),
+    };
+  }
+  return changed ? {
+    ...state,
+    opponentAI: { ...state.opponentAI, pressureByHuman },
+  } : state;
+}
+
+export function processIndependentThreatPressureForHumans(
+  state: GameState,
+  bus: EventBus,
+): GameState {
+  const initialOpponentAI = structuredClone(state.opponentAI ?? createEmptyOpponentAIState());
+  const profile = OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)];
+  const humanIds = Object.values(state.civilizations)
+    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .map(civ => civ.id)
+    .sort();
+  initialOpponentAI.pressureByHuman = Object.fromEntries(humanIds.map(humanId => [
+    humanId,
+    initialOpponentAI.pressureByHuman[humanId] ?? emptyPressureLedger(),
+  ]));
+  const pressureByHuman: Record<string, HumanPressureLedger> = {};
+  for (const humanId of humanIds) {
+    const previous = initialOpponentAI.pressureByHuman[humanId] ?? emptyPressureLedger();
+    const activeIndependentThreatIds = deriveActiveIndependentThreatIds(state, humanId);
+    const resolved = previous.activeIndependentThreatIds
+      .filter(threatId => !activeIndependentThreatIds.includes(threatId));
+    pressureByHuman[humanId] = {
+      ...previous,
+      activeIndependentThreatIds,
+      ...(resolved.length > 0 ? {
+        recoveryUntilTurn: state.turn + profile.recoveryRounds,
+        lastResolvedThreatTurn: state.turn,
+      } : {}),
+    };
+  }
+  initialOpponentAI.pressureByHuman = pressureByHuman;
+  let nextState: GameState = { ...state, opponentAI: initialOpponentAI };
+  const spawnPolicy: IndependentThreatSpawnPolicy = {
+    canStart: (candidateState, candidate) =>
+      candidate.affectedHumanIds.every(humanId =>
+        canStartIndependentThreat(candidateState, humanId, candidate.threatId).allowed),
+  };
+  for (const humanId of humanIds) {
+    const landmassIds = [...new Set(
+      nextState.civilizations[humanId].cities.flatMap(cityId => {
+        const city = nextState.cities[cityId];
+        const regionKey = city
+          ? nextState.map.tiles[hexKey(city.position)]?.regionKey
+          : undefined;
+        return regionKey ? [regionKey] : [];
+      }),
+    )].sort();
+    for (const landmassId of landmassIds) {
+      let candidate: IndependentThreatSpawnCandidate | null = null;
+      const previousCounter = nextState.idCounters.nextCampId;
+      const spawned = processLandResurgence(nextState, humanId, landmassId, bus, {
+        spawnPolicy: {
+          canStart: (candidateState, nextCandidate) => {
+            candidate = nextCandidate;
+            return spawnPolicy.canStart(candidateState, nextCandidate);
+          },
+        },
+      });
+      if (spawned.idCounters.nextCampId === previousCounter || !candidate) continue;
+      const accepted = candidate as IndependentThreatSpawnCandidate;
+      nextState = reserveIndependentThreatForHumans(
+        spawned,
+        accepted.threatId,
+        accepted.affectedHumanIds,
+      );
+    }
+  }
+
+  return nextState;
+}
 
 // ── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -115,6 +428,7 @@ export function processLandResurgence(
   civId: string,
   landmassId: string,
   bus: EventBus,
+  options: { spawnPolicy?: IndependentThreatSpawnPolicy } = {},
 ): GameState {
   const cooldownKey = `${civId}:${landmassId}`;
   const cooldownUntil = state.resurgentCampCooldownByCivLandmass?.[cooldownKey] ?? 0;
@@ -157,7 +471,22 @@ export function processLandResurgence(
   const strength = resurgenceCampStrength(state.era, rng);
   const civ = state.civilizations[civId];
 
-  const campId = `camp-${state.idCounters.nextCampId++}`;
+  const campId = `camp-${state.idCounters.nextCampId}`;
+  const affectedHumanIds = [...new Set([
+    civId,
+    ...deriveHumansMateriallyAffectedByPosition(
+      state,
+      chosen.coord,
+      BARBARIAN_OPERATIONAL_RADIUS,
+    ),
+  ])].sort();
+  if (options.spawnPolicy && !options.spawnPolicy.canStart(state, {
+    threatId: `barbarian:${campId}`,
+    position: { ...chosen.coord },
+    affectedHumanIds,
+  })) {
+    return state;
+  }
   const camp: BarbarianCamp = {
     id: campId,
     position: { ...chosen.coord },
@@ -169,6 +498,7 @@ export function processLandResurgence(
 
   const updatedState: GameState = {
     ...state,
+    idCounters: { ...state.idCounters, nextCampId: state.idCounters.nextCampId + 1 },
     barbarianCamps: { ...state.barbarianCamps, [campId]: camp },
     resurgentCampCooldownByCivLandmass: {
       ...(state.resurgentCampCooldownByCivLandmass ?? {}),

--- a/src/ui/campaign-entry-flow.ts
+++ b/src/ui/campaign-entry-flow.ts
@@ -16,7 +16,6 @@ export type CampaignEntryCandidate =
   | { kind: 'import'; state: GameState };
 
 export interface CampaignEntryDependencies {
-  purposefulAIEnabled: boolean;
   persistStoredChoice: typeof rewriteLoadedSaveEntry;
   persistImport: typeof autoSave;
   showChallengePrompt: typeof showLegacyOpponentChallengePrompt;
@@ -39,7 +38,7 @@ export function beginCampaignEntry(
     return 'entered';
   };
 
-  if (!dependencies.purposefulAIEnabled || isOpponentChallenge(normalized.opponentChallenge)) {
+  if (isOpponentChallenge(normalized.opponentChallenge)) {
     return enter(normalized);
   }
 

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -1,6 +1,5 @@
 import type { BeastsMode, CustomCivDefinition, SoloSetupConfig, MapScript, OpponentChallenge } from '@/core/types';
 import { MAP_DIMENSIONS } from '@/core/game-state';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { createCivSelectPanel } from '@/ui/civ-select';
 import { createCustomCivPanel } from '@/ui/custom-civ-panel';
 import { getPlayableCivDefinitions } from '@/systems/civ-registry';
@@ -20,7 +19,6 @@ export interface CampaignSetupCallbacks {
 
 export interface CampaignSetupOptions {
   initialCustomCivilizations?: CustomCivDefinition[];
-  purposefulAIEnabled?: boolean;
 }
 
 function createLabeledSelect(labelText: string, id: string): { wrapper: HTMLDivElement; select: HTMLSelectElement } {
@@ -66,7 +64,6 @@ function syncChoiceButtonState(button: HTMLButtonElement, selected: boolean): vo
 
 export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSetupCallbacks, options?: CampaignSetupOptions): HTMLElement {
   container.querySelector('#campaign-setup')?.remove();
-  const purposefulAIEnabled = options?.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const shell = createSetupShell({
     panelId: 'campaign-setup',
@@ -331,21 +328,19 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
 
   let selectedOpponentChallenge: OpponentChallenge = 'standard';
-  if (purposefulAIEnabled) {
-    const challengeSection = createSetupSection({
-      title: 'Opponent Challenge',
-      description: 'Choose how computer rivals and roaming threats plan and coordinate.',
-    });
-    challengeSection.section.dataset.opponentChallengeSection = '';
-    hero.appendChild(challengeSection.section);
-    challengeSection.content.appendChild(createOpponentChallengeSelector({
-      selected: selectedOpponentChallenge,
-      mode: 'new-game',
-      onSelect: challenge => {
-        selectedOpponentChallenge = challenge;
-      },
-    }));
-  }
+  const challengeSection = createSetupSection({
+    title: 'Opponent Challenge',
+    description: 'Choose how computer rivals and roaming threats plan and coordinate.',
+  });
+  challengeSection.section.dataset.opponentChallengeSection = '';
+  hero.appendChild(challengeSection.section);
+  challengeSection.content.appendChild(createOpponentChallengeSelector({
+    selected: selectedOpponentChallenge,
+    mode: 'new-game',
+    onSelect: challenge => {
+      selectedOpponentChallenge = challenge;
+    },
+  }));
 
   // Legendary Beasts mode section
   let beastsModeSelected: BeastsMode = 'wild';
@@ -500,7 +495,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       gameTitle,
       customCivilizations,
       mapScript: mapScriptSelect.value as MapScript,
-      ...(purposefulAIEnabled ? { opponentChallenge: selectedOpponentChallenge } : {}),
+      opponentChallenge: selectedOpponentChallenge,
       settingsOverrides: { beastsMode: beastsModeSelected },
     });
   });

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -1,6 +1,5 @@
 import type { CustomCivDefinition, HotSeatConfig, HotSeatPlayer, MapScript, OpponentChallenge } from '@/core/types';
 import { MAP_DIMENSIONS } from '@/core/game-state';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import { createCivSelectPanel } from './civ-select';
 import { createCustomCivPanel } from './custom-civ-panel';
 import { createDefaultSettings } from '@/core/game-state';
@@ -18,7 +17,6 @@ export interface HotSeatSetupCallbacks {
 
 export interface HotSeatSetupOptions {
   initialCustomCivilizations?: CustomCivDefinition[];
-  purposefulAIEnabled?: boolean;
 }
 
 export function showHotSeatSetup(
@@ -28,7 +26,6 @@ export function showHotSeatSetup(
 ): void {
   const existing = document.getElementById('hotseat-setup');
   if (existing) existing.remove();
-  const purposefulAIEnabled = options?.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const panel = document.createElement('div');
   panel.id = 'hotseat-setup';
@@ -220,11 +217,7 @@ export function showHotSeatSetup(
     nextBtn.style.cssText = 'padding:10px 24px;min-height:44px;background:rgba(232,193,112,0.3);border:2px solid #e8c170;border-radius:8px;color:#e8c170;cursor:pointer;font-size:14px;font-weight:bold;';
     nextBtn.textContent = 'Next';
     nextBtn.addEventListener('click', () => {
-      if (purposefulAIEnabled) {
-        showOpponentChallengeStage();
-      } else {
-        showPlayerCountStage();
-      }
+      showOpponentChallengeStage();
     });
 
     nav.appendChild(backBtn);
@@ -461,10 +454,6 @@ export function showHotSeatSetup(
     };
 
     panel.remove();
-    if (purposefulAIEnabled) {
-      callbacks.onComplete(config, selectedOpponentChallenge);
-    } else {
-      callbacks.onComplete(config);
-    }
+    callbacks.onComplete(config, selectedOpponentChallenge);
   }
 }

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -6,6 +6,7 @@ import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { REVOLT_UNREST_TURNS, BREAKAWAY_REVOLT_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import type { NotificationEntry } from '@/core/notification-log';
+import { presentStrategicWarning } from '@/ui/strategic-warning-presentation';
 
 export type NotificationSink = (
   civId: string,
@@ -239,6 +240,33 @@ export function queueFirstContactPendingEvents(
   const bName = state.civilizations[civB]?.name ?? civB;
   collectEvent(state.pendingEvents, civA, { type: 'first-contact', message: `Encountered ${bName}.`, turn: state.turn });
   collectEvent(state.pendingEvents, civB, { type: 'first-contact', message: `Encountered ${aName}.`, turn: state.turn });
+}
+
+export function routeStrategicWarning(
+  event: GameEvents['ai:strategic-warning'],
+  sink: NotificationSink,
+): void {
+  const presentation = presentStrategicWarning(event);
+  sink(
+    event.viewerId,
+    presentation.message,
+    presentation.type,
+    presentation.target,
+  );
+}
+
+export function queueStrategicWarningPendingEvent(
+  state: GameState,
+  event: GameEvents['ai:strategic-warning'],
+): void {
+  state.pendingEvents ??= {};
+  const presentation = presentStrategicWarning(event);
+  collectEvent(state.pendingEvents, event.viewerId, {
+    type: 'ai:strategic-warning',
+    message: presentation.message,
+    turn: state.turn,
+    ...(presentation.target ? { target: presentation.target } : {}),
+  });
 }
 
 // Routes to the defender's owner regardless of who is currently acting.

--- a/src/ui/pause-menu-panel.ts
+++ b/src/ui/pause-menu-panel.ts
@@ -1,7 +1,6 @@
 import { createSavePanel } from '@/ui/save-panel';
 import { createGameButton } from '@/ui/ui-kit';
 import type { OpponentChallenge } from '@/core/types';
-import { PURPOSEFUL_AI_FEATURE_ENABLED } from '@/core/feature-flags';
 import {
   OPPONENT_CHALLENGE_COPY,
   createOpponentChallengeSelector,
@@ -33,10 +32,6 @@ export interface PauseMenuCallbacks {
   opponentChallenge: OpponentChallenge;
   pendingOpponentChallenge?: OpponentChallenge;
   onOpponentChallengeChange: (challenge: OpponentChallenge) => void;
-}
-
-export interface PauseMenuOptions {
-  purposefulAIEnabled?: boolean;
 }
 
 interface PauseMenuViewState {
@@ -226,7 +221,6 @@ function buildOpponentChallengeSettings(
 }
 
 interface PauseMenuMainViewOptions {
-  purposefulAIEnabled: boolean;
   announcement: string;
   onOpponentChallengeSelect: (challenge: OpponentChallenge) => void;
 }
@@ -279,13 +273,11 @@ function buildMainView(
   newGameBtn.addEventListener('click', () => buildConfirmView(panel, body, container, callbacks, options));
   body.appendChild(newGameBtn);
 
-  if (options.purposefulAIEnabled) {
-    body.appendChild(buildOpponentChallengeSettings(
-      callbacks,
-      options.announcement,
-      options.onOpponentChallengeSelect,
-    ));
-  }
+  body.appendChild(buildOpponentChallengeSettings(
+    callbacks,
+    options.announcement,
+    options.onOpponentChallengeSelect,
+  ));
 
   // Spec 3: per-channel audio settings at bottom of pause menu
   body.appendChild(buildAudioSettings(callbacks));
@@ -339,11 +331,9 @@ function buildConfirmView(
 function renderPauseMenu(
   container: HTMLElement,
   callbacks: PauseMenuCallbacks,
-  options: PauseMenuOptions,
   viewState: PauseMenuViewState,
 ): HTMLElement {
   document.getElementById('pause-menu')?.remove();
-  const purposefulAIEnabled = options.purposefulAIEnabled ?? PURPOSEFUL_AI_FEATURE_ENABLED;
 
   const overlay = document.createElement('div');
   overlay.id = 'pause-menu';
@@ -363,7 +353,7 @@ function renderPauseMenu(
     border: '1px solid rgba(255,255,255,0.2)',
     borderRadius: '12px',
     padding: '20px',
-    width: purposefulAIEnabled ? 'min(760px, calc(100vw - 32px))' : '280px',
+    width: 'min(760px, calc(100vw - 32px))',
     maxHeight: 'min(90dvh, 760px)',
     overflowY: 'auto',
     color: '#f4f1e8',
@@ -377,7 +367,6 @@ function renderPauseMenu(
   container.appendChild(overlay);
 
   buildMainView(overlay, body, container, callbacks, {
-    purposefulAIEnabled,
     announcement: viewState.announcement ?? '',
     onOpponentChallengeSelect: challenge => {
       callbacks.onOpponentChallengeChange(challenge);
@@ -387,7 +376,6 @@ function renderPauseMenu(
       renderPauseMenu(
         container,
         { ...callbacks, pendingOpponentChallenge },
-        options,
         {
           announcement: pendingOpponentChallenge
             ? `${OPPONENT_CHALLENGE_COPY[challenge].label} will apply next round`
@@ -410,7 +398,6 @@ function renderPauseMenu(
 export function showPauseMenu(
   container: HTMLElement,
   callbacks: PauseMenuCallbacks,
-  options: PauseMenuOptions = {},
 ): HTMLElement {
-  return renderPauseMenu(container, callbacks, options, {});
+  return renderPauseMenu(container, callbacks, {});
 }

--- a/src/ui/strategic-warning-presentation.ts
+++ b/src/ui/strategic-warning-presentation.ts
@@ -1,0 +1,76 @@
+import type { GameEvents } from '@/core/types';
+
+export interface StrategicWarningPresentation {
+  message: string;
+  type: 'info' | 'warning' | 'success';
+  target?: GameEvents['ai:strategic-warning']['target'];
+}
+
+export function presentStrategicWarning(
+  event: GameEvents['ai:strategic-warning'],
+): StrategicWarningPresentation {
+  if (event.kind === 'recovery') {
+    return {
+      message: 'The raid was broken. Independent threats will need time to regroup.',
+      type: 'success',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.kind === 'resource-restored') {
+    return {
+      message: `Access to ${event.resource ?? 'the resource'} at the ${event.regionLabel ?? 'outpost'} has been restored.`,
+      type: 'success',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.kind === 'resource-denied') {
+    return {
+      message: `Hostile raiders have cut access to ${event.resource ?? 'a resource'} at the ${event.regionLabel ?? 'outpost'}. Drive them off to restore the resource.`,
+      type: 'warning',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.actorId.startsWith('pirate')) {
+    const message = event.kind === 'blockade'
+      ? 'Pirate activity indicates a blockade is forming. Review known pirate waters and protect coastal trade.'
+      : 'Pirate activity indicates a raid is forming. Review known pirate waters and protect exposed shipping.';
+    return {
+      message,
+      type: 'warning',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.kind === 'raid' && event.resource) {
+    return {
+      message: `Raiders are moving toward the ${event.targetLabel ?? `${event.resource} outpost`}. Intercept them or destroy their camp.`,
+      type: 'warning',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.kind === 'withdrawing') {
+    return {
+      message: `${event.actorName} forces are withdrawing. Their immediate pressure may be easing.`,
+      type: 'info',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.evidence === 'remembered') {
+    return {
+      message: `Scouts last reported ${event.actorName} troops gathering in the ${event.regionLabel ?? 'border marches'}. Their current position is uncertain.`,
+      type: 'warning',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  if (event.targetLabel) {
+    return {
+      message: `A ${event.actorName} force is gathering against ${event.targetLabel}. Reinforce the city, disrupt the rally, or seek peace.`,
+      type: 'warning',
+      ...(event.target ? { target: event.target } : {}),
+    };
+  }
+  return {
+    message: `A ${event.actorName} force is gathering near our border. Reinforce nearby cities or scout their approach.`,
+    type: 'warning',
+    ...(event.target ? { target: event.target } : {}),
+  };
+}

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -1,5 +1,10 @@
 import type { GameState } from '@/core/types';
-import { generateSummary, type TurnSummary } from '@/core/hotseat-events';
+import {
+  clearEventsForPlayer,
+  generateSummary,
+  type TurnSummary,
+} from '@/core/hotseat-events';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
 
@@ -16,6 +21,47 @@ export interface TurnHandoffController {
     callbacks: { onRetry: () => void; onReturnToSaves: () => void },
   ): void;
   remove(): void;
+}
+
+export interface TurnHandoffAcknowledgement {
+  state: GameState;
+  playStrategicWarningAudio: boolean;
+}
+
+export function acknowledgeTurnHandoffSummary(
+  state: GameState,
+  viewerId: string,
+  summary: TurnSummary,
+): TurnHandoffAcknowledgement {
+  const hasStrategicWarning = summary.events.some(
+    event => event.type === 'ai:strategic-warning',
+  );
+  const opponentAI = structuredClone(
+    state.opponentAI ?? createEmptyOpponentAIState(),
+  );
+  const ledger = opponentAI.pressureByHuman[viewerId] ?? {
+    activeIndependentThreatIds: [],
+    recoveryUntilTurn: 0,
+    lastResolvedThreatTurn: null,
+    lastWarningTurnByKey: {},
+    lastStrategicAudioTurn: null,
+  };
+  const playStrategicWarningAudio = hasStrategicWarning
+    && ledger.lastStrategicAudioTurn !== summary.turn;
+  if (hasStrategicWarning) {
+    opponentAI.pressureByHuman[viewerId] = {
+      ...ledger,
+      lastStrategicAudioTurn: summary.turn,
+    };
+  }
+  return {
+    state: {
+      ...state,
+      pendingEvents: clearEventsForPlayer(state.pendingEvents ?? {}, viewerId),
+      ...(hasStrategicWarning ? { opponentAI } : {}),
+    },
+    playStrategicWarningAudio,
+  };
 }
 
 let activeHandoffController: TurnHandoffController | null = null;

--- a/tests/ai/ai-plan-portfolio.test.ts
+++ b/tests/ai/ai-plan-portfolio.test.ts
@@ -224,6 +224,37 @@ describe('major-civilization plan portfolios', () => {
     })).portfolio.defensePlansByCityId.old).toBeUndefined();
   });
 
+  it('does not retain a defense plan beyond its explicit expiry', () => {
+    const expired = plan('defend-expired', {
+      objective: 'defend',
+      target: { kind: 'city', id: 'old', lastKnownPosition: { q: 1, r: 1 } },
+      expiresAfterTurn: 9,
+      lastProgressTurn: 9,
+    });
+
+    const result = refreshMajorCivPortfolio(context({
+      portfolio: {
+        ...createEmptyMajorCivPortfolio(),
+        defensePlansByCityId: { old: expired },
+      },
+      cityThreats: [{
+        cityId: 'old',
+        position: { q: 1, r: 1 },
+        theaterId: 'home',
+        travelTurns: 2,
+        alreadyAttackedTerritory: true,
+        captureRisk: 80,
+        hostileStrength: 30,
+        isCapital: false,
+        isLastCity: false,
+        threatStillValid: true,
+      }],
+    }));
+
+    expect(result.portfolio.defensePlansByCityId.old?.id).not.toBe('defend-expired');
+    expect(result.portfolio.defensePlansByCityId.old?.createdTurn).toBe(10);
+  });
+
   it('derives receding-defense grace from persisted progress when no counter is supplied', () => {
     const recent = plan('defend-recent', {
       objective: 'defend',

--- a/tests/ai/ai-round-scheduler.test.ts
+++ b/tests/ai/ai-round-scheduler.test.ts
@@ -48,18 +48,20 @@ describe('AI round scheduler', () => {
     const seen: string[] = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      execute: (current, civId) => {
-        seen.push(civId);
-        return current;
+      prepare: (snapshot, civId) => prepared(snapshot as typeof state, civId),
+      executePrepared: (current, value) => {
+        seen.push(value.civId);
+        return { state: current };
       },
     });
 
     expect(seen).toEqual(['ai-2', 'ai-3', 'ai-1']);
     expect(result.state.opponentAI?.lastProcessedRound).toBe(1);
     processNonHumanMajorRound(result.state, new EventBus(), {
-      execute: (current, civId) => {
-        seen.push(civId);
-        return current;
+      prepare: (snapshot, civId) => prepared(snapshot as typeof state, civId),
+      executePrepared: (current, value) => {
+        seen.push(value.civId);
+        return { state: current };
       },
     });
     expect(seen).toHaveLength(3);
@@ -87,21 +89,24 @@ describe('AI round scheduler', () => {
 
   it('freezes the actor list so AI records added during execution wait until next round', () => {
     const state = createNewGame(undefined, 'scheduler-frozen', 'small');
-    const execute = vi.fn((current, civId: string) => {
-      if (civId === 'ai-1') {
+    const executePrepared = vi.fn((current, value: PreparedMajorCivPlan) => {
+      if (value.civId === 'ai-1') {
         current.civilizations['ai-new'] = {
           ...structuredClone(current.civilizations['ai-1']),
           id: 'ai-new',
           name: 'Late Arrival',
         };
       }
-      return current;
+      return { state: current };
     });
 
-    processNonHumanMajorRound(state, new EventBus(), { execute });
+    processNonHumanMajorRound(state, new EventBus(), {
+      prepare: (snapshot, civId) => prepared(snapshot as typeof state, civId),
+      executePrepared,
+    });
 
-    expect(execute).toHaveBeenCalledTimes(1);
-    expect(execute).not.toHaveBeenCalledWith(expect.anything(), 'ai-new', expect.anything());
+    expect(executePrepared).toHaveBeenCalledTimes(1);
+    expect(executePrepared.mock.calls.every(([, value]) => value.civId !== 'ai-new')).toBe(true);
   });
 
   it('handles zero actors and negative or large rotation rounds deterministically', () => {
@@ -121,7 +126,6 @@ describe('AI round scheduler', () => {
     const snapshots: Readonly<typeof state>[] = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         snapshots.push(snapshot);
         return prepared(snapshot as typeof state, civId);
@@ -147,7 +151,6 @@ describe('AI round scheduler', () => {
     const seen: PreparedMajorCivPlan[] = [];
 
     processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
         value.portfolio.primaryPlan = {
@@ -204,7 +207,6 @@ describe('AI round scheduler', () => {
     bus.on('city:founded', founded);
 
     const result = processNonHumanMajorRound(state, bus, {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
         const settler = state.units[settlerId];
@@ -264,7 +266,6 @@ describe('AI round scheduler', () => {
     const executed: PreparedMajorCivPlan[] = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
         if (civId === 'ai-2') {
@@ -342,7 +343,6 @@ describe('AI round scheduler', () => {
     let executedAiTwo: PreparedMajorCivPlan | null = null;
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
         if (civId === 'ai-2') {
@@ -445,7 +445,6 @@ describe('AI round scheduler', () => {
     }> = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         const value = prepared(snapshot as typeof state, civId);
         if (civId === 'ai-2') {
@@ -493,21 +492,6 @@ describe('AI round scheduler', () => {
     expect(result.state.opponentAI?.majorCivs['ai-2']?.primaryPlan).toBeNull();
   });
 
-  it('keeps the existing live AI path when strategic planning is disabled', () => {
-    const state = createNewGame(undefined, 'scheduler-disabled', 'small');
-    const prepare = vi.fn();
-    const execute = vi.fn(current => current);
-
-    processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: false,
-      prepare,
-      execute,
-    });
-
-    expect(prepare).not.toHaveBeenCalled();
-    expect(execute).toHaveBeenCalledOnce();
-  });
-
   it('isolates a failed actor preparation and reports it without blocking peers', () => {
     const state = createNewGame({
       civType: 'egypt',
@@ -519,7 +503,6 @@ describe('AI round scheduler', () => {
     const executed: string[] = [];
 
     const result = processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => civId === 'ai-1'
         ? {
             ...prepared(snapshot as typeof state, civId),
@@ -553,7 +536,6 @@ describe('AI round scheduler', () => {
     const executedIds: string[] = [];
 
     processNonHumanMajorRound(state, new EventBus(), {
-      strategicPlanningEnabled: true,
       prepare: (snapshot, civId) => {
         preparedIds.push(civId);
         return prepared(snapshot as typeof state, civId);

--- a/tests/ai/basic-ai-beasts.test.ts
+++ b/tests/ai/basic-ai-beasts.test.ts
@@ -110,9 +110,7 @@ describe('AI vs beasts', () => {
     const bus = new EventBus();
     bus.on('combat:resolved', payload => combatEvents.push(payload));
 
-    const result = processAITurn(state, 'ai-1', bus, {
-      purposefulAIEnabled: true,
-    });
+    const result = processAITurn(state, 'ai-1', bus);
 
     expect(combatEvents).toHaveLength(0);
     expect(result.units['beast-1']).toBeDefined();
@@ -123,9 +121,7 @@ describe('AI vs beasts', () => {
     ).toHaveLength(0);
   });
 
-  it('attacks an adjacent beast when enabled AND local strength advantage >= 1.5x', () => {
-    // swordsman (str 25, health 100) vs badly wounded boar (str 18, health 20)
-    // myStrength = 25; beastStrength = 18 * 0.2 = 3.6; 25 >= 3.6 * 1.5 → attack
+  it('does not bypass strategic planning for an opportunistic beast attack', () => {
     const state = makeBeastState({
       aiUnitType: 'swordsman', aiUnitHealth: 100,
       beastType: 'beast_boar', beastHealth: 20,
@@ -137,7 +133,7 @@ describe('AI vs beasts', () => {
 
     processAITurn(state, 'ai-1', bus);
 
-    expect(combatEvents).toHaveLength(1);
+    expect(combatEvents).toHaveLength(0);
   });
 
   it('does not attack when enabled but the beast is too strong (< 1.5x advantage)', () => {

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -232,9 +232,7 @@ describe('purposeful AI administrative intel', () => {
         confidence: 'remembered',
       }));
 
-    const result = processAITurn(state, aiId, new EventBus(), {
-      purposefulAIEnabled: true,
-    });
+    const result = processAITurn(state, aiId, new EventBus());
 
     expect(result.cities[city.id].productionQueue[0]).toBe('expedition');
     expect(result.civilizations[aiId].techState.currentResearch).not.toBeNull();
@@ -271,9 +269,7 @@ describe('purposeful AI administrative intel', () => {
     state.espionage ??= {};
     state.espionage[aiId] = createEspionageCivState();
 
-    const result = processAITurn(state, aiId, new EventBus(), {
-      purposefulAIEnabled: true,
-    });
+    const result = processAITurn(state, aiId, new EventBus());
 
     expect(result.units['exhausted-spy'].position).toEqual(spyStart);
   });
@@ -424,7 +420,7 @@ describe('AI attack targeting', () => {
     expect(state.units[defender.id]).toBeDefined();
   });
 
-  it('lets AI archers attack visible-by-rule hostile units at explicit range', () => {
+  it('does not launch an unplanned ranged attack from contact alone', () => {
     const state = createNewGame(undefined, 'ai-archer-range', 'small');
     const attacker = createUnit('archer', 'ai-1', { q: 0, r: 0 }, mkC());
     attacker.id = 'ai-archer';
@@ -441,7 +437,7 @@ describe('AI attack targeting', () => {
 
     processAITurn(state, 'ai-1', bus);
 
-    expect(combatEvents).toHaveLength(1);
+    expect(combatEvents).toHaveLength(0);
     expect(state.units[attacker.id]?.position).toEqual({ q: 0, r: 0 });
   });
 
@@ -1425,7 +1421,7 @@ describe('processAITurn', () => {
     expect(result.pendingDiplomacyRequests?.[0]?.toCivId).toBe('ai-1');
   });
 
-  it('assaults and occupies an exposed enemy city', () => {
+  it('does not bypass plan progression to capture an exposed city', () => {
     const state = makeAdjacentExposedCityState({ population: 5 });
     const bus = new EventBus();
     const moves: GameEvents['unit:move'][] = [];
@@ -1433,18 +1429,11 @@ describe('processAITurn', () => {
 
     const result = processAITurn(state, 'ai-1', bus);
 
-    expect(result.cities['city-player'].owner).toBe('ai-1');
-    expect(result.cities['city-player'].population).toBe(2);
-    expect(result.cities['city-player'].occupation?.turnsRemaining).toBe(10);
-    expect(moves).toHaveLength(1);
-    expect(moves[0]).toMatchObject({
-      unitId: 'ai-attacker',
-      from: { q: 0, r: 0 },
-      to: { q: 1, r: 0 },
-    });
+    expect(result.cities['city-player'].owner).toBe('player');
+    expect(moves).toHaveLength(0);
   });
 
-  it('emits territory tile-flipped events when AI captures an improved city tile', () => {
+  it('does not emit capture transitions without a plan-authorized capture', () => {
     const state = makeAdjacentExposedCityState({ population: 5 });
     state.map.tiles[hexKey({ q: 1, r: 0 })] = {
       ...state.map.tiles[hexKey({ q: 1, r: 0 })],
@@ -1459,13 +1448,7 @@ describe('processAITurn', () => {
 
     processAITurn(state, 'ai-1', bus);
 
-    expect(territoryEvents).toContainEqual(expect.objectContaining({
-      coord: { q: 1, r: 0 },
-      previousOwner: 'player',
-      newOwner: 'ai-1',
-      improvement: 'farm',
-      constructionCancelled: false,
-    }));
+    expect(territoryEvents).toEqual([]);
   });
 
   it('does not throw on a fresh game', () => {
@@ -1556,7 +1539,7 @@ describe('processAITurn', () => {
         owner: 'ai-1',
       },
     });
-    expect(newState.cities[aiCiv.cities[0]].productionQueue).toEqual(['warrior']);
+    expect(newState.cities[aiCiv.cities[0]].productionQueue.length).toBeGreaterThan(0);
   });
 
   it('does not found an AI city inside the shared city spacing boundary', () => {
@@ -1596,16 +1579,16 @@ describe('processAITurn', () => {
     expect(result.units[settlerId]).toBeDefined();
   });
 
-  it('AI attacks adjacent rebel units during revolt cleanup', () => {
+  it('does not use the removed opportunistic rebel chase', () => {
     const state = makeAiRebelState();
     const bus = new EventBus();
 
     const newState = processAITurn(state, 'ai-1', bus);
 
-    expect(newState.units['unit-rebel']).toBeUndefined();
+    expect(newState.units['unit-rebel']).toBeDefined();
   });
 
-  it('applies the river crossing combat penalty to AI attacks', () => {
+  it('does not resolve unplanned attacks across either open or river edges', () => {
     const openState = makeAiRebelState();
     const crossingState = makeAiRebelState();
     openState.units['unit-rebel'].health = 100;
@@ -1622,18 +1605,14 @@ describe('processAITurn', () => {
 
       processAITurn(state, 'ai-1', bus);
 
-      expect(events).toHaveLength(1);
-      return events[0]!.result;
+      return events;
     };
 
-    const openResult = resolveAttack(openState);
-    const crossingResult = resolveAttack(crossingState);
-
-    expect(crossingResult.defenderDamage).toBeLessThan(openResult.defenderDamage);
-    expect(crossingResult.attackerDamage).toBeGreaterThan(openResult.attackerDamage);
+    expect(resolveAttack(openState)).toEqual([]);
+    expect(resolveAttack(crossingState)).toEqual([]);
   });
 
-  it('awards AI units combat rewards when they defeat an adjacent enemy', () => {
+  it('does not award combat rewards when no planned combat occurred', () => {
     const state = makeAiRebelState();
     state.units['unit-ai'] = { ...state.units['unit-ai'], health: 60 };
     state.units['unit-rebel'] = { ...state.units['unit-rebel'], health: 1 };
@@ -1641,10 +1620,8 @@ describe('processAITurn', () => {
 
     const result = processAITurn(state, 'ai-1', bus);
 
-    expect(result.units['unit-rebel']).toBeUndefined();
-    expect(result.units['unit-ai'].experience).toBeGreaterThan(0);
-    expect(result.units['unit-ai'].health).toBeGreaterThan(50);
-    expect(result.civilizations['ai-1'].gold).toBeGreaterThan(0);
+    expect(result.units['unit-rebel']).toBeDefined();
+    expect(result.units['unit-ai'].experience).toBe(0);
   });
 
   it('AI stations a defensive spy in its capital by stage 3', () => {
@@ -1672,14 +1649,14 @@ describe('processAITurn', () => {
     expect(newState.espionage!['ai-1'].counterIntelligence['city-ai']).toBeGreaterThan(0);
   });
 
-  it('AI declares war on its own secession state instead of treating it like normal diplomacy', () => {
+  it('does not bypass strategic war gates for a newly seen secession state', () => {
     const state = makeAiBreakawayState();
     const bus = new EventBus();
 
     const newState = processAITurn(state, 'ai-1', bus);
 
-    expect(newState.civilizations['ai-1'].diplomacy.atWarWith).toContain('breakaway-city-border');
-    expect(newState.civilizations['breakaway-city-border'].diplomacy.atWarWith).toContain('ai-1');
+    expect(newState.civilizations['ai-1'].diplomacy.atWarWith)
+      .not.toContain('breakaway-city-border');
   });
 
   it('abandons a legendary wonder race when a rival is far ahead and reuses the carryover in the same city', () => {
@@ -1704,9 +1681,7 @@ describe('processAITurn', () => {
     const lostEvents: Array<{ wonderId: string; cityId: string }> = [];
     bus.on('wonder:legendary-lost', event => lostEvents.push(event));
 
-    const result = processAITurn(state, 'ai-1', bus, {
-      purposefulAIEnabled: true,
-    });
+    const result = processAITurn(state, 'ai-1', bus);
 
     expect(result.legendaryWonderProjects!['grand-canal'].phase)
       .toBe('lost_race');
@@ -1753,7 +1728,7 @@ describe('processAITurn', () => {
     expect(lostEvents).toHaveLength(2);
   });
 
-  it('uses Stage 7 (cyber_attack) espionage remotely when an idle spy has cyber-intelligence tech', () => {
+  it('does not target a hidden city for a remote cyber mission', () => {
     const state = makeAiDefenseSpyState();
     const bus = new EventBus();
     state.civilizations['ai-1'].techState.completed = [
@@ -1788,9 +1763,7 @@ describe('processAITurn', () => {
 
     const result = processAITurn(state, 'ai-1', bus);
 
-    expect(result.espionage!['ai-1'].spies['spy-ai-1'].currentMission?.type).toBe('cyber_attack');
-    expect(result.espionage!['ai-1'].spies['spy-ai-1'].currentMission?.targetCivId).toBe('player');
-    expect(result.espionage!['ai-1'].spies['spy-ai-1'].currentMission?.targetCityId).toBe('city-player');
+    expect(result.espionage!['ai-1'].spies['spy-ai-1'].currentMission).toBeNull();
   });
 
   it('records first contact when ai visibility refresh reveals the player during its turn', () => {
@@ -1846,19 +1819,17 @@ describe('processAITurn', () => {
     expect(new Set(wonderIds).size).toBe(wonderIds.length);
   });
 
-  it('records stronghold history when an ai civ clears a barbarian camp', () => {
+  it('does not record stronghold history without a planned camp attack', () => {
     const state = makeAiBarbarianCampAttackState();
     const bus = new EventBus();
 
     const result = processAITurn(state, 'ai-1', bus);
 
-    expect(result.legendaryWonderHistory?.destroyedStrongholds).toContainEqual(
-      expect.objectContaining({ civId: 'ai-1', campId: 'camp-1' }),
-    );
-    expect(result.barbarianCamps['camp-1']).toBeUndefined();
+    expect(result.legendaryWonderHistory?.destroyedStrongholds).toEqual([]);
+    expect(result.barbarianCamps['camp-1']).toBeDefined();
   });
 
-  it('lets an ai civ satisfy stronghold-backed wonder quests after clearing a camp', () => {
+  it('does not complete a stronghold quest without a canonical camp clear', () => {
     const state = makeAiBarbarianCampAttackState();
     const bus = new EventBus();
 
@@ -1868,7 +1839,8 @@ describe('processAITurn', () => {
       candidate.ownerId === 'ai-1' && candidate.wonderId === 'sun-spire',
     );
 
-    expect(project?.questSteps.find(step => step.id === 'defeat-nearby-stronghold')?.completed).toBe(true);
+    expect(project?.questSteps.find(step => step.id === 'defeat-nearby-stronghold')?.completed)
+      .toBe(false);
   });
 });
 
@@ -2056,12 +2028,12 @@ describe('Expedition AI parity', () => {
     } as unknown as GameState;
   }
 
-  it('queues an Expedition when foraging tech is researched and an unowned resource tile exists', () => {
+  it('does not queue an Expedition from a hidden resource tile', () => {
     const state = makeExpeditionAiState({ completedTechs: ['foraging'] });
     const bus = new EventBus();
     const newState = processAITurn(state, 'ai-1', bus);
     const city = Object.values(newState.cities).find(c => c.owner === 'ai-1')!;
-    expect(city.productionQueue).toContain('expedition');
+    expect(city.productionQueue).not.toContain('expedition');
   });
 
   it('calls performEstablishOutpost when Expedition is on an eligible resource tile', () => {
@@ -2443,7 +2415,7 @@ describe('AI naval warship movement', () => {
     } as GameState;
   }
 
-  it('warship moves toward a visible hostile naval unit rather than into unexplored ocean', () => {
+  it('does not run the removed opportunistic naval chase', () => {
     // Setup: AI galley at (2,0), enemy galley at (4,0).
     // (0,0) and (1,0) are unexplored — current code would pick those.
     // (3,0) is explored and closest reachable tile to enemy — fixed code picks it.
@@ -2455,10 +2427,10 @@ describe('AI naval warship movement', () => {
     const galley = result.units['ai-galley'];
     const initialDist = hexDistance({ q: 2, r: 0 }, { q: 4, r: 0 }); // 2
     const finalDist = hexDistance(galley.position, { q: 4, r: 0 });
-    expect(finalDist).toBeLessThan(initialDist);
+    expect(finalDist).toBe(initialDist);
   });
 
-  it('warship attacks an adjacent enemy naval unit at war', () => {
+  it('does not run the removed opportunistic naval attack', () => {
     const state = makeNavalWarshipState();
     // Move enemy galley adjacent to AI galley
     state.units['enemy-galley'] = { ...state.units['enemy-galley'], position: { q: 3, r: 0 } };
@@ -2468,7 +2440,7 @@ describe('AI naval warship movement', () => {
 
     processAITurn(state, 'ai-1', bus);
 
-    expect(combatEvents).toHaveLength(1);
+    expect(combatEvents).toHaveLength(0);
   });
 });
 
@@ -2502,12 +2474,12 @@ describe('AI grenadier production priority', () => {
     expect(state.cities['city-ai'].productionQueue).not.toContain('grenadier');
   });
 
-  it('queues grenadier as first priority when grenade-warfare is researched and none exist', () => {
+  it('uses catalog scoring instead of hardcoding grenadier as first priority', () => {
     const state = makeGrenadierState();
     state.civilizations['ai-1'].techState.completed = ['grenade-warfare', 'iron-forging', 'swords'];
     const result = processAITurn(state, 'ai-1', new EventBus());
     const updatedCity = result.cities['city-ai'];
-    expect(updatedCity.productionQueue[0]).toBe('grenadier');
+    expect(updatedCity.productionQueue[0]).not.toBe('grenadier');
   });
 
   it('does not queue a second grenadier when one already exists', () => {

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -105,6 +105,99 @@ describe('AudioSystem integration', () => {
     expect(ctx.transcript.length).toBe(before);
   });
 
+  it('plays one strategic warning cue for the current viewer and turn', async () => {
+    const state = makeState({ turn: 7 });
+    ctx.state = 'running';
+    system.start(state, busHelper.bus, () => state);
+    await flushPromises();
+    ctx.clearTranscript();
+
+    const warning = {
+      viewerId: 'rome',
+      actorId: 'egypt',
+      actorName: 'Egyptian',
+      warningKey: 'rome:egypt:mobilizing:border',
+      kind: 'mobilizing',
+      evidence: 'visible',
+      playAudio: true,
+    };
+    busHelper.emit('ai:strategic-warning', warning);
+    busHelper.emit('ai:strategic-warning', { ...warning, warningKey: `${warning.warningKey}:second` });
+    await flushPromises();
+
+    expect(ctx.transcript.filter(entry => entry.op === 'start')).toHaveLength(1);
+  });
+
+  it('plays a hot-seat strategic warning only after an explicit post-handoff audio event', async () => {
+    const state = makeState({ turn: 8 });
+    ctx.state = 'running';
+    let suppressed = true;
+    system.start(state, busHelper.bus, () => state, () => suppressed);
+    await flushPromises();
+    ctx.clearTranscript();
+
+    busHelper.emit('ai:strategic-warning', {
+      viewerId: 'rome',
+      actorId: 'egypt',
+      actorName: 'Egyptian',
+      warningKey: 'rome:egypt:mobilizing:border',
+      kind: 'mobilizing',
+      evidence: 'visible',
+      playAudio: true,
+    });
+    await flushPromises();
+    expect(ctx.transcript.some(entry => entry.op === 'start')).toBe(false);
+
+    suppressed = false;
+    busHelper.emit('ai:strategic-warning-audio', { viewerId: 'rome', turn: 8 });
+    await flushPromises();
+    expect(ctx.transcript.filter(entry => entry.op === 'start')).toHaveLength(1);
+  });
+
+  it.each([
+    ['wrong viewer', { currentPlayer: 'egypt' }, true, 'running'],
+    ['sound muted', { settings: { ...makeState().settings, soundEnabled: false } }, true, 'running'],
+    ['stingers disabled', { settings: { ...makeState().settings, stingerEnabled: false } }, true, 'running'],
+    ['presentation suppressed', {}, false, 'running'],
+    ['context suspended', {}, true, 'suspended'],
+    ['context closed', {}, true, 'closed'],
+  ] as const)('blocks strategic warning audio when %s', async (
+    _label,
+    overrides,
+    presentationAllowed,
+    contextState,
+  ) => {
+    const state = makeState({ turn: 9, ...(overrides as Partial<GameState>) });
+    ctx.state = contextState;
+    system.start(state, busHelper.bus, () => state, () => !presentationAllowed);
+    await flushPromises();
+    ctx.clearTranscript();
+
+    busHelper.emit('ai:strategic-warning-audio', { viewerId: 'rome', turn: 9 });
+    await flushPromises();
+
+    expect(ctx.transcript.some(entry => entry.op === 'start')).toBe(false);
+  });
+
+  it('blocks strategic warning audio while the document is backgrounded', async () => {
+    const state = makeState({ turn: 10 });
+    ctx.state = 'running';
+    vi.stubGlobal('document', {
+      hidden: true,
+      visibilityState: 'hidden',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    system.start(state, busHelper.bus, () => state);
+    await flushPromises();
+    ctx.clearTranscript();
+
+    busHelper.emit('ai:strategic-warning-audio', { viewerId: 'rome', turn: 10 });
+    await flushPromises();
+
+    expect(ctx.transcript.some(entry => entry.op === 'start')).toBe(false);
+  });
+
   // Flow E: peace signed (last war)
   it('Flow E: peace:made with warCount=1 transitions to peace', () => {
     system.start(makeState(), busHelper.bus);

--- a/tests/audio/music-director.test.ts
+++ b/tests/audio/music-director.test.ts
@@ -63,6 +63,22 @@ describe('MusicDirector', () => {
     expect(mixer.playOneShot).toHaveBeenCalledWith('stinger', fakeBuffer);
   });
 
+  it('reuses the era-transition cue for strategic warnings and rechecks eligibility after load', async () => {
+    let resolveLoad!: (buffer: AudioBuffer) => void;
+    vi.mocked(loader.get).mockReturnValueOnce(new Promise(resolve => {
+      resolveLoad = resolve;
+    }));
+    let eligible = true;
+
+    director.handleStrategicWarning(3, () => eligible);
+    expect(loader.get).toHaveBeenCalledWith(STINGER.eraTransitionCue[resolveEra(3)].file);
+    eligible = false;
+    resolveLoad(fakeBuffer);
+    await flushPromises();
+
+    expect(mixer.playOneShot).not.toHaveBeenCalled();
+  });
+
   it('plays eraAdvance stinger for the resolved era', async () => {
     director.handleEraAdvanced({ era: 3, civType: 'rome' });
     await flushPromises();

--- a/tests/audio/sfx-director.test.ts
+++ b/tests/audio/sfx-director.test.ts
@@ -135,6 +135,40 @@ describe('SfxDirector', () => {
     }
   });
 
+  it('rechecks suppression after a delayed movement buffer finishes loading', async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveLoad!: (buffer: AudioBuffer) => void;
+      loader.get = vi.fn((_path: string) => new Promise<AudioBuffer>(resolve => {
+        resolveLoad = resolve;
+      }));
+      let suppressed = false;
+      const units = { u1: makeUnit('u1', 'warrior') };
+      director.start(units, busHelper.bus, stateProvider(units), () => suppressed);
+      busHelper.emit('unit:move', {
+        unitId: 'u1',
+        from: { q: 0, r: 0 },
+        to: { q: 1, r: 0 },
+        path: [{ q: 0, r: 0 }, { q: 1, r: 0 }],
+        presentationByViewer: {
+          player: {
+            unit: units.u1,
+            visibleSegments: [[{ q: 0, r: 0 }, { q: 1, r: 0 }]],
+          },
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      suppressed = true;
+      resolveLoad({} as AudioBuffer);
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(mixer.playOneShot).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not fall back to final fog when the event-time viewer was omitted', async () => {
     vi.useFakeTimers();
     try {

--- a/tests/core/completed-round-orchestrator.test.ts
+++ b/tests/core/completed-round-orchestrator.test.ts
@@ -37,7 +37,7 @@ describe('runCompletedRound', () => {
     expect(state.gameTitle).not.toBe('improved-ai');
   });
 
-  it.each(['improvements', 'majors', 'world'] as const)(
+  it.each(['improvements', 'majors', 'world', 'postprocess'] as const)(
     'restores the untouched input and discards events when %s throws',
     failingPhase => {
       const state = createNewGame(undefined, `round-failure-${failingPhase}`, 'small');
@@ -54,6 +54,18 @@ describe('runCompletedRound', () => {
         world: (current: typeof state) => {
           if (failingPhase === 'world') throw new Error('failed');
           return { ...current, turn: 40 };
+        },
+        postprocess: (
+          _before: Readonly<typeof state>,
+          current: typeof state,
+          bus: EventBus,
+        ) => {
+          bus.emit('ai:strategic-warning-audio', {
+            viewerId: current.currentPlayer,
+            turn: current.turn,
+          });
+          if (failingPhase === 'postprocess') throw new Error('failed');
+          return current;
         },
       };
 

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -244,4 +244,73 @@ describe('opponent AI state normalization', () => {
     expect(plan.traces).toBeUndefined();
     expect(plan.cachedPath).toBeUndefined();
   });
+
+  it('normalizes living-human ledger owners while preserving valid threat IDs for resolution', () => {
+    const state = makeState();
+    const player = state.civilizations.player;
+    state.civilizations['player-2'] = {
+      ...structuredClone(player),
+      id: 'player-2',
+      name: 'Second Player',
+      cities: [],
+      units: [],
+    };
+    state.civilizations['dead-human'] = {
+      ...structuredClone(player),
+      id: 'dead-human',
+      name: 'Dead Player',
+      cities: [],
+      units: [],
+      isEliminated: true,
+    };
+    state.barbarianCamps.live = {
+      id: 'live',
+      position: { q: 1, r: 1 },
+      strength: 5,
+      spawnCooldown: 1,
+    };
+    state.opponentAI!.pressureByHuman = {
+      player: {
+        activeIndependentThreatIds: [
+          'barbarian:missing',
+          'barbarian:live',
+          'pirate:missing',
+          'beast:missing',
+          'major:ai-1',
+          'barbarian:live',
+        ],
+        recoveryUntilTurn: Number.NaN,
+        lastResolvedThreatTurn: Number.NaN,
+        lastWarningTurnByKey: { valid: 3, invalid: Number.NaN },
+        lastStrategicAudioTurn: Number.NaN,
+      },
+      'dead-human': {
+        activeIndependentThreatIds: [],
+        recoveryUntilTurn: 0,
+        lastResolvedThreatTurn: null,
+        lastWarningTurnByKey: {},
+        lastStrategicAudioTurn: null,
+      },
+    };
+    const snapshot = structuredClone(state);
+
+    const normalized = normalizeOpponentAIState(state);
+
+    expect(Object.keys(normalized.opponentAI!.pressureByHuman)).toEqual(['player', 'player-2']);
+    expect(normalized.opponentAI!.pressureByHuman.player).toEqual({
+      activeIndependentThreatIds: [
+        'barbarian:live',
+        'barbarian:missing',
+        'beast:missing',
+        'pirate:missing',
+      ],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: { valid: 3 },
+      lastStrategicAudioTurn: null,
+    });
+    expect(normalized.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+      .toEqual([]);
+    expect(state).toEqual(snapshot);
+  });
 });

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -115,14 +115,10 @@ describe('processTurn', () => {
       new EventBus(),
     ).barbarianCamps).some(camp => camp.resurgent)).toBe(true);
 
-    const legacy = processTurn(structuredClone(state), new EventBus());
-    const purposeful = processTurn(structuredClone(state), new EventBus(), {
-      purposefulAIEnabled: true,
-    });
+    const result = processTurn(structuredClone(state), new EventBus());
 
-    expect(Object.values(legacy.barbarianCamps).filter(camp => camp.resurgent)).toHaveLength(0);
-    expect(Object.values(purposeful.barbarianCamps).some(camp => camp.resurgent)).toBe(true);
-    expect(purposeful.opponentAI!.pressureByHuman['ai-1'].activeIndependentThreatIds)
+    expect(Object.values(result.barbarianCamps).some(camp => camp.resurgent)).toBe(true);
+    expect(result.opponentAI!.pressureByHuman['ai-1'].activeIndependentThreatIds)
       .toEqual(expect.arrayContaining([expect.stringMatching(/^barbarian:camp-/)]));
   });
 

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -16,6 +16,7 @@ import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture'
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 import { createUnit } from '@/systems/unit-system';
 import { createTechState } from '@/systems/tech-system';
+import { processIndependentThreatPressureForHumans } from '@/systems/threat-pressure-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -57,6 +58,74 @@ function createWrappedGrasslandMap(width: number, height: number): GameState['ma
 }
 
 describe('processTurn', () => {
+  it('uses per-human pressure only on the enabled completed-round path', () => {
+    const state = createNewGame(undefined, 'per-human-pressure', 'small');
+    state.turn = 30;
+    state.era = 3;
+    state.barbarianCamps = {};
+    state.units = {};
+    state.map = {
+      width: 20,
+      height: 1,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: Object.fromEntries(Array.from({ length: 20 }, (_, q) => [
+        `${q},0`,
+        {
+          coord: { q, r: 0 },
+          terrain: 'grassland',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          owner: q < 5 ? 'player' : q > 9 && q < 15 ? 'ai-1' : null,
+          improvementTurnsLeft: 0,
+          hasRiver: false,
+          wonder: null,
+          regionKey: 'continent-0',
+        },
+      ])),
+    };
+    const secondHuman = state.civilizations['ai-1'];
+    secondHuman.isHuman = true;
+    secondHuman.isEliminated = false;
+    const playerCity = foundCity('player', { q: 0, r: 0 }, state.map, state.idCounters);
+    const secondCity = foundCity('ai-1', { q: 10, r: 0 }, state.map, state.idCounters);
+    playerCity.workedTiles = [];
+    playerCity.productionQueue = [];
+    secondCity.workedTiles = [];
+    secondCity.productionQueue = [];
+    state.cities = { [playerCity.id]: playerCity, [secondCity.id]: secondCity };
+    state.resurgentCampCooldownByCivLandmass = { 'player:continent-0': 999 };
+    state.civilizations.player.cities = [playerCity.id];
+    state.civilizations.player.units = [];
+    secondHuman.cities = [secondCity.id];
+    secondHuman.units = [];
+    for (const civ of Object.values(state.civilizations)) {
+      const regionKeys = civ.cities.flatMap(cityId => {
+        const city = state.cities[cityId];
+        const regionKey = city ? state.map.tiles[hexKey(city.position)]?.regionKey : undefined;
+        return regionKey ? [regionKey] : [];
+      });
+      civ.lastCombatTurnByLandmass = Object.fromEntries(
+        regionKeys.map(regionKey => [regionKey, civ.id === 'ai-1' ? 0 : state.turn]),
+      );
+    }
+    expect(Object.values(processIndependentThreatPressureForHumans(
+      structuredClone(state),
+      new EventBus(),
+    ).barbarianCamps).some(camp => camp.resurgent)).toBe(true);
+
+    const legacy = processTurn(structuredClone(state), new EventBus());
+    const purposeful = processTurn(structuredClone(state), new EventBus(), {
+      purposefulAIEnabled: true,
+    });
+
+    expect(Object.values(legacy.barbarianCamps).filter(camp => camp.resurgent)).toHaveLength(0);
+    expect(Object.values(purposeful.barbarianCamps).some(camp => camp.resurgent)).toBe(true);
+    expect(purposeful.opponentAI!.pressureByHuman['ai-1'].activeIndependentThreatIds)
+      .toEqual(expect.arrayContaining([expect.stringMatching(/^barbarian:camp-/)]));
+  });
+
   it('increments the turn counter', () => {
     const state = createNewGame(undefined, 'turn-test');
     const bus = new EventBus();

--- a/tests/e2e/issue-365-map-presentation.spec.ts
+++ b/tests/e2e/issue-365-map-presentation.spec.ts
@@ -36,8 +36,14 @@ async function installFixture(page: Page): Promise<void> {
 
 async function continueFixture(page: Page): Promise<void> {
   await page.goto('/');
-  await page.getByRole('button', { name: 'Continue' }).click();
-  await expect(page.getByRole('button', { name: 'Continue' })).toBeHidden();
+  const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
+  await continueButton.click();
+  await expect(page.getByRole('dialog', { name: 'Choose Opponent Challenge' })).toBeVisible();
+  await page.locator(
+    '[data-opponent-challenge-selector="migration"] [data-challenge="standard"]',
+  ).click();
+  await page.getByRole('button', { name: 'Continue Campaign', exact: true }).click();
+  await expect(continueButton).toBeHidden();
   await expect(page.locator('#game-canvas')).toBeVisible();
   await page.waitForTimeout(500);
 }

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -29,6 +29,29 @@ describe('completed-round AI wiring', () => {
     expect(main).not.toContain("getAIPlayers(");
     expect(main).not.toContain("'ai-1'");
   });
+
+  it('keeps strategic warnings dark behind the real false flag while wiring postprocess', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+
+    expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus');
+    expect(main).toContain('purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED');
+    expect(main).toContain("bus.on('ai:strategic-warning'");
+  });
+
+  it('emits one warning cue only after the exact rendered handoff summary is acknowledged', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const handoff = main.slice(
+      main.indexOf('async function beginHotSeatHandoff'),
+      main.indexOf('async function endTurn'),
+    );
+
+    expect(handoff).toContain('onReady: async summary =>');
+    expect(handoff).toMatch(
+      /acknowledgeTurnHandoffSummary\(\s*gameState,\s*nextSlotId,\s*summary,\s*\)/,
+    );
+    expect(handoff.indexOf('releaseHandoffToViewer(nextSlotId)'))
+      .toBeLessThan(handoff.indexOf("bus.emit('ai:strategic-warning-audio'"));
+  });
 });
 
 describe('shared city founding wiring', () => {

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -30,11 +30,11 @@ describe('completed-round AI wiring', () => {
     expect(main).not.toContain("'ai-1'");
   });
 
-  it('keeps strategic warnings dark behind the real false flag while wiring postprocess', () => {
+  it('runs strategic warning postprocess on the live completed-round path', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
 
     expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus');
-    expect(main).toContain('purposefulAIEnabled: PURPOSEFUL_AI_FEATURE_ENABLED');
+    expect(main).toContain('applyStrategicWarningTransitions(beforeRound, current, eventBus)');
     expect(main).toContain("bus.on('ai:strategic-warning'");
   });
 
@@ -114,15 +114,15 @@ describe('shared city assault wiring', () => {
     );
   });
 
-  it('routes player and legacy AI capture transitions through the shared emitter', () => {
+  it('routes player and strategic AI capture transitions through the shared emitter', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
-    const basicAi = readFileSync(
-      resolve(PROJECT_ROOT, 'src/ai/basic-ai.ts'),
+    const strategicAi = readFileSync(
+      resolve(PROJECT_ROOT, 'src/ai/ai-major-turn.ts'),
       'utf8',
     );
 
     expect(main).toContain('emitMajorCityCaptureEvents(');
-    expect(basicAi).toContain('emitMajorCityCaptureEvents(');
+    expect(strategicAi).toContain('emitMajorCityCaptureEvents(');
   });
 
   it('does not resolve minor-civilization conquest after failed movement', () => {

--- a/tests/simulation/ai-playability-fixture.ts
+++ b/tests/simulation/ai-playability-fixture.ts
@@ -263,9 +263,7 @@ function assertLegalChoices(
       throw new Error(`${seed}: ${civ.id} has no legal research choice`);
     }
     if (!lateEra) continue;
-    const resources = getCivAvailableResources(state, civ.id, {
-      hostileOccupationEnabled: true,
-    });
+    const resources = getCivAvailableResources(state, civ.id);
     for (const cityId of civ.cities) {
       const city = state.cities[cityId];
       if (!city) continue;
@@ -422,21 +420,15 @@ function simulate(
     const completed = runCompletedRound(state, bus, {
       improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
       majors: (current, eventBus) => {
-        const result = processNonHumanMajorRound(current, eventBus, {
-          strategicPlanningEnabled: true,
-        });
+        const result = processNonHumanMajorRound(current, eventBus);
         traces = result.traces;
         planningErrors = result.planningErrors.map(error =>
           `${error.actorId}: ${error.message}`);
         return result.state;
       },
-      world: (current, eventBus) => processTurn(current, eventBus, {
-        purposefulAIEnabled: true,
-      }),
+      world: (current, eventBus) => processTurn(current, eventBus),
       postprocess: (beforeRound, current, eventBus) =>
-        applyStrategicWarningTransitions(beforeRound, current, eventBus, {
-          purposefulAIEnabled: true,
-        }),
+        applyStrategicWarningTransitions(beforeRound, current, eventBus),
     });
     if (!completed.ok) {
       throw new Error(`${options.seed}: completed round ${round + 1} failed`, {

--- a/tests/simulation/ai-playability-fixture.ts
+++ b/tests/simulation/ai-playability-fixture.ts
@@ -1,0 +1,586 @@
+import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
+import type { AIDecisionTrace } from '@/ai/ai-decision-trace';
+import { getAIStrategicRoles } from '@/ai/ai-unit-roles';
+import { runCompletedRound } from '@/core/completed-round-orchestrator';
+import { EventBus } from '@/core/event-bus';
+import { createHotSeatGame, createNewGame } from '@/core/game-state';
+import { OPPONENT_CHALLENGE_PROFILES } from '@/core/opponent-challenge';
+import type {
+  AIStrategicPlan,
+  GameEvents,
+  GameState,
+  OpponentChallenge,
+  UnitType,
+} from '@/core/types';
+import { getTrainableUnitsForCity, TRAINABLE_UNITS } from '@/systems/city-system';
+import { foundCityInState } from '@/systems/city-founding-system';
+import { getVisibility } from '@/systems/fog-of-war';
+import { hexKey } from '@/systems/hex-utils';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { isTrustedObservedLastSeenTile } from '@/systems/last-seen-presentation';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-system';
+import { TECH_TREE, resolveCivilizationEra } from '@/systems/tech-definitions';
+import { getAvailableTechs } from '@/systems/tech-system';
+import { processTurn } from '@/core/turn-manager';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type AIPersonality =
+  | 'aggressive'
+  | 'diplomatic'
+  | 'expansionist'
+  | 'trader';
+
+export interface AISimulationOptions {
+  seed: string;
+  challenge: OpponentChallenge;
+  turns: number;
+  mapSize: 'small' | 'medium' | 'large';
+  humanCount: number;
+  aiCount: number;
+  personalitySet: AIPersonality[];
+}
+
+export interface AISimulationMetrics {
+  turns: number;
+  cityCaptures: number;
+  campsResolved: number;
+  pirateRaids: number;
+  plansCreated: number;
+  plansCompleted: number;
+  plansAbandoned: number;
+  planProgressTransitions: number;
+  maxNoProgressRounds: number;
+  modernUnitShareByCiv: Record<string, number>;
+  eraByCiv: Record<string, number>;
+  maxObjectiveCandidatesPerActor: number;
+  maxPathQueriesPerActor: number;
+  maxIndependentThreatsByHuman: Record<string, number>;
+  visibleWarningLeadRounds: number[];
+  roundDurationsMs: number[];
+  elapsedMs: number;
+}
+
+const PERSONALITY_CIV: Record<AIPersonality, string> = {
+  aggressive: 'mongolia',
+  diplomatic: 'babylon',
+  expansionist: 'egypt',
+  trader: 'persia',
+};
+
+const WORLD_OWNERS = new Set(['barbarian', 'pirate', 'rebels', 'beasts']);
+
+function plansForState(state: GameState): Map<string, AIStrategicPlan> {
+  const plans = new Map<string, AIStrategicPlan>();
+  for (const portfolio of Object.values(state.opponentAI?.majorCivs ?? {})) {
+    if (portfolio.primaryPlan) plans.set(portfolio.primaryPlan.id, portfolio.primaryPlan);
+    for (const plan of Object.values(portfolio.defensePlansByCityId)) {
+      plans.set(plan.id, plan);
+    }
+  }
+  return plans;
+}
+
+function initializeScenario(options: AISimulationOptions): GameState {
+  if (options.personalitySet.length < options.aiCount) {
+    throw new Error(`${options.seed}: personalitySet must cover every AI`);
+  }
+  const totalPlayers = options.humanCount + options.aiCount;
+  const state = options.humanCount === 1
+    ? createNewGame({
+        civType: 'rome',
+        seed: options.seed,
+        mapSize: options.mapSize,
+        opponentCount: options.aiCount,
+        gameTitle: options.seed,
+        opponentChallenge: options.challenge,
+        settingsOverrides: { tutorialEnabled: false },
+        mapScript: 'balanced',
+      })
+    : createHotSeatGame({
+        playerCount: totalPlayers,
+        mapSize: options.mapSize,
+        mapScript: 'balanced',
+        players: [
+          ...Array.from({ length: options.humanCount }, (_, index) => ({
+            name: `Human ${index + 1}`,
+            slotId: `player-${index + 1}`,
+            civType: ['rome', 'greece', 'china'][index % 3]!,
+            isHuman: true,
+          })),
+          ...Array.from({ length: options.aiCount }, (_, index) => ({
+            name: `AI ${index + 1}`,
+            slotId: `ai-${index + 1}`,
+            civType: PERSONALITY_CIV[options.personalitySet[index]!],
+            isHuman: false,
+          })),
+        ],
+      }, options.seed, options.seed, options.challenge);
+
+  const aiIds = Object.values(state.civilizations)
+    .filter(civ => !civ.isHuman)
+    .map(civ => civ.id)
+    .sort();
+  for (let index = 0; index < aiIds.length; index++) {
+    state.civilizations[aiIds[index]!]!.civType =
+      PERSONALITY_CIV[options.personalitySet[index]!]!;
+  }
+  state.gameId = `simulation:${options.seed}`;
+
+  let founded = state;
+  const setupBus = new EventBus();
+  for (const civId of Object.keys(founded.civilizations).sort()) {
+    const settlerId = founded.civilizations[civId]!.units.find(
+      unitId => founded.units[unitId]?.type === 'settler',
+    );
+    if (!settlerId) throw new Error(`${options.seed}: ${civId} has no starting settler`);
+    founded = foundCityInState(founded, settlerId, setupBus).state;
+  }
+  return founded;
+}
+
+function assertFiniteSerializable(state: GameState, seed: string): void {
+  const json = JSON.stringify(state);
+  if (!json) throw new Error(`${seed}: state is not serializable`);
+  const visit = (value: unknown, path: string): void => {
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      throw new Error(`${seed}: non-finite number at ${path}`);
+    }
+    if (!value || typeof value !== 'object') return;
+    for (const [key, child] of Object.entries(value)) visit(child, `${path}.${key}`);
+  };
+  visit(state, 'state');
+}
+
+function assertOwnersAndReferences(state: GameState, seed: string): void {
+  for (const unit of Object.values(state.units)) {
+    if (
+      !state.civilizations[unit.owner]
+      && !state.minorCivs[unit.owner]
+      && !state.pirates?.factions[unit.owner]
+      && !WORLD_OWNERS.has(unit.owner)
+    ) {
+      throw new Error(`${seed}: unit ${unit.id} has invalid owner ${unit.owner}`);
+    }
+  }
+  for (const city of Object.values(state.cities)) {
+    if (!state.civilizations[city.owner] && !state.minorCivs[city.owner]) {
+      throw new Error(`${seed}: city ${city.id} has invalid owner ${city.owner}`);
+    }
+  }
+  for (const civ of Object.values(state.civilizations)) {
+    for (const unitId of civ.units) {
+      const unit = state.units[unitId];
+      if (unit && unit.owner !== civ.id) {
+        throw new Error(`${seed}: ${civ.id} references wrong-owner unit ${unitId}`);
+      }
+    }
+    for (const cityId of civ.cities) {
+      const city = state.cities[cityId];
+      if (city && city.owner !== civ.id) {
+        throw new Error(`${seed}: ${civ.id} references wrong-owner city ${cityId}`);
+      }
+    }
+  }
+}
+
+function targetWasPerceived(
+  state: GameState,
+  actorId: string,
+  plan: AIStrategicPlan,
+): boolean {
+  if (plan.target.kind === 'region') return true;
+  const actor = state.civilizations[actorId];
+  if (!actor) return false;
+  const position = plan.target.kind === 'resource'
+    ? plan.target.position
+    : plan.target.lastKnownPosition;
+  if (plan.target.kind === 'city' && state.cities[plan.target.id]?.owner === actorId) {
+    return true;
+  }
+  if (plan.target.kind === 'unit' && state.units[plan.target.id]?.owner === actorId) {
+    return true;
+  }
+  if (getVisibility(actor.visibility, position) === 'visible') return true;
+  const remembered = actor.visibility.lastSeen?.[hexKey(position)];
+  if (!isTrustedObservedLastSeenTile(remembered)) return false;
+  if (plan.target.kind === 'city') return remembered.city?.id === plan.target.id;
+  if (plan.target.kind === 'unit') {
+    const targetUnitId = plan.target.id;
+    return remembered.units?.some(unit => unit.id === targetUnitId) ?? false;
+  }
+  if (plan.target.kind === 'resource') return remembered.resource === plan.target.resource;
+  return plan.target.kind === 'camp';
+}
+
+function assertPlanInvariants(state: GameState, seed: string): void {
+  for (const [actorId, portfolio] of Object.entries(state.opponentAI?.majorCivs ?? {})) {
+    const plans = [
+      ...(portfolio.primaryPlan ? [portfolio.primaryPlan] : []),
+      ...Object.values(portfolio.defensePlansByCityId),
+    ];
+    if (Object.keys(portfolio.defensePlansByCityId).length > 4) {
+      throw new Error(`${seed}: ${actorId} exceeded four retained defense plans`);
+    }
+    for (const plan of plans) {
+      if (state.turn > plan.expiresAfterTurn) {
+        throw new Error(`${seed}: ${plan.id} remained active after expiry`);
+      }
+      if (!targetWasPerceived(state, actorId, plan)) {
+        throw new Error(`${seed}: ${plan.id} has an unearned exact target`);
+      }
+      for (const unitId of plan.assignedUnitIds) {
+        if (state.units[unitId]?.owner !== actorId) {
+          throw new Error(`${seed}: ${plan.id} assigned dead or wrong-owner ${unitId}`);
+        }
+      }
+    }
+  }
+}
+
+function assertLegalChoices(
+  state: GameState,
+  traces: readonly AIDecisionTrace[],
+  seed: string,
+  lateEra: boolean,
+): void {
+  for (const trace of traces) {
+    if (trace.candidates.length > 12) {
+      throw new Error(`${seed}: ${trace.actorId} trace exceeded 12 candidates`);
+    }
+    if (trace.selectedId) {
+      const selected = trace.candidates.find(candidate => candidate.id === trace.selectedId);
+      if (!selected?.eligible) {
+        throw new Error(`${seed}: ${trace.actorId} selected ineligible ${trace.decision}`);
+      }
+    }
+  }
+  for (const civ of Object.values(state.civilizations).filter(civ => !civ.isHuman && !civ.isEliminated)) {
+    const hasCity = civ.cities.some(cityId => state.cities[cityId]?.owner === civ.id);
+    if (!hasCity) continue;
+    if (!civ.techState.currentResearch && getAvailableTechs(civ.techState).length === 0
+      && civ.techState.completed.length < TECH_TREE.length) {
+      throw new Error(`${seed}: ${civ.id} has no legal research choice`);
+    }
+    if (!lateEra) continue;
+    const resources = getCivAvailableResources(state, civ.id, {
+      hostileOccupationEnabled: true,
+    });
+    for (const cityId of civ.cities) {
+      const city = state.cities[cityId];
+      if (!city) continue;
+      const queuedUnit = TRAINABLE_UNITS.find(entry => entry.type === city.productionQueue[0]);
+      if (
+        queuedUnit
+        && !getTrainableUnitsForCity(
+          city,
+          civ.techState.completed,
+          state.map,
+          civ.civType,
+          resources,
+        ).some(entry => entry.type === queuedUnit.type)
+      ) {
+        throw new Error(`${seed}: ${civ.id} queued blocked unit ${queuedUnit.type}`);
+      }
+    }
+  }
+}
+
+function modernForceMetrics(state: GameState): {
+  modernUnitShareByCiv: Record<string, number>;
+  eraByCiv: Record<string, number>;
+} {
+  const modernUnitShareByCiv: Record<string, number> = {};
+  const eraByCiv: Record<string, number> = {};
+  for (const civ of Object.values(state.civilizations).filter(civ => !civ.isHuman && !civ.isEliminated)) {
+    const completed = new Set(civ.techState.completed);
+    const routed = new Set(
+      Object.keys(state.opponentAI?.majorCivs[civ.id]?.upgradeRoutesByUnitId ?? {}),
+    );
+    const combat = civ.units
+      .map(unitId => state.units[unitId])
+      .filter(unit => unit && UNIT_DEFINITIONS[unit.type].strength > 0 && !routed.has(unit.id));
+    const modern = combat.filter(unit => {
+      const entry = TRAINABLE_UNITS.find(candidate => candidate.type === unit!.type);
+      return entry && (!entry.obsoletedByTech || !completed.has(entry.obsoletedByTech));
+    });
+    modernUnitShareByCiv[civ.id] = combat.length === 0 ? 0 : modern.length / combat.length;
+    eraByCiv[civ.id] = resolveCivilizationEra(civ.techState.completed);
+  }
+  return { modernUnitShareByCiv, eraByCiv };
+}
+
+function assertLateEraForce(state: GameState, seed: string): void {
+  for (const civ of Object.values(state.civilizations).filter(civ => !civ.isHuman && !civ.isEliminated)) {
+    const unitTypes = civ.units
+      .map(unitId => state.units[unitId]?.type)
+      .filter((type): type is UnitType => Boolean(type));
+    if (!unitTypes.some(type => getAIStrategicRoles(type).some(
+      role => role === 'capture' || role === 'frontline',
+    ))) {
+      throw new Error(`${seed}: ${civ.id} has no capture/frontline unit`);
+    }
+    const trainable = TRAINABLE_UNITS.filter(entry =>
+      (!entry.techRequired || civ.techState.completed.includes(entry.techRequired))
+      && (!entry.obsoletedByTech || !civ.techState.completed.includes(entry.obsoletedByTech)));
+    const supportTrainable = trainable.some(entry =>
+      getAIStrategicRoles(entry.type).some(role => role === 'ranged' || role === 'siege'));
+    if (
+      supportTrainable
+      && !unitTypes.some(type =>
+        getAIStrategicRoles(type).some(role => role === 'ranged' || role === 'siege'))
+    ) {
+      throw new Error(`${seed}: ${civ.id} has no ranged/siege support`);
+    }
+  }
+}
+
+function simulate(
+  options: AISimulationOptions,
+  lateEra: boolean,
+): AISimulationMetrics {
+  let state = initializeScenario(options);
+  if (lateEra) {
+    const eraNineTechs = TECH_TREE.filter(tech => tech.era <= 9).map(tech => tech.id);
+    state.era = 9;
+    for (const civ of Object.values(state.civilizations)) {
+      civ.techState.completed = [...eraNineTechs];
+      civ.techState.currentResearch = null;
+      civ.techState.researchQueue = [];
+      civ.techState.researchProgress = 0;
+      civ.gold = 1_000;
+      if (civ.isHuman) continue;
+      const warrior = civ.units.map(id => state.units[id]).find(unit => unit?.type === 'warrior');
+      if (warrior) {
+        warrior.type = 'tank';
+        warrior.movementPointsLeft = UNIT_DEFINITIONS.tank.movementPoints;
+      }
+      const city = civ.cities.map(id => state.cities[id]).find(Boolean);
+      if (city) {
+        const support = createUnit('biplane', civ.id, city.position, state.idCounters);
+        state.units[support.id] = support;
+        civ.units.push(support.id);
+      }
+    }
+  }
+
+  const metrics: AISimulationMetrics = {
+    turns: 0,
+    cityCaptures: 0,
+    campsResolved: 0,
+    pirateRaids: 0,
+    plansCreated: 0,
+    plansCompleted: 0,
+    plansAbandoned: 0,
+    planProgressTransitions: 0,
+    maxNoProgressRounds: 0,
+    modernUnitShareByCiv: {},
+    eraByCiv: {},
+    maxObjectiveCandidatesPerActor: 0,
+    maxPathQueriesPerActor: 0,
+    maxIndependentThreatsByHuman: {},
+    visibleWarningLeadRounds: [],
+    roundDurationsMs: [],
+    elapsedMs: 0,
+  };
+  const humanIds = Object.values(state.civilizations)
+    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .map(civ => civ.id)
+    .sort();
+  for (const id of humanIds) metrics.maxIndependentThreatsByHuman[id] = 0;
+
+  const warningRoundByViewerActor = new Map<string, number>();
+  const startedAt = performance.now();
+  for (let round = 0; round < options.turns; round++) {
+    const roundStart = performance.now();
+    const beforePlans = plansForState(state);
+    const beforeInput = JSON.stringify(state);
+    let traces: AIDecisionTrace[] = [];
+    let planningErrors: string[] = [];
+    const bus = new EventBus();
+    const captures: GameEvents['city:captured'][] = [];
+    bus.on('city:captured', event => {
+      metrics.cityCaptures += 1;
+      captures.push(event);
+    });
+    bus.on('barbarian:camp-destroyed', () => {
+      metrics.campsResolved += 1;
+    });
+    bus.on('threat:pirate-plunder', () => {
+      metrics.pirateRaids += 1;
+    });
+    bus.on('pirate:audio-cue', event => {
+      if (event.cue === 'raid') metrics.pirateRaids += 1;
+    });
+    bus.on('ai:strategic-warning', warning => {
+      warningRoundByViewerActor.set(
+        `${warning.viewerId}:${warning.actorId}`,
+        round,
+      );
+    });
+
+    const completed = runCompletedRound(state, bus, {
+      improvements: (current, eventBus) => processImprovementTurns(current, eventBus),
+      majors: (current, eventBus) => {
+        const result = processNonHumanMajorRound(current, eventBus, {
+          strategicPlanningEnabled: true,
+        });
+        traces = result.traces;
+        planningErrors = result.planningErrors.map(error =>
+          `${error.actorId}: ${error.message}`);
+        return result.state;
+      },
+      world: (current, eventBus) => processTurn(current, eventBus, {
+        purposefulAIEnabled: true,
+      }),
+      postprocess: (beforeRound, current, eventBus) =>
+        applyStrategicWarningTransitions(beforeRound, current, eventBus, {
+          purposefulAIEnabled: true,
+        }),
+    });
+    if (!completed.ok) {
+      throw new Error(`${options.seed}: completed round ${round + 1} failed`, {
+        cause: completed.error,
+      });
+    }
+    if (JSON.stringify(state) !== beforeInput) {
+      throw new Error(`${options.seed}: completed-round input mutated`);
+    }
+    state = completed.state;
+    const commitErrors = completed.events.commitTo(bus);
+    if (commitErrors.length > 0) {
+      throw new Error(`${options.seed}: event commit failed`, { cause: commitErrors[0] });
+    }
+    if (planningErrors.length > 0) {
+      throw new Error(`${options.seed}: planning failed: ${planningErrors.join('; ')}`);
+    }
+
+    const livingAIs = Object.values(state.civilizations)
+      .filter(civ => !civ.isHuman && !civ.isEliminated)
+      .filter(civ =>
+        civ.cities.some(id => state.cities[id]?.owner === civ.id)
+        || civ.units.some(id => state.units[id]?.owner === civ.id));
+    for (const civ of livingAIs) {
+      const portfolio = state.opponentAI?.majorCivs[civ.id];
+      if (
+        portfolio?.lastPlannedTurn !== state.turn - 1
+        || portfolio.lastExecutedTurn !== state.turn - 1
+      ) {
+        throw new Error(`${options.seed}: ${civ.id} did not prepare and execute exactly once`);
+      }
+    }
+
+    const afterPlans = plansForState(state);
+    for (const [id, plan] of afterPlans) {
+      const before = beforePlans.get(id);
+      if (!before) {
+        metrics.plansCreated += 1;
+        metrics.planProgressTransitions += 1;
+      } else if (
+        before.phase !== plan.phase
+        || before.lastProgressTurn !== plan.lastProgressTurn
+      ) {
+        metrics.planProgressTransitions += 1;
+      }
+      metrics.maxNoProgressRounds = Math.max(
+        metrics.maxNoProgressRounds,
+        state.turn - plan.lastProgressTurn,
+      );
+    }
+    for (const [id, before] of beforePlans) {
+      if (afterPlans.has(id)) continue;
+      const completedTarget =
+        before.target.kind === 'city' && state.cities[before.target.id]?.owner === before.actorId
+        || before.target.kind === 'unit' && !state.units[before.target.id]
+        || before.target.kind === 'camp' && !state.barbarianCamps[before.target.id];
+      if (completedTarget) metrics.plansCompleted += 1;
+      else metrics.plansAbandoned += 1;
+    }
+
+    for (const trace of traces) {
+      metrics.maxObjectiveCandidatesPerActor = Math.max(
+        metrics.maxObjectiveCandidatesPerActor,
+        trace.candidates.length,
+      );
+      if (trace.decision === 'objective') {
+        metrics.maxPathQueriesPerActor = Math.max(
+          metrics.maxPathQueriesPerActor,
+          Math.min(24, trace.candidates.length),
+        );
+      }
+    }
+    for (const humanId of humanIds) {
+      const ledger = state.opponentAI?.pressureByHuman[humanId];
+      if (!ledger) throw new Error(`${options.seed}: missing pressure ledger for ${humanId}`);
+      const activeCount = ledger.activeIndependentThreatIds.length;
+      metrics.maxIndependentThreatsByHuman[humanId] = Math.max(
+        metrics.maxIndependentThreatsByHuman[humanId] ?? 0,
+        activeCount,
+      );
+      const cap = OPPONENT_CHALLENGE_PROFILES[options.challenge].maxIndependentCrisesPerHuman;
+      if (activeCount > cap) {
+        throw new Error(`${options.seed}: ${humanId} exceeded pressure cap ${cap}`);
+      }
+    }
+    for (const threatId of new Set(humanIds.flatMap(
+      humanId => state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds,
+    ))) {
+      const materiallyAffected = humanIds.filter(humanId =>
+        state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds.includes(threatId));
+      if (materiallyAffected.length > 1 && materiallyAffected.some(humanId =>
+        !state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds.includes(threatId))) {
+        throw new Error(`${options.seed}: shared threat ${threatId} has inconsistent ledgers`);
+      }
+    }
+
+    for (const capture of captures) {
+      if (!humanIds.includes(capture.previousOwner)) continue;
+      const key = `${capture.previousOwner}:${capture.newOwner}`;
+      const warningRound = warningRoundByViewerActor.get(key);
+      const priorPlan = [...beforePlans.values()].find(plan =>
+        plan.actorId === capture.newOwner
+        && plan.target.kind === 'city'
+        && plan.target.id === capture.cityId);
+      if (priorPlan && warningRound === undefined) {
+        throw new Error(`${options.seed}: visible planned capture lacked strategic warning evidence`);
+      }
+      if (warningRound !== undefined) {
+        metrics.visibleWarningLeadRounds.push(round - warningRound);
+      }
+    }
+
+    assertFiniteSerializable(state, options.seed);
+    assertOwnersAndReferences(state, options.seed);
+    assertPlanInvariants(state, options.seed);
+    assertLegalChoices(state, traces, options.seed, lateEra);
+    metrics.roundDurationsMs.push(performance.now() - roundStart);
+    metrics.turns += 1;
+  }
+  metrics.elapsedMs = performance.now() - startedAt;
+  Object.assign(metrics, modernForceMetrics(state));
+  if (lateEra) {
+    assertLateEraForce(state, options.seed);
+    for (const [civId, share] of Object.entries(metrics.modernUnitShareByCiv)) {
+      if (share < 0.6) {
+        const deployed = state.civilizations[civId]?.units
+          .map(unitId => state.units[unitId]?.type)
+          .filter(Boolean)
+          .join(', ');
+        throw new Error(
+          `${options.seed}: ${civId} modern combat share ${share} is below 0.6 (${deployed})`,
+        );
+      }
+    }
+  }
+  return metrics;
+}
+
+export function simulateAIRounds(options: AISimulationOptions): AISimulationMetrics {
+  return simulate(options, false);
+}
+
+export function simulateLateEraAIRounds(
+  options: AISimulationOptions,
+): AISimulationMetrics {
+  return simulate(options, true);
+}

--- a/tests/simulation/ai-playability.test.ts
+++ b/tests/simulation/ai-playability.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { OpponentChallenge } from '@/core/types';
+import {
+  simulateAIRounds,
+  simulateLateEraAIRounds,
+  type AISimulationOptions,
+} from './ai-playability-fixture';
+
+const SHORT_SCENARIOS: AISimulationOptions[] = [
+  {
+    seed: 'playability-a',
+    challenge: 'explorer',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 1,
+    aiCount: 2,
+    personalitySet: ['aggressive', 'diplomatic'],
+  },
+  {
+    seed: 'playability-b',
+    challenge: 'standard',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 1,
+    aiCount: 2,
+    personalitySet: ['expansionist', 'trader'],
+  },
+  {
+    seed: 'playability-c',
+    challenge: 'veteran',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 1,
+    aiCount: 2,
+    personalitySet: ['aggressive', 'expansionist'],
+  },
+  {
+    seed: 'playability-d',
+    challenge: 'explorer',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 1,
+    aiCount: 2,
+    personalitySet: ['diplomatic', 'trader'],
+  },
+  {
+    seed: 'playability-e',
+    challenge: 'standard',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 2,
+    aiCount: 1,
+    personalitySet: ['aggressive'],
+  },
+  {
+    seed: 'playability-f',
+    challenge: 'veteran',
+    turns: 30,
+    mapSize: 'small',
+    humanCount: 2,
+    aiCount: 1,
+    personalitySet: ['trader'],
+  },
+];
+
+function extendedScenarios(): AISimulationOptions[] {
+  const challenges: OpponentChallenge[] = ['explorer', 'standard', 'veteran'];
+  return Array.from({ length: 30 }, (_, index) => ({
+    seed: `playability-extended-${String(index + 1).padStart(2, '0')}`,
+    challenge: challenges[index % challenges.length]!,
+    turns: 60,
+    mapSize: index < 12 ? 'small' : index < 24 ? 'medium' : 'large',
+    humanCount: index < 24 ? 1 : 3,
+    aiCount: index < 24 ? 2 : 1,
+    personalitySet: [
+      ['aggressive', 'diplomatic', 'expansionist', 'trader'][index % 4]!,
+      ['trader', 'expansionist', 'diplomatic', 'aggressive'][index % 4]!,
+    ].slice(0, index < 24 ? 2 : 1) as AISimulationOptions['personalitySet'],
+  }));
+}
+
+describe('purposeful AI playability simulation', () => {
+  const scenarios = process.env.AI_SIM_EXTENDED === '1'
+    ? extendedScenarios()
+    : SHORT_SCENARIOS;
+
+  it.each(scenarios)(
+    '$seed completes bounded production rounds without violating strategic invariants',
+    options => {
+      const metrics = simulateAIRounds(options);
+
+      expect(metrics.turns).toBe(options.turns);
+      expect(metrics.maxObjectiveCandidatesPerActor).toBeLessThanOrEqual(12);
+      expect(metrics.maxPathQueriesPerActor).toBeLessThanOrEqual(24);
+      expect(metrics.roundDurationsMs).toHaveLength(options.turns);
+      expect(metrics.elapsedMs).toBeGreaterThanOrEqual(0);
+      expect(Object.values(metrics.maxIndependentThreatsByHuman))
+        .toHaveLength(options.humanCount);
+
+      console.info(JSON.stringify({
+        scenario: options.seed,
+        challenge: options.challenge,
+        mapSize: options.mapSize,
+        captures: metrics.cityCaptures,
+        campsResolved: metrics.campsResolved,
+        pirateRaids: metrics.pirateRaids,
+        planProgress: metrics.planProgressTransitions,
+        warningLead: metrics.visibleWarningLeadRounds,
+        modernShare: metrics.modernUnitShareByCiv,
+        maxThreats: metrics.maxIndependentThreatsByHuman,
+        elapsedMs: Math.round(metrics.elapsedMs),
+      }));
+    },
+    120_000,
+  );
+
+  it('keeps a viable modern mixed force in the deterministic Era 9 fixture', () => {
+    const metrics = simulateLateEraAIRounds({
+      seed: 'playability-era-9',
+      challenge: 'standard',
+      turns: 20,
+      mapSize: 'small',
+      humanCount: 1,
+      aiCount: 2,
+      personalitySet: ['aggressive', 'trader'],
+    });
+
+    for (const share of Object.values(metrics.modernUnitShareByCiv)) {
+      expect(share).toBeGreaterThanOrEqual(0.6);
+    }
+    for (const era of Object.values(metrics.eraByCiv)) {
+      expect(era).toBeGreaterThanOrEqual(9);
+    }
+  }, 120_000);
+});

--- a/tests/systems/era-10.test.ts
+++ b/tests/systems/era-10.test.ts
@@ -224,12 +224,12 @@ function makeAiState(opts: {
 }
 
 describe('era 10 AI queuing', () => {
-  it('AI queues jet_fighter when jet-aviation is researched and none exists', () => {
+  it('uses catalog scoring instead of a hardcoded jet-fighter priority', () => {
     const state = makeAiState({ completedTechs: ['jet-aviation'] });
     const bus = new EventBus();
     const result = processAITurn(state, 'ai-1', bus);
     const city = Object.values(result.cities).find(c => c.owner === 'ai-1')!;
-    expect(city.productionQueue).toContain('jet_fighter');
+    expect(city.productionQueue.length).toBeGreaterThan(0);
   });
 
   it('AI does not queue a second jet_fighter when one already exists', () => {
@@ -240,12 +240,12 @@ describe('era 10 AI queuing', () => {
     expect(city.productionQueue).not.toContain('jet_fighter');
   });
 
-  it('AI queues carrier when carrier-warfare is researched, city is coastal, no carrier exists', () => {
+  it('uses catalog scoring instead of a hardcoded carrier priority', () => {
     const state = makeAiState({ completedTechs: ['carrier-warfare'], coastal: true });
     const bus = new EventBus();
     const result = processAITurn(state, 'ai-1', bus);
     const city = Object.values(result.cities).find(c => c.owner === 'ai-1')!;
-    expect(city.productionQueue).toContain('carrier');
+    expect(city.productionQueue.length).toBeGreaterThan(0);
   });
 
   it('AI does not queue a second carrier when one already exists', () => {
@@ -300,7 +300,7 @@ describe('era 10 AI queuing', () => {
     const bus = new EventBus();
     const result = processAITurn(state, 'ai-1', bus);
     const carrierCities = Object.values(result.cities).filter(c => c.owner === 'ai-1' && c.productionQueue.includes('carrier'));
-    expect(carrierCities).toHaveLength(1);
+    expect(carrierCities.length).toBeLessThanOrEqual(1);
   });
 });
 

--- a/tests/systems/era-11.test.ts
+++ b/tests/systems/era-11.test.ts
@@ -223,12 +223,12 @@ function makeAi11State(opts: {
 }
 
 describe('era 11 AI queuing', () => {
-  it('AI queues attack_helicopter when helicopter-warfare is researched and none exists', () => {
+  it('uses catalog scoring instead of a hardcoded attack-helicopter priority', () => {
     const state = makeAi11State({ completedTechs: ['helicopter-warfare'] });
     const bus = new EventBus();
     const result = processAITurn(state, 'ai-1', bus);
     const city = Object.values(result.cities).find(c => c.owner === 'ai-1')!;
-    expect(city.productionQueue).toContain('attack_helicopter');
+    expect(city.productionQueue.length).toBeGreaterThan(0);
   });
 
   it('AI does not queue a second attack_helicopter when one already exists', () => {
@@ -285,12 +285,12 @@ describe('era 11 AI queuing', () => {
     expect(helicopterCities.length).toBeLessThanOrEqual(1);
   });
 
-  it('AI queues missile_submarine when nuclear-submarines is researched, city is coastal, none exists', () => {
+  it('uses catalog scoring instead of a hardcoded missile-submarine priority', () => {
     const state = makeAi11State({ completedTechs: ['nuclear-submarines'], coastal: true });
     const bus = new EventBus();
     const result = processAITurn(state, 'ai-1', bus);
     const city = Object.values(result.cities).find(c => c.owner === 'ai-1')!;
-    expect(city.productionQueue).toContain('missile_submarine');
+    expect(city.productionQueue.length).toBeGreaterThan(0);
   });
 
   it('AI does not queue a second missile_submarine when one already exists', () => {

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -117,7 +117,6 @@ describe('minor civ turn processing', () => {
     const result = processMinorCivTurn(
       state,
       new EventBus(),
-      { purposefulAIEnabled: true },
     );
 
     expect(state).toEqual(before);
@@ -147,7 +146,6 @@ describe('minor civ turn processing', () => {
     const result = processMinorCivTurn(
       state,
       new EventBus(),
-      { purposefulAIEnabled: true },
     );
 
     expect(result.opponentAI?.minorCivs[mcId].target).toMatchObject({
@@ -175,7 +173,6 @@ describe('minor civ turn processing', () => {
     const result = processMinorCivTurn(
       state,
       new EventBus(),
-      { purposefulAIEnabled: true },
     );
 
     expect(hexDistance(result.units[garrison.id].position, city.position))

--- a/tests/systems/pirate-ecology.test.ts
+++ b/tests/systems/pirate-ecology.test.ts
@@ -149,6 +149,49 @@ describe('pirate activation and pressure', () => {
     expect(next.pirates!.nextSpawnCheckTurn).toBe(24);
     expect(next.pirates!.factions).toEqual({});
   });
+
+  it('keeps pressure and all side effects unspent when the independent-threat policy denies a spawn', () => {
+    const state = stateWithMap(mapWith([
+      [3, 3, 'plains'], [3, 2, 'coast'], [4, 2, 'coast'], [4, 3, 'coast'],
+      [8, 3, 'plains'],
+    ]));
+    state.turn = 20;
+    state.civilizations.player.techState.completed = ['galleys'];
+    addCity(state, 'nearby-port', 'player', { q: 8, r: 3 });
+    state.pirates = {
+      ...createEmptyPirateState(),
+      activatedTurn: 1,
+      nextSpawnCheckTurn: 20,
+      pressure: { value: 17, suppression: [] },
+    };
+    const beforeCounters = structuredClone(state.idCounters);
+    const bus = new EventBus();
+    const created: string[] = [];
+    const audio: unknown[] = [];
+    const spawned: unknown[] = [];
+    bus.on('unit:created', event => created.push(event.unit.id));
+    bus.on('pirate:faction-spawned', event => spawned.push(event));
+    bus.on('pirate:audio-cue', event => audio.push(event));
+
+    const next = processPirateEcology(state, bus, 'denied-pressure', {
+      spawnPolicy: {
+        canStart: (_candidateState, candidate) => {
+          expect(candidate.threatId).toBe('pirate:pirate-1');
+          expect(candidate.affectedHumanIds).toEqual(['player']);
+          return false;
+        },
+      },
+    });
+
+    expect(next.pirates!.pressure.value).toBe(18);
+    expect(next.pirates!.nextSpawnCheckTurn).toBe(24);
+    expect(next.pirates!.factions).toEqual({});
+    expect(next.pirates!.intelByCiv).toEqual({});
+    expect(next.idCounters).toEqual(beforeCounters);
+    expect(created).toEqual([]);
+    expect(spawned).toEqual([]);
+    expect(audio).toEqual([]);
+  });
 });
 
 describe('pirate habitat candidates', () => {

--- a/tests/systems/pirate-end-to-end.test.ts
+++ b/tests/systems/pirate-end-to-end.test.ts
@@ -54,7 +54,7 @@ describe('pirate feature completion gate', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
     expect(definitions).not.toContain('PIRATE_IMPLEMENTATION_READY');
     expect(turns).not.toContain('PIRATE_IMPLEMENTATION_READY');
-    expect(turns).toContain('includeLegacyPirates: false');
+    expect(turns).not.toContain('includeLegacyPirates');
     expect(turns).not.toContain('processPirateFleets(');
     expect(main).not.toContain("bus.on('threat:pirate-");
     expect(main).not.toContain('(gameState as any).pirateFleets');

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -99,9 +99,7 @@ describe('completed-round pirate coordinator', () => {
     bus.on('pirate:faction-spawned', event => sideEffects.push(event));
     bus.on('pirate:audio-cue', event => sideEffects.push(event));
 
-    const result = processPiratesForCompletedRound(state, bus, {
-      purposefulAIEnabled: true,
-    });
+    const result = processPiratesForCompletedRound(state, bus);
 
     expect(result.state.pirates!.factions).toEqual({});
     expect(result.state.pirates!.pressure.value).toBe(18);
@@ -131,7 +129,6 @@ describe('completed-round pirate coordinator', () => {
     const result = processPiratesForCompletedRound(
       state,
       bus,
-      { purposefulAIEnabled: true },
     );
 
     expect(state).toEqual(before);
@@ -162,7 +159,6 @@ describe('completed-round pirate coordinator', () => {
     const result = processPiratesForCompletedRound(
       state,
       new EventBus(),
-      { purposefulAIEnabled: true },
     );
 
     expect(result.state.pirates!.factions['pirate-1']).toBeDefined();
@@ -187,7 +183,6 @@ describe('completed-round pirate coordinator', () => {
     const result = processPiratesForCompletedRound(
       state,
       new EventBus(),
-      { purposefulAIEnabled: true },
     );
 
     expect(result.state.pirates!.factions['pirate-1'].intent?.mode).toBe('withdraw');

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -4,6 +4,7 @@ import { createNewGame } from '@/core/game-state';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
 import type { City, CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/types';
 import { processPiratesForCompletedRound, PIRATE_ROUND_TRACE } from '@/systems/pirate-system';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
 
 function fixture(): GameState {
   const state = createNewGame(undefined, 'pirate-round', 'small');
@@ -60,6 +61,57 @@ function faction(headquarters: PirateFactionState['headquarters'], shipIds: stri
 }
 
 describe('completed-round pirate coordinator', () => {
+  it('threads pressure gating through ecology without faction, unit, intel, notification, or audio side effects', () => {
+    const state = fixture();
+    state.opponentChallenge = 'explorer';
+    state.opponentAI = createEmptyOpponentAIState();
+    state.barbarianCamps['existing-pressure'] = {
+      id: 'existing-pressure',
+      position: { q: 1, r: 1 },
+      strength: 5,
+      spawnCooldown: 2,
+    };
+    state.opponentAI.pressureByHuman.player = {
+      activeIndependentThreatIds: ['barbarian:existing-pressure'],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+    state.civilizations.player.techState.completed = ['galleys'];
+    state.pirates = {
+      ...createEmptyPirateState(),
+      activatedTurn: 1,
+      nextSpawnCheckTurn: state.turn,
+      pressure: { value: 17, suppression: [] },
+    };
+    const playerCity = {
+      ...Object.values(createNewGame(undefined, 'pirate-city-template', 'small').cities)[0],
+      id: 'distant-port',
+      owner: 'player',
+      position: { q: 0, r: 0 },
+    };
+    state.cities[playerCity.id] = playerCity;
+    state.civilizations.player.cities = [playerCity.id];
+    const bus = new EventBus();
+    const sideEffects: unknown[] = [];
+    bus.on('unit:created', event => sideEffects.push(event));
+    bus.on('pirate:faction-spawned', event => sideEffects.push(event));
+    bus.on('pirate:audio-cue', event => sideEffects.push(event));
+
+    const result = processPiratesForCompletedRound(state, bus, {
+      purposefulAIEnabled: true,
+    });
+
+    expect(result.state.pirates!.factions).toEqual({});
+    expect(result.state.pirates!.pressure.value).toBe(18);
+    expect(Object.values(result.state.pirates!.intelByCiv).every(
+      viewerIntel => Object.keys(viewerIntel).length === 0,
+    )).toBe(true);
+    expect(result.state.pendingEvents?.player ?? []).toEqual([]);
+    expect(sideEffects).toEqual([]);
+  });
+
   it('moves a purposeful fleet along canonical multi-step cohesive paths and retains intent', () => {
     const state = fixture();
     addCity(state);

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -139,19 +139,10 @@ describe('getCivAvailableResources', () => {
     };
 
     expect(isResourceTileDeniedByHostileOccupation(state, 'player', { q: 4, r: 3 })).toBe(true);
-    expect(getCivAvailableResources(state, 'player').has('silk')).toBe(true);
-    expect(getCivAvailableResources(
-      state,
-      'player',
-      { hostileOccupationEnabled: true },
-    ).has('silk')).toBe(false);
+    expect(getCivAvailableResources(state, 'player').has('silk')).toBe(false);
 
     delete state.units.raider;
-    expect(getCivAvailableResources(
-      state,
-      'player',
-      { hostileOccupationEnabled: true },
-    ).has('silk')).toBe(true);
+    expect(getCivAvailableResources(state, 'player').has('silk')).toBe(true);
   });
 
   it('does not deny resources for cargo, neutral, or friendly occupants', () => {
@@ -219,11 +210,7 @@ describe('getCivAvailableResources', () => {
         position: { q: 3, r: 3 },
       } as never,
     };
-    expect(getCivAvailableResources(
-      cityCenter,
-      'player',
-      { hostileOccupationEnabled: true },
-    ).has('horses')).toBe(true);
+    expect(getCivAvailableResources(cityCenter, 'player').has('horses')).toBe(true);
   });
 
   it('returns empty set for unknown civId', () => {

--- a/tests/systems/strategic-warning-system.test.ts
+++ b/tests/systems/strategic-warning-system.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import {
+  createEmptyMajorCivPlanPortfolio,
+  createEmptyOpponentAIState,
+} from '@/core/opponent-ai-state';
+import type { AIStrategicPlan, GameState, HexCoord } from '@/core/types';
+import {
+  applyStrategicWarningTransitions,
+  deriveStrategicWarningTransitions,
+} from '@/systems/strategic-warning-system';
+import { EventBus } from '@/core/event-bus';
+import { createEmptyPirateState } from '@/core/pirate-state';
+import { foundCity } from '@/systems/city-system';
+
+function makePlan(
+  actorId: string,
+  assignedUnitId: string,
+  target: AIStrategicPlan['target'],
+  phase: AIStrategicPlan['phase'] = 'mobilizing',
+): AIStrategicPlan {
+  return {
+    id: `plan:${actorId}:capture`,
+    actorId,
+    objective: 'capture',
+    target,
+    theaterId: 'test-theater',
+    phase,
+    reasonCodes: ['continue-active-war'],
+    commitment: 0.8,
+    createdTurn: 2,
+    reconsiderAfterTurn: 4,
+    expiresAfterTurn: 10,
+    lastProgressTurn: 2,
+    requiredRoles: { capture: 1 },
+    assignedUnitIds: [assignedUnitId],
+  };
+}
+
+function fixture(): { before: GameState; after: GameState; aiId: string; aiUnitId: string } {
+  const before = createNewGame({
+    civType: 'rome',
+    mapSize: 'small',
+    opponentCount: 1,
+    gameTitle: 'Warning Test',
+    seed: 'strategic-warning',
+  });
+  before.opponentAI = createEmptyOpponentAIState();
+  before.opponentAI.pressureByHuman.player = {
+    activeIndependentThreatIds: [],
+    recoveryUntilTurn: 0,
+    lastResolvedThreatTurn: null,
+    lastWarningTurnByKey: {},
+    lastStrategicAudioTurn: null,
+  };
+  const aiId = 'ai-1';
+  const aiUnitId = before.civilizations[aiId].units[0]!;
+  const playerPosition = before.units[before.civilizations.player.units[0]!]!.position;
+  const aiPosition = before.units[aiUnitId].position;
+  const playerCity = foundCity('player', playerPosition, before.map, before.idCounters);
+  const aiCity = foundCity(aiId, aiPosition, before.map, before.idCounters);
+  before.cities = { [playerCity.id]: playerCity, [aiCity.id]: aiCity };
+  before.civilizations.player.cities = [playerCity.id];
+  before.civilizations[aiId].cities = [aiCity.id];
+  before.opponentAI.majorCivs[aiId] = createEmptyMajorCivPlanPortfolio();
+  const after = structuredClone(before);
+  after.turn = before.turn + 1;
+  return { before, after, aiId, aiUnitId };
+}
+
+function setVisibility(state: GameState, viewerId: string, coord: HexCoord, value: 'visible' | 'fog'): void {
+  state.civilizations[viewerId].visibility.tiles[`${coord.q},${coord.r}`] = value;
+}
+
+describe('strategic warning transition derivation', () => {
+  it('warns about a visible mobilization without leaking its hidden target', () => {
+    const { before, after, aiId, aiUnitId } = fixture();
+    const unit = after.units[aiUnitId];
+    setVisibility(after, 'player', unit.position, 'visible');
+    after.opponentAI!.majorCivs[aiId].primaryPlan = makePlan(aiId, aiUnitId, {
+      kind: 'city',
+      id: 'hidden-city',
+      lastKnownPosition: { q: 99, r: 99 },
+    });
+
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    });
+
+    expect(warning).toMatchObject({
+      viewerId: 'player',
+      actorId: aiId,
+      actorName: after.civilizations[aiId].name,
+      kind: 'mobilizing',
+      evidence: 'visible',
+      playAudio: true,
+    });
+    expect(warning.target).toBeUndefined();
+    expect(warning.targetLabel).toBeUndefined();
+  });
+
+  it('includes an exact target only when that target is viewer-safe', () => {
+    const { before, after, aiId, aiUnitId } = fixture();
+    const unit = after.units[aiUnitId];
+    setVisibility(after, 'player', unit.position, 'visible');
+    const targetCity = Object.values(after.cities).find(city => city.owner === aiId)!;
+    setVisibility(after, 'player', targetCity.position, 'visible');
+    after.opponentAI!.majorCivs[aiId].primaryPlan = makePlan(aiId, aiUnitId, {
+      kind: 'city',
+      id: targetCity.id,
+      lastKnownPosition: targetCity.position,
+    });
+
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    });
+
+    expect(warning.targetLabel).toBe(targetCity.name);
+    expect(warning.target).toEqual({
+      kind: 'map',
+      coord: targetCity.position,
+      label: targetCity.name,
+    });
+  });
+
+  it('uses trusted remembered unit evidence and marks current position uncertain', () => {
+    const { before, after, aiId, aiUnitId } = fixture();
+    const unit = after.units[aiUnitId];
+    setVisibility(after, 'player', unit.position, 'fog');
+    after.civilizations.player.visibility.lastSeen = {
+      [`${unit.position.q},${unit.position.r}`]: {
+        coord: unit.position,
+        terrain: after.map.tiles[`${unit.position.q},${unit.position.r}`].terrain,
+        elevation: 'lowland',
+        resource: null,
+        improvement: 'none',
+        improvementTurnsLeft: 0,
+        owner: null,
+        hasRiver: false,
+        wonder: null,
+        observedTurn: before.turn,
+        source: 'observed',
+        units: [{ id: aiUnitId, owner: aiId, type: unit.type, healthBand: 'healthy' }],
+      },
+    };
+    after.opponentAI!.majorCivs[aiId].primaryPlan = makePlan(aiId, aiUnitId, {
+      kind: 'region',
+      id: 'east',
+      anchor: { q: 8, r: 4 },
+    });
+
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([
+      expect.objectContaining({ evidence: 'remembered', regionLabel: expect.any(String) }),
+    ]);
+  });
+
+  it('does not turn a hidden internal plan or another viewer evidence into knowledge', () => {
+    const { before, after, aiId, aiUnitId } = fixture();
+    const unit = after.units[aiUnitId];
+    setVisibility(after, 'player', unit.position, 'fog');
+    setVisibility(after, 'ai-1', unit.position, 'visible');
+    after.opponentAI!.majorCivs[aiId].primaryPlan = makePlan(aiId, aiUnitId, {
+      kind: 'city',
+      id: 'hidden',
+      lastKnownPosition: { q: 8, r: 8 },
+    });
+
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+  });
+
+  it('derives pirate behavior only from the viewer persisted intel snapshot', () => {
+    const { before, after } = fixture();
+    before.pirates = createEmptyPirateState();
+    after.pirates = createEmptyPirateState();
+    after.pirates.factions['pirate-1'] = {
+      id: 'pirate-1',
+      name: 'Secret Richer Name',
+      spawnedRound: 1,
+      behavior: 'blockading',
+      maritimeStage: 2,
+      notoriety: 1,
+      shipIds: [],
+      headquarters: {
+        kind: 'coastal-enclave',
+        position: { q: 4, r: 4 },
+        integrity: 100,
+        maxIntegrity: 100,
+      },
+      tributeByCiv: {},
+      demandByCiv: {},
+      contract: null,
+      intent: null,
+      transitionGuards: { emittedEventKeys: [] },
+    };
+    before.pirates.intelByCiv.player = {
+      'pirate-1': {
+        factionId: 'pirate-1',
+        level: 'sighted',
+        discoveredRound: 1,
+        lastUpdatedRound: 1,
+        knownBehavior: 'patrolling',
+      },
+    };
+    after.pirates.intelByCiv.player = structuredClone(before.pirates.intelByCiv.player);
+
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+
+    after.pirates.intelByCiv.player['pirate-1'].knownBehavior = 'blockading';
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    });
+    expect(warning).toMatchObject({
+      actorId: 'pirate-1',
+      actorName: 'Pirates',
+      kind: 'blockade',
+      evidence: 'earned-intel',
+    });
+    expect(warning.actorName).not.toContain('Secret');
+  });
+
+  it('requires locally scouted raiders before exposing a barbarian resource warning', () => {
+    const { before, after } = fixture();
+    const resourceCoord = after.cities[after.civilizations.player.cities[0]!].position;
+    after.map.tiles[`${resourceCoord.q},${resourceCoord.r}`].resource = 'iron';
+    setVisibility(after, 'player', resourceCoord, 'visible');
+    const raiderId = 'barbarian-raider';
+    after.units[raiderId] = {
+      id: raiderId,
+      type: 'warrior',
+      owner: 'barbarian',
+      position: { q: resourceCoord.q + 1, r: resourceCoord.r },
+      movementPointsLeft: 2,
+      health: 100,
+      experience: 0,
+      hasMoved: false,
+      hasActed: false,
+      isResting: false,
+    };
+    setVisibility(after, 'player', after.units[raiderId].position, 'fog');
+    const barbarianPlan = makePlan(
+      'camp-1',
+      raiderId,
+      { kind: 'resource', resource: 'iron', position: resourceCoord },
+      'advancing',
+    );
+    barbarianPlan.objective = 'raid';
+    after.opponentAI!.barbarianCamps['camp-1'] = barbarianPlan;
+
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+
+    setVisibility(after, 'player', after.units[raiderId].position, 'visible');
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([
+      expect.objectContaining({
+        actorId: 'barbarian:camp-1',
+        kind: 'raid',
+        resource: 'iron',
+      }),
+    ]);
+  });
+
+  it('emits available-to-denied and denied-to-restored resource transitions exactly once', () => {
+    const { before, after } = fixture();
+    const city = Object.values(after.cities).find(candidate => candidate.owner === 'player')!;
+    const coord = city.ownedTiles[0]!;
+    const key = `${coord.q},${coord.r}`;
+    for (const state of [before, after]) {
+      state.map.tiles[key] = {
+        ...state.map.tiles[key],
+        resource: 'iron',
+        improvement: 'mine',
+        improvementTurnsLeft: 0,
+        owner: 'player',
+      };
+      state.civilizations.player.techState.completed.push('bronze-working');
+    }
+    after.units.raider = {
+      id: 'raider',
+      type: 'warrior',
+      owner: 'barbarian',
+      position: coord,
+      movementPointsLeft: 0,
+      health: 100,
+      experience: 0,
+      hasMoved: true,
+      hasActed: false,
+      isResting: false,
+    };
+
+    const denied = deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    });
+    expect(denied).toEqual([
+      expect.objectContaining({
+        kind: 'resource-denied',
+        resource: 'iron',
+        target: { kind: 'map', coord, label: expect.any(String) },
+      }),
+    ]);
+    expect(deriveStrategicWarningTransitions(after, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+
+    const restored = structuredClone(after);
+    delete restored.units.raider;
+    restored.turn++;
+    expect(deriveStrategicWarningTransitions(after, restored, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([
+      expect.objectContaining({ kind: 'resource-restored', resource: 'iron' }),
+    ]);
+    expect(deriveStrategicWarningTransitions(restored, restored, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+  });
+
+  it('ignores non-hostile, transported, and second-occupier resource near misses', () => {
+    const { before, after } = fixture();
+    const city = Object.values(after.cities).find(candidate => candidate.owner === 'player')!;
+    const coord = city.ownedTiles[0]!;
+    const key = `${coord.q},${coord.r}`;
+    for (const state of [before, after]) {
+      state.map.tiles[key] = {
+        ...state.map.tiles[key],
+        resource: 'iron',
+        improvement: 'mine',
+        improvementTurnsLeft: 0,
+        owner: 'player',
+      };
+      state.civilizations.player.techState.completed.push('bronze-working');
+    }
+    after.units.cargo = {
+      id: 'cargo',
+      type: 'warrior',
+      owner: 'barbarian',
+      transportId: 'transport',
+      position: coord,
+    } as GameState['units'][string];
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+
+    delete after.units.cargo;
+    after.units.neutral = {
+      id: 'neutral',
+      type: 'warrior',
+      owner: 'ai-1',
+      position: coord,
+    } as GameState['units'][string];
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+
+    const deniedBefore = structuredClone(before);
+    const deniedAfter = structuredClone(after);
+    delete deniedAfter.units.neutral;
+    for (const state of [deniedBefore, deniedAfter]) {
+      state.units.raider = {
+        id: 'raider',
+        type: 'warrior',
+        owner: 'barbarian',
+        position: coord,
+      } as GameState['units'][string];
+    }
+    deniedAfter.units.raider.id = 'replacement-raider';
+    expect(deriveStrategicWarningTransitions(deniedBefore, deniedAfter, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+  });
+
+  it('emits recovery only from an explicit pressure-ledger resolution and stays dark when disabled', () => {
+    const { before, after } = fixture();
+    before.opponentAI!.pressureByHuman.player.activeIndependentThreatIds = ['barbarian:camp-1'];
+    after.opponentAI!.pressureByHuman.player = {
+      ...after.opponentAI!.pressureByHuman.player,
+      activeIndependentThreatIds: [],
+      lastResolvedThreatTurn: after.turn,
+      recoveryUntilTurn: after.turn + 2,
+    };
+
+    expect(deriveStrategicWarningTransitions(before, after, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([expect.objectContaining({ kind: 'recovery' })]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
+  });
+
+  it('applies dedup ledger updates immutably and emits at most one audio request per viewer round', () => {
+    const { before, after, aiId, aiUnitId } = fixture();
+    setVisibility(after, 'player', after.units[aiUnitId].position, 'visible');
+    after.opponentAI!.majorCivs[aiId].primaryPlan = makePlan(aiId, aiUnitId, {
+      kind: 'region',
+      id: 'border',
+      anchor: { q: 4, r: 4 },
+    });
+    const snapshot = structuredClone(after);
+    const bus = new EventBus();
+    const warnings: unknown[] = [];
+    bus.on('ai:strategic-warning', warning => warnings.push(warning));
+
+    const applied = applyStrategicWarningTransitions(before, after, bus, {
+      purposefulAIEnabled: true,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings.filter((warning: any) => warning.playAudio)).toHaveLength(1);
+    expect(Object.keys(applied.opponentAI!.pressureByHuman.player.lastWarningTurnByKey))
+      .toHaveLength(1);
+    expect(after).toEqual(snapshot);
+    expect(deriveStrategicWarningTransitions(before, applied, 'player', {
+      purposefulAIEnabled: true,
+    })).toEqual([]);
+  });
+});

--- a/tests/systems/strategic-warning-system.test.ts
+++ b/tests/systems/strategic-warning-system.test.ts
@@ -83,9 +83,7 @@ describe('strategic warning transition derivation', () => {
       lastKnownPosition: { q: 99, r: 99 },
     });
 
-    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    });
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player');
 
     expect(warning).toMatchObject({
       viewerId: 'player',
@@ -111,9 +109,7 @@ describe('strategic warning transition derivation', () => {
       lastKnownPosition: targetCity.position,
     });
 
-    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    });
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player');
 
     expect(warning.targetLabel).toBe(targetCity.name);
     expect(warning.target).toEqual({
@@ -149,9 +145,7 @@ describe('strategic warning transition derivation', () => {
       anchor: { q: 8, r: 4 },
     });
 
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([
       expect.objectContaining({ evidence: 'remembered', regionLabel: expect.any(String) }),
     ]);
   });
@@ -167,9 +161,7 @@ describe('strategic warning transition derivation', () => {
       lastKnownPosition: { q: 8, r: 8 },
     });
 
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
   });
 
   it('derives pirate behavior only from the viewer persisted intel snapshot', () => {
@@ -207,14 +199,10 @@ describe('strategic warning transition derivation', () => {
     };
     after.pirates.intelByCiv.player = structuredClone(before.pirates.intelByCiv.player);
 
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
 
     after.pirates.intelByCiv.player['pirate-1'].knownBehavior = 'blockading';
-    const [warning] = deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    });
+    const [warning] = deriveStrategicWarningTransitions(before, after, 'player');
     expect(warning).toMatchObject({
       actorId: 'pirate-1',
       actorName: 'Pirates',
@@ -252,14 +240,10 @@ describe('strategic warning transition derivation', () => {
     barbarianPlan.objective = 'raid';
     after.opponentAI!.barbarianCamps['camp-1'] = barbarianPlan;
 
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
 
     setVisibility(after, 'player', after.units[raiderId].position, 'visible');
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([
       expect.objectContaining({
         actorId: 'barbarian:camp-1',
         kind: 'raid',
@@ -296,9 +280,7 @@ describe('strategic warning transition derivation', () => {
       isResting: false,
     };
 
-    const denied = deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    });
+    const denied = deriveStrategicWarningTransitions(before, after, 'player');
     expect(denied).toEqual([
       expect.objectContaining({
         kind: 'resource-denied',
@@ -306,21 +288,15 @@ describe('strategic warning transition derivation', () => {
         target: { kind: 'map', coord, label: expect.any(String) },
       }),
     ]);
-    expect(deriveStrategicWarningTransitions(after, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(after, after, 'player')).toEqual([]);
 
     const restored = structuredClone(after);
     delete restored.units.raider;
     restored.turn++;
-    expect(deriveStrategicWarningTransitions(after, restored, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([
+    expect(deriveStrategicWarningTransitions(after, restored, 'player')).toEqual([
       expect.objectContaining({ kind: 'resource-restored', resource: 'iron' }),
     ]);
-    expect(deriveStrategicWarningTransitions(restored, restored, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(restored, restored, 'player')).toEqual([]);
   });
 
   it('ignores non-hostile, transported, and second-occupier resource near misses', () => {
@@ -345,9 +321,7 @@ describe('strategic warning transition derivation', () => {
       transportId: 'transport',
       position: coord,
     } as GameState['units'][string];
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
 
     delete after.units.cargo;
     after.units.neutral = {
@@ -356,9 +330,7 @@ describe('strategic warning transition derivation', () => {
       owner: 'ai-1',
       position: coord,
     } as GameState['units'][string];
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
 
     const deniedBefore = structuredClone(before);
     const deniedAfter = structuredClone(after);
@@ -372,12 +344,10 @@ describe('strategic warning transition derivation', () => {
       } as GameState['units'][string];
     }
     deniedAfter.units.raider.id = 'replacement-raider';
-    expect(deriveStrategicWarningTransitions(deniedBefore, deniedAfter, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(deniedBefore, deniedAfter, 'player')).toEqual([]);
   });
 
-  it('emits recovery only from an explicit pressure-ledger resolution and stays dark when disabled', () => {
+  it('emits recovery only from an explicit pressure-ledger resolution', () => {
     const { before, after } = fixture();
     before.opponentAI!.pressureByHuman.player.activeIndependentThreatIds = ['barbarian:camp-1'];
     after.opponentAI!.pressureByHuman.player = {
@@ -387,10 +357,8 @@ describe('strategic warning transition derivation', () => {
       recoveryUntilTurn: after.turn + 2,
     };
 
-    expect(deriveStrategicWarningTransitions(before, after, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([expect.objectContaining({ kind: 'recovery' })]);
-    expect(deriveStrategicWarningTransitions(before, after, 'player')).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, after, 'player'))
+      .toEqual([expect.objectContaining({ kind: 'recovery' })]);
   });
 
   it('applies dedup ledger updates immutably and emits at most one audio request per viewer round', () => {
@@ -406,17 +374,13 @@ describe('strategic warning transition derivation', () => {
     const warnings: unknown[] = [];
     bus.on('ai:strategic-warning', warning => warnings.push(warning));
 
-    const applied = applyStrategicWarningTransitions(before, after, bus, {
-      purposefulAIEnabled: true,
-    });
+    const applied = applyStrategicWarningTransitions(before, after, bus);
 
     expect(warnings).toHaveLength(1);
     expect(warnings.filter((warning: any) => warning.playAudio)).toHaveLength(1);
     expect(Object.keys(applied.opponentAI!.pressureByHuman.player.lastWarningTurnByKey))
       .toHaveLength(1);
     expect(after).toEqual(snapshot);
-    expect(deriveStrategicWarningTransitions(before, applied, 'player', {
-      purposefulAIEnabled: true,
-    })).toEqual([]);
+    expect(deriveStrategicWarningTransitions(before, applied, 'player')).toEqual([]);
   });
 });

--- a/tests/systems/threat-pressure-balance.test.ts
+++ b/tests/systems/threat-pressure-balance.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { computeThreatScore } from '@/systems/threat-pressure-system';
 import type { GameState, HexTile, Civilization } from '@/core/types';
+import { OPPONENT_CHALLENGE_PROFILES } from '@/core/opponent-challenge';
 
 function makeScenario(era: number, idleTurns: number, dominanceRatio: number): GameState {
   const tiles: Record<string, HexTile> = {};
@@ -38,6 +39,19 @@ function makeScenario(era: number, idleTurns: number, dominanceRatio: number): G
 }
 
 describe('threat score balance bands', () => {
+  it('uses the launch pressure caps and recovery bands without stat bonuses', () => {
+    expect(Object.fromEntries(Object.entries(OPPONENT_CHALLENGE_PROFILES).map(
+      ([challenge, profile]) => [challenge, {
+        cap: profile.maxIndependentCrisesPerHuman,
+        recovery: profile.recoveryRounds,
+      }],
+    ))).toEqual({
+      explorer: { cap: 1, recovery: 3 },
+      standard: { cap: 2, recovery: 2 },
+      veteran: { cap: 3, recovery: 1 },
+    });
+  });
+
   it('era-2, 6 idle turns, 50% dominance: score ≥ 2.5 (land resurgence eligible)', () => {
     const state = makeScenario(2, 6, 0.5);
     expect(computeThreatScore(state, 'p1', 'continent-0')).toBeGreaterThanOrEqual(2.5);

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -2,8 +2,23 @@ import { describe, it, expect } from 'vitest';
 import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { generateContinentMap } from '@/systems/continent-map-generator';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
-import { computeThreatScore, empireShare, nearestLandmassId, recordCombatForCiv, processLandResurgence, processThreatPressure, processPirateSpawn, processPirateFleets, PIRATE_OWNER } from '@/systems/threat-pressure-system';
+import {
+  canStartIndependentThreat,
+  computeThreatScore,
+  deriveActiveIndependentThreatIds,
+  empireShare,
+  nearestLandmassId,
+  recordCombatForCiv,
+  processIndependentThreatPressureForHumans,
+  processLandResurgence,
+  processThreatPressure,
+  processPirateSpawn,
+  processPirateFleets,
+  PIRATE_OWNER,
+} from '@/systems/threat-pressure-system';
 import type { GameMap, GameState, HexTile, Civilization } from '@/core/types';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
+import { EventBus } from '@/core/event-bus';
 
 function makeTestState(overrides: Partial<GameState> = {}): GameState {
   const tiles: Record<string, HexTile> = {};
@@ -162,6 +177,28 @@ describe('processLandResurgence', () => {
     expect(camp?.strength).toBeGreaterThanOrEqual(6); // era-2 minimum
     expect(camp?.strength).toBeLessThanOrEqual(10);   // era-2 maximum
   });
+
+  it('does not consume IDs, cooldown, or events when a governed resurgence is denied', () => {
+    const state = makeResurgenceState();
+    const beforeCounters = structuredClone(state.idCounters);
+    const events: string[] = [];
+    const bus = { emit: (event: string) => events.push(event) } as any;
+
+    const updated = processLandResurgence(state, 'p1', 'continent-0', bus, {
+      spawnPolicy: {
+        canStart: (_candidateState, candidate) => {
+          expect(candidate.threatId).toBe(`barbarian:camp-${state.idCounters.nextCampId}`);
+          expect(candidate.affectedHumanIds).toContain('p1');
+          return false;
+        },
+      },
+    });
+
+    expect(updated).toBe(state);
+    expect(state.idCounters).toEqual(beforeCounters);
+    expect(state.resurgentCampCooldownByCivLandmass).toBeUndefined();
+    expect(events).toEqual([]);
+  });
 });
 
 describe('processThreatPressure — hot-seat isolation', () => {
@@ -194,6 +231,360 @@ describe('processThreatPressure — hot-seat isolation', () => {
     const score1 = computeThreatScore(state, 'p1', 'continent-1');
     expect(score0).toBeGreaterThan(2.5);
     expect(score1).toBeGreaterThan(2.5);
+  });
+});
+
+describe('independent threat pressure governor', () => {
+  function makeHuman(id: string, cityId: string, position: { q: number; r: number }): Civilization {
+    return {
+      ...structuredClone(makeTestState().civilizations.p1),
+      id,
+      name: id,
+      cities: [cityId],
+      units: [],
+      isHuman: true,
+      isEliminated: false,
+      visibility: { tiles: {} },
+    };
+  }
+
+  function makePressureState(challenge: 'explorer' | 'standard' | 'veteran' = 'standard'): GameState {
+    const state = makeTestState({
+      opponentChallenge: challenge,
+      opponentAI: createEmptyOpponentAIState(),
+    });
+    state.civilizations = {
+      'player-3': makeHuman('player-3', 'city-3', { q: 8, r: 0 }),
+      'player-1': makeHuman('player-1', 'city-1', { q: 0, r: 0 }),
+      'player-2': makeHuman('player-2', 'city-2', { q: 4, r: 0 }),
+    };
+    state.cities = {
+      'city-1': { id: 'city-1', owner: 'player-1', position: { q: 0, r: 0 } } as any,
+      'city-2': { id: 'city-2', owner: 'player-2', position: { q: 4, r: 0 } } as any,
+      'city-3': { id: 'city-3', owner: 'player-3', position: { q: 8, r: 0 } } as any,
+    };
+    state.currentPlayer = 'player-3';
+    return state;
+  }
+
+  function addPirateThreat(state: GameState, factionId: string, targetCivId: string): void {
+    state.pirates = {
+      version: 1,
+      factions: {
+        ...(state.pirates?.factions ?? {}),
+        [factionId]: {
+          id: factionId,
+          name: factionId,
+          spawnedRound: state.turn,
+          behavior: 'raiding',
+          maritimeStage: 1,
+          notoriety: 0,
+          shipIds: [],
+          headquarters: {
+            kind: 'coastal-enclave',
+            position: { q: 2, r: 0 },
+            integrity: 100,
+            maxIntegrity: 100,
+          },
+          tributeByCiv: {},
+          demandByCiv: {},
+          contract: null,
+          intent: { kind: 'raid', targetCivId, plannedRound: state.turn },
+          transitionGuards: { emittedEventKeys: [] },
+        },
+      },
+      history: [],
+      pressure: { value: 0, suppression: [] },
+      intelByCiv: {},
+      nextSpawnCheckTurn: 0,
+      activatedTurn: 0,
+      activationWarningDeliveredByCiv: {},
+    } as GameState['pirates'];
+  }
+
+  it('reconciles every living human once in stable civilization ID order regardless of current player', () => {
+    const state = makePressureState();
+    state.civilizations['player-2'].isEliminated = true;
+
+    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+
+    expect(Object.keys(result.opponentAI!.pressureByHuman))
+      .toEqual(['player-1', 'player-3']);
+    expect(state.opponentAI!.pressureByHuman).toEqual({});
+  });
+
+  it.each([
+    ['explorer', 1],
+    ['standard', 2],
+    ['veteran', 3],
+  ] as const)('%s caps new independent threats at %i per human', (challenge, cap) => {
+    const state = makePressureState(challenge);
+    state.opponentAI!.pressureByHuman['player-1'] = {
+      activeIndependentThreatIds: Array.from({ length: cap }, (_, index) => `barbarian:camp-${index}`),
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+    for (let index = 0; index < cap; index++) {
+      state.barbarianCamps[`camp-${index}`] = {
+        id: `camp-${index}`,
+        position: { q: index + 1, r: 0 },
+        strength: 5,
+        spawnCooldown: 2,
+      };
+    }
+
+    expect(canStartIndependentThreat(state, 'player-1', 'barbarian:camp-new'))
+      .toMatchObject({ allowed: false, reason: 'pressure-cap', activeCount: cap, cap });
+  });
+
+  it('keeps shared threat identity per human without sharing their pressure budgets', () => {
+    const state = makePressureState('explorer');
+    addPirateThreat(state, 'pirate-7', 'player-1');
+    state.pirates!.factions['pirate-7'].contract = {
+      employerId: 'player-3',
+      targetId: 'player-2',
+      startedRound: 1,
+      expiresAfterRound: 20,
+      successfulRaidCount: 0,
+      exposed: false,
+      exposureResolvedRaidKeys: [],
+    };
+
+    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+
+    expect(result.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+      .toEqual(['pirate:pirate-7']);
+    expect(result.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+      .toEqual(['pirate:pirate-7']);
+    expect(canStartIndependentThreat(result, 'player-3', 'barbarian:new'))
+      .toMatchObject({ allowed: true, activeCount: 0 });
+  });
+
+  it('starts a shared resurgence only when every newly affected human has cap room', () => {
+    const makeEligible = () => {
+      const state = makePressureState('explorer');
+      state.turn = 30;
+      state.era = 3;
+      state.civilizations['player-3'].isEliminated = true;
+      state.cities['city-2'].position = { q: 8, r: 0 };
+      state.civilizations['player-1'].lastCombatTurnByLandmass = { 'continent-0': 0 };
+      state.civilizations['player-2'].lastCombatTurnByLandmass = { 'continent-0': 0 };
+      state.map.tiles = Object.fromEntries(Array.from({ length: 9 }, (_, q) => [
+        `${q},0`,
+        {
+          ...state.map.tiles['0,0'],
+          coord: { q, r: 0 },
+          owner: q < 4 ? 'player-1' : q > 4 ? 'player-2' : null,
+          regionKey: 'continent-0',
+        },
+      ]));
+      return state;
+    };
+
+    const allowed = processIndependentThreatPressureForHumans(makeEligible(), new EventBus());
+    const [sharedId] = allowed.opponentAI!.pressureByHuman['player-1']
+      .activeIndependentThreatIds;
+    expect(sharedId).toMatch(/^barbarian:camp-/);
+    expect(allowed.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+      .toContain(sharedId);
+
+    const blocked = makeEligible();
+    addPirateThreat(blocked, 'pirate-1', 'player-2');
+    blocked.opponentAI!.pressureByHuman['player-2'] = {
+      activeIndependentThreatIds: ['pirate:pirate-1'],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+    const blockedEvents: unknown[] = [];
+    const bus = new EventBus();
+    bus.on('threat:barbarian-resurgence', event => blockedEvents.push(event));
+
+    const result = processIndependentThreatPressureForHumans(blocked, bus);
+
+    expect(result.barbarianCamps).toEqual({});
+    expect(result.idCounters.nextCampId).toBe(blocked.idCounters.nextCampId);
+    expect(result.resurgentCampCooldownByCivLandmass).toBeUndefined();
+    expect(blockedEvents).toEqual([]);
+  });
+
+  it('blocks migration and recovery only for new starts while leaving an existing over-cap threat alive', () => {
+    const state = makePressureState('explorer');
+    addPirateThreat(state, 'pirate-1', 'player-1');
+    addPirateThreat(state, 'pirate-2', 'player-1');
+    state.opponentAI!.migrationGraceRoundsRemaining = 1;
+    state.opponentAI!.pressureByHuman['player-1'] = {
+      activeIndependentThreatIds: ['pirate:pirate-1', 'pirate:pirate-2'],
+      recoveryUntilTurn: state.turn + 3,
+      lastResolvedThreatTurn: state.turn - 1,
+      lastWarningTurnByKey: { existing: 4 },
+      lastStrategicAudioTurn: 5,
+    };
+
+    expect(canStartIndependentThreat(state, 'player-1', 'pirate:pirate-1'))
+      .toMatchObject({ allowed: true, reason: 'allowed', activeCount: 2, cap: 1 });
+    expect(canStartIndependentThreat(state, 'player-1', 'barbarian:new'))
+      .toMatchObject({ allowed: false, reason: 'migration-grace' });
+
+    state.opponentAI!.migrationGraceRoundsRemaining = 0;
+    expect(canStartIndependentThreat(state, 'player-1', 'barbarian:new'))
+      .toMatchObject({ allowed: false, reason: 'recovery' });
+
+    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+    expect(result.pirates!.factions['pirate-1']).toEqual(state.pirates!.factions['pirate-1']);
+    expect(result.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+      .toEqual(['pirate:pirate-1', 'pirate:pirate-2']);
+  });
+
+  it.each([
+    ['explorer', 3],
+    ['standard', 2],
+    ['veteran', 1],
+  ] as const)('%s begins %i rounds of recovery only after explicit destruction', (challenge, rounds) => {
+    const state = makePressureState(challenge);
+    addPirateThreat(state, 'pirate-1', 'player-1');
+    state.opponentAI!.pressureByHuman['player-1'] = {
+      activeIndependentThreatIds: ['pirate:pirate-1'],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: { retained: 2 },
+      lastStrategicAudioTurn: 3,
+    };
+    state.pirates!.factions['pirate-1'].intent = null;
+
+    const retargeted = processIndependentThreatPressureForHumans(state, new EventBus());
+    expect(retargeted.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+      .toEqual(['pirate:pirate-1']);
+    expect(retargeted.opponentAI!.pressureByHuman['player-1'].recoveryUntilTurn).toBe(0);
+
+    delete state.pirates!.factions['pirate-1'];
+    const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
+    expect(resolved.opponentAI!.pressureByHuman['player-1']).toEqual({
+      activeIndependentThreatIds: [],
+      recoveryUntilTurn: state.turn + rounds,
+      lastResolvedThreatTurn: state.turn,
+      lastWarningTurnByKey: { retained: 2 },
+      lastStrategicAudioTurn: 3,
+    });
+
+    const repeated = processIndependentThreatPressureForHumans(resolved, new EventBus());
+    expect(repeated.opponentAI!.pressureByHuman['player-1']).toEqual(
+      resolved.opponentAI!.pressureByHuman['player-1'],
+    );
+  });
+
+  it('starts recovery for destroyed camps and explicitly slain beasts', () => {
+    const state = makePressureState('standard');
+    state.barbarianCamps['camp-1'] = {
+      id: 'camp-1',
+      position: { q: 2, r: 0 },
+      strength: 5,
+      spawnCooldown: 2,
+    };
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-giant_boar': {
+          id: 'lair-giant_boar',
+          beastId: 'giant_boar',
+          position: { q: 2, r: 0 },
+          status: 'awake',
+          strength: 1,
+          unitIds: [],
+        },
+      },
+      sightingsByCiv: {},
+    };
+    state.opponentAI!.pressureByHuman['player-1'] = {
+      activeIndependentThreatIds: ['barbarian:camp-1', 'beast:lair-giant_boar'],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+    const stillActive = processIndependentThreatPressureForHumans(state, new EventBus());
+    expect(stillActive.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+      .toEqual(['barbarian:camp-1', 'beast:lair-giant_boar']);
+
+    delete state.barbarianCamps['camp-1'];
+    state.beasts.lairs['lair-giant_boar'].status = 'slain';
+    const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
+
+    expect(resolved.opponentAI!.pressureByHuman['player-1']).toMatchObject({
+      activeIndependentThreatIds: [],
+      lastResolvedThreatTurn: state.turn,
+      recoveryUntilTurn: state.turn + 2,
+    });
+  });
+
+  it('reconciles a resolution before considering a same-round replacement spawn', () => {
+    const state = makePressureState('standard');
+    state.turn = 30;
+    state.era = 3;
+    state.civilizations['player-2'].isEliminated = true;
+    state.civilizations['player-3'].isEliminated = true;
+    state.civilizations['player-1'].lastCombatTurnByLandmass = { 'continent-0': 0 };
+    state.cities = {
+      'city-1': { ...state.cities['city-1'], position: { q: 0, r: 0 } },
+    };
+    state.civilizations['player-1'].cities = ['city-1'];
+    state.map.tiles = Object.fromEntries(Array.from({ length: 20 }, (_, q) => [
+      `${q},0`,
+      {
+        ...state.map.tiles['0,0'],
+        coord: { q, r: 0 },
+        owner: q < 10 ? 'player-1' : null,
+        regionKey: 'continent-0',
+      },
+    ]));
+    state.opponentAI!.pressureByHuman['player-1'] = {
+      activeIndependentThreatIds: ['barbarian:destroyed'],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+
+    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+
+    expect(result.barbarianCamps).toEqual({});
+    expect(result.opponentAI!.pressureByHuman['player-1']).toMatchObject({
+      activeIndependentThreatIds: [],
+      recoveryUntilTurn: state.turn + 2,
+      lastResolvedThreatTurn: state.turn,
+    });
+  });
+
+  it('counts only barbarians, modern pirates, and materially threatening awake beasts', () => {
+    const state = makePressureState();
+    state.civilizations.ai = {
+      ...makeHuman('ai', 'ai-city', { q: 9, r: 0 }),
+      isHuman: false,
+    };
+    state.cities['ai-city'] = { id: 'ai-city', owner: 'ai', position: { q: 9, r: 0 } } as any;
+    state.civilizations['player-1'].diplomacy.atWarWith = ['ai', 'player-2'];
+    state.minorCivs.minor = { id: 'minor', isDestroyed: false } as any;
+    state.units.rebel = { id: 'rebel', owner: 'rebels', position: { q: 0, r: 1 } } as any;
+    state.beasts = {
+      mode: 'wild',
+      lairs: {
+        'lair-giant_boar': {
+          id: 'lair-giant_boar',
+          beastId: 'giant_boar',
+          position: { q: 2, r: 0 },
+          status: 'awake',
+          strength: 1,
+          unitIds: [],
+        },
+      },
+      sightingsByCiv: {},
+    };
+
+    expect(deriveActiveIndependentThreatIds(state, 'player-1'))
+      .toEqual(['beast:lair-giant_boar']);
   });
 });
 

--- a/tests/ui/campaign-entry-flow.test.ts
+++ b/tests/ui/campaign-entry-flow.test.ts
@@ -28,7 +28,6 @@ function makeDependencies(
   overrides: Partial<CampaignEntryDependencies> = {},
 ): CampaignEntryDependencies {
   return {
-    purposefulAIEnabled: true,
     persistStoredChoice: vi.fn(async () => {}),
     persistImport: vi.fn(async () => {}),
     showChallengePrompt: showLegacyOpponentChallengePrompt,
@@ -154,23 +153,4 @@ describe('campaign entry flow', () => {
     }
   });
 
-  it('bypasses the prompt while the rollout flag is false', async () => {
-    const showChallengePrompt = vi.fn(showLegacyOpponentChallengePrompt);
-    const dependencies = makeDependencies({
-      purposefulAIEnabled: false,
-      showChallengePrompt,
-    });
-
-    const result = await beginCampaignEntry({
-      kind: 'stored',
-      loaded: {
-        state: normalizeLoadedState(makeState('disabled-legacy', null)),
-        source: { id: 'slot-legacy', kind: 'manual' },
-      },
-    }, makeInvoker(), dependencies);
-
-    expect(result).toBe('entered');
-    expect(showChallengePrompt).not.toHaveBeenCalled();
-    expect(dependencies.persistStoredChoice).not.toHaveBeenCalled();
-  });
 });

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -102,13 +102,13 @@ describe('campaign-setup', () => {
     expect(startButton.dataset.ready).toBe('true');
   });
 
-  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+  it('always exposes opponent challenge controls after launch', () => {
     showCampaignSetup(document.body, {
       onStartSolo: vi.fn(),
       onCancel: vi.fn(),
     });
 
-    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
+    expect(document.querySelector('[data-opponent-challenge-selector]')).not.toBeNull();
   });
 
   it('passes the selected challenge from enabled solo setup', () => {
@@ -116,7 +116,6 @@ describe('campaign-setup', () => {
     const panel = showCampaignSetup(
       document.body,
       { onStartSolo, onCancel: vi.fn() },
-      { purposefulAIEnabled: true },
     );
 
     panel.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -39,6 +39,7 @@ function setInputValue(selector: string, value: string): void {
 
 function advanceThroughMapType(): void {
   click('#hs-map-type-next');
+  click('#hs-challenge-next');
 }
 
 function chooseCiv(civId: string): void {
@@ -84,17 +85,17 @@ beforeEach(() => {
 });
 
 describe('hotseat-setup', () => {
-  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+  it('always routes through opponent challenge selection after launch', () => {
     showHotSeatSetup(document.body, {
       onComplete: vi.fn(),
       onCancel: vi.fn(),
     });
 
     click('[data-size="small"]');
-    advanceThroughMapType();
+    click('#hs-map-type-next');
 
-    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
-    expect(document.body.textContent).toContain('How Many Players?');
+    expect(document.querySelector('[data-opponent-challenge-selector]')).not.toBeNull();
+    expect(document.body.textContent).toContain('Choose Opponent Challenge');
   });
 
   it('chooses challenge as a group before private hot-seat setup and returns it separately', () => {
@@ -102,7 +103,6 @@ describe('hotseat-setup', () => {
     showHotSeatSetup(
       document.body,
       { onComplete, onCancel: vi.fn() },
-      { purposefulAIEnabled: true },
     );
 
     click('[data-size="small"]');
@@ -197,7 +197,7 @@ describe('hotseat-setup', () => {
           isHuman: true,
         }),
       ]),
-    }));
+    }), 'standard');
   });
 
   it('preserves a saved custom civ in the hot-seat completion config registry', () => {
@@ -235,7 +235,7 @@ describe('hotseat-setup', () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
       customCivilizations: [customCiv],
-    }));
+    }), 'standard');
   });
 
   it('reopens the hot-seat civ picker with one live picker after saving a custom civ and lets the flow continue', async () => {
@@ -593,7 +593,7 @@ describe('hotseat-setup', () => {
 
       expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
         mapScript: 'balanced',
-      }));
+      }), 'standard');
     });
 
     it('defaults to earth when no map type card is clicked before Next', () => {
@@ -613,7 +613,7 @@ describe('hotseat-setup', () => {
 
       expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
         mapScript: 'earth',
-      }));
+      }), 'standard');
     });
   });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -15,6 +15,8 @@ import {
   routePeaceMade,
   routePeaceRequested,
   routeWarDeclared,
+  queueStrategicWarningPendingEvent,
+  routeStrategicWarning,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -48,6 +50,55 @@ function makeState(partial: Partial<GameState> = {}): GameState {
 }
 
 describe('notification routing', () => {
+  it('routes a strategic warning only to its viewer with the already-safe map target', () => {
+    const { sink, calls } = makeSink();
+    const target = { kind: 'map' as const, coord: { q: 4, r: 2 }, label: 'Ravenna' };
+
+    routeStrategicWarning({
+      viewerId: 'p2',
+      actorId: 'rome',
+      actorName: 'Roman',
+      warningKey: 'p2:rome:mobilizing:4,2',
+      kind: 'mobilizing',
+      evidence: 'visible',
+      targetLabel: 'Ravenna',
+      target,
+      playAudio: true,
+    }, sink);
+
+    expect(calls).toEqual([{
+      civId: 'p2',
+      message: 'A Roman force is gathering against Ravenna. Reinforce the city, disrupt the rally, or seek peace.',
+      type: 'warning',
+      target,
+    }]);
+  });
+
+  it('persists the same safe strategic warning row for a hot-seat handoff', () => {
+    const state = makeState({ pendingEvents: {} } as Partial<GameState>);
+    const target = { kind: 'map' as const, coord: { q: 4, r: 2 }, label: 'Ravenna' };
+
+    queueStrategicWarningPendingEvent(state, {
+      viewerId: 'p2',
+      actorId: 'rome',
+      actorName: 'Roman',
+      warningKey: 'p2:rome:mobilizing:4,2',
+      kind: 'mobilizing',
+      evidence: 'visible',
+      targetLabel: 'Ravenna',
+      target,
+      playAudio: true,
+    });
+
+    expect(state.pendingEvents?.p2).toEqual([{
+      type: 'ai:strategic-warning',
+      message: 'A Roman force is gathering against Ravenna. Reinforce the city, disrupt the rally, or seek peace.',
+      turn: state.turn,
+      target,
+    }]);
+    expect(state.pendingEvents?.p1).toBeUndefined();
+  });
+
   it('war-declared writes to both attacker and defender logs', () => {
     const state = makeState();
     const { sink, calls } = makeSink();

--- a/tests/ui/pause-menu-panel.test.ts
+++ b/tests/ui/pause-menu-panel.test.ts
@@ -38,10 +38,10 @@ beforeEach(() => {
 });
 
 describe('pause-menu-panel', () => {
-  it('keeps opponent challenge controls hidden while purposeful AI is disabled', () => {
+  it('always exposes opponent challenge controls after launch', () => {
     showPauseMenu(document.body, makeCallbacks());
 
-    expect(document.querySelector('[data-opponent-challenge-selector]')).toBeNull();
+    expect(document.querySelector('[data-opponent-challenge-selector]')).not.toBeNull();
   });
 
   it('shows active and pending challenge without claiming pending is active', () => {
@@ -51,7 +51,6 @@ describe('pause-menu-panel', () => {
         opponentChallenge: 'standard',
         pendingOpponentChallenge: 'explorer',
       }),
-      { purposefulAIEnabled: true },
     );
 
     expect(panel.textContent).toContain('Standard active');
@@ -67,7 +66,6 @@ describe('pause-menu-panel', () => {
         opponentChallenge: 'standard',
         onOpponentChallengeChange,
       }),
-      { purposefulAIEnabled: true },
     );
 
     document.querySelector<HTMLButtonElement>('[data-challenge="explorer"]')!.click();

--- a/tests/ui/strategic-warning-presentation.test.ts
+++ b/tests/ui/strategic-warning-presentation.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { GameEvents } from '@/core/types';
+import { presentStrategicWarning } from '@/ui/strategic-warning-presentation';
+
+function warning(
+  overrides: Partial<GameEvents['ai:strategic-warning']> = {},
+): GameEvents['ai:strategic-warning'] {
+  return {
+    viewerId: 'player',
+    actorId: 'rome',
+    actorName: 'Roman',
+    warningKey: 'player:rome:mobilizing:border',
+    kind: 'mobilizing',
+    evidence: 'visible',
+    playAudio: true,
+    ...overrides,
+  };
+}
+
+describe('strategic warning presentation', () => {
+  it('renders visible mobilization without a hidden target', () => {
+    expect(presentStrategicWarning(warning())).toEqual({
+      message: 'A Roman force is gathering near our border. Reinforce nearby cities or scout their approach.',
+      type: 'warning',
+    });
+  });
+
+  it('renders a safe visible target and preserves its map link', () => {
+    const target = { kind: 'map' as const, coord: { q: 3, r: 4 }, label: 'Ravenna' };
+    expect(presentStrategicWarning(warning({
+      targetLabel: 'Ravenna',
+      target,
+    }))).toEqual({
+      message: 'A Roman force is gathering against Ravenna. Reinforce the city, disrupt the rally, or seek peace.',
+      type: 'warning',
+      target,
+    });
+  });
+
+  it('marks remembered force positions as uncertain', () => {
+    expect(presentStrategicWarning(warning({
+      evidence: 'remembered',
+      regionLabel: 'eastern marches',
+    })).message).toBe(
+      'Scouts last reported Roman troops gathering in the eastern marches. Their current position is uncertain.',
+    );
+  });
+
+  it.each([
+    [
+      { actorId: 'barbarian:camp', actorName: 'Raiders', kind: 'raid', resource: 'iron', targetLabel: 'iron outpost' },
+      'Raiders are moving toward the iron outpost. Intercept them or destroy their camp.',
+      'warning',
+    ],
+    [
+      { actorId: 'barbarian:camp', actorName: 'Raiders', kind: 'resource-denied', resource: 'iron', regionLabel: 'northern outpost' },
+      'Hostile raiders have cut access to iron at the northern outpost. Drive them off to restore the resource.',
+      'warning',
+    ],
+    [
+      { actorId: 'barbarian:camp', actorName: 'Raiders', kind: 'resource-restored', resource: 'iron', regionLabel: 'northern outpost' },
+      'Access to iron at the northern outpost has been restored.',
+      'success',
+    ],
+    [
+      { actorId: 'independent-threats', actorName: 'Raiders', kind: 'recovery' },
+      'The raid was broken. Independent threats will need time to regroup.',
+      'success',
+    ],
+  ] as const)('renders required warning copy', (overrides, message, type) => {
+    expect(presentStrategicWarning(warning(overrides as Partial<GameEvents['ai:strategic-warning']>)))
+      .toMatchObject({ message, type });
+  });
+
+  it('uses viewer-safe generic pirate wording', () => {
+    const presented = presentStrategicWarning(warning({
+      actorId: 'pirate-1',
+      actorName: 'Pirates',
+      kind: 'blockade',
+      evidence: 'earned-intel',
+    }));
+    expect(presented.message).toBe('Pirate activity indicates a blockade is forming. Review known pirate waters and protect coastal trade.');
+    expect(presented.message).not.toContain('pirate-1');
+  });
+});

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -2,7 +2,12 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createHotSeatGame } from '@/core/game-state';
-import { showTurnHandoff } from '@/ui/turn-handoff';
+import {
+  acknowledgeTurnHandoffSummary,
+  showTurnHandoff,
+} from '@/ui/turn-handoff';
+import { generateSummary } from '@/core/hotseat-events';
+import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
 
 function makeFixture() {
   const state = createHotSeatGame({
@@ -24,6 +29,65 @@ function makeFixture() {
 afterEach(() => document.body.replaceChildren());
 
 describe('turn handoff', () => {
+  it('acknowledges multiple warning rows with one post-handoff cue and does not replay after reload', () => {
+    const { state } = makeFixture();
+    state.opponentAI = createEmptyOpponentAIState();
+    state.opponentAI.pressureByHuman['player-2'] = {
+      activeIndependentThreatIds: [],
+      recoveryUntilTurn: 0,
+      lastResolvedThreatTurn: null,
+      lastWarningTurnByKey: {},
+      lastStrategicAudioTurn: null,
+    };
+    state.pendingEvents = {
+      'player-2': [
+        { type: 'ai:strategic-warning', message: 'Warning one', turn: state.turn },
+        { type: 'ai:strategic-warning', message: 'Warning two', turn: state.turn },
+      ],
+    };
+    const summary = generateSummary(state, 'player-2');
+
+    const first = acknowledgeTurnHandoffSummary(state, 'player-2', summary);
+    const reloadedSummary = generateSummary(first.state, 'player-2');
+    const replay = acknowledgeTurnHandoffSummary(first.state, 'player-2', {
+      ...summary,
+      events: summary.events,
+    });
+
+    expect(first.playStrategicWarningAudio).toBe(true);
+    expect(first.state.pendingEvents?.['player-2']).toEqual([]);
+    expect(first.state.opponentAI!.pressureByHuman['player-2'].lastStrategicAudioTurn)
+      .toBe(summary.turn);
+    expect(reloadedSummary.events).toEqual([]);
+    expect(replay.playStrategicWarningAudio).toBe(false);
+  });
+
+  it('renders viewer warning rows after identity confirmation and passes that exact summary on Start Turn', async () => {
+    const { state, layer } = makeFixture();
+    const warning = {
+      type: 'ai:strategic-warning',
+      message: 'A Roman force is gathering near our border.',
+      turn: state.turn,
+      target: { kind: 'map' as const, coord: { q: 2, r: 3 }, label: 'Border' },
+    };
+    state.pendingEvents = { 'player-2': [warning] };
+    const onReady = vi.fn();
+    showTurnHandoff(layer, state, 'player-2', 'Bob', {
+      initiallyReady: true,
+      onReady,
+    });
+
+    expect(document.body.textContent).not.toContain(warning.message);
+    document.querySelector<HTMLButtonElement>('#handoff-confirm')!.click();
+    expect(document.querySelector('[data-handoff-summary-events]')?.textContent)
+      .toContain(warning.message);
+    document.querySelector<HTMLButtonElement>('#handoff-start')!.click();
+
+    await vi.waitFor(() => expect(onReady).toHaveBeenCalledOnce());
+    const renderedSummary = onReady.mock.calls[0]![0];
+    expect(renderedSummary.events).toEqual([warning]);
+  });
+
   it('is opaque and blocked until setReady supplies the completed state', async () => {
     const { state, shell, layer } = makeFixture();
     const onReady = vi.fn();


### PR DESCRIPTION
Closes #412

## Summary

- Govern barbarian, pirate, and beast pressure independently for every living human, with stable threat identities, per-challenge caps, migration grace, and recovery windows.
- Derive viewer-safe strategic warnings only from visible, remembered, or earned intel; persist them through notification and hot-seat handoff flows and play at most one reused stinger after the incoming player opens the turn.
- Add deterministic short and extended playability simulations using the production completed-round pipeline, including late-era force composition and bounded-work invariants.
- Launch the purposeful opponent path unconditionally, expose Explorer/Standard/Veteran throughout setup and pause flows, and remove feature flags plus replaced legacy military, production, research, and world-actor branches.
- Expire stale defense plans at their canonical reconsideration boundary, discovered by the simulation matrix.

## Fairness

Challenge levels change planning willingness, force caps, recovery, bounded risk, and seeded mistakes only. They grant no combat-stat, movement, economy, research, resource, or visibility bonuses.

No balance constants required tuning after the named short and extended matrices passed.

## Hot-seat privacy

Warnings are committed to the intended viewer while presentation is suppressed, rendered only after identity confirmation, acknowledged from the exact displayed summary, and sounded only after `Start Turn`. Automated coverage proves other humans do not receive the row and that acknowledgement/reload does not replay the cue.

## Verification

- Changed-source rule checks: passed
- Rollout/replaced-legacy symbol search: empty
- Focused launch/UI/system suites: passed
- `yarn build`: passed; web assets retain `/conquestoria/`
- `yarn build:tauri`: passed; assets use relative `./assets/`
- Full Vitest and hook suite: 337 files, 5,052 passed, 2 skipped
- Web smoke: 5 Chromium checks passed, including legacy challenge migration and desktop/mobile map presentation
- Wonder regressions: 13 files, 319 passed
- Short AI playability matrix: 7 passed
- Extended AI playability matrix: 31 passed across 30 fixed 60-round scenarios in 155.13 seconds

## Manual / subjective QA

- 360×800 new-game setup: all three challenge cards were readable and reachable, no horizontal overflow was present, and campaign start remained disabled until civilization selection.
- The in-app browser reset repeatedly during the laptop/manual replay pass. Desktop/mobile rendering and legacy migration are covered by the Chromium smoke suite, but laptop screenshots plus subjective audio/play-feel checks remain a draft-PR follow-up before marking ready.
- Hot-seat privacy, single-cue timing, mute/background/suppression behavior, and reload/no-replay behavior are automated rather than inferred from manual play.
