### PR TITLE
feat(economy): MR7 — roads end-to-end + road-family effects

### DIFF
--- a/.claude/rules/game-balance.md
+++ b/.claude/rules/game-balance.md
@@ -47,7 +47,11 @@ Movement bonuses are the most easily broken stat — small integers stack to pro
 | Navigator's Compass wonder | wonder (special) | naval units | +1 move | era 5+ (permanent) |
 | Road Corps national project | national project | — | (road construction speed, no movement) | era 3–5 |
 | National Railway national project | national project | — | (trade route gold, no movement) | era 7–9 |
-| `railway-expansion` tech | tech | all land units | ×2 speed on roads (not additive +N) | era 7+ |
+| `military-logistics` tech | tech | all land units | road entry cost 1 → 0.5 (not additive +N) | era 4+ |
+| `railway-expansion` tech | tech | all land units | road entry cost 1 → 0.5 (not additive +N; does not stack with Military Logistics) | era 7+ |
+| `gps-navigation` tech | tech | land units in own territory | ignores hills/forest extra cost (terrain cost 1) | era 12+ |
+
+**Roads discount, they don't stack:** entering a `hasRoad` tile always costs 1 movement, or 0.5 if the moving unit's owner has `military-logistics` **or** `railway-expansion` — never both at once (0.5 is the floor, not 0.25). See `tests/systems/road-system.test.ts` for the explicit no-stack regression.
 
 **Why Road Corps and National Railway don't grant movement:** early drafts gave both +1 road movement, which stacked to +2 on roads for an era 3–8 overlap window. Both were revised to non-movement effects to respect this policy.
 

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -144,6 +144,10 @@ Canvas-drawn emoji icons. Target: replace with proper SVG marker images.
 | quarry | ⚠️ `'⚒️'` emoji |
 | resource_outpost | ✅ SVG marker (`src/renderer/improvements/resource-outpost-marker.ts`) |
 
+Roads are **not** an improvement marker — they're a tile overlay (`HexTile.hasRoad`) drawn as
+programmatic canvas lines between hex centers in `src/renderer/hex-renderer.ts` → `drawRoads`,
+the same technique used for rivers (`drawRivers`). No sprite art exists or is planned yet.
+
 ### Legendary Wonders — `src/systems/legendary-wonder-definitions.ts`
 No map sprites yet. Production queue falls back to `'🏗️'`. Codex images exist in `public/images/wonders/codex/*.jpg` (lore art only, not map sprites).
 

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -394,6 +394,8 @@ function executeAction(
       for (const event of result.events) {
         if (event.type === 'improvement:started') {
           bus.emit('improvement:started', event.payload);
+        } else if (event.type === 'road:started') {
+          bus.emit('road:started', event.payload);
         } else {
           bus.emit('unit:destroyed', event.payload);
         }

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -59,6 +59,8 @@ import {
   applyWorkerAction,
   getWorkerChargesRemaining,
 } from '@/systems/worker-action-system';
+import { chooseRoadBuilderUnit } from '@/systems/road-network';
+import { canBuildRoad } from '@/systems/road-system';
 import { getAIStrategicRoles, hasAICombatRole } from './ai-unit-roles';
 import { isAIHostileOwner } from './ai-hostility';
 
@@ -468,6 +470,21 @@ function rankCivilianAndTransportActions(
     const completedTechs = context.state.civilizations[context.actorId]?.techState.completed ?? [];
     const isCityTile = Object.values(context.state.cities)
       .some(city => hexKey(city.position) === hexKey(unit.position));
+
+    const roadBuilder = chooseRoadBuilderUnit(context.state, context.actorId);
+    if (roadBuilder && roadBuilder.workerId === unit.id) {
+      if (hexKey(unit.position) === hexKey(roadBuilder.targetCoord)) {
+        if (canBuildRoad(tile, completedTechs, context.actorId, isCityTile)) {
+          return [ranked({ kind: 'worker-action', unitId: unit.id, action: 'build_road' }, 640)];
+        }
+      } else if (unit.movementPointsLeft > 0) {
+        const path = findPath(unit.position, roadBuilder.targetCoord, context.state.map, 'land', { unit, completedTechs });
+        if (path && path.length > 1) {
+          return [ranked({ kind: 'move', unitId: unit.id, destination: path[1]! }, 630)];
+        }
+      }
+    }
+
     const actions = getAvailableWorkerActions(
       tile,
       completedTechs,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -227,7 +227,7 @@ export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill'
   | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'resource_outpost' | 'none';
 // resource_outpost is excluded: only Expeditions can establish outposts, not Workers
 export type BuildableImprovementType = Exclude<ImprovementType, 'none' | 'resource_outpost'>;
-export type WorkerActionType = BuildableImprovementType | 'drain_swamp';
+export type WorkerActionType = BuildableImprovementType | 'drain_swamp' | 'build_road';
 
 export interface HexTile {
   coord: HexCoord;
@@ -241,6 +241,10 @@ export interface HexTile {
   hasRiver: boolean;
   wonder: string | null;           // wonder definition ID
   regionKey?: string;              // landmass ID for threat pressure (e.g. 'continent-0', 'island-2')
+  // Roads are an overlay, not a replacement improvement — a tile can have a farm AND a road.
+  hasRoad?: boolean;               // optional: legacy saves default falsy, no migration needed
+  roadTurnsLeft?: number;          // turns remaining to complete an in-progress road
+  roadOwner?: string;              // civ that started the in-progress road
 }
 
 export interface GameMap {
@@ -295,6 +299,7 @@ export interface LastSeenTilePresentation {
   owner: string | null;
   hasRiver: boolean;
   wonder: string | null;
+  hasRoad?: boolean;
   city?: LastSeenCityPresentation;
   observedTurn?: number;
   source?: 'observed' | 'legacy-reconstructed';
@@ -348,7 +353,7 @@ export interface UnitDefinition {
 }
 
 export interface WorkerTask {
-  action: BuildableImprovementType;
+  action: WorkerActionType;
   coord: HexCoord;
 }
 
@@ -1496,6 +1501,8 @@ export interface GameEvents {
   'fog:revealed': { tiles: HexCoord[] };
   'improvement:started': { unitId: string; coord: HexCoord; type: ImprovementType };
   'improvement:completed': { coord: HexCoord; type: ImprovementType };
+  'road:started': { unitId: string; coord: HexCoord };
+  'road:completed': { coord: HexCoord };
   'territory:tile-flipped': {
     coord: HexCoord;
     previousOwner: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -188,7 +188,7 @@ import {
 } from '@/systems/transport-system';
 import { getPendingUnload, getUnloadRange, setPendingUnload, clearPendingUnload } from '@/ui/transport-ui-state';
 import { getCapitalCity } from '@/systems/capital-system';
-import type { CombatResult, GameState, HexCoord, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, ImprovementType, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
 import {
   appendNotification,
   getNotificationsForPlayer,
@@ -1980,6 +1980,8 @@ function selectUnit(
             for (const event of result.events) {
               if (event.type === 'improvement:started') {
                 bus.emit('improvement:started', event.payload);
+              } else if (event.type === 'road:started') {
+                bus.emit('road:started', event.payload);
               } else {
                 bus.emit('unit:destroyed', event.payload);
               }
@@ -2247,6 +2249,8 @@ function performWorkerAction(action: WorkerActionType): void {
   for (const event of result.events) {
     if (event.type === 'improvement:started') {
       bus.emit('improvement:started', event.payload);
+    } else if (event.type === 'road:started') {
+      bus.emit('road:started', event.payload);
     } else {
       bus.emit('unit:destroyed', event.payload);
     }
@@ -2969,9 +2973,12 @@ function handleHexTap(rawCoord: HexCoord): void {
         const selectedId = selectedUnitId;
         const task = gameState.units[selectedId]?.workerTask;
         const taskTile = task ? gameState.map.tiles[hexKey(task.coord)] : undefined;
+        const isRoadTask = task?.action === 'build_road';
         createWorkerTaskWarningPanel(uiLayer, {
-          improvementName: task ? getImprovementDisplayName(task.action) : 'Improvement',
-          turnsLeft: taskTile?.improvementTurnsLeft ?? 1,
+          improvementName: task
+            ? (isRoadTask ? 'Road' : getImprovementDisplayName(task.action as ImprovementType))
+            : 'Improvement',
+          turnsLeft: (isRoadTask ? taskTile?.roadTurnsLeft : taskTile?.improvementTurnsLeft) ?? 1,
           onCancel: () => selectUnit(selectedId),
           onConfirm: () => {
             executeAnimatedUnitMove(selectedId, () => confirmBusyWorkerMove(gameState, selectedId, coord, {

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -1,5 +1,5 @@
 import type { GameMap, HexCoord, HexTile, TerrainType, VisibilityMap } from '@/core/types';
-import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY } from '@/systems/hex-utils';
+import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY, hexNeighbors, getWrappedHexNeighbors, hexKey } from '@/systems/hex-utils';
 import { Camera } from './camera';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
@@ -218,6 +218,96 @@ export function drawRivers(
 function canRenderRiverEndpoint(map: GameMap, visibility: VisibilityMap | undefined, coord: HexCoord): boolean {
   const presentation = resolveTilePresentationForViewer(map, visibility, coord);
   return presentation.kind === 'live' || presentation.kind === 'last-seen';
+}
+
+// --- Roads (drawn as programmatic lines, like rivers — no sprite art yet) ---
+
+function roadConnects(
+  map: GameMap,
+  visibility: VisibilityMap | undefined,
+  cityTileKeys: ReadonlySet<string>,
+  coord: HexCoord,
+): boolean {
+  const presentation = resolveTilePresentationForViewer(map, visibility, coord);
+  if (presentation.kind !== 'live' && presentation.kind !== 'last-seen') return false;
+  return Boolean(presentation.tile.hasRoad) || cityTileKeys.has(hexKey(coord));
+}
+
+function drawRoadSegment(
+  ctx: CanvasRenderingContext2D,
+  camera: Camera,
+  from: HexCoord,
+  to: HexCoord,
+): void {
+  const fromPixel = hexToPixel(from, camera.hexSize);
+  const toPixel = hexToPixel(to, camera.hexSize);
+  const fromScreen = camera.worldToScreen(fromPixel.x, fromPixel.y);
+  const toScreen = camera.worldToScreen(toPixel.x, toPixel.y);
+  ctx.beginPath();
+  ctx.moveTo(fromScreen.x, fromScreen.y);
+  ctx.lineTo(toScreen.x, toScreen.y);
+  ctx.stroke();
+}
+
+function forEachRoadSegment(
+  map: GameMap,
+  visibility: VisibilityMap | undefined,
+  cityTileKeys: ReadonlySet<string>,
+  onSegment: (from: HexCoord, to: HexCoord) => void,
+): void {
+  const seenPairs = new Set<string>();
+  for (const tile of Object.values(map.tiles)) {
+    if (!roadConnects(map, visibility, cityTileKeys, tile.coord)) continue;
+    const neighbors = map.wrapsHorizontally
+      ? getWrappedHexNeighbors(tile.coord, map.width)
+      : hexNeighbors(tile.coord);
+    for (const neighbor of neighbors) {
+      if (!roadConnects(map, visibility, cityTileKeys, neighbor)) continue;
+      const pairKey = [hexKey(tile.coord), hexKey(neighbor)].sort().join('|');
+      if (seenPairs.has(pairKey)) continue;
+      seenPairs.add(pairKey);
+      onSegment(tile.coord, neighbor);
+    }
+  }
+}
+
+export function drawRoads(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  cityTileKeys: ReadonlySet<string>,
+  viewerVisibility?: VisibilityMap,
+): void {
+  ctx.strokeStyle = '#8a6a3a';
+  ctx.lineWidth = 3 * camera.zoom;
+  ctx.lineCap = 'round';
+
+  forEachRoadSegment(map, viewerVisibility, cityTileKeys, (from, to) => {
+    if (camera.isHexVisible(from) || camera.isHexVisible(to)) {
+      drawRoadSegment(ctx, camera, from, to);
+    }
+  });
+
+  if (map.wrapsHorizontally) {
+    drawWrapGhostRoads(ctx, map, camera, cityTileKeys, viewerVisibility);
+  }
+}
+
+export function drawWrapGhostRoads(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  cityTileKeys: ReadonlySet<string>,
+  viewerVisibility?: VisibilityMap,
+): void {
+  forEachRoadSegment(map, viewerVisibility, cityTileKeys, (from, to) => {
+    for (const offset of getHorizontalWrapOffsetsForRiver(from, to, map.width)) {
+      const ghostFrom: HexCoord = { q: from.q + offset, r: from.r };
+      const ghostTo: HexCoord = { q: to.q + offset, r: to.r };
+      if (!camera.isHexVisible(ghostFrom) && !camera.isHexVisible(ghostTo)) continue;
+      drawRoadSegment(ctx, camera, ghostFrom, ghostTo);
+    }
+  });
 }
 
 function drawRiverSegment(

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -1,12 +1,12 @@
 import type { GameState, HexCoord, Unit, VisibilityMap } from '@/core/types';
 import { Camera } from './camera';
-import { drawHexMap, drawRivers, drawMinorCivTerritory, drawHexHighlight } from './hex-renderer';
+import { drawHexMap, drawRivers, drawRoads, drawMinorCivTerritory, drawHexHighlight } from './hex-renderer';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { drawFogOfWar } from './fog-renderer';
 import { drawUnitPresentations } from './unit-renderer';
 import { drawCities } from './city-renderer';
 import { AnimationSystem } from './animation-system';
-import { hexToPixel } from '@/systems/hex-utils';
+import { hexToPixel, hexKey } from '@/systems/hex-utils';
 import { getHorizontalWrapRenderCoords } from './wrap-rendering';
 import { getVisibility } from '@/systems/fog-of-war';
 import { createMovementAnimation, getMovementAnimationPosition, getMovingUnitIds, type UnitMovementAnimation } from './unit-movement-animation';
@@ -446,6 +446,10 @@ export class RenderLoop {
 
     // Draw rivers
     drawRivers(this.ctx, this.state.map, this.camera, viewerVisibility);
+
+    // Draw roads (overlay, drawn under units — see drawUnits below)
+    const cityTileKeys = new Set(Object.values(this.state.cities).map(city => hexKey(city.position)));
+    drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility);
 
     // Draw minor civ territory
     if (this.state.minorCivs) {

--- a/src/renderer/tile-presentation.ts
+++ b/src/renderer/tile-presentation.ts
@@ -34,6 +34,7 @@ function lastSeenToTile(snapshot: LastSeenTilePresentation): HexTile {
     improvementTurnsLeft: snapshot.improvementTurnsLeft,
     hasRiver: snapshot.hasRiver,
     wonder: snapshot.wonder,
+    hasRoad: snapshot.hasRoad,
   };
 }
 

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -25,7 +25,10 @@ import {
   getCivWonderTechGold,
   getCivRoutePartnerTechGold,
   getMaintenanceDiscountMultiplier,
+  getRoadTileTechGold,
+  getConnectedCityTechGold,
 } from './tech-yield-system';
+import { getOwnedRoadTileCount, getCitiesConnectedToCapital } from './road-network';
 import { isAtWar } from './diplomacy-system';
 
 export const ECONOMY_RULES = {
@@ -511,6 +514,8 @@ export function projectCivGrossGold(
   grossGold += npCivBonuses.gold ?? 0;
   grossGold += getCivLuxuryTechGold(civ.techState.completed, getCivHappinessFromResources(state, civId));
   grossGold += getEmpireFlatTechYields(civ.techState.completed).gold;
+  grossGold += getRoadTileTechGold(civ.techState.completed, getOwnedRoadTileCount(state, civId));
+  grossGold += getConnectedCityTechGold(civ.techState.completed, getCitiesConnectedToCapital(state, civId).size);
 
   const completedWonderCount = Object.values(state.completedLegendaryWonders ?? {})
     .filter(wonder => wonder.ownerId === civId).length;

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -217,14 +217,17 @@ export function canDrainSwamp(
   return tile.terrain === 'swamp' && tile.improvement === 'none';
 }
 
+/** Improvement/drain_swamp actions only — road building is a separate overlay handled by road-system.ts. */
+export type ImprovementWorkerActionType = BuildableImprovementType | 'drain_swamp';
+
 export function getAvailableWorkerActions(
   tile: HexTile | undefined,
   completedTechs: string[] = [],
   ownerId?: string,
   options: WorkerActionEligibilityOptions = {},
-): WorkerActionType[] {
+): ImprovementWorkerActionType[] {
   if (!tile) return [];
-  const actions: WorkerActionType[] = [];
+  const actions: ImprovementWorkerActionType[] = [];
   for (const type of Object.keys(IMPROVEMENT_DEFINITIONS) as BuildableImprovementType[]) {
     if (canBuildImprovement(tile, type, completedTechs, ownerId, options)) actions.push(type);
   }
@@ -234,7 +237,7 @@ export function getAvailableWorkerActions(
 
 export function getWorkerActionBlockerReason(
   tile: HexTile | undefined,
-  action: WorkerActionType,
+  action: ImprovementWorkerActionType,
   completedTechs: string[] = [],
   ownerId?: string,
   options: WorkerActionEligibilityOptions = {},
@@ -297,7 +300,7 @@ export function formatImprovementYieldLabel(type: ImprovementType): string {
   return parts.length ? `(${parts.join(', ')})` : '';
 }
 
-export function getWorkerActionLabel(action: WorkerActionType): string {
+export function getWorkerActionLabel(action: ImprovementWorkerActionType): string {
   if (action === 'drain_swamp') return 'Drain Swamp (20% worker risk)';
   const yieldLabel = formatImprovementYieldLabel(action);
   return `Build ${getImprovementDisplayName(action)}${yieldLabel ? ` ${yieldLabel}` : ''}`;

--- a/src/systems/improvement-turn-system.ts
+++ b/src/systems/improvement-turn-system.ts
@@ -2,7 +2,10 @@ import type { EventBus } from '@/core/event-bus';
 import { appendNotification } from '@/core/notification-log';
 import type { GameState } from '@/core/types';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
-import { clearCompletedWorkerTasksForImprovement } from '@/systems/worker-action-system';
+import {
+  clearCompletedWorkerTasksForImprovement,
+  clearCompletedWorkerTasksForRoad,
+} from '@/systems/worker-action-system';
 
 export function processImprovementTurns(state: GameState, bus: EventBus): GameState {
   let next = structuredClone(state);
@@ -31,6 +34,31 @@ export function processImprovementTurns(state: GameState, bus: EventBus): GameSt
         },
       });
       completedTile.improvementOwner = undefined;
+    }
+  }
+
+  for (const [key, tile] of Object.entries(next.map.tiles)) {
+    if ((tile.roadTurnsLeft ?? 0) <= 0) continue;
+    tile.roadTurnsLeft = (tile.roadTurnsLeft ?? 0) - 1;
+    if (tile.roadTurnsLeft > 0) continue;
+
+    const roadOwner = tile.roadOwner;
+    tile.hasRoad = true;
+    bus.emit('road:completed', { coord: { ...tile.coord } });
+    next = clearCompletedWorkerTasksForRoad(next, tile.coord);
+    const completedTile = next.map.tiles[key]!;
+    if (roadOwner) {
+      appendNotification(next, roadOwner, {
+        message: 'Road completed!',
+        type: 'success',
+        turn: next.turn,
+        target: {
+          kind: 'map',
+          coord: { ...completedTile.coord },
+          label: 'Road',
+        },
+      });
+      completedTile.roadOwner = undefined;
     }
   }
   return next;

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -95,6 +95,7 @@ function createTilePresentation(
     owner: tile.owner,
     hasRiver: tile.hasRiver,
     wonder: tile.wonder,
+    hasRoad: tile.hasRoad,
     city: city
       ? { id: city.id, name: city.name, owner: city.owner, population: city.population }
       : undefined,

--- a/src/systems/road-network.ts
+++ b/src/systems/road-network.ts
@@ -1,0 +1,133 @@
+import type { GameState, HexCoord } from '@/core/types';
+import { hexKey, hexNeighbors, getWrappedHexNeighbors } from './hex-utils';
+import { getCapitalCityId } from './capital-system';
+import { canBuildRoad } from './road-system';
+import { findPath } from './unit-system';
+import { getWorkerChargesRemaining } from './worker-action-system';
+
+/**
+ * Cities (other than the capital itself) reachable from the capital by walking
+ * only road tiles or the civ's own city tiles. Pure/memoizable per turn.
+ */
+export function getCitiesConnectedToCapital(state: GameState, civId: string): Set<string> {
+  const connected = new Set<string>();
+  const capitalId = getCapitalCityId(state, civId);
+  if (!capitalId) return connected;
+  const capital = state.cities[capitalId];
+  if (!capital) return connected;
+
+  const ownCityIdByTileKey = new Map<string, string>();
+  for (const cityId of state.civilizations[civId]?.cities ?? []) {
+    if (cityId === capitalId) continue;
+    const city = state.cities[cityId];
+    if (city) ownCityIdByTileKey.set(hexKey(city.position), cityId);
+  }
+
+  const startKey = hexKey(capital.position);
+  const visited = new Set<string>([startKey]);
+  const queue: HexCoord[] = [capital.position];
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const neighbors = state.map.wrapsHorizontally
+      ? getWrappedHexNeighbors(current, state.map.width)
+      : hexNeighbors(current);
+
+    for (const neighbor of neighbors) {
+      const key = hexKey(neighbor);
+      if (visited.has(key)) continue;
+      const tile = state.map.tiles[key];
+      if (!tile) continue;
+      const cityIdHere = ownCityIdByTileKey.get(key);
+      if (!tile.hasRoad && !cityIdHere) continue;
+      visited.add(key);
+      queue.push(neighbor);
+      if (cityIdHere) connected.add(cityIdHere);
+    }
+  }
+
+  return connected;
+}
+
+export function getOwnedRoadTileCount(state: GameState, civId: string): number {
+  let count = 0;
+  for (const tile of Object.values(state.map.tiles)) {
+    if (tile.hasRoad && tile.owner === civId) count += 1;
+  }
+  return count;
+}
+
+/**
+ * Deterministic AI road-building target: the first tile lacking a road along
+ * the shortest land path between the capital and the nearest disconnected
+ * owned city. Returns null if the civ has no road tech or is fully connected.
+ */
+export function getRoadBuildTarget(state: GameState, civId: string): HexCoord | null {
+  const civ = state.civilizations[civId];
+  if (!civ) return null;
+  const completedTechs = civ.techState.completed;
+  if (!completedTechs.includes('road-building')) return null;
+
+  const capitalId = getCapitalCityId(state, civId);
+  if (!capitalId) return null;
+  const capital = state.cities[capitalId];
+  if (!capital) return null;
+
+  const connected = getCitiesConnectedToCapital(state, civId);
+  const cityKeys = new Set(
+    Object.values(state.cities)
+      .filter(city => city.owner === civId)
+      .map(city => hexKey(city.position)),
+  );
+
+  const candidateCityIds = civ.cities
+    .filter(cityId => cityId !== capitalId && !connected.has(cityId))
+    .sort((left, right) => left.localeCompare(right));
+
+  for (const cityId of candidateCityIds) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+    const path = findPath(capital.position, city.position, state.map, 'land', { completedTechs });
+    if (!path) continue;
+
+    for (const coord of path) {
+      const key = hexKey(coord);
+      if (cityKeys.has(key)) continue;
+      const tile = state.map.tiles[key];
+      if (!canBuildRoad(tile, completedTechs, civId, false)) continue;
+      return coord;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Picks at most one idle worker per civ per turn to build the next road link
+ * toward a disconnected city — keeps AI road-building simple and deterministic.
+ */
+export function chooseRoadBuilderUnit(
+  state: GameState,
+  civId: string,
+): { workerId: string; targetCoord: HexCoord } | null {
+  const target = getRoadBuildTarget(state, civId);
+  if (!target) return null;
+
+  const distanceToTarget = (coord: HexCoord): number => {
+    const path = findPath(coord, target, state.map, 'land');
+    return path ? path.length : Infinity;
+  };
+
+  const workers = Object.values(state.units)
+    .filter(unit =>
+      unit.owner === civId
+      && unit.type === 'worker'
+      && !unit.hasActed
+      && getWorkerChargesRemaining(unit) > 0)
+    .sort((left, right) =>
+      distanceToTarget(left.position) - distanceToTarget(right.position)
+      || left.id.localeCompare(right.id));
+
+  const worker = workers[0];
+  return worker ? { workerId: worker.id, targetCoord: target } : null;
+}

--- a/src/systems/road-system.ts
+++ b/src/systems/road-system.ts
@@ -1,0 +1,56 @@
+import type { HexTile } from '@/core/types';
+import { getMovementCostForUnit } from './unit-system';
+
+export const ROAD_BUILD_TURNS = 2;
+export const ROAD_BUILD_TURNS_FAST = 1; // road_corps national project: "Roads built faster"
+
+export type RoadBlockerReason =
+  | 'outside-territory'
+  | 'requires-tech'
+  | 'already-has-road'
+  | 'invalid-terrain'
+  | 'city-center'
+  | 'none';
+
+export function getRoadBlockerReason(
+  tile: HexTile | undefined,
+  completedTechs: string[],
+  ownerId: string,
+  isCityTile = false,
+): RoadBlockerReason {
+  if (!tile) return 'invalid-terrain';
+  if (isCityTile) return 'city-center';
+  if (tile.owner !== null && tile.owner !== ownerId) return 'outside-territory';
+  if (!completedTechs.includes('road-building')) return 'requires-tech';
+  if (tile.hasRoad) return 'already-has-road';
+  if (getMovementCostForUnit(tile.terrain, 'land') === Infinity) return 'invalid-terrain';
+  return 'none';
+}
+
+export function canBuildRoad(
+  tile: HexTile | undefined,
+  completedTechs: string[],
+  ownerId: string,
+  isCityTile = false,
+): boolean {
+  return getRoadBlockerReason(tile, completedTechs, ownerId, isCityTile) === 'none';
+}
+
+export function formatRoadBlockerReason(reason: RoadBlockerReason): string {
+  switch (reason) {
+    case 'outside-territory': return 'Outside your territory';
+    case 'requires-tech': return 'Requires Road Building tech';
+    case 'already-has-road': return 'Already has a road';
+    case 'invalid-terrain': return 'Cannot build a road here';
+    case 'city-center': return 'City centers already connect';
+    case 'none': return '';
+  }
+}
+
+export function getRoadBuildTurns(hasRoadCorpsActive: boolean): number {
+  return hasRoadCorpsActive ? ROAD_BUILD_TURNS_FAST : ROAD_BUILD_TURNS;
+}
+
+export function getRoadMovementDiscount(completedTechs: string[]): boolean {
+  return completedTechs.includes('military-logistics') || completedTechs.includes('railway-expansion');
+}

--- a/src/systems/tech-definitions-eras1-4.ts
+++ b/src/systems/tech-definitions-eras1-4.ts
@@ -50,7 +50,7 @@ export const TECH_TREE_ERAS_1_4: Tech[] = [
   { id: 'bridge-building', name: 'Bridge Building', track: 'exploration', cost: 60, prerequisites: ['road-building'], unlocks: ['River crossings cost no extra movement'], era: 3 },
   { id: 'harbor-tech', name: 'Harbors', track: 'exploration', cost: 70, prerequisites: ['sailing', 'currency'], unlocks: [], unlocksBuildings: ['harbor'], era: 3 },
   { id: 'exploration-tech', name: 'Exploration', track: 'exploration', cost: 85, prerequisites: ['celestial-navigation'], unlocks: ['All units +1 vision range'], era: 4 },
-  { id: 'military-logistics', name: 'Military Logistics', track: 'exploration', cost: 100, prerequisites: ['road-building', 'tactics'], unlocks: ['Units move +1 on roads'], era: 4 },
+  { id: 'military-logistics', name: 'Military Logistics', track: 'exploration', cost: 100, prerequisites: ['road-building', 'tactics'], unlocks: ['Roads cost half movement'], era: 4 },
 
   // === AGRICULTURE TRACK (8 techs, new) ===
   { id: 'foraging', name: 'Foraging', track: 'agriculture', cost: 5, prerequisites: [], unlocks: ['Food storage', 'Reveal Ivory resource', 'Reveal Furs resource'], unlocksUnits: ['expedition'], era: 1 },

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -115,7 +115,7 @@ const ERA_5_TECHS: Tech[] = [
     unlocks: ['+1 science per library empire-wide'], era: 5 },
   { id: 'postal-service', name: 'Postal Service', track: 'communication', cost: 145,
     prerequisites: ['road-building'],
-    unlocks: ['+1 gold per road tile in empire'], era: 5 },
+    unlocks: ['+1 gold per road tile in your territory (max +10)'], era: 5 },
 
   // ESPIONAGE (2)
   { id: 'black-chambers', name: 'Black Chambers', track: 'espionage', cost: 155,
@@ -237,7 +237,7 @@ const ERA_6_TECHS: Tech[] = [
     unlocks: ['+2 science empire-wide'], era: 6 },
   { id: 'courier-network', name: 'Courier Network', track: 'communication', cost: 180,
     prerequisites: ['postal-service'],
-    unlocks: ['+1 gold per road connection between your cities'], era: 6 },
+    unlocks: ['+1 gold per own city connected by road to your capital'], era: 6 },
 
   // ESPIONAGE (2)
   { id: 'counter-espionage', name: 'Counter-Espionage', track: 'espionage', cost: 185,
@@ -296,7 +296,7 @@ const ERA_7_TECHS: Tech[] = [
   // EXPLORATION (2)
   { id: 'colonial-railways', name: 'Colonial Railways', track: 'exploration', cost: 200,
     prerequisites: ['land-survey', 'courier-network'],
-    unlocks: ['+2 gold per city connected by road to capital; railway construction speeds up settler founding'], era: 7 },
+    unlocks: ['+2 gold per city connected by road to your capital'], era: 7 },
   { id: 'manifest-destiny', name: 'Manifest Destiny', track: 'exploration', cost: 210,
     prerequisites: ['colonial-administration', 'land-survey'],
     unlocks: ['Settlers cost 20% less production; frontier cities founded with +5 food bonus'], era: 7 },
@@ -347,7 +347,7 @@ const ERA_7_TECHS: Tech[] = [
     unlocks: ['Steel Mill unlocked — advanced iron processing building'], unlocksBuildings: ['steel_mill'], era: 7 },
   { id: 'railway-expansion', name: 'Railway Expansion', track: 'metallurgy', cost: 215,
     prerequisites: ['precision-casting', 'fortification-engineering'],
-    unlocks: ['Land units move ×2 on road tiles; National Railway national project available'], unlocksBuildings: ['national_railway'], era: 7 },
+    unlocks: ['Roads become railways: half movement on roads (does not stack with Military Logistics); National Railway national project available'], unlocksBuildings: ['national_railway'], era: 7 },
 
   // CONSTRUCTION (2)
   { id: 'urban-planning', name: 'Urban Planning', track: 'construction', cost: 200,

--- a/src/systems/tech-definitions-eras8.ts
+++ b/src/systems/tech-definitions-eras8.ts
@@ -43,7 +43,7 @@ const ERA_8_TECHS: Tech[] = [
   // EXPLORATION (2)
   { id: 'transcontinental-rail', name: 'Transcontinental Rail', track: 'exploration', cost: 245,
     prerequisites: ['colonial-railways', 'railway-expansion'],
-    unlocks: ['Continental railway networks halve travel time between cities; +2 gold per rail connection'], era: 8 },
+    unlocks: ['Railway-connected cities earn +2 gold'], era: 8 },
   { id: 'imperial-survey', name: 'Imperial Survey', track: 'exploration', cost: 240,
     prerequisites: ['manifest-destiny', 'electric-telegraph'],
     unlocks: ['Systematic mapping of imperial territory; scouts reveal terrain faster; +1 vision range scouts'], era: 8 },

--- a/src/systems/tech-yield-definitions.ts
+++ b/src/systems/tech-yield-definitions.ts
@@ -63,7 +63,7 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   { techId: 'plantation-farming', label: 'Farms yield +1 food', effect: { kind: 'perImprovement', improvement: 'farm', yields: { food: 1 } } },
   { techId: 'monastic-orders', label: '+1 science and +1 gold per city with temple', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['temple'], yields: { science: 1, gold: 1 } } },
   { techId: 'reformation', label: '+2 science in cities with a temple', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['temple'], yields: { science: 2 } } },
-  // postal-service: '+1 gold per road tile in empire' — road-dependent, deferred to MR7
+  // postal-service: '+1 gold per road tile in your territory (max +10)' — resolved by getRoadTileTechGold (needs the owned-road-tile count, not table-drivable).
 
   // --- Era 6 ---
   { techId: 'mercantilism', label: '+5% gold empire-wide', effect: { kind: 'empirePercent', resource: 'gold', percent: 5 } },
@@ -82,7 +82,7 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   { techId: 'aqueduct-expansion', label: '+2 food in all cities with aqueduct', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['aqueduct'], yields: { food: 2 } } },
   { techId: 'newspaper-press', label: '+2 science empire-wide', effect: { kind: 'cityFlat', yields: { science: 2 } } },
   { techId: 'ecumenical-council', label: '+2 gold per city with a temple empire-wide', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['temple'], yields: { gold: 2 } } },
-  // courier-network: road-dependent, deferred to MR7
+  // courier-network / colonial-railways / transcontinental-rail: resolved by getConnectedCityTechGold (needs road-BFS connectivity, not table-drivable).
 
   // --- Era 7 ---
   { techId: 'mass-production', label: '+10% production empire-wide', effect: { kind: 'empirePercent', resource: 'production', percent: 10 } },
@@ -177,6 +177,8 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   { techId: 'electronic-computing', label: '+3 science in cities with a research institute', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['research_institute'], yields: { science: 3 } } },
   { techId: 'liberation-theology', label: '+1 food in cities with a temple', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['temple'], yields: { food: 1 } } },
   { techId: 'interfaith-council', label: '+1 science in cities with a religion building', effect: { kind: 'cityFlatConditional', requiresAnyBuilding: ['temple', 'monastery'], yields: { science: 1 } } },
+  // highway-network has no road-tile dependency ("+2 gold empire-wide" as written) — grouped here with the other road-family effects.
+  { techId: 'highway-network', label: '+2 gold empire-wide', effect: { kind: 'empireFlat', yields: { gold: 2 } } },
 
   // --- Era 11 ---
   { techId: 'stagflation-response', label: '+3 gold all cities', effect: { kind: 'cityFlat', yields: { gold: 3 } } },

--- a/src/systems/tech-yield-system.ts
+++ b/src/systems/tech-yield-system.ts
@@ -213,6 +213,25 @@ export function getTradeRouteTechGold(
   return gold;
 }
 
+/** postal-service: +1 gold per road tile the civ owns, capped at +10. */
+export function getRoadTileTechGold(completedTechs: string[], ownedRoadTileCount: number): number {
+  if (!completedTechs.includes('postal-service')) return 0;
+  return Math.min(10, ownedRoadTileCount);
+}
+
+/**
+ * Gold per city road-connected to the capital. courier-network (+1),
+ * colonial-railways (+2), and transcontinental-rail (+2, requires
+ * railway-expansion too) all stack per the MR7 spec — up to +5/connected city.
+ */
+export function getConnectedCityTechGold(completedTechs: string[], connectedCityCount: number): number {
+  let perCity = 0;
+  if (completedTechs.includes('courier-network')) perCity += 1;
+  if (completedTechs.includes('colonial-railways')) perCity += 2;
+  if (completedTechs.includes('transcontinental-rail') && completedTechs.includes('railway-expansion')) perCity += 2;
+  return perCity * connectedCityCount;
+}
+
 /** Flat gold per distinct owned luxury resource (e.g. distillation). */
 export function getCivLuxuryTechGold(completedTechs: string[], ownedLuxuryResourceCount: number): number {
   const techSet = new Set(completedTechs);

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -65,14 +65,18 @@ export type ExecuteUnitMoveResult =
       discoveredWonders: [];
     };
 
+function isWorkerTaskInProgress(tile: GameState['map']['tiles'][string] | undefined, task: NonNullable<GameState['units'][string]['workerTask']>): boolean {
+  if (!tile) return false;
+  if (task.action === 'build_road') return (tile.roadTurnsLeft ?? 0) > 0;
+  return tile.improvement === task.action && tile.improvementTurnsLeft > 0;
+}
+
 export function isWorkerBusy(state: GameState, unitId: string): boolean {
   const unit = state.units[unitId];
   if (!unit || unit.type !== 'worker' || !unit.workerTask) return false;
   const taskKey = hexKey(unit.workerTask.coord);
   const tile = state.map.tiles[taskKey];
-  return hexKey(unit.position) === taskKey
-    && tile?.improvement === unit.workerTask.action
-    && tile.improvementTurnsLeft > 0;
+  return hexKey(unit.position) === taskKey && isWorkerTaskInProgress(tile, unit.workerTask);
 }
 
 export function abandonWorkerTask(state: GameState, unitId: string): void {
@@ -80,9 +84,13 @@ export function abandonWorkerTask(state: GameState, unitId: string): void {
   if (!unit?.workerTask) return;
   const key = hexKey(unit.workerTask.coord);
   const tile = state.map.tiles[key];
-  if (tile?.improvement === unit.workerTask.action && tile.improvementTurnsLeft > 0) {
-    tile.improvement = 'none';
-    tile.improvementTurnsLeft = 0;
+  if (isWorkerTaskInProgress(tile, unit.workerTask)) {
+    if (unit.workerTask.action === 'build_road') {
+      tile!.roadTurnsLeft = 0;
+    } else {
+      tile!.improvement = 'none';
+      tile!.improvementTurnsLeft = 0;
+    }
   }
   state.units = {
     ...state.units,

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -679,12 +679,27 @@ export function getMovementStepCost(
   const tile = map.tiles[hexKey(to)];
   if (!tile) return Infinity;
 
-  const terrainCost = getMovementCostForUnitInContext(unit, tile.terrain, context);
-  if (terrainCost === Infinity) return Infinity;
-
   const domain = UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+  const completedTechs = context.completedTechs ?? [];
+  let terrainCost: number;
+
+  if (domain === 'land' && tile.hasRoad) {
+    // Roads cost 1 movement regardless of terrain; Military Logistics OR Railway
+    // Expansion halves that to 0.5 — the two do not stack (see game-balance.md).
+    const hasRoadDiscount = completedTechs.includes('military-logistics')
+      || completedTechs.includes('railway-expansion');
+    terrainCost = hasRoadDiscount ? 0.5 : 1;
+  } else {
+    terrainCost = getMovementCostForUnitInContext(unit, tile.terrain, context);
+    if (terrainCost === Infinity) return Infinity;
+
+    if (domain === 'land' && tile.owner === unit.owner && completedTechs.includes('gps-navigation')) {
+      terrainCost = 1;
+    }
+  }
+
   const crossesUnbridgedRiver = domain !== 'naval' && domain !== 'air'
-    && !context.completedTechs?.includes('bridge-building')
+    && !completedTechs.includes('bridge-building')
     && isRiverBetween(map, from, to);
   return terrainCost + (crossesUnbridgedRiver ? 1 : 0);
 }

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -16,6 +16,8 @@ import {
   getWorkerActionBlockerReason,
   getWorkerActionLabel,
 } from './improvement-system';
+import { getRoadBlockerReason, getRoadBuildTurns } from './road-system';
+import { getActiveNationalProjectsForCiv } from './national-project-system';
 
 export const DEFAULT_WORKER_CHARGES = 2;
 export const MAX_WORKER_CHARGES = 5;
@@ -24,6 +26,7 @@ export const SWAMP_DRAIN_WORKER_LOSS_CHANCE = 0.2;
 
 type WorkerActionEvent =
   | { type: 'improvement:started'; payload: GameEvents['improvement:started'] }
+  | { type: 'road:started'; payload: GameEvents['road:started'] }
   | { type: 'unit:destroyed'; payload: GameEvents['unit:destroyed'] };
 
 export type WorkerActionFailureReason =
@@ -61,7 +64,7 @@ export type WorkerActionResult =
     };
 
 function isBuildableImprovement(action: WorkerActionType): action is BuildableImprovementType {
-  return action !== 'drain_swamp';
+  return action !== 'drain_swamp' && action !== 'build_road';
 }
 
 export function getWorkerChargesRemaining(unit: Unit): number {
@@ -125,8 +128,62 @@ export function applyWorkerAction(
   if (!tile) return { ok: false, state, reason: 'missing-tile', events: [] };
 
   const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
+  const isCityTile = isCityCenterTile(state, unit.position);
+
+  if (action === 'build_road') {
+    const roadReason = getRoadBlockerReason(tile, completedTechs, unit.owner, isCityTile);
+    if (roadReason !== 'none') {
+      return {
+        ok: false,
+        state,
+        reason: roadReason === 'outside-territory' ? 'outside-territory' : 'invalid-action',
+        events: [],
+      };
+    }
+
+    const hasRoadCorps = getActiveNationalProjectsForCiv(state, unit.owner).some(np => np.id === 'road_corps');
+    const buildTurns = getRoadBuildTurns(hasRoadCorps);
+    const chargesAfterRoad = Math.max(0, chargesBefore - 1);
+    const nextTile = { ...tile, roadTurnsLeft: buildTurns, roadOwner: unit.owner };
+    const updatedRoadUnit = {
+      ...unit,
+      hasActed: true,
+      movementPointsLeft: 0,
+      chargesRemaining: chargesAfterRoad,
+      workerTask: { action: 'build_road' as const, coord: { ...tile.coord } },
+    };
+
+    let nextRoadState: GameState = {
+      ...state,
+      map: { ...state.map, tiles: { ...state.map.tiles, [key]: nextTile } },
+      units: { ...state.units, [unitId]: updatedRoadUnit },
+    };
+
+    const roadEvents: WorkerActionEvent[] = [
+      { type: 'road:started', payload: { unitId, coord: { ...tile.coord } } },
+    ];
+    const roadWorkerConsumed = chargesAfterRoad === 0;
+    if (roadWorkerConsumed) {
+      nextRoadState = removeUnit(nextRoadState, updatedRoadUnit);
+      roadEvents.push({ type: 'unit:destroyed', payload: { unitId, position: { ...unit.position } } });
+    }
+
+    return {
+      ok: true,
+      state: nextRoadState,
+      action,
+      message: `Building Road (${buildTurns} turns)${roadWorkerConsumed ? ' - worker used up' : ` - ${chargesAfterRoad}/${DEFAULT_WORKER_CHARGES} charges left`}`,
+      events: roadEvents,
+      workerConsumed: roadWorkerConsumed,
+      workerLost: false,
+      chargesRemaining: chargesAfterRoad,
+      forestProductionBonus: 0,
+      boostedCityId: null,
+    };
+  }
+
   const eligibilityOptions = {
-    isCityTile: isCityCenterTile(state, unit.position),
+    isCityTile,
     allowReplacement: options.allowReplacement,
     knownResource: getKnownTileResourceForWorkerAction(tile, completedTechs),
   };
@@ -260,6 +317,32 @@ export function clearCompletedWorkerTasksForImprovement(
       unit.workerTask
       && hexKey(unit.workerTask.coord) === key
       && unit.workerTask.action === tile.improvement
+    ) {
+      nextUnits[unitId] = { ...unit, workerTask: undefined };
+      changed = true;
+    } else {
+      nextUnits[unitId] = unit;
+    }
+  }
+
+  return changed ? { ...state, units: nextUnits } : state;
+}
+
+export function clearCompletedWorkerTasksForRoad(
+  state: GameState,
+  coord: HexCoord,
+): GameState {
+  const key = hexKey(coord);
+  const tile = state.map.tiles[key];
+  if (!tile || (tile.roadTurnsLeft ?? 0) > 0) return state;
+
+  let changed = false;
+  const nextUnits: GameState['units'] = {};
+  for (const [unitId, unit] of Object.entries(state.units)) {
+    if (
+      unit.workerTask
+      && unit.workerTask.action === 'build_road'
+      && hexKey(unit.workerTask.coord) === key
     ) {
       nextUnits[unitId] = { ...unit, workerTask: undefined };
       changed = true;

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -7,6 +7,7 @@ import { TRAINABLE_UNITS, BUILDINGS } from '@/systems/city-system';
 import {
   formatImprovementYieldLabel,
   formatWorkerActionBlockerReason,
+  type ImprovementWorkerActionType,
   getAvailableWorkerActions,
   getImprovementDisplayName,
   getKnownTileResourceForWorkerAction,
@@ -17,6 +18,7 @@ import {
   type WorkerActionEligibilityOptions,
 } from '@/systems/improvement-system';
 import { DEFAULT_WORKER_CHARGES, getWorkerChargesRemaining } from '@/systems/worker-action-system';
+import { getRoadBlockerReason, formatRoadBlockerReason } from '@/systems/road-system';
 import { hexKey } from '@/systems/hex-utils';
 import { canFoundCityAt, formatCityFoundingBlockerMessage, getCityFoundingBlockers } from '@/systems/city-territory-system';
 import { resolveFromCity } from '@/systems/trade-system';
@@ -118,7 +120,7 @@ function nextTierLabel(currentLabel: string): string | null {
   return null;
 }
 
-const WORKER_ACTIONS: WorkerActionType[] = [
+const WORKER_ACTIONS: ImprovementWorkerActionType[] = [
   'farm', 'mine', 'lumber_camp', 'watermill',
   'plantation', 'pasture', 'camp', 'quarry',
   'drain_swamp',
@@ -367,6 +369,19 @@ export function renderSelectedUnitInfo(
         }
         actionsDiv.appendChild(makeButton(label, color, () => callbacks.onWorkerAction!(action)));
       }
+
+      const roadBlockerReason = getRoadBlockerReason(tile, completedTechs, unit.owner, isCityTile);
+      if (roadBlockerReason === 'none') {
+        actionsDiv.appendChild(makeButton('Build Road (2 turns)', '#8a6a3a', () => callbacks.onWorkerAction!('build_road')));
+      } else if (roadBlockerReason === 'requires-tech' || roadBlockerReason === 'outside-territory') {
+        const btn = makeButton('Build Road (2 turns)', '#8a6a3a');
+        btn.disabled = true;
+        btn.style.opacity = '0.5';
+        btn.style.cursor = 'not-allowed';
+        btn.title = formatRoadBlockerReason(roadBlockerReason);
+        actionsDiv.appendChild(btn);
+      }
+
       if (workerActions.length === 0) {
         const eligibilityOpts = workerEligibilityOptions;
         if (tile && tile.improvement !== 'none' && callbacks.onReplaceImprovement) {

--- a/src/ui/territory-inspection-panel.ts
+++ b/src/ui/territory-inspection-panel.ts
@@ -150,6 +150,8 @@ export function createTerritoryInspectionPanel(
     }
   }
   if (tile.improvement !== 'none') addLine(panel, 'Improvement', getImprovementDisplayName(tile.improvement));
+  if (tile.hasRoad) addLine(panel, 'Road', 'Built');
+  else if ((tile.roadTurnsLeft ?? 0) > 0) addLine(panel, 'Road', `In progress (${tile.roadTurnsLeft} turns)`);
   if (tile.wonder) addLine(panel, 'Wonder', getWonderDefinition(tile.wonder)?.name ?? tile.wonder);
 
   if (visibility === 'fog') {

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -606,3 +606,62 @@ describe('AI tactical action ranking', () => {
     expect(foundings).toHaveLength(1);
   });
 });
+
+describe('AI road-building', () => {
+  it('queues build_road for an idle worker standing on the road-building target tile', () => {
+    const state = makeState('veteran');
+    state.civilizations[AI].techState.completed = ['road-building'];
+    const capital = addCity(state, 'capital', AI, { q: 0, r: 0 });
+    const outpost = addCity(state, 'outpost', AI, { q: 2, r: 0 });
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key].owner = AI;
+    }
+    const worker = addUnit(state, 'road-worker', 'worker', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: capital.position },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), worker.id);
+    expect(action).toEqual({ kind: 'worker-action', unitId: worker.id, action: 'build_road' });
+    expect(outpost.id).toBe('outpost'); // sanity: second city exists and is the disconnection target
+  });
+
+  it('moves the worker toward the road target when not yet standing on it', () => {
+    const state = makeState('veteran');
+    state.civilizations[AI].techState.completed = ['road-building'];
+    addCity(state, 'capital', AI, { q: 0, r: 0 });
+    addCity(state, 'outpost', AI, { q: 2, r: 0 });
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key].owner = AI;
+    }
+    const worker = addUnit(state, 'road-worker', 'worker', AI, { q: 0, r: 1 });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: { q: 0, r: 0 } },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), worker.id);
+    expect(action.kind).toBe('move');
+  });
+
+  it('does not queue road-building without the tech (negative)', () => {
+    const state = makeState('veteran');
+    addCity(state, 'capital', AI, { q: 0, r: 0 });
+    addCity(state, 'outpost', AI, { q: 2, r: 0 });
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key].owner = AI;
+    }
+    const worker = addUnit(state, 'road-worker', 'worker', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: { q: 0, r: 0 } },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    const action = chooseUnitTacticalAction(context(state, plan), worker.id);
+    expect(action.kind === 'worker-action' ? action.action : null).not.toBe('build_road');
+  });
+});

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -458,3 +458,48 @@ describe('IMPROVEMENT_ICONS', () => {
     expect(IMPROVEMENT_ICONS['none']).toBeUndefined();
   });
 });
+
+describe('drawRoads', () => {
+  it('draws one segment between two adjacent road tiles, including wrap-around ghost tiles', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const map: GameMap = {
+      width: 4,
+      height: 1,
+      wrapsHorizontally: true,
+      rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+        '1,0': { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: false },
+        '3,0': { coord: { q: 3, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+      },
+    } as unknown as GameMap;
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, map, makeCamera(), new Set());
+    expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
+  });
+
+  it('draws a road segment into a city tile even without hasRoad on the city hex', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const map: GameMap = {
+      width: 2,
+      height: 1,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: false },
+        '1,0': { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+      },
+    } as unknown as GameMap;
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, map, makeCamera(), new Set(['0,0']));
+    expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
+  });
+
+  it('draws nothing when no tile has a road (negative)', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const map = makeMap();
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, map, makeCamera(), new Set());
+    expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBe(0);
+  });
+});

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -383,11 +383,11 @@ describe('getWorkerActionBlockerReason — missing-resource', () => {
   }
 
   it('plantation on grassland without resource returns missing-resource', () => {
-    expect(getWorkerActionBlockerReason(rt('grassland'), 'plantation' as import('@/core/types').WorkerActionType)).toBe('missing-resource');
+    expect(getWorkerActionBlockerReason(rt('grassland'), 'plantation' as import('@/systems/improvement-system').ImprovementWorkerActionType)).toBe('missing-resource');
   });
 
   it('plantation on grassland with known silk returns none', () => {
-    expect(getWorkerActionBlockerReason(rt('grassland', 'silk'), 'plantation' as import('@/core/types').WorkerActionType, [], undefined, { knownResource: 'silk' })).toBe('none');
+    expect(getWorkerActionBlockerReason(rt('grassland', 'silk'), 'plantation' as import('@/systems/improvement-system').ImprovementWorkerActionType, [], undefined, { knownResource: 'silk' })).toBe('none');
   });
 
   it('formatWorkerActionBlockerReason missing-resource returns human-readable message', () => {

--- a/tests/systems/road-network.test.ts
+++ b/tests/systems/road-network.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import type { City, GameState, HexTile } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { getCitiesConnectedToCapital, getOwnedRoadTileCount, getRoadBuildTarget } from '@/systems/road-network';
+
+function tile(overrides: Partial<HexTile>): HexTile {
+  return {
+    coord: { q: 0, r: 0 },
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: 'player',
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    ...overrides,
+  };
+}
+
+function city(overrides: Partial<City>): City {
+  return {
+    id: 'city-1',
+    name: 'City',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    population: 1,
+    food: 0,
+    foodNeeded: 20,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+/** Builds a flat, fully-explored land map so BFS tests don't depend on generateMap RNG. */
+function makeMap(width: number, wraps: boolean, roadKeys: Set<string>): GameState['map'] {
+  const tiles: Record<string, HexTile> = {};
+  for (let q = 0; q < width; q++) {
+    for (let r = 0; r < 3; r++) {
+      const key = `${q},${r}`;
+      tiles[key] = tile({ coord: { q, r }, hasRoad: roadKeys.has(key) });
+    }
+  }
+  return { width, height: 3, wrapsHorizontally: wraps, rivers: [], tiles };
+}
+
+function baseState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 1,
+    era: 1,
+    gameId: 'road-network-test',
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: makeMap(10, false, new Set()),
+    units: {},
+    cities: {},
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'generic',
+        cities: [],
+        units: [],
+        techState: { completed: ['road-building'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
+        gold: 0,
+        visibility: { tiles: {} },
+        knownCivilizations: [],
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'welcome', completedSteps: [] },
+    settings: {
+      mapSize: 'small', soundEnabled: true, musicEnabled: true, musicVolume: 0.5, sfxVolume: 0.7,
+      tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    legendaryWonderHistory: { destroyedStrongholds: [], discoveredSites: [] },
+    legendaryWonderIntel: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    pendingDiplomacyRequests: [],
+    ...overrides,
+  } as GameState;
+}
+
+describe('getCitiesConnectedToCapital', () => {
+  it('reports a city as connected when a continuous road links it to the capital', () => {
+    const roadKeys = new Set(['1,0', '2,0', '3,0', '4,0']);
+    const s = baseState({
+      map: makeMap(10, false, roadKeys),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 5, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'] },
+      },
+    });
+    const connected = getCitiesConnectedToCapital(s, 'player');
+    expect(connected.has('outpost')).toBe(true);
+    expect(connected.has('capital')).toBe(false); // capital never counts itself
+  });
+
+  it('reports a city as NOT connected when the road link is broken (negative)', () => {
+    const roadKeys = new Set(['1,0', '2,0', '4,0']); // gap at 3,0
+    const s = baseState({
+      map: makeMap(10, false, roadKeys),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 5, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'] },
+      },
+    });
+    expect(getCitiesConnectedToCapital(s, 'player').has('outpost')).toBe(false);
+  });
+
+  it('handles wrap-around maps', () => {
+    // Capital at q=0, outpost at q=9 on a width-10 wrapping map — connect via the wrap edge (q=9 -> q=0).
+    const roadKeys = new Set(['9,0']);
+    const s = baseState({
+      map: makeMap(10, true, roadKeys),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 9, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'] },
+      },
+    });
+    expect(getCitiesConnectedToCapital(s, 'player').has('outpost')).toBe(true);
+  });
+
+  it('a disconnected island city never connects (negative)', () => {
+    const s = baseState({
+      map: makeMap(10, false, new Set()),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        island: city({ id: 'island', position: { q: 8, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'island'] },
+      },
+    });
+    expect(getCitiesConnectedToCapital(s, 'player').size).toBe(0);
+  });
+});
+
+describe('getOwnedRoadTileCount', () => {
+  it('counts only road tiles owned by the given civ', () => {
+    const map = makeMap(3, false, new Set(['0,0', '1,0']));
+    map.tiles['2,0'] = { ...map.tiles['2,0'], hasRoad: true, owner: 'rival' };
+    const s = baseState({ map });
+    expect(getOwnedRoadTileCount(s, 'player')).toBe(2);
+  });
+});
+
+describe('getRoadBuildTarget', () => {
+  it('returns null once fully connected', () => {
+    const roadKeys = new Set(['1,0']);
+    const s = baseState({
+      map: makeMap(3, false, roadKeys),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 2, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'] },
+      },
+    });
+    expect(getRoadBuildTarget(s, 'player')).toBeNull();
+  });
+
+  it('returns the next unroaded tile toward a disconnected city', () => {
+    const s = baseState({
+      map: makeMap(3, false, new Set()),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 2, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'] },
+      },
+    });
+    const target = getRoadBuildTarget(s, 'player');
+    expect(target).toEqual({ q: 1, r: 0 });
+  });
+
+  it('returns null without road-building tech (negative)', () => {
+    const s = baseState({
+      map: makeMap(3, false, new Set()),
+      cities: {
+        capital: city({ id: 'capital', position: { q: 0, r: 0 } }),
+        outpost: city({ id: 'outpost', position: { q: 2, r: 0 } }),
+      },
+      civilizations: {
+        player: { ...baseState().civilizations.player, cities: ['capital', 'outpost'], techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any } },
+      },
+    });
+    expect(getRoadBuildTarget(s, 'player')).toBeNull();
+  });
+});

--- a/tests/systems/road-system.test.ts
+++ b/tests/systems/road-system.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest';
+import type { City, GameState, HexTile, Unit } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { applyWorkerAction, clearCompletedWorkerTasksForRoad } from '@/systems/worker-action-system';
+import { canBuildRoad, getRoadBlockerReason, getRoadBuildTurns } from '@/systems/road-system';
+import { processImprovementTurns } from '@/systems/improvement-turn-system';
+import { EventBus } from '@/core/event-bus';
+import { getMovementStepCost, UNIT_DEFINITIONS } from '@/systems/unit-system';
+
+function tile(overrides: Partial<HexTile>): HexTile {
+  return {
+    coord: { q: 0, r: 0 },
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: 'player',
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    ...overrides,
+  };
+}
+
+function city(overrides: Partial<City>): City {
+  return {
+    id: 'city-1',
+    name: 'Capital',
+    owner: 'player',
+    position: { q: 0, r: 1 },
+    population: 1,
+    food: 0,
+    foodNeeded: 20,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [{ q: 0, r: 0 }],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'outpost',
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+function worker(overrides: Partial<Unit>): Unit {
+  return {
+    id: 'worker-1',
+    type: 'worker',
+    owner: 'player',
+    position: { q: 0, r: 0 },
+    movementPointsLeft: 2,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+    chargesRemaining: 2,
+    ...overrides,
+  };
+}
+
+function state(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 3,
+    era: 1,
+    gameId: 'test-game',
+    currentPlayer: 'player',
+    gameOver: false,
+    winner: null,
+    map: {
+      width: 5,
+      height: 5,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': tile({ coord: { q: 0, r: 0 } }),
+      },
+    },
+    units: { 'worker-1': worker({}) },
+    cities: { 'city-1': city({}) },
+    civilizations: {
+      player: {
+        id: 'player',
+        name: 'Player',
+        color: '#4a90d9',
+        isHuman: true,
+        civType: 'generic',
+        cities: ['city-1'],
+        units: ['worker-1'],
+        techState: { completed: ['road-building'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} as any },
+        gold: 0,
+        visibility: { tiles: {} },
+        knownCivilizations: [],
+        score: 0,
+        diplomacy: createDiplomacyState(['player'], 'player'),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'welcome', completedSteps: [] },
+    settings: {
+      mapSize: 'small',
+      soundEnabled: true,
+      musicEnabled: true,
+      musicVolume: 0.5,
+      sfxVolume: 0.7,
+      tutorialEnabled: false,
+      advisorsEnabled: {} as any,
+      councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    legendaryWonderHistory: { destroyedStrongholds: [], discoveredSites: [] },
+    legendaryWonderIntel: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    pendingDiplomacyRequests: [],
+    ...overrides,
+  } as GameState;
+}
+
+describe('road build gating', () => {
+  it('blocks without road-building tech', () => {
+    expect(getRoadBlockerReason(tile({}), [], 'player')).toBe('requires-tech');
+    expect(canBuildRoad(tile({}), [], 'player')).toBe(false);
+  });
+
+  it('blocks on foreign territory', () => {
+    expect(getRoadBlockerReason(tile({ owner: 'rival' }), ['road-building'], 'player')).toBe('outside-territory');
+  });
+
+  it('allows neutral (unowned) territory', () => {
+    expect(getRoadBlockerReason(tile({ owner: null }), ['road-building'], 'player')).toBe('none');
+  });
+
+  it('blocks water terrain', () => {
+    expect(getRoadBlockerReason(tile({ terrain: 'ocean' }), ['road-building'], 'player')).toBe('invalid-terrain');
+    expect(getRoadBlockerReason(tile({ terrain: 'coast' }), ['road-building'], 'player')).toBe('invalid-terrain');
+  });
+
+  it('allows hills (passable land terrain)', () => {
+    expect(getRoadBlockerReason(tile({ terrain: 'hills' }), ['road-building'], 'player')).toBe('none');
+  });
+
+  it('blocks a duplicate build on a tile that already has a road', () => {
+    expect(getRoadBlockerReason(tile({ hasRoad: true }), ['road-building'], 'player')).toBe('already-has-road');
+  });
+
+  it('blocks city-center tiles', () => {
+    expect(getRoadBlockerReason(tile({}), ['road-building'], 'player', true)).toBe('city-center');
+  });
+});
+
+describe('road_corps national project build-speed', () => {
+  it('is 2 turns without the project, 1 turn with it active', () => {
+    expect(getRoadBuildTurns(false)).toBe(2);
+    expect(getRoadBuildTurns(true)).toBe(1);
+  });
+});
+
+describe('applyWorkerAction: build_road', () => {
+  it('starts a 2-turn road build and consumes a worker charge', () => {
+    const result = applyWorkerAction(state(), 'worker-1', 'build_road');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0'].roadTurnsLeft).toBe(2);
+    expect(result.state.map.tiles['0,0'].hasRoad).toBeFalsy();
+    expect(result.chargesRemaining).toBe(1);
+    expect(result.workerConsumed).toBe(false);
+    expect(result.events).toEqual([{ type: 'road:started', payload: { unitId: 'worker-1', coord: { q: 0, r: 0 } } }]);
+  });
+
+  it('consumes the worker on its last charge', () => {
+    const s = state({ units: { 'worker-1': worker({ chargesRemaining: 1 }) } });
+    const result = applyWorkerAction(s, 'worker-1', 'build_road');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.workerConsumed).toBe(true);
+    expect(result.state.units['worker-1']).toBeUndefined();
+  });
+
+  it('completes after 2 turns via processImprovementTurns, emitting road:completed exactly once', () => {
+    let s = applyWorkerAction(state(), 'worker-1', 'build_road');
+    expect(s.ok).toBe(true);
+    if (!s.ok) return;
+
+    const bus = new EventBus();
+    let completedCount = 0;
+    bus.on('road:completed', () => { completedCount += 1; });
+
+    let next = processImprovementTurns(s.state, bus);
+    expect(next.map.tiles['0,0'].hasRoad).toBeFalsy();
+    expect(next.map.tiles['0,0'].roadTurnsLeft).toBe(1);
+    expect(completedCount).toBe(0);
+
+    next = processImprovementTurns(next, bus);
+    expect(next.map.tiles['0,0'].hasRoad).toBe(true);
+    expect(completedCount).toBe(1);
+
+    // Steady-state scans must not re-fire the completion event.
+    next = processImprovementTurns(next, bus);
+    expect(completedCount).toBe(1);
+  });
+
+  it('road_corps national project completes the road in 1 turn', () => {
+    const s = state({
+      builtNationalProjects: { 'player:road_corps': { civId: 'player', cityId: 'city-1', eraBuilt: 1 } },
+    } as Partial<GameState>);
+    const started = applyWorkerAction(s, 'worker-1', 'build_road');
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    expect(started.state.map.tiles['0,0'].roadTurnsLeft).toBe(1);
+
+    const bus = new EventBus();
+    const next = processImprovementTurns(started.state, bus);
+    expect(next.map.tiles['0,0'].hasRoad).toBe(true);
+  });
+
+  it('clearCompletedWorkerTasksForRoad clears the worker task once the road finishes', () => {
+    const s = applyWorkerAction(state(), 'worker-1', 'build_road');
+    expect(s.ok).toBe(true);
+    if (!s.ok) return;
+    const finishedTile = { ...s.state.map.tiles['0,0'], roadTurnsLeft: 0, hasRoad: true };
+    const withFinishedTile = { ...s.state, map: { ...s.state.map, tiles: { ...s.state.map.tiles, '0,0': finishedTile } } };
+    const cleared = clearCompletedWorkerTasksForRoad(withFinishedTile, { q: 0, r: 0 });
+    expect(cleared.units['worker-1'].workerTask).toBeUndefined();
+  });
+});
+
+describe('road movement cost stacking (see .claude/rules/game-balance.md)', () => {
+  const map = {
+    width: 5,
+    height: 5,
+    wrapsHorizontally: false,
+    rivers: [] as any[],
+    tiles: {
+      '1,0': tile({ coord: { q: 1, r: 0 }, terrain: 'hills', hasRoad: true, owner: 'player' }),
+    },
+  };
+  const from = { q: 0, r: 0 };
+  const to = { q: 1, r: 0 };
+
+  function landUnit(overrides: Partial<Unit> = {}): Unit {
+    return worker({ type: 'warrior' as Unit['type'], ...overrides });
+  }
+
+  it('costs 1 movement over hills with a road, regardless of terrain', () => {
+    expect(UNIT_DEFINITIONS.warrior.domain ?? 'land').toBe('land');
+    const cost = getMovementStepCost(landUnit(), map as any, from, to, { completedTechs: [] });
+    expect(cost).toBe(1);
+  });
+
+  it('costs 0.5 with military-logistics', () => {
+    const cost = getMovementStepCost(landUnit(), map as any, from, to, { completedTechs: ['military-logistics'] });
+    expect(cost).toBe(0.5);
+  });
+
+  it('costs 0.5 with railway-expansion', () => {
+    const cost = getMovementStepCost(landUnit(), map as any, from, to, { completedTechs: ['railway-expansion'] });
+    expect(cost).toBe(0.5);
+  });
+
+  it('does not stack: both techs together still cost 0.5, never 0.25', () => {
+    const cost = getMovementStepCost(landUnit(), map as any, from, to, { completedTechs: ['military-logistics', 'railway-expansion'] });
+    expect(cost).toBe(0.5);
+  });
+
+  it('river crossing without bridge-building still adds +1 even on a road', () => {
+    const riverMap = { ...map, rivers: [{ from, to }] };
+    const cost = getMovementStepCost(landUnit(), riverMap as any, from, to, { completedTechs: [] });
+    expect(cost).toBe(2);
+  });
+
+  it('does not affect naval or air units (negative)', () => {
+    const navalCost = getMovementStepCost(worker({ type: 'galley' as Unit['type'] }), map as any, from, to, { completedTechs: [] });
+    expect(navalCost).toBe(Infinity); // hills is not ocean/coast — road never applies to naval domain
+  });
+});
+
+describe('gps-navigation terrain-cost override', () => {
+  const hillsMap = {
+    width: 5,
+    height: 5,
+    wrapsHorizontally: false,
+    rivers: [] as any[],
+    tiles: {
+      '1,0': tile({ coord: { q: 1, r: 0 }, terrain: 'hills', hasRoad: false, owner: 'player' }),
+    },
+  };
+  const from = { q: 0, r: 0 };
+  const to = { q: 1, r: 0 };
+
+  it('ignores hills extra cost in own territory with the tech', () => {
+    const cost = getMovementStepCost(worker({ type: 'warrior' as Unit['type'] }), hillsMap as any, from, to, { completedTechs: ['gps-navigation'] });
+    expect(cost).toBe(1);
+  });
+
+  it('does not apply in foreign territory (negative)', () => {
+    const foreignMap = {
+      ...hillsMap,
+      tiles: { '1,0': { ...hillsMap.tiles['1,0'], owner: 'rival' } },
+    };
+    const cost = getMovementStepCost(worker({ type: 'warrior' as Unit['type'] }), foreignMap as any, from, to, { completedTechs: ['gps-navigation'] });
+    expect(cost).toBe(2); // normal hills cost
+  });
+});
+
+describe('save-compat: legacy tiles without hasRoad', () => {
+  it('normalizes cleanly and behaves as no-road', () => {
+    const legacyTile = tile({ hasRoad: undefined, roadTurnsLeft: undefined });
+    expect(legacyTile.hasRoad).toBeUndefined();
+    expect(getRoadBlockerReason(legacyTile, ['road-building'], 'player')).toBe('none');
+    const cost = getMovementStepCost(
+      { ...worker({}), type: 'warrior' as Unit['type'] },
+      { width: 1, height: 1, wrapsHorizontally: false, rivers: [], tiles: { '0,0': legacyTile } } as any,
+      { q: -1, r: 0 },
+      { q: 0, r: 0 },
+      { completedTechs: [] },
+    );
+    expect(cost).toBe(1); // grassland base cost, no road discount applied
+  });
+});

--- a/tests/systems/tech-yield-system.test.ts
+++ b/tests/systems/tech-yield-system.test.ts
@@ -13,6 +13,8 @@ import {
   getTerrainTechYieldBonus,
   getMaintenanceDiscountMultiplier,
   getLowestCityScienceBonus,
+  getRoadTileTechGold,
+  getConnectedCityTechGold,
 } from '@/systems/tech-yield-system';
 import { TECH_YIELD_MODIFIERS, TECH_COST_DISCOUNTS, getFoundingBonusFood } from '@/systems/tech-yield-definitions';
 import { TECH_TREE } from '@/systems/tech-definitions';
@@ -438,5 +440,45 @@ describe('MR6: foodFromScience (genomics)', () => {
     const withoutGenomics = calculateCityYields(city, map, undefined, []);
     const withoutGenomicsAgain = calculateCityYields(city, map, undefined, []);
     expect(withoutGenomics.food).toBe(withoutGenomicsAgain.food);
+  });
+});
+
+describe('MR7: getRoadTileTechGold (postal-service)', () => {
+  it('is a no-op without the tech', () => {
+    expect(getRoadTileTechGold([], 7)).toBe(0);
+  });
+
+  it('grants +1 gold per owned road tile', () => {
+    expect(getRoadTileTechGold(['postal-service'], 4)).toBe(4);
+  });
+
+  it('caps at +10 regardless of road tile count', () => {
+    expect(getRoadTileTechGold(['postal-service'], 25)).toBe(10);
+  });
+});
+
+describe('MR7: getConnectedCityTechGold (courier-network / colonial-railways / transcontinental-rail)', () => {
+  it('is a no-op without any of the techs', () => {
+    expect(getConnectedCityTechGold([], 3)).toBe(0);
+  });
+
+  it('is a no-op for an unconnected city count of zero', () => {
+    expect(getConnectedCityTechGold(['courier-network', 'colonial-railways'], 0)).toBe(0);
+  });
+
+  it('courier-network alone grants +1 gold per connected city', () => {
+    expect(getConnectedCityTechGold(['courier-network'], 3)).toBe(3);
+  });
+
+  it('colonial-railways stacks with courier-network for +3 gold per connected city', () => {
+    expect(getConnectedCityTechGold(['courier-network', 'colonial-railways'], 2)).toBe(6);
+  });
+
+  it('transcontinental-rail requires railway-expansion too before it stacks in', () => {
+    expect(getConnectedCityTechGold(['courier-network', 'colonial-railways', 'transcontinental-rail'], 1)).toBe(3);
+    expect(getConnectedCityTechGold(
+      ['courier-network', 'colonial-railways', 'transcontinental-rail', 'railway-expansion'],
+      1,
+    )).toBe(5);
   });
 });


### PR DESCRIPTION
## Summary
- Implements the road system end-to-end per issue #466: `HexTile.hasRoad` overlay, `build_road` worker action (Road Building tech-gated, 2-turn build / 1-turn with Road Corps NP), movement discount, rendering, AI, and the ten dependent tech/national-project effects.
- Movement: road tiles cost 1 (0.5 with Military Logistics **or** Railway Expansion — capped, does not stack per `.claude/rules/game-balance.md`); rivers still add +1 without Bridge Building; GPS Navigation ignores hills/forest cost in own territory.
- Rendering: roads draw as lines between hex centers (same technique as rivers), including wrapped ghost tiles and fog-of-war memory (`LastSeenTilePresentation.hasRoad`).
- AI: idle workers path toward and build roads connecting disconnected cities to the capital — one road-builder per civ per turn, via a new BFS connectivity helper (`getCitiesConnectedToCapital`).
- Income: Postal Service (+1 gold/owned road tile, capped at +10), Courier Network / Colonial Railways / Transcontinental Rail (stacking gold per road-connected city), and Highway Network's flat empire-wide bonus.
- Re-texts the five affected tech unlock strings and updates the movement-stacking inventory table in `.claude/rules/game-balance.md`.
- `HexTile.hasRoad`/`roadTurnsLeft`/`roadOwner` are optional — legacy saves default falsy with no migration needed.

## Test plan
- [x] `bash scripts/run-with-mise.sh yarn build` — tsc + vite build, 0 errors
- [x] `bash scripts/run-with-mise.sh yarn test` — 350/350 test files, 5290 tests passing (incl. new `road-system.test.ts`, `road-network.test.ts`, road AI fixtures in `ai-tactics.test.ts`, road tech-yield cases in `tech-yield-system.test.ts`, road renderer smoke tests in `hex-renderer.test.ts`)
- [x] Movement-stacking negative test: Military Logistics + Railway Expansion together still cost 0.5, never 0.25
- [x] BFS connectivity: wrap-around maps and disconnected islands (negative)
- [x] `national-project-balance.test.ts` / `wonder-definitions.test.ts` still green

Closes #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)