### PR TITLE
[codex] Guide stranded land units back ashore

### DIFF
--- a/docs/superpowers/plans/2026-07-05-issue-447-water-recovery-ux.md
+++ b/docs/superpowers/plans/2026-07-05-issue-447-water-recovery-ux.md
@@ -1,0 +1,957 @@
+# Issue #447 Water-Recovery UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give land units loaded onto water a clear, truthful route back ashore without changing movement rules or mutating saves.
+
+**Architecture:** Add a pure shared recovery classifier that consumes the movement destinations already computed by the selection flow. Feed that result into map highlights, the selected-unit panel, and a testable blocked-movement feedback adapter used by the live tap handler. Keep save loading and canonical movement validation unchanged.
+
+**Tech Stack:** TypeScript, Canvas 2D renderer, DOM UI, Vitest.
+
+---
+
+## File map
+
+- Create `src/systems/unit-water-recovery.ts`: shared recovery classification and exact player-facing copy.
+- Create `tests/systems/unit-water-recovery.test.ts`: semantic boundary coverage for the shared classifier and copy.
+- Modify `src/input/selected-unit-highlights.ts`: derive recovery from existing movement truth and emit recovery highlights.
+- Modify `tests/input/selected-unit-highlights.test.ts`: prove recovery highlights do not change reachability or attack semantics.
+- Modify `src/renderer/render-loop.ts`: add the `water-recovery` highlight variant and amber color.
+- Modify `tests/renderer/render-loop-wrap.test.ts`: prove the new highlight reaches the Canvas draw path with the intended color.
+- Create `src/input/selected-unit-movement-feedback.ts`: testable adapter for blocked-movement notifications and reselection.
+- Create `tests/input/selected-unit-movement-feedback.test.ts`: verify contextual and generic feedback through production callbacks.
+- Modify `src/ui/selected-unit-info.ts`: render recoverable/blocked guidance supplied by the selection flow.
+- Modify `tests/ui/selected-unit-info.test.ts`: assert visible guidance and its negative boundary.
+- Modify `src/main.ts`: pass recovery presentation to the panel and delegate blocked movement feedback.
+- Modify `tests/main.integration.test.ts`: ensure the live tap path delegates to the tested feedback adapter.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Warrior stands on water with a legal non-combat land exit | Select Warrior | Panel explains recovery; legal land exits are amber |
+| Recoverable Warrior is selected | Tap amber land exit | Existing movement executes; warning and amber recovery highlights disappear on rerender |
+| Recoverable Warrior is selected | Tap another water tile | Contextual return-ashore warning appears; selection and amber exits remain |
+| Warrior stands on water without a legal non-combat land exit | Select Warrior | Panel says no land escape is reachable this turn; no amber exit appears |
+| Ordinary Warrior stands on land | Tap water | Existing generic `Land units cannot cross water yet.` warning remains |
+| Naval, air, or transported unit is on water | Select unit | Existing presentation remains; no land-recovery guidance appears |
+
+## Misleading UI Risks
+
+- `recoverable` requires at least one destination already accepted by the canonical movement preview.
+- Water destinations and hostile attack targets must not become amber recovery exits.
+- A water-starting land unit with no legal non-combat land move must be `blocked`, not `recoverable`.
+- Cargo with `transportId`, naval units, air units, and land units already on land must remain outside this semantic group.
+- Moving ashore must remove all recovery presentation on the next selection render.
+
+## Interaction Replay Checklist
+
+- [ ] Select a recoverable water-starting Warrior.
+- [ ] Verify panel guidance and amber exits.
+- [ ] Tap invalid water and verify contextual feedback plus reselection.
+- [ ] Move through the existing movement path to an amber land exit.
+- [ ] Rerender selection and verify recovery guidance is absent.
+- [ ] Repeat selection for a normal land unit and verify generic water feedback remains.
+
+---
+
+### Task 1: Shared water-recovery model and copy
+
+**Files:**
+- Create: `src/systems/unit-water-recovery.ts`
+- Create: `tests/systems/unit-water-recovery.test.ts`
+
+- [ ] **Step 1: Write the failing semantic-boundary tests**
+
+Create `tests/systems/unit-water-recovery.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, HexCoord, UnitType } from '@/core/types';
+import { createUnit } from '@/systems/unit-system';
+import {
+  getLandUnitWaterRecovery,
+  getLandUnitWaterRecoveryPanelMessage,
+  getLandUnitWaterRecoveryTapMessage,
+} from '@/systems/unit-water-recovery';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function tile(coord: HexCoord, terrain: GameState['map']['tiles'][string]['terrain']) {
+  return {
+    coord,
+    terrain,
+    elevation: 'lowland' as const,
+    resource: null,
+    owner: null,
+    improvement: 'none' as const,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function recoveryState(type: UnitType = 'warrior'): GameState {
+  const state = createNewGame(undefined, `water-recovery-${type}`, 'small');
+  const unit = { ...createUnit(type, 'player', { q: 1, r: 1 }, mkC()), id: 'subject' };
+  state.currentPlayer = 'player';
+  state.units = { subject: unit };
+  state.civilizations.player.units = ['subject'];
+  state.map.tiles = {
+    '1,1': tile({ q: 1, r: 1 }, 'coast'),
+    '2,1': tile({ q: 2, r: 1 }, 'plains'),
+    '1,2': tile({ q: 1, r: 2 }, 'coast'),
+  };
+  return state;
+}
+
+describe('land-unit water recovery', () => {
+  it('is recoverable only through supplied legal land destinations', () => {
+    const state = recoveryState();
+
+    const result = getLandUnitWaterRecovery(
+      state,
+      'subject',
+      [{ q: 2, r: 1 }, { q: 1, r: 2 }],
+    );
+
+    expect(result).toEqual({
+      kind: 'recoverable',
+      destinations: [{ q: 2, r: 1 }],
+    });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBe(
+      'This land unit is on water. Move to an amber land tile to return ashore.',
+    );
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBe(
+      'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.',
+    );
+  });
+
+  it('reports blocked when no legal non-combat land destination exists', () => {
+    const result = getLandUnitWaterRecovery(recoveryState(), 'subject', []);
+
+    expect(result).toEqual({ kind: 'blocked', destinations: [] });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBe(
+      'This land unit is stranded on water. No land escape is currently reachable this turn.',
+    );
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBe(
+      'This land unit is stranded on water with no reachable land escape this turn.',
+    );
+  });
+
+  it.each([
+    ['land unit already on land', 'warrior', false],
+    ['naval unit on water', 'galley', true],
+    ['air unit on water', 'observation_balloon', true],
+  ] as const)('returns none for %s', (_label, type, keepWater) => {
+    const state = recoveryState(type);
+    if (!keepWater) state.map.tiles['1,1'] = tile({ q: 1, r: 1 }, 'plains');
+
+    const result = getLandUnitWaterRecovery(state, 'subject', [{ q: 2, r: 1 }]);
+
+    expect(result).toEqual({ kind: 'none', destinations: [] });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBeNull();
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBeNull();
+  });
+
+  it('returns none for transported cargo synchronized onto water', () => {
+    const state = recoveryState();
+    state.units.subject.transportId = 'transport-1';
+
+    expect(getLandUnitWaterRecovery(state, 'subject', [{ q: 2, r: 1 }]))
+      .toEqual({ kind: 'none', destinations: [] });
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-water-recovery.test.ts
+```
+
+Expected: FAIL because `@/systems/unit-water-recovery` does not exist.
+
+- [ ] **Step 3: Implement the minimal shared model**
+
+Create `src/systems/unit-water-recovery.ts`:
+
+```ts
+import type { GameState, HexCoord } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type LandUnitWaterRecovery =
+  | { kind: 'none'; destinations: [] }
+  | { kind: 'recoverable'; destinations: HexCoord[] }
+  | { kind: 'blocked'; destinations: [] };
+
+export const NO_LAND_UNIT_WATER_RECOVERY: LandUnitWaterRecovery = {
+  kind: 'none',
+  destinations: [],
+};
+
+export function getLandUnitWaterRecovery(
+  state: GameState,
+  unitId: string,
+  movementDestinations: readonly HexCoord[],
+): LandUnitWaterRecovery {
+  const unit = state.units[unitId];
+  if (!unit || unit.transportId) return { kind: 'none', destinations: [] };
+  if ((UNIT_DEFINITIONS[unit.type]?.domain ?? 'land') !== 'land') {
+    return { kind: 'none', destinations: [] };
+  }
+  const currentTerrain = state.map.tiles[hexKey(unit.position)]?.terrain;
+  if (currentTerrain !== 'coast' && currentTerrain !== 'ocean') {
+    return { kind: 'none', destinations: [] };
+  }
+
+  const destinations = movementDestinations.filter(coord => {
+    const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+    return terrain !== undefined && terrain !== 'coast' && terrain !== 'ocean';
+  });
+  return destinations.length > 0
+    ? { kind: 'recoverable', destinations }
+    : { kind: 'blocked', destinations: [] };
+}
+
+export function getLandUnitWaterRecoveryPanelMessage(
+  recovery: LandUnitWaterRecovery,
+): string | null {
+  if (recovery.kind === 'recoverable') {
+    return 'This land unit is on water. Move to an amber land tile to return ashore.';
+  }
+  if (recovery.kind === 'blocked') {
+    return 'This land unit is stranded on water. No land escape is currently reachable this turn.';
+  }
+  return null;
+}
+
+export function getLandUnitWaterRecoveryTapMessage(
+  recovery: LandUnitWaterRecovery,
+): string | null {
+  if (recovery.kind === 'recoverable') {
+    return 'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.';
+  }
+  if (recovery.kind === 'blocked') {
+    return 'This land unit is stranded on water with no reachable land escape this turn.';
+  }
+  return null;
+}
+```
+
+- [ ] **Step 4: Run the shared-model test and verify GREEN**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-water-recovery.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the source-rule checker**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/unit-water-recovery.ts
+```
+
+Expected: PASS with no violations.
+
+- [ ] **Step 6: Commit the shared model**
+
+```bash
+git add src/systems/unit-water-recovery.ts tests/systems/unit-water-recovery.test.ts
+git commit -m "feat(movement): classify stranded land-unit recovery"
+```
+
+---
+
+### Task 2: Recovery highlights and Canvas treatment
+
+**Files:**
+- Modify: `src/input/selected-unit-highlights.ts`
+- Modify: `tests/input/selected-unit-highlights.test.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Modify: `tests/renderer/render-loop-wrap.test.ts`
+
+- [ ] **Step 1: Add failing highlight tests**
+
+Append to `tests/input/selected-unit-highlights.test.ts`:
+
+```ts
+it('marks legal non-combat land exits as water-recovery without changing movement truth', () => {
+  const state = createNewGame(undefined, 'water-recovery-highlight', 'small');
+  state.currentPlayer = 'player';
+  state.units = {
+    warrior: {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()),
+      id: 'warrior',
+      movementPointsLeft: 2,
+    },
+  };
+  state.civilizations.player.units = ['warrior'];
+  state.civilizations.player.visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+  state.map.tiles['1,1'] = {
+    ...state.map.tiles['1,1'],
+    coord: { q: 1, r: 1 },
+    terrain: 'coast',
+  };
+  state.map.tiles['2,1'] = {
+    ...state.map.tiles['2,1'],
+    coord: { q: 2, r: 1 },
+    terrain: 'plains',
+  };
+
+  const result = buildSelectedUnitHighlights(state, 'warrior');
+
+  expect(result.waterRecovery.kind).toBe('recoverable');
+  expect(result.movementRange.map(hexKey)).toContain('2,1');
+  expect(result.highlights).toContainEqual({
+    coord: { q: 2, r: 1 },
+    type: 'water-recovery',
+  });
+});
+
+it('keeps hostile land targets as attack highlights during water recovery', () => {
+  const state = createNewGame(undefined, 'water-recovery-attack', 'small');
+  state.currentPlayer = 'player';
+  state.units = {
+    warrior: {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()),
+      id: 'warrior',
+      movementPointsLeft: 2,
+    },
+    enemy: {
+      ...createUnit('warrior', 'ai-1', { q: 2, r: 1 }, mkC()),
+      id: 'enemy',
+    },
+  };
+  state.civilizations.player.units = ['warrior'];
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  state.civilizations.player.visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+  state.map.tiles['1,1'] = { ...state.map.tiles['1,1'], terrain: 'coast' };
+  state.map.tiles['2,1'] = { ...state.map.tiles['2,1'], terrain: 'plains' };
+
+  const result = buildSelectedUnitHighlights(state, 'warrior');
+
+  expect(result.highlights).toContainEqual({
+    coord: { q: 2, r: 1 },
+    type: 'attack',
+  });
+  expect(result.highlights).not.toContainEqual({
+    coord: { q: 2, r: 1 },
+    type: 'water-recovery',
+  });
+});
+```
+
+Add to `tests/renderer/render-loop-wrap.test.ts`:
+
+```ts
+it('draws water-recovery highlights with the amber recovery color', () => {
+  rendererMocks.drawHexHighlight.mockReset();
+  const loop = new RenderLoop(createCanvas());
+  const state = {
+    turn: 1,
+    currentPlayer: 'player',
+    map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+    tribalVillages: {},
+    minorCivs: {},
+    cities: {},
+    units: {},
+    civilizations: {
+      player: { color: '#4a90d9', visibility: { tiles: {} } },
+    },
+  } as unknown as GameState;
+
+  loop.setGameState(state);
+  loop.setHighlights([{ coord: { q: 0, r: 0 }, type: 'water-recovery' }]);
+  loop.camera.isHexVisible = () => true;
+
+  (loop as unknown as { render: () => void }).render();
+
+  expect(rendererMocks.drawHexHighlight).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.any(Number),
+    expect.any(Number),
+    expect.any(Number),
+    'rgba(245, 184, 73, 0.55)',
+  );
+});
+```
+
+- [ ] **Step 2: Run highlight tests and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts
+```
+
+Expected: FAIL because `waterRecovery` and `water-recovery` are not defined.
+
+- [ ] **Step 3: Integrate recovery into selection highlights**
+
+In `src/input/selected-unit-highlights.ts`:
+
+```ts
+import {
+  getLandUnitWaterRecovery,
+  NO_LAND_UNIT_WATER_RECOVERY,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
+```
+
+Extend the result:
+
+```ts
+export interface SelectedUnitHighlightResult {
+  movementRange: HexCoord[];
+  attackTargets: AttackTarget[];
+  highlights: HexHighlight[];
+  waterRecovery: LandUnitWaterRecovery;
+}
+```
+
+Return `waterRecovery: NO_LAND_UNIT_WATER_RECOVERY` from the missing/foreign-unit branch.
+After computing `attackKeys`, derive and apply recovery:
+
+```ts
+const nonCombatMovementRange = movementRange
+  .filter(coord => !attackKeys.has(hexKey(coord)));
+const waterRecovery = getLandUnitWaterRecovery(
+  state,
+  unitId,
+  nonCombatMovementRange,
+);
+const recoveryKeys = new Set(
+  waterRecovery.destinations.map(coord => hexKey(coord)),
+);
+
+const moveHighlights = nonCombatMovementRange.map(coord => ({
+  coord,
+  type: recoveryKeys.has(hexKey(coord))
+    ? 'water-recovery' as const
+    : 'move' as const,
+}));
+const workerHighlights = buildWorkerGuidanceHighlights(
+  state,
+  unitId,
+  movementRange,
+).filter(highlight => !recoveryKeys.has(hexKey(highlight.coord)));
+```
+
+Return `waterRecovery` with the existing fields.
+
+- [ ] **Step 4: Add the renderer variant**
+
+In `src/renderer/render-loop.ts`, extend `HexHighlight['type']` with
+`'water-recovery'` and add:
+
+```ts
+'water-recovery': 'rgba(245, 184, 73, 0.55)',
+```
+
+to `HEX_HIGHLIGHT_COLORS`.
+
+- [ ] **Step 5: Run highlight tests and verify GREEN**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run source-rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/input/selected-unit-highlights.ts src/renderer/render-loop.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit recovery highlights**
+
+```bash
+git add src/input/selected-unit-highlights.ts src/renderer/render-loop.ts tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts
+git commit -m "feat(ui): highlight stranded-unit land exits"
+```
+
+---
+
+### Task 3: Panel guidance and live invalid-tap feedback
+
+**Files:**
+- Create: `src/input/selected-unit-movement-feedback.ts`
+- Create: `tests/input/selected-unit-movement-feedback.test.ts`
+- Modify: `src/ui/selected-unit-info.ts`
+- Modify: `tests/ui/selected-unit-info.test.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/main.integration.test.ts`
+
+- [ ] **Step 1: Add failing feedback-adapter tests**
+
+Create `tests/input/selected-unit-movement-feedback.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, HexCoord } from '@/core/types';
+import { handleSelectedUnitMovementBlocker } from '@/input/selected-unit-movement-feedback';
+import { createUnit } from '@/systems/unit-system';
+import { getLandUnitWaterRecovery } from '@/systems/unit-water-recovery';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function tile(coord: HexCoord, terrain: GameState['map']['tiles'][string]['terrain']) {
+  return {
+    coord,
+    terrain,
+    elevation: 'lowland' as const,
+    resource: null,
+    owner: null,
+    improvement: 'none' as const,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function feedbackState(onWater: boolean): GameState {
+  const state = createNewGame(undefined, `water-feedback-${onWater}`, 'small');
+  const unit = { ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()), id: 'warrior' };
+  state.currentPlayer = 'player';
+  state.units = { warrior: unit };
+  state.civilizations.player.units = ['warrior'];
+  state.map.tiles = {
+    '1,1': tile({ q: 1, r: 1 }, onWater ? 'coast' : 'plains'),
+    '2,1': tile({ q: 2, r: 1 }, 'plains'),
+    '1,2': tile({ q: 1, r: 2 }, 'coast'),
+  };
+  state.civilizations.player.visibility.tiles = {
+    '1,1': 'visible',
+    '2,1': 'visible',
+    '1,2': 'visible',
+  };
+  return state;
+}
+
+describe('selected-unit blocked movement feedback', () => {
+  it('shows contextual recovery copy and reselects after a water tap', () => {
+    const state = feedbackState(true);
+    const recovery = getLandUnitWaterRecovery(
+      state,
+      'warrior',
+      [{ q: 2, r: 1 }],
+    );
+    const showNotification = vi.fn();
+    const reselectUnit = vi.fn();
+
+    const handled = handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit },
+    );
+
+    expect(handled).toBe(true);
+    expect(showNotification).toHaveBeenCalledWith(
+      'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.',
+      'warning',
+    );
+    expect(reselectUnit).toHaveBeenCalledWith('warrior');
+  });
+
+  it('keeps generic water copy for an ordinary land unit on land', () => {
+    const state = feedbackState(false);
+    const recovery = getLandUnitWaterRecovery(state, 'warrior', []);
+    const showNotification = vi.fn();
+
+    handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit: vi.fn() },
+    );
+
+    expect(showNotification).toHaveBeenCalledWith(
+      'Land units cannot cross water yet.',
+      'warning',
+    );
+  });
+
+  it('uses blocked recovery copy when no land exit is reachable', () => {
+    const state = feedbackState(true);
+    const recovery = getLandUnitWaterRecovery(state, 'warrior', []);
+    const showNotification = vi.fn();
+
+    handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit: vi.fn() },
+    );
+
+    expect(showNotification).toHaveBeenCalledWith(
+      'This land unit is stranded on water with no reachable land escape this turn.',
+      'warning',
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Add failing selected-unit panel tests**
+
+Append to `tests/ui/selected-unit-info.test.ts` using the file's existing
+`installMockDocument`, `collectAllText`, and `createNewGame` fixtures:
+
+```ts
+describe('land-unit water recovery guidance', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('renders recoverable guidance supplied by the live selection presentation', () => {
+    const state = createNewGame(undefined, 'water-panel-recoverable', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(
+      container as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      {
+        waterRecovery: {
+          kind: 'recoverable',
+          destinations: [{ q: 2, r: 1 }],
+        },
+      },
+    );
+
+    expect(collectAllText(container).join(' ')).toContain(
+      'This land unit is on water. Move to an amber land tile to return ashore.',
+    );
+  });
+
+  it('renders blocked guidance and omits guidance for none', () => {
+    const state = createNewGame(undefined, 'water-panel-blocked', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const blocked = new MockElement('div');
+    const normal = new MockElement('div');
+
+    renderSelectedUnitInfo(
+      blocked as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      { waterRecovery: { kind: 'blocked', destinations: [] } },
+    );
+    renderSelectedUnitInfo(
+      normal as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      { waterRecovery: { kind: 'none', destinations: [] } },
+    );
+
+    expect(collectAllText(blocked).join(' ')).toContain(
+      'This land unit is stranded on water. No land escape is currently reachable this turn.',
+    );
+    expect(collectAllText(normal).join(' ')).not.toContain('return ashore');
+    expect(collectAllText(normal).join(' ')).not.toContain('stranded on water');
+  });
+});
+```
+
+- [ ] **Step 3: Run the new feedback and panel tests and verify RED**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-movement-feedback.test.ts tests/ui/selected-unit-info.test.ts
+```
+
+Expected: FAIL because the feedback adapter and fifth panel argument do not exist.
+
+- [ ] **Step 4: Implement the blocked-movement feedback adapter**
+
+Create `src/input/selected-unit-movement-feedback.ts`:
+
+```ts
+import type { GameState, HexCoord } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { getMovementBlockerReason } from '@/systems/unit-system';
+import {
+  getLandUnitWaterRecoveryTapMessage,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
+
+export interface SelectedUnitMovementFeedbackCallbacks {
+  showNotification: (message: string, type: 'info' | 'warning') => void;
+  reselectUnit: (unitId: string) => void;
+}
+
+export function handleSelectedUnitMovementBlocker(
+  state: GameState,
+  unitId: string,
+  target: HexCoord,
+  waterRecovery: LandUnitWaterRecovery,
+  callbacks: SelectedUnitMovementFeedbackCallbacks,
+): boolean {
+  const unit = state.units[unitId];
+  if (!unit) return false;
+  const civ = state.civilizations[state.currentPlayer];
+  const visibilityState = civ?.visibility
+    ? getVisibility(civ.visibility, target)
+    : undefined;
+  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  const reason = getMovementBlockerReason(
+    unit,
+    target,
+    state.map,
+    { visibilityState, completedTechs },
+  );
+  if (!reason) return false;
+
+  const recoveryMessage = reason.code === 'impassable-water'
+    ? getLandUnitWaterRecoveryTapMessage(waterRecovery)
+    : null;
+  const type = reason.code === 'unexplored' || reason.code === 'unknown-tile'
+    ? 'info'
+    : 'warning';
+  callbacks.showNotification(recoveryMessage ?? reason.message, type);
+  callbacks.reselectUnit(unitId);
+  return true;
+}
+```
+
+- [ ] **Step 5: Render panel guidance**
+
+In `src/ui/selected-unit-info.ts`, import the recovery type and panel formatter:
+
+```ts
+import {
+  getLandUnitWaterRecoveryPanelMessage,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
+```
+
+Add:
+
+```ts
+export interface SelectedUnitInfoPresentation {
+  waterRecovery?: LandUnitWaterRecovery;
+}
+```
+
+Extend `renderSelectedUnitInfo` with a defaulted fifth argument:
+
+```ts
+export function renderSelectedUnitInfo(
+  container: HTMLElement,
+  state: GameState,
+  unitId: string,
+  callbacks: SelectedUnitInfoCallbacks,
+  presentation: SelectedUnitInfoPresentation = {},
+): void {
+```
+
+After the description, render the exact guidance when present:
+
+```ts
+const waterRecoveryMessage = presentation.waterRecovery
+  ? getLandUnitWaterRecoveryPanelMessage(presentation.waterRecovery)
+  : null;
+if (waterRecoveryMessage) {
+  const recoveryLine = document.createElement('div');
+  recoveryLine.style.cssText = 'margin-top:8px;padding:8px;border-radius:8px;background:rgba(245,184,73,0.16);color:#f5b849;font-size:11px;font-weight:600;';
+  recoveryLine.textContent = waterRecoveryMessage;
+  wrapper.appendChild(recoveryLine);
+}
+```
+
+- [ ] **Step 6: Wire the live selection and tap paths**
+
+In `src/main.ts`:
+
+1. import `handleSelectedUnitMovementBlocker`;
+2. remove the now-unused `getMovementBlockerReason` import from `@/systems/unit-system`;
+3. pass `{ waterRecovery: highlightResult.waterRecovery }` as the fifth argument to
+   `renderSelectedUnitInfo`;
+4. replace only the generic `getMovementBlockerReason` notification tail in
+   `handleHexTap` with:
+
+```ts
+const nonCombatMovementRange = movementRange.filter(coord =>
+  !attackRange.some(target => hexKey(target) === hexKey(coord)));
+const waterRecovery = getLandUnitWaterRecovery(
+  gameState,
+  selectedUnitId,
+  nonCombatMovementRange,
+);
+if (handleSelectedUnitMovementBlocker(
+  gameState,
+  selectedUnitId,
+  coord,
+  waterRecovery,
+  {
+    showNotification,
+    reselectUnit: selectUnit,
+  },
+)) {
+  return;
+}
+```
+
+Import `getLandUnitWaterRecovery` from the shared system module. Keep committed-route and
+naval-only beast feedback ahead of this adapter exactly as they are.
+
+- [ ] **Step 7: Add live-wiring coverage**
+
+Append to `tests/main.integration.test.ts`:
+
+```ts
+describe('land-unit water recovery wiring', () => {
+  it('routes the live selected-unit panel and blocked-tap path through recovery helpers', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const selectFlow = main.slice(
+      main.indexOf('function selectUnit('),
+      main.indexOf('function deselectUnit('),
+    );
+    const tapFlow = main.slice(
+      main.indexOf('const selectedUnitCanMoveToTappedHex'),
+      main.indexOf('const defenderEntryAtHex'),
+    );
+
+    expect(selectFlow).toContain('waterRecovery: highlightResult.waterRecovery');
+    expect(tapFlow).toContain('handleSelectedUnitMovementBlocker(');
+    expect(tapFlow).toContain('reselectUnit: selectUnit');
+  });
+});
+```
+
+This source-level assertion is only the delegation check. Behavioral coverage lives in
+the production feedback-adapter, selection-highlight, and panel-render tests above.
+
+- [ ] **Step 8: Run all Task 3 tests and verify GREEN**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-movement-feedback.test.ts tests/ui/selected-unit-info.test.ts tests/main.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Replay the full focused interaction test set**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/unit-water-recovery.test.ts tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts tests/input/selected-unit-movement-feedback.test.ts tests/ui/selected-unit-info.test.ts tests/main.integration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Run source-rule checks**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/unit-water-recovery.ts src/input/selected-unit-highlights.ts src/renderer/render-loop.ts src/input/selected-unit-movement-feedback.ts src/ui/selected-unit-info.ts src/main.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit the player-visible recovery flow**
+
+```bash
+git add src/input/selected-unit-movement-feedback.ts src/ui/selected-unit-info.ts src/main.ts tests/input/selected-unit-movement-feedback.test.ts tests/ui/selected-unit-info.test.ts tests/main.integration.test.ts
+git commit -m "fix(ui): guide stranded land units back ashore"
+```
+
+---
+
+### Task 4: Final verification and review
+
+**Files:**
+- Verify all changed source, tests, spec, and plan files.
+
+- [ ] **Step 1: Run TypeScript and production build verification**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the full test and hook suite**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect committed and uncommitted deltas**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD
+git diff
+git status --short --branch
+```
+
+Expected:
+
+- committed delta contains only the issue #447 design, plan, implementation, and tests;
+- uncommitted delta is empty;
+- branch is ahead of `origin/main`;
+- no unrelated main-worktree changes appear.
+
+- [ ] **Step 4: Confirm the design contract line by line**
+
+Verify:
+
+- no save-load mutation was added;
+- land-on-water movement rules remain unchanged;
+- recoverable, blocked, ordinary land, naval, air, and cargo cases are covered;
+- recovery exits use amber and attack targets remain red;
+- invalid taps preserve selection through the tested reselection callback;
+- moving ashore removes recovery presentation because the shared predicate returns `none`.

--- a/docs/superpowers/specs/2026-07-05-issue-447-water-recovery-ux-design.md
+++ b/docs/superpowers/specs/2026-07-05-issue-447-water-recovery-ux-design.md
@@ -71,7 +71,9 @@ When recovery is `recoverable`:
 - hostile land targets remain attack highlights and are not presented as guaranteed
   recovery exits.
 
-The renderer gives `water-recovery` a distinct amber treatment. Ordinary move, attack,
+The renderer gives `water-recovery` a distinct amber treatment with a pale
+high-contrast outline. The outline keeps the recovery affordance visible on yellow
+plains and other terrain whose base palette is close to amber. Ordinary move, attack,
 and worker guidance colors remain unchanged.
 
 `selectUnit` passes the derived recovery result to `renderSelectedUnitInfo`. The panel
@@ -98,6 +100,20 @@ recovery-specific guidance:
 
 The tap does not mutate state, deselect the unit, or clear highlights. A normal land unit
 standing on land continues to receive `Land units cannot cross water yet.`
+
+Warning-level blocked taps play the standard invalid-action error cue and silently
+refresh the selected-unit presentation. They must not replay the ordinary unit-selection
+cue. Informational fog/unknown-tile feedback keeps the notification cue without adding
+the error cue.
+
+## Accessibility and mobile presentation
+
+Recovery guidance is a polite status region with a stable recovery-kind data attribute
+for browser regression coverage. Its text is at least 12px with a bordered treatment and
+must remain fully contained in the 390px mobile viewport.
+
+Route-committed units are excluded from recovery presentation because the player cannot
+manually move them. Their selection has no movement, attack, or recovery highlights.
 
 ## Player truth table
 
@@ -160,6 +176,14 @@ Add the smallest regressions that prove the contract:
 - live flow:
   - an invalid water tap preserves selection/highlights;
   - moving ashore removes the derived recovery presentation on rerender.
+- browser replay:
+  - load a real saved-game fixture containing a Warrior on coast;
+  - select it through the live stack picker;
+  - verify amber fill plus high-contrast outlines and panel status guidance;
+  - tap water and verify contextual warning, error cue, no selection cue, and preserved
+    guidance;
+  - move ashore and verify recovery presentation disappears;
+  - repeat the presentation check at a 390px mobile viewport.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-05-issue-447-water-recovery-ux-design.md
+++ b/docs/superpowers/specs/2026-07-05-issue-447-water-recovery-ux-design.md
@@ -1,0 +1,173 @@
+# Issue #447 Water-Recovery UX — Design
+
+## Context
+
+Issue #447 shows a loaded hot-seat save with a Warrior standing on a coast tile. The
+reported symptom says the unit cannot move, but current movement rules allow an
+untransported land unit that starts on water to move back onto a legal land tile. The
+generic warning, `Land units cannot cross water yet.`, appears when the player taps
+another water tile and does not explain that recovery path.
+
+The chosen approach treats this as a targeted UX-recovery problem. It preserves the save
+exactly, exposes the legal route back to land, and does not broaden land-unit water
+movement.
+
+## Goals
+
+- Explain why an untransported land unit is standing on water and how to recover it.
+- Make legal non-combat land exits visually distinct from ordinary movement.
+- Keep the unit selected and the recovery guidance visible after an invalid water tap.
+- Represent the no-exit case honestly instead of pointing to nonexistent highlights.
+- Preserve all existing movement, combat, cargo, save, and terrain rules.
+
+## Non-goals
+
+- Do not relocate units during save loading.
+- Do not mutate or version the save format.
+- Do not allow land units to enter coast or ocean tiles.
+- Do not change transport load/unload behavior.
+- Do not diagnose or repair the historical code path that originally produced the saved
+  position; the available issue evidence does not identify that source.
+
+## Shared recovery model
+
+Add one pure shared helper in `src/systems/unit-water-recovery.ts`.
+
+The helper receives the current `GameState`, a unit ID, and the already-computed
+non-combat movement destinations. It returns a discriminated result:
+
+```ts
+type LandUnitWaterRecovery =
+  | { kind: 'none'; destinations: [] }
+  | { kind: 'recoverable'; destinations: HexCoord[] }
+  | { kind: 'blocked'; destinations: [] };
+```
+
+Recovery is active only when all of these are true:
+
+1. the unit exists;
+2. its definition domain is `land`;
+3. it is not cargo (`transportId` is absent); and
+4. its current map tile is `coast` or `ocean`.
+
+For an active recovery, destinations are the supplied legal non-combat movement
+destinations whose map terrain is not `coast` or `ocean`. At least one destination yields
+`recoverable`; none yields `blocked`.
+
+The helper does not calculate movement, inspect UI state, or mutate the game. Movement
+eligibility remains owned by the existing movement-range and validation systems.
+
+## Selection and rendering flow
+
+`buildSelectedUnitHighlights` continues to calculate movement and attack destinations
+once. After excluding attack targets from ordinary move destinations, it derives the
+water-recovery result through the shared helper and returns that result with the existing
+selection presentation.
+
+When recovery is `recoverable`:
+
+- legal non-combat land exits use a new `water-recovery` highlight type;
+- those exits remain in `movementRange`, so the existing tap-to-move path executes them;
+- hostile land targets remain attack highlights and are not presented as guaranteed
+  recovery exits.
+
+The renderer gives `water-recovery` a distinct amber treatment. Ordinary move, attack,
+and worker guidance colors remain unchanged.
+
+`selectUnit` passes the derived recovery result to `renderSelectedUnitInfo`. The panel
+renders an amber guidance line:
+
+> This land unit is on water. Move to an amber land tile to return ashore.
+
+For `blocked`, the panel instead renders:
+
+> This land unit is stranded on water. No land escape is currently reachable this turn.
+
+The guidance is derived presentation only. It disappears automatically when the unit
+moves onto land and the selected-unit presentation rerenders.
+
+## Invalid-tap feedback
+
+The existing invalid-destination path continues to use
+`getMovementBlockerReason`. When that reason is `impassable-water` and the selected unit
+has an active water-recovery state, the live caller replaces the generic copy with
+recovery-specific guidance:
+
+- `recoverable`: `Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.`
+- `blocked`: `This land unit is stranded on water with no reachable land escape this turn.`
+
+The tap does not mutate state, deselect the unit, or clear highlights. A normal land unit
+standing on land continues to receive `Land units cannot cross water yet.`
+
+## Player truth table
+
+| Before | Player action | State change | Immediate visible result |
+|---|---|---|---|
+| Land unit stands on water with a legal non-combat land exit | Select unit | None | Panel shows recovery guidance; legal exits are amber |
+| Recoverable unit is selected | Tap amber land exit | Existing movement mutation only | Unit moves ashore; recovery warning and amber recovery highlights disappear |
+| Recoverable unit is selected | Tap another water tile | None | Contextual “return ashore” warning appears; selection and amber exits remain |
+| Land unit stands on water with no legal non-combat land exit this turn | Select unit | None | Panel says no land escape is currently reachable; no amber exit is shown |
+| Blocked recovery unit is selected | Tap water | None | Contextual blocked warning appears; unit remains selected |
+| Ordinary land unit stands on land | Tap water | None | Existing generic water warning remains |
+| Naval, air, or transported land unit is on water | Select or tap | Existing behavior only | No water-recovery guidance or amber recovery highlight appears |
+
+## Misleading UI risks and boundaries
+
+- A water tile is never labeled as a recovery destination.
+- A hostile land target remains red/attack-oriented and is not described as a guaranteed
+  movement exit.
+- `transportId` cargo is never called stranded, even though its synchronized position can
+  be water.
+- Naval and air units never receive land-unit recovery guidance.
+- A land unit already on land never receives recovery guidance.
+- A land unit with zero legal non-combat land destinations receives `blocked`, not
+  `recoverable`.
+- Movement-range membership remains the source of truth. The UX must not independently
+  claim that a tile is reachable.
+
+## Interaction replay
+
+Regression coverage will replay the live presentation sequence:
+
+1. select a recoverable Warrior on water;
+2. assert amber recovery exits and panel guidance;
+3. tap an invalid water destination and assert contextual feedback while selection and
+   recovery presentation remain;
+4. execute the existing move to a legal land exit;
+5. rerender selection and assert recovery guidance no longer appears.
+
+The interaction can be split across focused tests only where the same production helpers
+and live caller contract are exercised. A source-shape assertion alone is insufficient.
+
+## Testing
+
+Add the smallest regressions that prove the contract:
+
+- shared helper:
+  - recoverable land unit on water with a legal non-combat land destination;
+  - blocked land unit on water;
+  - negative cases for land-on-land, naval, air, and transported cargo;
+- selected-unit highlights:
+  - recovery land exits use `water-recovery`;
+  - attack targets keep `attack`;
+  - `movementRange` still contains the legal exit;
+- selected-unit panel:
+  - recoverable and blocked text render exactly;
+  - guidance disappears for every negative semantic boundary;
+- invalid-tap feedback:
+  - recoverable and blocked copy are selected only for an active recovery;
+  - ordinary land-on-land water taps keep the existing generic copy;
+- live flow:
+  - an invalid water tap preserves selection/highlights;
+  - moving ashore removes the derived recovery presentation on rerender.
+
+## Verification
+
+For changed source files:
+
+- run `scripts/check-src-rule-violations.sh` with every changed `src/` path;
+- run all mirrored tests in one targeted Vitest command;
+- run `bash scripts/run-with-mise.sh yarn build`;
+- run `bash scripts/run-with-mise.sh yarn test`.
+
+Before completion, inspect both `origin/main...HEAD` and the uncommitted worktree delta.

--- a/scripts/run-with-mise.sh
+++ b/scripts/run-with-mise.sh
@@ -90,7 +90,7 @@ if [ -n "$MAIN_ROOT" ] && [ "$CURRENT_ROOT" != "$MAIN_ROOT" ]; then
       # string, so it must be kept in sync here by hand.
       (cd "$MAIN_ROOT" && run_without_local_git_env "$MAIN_RUN" yarn tsc --project "$CURRENT_ROOT/tsconfig.json" --noEmit) \
         && (cd "$MAIN_ROOT" && run_without_local_git_env "$MAIN_RUN" yarn vite build "$CURRENT_ROOT") \
-        && (cd "$CURRENT_ROOT" && node "$CURRENT_ROOT/scripts/version-sw-cache.mjs")
+        && run_without_local_git_env "$CURRENT_ROOT/scripts/run-with-mise.sh" yarn node "$CURRENT_ROOT/scripts/version-sw-cache.mjs"
       exit
       ;;
     yarn,build:tauri)

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -105,6 +105,14 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
       waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
     };
   }
+  if (unit.committedToRouteId) {
+    return {
+      movementRange: [],
+      attackTargets: [],
+      highlights: [],
+      waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
+    };
+  }
 
   const occupancy = buildUnitOccupancy(state.units);
   const hostileOwners = buildHostileOwners(state, state.currentPlayer);

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -6,11 +6,17 @@ import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { getAvailableWorkerActions, getKnownTileResourceForWorkerAction } from '@/systems/improvement-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getMovementRange } from '@/systems/unit-system';
+import {
+  getLandUnitWaterRecovery,
+  NO_LAND_UNIT_WATER_RECOVERY,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
 
 export interface SelectedUnitHighlightResult {
   movementRange: HexCoord[];
   attackTargets: AttackTarget[];
   highlights: HexHighlight[];
+  waterRecovery: LandUnitWaterRecovery;
 }
 
 const WORKER_ACTIONS: WorkerActionType[] = ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp'];
@@ -92,7 +98,12 @@ function isPreviewableMoveDestination(state: GameState, from: HexCoord, to: HexC
 export function buildSelectedUnitHighlights(state: GameState, unitId: string): SelectedUnitHighlightResult {
   const unit = state.units[unitId];
   if (!unit || unit.owner !== state.currentPlayer) {
-    return { movementRange: [], attackTargets: [], highlights: [] };
+    return {
+      movementRange: [],
+      attackTargets: [],
+      highlights: [],
+      waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
+    };
   }
 
   const occupancy = buildUnitOccupancy(state.units);
@@ -109,17 +120,32 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
   const attackTargets = getAttackTargets(state, unit, { viewerId: state.currentPlayer })
     .filter(target => target.result.targetType === 'unit');
   const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));
+  const nonCombatMovementRange = movementRange
+    .filter(coord => !attackKeys.has(hexKey(coord)));
+  const waterRecovery = getLandUnitWaterRecovery(
+    state,
+    unitId,
+    nonCombatMovementRange,
+  );
+  const recoveryKeys = new Set(
+    waterRecovery.destinations.map(coord => hexKey(coord)),
+  );
 
-  const moveHighlights = movementRange
-    .filter(coord => !attackKeys.has(hexKey(coord)))
-    .map(coord => ({ coord, type: 'move' as const }));
+  const moveHighlights = nonCombatMovementRange.map(coord => ({
+    coord,
+    type: recoveryKeys.has(hexKey(coord))
+      ? 'water-recovery' as const
+      : 'move' as const,
+  }));
 
   const attackHighlights = attackTargets.map(target => ({ coord: target.coord, type: 'attack' as const }));
-  const workerHighlights = buildWorkerGuidanceHighlights(state, unitId, movementRange);
+  const workerHighlights = buildWorkerGuidanceHighlights(state, unitId, movementRange)
+    .filter(highlight => !recoveryKeys.has(hexKey(highlight.coord)));
 
   return {
     movementRange,
     attackTargets,
     highlights: [...moveHighlights, ...attackHighlights, ...workerHighlights],
+    waterRecovery,
   };
 }

--- a/src/input/selected-unit-movement-feedback.ts
+++ b/src/input/selected-unit-movement-feedback.ts
@@ -9,6 +9,7 @@ import {
 export interface SelectedUnitMovementFeedbackCallbacks {
   showNotification: (message: string, type: 'info' | 'warning') => void;
   reselectUnit: (unitId: string) => void;
+  playError: () => void;
 }
 
 export function handleSelectedUnitMovementBlocker(
@@ -40,6 +41,7 @@ export function handleSelectedUnitMovementBlocker(
     ? 'info'
     : 'warning';
   callbacks.showNotification(recoveryMessage ?? reason.message, type);
+  if (type === 'warning') callbacks.playError();
   callbacks.reselectUnit(unitId);
   return true;
 }

--- a/src/input/selected-unit-movement-feedback.ts
+++ b/src/input/selected-unit-movement-feedback.ts
@@ -1,0 +1,45 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { getVisibility } from '@/systems/fog-of-war';
+import { getMovementBlockerReason } from '@/systems/unit-system';
+import {
+  getLandUnitWaterRecoveryTapMessage,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
+
+export interface SelectedUnitMovementFeedbackCallbacks {
+  showNotification: (message: string, type: 'info' | 'warning') => void;
+  reselectUnit: (unitId: string) => void;
+}
+
+export function handleSelectedUnitMovementBlocker(
+  state: GameState,
+  unitId: string,
+  target: HexCoord,
+  waterRecovery: LandUnitWaterRecovery,
+  callbacks: SelectedUnitMovementFeedbackCallbacks,
+): boolean {
+  const unit = state.units[unitId];
+  if (!unit) return false;
+  const civ = state.civilizations[state.currentPlayer];
+  const visibilityState = civ?.visibility
+    ? getVisibility(civ.visibility, target)
+    : undefined;
+  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  const reason = getMovementBlockerReason(
+    unit,
+    target,
+    state.map,
+    { visibilityState, completedTechs },
+  );
+  if (!reason) return false;
+
+  const recoveryMessage = reason.code === 'impassable-water'
+    ? getLandUnitWaterRecoveryTapMessage(waterRecovery)
+    : null;
+  const type = reason.code === 'unexplored' || reason.code === 'unknown-tile'
+    ? 'info'
+    : 'warning';
+  callbacks.showNotification(recoveryMessage ?? reason.message, type);
+  callbacks.reselectUnit(unitId);
+  return true;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,7 +21,7 @@ import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
 import { MouseHandler } from '@/input/mouse-handler';
 import { installKeyboardShortcuts } from '@/input/keyboard-shortcuts';
 import { hexKey, hexToPixel, hexesInRange, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
-import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, getMovementBlockerReason, findPath } from '@/systems/unit-system';
+import { moveUnit, getMovementCost, UNIT_DEFINITIONS, UNIT_DESCRIPTIONS, restUnit, canHeal, getUnmovedUnits, createUnit, findPath } from '@/systems/unit-system';
 import { classifyOwner, isAlwaysHostilePair, isMajorCivOwner } from '@/core/owner-kind';
 import { BUILDINGS, getProductionDisplayName } from '@/systems/city-system';
 import { foundCityInState } from '@/systems/city-founding-system';
@@ -40,6 +40,8 @@ import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
+import { handleSelectedUnitMovementBlocker } from '@/input/selected-unit-movement-feedback';
+import { getLandUnitWaterRecovery } from '@/systems/unit-water-recovery';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
@@ -1982,7 +1984,7 @@ function selectUnit(unitId: string, opts?: { pendingUnloadUnitName?: string }): 
           },
         });
       },
-    });
+    }, { waterRecovery: highlightResult.waterRecovery });
   }
 
   SFX.select();
@@ -2625,14 +2627,23 @@ function handleHexTap(rawCoord: HexCoord): void {
           return;
         }
       }
-      const civ = currentCiv();
-      const visibilityState = civ.visibility ? getVisibility(civ.visibility, coord) : undefined;
-      const completedTechs = gameState.civilizations[selectedUnit.owner]?.techState.completed ?? [];
-      const reason = getMovementBlockerReason(selectedUnit, coord, gameState.map, { visibilityState, completedTechs });
-      if (reason) {
-        const type = reason.code === 'unexplored' || reason.code === 'unknown-tile' ? 'info' : 'warning';
-        showNotification(reason.message, type);
-        selectUnit(selectedUnitId);
+      const nonCombatMovementRange = movementRange.filter(moveCoord =>
+        !attackRange.some(target => hexKey(target) === hexKey(moveCoord)));
+      const waterRecovery = getLandUnitWaterRecovery(
+        gameState,
+        selectedUnitId,
+        nonCombatMovementRange,
+      );
+      if (handleSelectedUnitMovementBlocker(
+        gameState,
+        selectedUnitId,
+        coord,
+        waterRecovery,
+        {
+          showNotification,
+          reselectUnit: selectUnit,
+        },
+      )) {
         return;
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,10 @@ import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
 import { handleSelectedUnitMovementBlocker } from '@/input/selected-unit-movement-feedback';
-import { getLandUnitWaterRecovery } from '@/systems/unit-water-recovery';
+import {
+  NO_LAND_UNIT_WATER_RECOVERY,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { recordCombatForCiv } from '@/systems/threat-pressure-system';
 import { applyWorkerAction } from '@/systems/worker-action-system';
@@ -244,6 +247,7 @@ import { applyStrategicWarningTransitions } from '@/systems/strategic-warning-sy
 let gameState: GameState;
 let drawer: TreasuryDrawer;
 let selectedUnitId: string | null = null;
+let selectedUnitWaterRecovery: LandUnitWaterRecovery = NO_LAND_UNIT_WATER_RECOVERY;
 let selectedPirateFactionId: string | null = null;
 let selectedPirateHistoryId: string | null = null;
 let movementRange: HexCoord[] = [];
@@ -1624,7 +1628,13 @@ function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
   }, { selectedUnitId });
 }
 
-function selectUnit(unitId: string, opts?: { pendingUnloadUnitName?: string }): void {
+function selectUnit(
+  unitId: string,
+  opts?: {
+    pendingUnloadUnitName?: string;
+    suppressSelectionSfx?: boolean;
+  },
+): void {
   if (renderLoop.hasMovingUnit(unitId)) {
     showNotification('Unit is moving.', 'info');
     return;
@@ -1635,6 +1645,7 @@ function selectUnit(unitId: string, opts?: { pendingUnloadUnitName?: string }): 
   renderLoop.setSelectedUnitId(unitId);
 
   const highlightResult = buildSelectedUnitHighlights(gameState, unitId);
+  selectedUnitWaterRecovery = highlightResult.waterRecovery;
   if (gameState.units[unitId]?.committedToRouteId) {
     // Committed caravans cannot move or attack — keep highlights empty
     movementRange = [];
@@ -1987,11 +1998,12 @@ function selectUnit(unitId: string, opts?: { pendingUnloadUnitName?: string }): 
     }, { waterRecovery: highlightResult.waterRecovery });
   }
 
-  SFX.select();
+  if (!opts?.suppressSelectionSfx) SFX.select();
 }
 
 function deselectUnit(): void {
   selectedUnitId = null;
+  selectedUnitWaterRecovery = NO_LAND_UNIT_WATER_RECOVERY;
   renderLoop.setSelectedUnitId(null);
   movementRange = [];
   attackRange = [];
@@ -2627,21 +2639,15 @@ function handleHexTap(rawCoord: HexCoord): void {
           return;
         }
       }
-      const nonCombatMovementRange = movementRange.filter(moveCoord =>
-        !attackRange.some(target => hexKey(target) === hexKey(moveCoord)));
-      const waterRecovery = getLandUnitWaterRecovery(
-        gameState,
-        selectedUnitId,
-        nonCombatMovementRange,
-      );
       if (handleSelectedUnitMovementBlocker(
         gameState,
         selectedUnitId,
         coord,
-        waterRecovery,
+        selectedUnitWaterRecovery,
         {
           showNotification,
-          reselectUnit: selectUnit,
+          reselectUnit: unitId => selectUnit(unitId, { suppressSelectionSfx: true }),
+          playError: SFX.error,
         },
       )) {
         return;

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -404,6 +404,7 @@ export function drawHexHighlight(
   cy: number,
   size: number,
   color: string,
+  outlineColor?: string,
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -416,6 +417,12 @@ export function drawHexHighlight(
   ctx.closePath();
   ctx.fillStyle = color;
   ctx.fill();
+  if (outlineColor) {
+    ctx.strokeStyle = outlineColor;
+    ctx.lineWidth = 3;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+  }
 }
 
 export function drawMinorCivTerritory(

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -146,12 +146,13 @@ export function positionMovingPirateHeadquarters(
 
 export interface HexHighlight {
   coord: HexCoord;
-  type: 'move' | 'attack' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
+  type: 'move' | 'attack' | 'water-recovery' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
 }
 
 const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
   move: 'rgba(74, 144, 217, 0.35)',
   attack: 'rgba(217, 74, 74, 0.45)',
+  'water-recovery': 'rgba(245, 184, 73, 0.55)',
   'worker-buildable': 'rgba(80, 200, 120, 0.45)',
   'worker-owned-blocked': 'rgba(232, 193, 112, 0.40)',
   'worker-foreign-blocked': 'rgba(217, 74, 74, 0.35)',

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -158,6 +158,10 @@ const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
   'worker-foreign-blocked': 'rgba(217, 74, 74, 0.35)',
 };
 
+const HEX_HIGHLIGHT_OUTLINES: Partial<Record<HexHighlight['type'], string>> = {
+  'water-recovery': '#fff0a8',
+};
+
 function prefersReducedMotion(): boolean {
   return typeof window !== 'undefined'
     && typeof window.matchMedia === 'function'
@@ -477,7 +481,8 @@ export class RenderLoop {
         const screen = this.camera.worldToScreen(pixel.x, pixel.y);
         const scaledSize = this.camera.hexSize * this.camera.zoom;
         const color = HEX_HIGHLIGHT_COLORS[highlight.type];
-        drawHexHighlight(this.ctx, screen.x, screen.y, scaledSize, color);
+        const outline = HEX_HIGHLIGHT_OUTLINES[highlight.type];
+        drawHexHighlight(this.ctx, screen.x, screen.y, scaledSize, color, outline);
       }
     }
 

--- a/src/systems/unit-water-recovery.ts
+++ b/src/systems/unit-water-recovery.ts
@@ -1,0 +1,61 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+export type LandUnitWaterRecovery =
+  | { kind: 'none'; destinations: [] }
+  | { kind: 'recoverable'; destinations: HexCoord[] }
+  | { kind: 'blocked'; destinations: [] };
+
+export const NO_LAND_UNIT_WATER_RECOVERY: LandUnitWaterRecovery = {
+  kind: 'none',
+  destinations: [],
+};
+
+export function getLandUnitWaterRecovery(
+  state: GameState,
+  unitId: string,
+  movementDestinations: readonly HexCoord[],
+): LandUnitWaterRecovery {
+  const unit = state.units[unitId];
+  if (!unit || unit.transportId) return { kind: 'none', destinations: [] };
+  if ((UNIT_DEFINITIONS[unit.type]?.domain ?? 'land') !== 'land') {
+    return { kind: 'none', destinations: [] };
+  }
+  const currentTerrain = state.map.tiles[hexKey(unit.position)]?.terrain;
+  if (currentTerrain !== 'coast' && currentTerrain !== 'ocean') {
+    return { kind: 'none', destinations: [] };
+  }
+
+  const destinations = movementDestinations.filter(coord => {
+    const terrain = state.map.tiles[hexKey(coord)]?.terrain;
+    return terrain !== undefined && terrain !== 'coast' && terrain !== 'ocean';
+  });
+  return destinations.length > 0
+    ? { kind: 'recoverable', destinations }
+    : { kind: 'blocked', destinations: [] };
+}
+
+export function getLandUnitWaterRecoveryPanelMessage(
+  recovery: LandUnitWaterRecovery,
+): string | null {
+  if (recovery.kind === 'recoverable') {
+    return 'This land unit is on water. Move to an amber land tile to return ashore.';
+  }
+  if (recovery.kind === 'blocked') {
+    return 'This land unit is stranded on water. No land escape is currently reachable this turn.';
+  }
+  return null;
+}
+
+export function getLandUnitWaterRecoveryTapMessage(
+  recovery: LandUnitWaterRecovery,
+): string | null {
+  if (recovery.kind === 'recoverable') {
+    return 'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.';
+  }
+  if (recovery.kind === 'blocked') {
+    return 'This land unit is stranded on water with no reachable land escape this turn.';
+  }
+  return null;
+}

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -197,12 +197,16 @@ export function renderSelectedUnitInfo(
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
 
-  const waterRecoveryMessage = presentation.waterRecovery
-    ? getLandUnitWaterRecoveryPanelMessage(presentation.waterRecovery)
+  const waterRecovery = presentation.waterRecovery;
+  const waterRecoveryMessage = waterRecovery
+    ? getLandUnitWaterRecoveryPanelMessage(waterRecovery)
     : null;
-  if (waterRecoveryMessage) {
+  if (waterRecovery && waterRecoveryMessage) {
     const recoveryLine = document.createElement('div');
-    recoveryLine.style.cssText = 'margin-top:8px;padding:8px;border-radius:8px;background:rgba(245,184,73,0.16);color:#f5b849;font-size:11px;font-weight:600;';
+    recoveryLine.dataset.waterRecoveryKind = waterRecovery.kind;
+    recoveryLine.setAttribute('role', 'status');
+    recoveryLine.setAttribute('aria-live', 'polite');
+    recoveryLine.style.cssText = 'margin-top:8px;padding:8px;border:1px solid rgba(245,184,73,0.45);border-radius:8px;background:rgba(245,184,73,0.16);color:#f5b849;font-size:12px;font-weight:600;line-height:1.4;';
     recoveryLine.textContent = waterRecoveryMessage;
     wrapper.appendChild(recoveryLine);
   }

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -24,6 +24,10 @@ import { canEstablishOutpost } from '@/systems/resource-acquisition-system';
 import { getTransportCargo, getTransportCapacity, getTransportCargoUsed } from '@/systems/transport-system';
 import { calculateCivUnitMaintenance } from '@/systems/economy-system';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
+import {
+  getLandUnitWaterRecoveryPanelMessage,
+  type LandUnitWaterRecovery,
+} from '@/systems/unit-water-recovery';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -87,6 +91,10 @@ export interface SelectedUnitInfoCallbacks {
   onOpenPirateAssault?: (factionId: string, unitId: string) => void;
 }
 
+export interface SelectedUnitInfoPresentation {
+  waterRecovery?: LandUnitWaterRecovery;
+}
+
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
   const button = document.createElement('button');
   button.type = 'button';
@@ -137,6 +145,7 @@ export function renderSelectedUnitInfo(
   state: GameState,
   unitId: string,
   callbacks: SelectedUnitInfoCallbacks,
+  presentation: SelectedUnitInfoPresentation = {},
 ): void {
   const unit = state.units[unitId];
   if (!unit) {
@@ -187,6 +196,16 @@ export function renderSelectedUnitInfo(
 
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
+
+  const waterRecoveryMessage = presentation.waterRecovery
+    ? getLandUnitWaterRecoveryPanelMessage(presentation.waterRecovery)
+    : null;
+  if (waterRecoveryMessage) {
+    const recoveryLine = document.createElement('div');
+    recoveryLine.style.cssText = 'margin-top:8px;padding:8px;border-radius:8px;background:rgba(245,184,73,0.16);color:#f5b849;font-size:11px;font-weight:600;';
+    recoveryLine.textContent = waterRecoveryMessage;
+    wrapper.appendChild(recoveryLine);
+  }
 
   const tier = getVeterancyTier(unit);
   const nextTierXp = getExperienceToNextTier(unit);

--- a/tests/e2e/issue-447-water-recovery.spec.ts
+++ b/tests/e2e/issue-447-water-recovery.spec.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
+
+const FIXTURE_TEXT = readFileSync(
+  join(__dirname, '..', 'fixtures', 'issue-365-crowded-map-save.json'),
+  'utf8',
+);
+const ORIGIN = { q: 17, r: 4 };
+const LAND_EXIT = { q: 18, r: 4 };
+const WATER_TARGET = { q: 18, r: 3 };
+
+async function installFixture(page: Page): Promise<void> {
+  await page.addInitScript((fixtureText) => {
+    localStorage.setItem('conquestoria-autosave', fixtureText);
+    window.__issue447ToneFrequencies = [];
+    window.__issue447AmberFills = 0;
+
+    const originalCreateOscillator = AudioContext.prototype.createOscillator;
+    AudioContext.prototype.createOscillator = function patchedCreateOscillator() {
+      const oscillator = originalCreateOscillator.call(this);
+      const originalSetValueAtTime = oscillator.frequency.setValueAtTime.bind(oscillator.frequency);
+      oscillator.frequency.setValueAtTime = (value, startTime) => {
+        window.__issue447ToneFrequencies?.push(value);
+        return originalSetValueAtTime(value, startTime);
+      };
+      return oscillator;
+    };
+
+    const originalFill = CanvasRenderingContext2D.prototype.fill;
+    CanvasRenderingContext2D.prototype.fill = function patchedFill(
+      ...args:
+        | [fillRule?: CanvasFillRule]
+        | [path: Path2D, fillRule?: CanvasFillRule]
+    ) {
+      if (String(this.fillStyle) === 'rgba(245, 184, 73, 0.55)') {
+        window.__issue447AmberFills = (window.__issue447AmberFills ?? 0) + 1;
+      }
+      return Reflect.apply(originalFill, this, args);
+    };
+  }, FIXTURE_TEXT);
+}
+
+async function continueFixture(page: Page): Promise<void> {
+  await page.goto('/');
+  const continueButton = page.getByRole('button', { name: 'Continue', exact: true });
+  await continueButton.click();
+  await expect(page.getByRole('dialog', { name: 'Choose Opponent Challenge' })).toBeVisible();
+  await page.locator(
+    '[data-opponent-challenge-selector="migration"] [data-challenge="standard"]',
+  ).click();
+  await page.getByRole('button', { name: 'Continue Campaign', exact: true }).click();
+  await expect(continueButton).toBeHidden();
+  await expect(page.locator('#game-canvas')).toBeVisible();
+  await page.waitForTimeout(500);
+}
+
+function pointyHexPixel(coord: { q: number; r: number }): { x: number; y: number } {
+  return {
+    x: Math.sqrt(3) * (coord.q + coord.r / 2) * 48,
+    y: 1.5 * coord.r * 48,
+  };
+}
+
+async function getOnScreenBox(page: Page, selector: string) {
+  const locator = page.locator(selector);
+  const viewport = page.viewportSize()!;
+  const count = await locator.count();
+  for (let index = 0; index < count; index++) {
+    const box = await locator.nth(index).boundingBox();
+    if (
+      box
+      && box.x + box.width > 0
+      && box.y + box.height > 0
+      && box.x < viewport.width
+      && box.y < viewport.height
+    ) {
+      return box;
+    }
+  }
+  throw new Error(`No on-screen copy for ${selector}`);
+}
+
+async function selectLeadWarrior(page: Page) {
+  const stackBox = await getOnScreenBox(
+    page,
+    '#unit-sprites > [data-member-ids*="issue-365-lead"]',
+  );
+  await page.mouse.click(
+    stackBox.x + stackBox.width / 2,
+    stackBox.y + stackBox.height / 2,
+  );
+  const leadButton = page.locator(
+    '[data-unit-stack-item="true"][data-unit-id="issue-365-lead"]',
+  );
+  await expect(leadButton).toBeVisible();
+  await leadButton.click();
+  return stackBox;
+}
+
+async function clickHexFromOrigin(
+  page: Page,
+  originBox: { x: number; y: number; width: number; height: number },
+  target: { q: number; r: number },
+): Promise<void> {
+  const originPixel = pointyHexPixel(ORIGIN);
+  const targetPixel = pointyHexPixel(target);
+  await page.mouse.click(
+    originBox.x + originBox.width / 2 + targetPixel.x - originPixel.x,
+    originBox.y + originBox.height / 2 + targetPixel.y - originPixel.y,
+  );
+}
+
+test('saved water unit stays selected after a blocked tap and can return ashore', async ({ page }, testInfo) => {
+  await installFixture(page);
+  await continueFixture(page);
+  const originBox = await selectLeadWarrior(page);
+  const guidance = page.locator('[data-water-recovery-kind="recoverable"]');
+
+  await expect(guidance).toContainText('Move to an amber land tile to return ashore.');
+  expect(await page.evaluate(() => window.__issue447AmberFills ?? 0)).toBeGreaterThan(0);
+
+  await page.evaluate(() => { window.__issue447ToneFrequencies = []; });
+  await clickHexFromOrigin(page, originBox, WATER_TARGET);
+
+  await expect(page.locator('#notifications')).toContainText(
+    'Move this land unit to an amber land tile to return ashore',
+  );
+  await expect(guidance).toBeVisible();
+  const blockedTapTones = await page.evaluate(() => window.__issue447ToneFrequencies ?? []);
+  expect(blockedTapTones).toContain(200);
+  expect(blockedTapTones).not.toContain(600);
+  await page.screenshot({
+    path: testInfo.outputPath('issue-447-desktop-recovery.png'),
+    fullPage: true,
+  });
+
+  await clickHexFromOrigin(page, originBox, LAND_EXIT);
+
+  await expect(guidance).toHaveCount(0);
+  await expect(page.locator(
+    '#unit-sprites > [data-entity-id="issue-365-lead"]',
+  )).not.toHaveCount(0);
+});
+
+test('recovery guidance remains legible and contained on mobile', async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await installFixture(page);
+  await continueFixture(page);
+  await selectLeadWarrior(page);
+
+  const guidance = page.locator('[data-water-recovery-kind="recoverable"]');
+  await expect(guidance).toBeVisible();
+  const box = await guidance.boundingBox();
+  expect(box?.x).toBeGreaterThanOrEqual(0);
+  expect((box?.x ?? 0) + (box?.width ?? 0)).toBeLessThanOrEqual(390);
+  expect(await guidance.evaluate(element => getComputedStyle(element).fontSize)).toBe('12px');
+  expect(await guidance.getAttribute('role')).toBe('status');
+  await page.screenshot({
+    path: testInfo.outputPath('issue-447-mobile-recovery.png'),
+    fullPage: true,
+  });
+});
+
+declare global {
+  interface Window {
+    __issue447ToneFrequencies?: number[];
+    __issue447AmberFills?: number;
+  }
+}

--- a/tests/hooks/run-with-mise-worktree.test.sh
+++ b/tests/hooks/run-with-mise-worktree.test.sh
@@ -58,6 +58,13 @@ exit 0
 EOF
 chmod +x "$fake_bin/mise"
 
+cat > "$fake_bin/node" <<'EOF'
+#!/bin/sh
+echo "worktree wrapper invoked node outside mise" >&2
+exit 43
+EOF
+chmod +x "$fake_bin/node"
+
 linked_git_dir="$(git -C "$linked" rev-parse --git-dir)"
 
 rm -f "$mise_log"
@@ -104,6 +111,19 @@ cat > "$linked/tests/hooks/run.sh" <<'EOF'
 }
 EOF
 chmod +x "$linked/tests/hooks/run.sh"
+
+rm -f "$mise_log"
+(
+  cd "$linked"
+  PATH="$fake_bin:$PATH" \
+    MISE_LOG="$mise_log" \
+    ./scripts/run-with-mise.sh yarn build
+)
+grep -Fq "$linked|exec -- node $linked/scripts/version-sw-cache.mjs" "$mise_log" || {
+  echo "worktree build did not route service-worker versioning through mise"
+  exit 1
+}
+
 verify_marker="$tmpdir/linked-verifier-ran"
 cat > "$linked/scripts/verify-before-push.sh" <<EOF
 #!/bin/sh

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -8,6 +8,71 @@ import { createUnit } from '@/systems/unit-system';
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
 describe('selected-unit-highlights', () => {
+  it('marks legal non-combat land exits as water-recovery without changing movement truth', () => {
+    const state = createNewGame(undefined, 'water-recovery-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: {
+        ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()),
+        id: 'warrior',
+        movementPointsLeft: 2,
+      },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+    state.map.tiles['1,1'] = {
+      ...state.map.tiles['1,1'],
+      coord: { q: 1, r: 1 },
+      terrain: 'coast',
+    };
+    state.map.tiles['2,1'] = {
+      ...state.map.tiles['2,1'],
+      coord: { q: 2, r: 1 },
+      terrain: 'plains',
+    };
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.waterRecovery.kind).toBe('recoverable');
+    expect(result.movementRange.map(hexKey)).toContain('2,1');
+    expect(result.highlights).toContainEqual({
+      coord: { q: 2, r: 1 },
+      type: 'water-recovery',
+    });
+  });
+
+  it('keeps hostile land targets as attack highlights during water recovery', () => {
+    const state = createNewGame(undefined, 'water-recovery-attack', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      warrior: {
+        ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()),
+        id: 'warrior',
+        movementPointsLeft: 2,
+      },
+      enemy: {
+        ...createUnit('warrior', 'ai-1', { q: 2, r: 1 }, mkC()),
+        id: 'enemy',
+      },
+    };
+    state.civilizations.player.units = ['warrior'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations.player.visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+    state.map.tiles['1,1'] = { ...state.map.tiles['1,1'], terrain: 'coast' };
+    state.map.tiles['2,1'] = { ...state.map.tiles['2,1'], terrain: 'plains' };
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.highlights).toContainEqual({
+      coord: { q: 2, r: 1 },
+      type: 'attack',
+    });
+    expect(result.highlights).not.toContainEqual({
+      coord: { q: 2, r: 1 },
+      type: 'water-recovery',
+    });
+  });
+
   it('does not mark non-adjacent melee targets as attack highlights', () => {
     const state = createNewGame(undefined, 'melee-highlight', 'small');
     state.currentPlayer = 'player';

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -41,6 +41,47 @@ describe('selected-unit-highlights', () => {
     });
   });
 
+  it('derives recovery for the active hot-seat player instead of a hardcoded owner', () => {
+    const state = createNewGame(undefined, 'water-recovery-hot-seat-viewer', 'small');
+    state.currentPlayer = 'ai-1';
+    state.hotSeat = {
+      playerCount: 2,
+      mapSize: 'small',
+      players: [
+        { name: 'Player One', slotId: 'player', civType: 'generic', isHuman: true },
+        { name: 'Player Two', slotId: 'ai-1', civType: 'generic', isHuman: true },
+      ],
+    };
+    state.units = {
+      warrior: {
+        ...createUnit('warrior', 'ai-1', { q: 1, r: 1 }, mkC()),
+        id: 'warrior',
+        movementPointsLeft: 2,
+      },
+    };
+    state.civilizations.player.units = [];
+    state.civilizations['ai-1'].units = ['warrior'];
+    state.civilizations['ai-1'].visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+    state.map.tiles['1,1'] = {
+      ...state.map.tiles['1,1'],
+      coord: { q: 1, r: 1 },
+      terrain: 'coast',
+    };
+    state.map.tiles['2,1'] = {
+      ...state.map.tiles['2,1'],
+      coord: { q: 2, r: 1 },
+      terrain: 'plains',
+    };
+
+    const result = buildSelectedUnitHighlights(state, 'warrior');
+
+    expect(result.waterRecovery.kind).toBe('recoverable');
+    expect(result.highlights).toContainEqual({
+      coord: { q: 2, r: 1 },
+      type: 'water-recovery',
+    });
+  });
+
   it('keeps hostile land targets as attack highlights during water recovery', () => {
     const state = createNewGame(undefined, 'water-recovery-attack', 'small');
     state.currentPlayer = 'player';
@@ -71,6 +112,38 @@ describe('selected-unit-highlights', () => {
       coord: { q: 2, r: 1 },
       type: 'water-recovery',
     });
+  });
+
+  it('does not offer water recovery to a route-committed land unit', () => {
+    const state = createNewGame(undefined, 'water-recovery-committed-route', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      caravan: {
+        ...createUnit('caravan', 'player', { q: 1, r: 1 }, mkC()),
+        id: 'caravan',
+        movementPointsLeft: 3,
+        committedToRouteId: 'route-1',
+      },
+    };
+    state.civilizations.player.units = ['caravan'];
+    state.civilizations.player.visibility.tiles = { '1,1': 'visible', '2,1': 'visible' };
+    state.map.tiles['1,1'] = {
+      ...state.map.tiles['1,1'],
+      coord: { q: 1, r: 1 },
+      terrain: 'coast',
+    };
+    state.map.tiles['2,1'] = {
+      ...state.map.tiles['2,1'],
+      coord: { q: 2, r: 1 },
+      terrain: 'plains',
+    };
+
+    const result = buildSelectedUnitHighlights(state, 'caravan');
+
+    expect(result.waterRecovery).toEqual({ kind: 'none', destinations: [] });
+    expect(result.movementRange).toEqual([]);
+    expect(result.attackTargets).toEqual([]);
+    expect(result.highlights).toEqual([]);
   });
 
   it('does not mark non-adjacent melee targets as attack highlights', () => {

--- a/tests/input/selected-unit-movement-feedback.test.ts
+++ b/tests/input/selected-unit-movement-feedback.test.ts
@@ -50,13 +50,14 @@ describe('selected-unit blocked movement feedback', () => {
     );
     const showNotification = vi.fn();
     const reselectUnit = vi.fn();
+    const playError = vi.fn();
 
     const handled = handleSelectedUnitMovementBlocker(
       state,
       'warrior',
       { q: 1, r: 2 },
       recovery,
-      { showNotification, reselectUnit },
+      { showNotification, reselectUnit, playError },
     );
 
     expect(handled).toBe(true);
@@ -65,6 +66,7 @@ describe('selected-unit blocked movement feedback', () => {
       'warning',
     );
     expect(reselectUnit).toHaveBeenCalledWith('warrior');
+    expect(playError).toHaveBeenCalledTimes(1);
   });
 
   it('keeps generic water copy for an ordinary land unit on land', () => {
@@ -77,7 +79,7 @@ describe('selected-unit blocked movement feedback', () => {
       'warrior',
       { q: 1, r: 2 },
       recovery,
-      { showNotification, reselectUnit: vi.fn() },
+      { showNotification, reselectUnit: vi.fn(), playError: vi.fn() },
     );
 
     expect(showNotification).toHaveBeenCalledWith(
@@ -90,18 +92,38 @@ describe('selected-unit blocked movement feedback', () => {
     const state = feedbackState(true);
     const recovery = getLandUnitWaterRecovery(state, 'warrior', []);
     const showNotification = vi.fn();
+    const playError = vi.fn();
 
     handleSelectedUnitMovementBlocker(
       state,
       'warrior',
       { q: 1, r: 2 },
       recovery,
-      { showNotification, reselectUnit: vi.fn() },
+      { showNotification, reselectUnit: vi.fn(), playError },
     );
 
     expect(showNotification).toHaveBeenCalledWith(
       'This land unit is stranded on water with no reachable land escape this turn.',
       'warning',
     );
+    expect(playError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not play the error cue for informational fog feedback', () => {
+    const state = feedbackState(false);
+    state.civilizations.player.visibility.tiles['2,1'] = 'unexplored';
+    const showNotification = vi.fn();
+    const playError = vi.fn();
+
+    handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 2, r: 1 },
+      getLandUnitWaterRecovery(state, 'warrior', []),
+      { showNotification, reselectUnit: vi.fn(), playError },
+    );
+
+    expect(showNotification).toHaveBeenCalledWith('Too far away to spot.', 'info');
+    expect(playError).not.toHaveBeenCalled();
   });
 });

--- a/tests/input/selected-unit-movement-feedback.test.ts
+++ b/tests/input/selected-unit-movement-feedback.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, HexCoord } from '@/core/types';
+import { handleSelectedUnitMovementBlocker } from '@/input/selected-unit-movement-feedback';
+import { createUnit } from '@/systems/unit-system';
+import { getLandUnitWaterRecovery } from '@/systems/unit-water-recovery';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function tile(coord: HexCoord, terrain: GameState['map']['tiles'][string]['terrain']) {
+  return {
+    coord,
+    terrain,
+    elevation: 'lowland' as const,
+    resource: null,
+    owner: null,
+    improvement: 'none' as const,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function feedbackState(onWater: boolean): GameState {
+  const state = createNewGame(undefined, `water-feedback-${onWater}`, 'small');
+  const unit = { ...createUnit('warrior', 'player', { q: 1, r: 1 }, mkC()), id: 'warrior' };
+  state.currentPlayer = 'player';
+  state.units = { warrior: unit };
+  state.civilizations.player.units = ['warrior'];
+  state.map.tiles = {
+    '1,1': tile({ q: 1, r: 1 }, onWater ? 'coast' : 'plains'),
+    '2,1': tile({ q: 2, r: 1 }, 'plains'),
+    '1,2': tile({ q: 1, r: 2 }, 'coast'),
+  };
+  state.civilizations.player.visibility.tiles = {
+    '1,1': 'visible',
+    '2,1': 'visible',
+    '1,2': 'visible',
+  };
+  return state;
+}
+
+describe('selected-unit blocked movement feedback', () => {
+  it('shows contextual recovery copy and reselects after a water tap', () => {
+    const state = feedbackState(true);
+    const recovery = getLandUnitWaterRecovery(
+      state,
+      'warrior',
+      [{ q: 2, r: 1 }],
+    );
+    const showNotification = vi.fn();
+    const reselectUnit = vi.fn();
+
+    const handled = handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit },
+    );
+
+    expect(handled).toBe(true);
+    expect(showNotification).toHaveBeenCalledWith(
+      'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.',
+      'warning',
+    );
+    expect(reselectUnit).toHaveBeenCalledWith('warrior');
+  });
+
+  it('keeps generic water copy for an ordinary land unit on land', () => {
+    const state = feedbackState(false);
+    const recovery = getLandUnitWaterRecovery(state, 'warrior', []);
+    const showNotification = vi.fn();
+
+    handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit: vi.fn() },
+    );
+
+    expect(showNotification).toHaveBeenCalledWith(
+      'Land units cannot cross water yet.',
+      'warning',
+    );
+  });
+
+  it('uses blocked recovery copy when no land exit is reachable', () => {
+    const state = feedbackState(true);
+    const recovery = getLandUnitWaterRecovery(state, 'warrior', []);
+    const showNotification = vi.fn();
+
+    handleSelectedUnitMovementBlocker(
+      state,
+      'warrior',
+      { q: 1, r: 2 },
+      recovery,
+      { showNotification, reselectUnit: vi.fn() },
+    );
+
+    expect(showNotification).toHaveBeenCalledWith(
+      'This land unit is stranded on water with no reachable land escape this turn.',
+      'warning',
+    );
+  });
+});

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -34,7 +34,10 @@ describe('land-unit water recovery wiring', () => {
 
     expect(selectFlow).toContain('waterRecovery: highlightResult.waterRecovery');
     expect(tapFlow).toContain('handleSelectedUnitMovementBlocker(');
-    expect(tapFlow).toContain('reselectUnit: selectUnit');
+    expect(tapFlow).toContain('selectedUnitWaterRecovery');
+    expect(tapFlow).not.toContain('getLandUnitWaterRecovery(');
+    expect(tapFlow).toContain('reselectUnit: unitId => selectUnit(unitId, { suppressSelectionSfx: true })');
+    expect(tapFlow).toContain('playError: SFX.error');
   });
 });
 

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -20,6 +20,24 @@ describe('campaign entry wiring', () => {
   });
 });
 
+describe('land-unit water recovery wiring', () => {
+  it('routes the live selected-unit panel and blocked-tap path through recovery helpers', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const selectFlow = main.slice(
+      main.indexOf('function selectUnit('),
+      main.indexOf('function deselectUnit('),
+    );
+    const tapFlow = main.slice(
+      main.indexOf('const selectedUnitCanMoveToTappedHex'),
+      main.indexOf('const defenderEntryAtHex'),
+    );
+
+    expect(selectFlow).toContain('waterRecovery: highlightResult.waterRecovery');
+    expect(tapFlow).toContain('handleSelectedUnitMovementBlocker(');
+    expect(tapFlow).toContain('reselectUnit: selectUnit');
+  });
+});
+
 describe('completed-round AI wiring', () => {
   it('uses one shared non-human scheduler for solo and hot-seat completed rounds', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import type { Camera } from '@/renderer/camera';
-import { drawHexMap, drawMinorCivTerritory, IMPROVEMENT_ICONS } from '@/renderer/hex-renderer';
+import {
+  drawHexHighlight,
+  drawHexMap,
+  drawMinorCivTerritory,
+  IMPROVEMENT_ICONS,
+} from '@/renderer/hex-renderer';
 import type { GameMap, VisibilityMap } from '@/core/types';
 
 class MockCanvasContext {
@@ -186,6 +191,25 @@ describe('hex renderer privacy', () => {
 
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeLessThan(19);
+  });
+});
+
+describe('hex highlight rendering', () => {
+  it('adds a high-contrast outline when the highlight style supplies one', () => {
+    const mock = new MockCanvasContext();
+
+    drawHexHighlight(
+      mock as unknown as CanvasRenderingContext2D,
+      50,
+      50,
+      48,
+      'rgba(245, 184, 73, 0.55)',
+      '#fff0a8',
+    );
+
+    expect(mock.fillStyle).toBe('rgba(245, 184, 73, 0.55)');
+    expect(mock.strokeCalls).toEqual(['#fff0a8']);
+    expect(mock.lineWidth).toBe(3);
   });
 });
 

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -65,6 +65,37 @@ function createCanvas(): HTMLCanvasElement {
 describe('render-loop wrap parity', () => {
   (globalThis as typeof globalThis & { window?: unknown }).window = { devicePixelRatio: 1 } as Window & typeof globalThis;
 
+  it('draws water-recovery highlights with the amber recovery color', () => {
+    rendererMocks.drawHexHighlight.mockReset();
+    const loop = new RenderLoop(createCanvas());
+    const state = {
+      turn: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 3, wrapsHorizontally: false, tiles: {}, rivers: [] },
+      tribalVillages: {},
+      minorCivs: {},
+      cities: {},
+      units: {},
+      civilizations: {
+        player: { color: '#4a90d9', visibility: { tiles: {} } },
+      },
+    } as unknown as GameState;
+
+    loop.setGameState(state);
+    loop.setHighlights([{ coord: { q: 0, r: 0 }, type: 'water-recovery' }]);
+    loop.camera.isHexVisible = () => true;
+
+    (loop as unknown as { render: () => void }).render();
+
+    expect(rendererMocks.drawHexHighlight).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(Number),
+      expect.any(Number),
+      expect.any(Number),
+      'rgba(245, 184, 73, 0.55)',
+    );
+  });
+
   it('mirrors movement highlights through the horizontal seam', () => {
     rendererMocks.drawHexHighlight.mockReset();
     const loop = new RenderLoop(createCanvas());

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -93,6 +93,7 @@ describe('render-loop wrap parity', () => {
       expect.any(Number),
       expect.any(Number),
       'rgba(245, 184, 73, 0.55)',
+      '#fff0a8',
     );
   });
 

--- a/tests/systems/unit-water-recovery.test.ts
+++ b/tests/systems/unit-water-recovery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { GameState, HexCoord, UnitType } from '@/core/types';
+import { createUnit } from '@/systems/unit-system';
+import {
+  getLandUnitWaterRecovery,
+  getLandUnitWaterRecoveryPanelMessage,
+  getLandUnitWaterRecoveryTapMessage,
+} from '@/systems/unit-water-recovery';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function tile(coord: HexCoord, terrain: GameState['map']['tiles'][string]['terrain']) {
+  return {
+    coord,
+    terrain,
+    elevation: 'lowland' as const,
+    resource: null,
+    owner: null,
+    improvement: 'none' as const,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+function recoveryState(type: UnitType = 'warrior'): GameState {
+  const state = createNewGame(undefined, `water-recovery-${type}`, 'small');
+  const unit = { ...createUnit(type, 'player', { q: 1, r: 1 }, mkC()), id: 'subject' };
+  state.currentPlayer = 'player';
+  state.units = { subject: unit };
+  state.civilizations.player.units = ['subject'];
+  state.map.tiles = {
+    '1,1': tile({ q: 1, r: 1 }, 'coast'),
+    '2,1': tile({ q: 2, r: 1 }, 'plains'),
+    '1,2': tile({ q: 1, r: 2 }, 'coast'),
+  };
+  return state;
+}
+
+describe('land-unit water recovery', () => {
+  it('is recoverable only through supplied legal land destinations', () => {
+    const state = recoveryState();
+
+    const result = getLandUnitWaterRecovery(
+      state,
+      'subject',
+      [{ q: 2, r: 1 }, { q: 1, r: 2 }],
+    );
+
+    expect(result).toEqual({
+      kind: 'recoverable',
+      destinations: [{ q: 2, r: 1 }],
+    });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBe(
+      'This land unit is on water. Move to an amber land tile to return ashore.',
+    );
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBe(
+      'Move this land unit to an amber land tile to return ashore; it cannot move to another water tile.',
+    );
+  });
+
+  it('reports blocked when no legal non-combat land destination exists', () => {
+    const result = getLandUnitWaterRecovery(recoveryState(), 'subject', []);
+
+    expect(result).toEqual({ kind: 'blocked', destinations: [] });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBe(
+      'This land unit is stranded on water. No land escape is currently reachable this turn.',
+    );
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBe(
+      'This land unit is stranded on water with no reachable land escape this turn.',
+    );
+  });
+
+  it.each([
+    ['land unit already on land', 'warrior', false],
+    ['naval unit on water', 'galley', true],
+    ['air unit on water', 'observation_balloon', true],
+  ] as const)('returns none for %s', (_label, type, keepWater) => {
+    const state = recoveryState(type);
+    if (!keepWater) state.map.tiles['1,1'] = tile({ q: 1, r: 1 }, 'plains');
+
+    const result = getLandUnitWaterRecovery(state, 'subject', [{ q: 2, r: 1 }]);
+
+    expect(result).toEqual({ kind: 'none', destinations: [] });
+    expect(getLandUnitWaterRecoveryPanelMessage(result)).toBeNull();
+    expect(getLandUnitWaterRecoveryTapMessage(result)).toBeNull();
+  });
+
+  it('returns none for transported cargo synchronized onto water', () => {
+    const state = recoveryState();
+    state.units.subject.transportId = 'transport-1';
+
+    expect(getLandUnitWaterRecovery(state, 'subject', [{ q: 2, r: 1 }]))
+      .toEqual({ kind: 'none', destinations: [] });
+  });
+});

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -84,6 +84,78 @@ function findButtons(node: unknown): MockElement[] {
   return result;
 }
 
+describe('land-unit water recovery guidance', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('renders recoverable guidance supplied by the live selection presentation', () => {
+    const state = createNewGame(undefined, 'water-panel-recoverable', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(
+      container as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      {
+        waterRecovery: {
+          kind: 'recoverable',
+          destinations: [{ q: 2, r: 1 }],
+        },
+      },
+    );
+
+    expect(collectAllText(container).join(' ')).toContain(
+      'This land unit is on water. Move to an amber land tile to return ashore.',
+    );
+  });
+
+  it('renders blocked guidance and omits guidance for none', () => {
+    const state = createNewGame(undefined, 'water-panel-blocked', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const blocked = new MockElement('div');
+    const normal = new MockElement('div');
+
+    renderSelectedUnitInfo(
+      blocked as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      { waterRecovery: { kind: 'blocked', destinations: [] } },
+    );
+    renderSelectedUnitInfo(
+      normal as unknown as HTMLElement,
+      state,
+      'warrior',
+      {},
+      { waterRecovery: { kind: 'none', destinations: [] } },
+    );
+
+    expect(collectAllText(blocked).join(' ')).toContain(
+      'This land unit is stranded on water. No land escape is currently reachable this turn.',
+    );
+    expect(collectAllText(normal).join(' ')).not.toContain('return ashore');
+    expect(collectAllText(normal).join(' ')).not.toContain('stranded on water');
+  });
+});
+
 
 function makeSpyState(
   techs: string[],

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -10,6 +10,8 @@ class MockElement {
   tagName: string;
   children: MockElement[] = [];
   style = { cssText: '', display: '', opacity: '', cursor: '' };
+  dataset: Record<string, string> = {};
+  attributes: Record<string, string> = {};
   textContent = '';
   type = '';
   disabled = false;
@@ -32,6 +34,14 @@ class MockElement {
   addEventListener(event: string, listener: (...args: unknown[]) => void): void {
     this.listeners[event] ??= [];
     this.listeners[event].push(listener);
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes[name] = value;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes[name] ?? null;
   }
 
   replaceChildren(...newChildren: MockElement[]): void {
@@ -84,6 +94,16 @@ function findButtons(node: unknown): MockElement[] {
   return result;
 }
 
+function findWaterRecoveryGuidance(node: unknown): MockElement | undefined {
+  const el = node as MockElement;
+  if (el.dataset?.waterRecoveryKind) return el;
+  for (const child of el.children ?? []) {
+    const found = findWaterRecoveryGuidance(child);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 describe('land-unit water recovery guidance', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);
@@ -117,6 +137,12 @@ describe('land-unit water recovery guidance', () => {
     expect(collectAllText(container).join(' ')).toContain(
       'This land unit is on water. Move to an amber land tile to return ashore.',
     );
+    const guidance = findWaterRecoveryGuidance(container);
+    expect(guidance?.dataset.waterRecoveryKind).toBe('recoverable');
+    expect(guidance?.getAttribute('role')).toBe('status');
+    expect(guidance?.getAttribute('aria-live')).toBe('polite');
+    expect(guidance?.style.cssText).toContain('font-size:12px');
+    expect(guidance?.style.cssText).toContain('border:1px solid');
   });
 
   it('renders blocked guidance and omits guidance for none', () => {


### PR DESCRIPTION
## Summary

- classify untransported land units loaded on coast/ocean as recoverable or blocked without changing movement or save data
- highlight legal land exits in amber with a high-contrast outline and show accessible selected-unit guidance
- replace generic water feedback with recovery-specific copy while preserving selection and highlights
- use the standard invalid-action cue without replaying the unit-selection sound
- suppress misleading recovery presentation for transported, non-land, on-land, and route-committed units
- fix linked-worktree cache stamping through mise, discovered while running the required production build

## Root cause

The canonical movement system already lets a land unit that starts on water move onto a legal land tile. The loaded-save experience looked broken because the ordinary blue movement presentation did not identify that escape route, and tapping water only said that land units could not cross water. The save itself does not need relocation or migration.

## Player impact

A stranded Warrior now explains how to return ashore, visibly distinguishes legal recovery destinations, keeps those destinations visible after a blocked water tap, and removes the recovery treatment immediately after moving onto land. If no legal land exit is reachable this turn, the panel says so rather than promising a nonexistent move.

## Review hardening

The final review added:

- hot-seat viewer coverage
- route-committed negative coverage
- warning-vs-informational SFX assertions
- a polite status-region and 390px mobile layout contract
- a real saved-game browser replay covering selection, invalid water tap, SFX routing, move animation, and post-move UI refresh
- desktop and mobile screenshots captured by the browser regression

## Validation

- `scripts/check-src-rule-violations.sh` for every changed `src/` file
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` — 345 files passed; 5,176 tests passed, 2 skipped
- `bash scripts/run-with-mise.sh yarn test:web-smoke` — 7 browser tests passed
- inspected both `origin/main...HEAD` and the clean worktree delta after rebasing onto the latest `origin/main`

Closes #447
