### PR TITLE
fix(diplomacy): MR2 — dead tech ID reference integrity + espionage slot table

### DIFF
--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1149,11 +1149,11 @@ export function getCatalogProductionCost(itemId: string, era: number = 1): numbe
   return unit.cost;
 }
 
-const MELEE_RANGED_UNIT_TYPES: string[] = [
+export const MELEE_RANGED_UNIT_TYPES: string[] = [
   'warrior', 'axeman', 'spearman', 'swordsman', 'pikeman', 'musketeer', 'archer', 'crossbowman',
 ];
-const CAVALRY_UNIT_TYPES: string[] = ['horseman', 'cavalry', 'knight'];
-const SIEGE_UNIT_TYPES: string[] = ['catapult', 'ballista', 'cannon'];
+export const CAVALRY_UNIT_TYPES: string[] = ['horseman', 'cavalry', 'knight'];
+export const SIEGE_UNIT_TYPES: string[] = ['catapult', 'ballista', 'cannon'];
 
 function getBuildingDiscountMultiplier(itemId: string, cityBuildings: string[]): number {
   let best = 1;

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -260,9 +260,12 @@ export function tickTreaties(state: DiplomacyState): DiplomacyState {
   return { ...state, treaties: remaining };
 }
 
-const CIVICS_TECHS = ['code-of-laws', 'early-empire', 'political-philosophy', 'diplomacy', 'foreign-trade'];
-const TRADE_TECHS = ['trade-routes', 'currency', 'banking', 'coinage'];
-const ALLIANCE_TECHS = ['diplomacy', 'political-philosophy'];
+// IDs must exist in TECH_TREE — see tests/systems/diplomacy-tech-gates.test.ts
+export const TRADE_TECHS = ['trade-routes', 'currency', 'banking'];
+// IDs must exist in TECH_TREE — see tests/systems/diplomacy-tech-gates.test.ts
+export const ALLIANCE_TECHS = ['political-philosophy']; // its unlock text: "Unlock alliances"
+// IDs must exist in TECH_TREE — see tests/systems/diplomacy-tech-gates.test.ts
+export const NAP_TECHS = ['diplomacy-tech']; // its unlock text: "Unlock Non-Aggression Pacts"
 
 export function getAvailableActions(
   state: DiplomacyState,
@@ -278,7 +281,7 @@ export function getAvailableActions(
   } else {
     actions.push('declare_war');
 
-    const hasCivicsTech = completedTechs.some(t => CIVICS_TECHS.includes(t));
+    const hasNAPTech = completedTechs.some(t => NAP_TECHS.includes(t));
     const hasTradeTech = completedTechs.some(t => TRADE_TECHS.includes(t));
     const hasAllianceTech = completedTechs.some(t => ALLIANCE_TECHS.includes(t));
     const hasNAP = state.treaties.some(
@@ -289,7 +292,7 @@ export function getAvailableActions(
     );
     const relationship = getRelationship(state, targetCivId);
 
-    if ((era >= 2 || hasCivicsTech) && !hasNAP) {
+    if ((era >= 2 || hasNAPTech) && !hasNAP) {
       actions.push('non_aggression_pact');
     }
     if ((era >= 3 || hasTradeTech) && relationship > 0 && !hasTrade) {
@@ -310,13 +313,13 @@ export function getAvailableActions(
     }
 
     // Embargo (requires currency tech or era >= 2, not vassal)
-    const hasEmbargoTech = completedTechs.some(t => ['currency', 'foreign-trade', 'banking'].includes(t));
+    const hasEmbargoTech = completedTechs.some(t => EMBARGO_TECHS.includes(t));
     if ((era >= 2 || hasEmbargoTech) && !state.vassalage?.overlord) {
       actions.push('propose_embargo');
     }
 
     // League (requires writing tech, not in a league, not vassal)
-    const hasWritingTech = completedTechs.some(t => ['science-writing', 'communication-writing', 'writing'].includes(t));
+    const hasWritingTech = completedTechs.some(t => WRITING_TECHS.includes(t));
     if (hasWritingTech && !state.vassalage?.overlord) {
       actions.push('propose_league');
     }
@@ -808,7 +811,8 @@ export function onVassalAttacked(
 
 // --- Embargoes ---
 
-const EMBARGO_TECHS = ['currency', 'foreign-trade', 'banking'];
+// IDs must exist in TECH_TREE — see tests/systems/diplomacy-tech-gates.test.ts
+export const EMBARGO_TECHS = ['currency', 'banking'];
 
 export function canProposeEmbargo(
   completedTechs: string[],
@@ -918,7 +922,8 @@ export function endVassalageUnilateral(
 
 // --- Defensive Leagues ---
 
-const WRITING_TECHS = ['science-writing', 'communication-writing', 'writing'];
+// IDs must exist in TECH_TREE — see tests/systems/diplomacy-tech-gates.test.ts
+export const WRITING_TECHS = ['writing'];
 
 export function canProposeLeague(
   completedTechs: string[],

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -1048,12 +1048,15 @@ function pruneDetectedThreats(
 
 // --- Top-level turn integration ---
 
-const ESPIONAGE_TECH_MAX_SPIES: Record<string, number> = {
+export const ESPIONAGE_TECH_MAX_SPIES: Record<string, number> = {
   'espionage-scouting': 1,
   'espionage-informants': 2,
   'spy-networks': 3,
   'cryptography': 4,
   'counter-intelligence': 5,
+  'black-chambers': 6,          // era 5: "+1 spy slot empire-wide"
+  'covert-operations': 8,       // era 7: "+2 spy slots empire-wide"
+  'political-intelligence': 11, // era 8: "+3 spy slots empire-wide"
 };
 
 export function initializeEspionage(state: GameState): EspionageState {

--- a/tests/systems/catalog-id-integrity.test.ts
+++ b/tests/systems/catalog-id-integrity.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import {
+  TRADE_TECHS,
+  ALLIANCE_TECHS,
+  NAP_TECHS,
+  EMBARGO_TECHS,
+  WRITING_TECHS,
+} from '@/systems/diplomacy-system';
+import { ESPIONAGE_TECH_MAX_SPIES } from '@/systems/espionage-system';
+import { MELEE_RANGED_UNIT_TYPES, CAVALRY_UNIT_TYPES, SIEGE_UNIT_TYPES } from '@/systems/city-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+const techIds = new Set(TECH_TREE.map(t => t.id));
+const unitTypes = new Set(Object.keys(UNIT_DEFINITIONS));
+
+describe('catalog-id-integrity', () => {
+  describe('diplomacy tech gate lists reference real techs', () => {
+    it.each([
+      ['TRADE_TECHS', TRADE_TECHS],
+      ['ALLIANCE_TECHS', ALLIANCE_TECHS],
+      ['NAP_TECHS', NAP_TECHS],
+      ['EMBARGO_TECHS', EMBARGO_TECHS],
+      ['WRITING_TECHS', WRITING_TECHS],
+    ])('every id in %s exists in TECH_TREE', (_name, ids) => {
+      for (const id of ids) {
+        expect(techIds.has(id)).toBe(true);
+      }
+    });
+  });
+
+  it('every id in ESPIONAGE_TECH_MAX_SPIES exists in TECH_TREE', () => {
+    for (const id of Object.keys(ESPIONAGE_TECH_MAX_SPIES)) {
+      expect(techIds.has(id)).toBe(true);
+    }
+  });
+
+  describe('city-system discount unit lists reference real unit types', () => {
+    it.each([
+      ['MELEE_RANGED_UNIT_TYPES', MELEE_RANGED_UNIT_TYPES],
+      ['CAVALRY_UNIT_TYPES', CAVALRY_UNIT_TYPES],
+      ['SIEGE_UNIT_TYPES', SIEGE_UNIT_TYPES],
+    ])('every id in %s exists in UNIT_DEFINITIONS', (_name, ids) => {
+      for (const id of ids) {
+        expect(unitTypes.has(id)).toBe(true);
+      }
+    });
+  });
+});

--- a/tests/systems/diplomacy-league.test.ts
+++ b/tests/systems/diplomacy-league.test.ts
@@ -24,7 +24,7 @@ function makeDipState(overrides?: Partial<DiplomacyState>): DiplomacyState {
 describe('defensive leagues', () => {
   describe('canProposeLeague', () => {
     it('returns true with writing tech', () => {
-      expect(canProposeLeague(['science-writing'], [], null)).toBe(true);
+      expect(canProposeLeague(['writing'], [], null)).toBe(true);
     });
 
     it('returns false without writing tech', () => {
@@ -33,11 +33,11 @@ describe('defensive leagues', () => {
 
     it('returns false if already in a league', () => {
       const league: DefensiveLeague = { id: 'l-1', members: ['self'], formedTurn: 1 };
-      expect(canProposeLeague(['science-writing'], [], league)).toBe(false);
+      expect(canProposeLeague(['writing'], [], league)).toBe(false);
     });
 
     it('returns false if vassal', () => {
-      expect(canProposeLeague(['science-writing'], [], null, true)).toBe(false);
+      expect(canProposeLeague(['writing'], [], null, true)).toBe(false);
     });
   });
 

--- a/tests/systems/diplomacy-negative.test.ts
+++ b/tests/systems/diplomacy-negative.test.ts
@@ -39,11 +39,11 @@ describe('negative tests — blocked actions', () => {
 
   it('cannot join second league', () => {
     const league = { id: 'l-1', members: ['self', 'other'], formedTurn: 1 };
-    expect(canProposeLeague(['science-writing'], [], league)).toBe(false);
+    expect(canProposeLeague(['writing'], [], league)).toBe(false);
   });
 
   it('vassal cannot propose league', () => {
-    expect(canProposeLeague(['science-writing'], [], null, true)).toBe(false);
+    expect(canProposeLeague(['writing'], [], null, true)).toBe(false);
   });
 
   it('vassal cannot declare war independently', () => {

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -213,9 +213,9 @@ describe('diplomacy-system', () => {
       expect(actions).not.toContain('declare_war');
     });
 
-    it('includes non_aggression_pact with civics tech', () => {
+    it('includes non_aggression_pact with diplomacy-tech', () => {
       const state = createDiplomacyState(civIds, 'player');
-      const actions = getAvailableActions(state, 'ai-egypt', ['code-of-laws'], 1);
+      const actions = getAvailableActions(state, 'ai-egypt', ['diplomacy-tech'], 1);
       expect(actions).toContain('non_aggression_pact');
     });
 

--- a/tests/systems/diplomacy-tech-gates.test.ts
+++ b/tests/systems/diplomacy-tech-gates.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createDiplomacyState, getAvailableActions } from '@/systems/diplomacy-system';
+
+describe('diplomacy tech gates', () => {
+  it('era 1 civ WITH diplomacy-tech gets non_aggression_pact', () => {
+    const state = createDiplomacyState(['self', 'target'], 'self');
+    const actions = getAvailableActions(state, 'target', ['diplomacy-tech'], 1);
+    expect(actions).toContain('non_aggression_pact');
+  });
+
+  it('era 1 civ WITHOUT diplomacy-tech does not get non_aggression_pact', () => {
+    const state = createDiplomacyState(['self', 'target'], 'self');
+    const actions = getAvailableActions(state, 'target', [], 1);
+    expect(actions).not.toContain('non_aggression_pact');
+  });
+
+  it('era 4 civ with zero techs gets alliance (era fallback still works)', () => {
+    const state = createDiplomacyState(['self', 'target'], 'self');
+    const actions = getAvailableActions(state, 'target', [], 4);
+    expect(actions).toContain('alliance');
+  });
+});

--- a/tests/systems/espionage-system.test.ts
+++ b/tests/systems/espionage-system.test.ts
@@ -26,6 +26,7 @@ import {
   verifyAgent,
   } from '@/systems/espionage-system';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { createNewGame } from '@/core/game-state';
 
 // MR1: legacy fixture helper for tests that need a spy in state without going through city production
 function makeTestSpy(id: string, owner: string, overrides: Partial<Spy> = {}): Spy {
@@ -163,6 +164,40 @@ describe('espionage tech definitions', () => {
       for (const prereq of tech.prerequisites) {
         expect(allIds.has(prereq), `${tech.id} has invalid prerequisite ${prereq}`).toBe(true);
       }
+    }
+  });
+});
+
+describe('maxSpies progression via per-turn update', () => {
+  const progression: Array<[string, number]> = [
+    ['espionage-scouting', 1],
+    ['espionage-informants', 2],
+    ['spy-networks', 3],
+    ['cryptography', 4],
+    ['counter-intelligence', 5],
+    ['black-chambers', 6],
+    ['covert-operations', 8],
+    ['political-intelligence', 11],
+  ];
+
+  it('maxSpies climbs 1→2→3→4→5→6→8→11 as techs complete', () => {
+    let state = createNewGame(undefined, 'max-spies-progression', 'small');
+    const bus = new EventBus();
+    const completed: string[] = [];
+    for (const [techId, expectedMax] of progression) {
+      completed.push(techId);
+      state = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          player: {
+            ...state.civilizations.player,
+            techState: { ...state.civilizations.player.techState, completed: [...completed] },
+          },
+        },
+      };
+      state = processEspionageTurn(state, bus);
+      expect(state.espionage!.player.maxSpies).toBe(expectedMax);
     }
   });
 });

--- a/tests/ui/espionage-panel.test.ts
+++ b/tests/ui/espionage-panel.test.ts
@@ -169,6 +169,13 @@ describe('espionage-panel', () => {
       expect(data.activeSpyCount).toBe(0);
     });
 
+    it('reflects 8 spy slots after covert-operations', () => {
+      const state = makeEspUiState();
+      state.espionage!.player.maxSpies = 8;
+      const data = getEspionagePanelData(state);
+      expect(data.maxSpies).toBe(8);
+    });
+
     it('surfaces stage metadata for available missions', () => {
       const state = makeEspUiState();
       state.civilizations.player.techState.completed = [


### PR DESCRIPTION
## Summary
- Part of #472 (12-MR content audit remediation), MR2 — [MR2 sub-issue](https://github.com/a1flecke/conquestoria/issues/461).
- Replaces dead tech IDs in `diplomacy-system.ts` gate lists (`'diplomacy'`, `'foreign-trade'`, `'coinage'`, `'science-writing'`, `'communication-writing'` never existed in `TECH_TREE`) with the real IDs the unlock text promises. NAP now narrows to `diplomacy-tech` specifically instead of the broader (and partly-fake) civics list.
- Extends `ESPIONAGE_TECH_MAX_SPIES` so `black-chambers` (era 5), `covert-operations` (era 7), and `political-intelligence` (era 8) deliver their advertised spy slots — table now reaches 11 slots by era 8.
- Deduplicates the inline embargo/writing tech lists in `diplomacy-system.ts` to reuse the named, exported constants.
- Adds `tests/systems/catalog-id-integrity.test.ts` (new shared guard: every ID in the diplomacy gate lists, espionage slot table, and city-system unit-discount lists exists in the corresponding catalog) and `tests/systems/diplomacy-tech-gates.test.ts` (NAP/alliance gating behavior).
- Fixes three pre-existing tests that had been asserting against the dead tech IDs.

## Test plan
- [x] `bash scripts/run-with-mise.sh yarn build` — green
- [x] `bash scripts/run-with-mise.sh yarn test` — 5101 passed, 0 failed (plus hook smoke tests all green)
- [x] Drift check confirmed the MR2 spec's evidence (line numbers, dead IDs) still matched the current codebase before implementing — no changes landed in this area since the July 2026 audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)