### PR TITLE
fix(era12): MR1 — gene therapy, cyber drain, and upgrade-gate dead mechanics

### DIFF
--- a/src/ai/ai-upgrades.ts
+++ b/src/ai/ai-upgrades.ts
@@ -272,12 +272,9 @@ export function processAIUpgrades(
       continue;
     }
     const destinations = Object.values(working.cities)
-      .filter(cityCandidate => safeCity(
-        working,
-        civId,
-        cityCandidate,
-        prepared,
-      ))
+      .filter(cityCandidate =>
+        safeCity(working, civId, cityCandidate, prepared)
+        && getCanonicalUpgradeTarget(current, civ.techState.completed, cityCandidate.buildings))
       .flatMap(cityCandidate => {
         const path = routePath(
           working,

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -26,7 +26,7 @@ import {
 } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { applyAutoExploreOrder } from '@/systems/auto-explore-system';
-import { hexKey, hexDistance } from '@/systems/hex-utils';
+import { hexKey } from '@/systems/hex-utils';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import { buildCombatPresentation } from '@/systems/viewer-event-presentation';
 import { calculateCityYields } from '@/systems/resource-system';
@@ -60,6 +60,8 @@ import { createRng } from '@/systems/map-generator';
 import { processMinorCivTurn, checkEraAdvancement, processMinorCivEraUpgrade, checkCampEvolution } from '@/systems/minor-civ-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyProductionBonus } from '@/systems/city-system';
+import { chargeUnitsOnGeneTherapyResearch, applyGeneTherapyRecharge } from '@/systems/gene-therapy-system';
+import { processCyberDrain } from '@/systems/cyber-warfare-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
 import { applyPendingOpponentChallenge } from '@/core/opponent-challenge';
@@ -134,6 +136,9 @@ export function processTurn(
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
     const currentCivState = newState.civilizations[civId];
     const civDef = resolveCivDefinition(newState, civ.civType ?? '');
+    // Snapshot before production creates new units this turn — geneTherapyReady recharge
+    // must only consider units that already existed at turn start (see gene-therapy-system.ts).
+    const unitIdsAtTurnStart = [...civ.units];
     // Process cities: food, growth, production
     let totalScience = 0;
     let totalGold = 0;
@@ -182,31 +187,6 @@ export function processTurn(
       );
       totalGold += result.idleGoldBonus;
       totalScience += result.idleScienceBonus;
-
-      // Cyber drain: adjacent enemy cyber_units drain 2 gold per turn
-      {
-        const enemyCyberUnits = Object.values(newState.units).filter(
-          u => u.type === 'cyber_unit' && u.owner !== civId,
-        );
-        if (enemyCyberUnits.length > 0) {
-          const hasCDC = city.buildings.includes('cyber_defense_center');
-          const hasHub = city.buildings.includes('signals_hub');
-          const blockChance = hasCDC ? (hasHub ? 0.75 : 0.65) : 0;
-          for (const cyberUnit of enemyCyberUnits) {
-            if (hexDistance(cyberUnit.position, city.position) !== 1) continue;
-            let s = Math.abs(newState.turn * 16807 + city.id.charCodeAt(0) + cyberUnit.id.charCodeAt(0));
-            s = (s * 48271) % 2147483647;
-            const roll = s / 2147483647;
-            if (roll < blockChance) continue;
-            totalGold = Math.max(0, totalGold - 2);
-            bus.emit('city:cyber-drained', {
-              cityId, cityName: city.name,
-              drainerOwner: cyberUnit.owner, drainerUnitId: cyberUnit.id,
-              goldLost: 2,
-            });
-          }
-        }
-      }
 
       const maturityResult = applyCityMaturity(result.city, civ.techState.completed);
       newState.cities[cityId] = maturityResult.city;
@@ -285,8 +265,8 @@ export function processTurn(
           newUnit.movementPointsLeft += 1;
           newUnit.movementBonus = (newUnit.movementBonus ?? 0) + 1;
         }
-        if (newState.cities[cityId]?.buildings.includes('gene_therapy_clinic')) {
-          newUnit.geneTherapyReady = true;
+        if (civ.techState.completed.includes('gene-therapy')) {
+          newUnit.geneTherapyReady = newState.cities[cityId]?.buildings.includes('gene_therapy_clinic') ?? false;
         }
         newState.units[newUnit.id] = newUnit;
         newState.civilizations[civId].units.push(newUnit.id);
@@ -303,6 +283,17 @@ export function processTurn(
           bus.emit('espionage:spy-recruited', { civId, spy });
         }
       }
+    }
+
+    // Cyber drain: enemy cyber_units adjacent to this civ's cities steal 2 gold/turn each
+    // (blocked by Cyber Defense Center / Signals Hub); stolen gold is credited to the attacker.
+    const cyberDrainResult = processCyberDrain(newState, civId, totalGold);
+    totalGold = cyberDrainResult.remainingGold;
+    for (const [ownerCivId, amount] of Object.entries(cyberDrainResult.creditsByOwner)) {
+      grossGoldByCiv[ownerCivId] = (grossGoldByCiv[ownerCivId] ?? 0) + amount;
+    }
+    for (const event of cyberDrainResult.events) {
+      bus.emit('city:cyber-drained', { ...event, victimCivId: civId });
     }
 
     // Process research
@@ -326,6 +317,10 @@ export function processTurn(
     if (researchResult.completedTech) {
       const techId = researchResult.completedTech;
       bus.emit('tech:completed', { civId, techId });
+
+      if (techId === 'gene-therapy') {
+        newState = chargeUnitsOnGeneTherapyResearch(newState, civId);
+      }
 
       // Inline obsolescence scan — runs once synchronously per completed tech
       const obsoletedTypes = TRAINABLE_UNITS
@@ -402,15 +397,7 @@ export function processTurn(
     }
 
     // Reset geneTherapyReady cooldown for units that rested a full turn in a friendly city
-    for (const unitId of civ.units) {
-      const unit = newState.units[unitId];
-      if (!unit || unit.geneTherapyReady !== false) continue;
-      const posKey = `${unit.position.q},${unit.position.r}`;
-      const tile = newState.map.tiles[posKey];
-      if (cityPositionsSet.has(posKey) && tile?.owner === civId && !unit.hasMoved && !unit.hasActed) {
-        newState.units[unitId] = { ...unit, geneTherapyReady: true };
-      }
-    }
+    newState = applyGeneTherapyRecharge(newState, civId, unitIdsAtTurnStart);
 
     // Reset unit movement
     for (const unitId of civ.units) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1478,7 +1478,7 @@ export interface GameEvents {
   'city:national-project-expired': { civId: string; cityId: string; buildingId: string };
   'city:national-project-dequeued': { civId: string; cityId: string; buildingId: string };
   'city:unit-trained': { cityId: string; unitType: UnitType };
-  'city:cyber-drained': { cityId: string; cityName: string; drainerOwner: string; drainerUnitId: string; goldLost: number };
+  'city:cyber-drained': { cityId: string; cityName: string; drainerOwner: string; drainerUnitId: string; goldLost: number; blocked: boolean; victimCivId: string };
   'city:grew': { cityId: string; newPopulation: number };
   'city:maturity-upgraded': { cityId: string; previous: CityMaturity; current: CityMaturity };
   'economy:treasury-strain': { civId: string; level: Exclude<TreasuryStrainLevel, 'none'>; netGoldPerTurn: number; unpaidMaintenance: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3603,6 +3603,18 @@ bus.on('city:building-dropped', ({ cityId, buildingId }) => {
   );
 });
 
+bus.on('city:cyber-drained', ({ cityName, drainerOwner, goldLost, blocked, victimCivId }) => {
+  const drainerName = gameState.civilizations[drainerOwner]?.name ?? drainerOwner;
+  const victimName = gameState.civilizations[victimCivId]?.name ?? victimCivId;
+  if (blocked) {
+    appendToCivLog(victimCivId, `Cyber Defense Center blocked an intrusion in ${cityName}.`, 'success');
+    appendToCivLog(drainerOwner, `Cyber attack on ${cityName} was blocked by ${victimName}'s Cyber Defense Center.`, 'warning');
+    return;
+  }
+  appendToCivLog(victimCivId, `Cyber attack: ${cityName} lost ${goldLost} gold (${drainerName} cyber unit).`, 'warning');
+  appendToCivLog(drainerOwner, `Cyber unit stole ${goldLost} gold from ${victimName}'s ${cityName}.`, 'success');
+});
+
 bus.on('village:visited', ({ civId, outcome, message }) => {
   if (outcome === 'gold') advisorSystem.resetMessage('treasurer_village_gold');
   if (outcome === 'science') advisorSystem.resetMessage('scholar_village_science');

--- a/src/systems/cyber-warfare-system.ts
+++ b/src/systems/cyber-warfare-system.ts
@@ -1,0 +1,86 @@
+import type { GameState } from '@/core/types';
+import { hexDistance } from './hex-utils';
+import { isAtWar } from './diplomacy-system';
+
+export interface CyberDrainEvent {
+  cityId: string;
+  cityName: string;
+  drainerOwner: string;
+  drainerUnitId: string;
+  goldLost: number;
+  blocked: boolean;
+}
+
+export interface CyberDrainResult {
+  remainingGold: number;
+  creditsByOwner: Record<string, number>;
+  events: CyberDrainEvent[];
+}
+
+// Deterministic per-(turn, city, unit) roll in [0, 1) — same LCG shape used elsewhere
+// in turn-manager (e.g. barbarian spawns): no Math.random(), reproducible from state.
+export function computeCyberDrainRoll(turn: number, cityId: string, unitId: string): number {
+  let s = Math.abs(turn * 16807 + cityId.charCodeAt(0) + unitId.charCodeAt(0));
+  s = (s * 48271) % 2147483647;
+  return s / 2147483647;
+}
+
+// Cyber Unit gold drain: -2 gold/turn per adjacent enemy city the owner is at war with,
+// stolen (credited to the owner), not destroyed. Cyber Defense Center rolls to block it.
+// `incomeSoFar` is this civ's accumulated turn income up to this point — the drain is
+// capped so it never pushes that income below 0 (mirrors the pre-existing accumulator cap).
+export function processCyberDrain(
+  state: GameState,
+  civId: string,
+  incomeSoFar: number,
+): CyberDrainResult {
+  const civ = state.civilizations[civId];
+  const events: CyberDrainEvent[] = [];
+  const creditsByOwner: Record<string, number> = {};
+  if (!civ) return { remainingGold: incomeSoFar, creditsByOwner, events };
+
+  let remainingGold = incomeSoFar;
+
+  for (const cityId of [...civ.cities].sort()) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+
+    const enemyCyberUnits = Object.values(state.units)
+      .filter(u =>
+        u.type === 'cyber_unit'
+        && u.owner !== civId
+        && isAtWar(civ.diplomacy, u.owner)
+        && hexDistance(u.position, city.position) === 1)
+      .sort((a, b) => a.id.localeCompare(b.id));
+    if (enemyCyberUnits.length === 0) continue;
+
+    const hasCDC = city.buildings.includes('cyber_defense_center');
+    const hasHub = city.buildings.includes('signals_hub');
+    const blockChance = hasCDC ? (hasHub ? 0.75 : 0.65) : 0;
+
+    for (const cyberUnit of enemyCyberUnits) {
+      const roll = computeCyberDrainRoll(state.turn, city.id, cyberUnit.id);
+      const blocked = blockChance > 0 && roll < blockChance;
+
+      if (blocked) {
+        events.push({
+          cityId, cityName: city.name,
+          drainerOwner: cyberUnit.owner, drainerUnitId: cyberUnit.id,
+          goldLost: 0, blocked: true,
+        });
+        continue;
+      }
+
+      const amount = Math.min(2, Math.max(0, remainingGold));
+      remainingGold -= amount;
+      creditsByOwner[cyberUnit.owner] = (creditsByOwner[cyberUnit.owner] ?? 0) + amount;
+      events.push({
+        cityId, cityName: city.name,
+        drainerOwner: cyberUnit.owner, drainerUnitId: cyberUnit.id,
+        goldLost: amount, blocked: false,
+      });
+    }
+  }
+
+  return { remainingGold, creditsByOwner, events };
+}

--- a/src/systems/gene-therapy-system.ts
+++ b/src/systems/gene-therapy-system.ts
@@ -1,0 +1,59 @@
+import type { GameState } from '@/core/types';
+import { UNIT_DEFINITIONS } from './unit-system';
+
+// Charges every combat unit (strength > 0) owned by civId on gene-therapy research completion.
+// Strength-0 civilians (settler, worker, caravan, expedition, cyber_unit, transports) are left
+// undefined — UNIT_DESCRIPTIONS.cyber_unit explicitly says Gene Therapy does not apply.
+export function chargeUnitsOnGeneTherapyResearch(state: GameState, civId: string): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  let units = state.units;
+  for (const unitId of civ.units) {
+    const unit = units[unitId];
+    if (!unit) continue;
+    if ((UNIT_DEFINITIONS[unit.type]?.strength ?? 0) <= 0) continue;
+    if (units === state.units) units = { ...state.units };
+    units[unitId] = { ...unit, geneTherapyReady: true };
+  }
+
+  return units === state.units ? state : { ...state, units };
+}
+
+// Resets geneTherapyReady from false back to true for units that rested a full turn
+// (did not move or act) in a friendly city. Must run before hasMoved/hasActed are cleared.
+//
+// unitIds, if provided, overrides which unit ids are eligible (defaults to civ.units).
+// Callers must pass a snapshot taken before this turn's production runs — civ.units is
+// mutated in place as newly trained units are pushed onto it, so without this override a
+// unit trained this very turn (hasMoved:false, hasActed:false by construction) would be
+// wrongly swept into the "rested a full turn" recharge before it ever existed.
+export function applyGeneTherapyRecharge(
+  state: GameState,
+  civId: string,
+  unitIds?: readonly string[],
+): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+
+  const cityPositionsSet = new Set(
+    civ.cities
+      .map(id => state.cities[id])
+      .filter(Boolean)
+      .map(c => `${c!.position.q},${c!.position.r}`),
+  );
+
+  let units = state.units;
+  for (const unitId of unitIds ?? civ.units) {
+    const unit = units[unitId];
+    if (!unit || unit.geneTherapyReady !== false) continue;
+    const posKey = `${unit.position.q},${unit.position.r}`;
+    const tile = state.map.tiles[posKey];
+    if (!cityPositionsSet.has(posKey) || tile?.owner !== civId) continue;
+    if (unit.hasMoved || unit.hasActed) continue;
+    if (units === state.units) units = { ...state.units };
+    units[unitId] = { ...unit, geneTherapyReady: true };
+  }
+
+  return units === state.units ? state : { ...state, units };
+}

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -12,14 +12,20 @@ export function canUpgradeUnit(
   cities: Record<string, City>,
   completedTechs: string[],
   civGold?: number,
-): { canUpgrade: boolean; targetType: UnitType | null; cost: number } {
+): { canUpgrade: boolean; targetType: UnitType | null; cost: number; reason?: 'missing-building' } {
   const city = cities[cityId];
   if (!city || city.owner !== unit.owner) return { canUpgrade: false, targetType: null, cost: 0 };
   if (unit.position.q !== city.position.q || unit.position.r !== city.position.r) {
     return { canUpgrade: false, targetType: null, cost: 0 };
   }
-  const targetType = getCanonicalUpgradeTarget(unit, completedTechs);
-  if (!targetType) return { canUpgrade: false, targetType: null, cost: 0 };
+  const targetType = getCanonicalUpgradeTarget(unit, completedTechs, city.buildings);
+  if (!targetType) {
+    const targetInPrinciple = getCanonicalUpgradeTarget(unit, completedTechs);
+    if (targetInPrinciple) {
+      return { canUpgrade: false, targetType: null, cost: getUpgradeCost(targetInPrinciple), reason: 'missing-building' };
+    }
+    return { canUpgrade: false, targetType: null, cost: 0 };
+  }
   const cost = getUpgradeCost(targetType);
   if (civGold !== undefined && civGold < cost) return { canUpgrade: false, targetType: null, cost };
   return { canUpgrade: true, targetType, cost };
@@ -28,6 +34,7 @@ export function canUpgradeUnit(
 export function getCanonicalUpgradeTarget(
   unit: Unit,
   completedTechs: readonly string[],
+  cityBuildings?: readonly string[],
 ): UnitType | null {
   const currentEntry = TRAINABLE_UNITS.find(candidate => candidate.type === unit.type);
   if (
@@ -47,6 +54,9 @@ export function getCanonicalUpgradeTarget(
       && completedTechs.includes(target.obsoletedByTech)
     )
   ) {
+    return null;
+  }
+  if (target.trainedFromBuilding && cityBuildings && !cityBuildings.includes(target.trainedFromBuilding)) {
     return null;
   }
   return target.type;
@@ -90,7 +100,7 @@ export function applyUnitUpgradeToState(
   if (!city) {
     return { state, upgraded: false, reason: 'not-in-friendly-city' };
   }
-  const canonicalTarget = getCanonicalUpgradeTarget(unit, civ.techState.completed);
+  const canonicalTarget = getCanonicalUpgradeTarget(unit, civ.techState.completed, city.buildings);
   if (!canonicalTarget) {
     return { state, upgraded: false, reason: 'tech-unavailable' };
   }

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -2,7 +2,8 @@ import type { BuildableImprovementType, GameState, DisguiseType, HexCoord, Worke
 import { UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, canHeal } from '@/systems/unit-system';
 import { getExperienceToNextTier, getVeterancyCombatModifier, getVeterancyTier } from '@/systems/combat-reward-system';
 import { isSpyUnitType } from '@/systems/espionage-system';
-import { canUpgradeUnit } from '@/systems/unit-upgrade-system';
+import { canUpgradeUnit, getCanonicalUpgradeTarget } from '@/systems/unit-upgrade-system';
+import { TRAINABLE_UNITS, BUILDINGS } from '@/systems/city-system';
 import {
   formatImprovementYieldLabel,
   formatWorkerActionBlockerReason,
@@ -597,6 +598,16 @@ export function renderSelectedUnitInfo(
           () => callbacks.onUpgradeUnit!(unitId, homeCity.id),
         );
         actionsDiv.appendChild(btn);
+      } else if (upgrade.reason === 'missing-building') {
+        const targetType = getCanonicalUpgradeTarget(unit, completedTechs);
+        const requiredBuilding = targetType
+          ? TRAINABLE_UNITS.find(candidate => candidate.type === targetType)?.trainedFromBuilding
+          : undefined;
+        const buildingName = requiredBuilding ? BUILDINGS[requiredBuilding]?.name ?? requiredBuilding : 'the required building';
+        const blockerDiv = document.createElement('div');
+        blockerDiv.style.cssText = 'font-size:11px;color:#f8d28a;margin-top:4px;';
+        blockerDiv.textContent = `Upgrade requires ${buildingName} in this city.`;
+        wrapper.appendChild(blockerDiv);
       }
     }
   }

--- a/tests/ai/ai-upgrades.test.ts
+++ b/tests/ai/ai-upgrades.test.ts
@@ -163,6 +163,56 @@ describe('AI modernization', () => {
       .toEqual({});
   });
 
+  it('does not upgrade jet_fighter to stealth_bomber in a city without stealth_airbase', () => {
+    const state = setup();
+    const city = addCity(state, 'safe-city', { q: 0, r: 0 });
+    state.civilizations[AI].techState.completed.push('jet-aviation', 'stealth-technology');
+    addObsolete(state, 'flyer', city.position, { type: 'jet_fighter' as UnitType });
+
+    const result = processAIUpgrades(state, AI, prepared(state), new EventBus());
+
+    expect(result.upgradedUnitIds).toEqual([]);
+    expect(result.state.units.flyer.type).toBe('jet_fighter');
+  });
+
+  it('does not route a jet_fighter toward a safe city that lacks stealth_airbase', () => {
+    const state = setup();
+    addCity(state, 'no-airbase-city', { q: 2, r: 0 });
+    state.civilizations[AI].techState.completed.push('jet-aviation', 'stealth-technology');
+    addObsolete(state, 'flyer', { q: 0, r: 0 }, { type: 'jet_fighter' as UnitType });
+
+    const result = processAIUpgrades(state, AI, prepared(state), new EventBus());
+
+    expect(result.state.opponentAI!.majorCivs[AI].upgradeRoutesByUnitId).toEqual({});
+    expect(result.routedUnitIds).toEqual([]);
+  });
+
+  it('routes a jet_fighter toward a safe city that has stealth_airbase', () => {
+    const state = setup();
+    const city = addCity(state, 'airbase-city', { q: 2, r: 0 });
+    city.buildings = [...city.buildings, 'stealth_airbase'];
+    state.civilizations[AI].techState.completed.push('jet-aviation', 'stealth-technology');
+    addObsolete(state, 'flyer', { q: 0, r: 0 }, { type: 'jet_fighter' as UnitType });
+
+    const result = processAIUpgrades(state, AI, prepared(state), new EventBus());
+
+    expect(result.state.opponentAI!.majorCivs[AI].upgradeRoutesByUnitId.flyer?.cityId)
+      .toBe('airbase-city');
+  });
+
+  it('upgrades jet_fighter to stealth_bomber once the city has stealth_airbase', () => {
+    const state = setup();
+    const city = addCity(state, 'safe-city', { q: 0, r: 0 });
+    city.buildings = [...city.buildings, 'stealth_airbase'];
+    state.civilizations[AI].techState.completed.push('jet-aviation', 'stealth-technology');
+    addObsolete(state, 'flyer', city.position, { type: 'jet_fighter' as UnitType });
+
+    const result = processAIUpgrades(state, AI, prepared(state), new EventBus());
+
+    expect(result.upgradedUnitIds).toEqual(['flyer']);
+    expect(result.state.units.flyer.type).toBe('stealth_bomber');
+  });
+
   it('clears a route after arrival and successful upgrade', () => {
     const state = setup();
     const city = addCity(state, 'safe-city', { q: 0, r: 0 });

--- a/tests/systems/cyber-warfare-system.test.ts
+++ b/tests/systems/cyber-warfare-system.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import {
+  processCyberDrain,
+  computeCyberDrainRoll,
+} from '@/systems/cyber-warfare-system';
+import type { City, GameState, Unit } from '@/core/types';
+
+function makeCyberUnit(overrides: Partial<Unit> & { id: string; owner: string; position: { q: number; r: number } }): Unit {
+  return {
+    type: 'cyber_unit', health: 100, movementPointsLeft: 3,
+    hasMoved: true, hasActed: true, experience: 0, isResting: false,
+    ...overrides,
+  } as Unit;
+}
+
+function makeCity(overrides: Partial<City> & { id: string; owner: string; position: { q: number; r: number } }): City {
+  return {
+    name: overrides.id, buildings: [], productionQueue: [], productionProgress: 0,
+    food: 0, foodNeeded: 15, population: 1, ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'settled', unrestLevel: 0, unrestTurns: 0,
+    spyUnrestBonus: 0, idleProduction: null,
+    ...overrides,
+  } as unknown as City;
+}
+
+function makeState(opts: {
+  turn?: number;
+  cities: City[];
+  units: Unit[];
+  atWar?: boolean;
+}): GameState {
+  const atWar = opts.atWar ?? true;
+  return {
+    turn: opts.turn ?? 1, era: 12, currentPlayer: 'p1',
+    cities: Object.fromEntries(opts.cities.map(c => [c.id, c])),
+    units: Object.fromEntries(opts.units.map(u => [u.id, u])),
+    civilizations: {
+      p1: {
+        id: 'p1', name: 'Alpha', cities: opts.cities.filter(c => c.owner === 'p1').map(c => c.id),
+        diplomacy: { atWarWith: atWar ? ['p2'] : [], relationships: {}, treaties: [], events: [], treacheryScore: 0 } as any,
+        gold: 100,
+      },
+      p2: {
+        id: 'p2', name: 'Beta', cities: opts.cities.filter(c => c.owner === 'p2').map(c => c.id),
+        diplomacy: { atWarWith: atWar ? ['p1'] : [], relationships: {}, treaties: [], events: [], treacheryScore: 0 } as any,
+        gold: 100,
+      },
+    },
+  } as unknown as GameState;
+}
+
+describe('processCyberDrain', () => {
+  it('drains 2 gold from an at-war victim city with an adjacent enemy cyber unit and no CDC', () => {
+    const state = makeState({
+      turn: 1,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+    });
+
+    const result = processCyberDrain(state, 'p1', 10);
+
+    expect(result.remainingGold).toBe(8);
+    expect(result.creditsByOwner.p2).toBe(2);
+    expect(result.events).toEqual([
+      { cityId: 'city-p1', cityName: 'city-p1', drainerOwner: 'p2', drainerUnitId: 'cu1', goldLost: 2, blocked: false },
+    ]);
+  });
+
+  it('caps the drain at the available income this turn (min(2, victimGold))', () => {
+    const state = makeState({
+      turn: 1,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+    });
+
+    const result = processCyberDrain(state, 'p1', 1);
+
+    expect(result.remainingGold).toBe(0);
+    expect(result.creditsByOwner.p2).toBe(1);
+    expect(result.events[0].goldLost).toBe(1);
+  });
+
+  it('does not drain when the civs are not at war', () => {
+    const state = makeState({
+      turn: 1,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+      atWar: false,
+    });
+
+    const result = processCyberDrain(state, 'p1', 10);
+
+    expect(result.remainingGold).toBe(10);
+    expect(result.creditsByOwner).toEqual({});
+    expect(result.events).toEqual([]);
+  });
+
+  it('does not drain when the cyber unit is not adjacent (hexDistance > 1)', () => {
+    const state = makeState({
+      turn: 1,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 9, r: 9 } })],
+    });
+
+    const result = processCyberDrain(state, 'p1', 10);
+
+    expect(result.remainingGold).toBe(10);
+    expect(result.events).toEqual([]);
+  });
+
+  it('drains 4 total gold when two adjacent enemy cyber units threaten the same city', () => {
+    const state = makeState({
+      turn: 1,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [
+        makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } }),
+        makeCyberUnit({ id: 'cu2', owner: 'p2', position: { q: 0, r: 0 } }),
+      ],
+    });
+
+    const result = processCyberDrain(state, 'p1', 10);
+
+    expect(result.remainingGold).toBe(6);
+    expect(result.creditsByOwner.p2).toBe(4);
+    expect(result.events).toHaveLength(2);
+  });
+
+  it('blocks the drain when Cyber Defense Center rolls under the block chance, crediting no gold', () => {
+    // Find a (turn, cityId, unitId) combination whose roll is known relative to 0.65.
+    let turn = 1;
+    while (computeCyberDrainRoll(turn, 'city-p1', 'cu1') >= 0.65) turn++;
+
+    const state = makeState({
+      turn,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 }, buildings: ['cyber_defense_center'] })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+    });
+
+    const result = processCyberDrain(state, 'p1', 10);
+
+    expect(result.remainingGold).toBe(10);
+    expect(result.creditsByOwner).toEqual({});
+    expect(result.events).toEqual([
+      { cityId: 'city-p1', cityName: 'city-p1', drainerOwner: 'p2', drainerUnitId: 'cu1', goldLost: 0, blocked: true },
+    ]);
+  });
+
+  it('signals_hub raises the CDC block chance to 0.75 — a roll between 0.65 and 0.75 is blocked only with the hub', () => {
+    let turn = 1;
+    let roll = computeCyberDrainRoll(turn, 'city-p1', 'cu1');
+    while (!(roll >= 0.65 && roll < 0.75)) {
+      turn++;
+      roll = computeCyberDrainRoll(turn, 'city-p1', 'cu1');
+    }
+
+    const withoutHub = processCyberDrain(
+      makeState({
+        turn,
+        cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 }, buildings: ['cyber_defense_center'] })],
+        units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+      }),
+      'p1',
+      10,
+    );
+    expect(withoutHub.events[0].blocked).toBe(false);
+
+    const withHub = processCyberDrain(
+      makeState({
+        turn,
+        cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 }, buildings: ['cyber_defense_center', 'signals_hub'] })],
+        units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+      }),
+      'p1',
+      10,
+    );
+    expect(withHub.events[0].blocked).toBe(true);
+  });
+
+  it('is deterministic — the same state produces identical results across repeated calls', () => {
+    const state = makeState({
+      turn: 7,
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+    });
+
+    const first = processCyberDrain(state, 'p1', 10);
+    const second = processCyberDrain(state, 'p1', 10);
+
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/systems/era-12.test.ts
+++ b/tests/systems/era-12.test.ts
@@ -371,6 +371,58 @@ describe('cyber unit gold drain (Task 5)', () => {
   });
 });
 
+describe('cyber unit gold drain — theft and war-gate (Task 2 fixes)', () => {
+  it('credits the drained gold to the cyber unit owner instead of destroying it', () => {
+    const state = makeProcessTurnState({
+      p1Gold: 100,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 2, r: 0 },
+      p1Buildings: [],
+    });
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.civilizations['p2'].gold).toBeGreaterThan(state.civilizations['p2'].gold);
+  });
+
+  it('does NOT drain when the owner is not at war with the victim', () => {
+    const state = makeProcessTurnState({
+      p1Gold: 100,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 2, r: 0 },
+      p1Buildings: [],
+    });
+    const atPeaceState = {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        p1: { ...state.civilizations['p1'], diplomacy: { ...state.civilizations['p1'].diplomacy, atWarWith: [] } },
+        p2: { ...state.civilizations['p2'], diplomacy: { ...state.civilizations['p2'].diplomacy, atWarWith: [] } },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const events: any[] = [];
+    bus.on('city:cyber-drained', e => events.push(e));
+    processTurn(atPeaceState, bus);
+    expect(events).toEqual([]);
+  });
+
+  it('emits city:cyber-drained with blocked:true and no gold movement when CDC blocks it', () => {
+    const state = makeProcessTurnState({
+      p1Gold: 100,
+      p1CityPos: { q: 1, r: 0 },
+      cyberUnitPos: { q: 2, r: 0 },
+      p1Buildings: ['cyber_defense_center'],
+    });
+    const bus = new EventBus();
+    const events: any[] = [];
+    bus.on('city:cyber-drained', e => events.push(e));
+    const result = processTurn(state, bus);
+    expect(result.civilizations['p1'].gold).toBeGreaterThanOrEqual(100);
+    expect(events.some(e => e.blocked === true)).toBe(true);
+    expect(events.some(e => e.blocked === false)).toBe(false);
+  });
+});
+
 describe('cyberMarketDisruption tick (Task 5)', () => {
   it('decrements turnsRemaining and applies 1 gold penalty', () => {
     const state = makeProcessTurnState({ p1Gold: 10 });
@@ -403,7 +455,7 @@ describe('cyberMarketDisruption tick (Task 5)', () => {
 
 describe('gene therapy pre-charge (Task 5)', () => {
   it('unit trained in city with gene_therapy_clinic starts geneTherapyReady:true', () => {
-    const state = makeProcessTurnState({ p1Buildings: ['gene_therapy_clinic'] });
+    const state = makeProcessTurnState({ p1Buildings: ['gene_therapy_clinic'], p1Techs: ['gene-therapy'] });
     const stateWithQueue = {
       ...state,
       cities: {
@@ -442,6 +494,79 @@ describe('gene therapy pre-charge (Task 5)', () => {
     const newWarrior = Object.values(result.units).find(u => u.type === 'warrior' && u.owner === 'p1');
     expect(newWarrior).toBeDefined();
     expect(newWarrior!.geneTherapyReady).toBeUndefined();
+  });
+
+  it('unit trained without gene_therapy_clinic BUT with gene-therapy researched gets geneTherapyReady:false (not undefined)', () => {
+    const state = makeProcessTurnState({ p1Buildings: [], p1Techs: ['gene-therapy'] });
+    const stateWithQueue = {
+      ...state,
+      cities: {
+        ...state.cities,
+        'city-p1': {
+          ...state.cities['city-p1'],
+          productionQueue: ['warrior'],
+          productionProgress: 59,
+          idleProduction: 'production',
+        },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(stateWithQueue, bus);
+    const newWarrior = Object.values(result.units).find(u => u.type === 'warrior' && u.owner === 'p1');
+    expect(newWarrior).toBeDefined();
+    expect(newWarrior!.geneTherapyReady).toBe(false);
+  });
+});
+
+describe('gene therapy charge on research completion (Task 1)', () => {
+  it('charges all existing combat units and skips strength-0 units when gene-therapy completes', () => {
+    const base = makeProcessTurnState({
+      p1Units: ['warrior1', 'settler1'],
+      extraUnits: {
+        warrior1: { type: 'warrior', owner: 'p1', position: { q: 1, r: 0 } },
+        settler1: { type: 'settler', owner: 'p1', position: { q: 1, r: 0 } },
+      },
+    });
+    const state = {
+      ...base,
+      civilizations: {
+        ...base.civilizations,
+        p1: {
+          ...base.civilizations.p1,
+          techState: { ...base.civilizations.p1.techState, currentResearch: 'gene-therapy', researchProgress: 390 },
+        },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.units['warrior1']?.geneTherapyReady).toBe(true);
+    expect(result.units['settler1']?.geneTherapyReady).toBeUndefined();
+  });
+
+  it('parity: an AI civ (isHuman:false) also gets its units charged on gene-therapy completion', () => {
+    const base = makeProcessTurnState({});
+    const state = {
+      ...base,
+      units: {
+        ...base.units,
+        warriorAI: {
+          id: 'warriorAI', type: 'warrior', owner: 'p2', health: 100,
+          position: { q: 10, r: 10 }, movementPointsLeft: 1,
+          hasMoved: false, hasActed: false, experience: 0, isResting: false,
+        },
+      },
+      civilizations: {
+        ...base.civilizations,
+        p2: {
+          ...base.civilizations.p2,
+          units: [...base.civilizations.p2.units, 'warriorAI'],
+          techState: { ...base.civilizations.p2.techState, currentResearch: 'gene-therapy', researchProgress: 390 },
+        },
+      },
+    } as unknown as GameState;
+    const bus = new EventBus();
+    const result = processTurn(state, bus);
+    expect(result.units['warriorAI']?.geneTherapyReady).toBe(true);
   });
 });
 

--- a/tests/systems/gene-therapy-system.test.ts
+++ b/tests/systems/gene-therapy-system.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import {
+  chargeUnitsOnGeneTherapyResearch,
+  applyGeneTherapyRecharge,
+} from '@/systems/gene-therapy-system';
+import type { GameState, Unit } from '@/core/types';
+
+function makeUnit(overrides: Partial<Unit> & { id: string; type: Unit['type']; owner: string }): Unit {
+  return {
+    position: { q: 0, r: 0 },
+    health: 100,
+    movementPointsLeft: 2,
+    hasMoved: false,
+    hasActed: false,
+    experience: 0,
+    isResting: false,
+    ...overrides,
+  } as Unit;
+}
+
+function makeState(units: Record<string, Unit>, civUnitIds: string[]): GameState {
+  return {
+    turn: 5, era: 12, currentPlayer: 'p1',
+    units,
+    cities: {
+      'city-p1': {
+        id: 'city-p1', owner: 'p1', position: { q: 0, r: 0 },
+        buildings: [],
+      },
+    },
+    civilizations: {
+      p1: {
+        id: 'p1', name: 'Alpha', color: '#fff', isHuman: true, civType: 'generic',
+        units: civUnitIds, cities: ['city-p1'], gold: 0,
+        techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} } as any,
+      },
+    },
+    map: {
+      tiles: {
+        '0,0': { terrain: 'plains', owner: 'p1' },
+      },
+      width: 10, height: 10, wrapsHorizontally: false,
+    },
+  } as unknown as GameState;
+}
+
+describe('chargeUnitsOnGeneTherapyResearch', () => {
+  it('sets geneTherapyReady:true on every combat unit (strength > 0) owned by the civ', () => {
+    const state = makeState(
+      {
+        warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1' }),
+      },
+      ['warrior1'],
+    );
+
+    const result = chargeUnitsOnGeneTherapyResearch(state, 'p1');
+
+    expect(result.units.warrior1.geneTherapyReady).toBe(true);
+  });
+
+  it('skips strength-0 civilian units (settler, cyber_unit) — leaves geneTherapyReady undefined', () => {
+    const state = makeState(
+      {
+        settler1: makeUnit({ id: 'settler1', type: 'settler', owner: 'p1' }),
+        cyber1: makeUnit({ id: 'cyber1', type: 'cyber_unit', owner: 'p1' }),
+      },
+      ['settler1', 'cyber1'],
+    );
+
+    const result = chargeUnitsOnGeneTherapyResearch(state, 'p1');
+
+    expect(result.units.settler1.geneTherapyReady).toBeUndefined();
+    expect(result.units.cyber1.geneTherapyReady).toBeUndefined();
+  });
+
+  it('does not charge units owned by other civs', () => {
+    const state = makeState(
+      {
+        enemyWarrior: makeUnit({ id: 'enemyWarrior', type: 'warrior', owner: 'p2' }),
+      },
+      [],
+    );
+
+    const result = chargeUnitsOnGeneTherapyResearch(state, 'p1');
+
+    expect(result.units.enemyWarrior.geneTherapyReady).toBeUndefined();
+  });
+
+  it('does not mutate the input state', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1' }) },
+      ['warrior1'],
+    );
+    const before = structuredClone(state);
+
+    chargeUnitsOnGeneTherapyResearch(state, 'p1');
+
+    expect(state).toEqual(before);
+  });
+});
+
+describe('applyGeneTherapyRecharge', () => {
+  it('recharges an idle unit at geneTherapyReady:false resting in a friendly city', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1', geneTherapyReady: false }) },
+      ['warrior1'],
+    );
+
+    const result = applyGeneTherapyRecharge(state, 'p1');
+
+    expect(result.units.warrior1.geneTherapyReady).toBe(true);
+  });
+
+  it('does not recharge a unit that moved this turn', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1', geneTherapyReady: false, hasMoved: true }) },
+      ['warrior1'],
+    );
+
+    const result = applyGeneTherapyRecharge(state, 'p1');
+
+    expect(result.units.warrior1.geneTherapyReady).toBe(false);
+  });
+
+  it('does not recharge a unit outside a friendly city', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1', geneTherapyReady: false, position: { q: 9, r: 9 } }) },
+      ['warrior1'],
+    );
+
+    const result = applyGeneTherapyRecharge(state, 'p1');
+
+    expect(result.units.warrior1.geneTherapyReady).toBe(false);
+  });
+
+  it('does not affect a unit with geneTherapyReady:undefined', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1' }) },
+      ['warrior1'],
+    );
+
+    const result = applyGeneTherapyRecharge(state, 'p1');
+
+    expect(result.units.warrior1.geneTherapyReady).toBeUndefined();
+  });
+
+  it('does not mutate the input state', () => {
+    const state = makeState(
+      { warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1', geneTherapyReady: false }) },
+      ['warrior1'],
+    );
+    const before = structuredClone(state);
+
+    applyGeneTherapyRecharge(state, 'p1');
+
+    expect(state).toEqual(before);
+  });
+
+  it('only considers units in the optional unitIds allowlist — excludes units freshly trained this same turn', () => {
+    // warrior1 pre-existed the turn (in allowlist); warrior2 was just trained this turn
+    // (present in civ.units / state.units but NOT in the pre-turn allowlist) and must not be swept up.
+    const state = makeState(
+      {
+        warrior1: makeUnit({ id: 'warrior1', type: 'warrior', owner: 'p1', geneTherapyReady: false }),
+        warrior2: makeUnit({ id: 'warrior2', type: 'warrior', owner: 'p1', geneTherapyReady: false }),
+      },
+      ['warrior1', 'warrior2'],
+    );
+
+    const result = applyGeneTherapyRecharge(state, 'p1', ['warrior1']);
+
+    expect(result.units.warrior1.geneTherapyReady).toBe(true);
+    expect(result.units.warrior2.geneTherapyReady).toBe(false);
+  });
+});

--- a/tests/systems/unit-upgrade.test.ts
+++ b/tests/systems/unit-upgrade.test.ts
@@ -97,6 +97,75 @@ describe('explicit upgrade chains', () => {
   });
 });
 
+describe('trainedFromBuilding upgrade gate (Stealth Airbase)', () => {
+  const completedTechs = ['jet-aviation', 'stealth-technology'];
+
+  it('blocks jet_fighter -> stealth_bomber upgrade in a city without stealth_airbase, with reason missing-building', () => {
+    const unit = makeUnit('jet_fighter');
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 }, buildings: [] } as any;
+    const result = canUpgradeUnit(unit, 'c1', { c1: city }, completedTechs);
+    expect(result.canUpgrade).toBe(false);
+    expect(result.targetType).toBeNull();
+    expect(result.reason).toBe('missing-building');
+  });
+
+  it('allows jet_fighter -> stealth_bomber upgrade in a city with stealth_airbase and deducts gold', () => {
+    const unit = makeUnit('jet_fighter');
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 }, buildings: ['stealth_airbase'] } as any;
+    const result = canUpgradeUnit(unit, 'c1', { c1: city }, completedTechs, 1000);
+    expect(result.canUpgrade).toBe(true);
+    expect(result.targetType).toBe('stealth_bomber');
+  });
+
+  it('regression: musketeer -> rifleman (no trainedFromBuilding) is unaffected by building gate', () => {
+    const unit = makeUnit('musketeer');
+    const city = { id: 'c1', owner: 'player', position: { q: 0, r: 0 }, buildings: [] } as any;
+    const result = canUpgradeUnit(unit, 'c1', { c1: city }, ['tactics', 'rifled-infantry']);
+    expect(result.canUpgrade).toBe(true);
+    expect(result.targetType).toBe('rifleman');
+  });
+
+  it('applyUnitUpgradeToState rejects the upgrade when the host city lacks the required building', () => {
+    const state = createNewGame(undefined, 'building-gate-upgrade', 'small');
+    const civ = state.civilizations.player;
+    const source = civ.units.map(id => state.units[id]).find(Boolean)!;
+    const city = foundCity(civ.id, source.position, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    civ.cities = [city.id];
+    source.id = 'upgrade-unit';
+    source.type = 'jet_fighter';
+    state.units = { [source.id]: source };
+    civ.units = [source.id];
+    civ.techState.completed = completedTechs;
+    civ.gold = 1000;
+
+    const result = applyUnitUpgradeToState(state, 'upgrade-unit', 'stealth_bomber');
+
+    expect(result).toEqual({ state, upgraded: false, reason: 'tech-unavailable' });
+  });
+
+  it('applyUnitUpgradeToState allows the upgrade once stealth_airbase is present in the host city', () => {
+    const state = createNewGame(undefined, 'building-gate-upgrade-ok', 'small');
+    const civ = state.civilizations.player;
+    const source = civ.units.map(id => state.units[id]).find(Boolean)!;
+    const city = foundCity(civ.id, source.position, state.map, state.idCounters);
+    city.buildings = [...city.buildings, 'stealth_airbase'];
+    state.cities[city.id] = city;
+    civ.cities = [city.id];
+    source.id = 'upgrade-unit';
+    source.type = 'jet_fighter';
+    state.units = { [source.id]: source };
+    civ.units = [source.id];
+    civ.techState.completed = completedTechs;
+    civ.gold = 1000;
+
+    const result = applyUnitUpgradeToState(state, 'upgrade-unit', 'stealth_bomber');
+
+    expect(result.upgraded).toBe(true);
+    expect(result.state.units['upgrade-unit'].type).toBe('stealth_bomber');
+  });
+});
+
 describe('getUpgradeCost', () => {
   it('returns half of the target unit production cost from the canonical catalog', () => {
     const cost = getUpgradeCost('spy_informant');

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -1019,6 +1019,52 @@ describe('renderSelectedUnitInfo - fortify button', () => {
   });
 });
 
+describe('renderSelectedUnitInfo - upgrade button building gate', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  function makeJetFighterState(cityBuildings: string[]): GameState {
+    return {
+      turn: 1, era: 12, currentPlayer: 'player', gameOver: false, winner: null,
+      map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
+      units: {
+        'jet-1': { id: 'jet-1', type: 'jet_fighter', owner: 'player', position: { q: 0, r: 0 }, health: 100, experience: 0, movementPointsLeft: 2, hasMoved: false, hasActed: false, isResting: false },
+      },
+      cities: {
+        'city-1': { id: 'city-1', owner: 'player', position: { q: 0, r: 0 }, buildings: cityBuildings },
+      },
+      civilizations: {
+        player: { color: '#fff', gold: 1000, techState: { completed: ['jet-aviation', 'stealth-technology'] } },
+      },
+    } as unknown as GameState;
+  }
+
+  it('renders the Upgrade button when the city has stealth_airbase', () => {
+    const state = makeJetFighterState(['stealth_airbase']);
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'jet-1', {
+      onUpgradeUnit: () => {},
+    });
+
+    const texts = findButtons(container).map(b => b.textContent);
+    expect(texts.some(t => t.startsWith('Upgrade → Stealth Bomber'))).toBe(true);
+  });
+
+  it('hides the Upgrade button and shows a missing-building reason when stealth_airbase is absent', () => {
+    const state = makeJetFighterState([]);
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'jet-1', {
+      onUpgradeUnit: () => {},
+    });
+
+    const texts = findButtons(container).map(b => b.textContent);
+    expect(texts.some(t => t.startsWith('Upgrade'))).toBe(false);
+    expect(collectAllText(container).join(' ')).toContain('Stealth Airbase');
+  });
+});
+
 describe('renderSelectedUnitInfo - transport actions', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);


### PR DESCRIPTION
## Summary

MR1 from issue #472 (content audit remediation, sub-issue #460). This closes #460.

Three era-12 mechanics were promised to the player but incomplete after the earlier Information Age implementation ([PR #459](https://github.com/a1flecke/conquestoria/pull/459)):

- **Gene therapy**: existing units were never charged when `gene-therapy` tech completed — only newly-trained units built in a clinic city got the flag. Added `chargeUnitsOnGeneTherapyResearch` (new `src/systems/gene-therapy-system.ts`), wired to `tech:completed`. Also fixed training pre-charge to distinguish tech-without-clinic (`false`, on cooldown) from no-tech (`undefined`), and fixed a same-turn bug where freshly trained units were immediately swept into the end-of-turn recharge pass before they ever "rested" a turn.
- **Cyber drain**: had no at-war check (drained gold in peacetime — diplomacy-free griefing) and destroyed the drained gold instead of crediting it to the cyber unit's owner (spec says theft, not destruction). Extracted to `src/systems/cyber-warfare-system.ts` with both fixes, plus a CDC-blocked event and hot-seat-safe notification routing so both the victim and attacker see the outcome on their own side only.
- **Upgrade gate**: `getCanonicalUpgradeTarget` ignored `trainedFromBuilding`, so a Jet Fighter could gold-upgrade into a Stealth Bomber in any city, bypassing the Stealth Airbase requirement. Threaded `city.buildings` through `canUpgradeUnit` / `applyUnitUpgradeToState` / the AI upgrade-routing path (`ai-upgrades.ts`, including destination selection so the AI doesn't route/wait in a city that can never satisfy the gate), and added a "Requires Stealth Airbase in this city" message in the unit panel when that's the blocker.

## Test plan

- [x] New unit tests: `tests/systems/gene-therapy-system.test.ts`, `tests/systems/cyber-warfare-system.test.ts`
- [x] Extended: `tests/systems/era-12.test.ts`, `tests/systems/unit-upgrade.test.ts`, `tests/ai/ai-upgrades.test.ts`, `tests/ui/selected-unit-info.test.ts`
- [x] Verified each new/changed behavior fails without the fix (RED) before implementing (GREEN), including reverting fixes locally to confirm failures
- [x] `yarn build` — passes, no type errors
- [x] `yarn test` — 5026 passed, 2 skipped, 336 files
- [x] No `Math.random()`; all RNG deterministic (turn/id-hash seeded LCG); state mutations immutable throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)