### PR TITLE
fix(combat): MR3 — walls, star fort, and garrison techs become real

### DIFF
--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -14,6 +14,7 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { resolveCombat } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import {
   beginMajorCityAssault,
   canUnitOccupyCity,
@@ -21,7 +22,6 @@ import {
   resolveMajorCityCapture,
 } from '@/systems/city-capture-system';
 import { foundCityInState } from '@/systems/city-founding-system';
-import { resolveCivDefinition } from '@/systems/civ-registry';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { conquestMinorCiv } from '@/systems/minor-civ-system';
@@ -101,26 +101,6 @@ function deterministicCombatSeed(
     hash = Math.imul(hash, 16777619);
   }
   return Math.max(1, hash >>> 0);
-}
-
-function combatContext(state: GameState, attacker: Unit, defender: Unit) {
-  const defenderKey = hexKey(defender.position);
-  return {
-    attackerBonus: resolveCivDefinition(
-      state,
-      state.civilizations[attacker.owner]?.civType ?? '',
-    )?.bonusEffect,
-    defenderBonus: resolveCivDefinition(
-      state,
-      state.civilizations[defender.owner]?.civType ?? '',
-    )?.bonusEffect,
-    defenderCityHasAntiAir: Object.values(state.cities).some(city =>
-      hexKey(city.position) === defenderKey
-      && city.buildings.includes('anti_air_battery')),
-    attackerHasAirForceCommand: Object.values(state.cities).some(city =>
-      city.owner === attacker.owner
-      && city.buildings.includes('air_force_command')),
-  };
 }
 
 function actionMatches(
@@ -226,7 +206,7 @@ function executeAttack(
     defender,
     next.map,
     seed,
-    combatContext(next, attacker, defender),
+    buildCombatContextForDefender(next, attacker, defender),
     next.era,
   );
   const presentation = buildCombatPresentation(next, combat, attacker, defender);

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -19,11 +19,11 @@ import {
   calculateCombatStrengths,
   resolveCombat,
 } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { resolveMajorCityCapture } from '@/systems/city-capture-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { foundCity } from '@/systems/city-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
-import { resolveCivDefinition } from '@/systems/civ-registry';
 import { getVisibility } from '@/systems/fog-of-war';
 import {
   hexDistance,
@@ -163,19 +163,6 @@ function hostileOwners(state: GameState, actorId: string): Set<string> {
     if (isAIHostileOwner(state, actorId, unit.owner)) atWar.add(unit.owner);
   }
   return atWar;
-}
-
-function combatContext(state: GameState, attacker: Unit, defender: Unit) {
-  return {
-    attackerBonus: resolveCivDefinition(
-      state,
-      state.civilizations[attacker.owner]?.civType ?? '',
-    )?.bonusEffect,
-    defenderBonus: resolveCivDefinition(
-      state,
-      state.civilizations[defender.owner]?.civType ?? '',
-    )?.bonusEffect,
-  };
 }
 
 function visibleThreatCount(
@@ -321,7 +308,7 @@ function rankAttacks(
       unit,
       defender,
       context.state.map,
-      combatContext(context.state, unit, defender),
+      buildCombatContextForDefender(context.state, unit, defender),
     );
     const expectedDamageRatio = Math.min(
       2,
@@ -343,7 +330,7 @@ function rankAttacks(
       defender,
       context.state.map,
       combatSeed(context, action),
-      combatContext(context.state, unit, defender),
+      buildCombatContextForDefender(context.state, unit, defender),
       context.state.era,
     );
     const likelyFinish = !preview.defenderSurvived;
@@ -654,7 +641,7 @@ function applyPredictedAction(
         defender,
         next.map,
         seed,
-        combatContext(next, unit, defender),
+        buildCombatContextForDefender(next, unit, defender),
         next.era,
       );
       return applyCombatOutcomeToState(next, result, seed).state;

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -430,6 +430,7 @@ function chooseLegendaryWonderFallback(
     return 'warrior';
   }
 
+  // walls now grant ×1.25 city defense (combat-system getCityDefenseBreakdown)
   if (!city.buildings.includes('walls')) {
     return 'walls';
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { createWorkerReplacementConfirmPanel, createWorkerTaskWarningPanel } fro
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
@@ -2361,24 +2362,17 @@ function executeAttack(attackerId: string, targetKey: string): void {
 
   const seed = gameState.turn * 16807 + attacker.id.charCodeAt(0) + defender.id.charCodeAt(0);
   const attackerBonus = currentCivDef()?.bonusEffect;
-  const defenderBonus = resolveCivDefinition(gameState, gameState.civilizations[defender.owner]?.civType ?? '')?.bonusEffect;
   // Capture defender position before combat (defender may be removed from state after)
   const defenderPosition = { ...defender.position };
   // Capture route IDs before combat (units may be removed from state after)
   const attackerRouteId = attacker.committedToRouteId;
   const defenderRouteId = defender.committedToRouteId;
-  const defenderKey = hexKey(defender.position);
-  const defenderCityHasAntiAir = Object.values(gameState.cities).some(
-    c => hexKey(c.position) === defenderKey && c.buildings.includes('anti_air_battery'),
-  );
-  const attackerCivCities = Object.values(gameState.cities).filter(c => c.owner === attacker.owner);
-  const attackerHasAirForceCommand = attackerCivCities.some(c => c.buildings.includes('air_force_command'));
   const result = resolveCombat(
     attacker,
     gameState.units[defenderId] ?? defender,
     gameState.map,
     seed,
-    { attackerBonus, defenderBonus, defenderCityHasAntiAir, attackerHasAirForceCommand },
+    buildCombatContextForDefender(gameState, attacker, defender),
     gameState.era,
   );
   bus.emit('combat:resolved', {
@@ -2765,15 +2759,12 @@ function handleHexTap(rawCoord: HexCoord): void {
       }
       const atkDef = UNIT_DEFINITIONS[unit.type];
       const defDef = UNIT_DEFINITIONS[defender.type];
-      const attackerBonus = currentCivDef()?.bonusEffect;
-      const defenderBonus = resolveCivDefinition(
-        gameState,
-        gameState.civilizations[defender.owner]?.civType ?? '',
-      )?.bonusEffect;
-      const strengthPreview = calculateCombatStrengths(unit, defender, gameState.map, {
-        attackerBonus,
-        defenderBonus,
-      });
+      const strengthPreview = calculateCombatStrengths(
+        unit,
+        defender,
+        gameState.map,
+        buildCombatContextForDefender(gameState, unit, defender),
+      );
       const atkStr = Math.round(strengthPreview.attackerStrength);
       const defStr = Math.round(strengthPreview.defenderStrength);
 

--- a/src/systems/combat-context.ts
+++ b/src/systems/combat-context.ts
@@ -1,0 +1,43 @@
+import type { GameState, Unit } from '@/core/types';
+import type { CombatContext } from './combat-system';
+import { resolveCivDefinition } from './civ-registry';
+import { hexKey } from './hex-utils';
+import { UNIT_DEFINITIONS } from './unit-system';
+
+// Shared by the human attack flow (main.ts), every AI attack path
+// (ai-major-turn.ts, ai-tactics.ts), and the combat preview so the
+// three can never diverge in what defense modifiers a defender receives.
+export function buildCombatContextForDefender(
+  state: GameState,
+  attacker: Unit,
+  defender: Unit,
+): CombatContext {
+  const defenderKey = hexKey(defender.position);
+  const defenderCity = Object.values(state.cities).find(
+    city => hexKey(city.position) === defenderKey,
+  );
+
+  return {
+    attackerBonus: resolveCivDefinition(
+      state,
+      state.civilizations[attacker.owner]?.civType ?? '',
+    )?.bonusEffect,
+    defenderBonus: resolveCivDefinition(
+      state,
+      state.civilizations[defender.owner]?.civType ?? '',
+    )?.bonusEffect,
+    defenderCityHasAntiAir: Object.values(state.cities).some(city =>
+      hexKey(city.position) === defenderKey
+      && city.buildings.includes('anti_air_battery')),
+    attackerHasAirForceCommand: Object.values(state.cities).some(city =>
+      city.owner === attacker.owner
+      && city.buildings.includes('air_force_command')),
+    defenderCity: defenderCity
+      ? {
+          cityBuildings: defenderCity.buildings,
+          defenderCompletedTechs: state.civilizations[defender.owner]?.techState.completed ?? [],
+          attackerDomain: UNIT_DEFINITIONS[attacker.type]?.domain ?? 'land',
+        }
+      : undefined,
+  };
+}

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -41,10 +41,68 @@ export function selectDefenderForAttack(defenders: Unit[], map: GameMap): Unit |
   })[0];
 }
 
+export interface CityDefenseInput {
+  cityBuildings: readonly string[];
+  defenderCompletedTechs: readonly string[];
+  attackerDomain: 'land' | 'naval' | 'air';
+}
+
+export interface CityDefensePart {
+  source: string;
+  label: string;
+  kind: 'mult' | 'flat';
+  value: number;
+}
+
+export interface CityDefenseBreakdown {
+  multiplier: number;
+  flatBonus: number;
+  parts: CityDefensePart[];
+}
+
+export function getCityDefenseBreakdown(input: CityDefenseInput): CityDefenseBreakdown {
+  const hasWalls = input.cityBuildings.includes('walls');
+  const parts: CityDefensePart[] = [];
+  let multiplier = 1;
+  let flatBonus = 0;
+
+  if (hasWalls) {
+    multiplier *= 1.25;
+    parts.push({ source: 'walls', label: 'Walls ×1.25', kind: 'mult', value: 1.25 });
+  }
+
+  if (hasWalls && input.cityBuildings.includes('star_fort')) {
+    flatBonus += 5;
+    parts.push({ source: 'star_fort', label: 'Star Fort +5', kind: 'flat', value: 5 });
+  }
+
+  if (hasWalls && input.defenderCompletedTechs.includes('fortification-engineering')) {
+    flatBonus += 5;
+    parts.push({
+      source: 'fortification-engineering',
+      label: 'Fortification Engineering +5',
+      kind: 'flat',
+      value: 5,
+    });
+  }
+
+  if (input.defenderCompletedTechs.includes('professional-army')) {
+    multiplier *= 1.10;
+    parts.push({ source: 'professional-army', label: 'Professional Army ×1.10', kind: 'mult', value: 1.10 });
+  }
+
+  if (input.attackerDomain === 'naval' && input.defenderCompletedTechs.includes('torpedo-warfare')) {
+    flatBonus += 5;
+    parts.push({ source: 'torpedo-warfare', label: 'Torpedo Warfare +5', kind: 'flat', value: 5 });
+  }
+
+  return { multiplier, flatBonus, parts };
+}
+
 export interface CombatContext {
   attackerBonus?: CivBonusEffect;
   defenderBonus?: CivBonusEffect;
-  defenderInFortifiedCity?: boolean;
+  defenderCity?: CityDefenseInput;
   defenderCityHasAntiAir?: boolean;
   attackerHasAirForceCommand?: boolean;
 }
@@ -54,6 +112,7 @@ export interface CombatStrengthBreakdown {
   defenderStrength: number;
   terrainDefenseBonus: number;
   riverAttackPenalty: number;
+  cityDefense?: CityDefenseBreakdown;
 }
 
 export function calculateCombatStrengths(
@@ -94,6 +153,12 @@ export function calculateCombatStrengths(
     defenderStrength *= 1.25;
   }
 
+  let cityDefense: CityDefenseBreakdown | undefined;
+  if (context?.defenderCity) {
+    cityDefense = getCityDefenseBreakdown(context.defenderCity);
+    defenderStrength = defenderStrength * cityDefense.multiplier + cityDefense.flatBonus;
+  }
+
   // Anti-air battery: +8 flat defense against air attacker domain
   if (context?.defenderCityHasAntiAir && UNIT_DEFINITIONS[attacker.type]?.domain === 'air') {
     defenderStrength += 8;
@@ -116,6 +181,7 @@ export function calculateCombatStrengths(
     defenderStrength,
     terrainDefenseBonus,
     riverAttackPenalty,
+    cityDefense,
   };
 }
 
@@ -187,7 +253,7 @@ export function resolveCombat(
 
   // Ottoman siege bonus
   let siegeMultiplier = 1;
-  if (context?.attackerBonus?.type === 'siege_bonus' && context?.defenderInFortifiedCity) {
+  if (context?.attackerBonus?.type === 'siege_bonus' && context?.defenderCity) {
     siegeMultiplier = context.attackerBonus.damageMultiplier;
   }
 

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -12,5 +12,8 @@ export function formatCombatPreviewDetails(
   if (preview.riverAttackPenalty < 0) {
     details.push(`${Math.round(preview.riverAttackPenalty * 100)}% river crossing`);
   }
+  for (const part of preview.cityDefense?.parts ?? []) {
+    details.push(part.label);
+  }
   return details.join(' | ');
 }

--- a/tests/systems/city-defense.test.ts
+++ b/tests/systems/city-defense.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateCombatStrengths,
+  getCityDefenseBreakdown,
+  resolveCombat,
+  type CityDefenseInput,
+} from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
+import { createUnit } from '@/systems/unit-system';
+import { generateMap } from '@/systems/map-generator';
+import type { GameMap, GameState } from '@/core/types';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+const map = generateMap(30, 30, 'city-defense-test');
+
+function baseCityDefenseInput(overrides: Partial<CityDefenseInput> = {}): CityDefenseInput {
+  return {
+    cityBuildings: [],
+    defenderCompletedTechs: [],
+    attackerDomain: 'land',
+    ...overrides,
+  };
+}
+
+describe('getCityDefenseBreakdown', () => {
+  it('applies no modifiers with no buildings or techs', () => {
+    const breakdown = getCityDefenseBreakdown(baseCityDefenseInput());
+    expect(breakdown.multiplier).toBe(1);
+    expect(breakdown.flatBonus).toBe(0);
+    expect(breakdown.parts).toHaveLength(0);
+  });
+
+  it('walls grant ×1.25 defense multiplier', () => {
+    const breakdown = getCityDefenseBreakdown(baseCityDefenseInput({ cityBuildings: ['walls'] }));
+    expect(breakdown.multiplier).toBeCloseTo(1.25);
+    expect(breakdown.flatBonus).toBe(0);
+  });
+
+  it('star_fort adds +5 flat defense when walls are present', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['walls', 'star_fort'] }),
+    );
+    expect(breakdown.multiplier).toBeCloseTo(1.25);
+    expect(breakdown.flatBonus).toBe(5);
+  });
+
+  it('star_fort WITHOUT walls contributes nothing (negative test)', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({ cityBuildings: ['star_fort'] }),
+    );
+    expect(breakdown.multiplier).toBe(1);
+    expect(breakdown.flatBonus).toBe(0);
+  });
+
+  it('fortification-engineering adds +5 flat defense when walls are present', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({
+        cityBuildings: ['walls'],
+        defenderCompletedTechs: ['fortification-engineering'],
+      }),
+    );
+    expect(breakdown.flatBonus).toBe(5);
+  });
+
+  it('fortification-engineering WITHOUT walls contributes nothing (negative test)', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({ defenderCompletedTechs: ['fortification-engineering'] }),
+    );
+    expect(breakdown.flatBonus).toBe(0);
+  });
+
+  it('professional-army grants ×1.10 regardless of walls', () => {
+    const withoutWalls = getCityDefenseBreakdown(
+      baseCityDefenseInput({ defenderCompletedTechs: ['professional-army'] }),
+    );
+    expect(withoutWalls.multiplier).toBeCloseTo(1.10);
+
+    const withWalls = getCityDefenseBreakdown(
+      baseCityDefenseInput({
+        cityBuildings: ['walls'],
+        defenderCompletedTechs: ['professional-army'],
+      }),
+    );
+    expect(withWalls.multiplier).toBeCloseTo(1.25 * 1.10);
+  });
+
+  it('torpedo-warfare grants +5 flat only against a naval attacker (negative: land attacker)', () => {
+    const vsNaval = getCityDefenseBreakdown(
+      baseCityDefenseInput({ defenderCompletedTechs: ['torpedo-warfare'], attackerDomain: 'naval' }),
+    );
+    expect(vsNaval.flatBonus).toBe(5);
+
+    const vsLand = getCityDefenseBreakdown(
+      baseCityDefenseInput({ defenderCompletedTechs: ['torpedo-warfare'], attackerDomain: 'land' }),
+    );
+    expect(vsLand.flatBonus).toBe(0);
+  });
+
+  it('stacks walls + star_fort + fortification-engineering + professional-army in documented order', () => {
+    const breakdown = getCityDefenseBreakdown(
+      baseCityDefenseInput({
+        cityBuildings: ['walls', 'star_fort'],
+        defenderCompletedTechs: ['fortification-engineering', 'professional-army'],
+      }),
+    );
+    // multiplier: 1.25 (walls) * 1.10 (professional-army); flat: 5 (star_fort) + 5 (fort-eng)
+    expect(breakdown.multiplier).toBeCloseTo(1.25 * 1.10);
+    expect(breakdown.flatBonus).toBe(10);
+
+    // str-40 defender at full HP: 40 * multiplier + flat
+    const finalStrength = 40 * breakdown.multiplier + breakdown.flatBonus;
+    expect(finalStrength).toBeCloseTo(40 * 1.375 + 10);
+  });
+});
+
+describe('calculateCombatStrengths with defenderCity', () => {
+  it('applies ×1.25 defense with walls vs an identical no-walls baseline', () => {
+    const attacker = createUnit('swordsman', 'p1', { q: 5, r: 5 }, mkC());
+    const defender = createUnit('spearman', 'p2', { q: 6, r: 5 }, mkC());
+
+    const noWalls = calculateCombatStrengths(attacker, defender, map, {
+      defenderCity: baseCityDefenseInput(),
+    });
+    const withWalls = calculateCombatStrengths(attacker, defender, map, {
+      defenderCity: baseCityDefenseInput({ cityBuildings: ['walls'] }),
+    });
+
+    expect(withWalls.defenderStrength).toBeCloseTo(noWalls.defenderStrength * 1.25);
+  });
+
+  it('preview surfaces cityDefense breakdown parts', () => {
+    const attacker = createUnit('swordsman', 'p1', { q: 5, r: 5 }, mkC());
+    const defender = createUnit('spearman', 'p2', { q: 6, r: 5 }, mkC());
+
+    const preview = calculateCombatStrengths(attacker, defender, map, {
+      defenderCity: baseCityDefenseInput({ cityBuildings: ['walls', 'star_fort'] }),
+    });
+
+    expect(preview.cityDefense?.parts.map(p => p.label)).toEqual([
+      'Walls ×1.25',
+      'Star Fort +5',
+    ]);
+  });
+
+  it('does not apply city defense when defenderCity is absent', () => {
+    const attacker = createUnit('swordsman', 'p1', { q: 5, r: 5 }, mkC());
+    const defender = createUnit('spearman', 'p2', { q: 6, r: 5 }, mkC());
+
+    const preview = calculateCombatStrengths(attacker, defender, map);
+    expect(preview.cityDefense).toBeUndefined();
+  });
+});
+
+describe('buildCombatContextForDefender parity (human vs AI paths)', () => {
+  function makeState(): GameState {
+    const cityMap: GameMap = {
+      width: 4,
+      height: 4,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': {
+          coord: { q: 0, r: 0 }, terrain: 'plains', elevation: 'lowland',
+          resource: null, improvement: 'none', owner: 'p2',
+          improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+        },
+      },
+    };
+    const counters = mkC();
+    const defender = createUnit('spearman', 'p2', { q: 0, r: 0 }, counters);
+    const attacker = createUnit('swordsman', 'p1', { q: 1, r: 0 }, counters);
+    return {
+      map: cityMap,
+      units: { [attacker.id]: attacker, [defender.id]: defender },
+      cities: {
+        'city-1': {
+          id: 'city-1', name: 'Testville', owner: 'p2', position: { q: 0, r: 0 },
+          buildings: ['walls', 'star_fort'], population: 1, food: 0, production: 0,
+          productionQueue: [], improvementQueue: [],
+        } as unknown as GameState['cities'][string],
+      },
+      civilizations: {
+        p1: { civType: 'romans', techState: { completed: [] } } as unknown as GameState['civilizations'][string],
+        p2: {
+          civType: 'egyptians',
+          techState: { completed: ['fortification-engineering', 'professional-army'] },
+        } as unknown as GameState['civilizations'][string],
+      },
+    } as unknown as GameState;
+  }
+
+  it('produces an identical CityDefenseBreakdown regardless of call site', () => {
+    const state = makeState();
+    const attacker = Object.values(state.units).find(u => u.owner === 'p1')!;
+    const defender = Object.values(state.units).find(u => u.owner === 'p2')!;
+
+    const contextA = buildCombatContextForDefender(state, attacker, defender);
+    const contextB = buildCombatContextForDefender(state, attacker, defender);
+
+    expect(contextA.defenderCity).toEqual(contextB.defenderCity);
+    expect(contextA.defenderCity?.cityBuildings).toEqual(['walls', 'star_fort']);
+    expect(contextA.defenderCity?.defenderCompletedTechs).toEqual([
+      'fortification-engineering',
+      'professional-army',
+    ]);
+  });
+});
+
+describe('city defense balance guardrail', () => {
+  it('a walled era-2 city with a spearman defender remains takeable 2:1 (attacker wins ≥60%)', () => {
+    const trials = 200;
+    let attackerWins = 0;
+    for (let trial = 0; trial < trials; trial++) {
+      let defenderHealth = 100;
+      let attackersLeft = 2;
+      let currentAttackerHealth = 100;
+      let won = false;
+      let exchanges = 0;
+      while (attackersLeft > 0 && !won && exchanges < 60) {
+        const attacker = createUnit('swordsman', 'p1', { q: 5, r: 5 }, mkC());
+        const defender = createUnit('spearman', 'p2', { q: 6, r: 5 }, mkC());
+        const attackerUnit = { ...attacker, health: currentAttackerHealth };
+        const defenderUnit = { ...defender, health: defenderHealth };
+        const result = resolveCombat(
+          attackerUnit,
+          defenderUnit,
+          map,
+          trial * 7919 + exchanges * 31,
+          { defenderCity: baseCityDefenseInput({ cityBuildings: ['walls'] }) },
+        );
+        defenderHealth = Math.max(0, defenderHealth - result.defenderDamage);
+        currentAttackerHealth = Math.max(0, currentAttackerHealth - result.attackerDamage);
+        exchanges++;
+        if (defenderHealth <= 0) {
+          won = true;
+        } else if (currentAttackerHealth <= 0) {
+          attackersLeft--;
+          currentAttackerHealth = 100;
+        }
+      }
+      if (won) attackerWins++;
+    }
+    expect(attackerWins / trials).toBeGreaterThanOrEqual(0.6);
+  });
+});

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -26,4 +26,33 @@ describe('formatCombatPreviewDetails', () => {
 
     expect(details).not.toContain('river crossing');
   });
+
+  it('shows city defense modifier lines when the defender is in a walled city', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 10,
+      defenderStrength: 12.5,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+      cityDefense: {
+        multiplier: 1.25,
+        flatBonus: 0,
+        parts: [{ source: 'walls', label: 'Walls ×1.25', kind: 'mult', value: 1.25 }],
+      },
+    });
+
+    expect(details).toContain('Walls ×1.25');
+  });
+
+  it('omits city defense modifier lines when the defender is not in a city (negative test)', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 10,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+    });
+
+    expect(details).not.toContain('Walls');
+    expect(details).not.toContain('Star Fort');
+    expect(details).not.toContain('Professional Army');
+  });
 });


### PR DESCRIPTION
## Summary

Closes #462.

City-defense content had zero combat effect: `calculateCombatStrengths` (`src/systems/combat-system.ts`) read terrain, wonders, fortify stance, anti-air, and Air Force Command — never city buildings or defense techs. `CombatContext.defenderInFortifiedCity` was declared but never set by any caller (only ever read in the Ottoman siege-bonus check, where it was permanently `false`).

Implements the five effects from the spec:

| Content | Effect |
|---|---|
| `walls` building | ×1.25 defense for units defending on the city tile |
| `star_fort` building | +5 flat defense (requires `walls`) |
| `fortification-engineering` tech | +5 flat defense (requires `walls`) |
| `professional-army` tech (era 5) | ×1.10 defense in any friendly city |
| `torpedo-warfare` tech (era 8) | +5 flat defense on coastal city tiles vs naval attackers |

Order of composition (matches spec): terrain/wonder/homeland/forest multipliers → fortify ×1.25 → city-defense multiplier then flat → anti-air flat (unchanged).

## Design

- Added `CityDefenseInput` / `CityDefenseBreakdown` / `getCityDefenseBreakdown()` to `src/systems/combat-system.ts`.
- Replaced the dead `CombatContext.defenderInFortifiedCity: boolean` with `defenderCity?: CityDefenseInput`. The one prior reader (Ottoman `siege_bonus` check) now keys off `defenderCity !== undefined`, which is the correct, now-real signal for "defender is in a city" — this was a straightforward same-meaning replacement, not new scope.
- New shared builder `buildCombatContextForDefender(state, attacker, defender)` in `src/systems/combat-context.ts`, used by:
  - Human attack flow — `src/main.ts` (`executeAttack` and the tap-to-preview flow), replacing inline per-call construction.
  - AI attack path — `src/ai/ai-major-turn.ts` (removed its local `combatContext` helper).
  - AI attack path — `src/ai/ai-tactics.ts` (removed its local `combatContext` helper, which previously didn't even carry anti-air/AFC context).
  - This guarantees the three paths can never diverge on defender modifiers again.
- `src/ui/combat-preview.ts`'s `formatCombatPreviewDetails` now appends each active `cityDefense.parts[].label` (e.g. `"Walls ×1.25"`, `"Star Fort +5"`) — sourced from the same `CombatStrengthBreakdown` the human preview already computes, so there's no recomputation drift.
- `src/ai/basic-ai.ts:433` — added the required comment noting walls now grant real defense.

### All `resolveCombat`/`calculateCombatStrengths` call sites (grepped for verification)

- `src/main.ts` (human attack + preview) — **now uses shared builder**
- `src/ai/ai-major-turn.ts` — **now uses shared builder**
- `src/ai/ai-tactics.ts` (preview + tactical resolution, x3 call sites) — **now uses shared builder**
- `src/core/turn-manager.ts` (barbarian attacks, beast attacks) — unchanged, passes `undefined` context (as before this MR; no civ-bonus context was ever passed here either)
- `src/ai/basic-ai.ts` (warship vs. pirate) — unchanged, passes `undefined` context (as before)
- `src/systems/pirate-system.ts` (pirate vs. major civ) — unchanged, passes `undefined` context (as before)
- `src/systems/minor-civ-system.ts` (x2: minor civ attacks, minor-civ scuffles) — unchanged, passes `undefined` context (as before)

These non-civ attacker paths already omitted civ-bonus context prior to this MR; extending city-defense wiring to them is out of scope for MR3 (not in the acceptance criteria) and is flagged here per spec instruction to "list all call sites in the PR body."

## Tech text

No text changes needed — `professional-army`, `fortification-engineering`, and `torpedo-warfare` descriptions already match the implemented effects. `torpedo-warfare`'s "+8 naval ranged strength" half is intentionally left for MR4.

## Test plan

- [x] `tests/systems/city-defense.test.ts` (new): `getCityDefenseBreakdown` unit coverage (walls, star_fort with/without walls, fortification-engineering with/without walls, professional-army with/without walls, torpedo-warfare vs naval/land attacker, full stacking with exact numbers), `calculateCombatStrengths` integration (×1.25 vs baseline, breakdown parts surfaced, absent when no `defenderCity`), `buildCombatContextForDefender` parity test, and a 200-trial statistical balance guardrail (walled spearman vs. 2 swordsmen attackers, attacker win rate ≥ 60%).
- [x] `tests/ui/combat-preview.test.ts`: DOM/text assertions that `formatCombatPreviewDetails` includes `"Walls ×1.25"` when applicable and omits city-defense labels when the defender isn't in a city (negative test).
- [x] `bash scripts/run-with-mise.sh yarn build` — 0 exit, tsc confirms `defenderInFortifiedCity` has no remaining references.
- [x] `bash scripts/run-with-mise.sh yarn test` — 342 files / 5117 tests passed, 2 skipped (pre-existing, unrelated), all hook smoke tests passed.

**Next plan: `04-unit-modifier-engine.md`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)