### PR TITLE
fix: balance starts and skip eliminated hot-seat players

### DIFF
--- a/docs/superpowers/plans/2026-07-05-issue-439-start-placement-elimination.md
+++ b/docs/superpowers/plans/2026-07-05-issue-439-start-placement-elimination.md
@@ -786,4 +786,3 @@ gh pr create --base main --head codex/issue-439-root-causes \
 - Preview and creation share helpers rather than duplicate algorithms.
 - Exact failure and terminal-state precedence are specified.
 - Commands cover TypeScript (`build`) and runtime behavior (`test`).
-

--- a/docs/superpowers/plans/2026-07-05-issue-439-start-placement-elimination.md
+++ b/docs/superpowers/plans/2026-07-05-issue-439-start-placement-elimination.md
@@ -1,0 +1,789 @@
+# Issue #439 Start Placement and Elimination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make geographic map starts honestly selectable between balanced and historical policies, choose AI civilizations with awareness of the whole roster, and atomically eliminate defeated civilizations so hot-seat never hands them another turn.
+
+**Architecture:** Keep map geography independent from start policy. A pure placement module selects valid separated sites and then assigns civilizations; a separate pure roster module chooses deterministic, geographically diverse AI opponents. A canonical civilization-elimination transition owns all cleanup, while state-aware turn helpers and a two-phase privacy handoff derive the next human from post-simulation state.
+
+**Tech Stack:** TypeScript, DOM UI, seeded deterministic algorithms, Vitest, Vite.
+
+---
+
+## Reviewed implementation decisions
+
+The approved design was reviewed against the current code and tightened in these ways:
+
+1. `findStartPositions` remains a compatibility wrapper for generated-map callers, but all game creation calls a new `placeCivilizationStarts` API returning a discriminated `StartPlacementResult`. Balanced failure is data, not an implicit short result or uncaught setup exception.
+2. Site selection uses bounded deterministic branch-and-bound over a candidate shortlist after farthest-point attempts. The bound is explicit and tested; it never weakens the nine-hex invariant.
+3. Civilization assignment is solved by exhaustive permutation only after sites are fixed. With the supported maximum of eight civilizations, `8!` is bounded and preserves the soft historical-affinity contract.
+4. AI preview and actual game creation call the same `selectAIRoster` helper. UI cannot promise one roster while creation silently chooses another.
+5. Setup errors are returned through `onError` callbacks and rendered in-place. Existing selections remain intact.
+6. Elimination cleanup is immutable and returns exact metadata. City capture emits `civ:eliminated` only from that metadata, avoiding a second scan of final state.
+7. Hot-seat handoff has two explicit phases: anonymous privacy overlay, then identified recipient. Completed-round code cannot interpolate a provisional civilization name.
+8. Domination resolution precedes `all-humans-eliminated`; a surviving major civilization remains the winner when one exists.
+9. Legacy geographic saves normalize to `historical`, while all newly created geographic games default to `balanced`. No loaded unit or city moves.
+
+## File map
+
+- Modify `src/core/types.ts`: placement mode, terminal reason, setup fields, and typed placement failure.
+- Create `src/systems/start-placement-system.ts`: candidate quality, balanced selection, historical placement, assignment, diagnostics.
+- Create `tests/systems/start-placement-system.test.ts`: spacing, deterministic assignment, historical anchors, impossible-map failure.
+- Create `src/systems/ai-roster-selection.ts`: shared deterministic roster-aware AI choice and preview diagnostics.
+- Create `tests/systems/ai-roster-selection.test.ts`: determinism, catalog-order independence, uniqueness, partial-roster scoring.
+- Modify `src/systems/map-generator.ts`: expose geographic anchors and use strict placement compatibility behavior.
+- Modify `tests/systems/map-generator.test.ts`: prevent regression to silent close fallback.
+- Modify `src/core/game-state.ts`: resolve placement mode, use shared roster/placement helpers, persist mode, return setup errors.
+- Modify `tests/core/game-state.test.ts`: creation integration and exact requested AI roster.
+- Modify `src/ui/campaign-setup.ts`: geographic placement cards, shared roster preview, historical warning and confirmation.
+- Modify `tests/ui/campaign-setup.test.ts`: live solo setup click-through.
+- Modify `src/ui/hotseat-setup.ts`: independent AI count, placement stage, final review, warning and confirmation.
+- Modify `tests/ui/hotseat-setup.test.ts`: live staged flow and exact config.
+- Modify `src/storage/save-manager.ts`: migration for placement mode and terminal reason.
+- Modify `tests/storage/save-manager.test.ts`: legacy migration without relocation.
+- Create `src/systems/civilization-elimination-system.ts`: canonical immutable actor cleanup.
+- Create `tests/systems/civilization-elimination-system.test.ts`: complete cleanup, negative boundary, idempotence.
+- Modify `src/systems/city-capture-system.ts`: compose elimination and emit from transition metadata.
+- Modify `tests/systems/city-capture-system.test.ts`: occupy/raze/non-human parity and exactly-once event.
+- Modify `src/core/turn-cycling.ts`: state-aware active-human helpers.
+- Modify `tests/core/turn-cycling.test.ts`: pre-founding, skip, wrap, and round-completion semantics.
+- Modify `src/ui/turn-handoff.ts`: anonymous preparation state and late recipient binding.
+- Modify `tests/ui/turn-handoff.test.ts`: no stale identity and correct reveal.
+- Create `src/core/hotseat-outcome.ts`: post-simulation recipient and terminal resolution.
+- Create `tests/core/hotseat-outcome.test.ts`: domination precedence and no-human defeat.
+- Modify `src/ui/victory-panel.ts`: victory/defeat outcome presentation.
+- Modify `tests/ui/victory-panel.test.ts`: AI victory and all-human defeat copy.
+- Modify `src/main.ts`: two-phase handoff, post-transaction recipient, state-aware round completion, setup error rendering.
+- Modify `tests/main.integration.test.ts`: live handoff recomputation and terminal-save restoration.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result | Persisted result |
+|---|---|---|---|
+| New Earth setup | Select Earth | Balanced placement is selected and described as guaranteed separation | `startPlacementMode: 'balanced'` |
+| Earth + True Start + crowded roster | Press Start | Warning names the minimum distance; first press confirms risk | No game is created yet |
+| Confirmed crowded True Start | Press Start Crowded Historical Game | Game begins at exact known anchors | `startPlacementMode: 'historical'` |
+| Two hot-seat humans on Large Earth | Choose one AI | Review shows exactly one roster-aware AI, not six | Config has two humans plus one AI |
+| Balanced placement cannot fit roster | Press Start | Setup remains open with actionable reduce-roster/change-map error | No partial save/state |
+| Human loses final city | Capture resolves | Defeated civ’s remaining active pieces disappear and elimination is logged | Civ retained as historical `isEliminated` record |
+| Later human seat was eliminated | Current human ends turn | Handoff skips eliminated identity | Next active seat persisted |
+| AI eliminates provisional next human during round simulation | Simulation completes | Anonymous overlay reveals the actual survivor only afterward | Post-simulation recipient persisted |
+| No human survives | Simulation completes or save loads | Blocking Defeat panel appears; no handoff | `gameOverReason: 'all-humans-eliminated'` |
+| One major civ survives | Turn resolves or save loads | Winner sees Victory; defeated human viewer sees Defeat | `gameOverReason: 'domination'`, winner retained |
+
+## Misleading UI Risks
+
+- “Balanced” is shown only when the strict placement engine will enforce all pairwise distances.
+- True Start warning derives from the exact preview roster and anchor/fallback result used by creation.
+- Generated maps do not expose a meaningless historical option.
+- AI count is a chosen count and never inferred from map capacity.
+- AI roster preview is deterministic from the same seed/config inputs as game creation.
+- Anonymous handoff contains no next-player name, color, civilization icon, or accessibility label before post-simulation resolution.
+- Defeat is not mislabeled Victory when the winner is an AI or another hot-seat participant.
+- A civilization with zero cities before founding remains active; only `isEliminated` controls seat eligibility.
+
+## Interaction Replay Checklist
+
+- [ ] Start solo Earth setup; verify Balanced default and opponent count remain independently selectable.
+- [ ] Switch to True Start with a crowded roster; verify one confirmation press is required and the second starts.
+- [ ] Switch to a generated map; verify placement cards and historical warning disappear.
+- [ ] Run hot-seat setup with two humans and one AI; verify final review and exact resulting seat count.
+- [ ] Trigger a synthetic balanced placement failure; verify selections remain and no state is persisted.
+- [ ] Capture a final city with remaining defender units/cargo/spy/diplomacy references; verify complete cleanup.
+- [ ] End a turn with an eliminated later seat; verify the handoff skips it.
+- [ ] During completed-round simulation eliminate the provisional recipient; verify no stale identity appears.
+- [ ] Eliminate all humans; verify Defeat survives save/reload.
+- [ ] Load a legacy geographic save; verify existing coordinates are unchanged and placement is labeled Historical.
+
+---
+
+### Task 1: Persisted types and legacy normalization
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Modify: `src/storage/save-manager.ts`
+- Modify: `tests/storage/save-manager.test.ts`
+
+- [ ] **Step 1: Write failing migration tests**
+
+Add cases that load stripped legacy fixtures:
+
+```ts
+it('labels legacy geographic games historical without moving state', () => {
+  const legacy = makeSave({ mapScript: 'earth' });
+  delete legacy.state.startPlacementMode;
+  const beforeUnits = structuredClone(legacy.state.units);
+  const beforeCities = structuredClone(legacy.state.cities);
+
+  const loaded = normalizeLoadedState(legacy.state);
+
+  expect(loaded.startPlacementMode).toBe('historical');
+  expect(loaded.units).toEqual(beforeUnits);
+  expect(loaded.cities).toEqual(beforeCities);
+});
+
+it('infers domination for legacy terminal saves with a winner', () => {
+  const legacy = makeState({ gameOver: true, winner: 'rome' });
+  delete legacy.gameOverReason;
+  expect(normalizeLoadedState(legacy).gameOverReason).toBe('domination');
+});
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/storage/save-manager.test.ts
+```
+
+- [ ] **Step 3: Add the model**
+
+Add:
+
+```ts
+export type StartPlacementMode = 'balanced' | 'historical';
+export type GameOverReason = 'domination' | 'all-humans-eliminated';
+```
+
+Add optional `startPlacementMode` to setup configs, persisted optional `startPlacementMode` and `gameOverReason` to `GameState`, and preserve fields in config normalization.
+
+- [ ] **Step 4: Normalize only missing legacy fields**
+
+```ts
+const geographic = state.mapScript === 'earth'
+  || state.mapScript === 'old-world'
+  || state.mapScript === 'new-world';
+state.startPlacementMode ??= geographic ? 'historical' : 'balanced';
+if (state.gameOver && state.winner && !state.gameOverReason) {
+  state.gameOverReason = 'domination';
+}
+```
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/storage/save-manager.test.ts
+git add src/core/types.ts src/storage/save-manager.ts tests/storage/save-manager.test.ts
+git commit -m "feat(setup): persist start placement policy"
+```
+
+### Task 2: Strict start-placement engine
+
+**Files:**
+- Create: `src/systems/start-placement-system.ts`
+- Create: `tests/systems/start-placement-system.test.ts`
+- Modify: `src/systems/map-generator.ts`
+- Modify: `tests/systems/map-generator.test.ts`
+
+- [ ] **Step 1: Write exact regression and semantic-boundary tests**
+
+Tests must cover:
+
+```ts
+const result = placeCivilizationStarts({
+  map: largeEarth,
+  civilizationTypeIds: ['england', 'germany', 'rome'],
+  mapScript: 'earth',
+  mapSize: 'large',
+  mode: 'balanced',
+  seed: 'issue-439',
+});
+expect(result.ok).toBe(true);
+if (result.ok) {
+  expect(allPairwiseDistances(result.positions, largeEarth.width)).toSatisfy(
+    distances => distances.every(distance => distance >= MIN_MAJOR_CIV_START_DISTANCE),
+  );
+}
+```
+
+Also prove exact historical anchors, anchorless fallback validity, determinism, unchanged selected site set under civilization order, and a synthetic map with no nine-hex solution returning:
+
+```ts
+{ ok: false, reason: 'insufficient-separated-sites', requested: 3, available: 2 }
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/start-placement-system.test.ts tests/systems/map-generator.test.ts
+```
+
+- [ ] **Step 3: Expose anchor lookup without exposing mutable tables**
+
+In `map-generator.ts`:
+
+```ts
+export function getGeographicStartAnchor(
+  script: GeographicMapScript,
+  size: MapSize,
+  civilizationTypeId: string,
+): HexCoord | null {
+  const coord = GEO_START_TABLES[script]?.[size]?.[civilizationTypeId];
+  return coord ? { ...coord } : null;
+}
+```
+
+- [ ] **Step 4: Implement pure candidates and quality**
+
+Export:
+
+```ts
+interface StartCandidate {
+  coord: HexCoord;
+  quality: number;
+  tieRank: number;
+}
+
+export type StartPlacementResult =
+  | { ok: true; positions: HexCoord[]; assignments: StartAssignment[]; minimumDistance: number | null; fallbackCivilizationIds: string[] }
+  | { ok: false; reason: 'insufficient-separated-sites'; requested: number; available: number };
+```
+
+Candidate validity must reuse map passability/terrain rules, exclude polar rows, require local workable terrain, and sort by `tieRank` then coordinate to remove object-order dependence.
+
+- [ ] **Step 5: Implement strict balanced site selection**
+
+For each seeded candidate as first site, repeatedly choose the candidate maximizing:
+
+```ts
+[minimumDistanceToSelected, minimumQualityAfterAdd, totalQualityAfterAdd, tieRank]
+```
+
+Discard candidates with distance below nine. Keep the best complete solution. If greedy cannot complete, search a quality-limited deterministic conflict graph with a visited-node cap of 100,000. Return failure at the cap or exhausted graph; never append a close fallback.
+
+- [ ] **Step 6: Assign sites after selection**
+
+Enumerate site permutations and minimize total wrapped distance from known geographic anchors. Anchorless civilizations contribute neutral cost plus tie rank. The position array must remain aligned with input civilization IDs.
+
+- [ ] **Step 7: Implement historical mode**
+
+Reserve valid exact anchors first. Select valid unoccupied fallback sites for missing anchors deterministically, maximizing distance from all reserved sites. Exact anchors may be under nine; fallback cannot collide. Return `minimumDistance` and `fallbackCivilizationIds`.
+
+- [ ] **Step 8: Keep compatibility wrapper strict**
+
+Make `findStartPositions` delegate to balanced placement and throw a diagnostic error only for its legacy array-returning API. New creation code in Task 4 consumes the discriminated result directly.
+
+- [ ] **Step 9: Run GREEN, seed sweep, and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/start-placement-system.test.ts tests/systems/map-generator.test.ts
+git add src/systems/start-placement-system.ts src/systems/map-generator.ts tests/systems/start-placement-system.test.ts tests/systems/map-generator.test.ts
+git commit -m "feat(map): enforce strict balanced start placement"
+```
+
+### Task 3: Roster-aware AI selection
+
+**Files:**
+- Create: `src/systems/ai-roster-selection.ts`
+- Create: `tests/systems/ai-roster-selection.test.ts`
+
+- [ ] **Step 1: Write failing roster tests**
+
+Cover uniqueness, exact count, same seed determinism, shuffled-catalog invariance, humans plus previously chosen AIs in every scoring step, and the issue-439 roster:
+
+```ts
+const oldRoster = ['germany', 'rome'];
+const selected = selectAIRoster({
+  definitions: shuffledDefinitions,
+  humanCivilizationIds: ['england'],
+  count: 2,
+  mapScript: 'earth',
+  mapSize: 'large',
+  placementMode: 'historical',
+  seed: 'issue-439',
+});
+expect(minimumAnchorDistance(['england', ...selected.ids])).toBeGreaterThan(
+  minimumAnchorDistance(['england', ...oldRoster]),
+);
+```
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/ai-roster-selection.test.ts
+```
+
+- [ ] **Step 3: Implement one shared selector**
+
+```ts
+export interface AIRosterSelection {
+  civilizationTypeIds: string[];
+  minimumHistoricalDistance: number | null;
+  fallbackCivilizationTypeIds: string[];
+}
+```
+
+Sort definitions by ID before scoring. At each step maximize minimum anchor distance, then total distance, then seeded rank. Use deterministic virtual fallback coordinates for anchorless definitions so they are neither infinitely attractive nor treated as colocated.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/ai-roster-selection.test.ts
+git add src/systems/ai-roster-selection.ts tests/systems/ai-roster-selection.test.ts
+git commit -m "feat(ai): select opponents with roster awareness"
+```
+
+### Task 4: Wire roster and placement into game creation
+
+**Files:**
+- Modify: `src/core/game-state.ts`
+- Modify: `tests/core/game-state.test.ts`
+
+- [ ] **Step 1: Write failing creation tests**
+
+Prove new Earth games persist Balanced by default, supplied Historical preserves anchors, requested AI count is exact, and impossible placement returns an actionable `GameCreationError` without partial state.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/core/game-state.test.ts
+```
+
+- [ ] **Step 3: Centralize map generation and placement**
+
+Extract a private helper returning:
+
+```ts
+type PreparedMap = {
+  map: GameMap;
+  starts: HexCoord[];
+  placementMode: StartPlacementMode;
+};
+```
+
+Resolve geographic default to Balanced for new games. Generated scripts force Balanced. Call `guaranteeStartResources` only after final assigned starts.
+
+- [ ] **Step 4: Use shared AI roster selection**
+
+Solo creation selects the exact requested count through `selectAIRoster`. Hot-seat creation accepts configured seats from the reviewed setup and validates duplicates/capacity.
+
+- [ ] **Step 5: Surface typed setup failure**
+
+Introduce:
+
+```ts
+export class GameCreationError extends Error {
+  readonly code = 'start-placement-failed';
+}
+```
+
+UI callbacks catch only this expected error and remain open; unexpected errors continue to propagate/log.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/core/game-state.test.ts tests/systems/start-placement-system.test.ts tests/systems/ai-roster-selection.test.ts
+git add src/core/game-state.ts tests/core/game-state.test.ts
+git commit -m "feat(game): create campaigns from reviewed starts"
+```
+
+### Task 5: Solo setup policy and truthful warning
+
+**Files:**
+- Modify: `src/ui/campaign-setup.ts`
+- Modify: `tests/ui/campaign-setup.test.ts`
+
+- [ ] **Step 1: Write click-through tests**
+
+Prove Earth defaults Balanced, generated maps hide placement controls, True Start preview uses shared roster data, a crowded preview requires two explicit actions, and callback config contains the placement mode.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/campaign-setup.test.ts
+```
+
+- [ ] **Step 3: Add placement cards with the UI kit**
+
+Use `createGameButton` for every new action. Do not use raw buttons. Render:
+
+- `Balanced (Recommended)` — “Separated viable starts; historical regions are soft preferences.”
+- `True Start` — “Exact known homelands; nearby civilizations may begin close together.”
+
+Hide the block for generated maps and reset the mode to Balanced.
+
+- [ ] **Step 4: Bind preview and confirmation**
+
+Recompute `selectAIRoster` when civ, map, size, count, or mode changes. In crowded Historical mode, first Start click changes CTA to `Start Crowded Historical Game`; the next click with unchanged inputs starts. Any input change clears confirmation.
+
+- [ ] **Step 5: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/campaign-setup.test.ts
+git add src/ui/campaign-setup.ts tests/ui/campaign-setup.test.ts
+git commit -m "feat(ui): expose balanced and true starts"
+```
+
+### Task 6: Hot-seat AI count and final review
+
+**Files:**
+- Modify: `src/ui/hotseat-setup.ts`
+- Modify: `tests/ui/hotseat-setup.test.ts`
+
+- [ ] **Step 1: Write full-flow failing tests**
+
+Click through every stage and prove:
+
+- geographic placement stage defaults Balanced;
+- AI count defaults one and is bounded by `capacity - humans`;
+- two humans plus one AI yields exactly three seats;
+- review names selected humans and shared AI preview;
+- True Start warning/confirmation appears only below nine;
+- Back preserves choices.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/hotseat-setup.test.ts
+```
+
+- [ ] **Step 3: Add state and stages**
+
+Track `selectedPlacementMode` and `aiCount`. Stage order is:
+
+```text
+size -> geography -> placement (geographic only) -> challenge
+-> humans -> AI count -> names -> civilization picks -> review
+```
+
+The challenge stage remains because it controls AI behavior and is orthogonal to AI count.
+
+- [ ] **Step 4: Replace silent fill with reviewed roster**
+
+Delete `aiCount = max - playerCount`. In review, call `selectAIRoster` with chosen humans and append exactly the selected count to the config passed to `onComplete`.
+
+- [ ] **Step 5: Render review and historical confirmation**
+
+Show map, mode, humans, AI roster, fallback list, and historical minimum distance. Require the same two-step confirmation contract as solo setup when below nine.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/hotseat-setup.test.ts
+git add src/ui/hotseat-setup.ts tests/ui/hotseat-setup.test.ts
+git commit -m "feat(hotseat): review explicit AI roster"
+```
+
+### Task 7: Canonical civilization elimination
+
+**Files:**
+- Create: `src/systems/civilization-elimination-system.ts`
+- Create: `tests/systems/civilization-elimination-system.test.ts`
+
+- [ ] **Step 1: Build a dense failing fixture**
+
+The defeated actor must own a city-free civilization, normal unit, transport and cargo, spy records, relationships, wars, treaties, embargo membership, defensive-league membership, pending request, and opponent-AI records. Assert:
+
+- all owned units are absent from `state.units`;
+- `civilization.units` is empty and `isEliminated` true;
+- references from every other actor/global collection are scrubbed;
+- input state remains unchanged;
+- repeated call returns `{ eliminated: false }`;
+- a civ with another city is untouched.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/civilization-elimination-system.test.ts
+```
+
+- [ ] **Step 3: Implement immutable transition**
+
+Return:
+
+```ts
+export type CivilizationEliminationResult =
+  | { state: GameState; eliminated: false }
+  | {
+      state: GameState;
+      eliminated: true;
+      civId: string;
+      eliminatedBy: string;
+      removedUnitIds: string[];
+      removedSpyIds: string[];
+    };
+```
+
+Validate actor existence, `!isEliminated`, and `cities.length === 0`. Clone only modified branches. Remove all owned units in one set-based pass so transports and cargo disappear atomically. Scrub diplomacy, espionage, embargo, league, requests, and opponent-AI collections using their typed fields.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/civilization-elimination-system.test.ts
+git add src/systems/civilization-elimination-system.ts tests/systems/civilization-elimination-system.test.ts
+git commit -m "feat(civ): centralize elimination cleanup"
+```
+
+### Task 8: Compose elimination with all city-capture paths
+
+**Files:**
+- Modify: `src/systems/city-capture-system.ts`
+- Modify: `tests/systems/city-capture-system.test.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Cover final-city Occupy and Raze, another-city negative case, human and non-human capturers, remaining-unit cleanup, and exactly one `civ:eliminated` event from the returned transition.
+
+- [ ] **Step 2: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-capture-system.test.ts
+```
+
+- [ ] **Step 3: Compose transition after ownership mutation**
+
+Extend `MajorCityCaptureResult` with optional elimination metadata. Occupy and raze call `eliminateCivilization` after removing the city from the previous owner. `emitMajorCityCaptureEvents` emits only when metadata exists; remove final-state rescanning and direct `isEliminated` assignments.
+
+- [ ] **Step 4: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/city-capture-system.test.ts tests/systems/civilization-elimination-system.test.ts
+git add src/systems/city-capture-system.ts tests/systems/city-capture-system.test.ts
+git commit -m "fix(capture): atomically eliminate defeated civilizations"
+```
+
+### Task 9: State-aware hot-seat cycling and terminal outcome
+
+**Files:**
+- Modify: `src/core/turn-cycling.ts`
+- Create: `src/core/hotseat-outcome.ts`
+- Modify: `tests/core/turn-cycling.test.ts`
+- Create: `tests/core/hotseat-outcome.test.ts`
+
+- [ ] **Step 1: Write failing active-seat tests**
+
+Prove zero-city non-eliminated seats remain active, eliminated seats are skipped in configured order, wrap is deterministic, and eliminating a later seat makes the current seat round-complete.
+
+- [ ] **Step 2: Write failing outcome tests**
+
+Prove normal domination wins before no-human defeat, no active humans with multiple AI survivors produces `winner: null`, and a surviving next human is selected from post-simulation state.
+
+- [ ] **Step 3: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/core/turn-cycling.test.ts tests/core/hotseat-outcome.test.ts
+```
+
+- [ ] **Step 4: Implement pure state-aware helpers**
+
+```ts
+getActiveHumanPlayers(state: GameState): HotSeatPlayer[];
+getNextActiveHumanPlayerId(state: GameState, currentSlotId: string): string | null;
+isActiveHumanRoundComplete(state: GameState, currentSlotId: string): boolean;
+```
+
+Filter only by configured human seat plus existing non-eliminated civilization. Preserve original configured indexes for “later this round” semantics.
+
+- [ ] **Step 5: Implement post-round resolution**
+
+```ts
+resolveHotSeatPostSimulation(
+  state: GameState,
+  previousHumanId: string,
+): { state: GameState; nextHumanId: string | null };
+```
+
+First preserve existing domination if `gameOver/winner` is already set. Then detect a single major survivor for domination. Only afterward apply `all-humans-eliminated`. Otherwise select the next active human and persist `currentPlayer`.
+
+- [ ] **Step 6: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/core/turn-cycling.test.ts tests/core/hotseat-outcome.test.ts
+git add src/core/turn-cycling.ts src/core/hotseat-outcome.ts tests/core/turn-cycling.test.ts tests/core/hotseat-outcome.test.ts
+git commit -m "fix(hotseat): derive turns from surviving humans"
+```
+
+### Task 10: Two-phase handoff and correct terminal panel
+
+**Files:**
+- Modify: `src/ui/turn-handoff.ts`
+- Modify: `tests/ui/turn-handoff.test.ts`
+- Modify: `src/ui/victory-panel.ts`
+- Modify: `tests/ui/victory-panel.test.ts`
+- Modify: `src/main.ts`
+- Modify: `tests/main.integration.test.ts`
+
+- [ ] **Step 1: Write handoff and outcome UI tests**
+
+Prove an anonymous controller contains no civ/player identity, `setRecipient` reveals only the authoritative recipient, Defeat renders for AI domination/all-human loss, and default victory behavior stays compatible.
+
+- [ ] **Step 2: Write live integration regressions**
+
+Stub the completed-round transaction so it eliminates the provisional next human. Assert `main.ts` binds the actual survivor after the transaction. Add no-active-human and terminal-save load assertions.
+
+- [ ] **Step 3: Run RED**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/turn-handoff.test.ts tests/ui/victory-panel.test.ts tests/main.integration.test.ts
+```
+
+- [ ] **Step 4: Add anonymous-to-recipient controller**
+
+Allow:
+
+```ts
+showTurnHandoff(state, { recipient: null, onReady }): TurnHandoffController
+controller.setRecipient(authoritativeState, nextHumanId, playerName)
+```
+
+Before binding, visible and accessibility text says only `Preparing next turn…`; the Ready action is disabled. After binding, render the existing pass-to identity and enable Ready.
+
+- [ ] **Step 5: Generalize terminal presentation**
+
+Keep `showVictoryPanel` as the compatibility export but accept:
+
+```ts
+{ outcome: 'victory' | 'defeat'; reason: GameOverReason; winnerName?: string }
+```
+
+Defeat copy must distinguish domination by another civ from all humans eliminated.
+
+- [ ] **Step 6: Rewire `main.ts`**
+
+Intermediate handoff uses current state-aware helpers. Completed-round handoff opens anonymous, runs the transaction, calls `resolveHotSeatPostSimulation`, persists that state, then either binds the authoritative recipient or closes the overlay and shows Defeat. Replace config-only `isRoundComplete`. Catch `GameCreationError` in setup launchers and route it to setup’s in-place error surface.
+
+- [ ] **Step 7: Run GREEN and commit**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/ui/turn-handoff.test.ts tests/ui/victory-panel.test.ts tests/main.integration.test.ts tests/core/hotseat-outcome.test.ts
+git add src/ui/turn-handoff.ts src/ui/victory-panel.ts src/main.ts tests/ui/turn-handoff.test.ts tests/ui/victory-panel.test.ts tests/main.integration.test.ts
+git commit -m "fix(hotseat): reveal recipients after simulation"
+```
+
+### Task 11: Policy checks, browser replay, and inline code review
+
+- [ ] **Step 1: Run source-policy checks**
+
+```bash
+scripts/check-src-rule-violations.sh \
+  src/core/types.ts src/core/game-state.ts src/core/turn-cycling.ts src/core/hotseat-outcome.ts \
+  src/storage/save-manager.ts src/systems/map-generator.ts src/systems/start-placement-system.ts \
+  src/systems/ai-roster-selection.ts src/systems/civilization-elimination-system.ts \
+  src/systems/city-capture-system.ts src/ui/campaign-setup.ts src/ui/hotseat-setup.ts \
+  src/ui/turn-handoff.ts src/ui/victory-panel.ts src/main.ts
+```
+
+- [ ] **Step 2: Run all targeted tests together**
+
+```bash
+./scripts/run-with-mise.sh yarn test --run \
+  tests/storage/save-manager.test.ts tests/systems/map-generator.test.ts \
+  tests/systems/start-placement-system.test.ts tests/systems/ai-roster-selection.test.ts \
+  tests/core/game-state.test.ts tests/ui/campaign-setup.test.ts tests/ui/hotseat-setup.test.ts \
+  tests/systems/civilization-elimination-system.test.ts tests/systems/city-capture-system.test.ts \
+  tests/core/turn-cycling.test.ts tests/core/hotseat-outcome.test.ts \
+  tests/ui/turn-handoff.test.ts tests/ui/victory-panel.test.ts tests/main.integration.test.ts
+```
+
+- [ ] **Step 3: Run build and full suite**
+
+```bash
+./scripts/run-with-mise.sh yarn build
+./scripts/run-with-mise.sh yarn test
+```
+
+- [ ] **Step 4: Replay both setup modes and terminal paths in the browser**
+
+Run `./scripts/run-with-mise.sh yarn dev`, use the in-app browser, follow the Interaction Replay Checklist, and capture screenshots of Hot-seat final review and a crowded True Start warning.
+
+- [ ] **Step 5: Inspect committed and uncommitted changes**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD
+git diff
+```
+
+- [ ] **Step 6: Inline review checklist**
+
+Review every changed path for:
+
+- strict distance invariant with no hidden fallback;
+- deterministic ordering independent of object/catalog order;
+- preview/creation data consistency;
+- immutable and complete actor cleanup;
+- no stale handoff identity or privacy leak;
+- domination precedence and correct defeat labeling;
+- legacy-save non-mutation;
+- test assertions through production/live paths, not helper-only coverage;
+- UI-kit button compliance and 44px touch targets;
+- no direct player-specific hardcoding in hot-seat paths.
+
+Fix every finding, rerun affected targeted tests, build, and full suite.
+
+- [ ] **Step 7: Final review commit if required**
+
+```bash
+git add <reviewed-files>
+git commit -m "fix(issue-439): address inline review findings"
+```
+
+### Task 12: Publish the pull request
+
+- [ ] **Step 1: Verify branch state**
+
+```bash
+git status --short --branch
+git log --oneline origin/main..HEAD
+```
+
+- [ ] **Step 2: Push**
+
+```bash
+git push -u origin codex/issue-439-root-causes
+```
+
+- [ ] **Step 3: Create ready PR**
+
+The PR body must:
+
+- link and close issue #439;
+- explain balanced versus True Start behavior;
+- explain explicit roster-aware AI count;
+- describe canonical elimination and post-simulation handoff;
+- list targeted tests, build, full suite, policy checks, and browser replay;
+- include setup screenshots.
+
+```bash
+gh pr create --base main --head codex/issue-439-root-causes \
+  --title "fix: balance starts and skip eliminated hot-seat players" \
+  --body-file /tmp/issue-439-pr.md
+```
+
+## Plan self-review
+
+### Specification coverage
+
+| Approved contract | Implemented by |
+|---|---|
+| Geography independent from placement | Tasks 1, 2, 4, 5, 6 |
+| Strict nine-hex balanced spacing | Task 2 |
+| Exact historical opt-in and warning | Tasks 2, 5, 6 |
+| Roster-aware AI and explicit count | Tasks 3, 4, 6 |
+| No partial state on placement failure | Tasks 2, 4, 5, 6 |
+| Complete canonical elimination | Tasks 7, 8 |
+| State-aware human cycling | Task 9 |
+| Post-simulation authoritative recipient | Tasks 9, 10 |
+| Persistent defeat and correct panel | Tasks 1, 9, 10 |
+| Legacy saves preserve coordinates | Task 1 |
+| Full policy/targeted/build/suite/browser verification | Task 11 |
+
+### Test quality review
+
+- Exact reported England/Germany/Rome failure has a regression.
+- Every conjunctive rule has negative coverage: another city prevents elimination; only a historical map does not imply Historical mode; only one close pair triggers warning; zero cities alone does not skip a seat.
+- UI tests click the live controls and assert callback/presentation, not just helper return values.
+- Human and non-human capture paths share integration coverage.
+- Determinism tests shuffle catalog order and repeat seeds.
+- Save tests assert both new metadata and unchanged coordinates.
+- Handoff tests inspect visible and accessibility text for privacy.
+
+### Implementation completeness review
+
+- No placeholder function or pseudocode remains in the production task list.
+- Every new source file has a mirrored test.
+- Every UI state mutation has an immediate visible assertion.
+- Preview and creation share helpers rather than duplicate algorithms.
+- Exact failure and terminal-state precedence are specified.
+- Commands cover TypeScript (`build`) and runtime behavior (`test`).
+

--- a/docs/superpowers/specs/2026-07-05-issue-439-start-placement-elimination-design.md
+++ b/docs/superpowers/specs/2026-07-05-issue-439-start-placement-elimination-design.md
@@ -1,0 +1,479 @@
+# Issue 439 Start Placement and Elimination Design
+
+**Date:** 2026-07-05
+
+**Issue:** [#439 — Bugs wife found](https://github.com/a1flecke/conquestoria/issues/439)
+
+**Status:** Approved design
+
+## Summary
+
+Issue 439 contains two related early-game failures from a hot-seat campaign:
+
+1. A large Earth game placed London, Berlin, and Rome close enough for one human civilization to conquer another within the opening turns.
+2. After the defeated human lost the final city and remaining units, hot-seat handoff continued giving that eliminated civilization turns.
+
+The fixes must address the underlying contracts rather than special-case the reported civilizations:
+
+- Geographic map shape and start-placement policy become separate choices.
+- Balanced placement guarantees minimum separation and viable starts.
+- Exact historical placement remains available as an explicit, honestly described mode.
+- AI civilization selection becomes aware of the selected humans, map, placement mode, and other AI choices.
+- Major-civilization elimination becomes one canonical state transition.
+- Hot-seat turn cycling derives active players from authoritative game state after all relevant simulation.
+
+## Root Cause Analysis
+
+### Geographic starts bypass the spacing invariant
+
+`findStartPositions` enforces `MIN_MAJOR_CIV_START_DISTANCE` only for positions chosen by its greedy fallback. Known civilization entries in the Earth, Old World, and New World start tables are accepted first and explicitly bypass the minimum.
+
+The current large Earth table places:
+
+- England at `(41, 15)`
+- Germany at `(46, 14)`
+- Rome at `(44, 17)`
+
+Their wrapped hex distances are 5, 5, and 3. This matches the reported London/Berlin/Rome cluster. The game nevertheless displays setup guidance that balanced starts prevent adjacent rivals, without explaining that the default Earth path ignores that guarantee.
+
+### One map choice combines two incompatible promises
+
+The current `earth`, `old-world`, and `new-world` scripts define both:
+
+- geographic terrain and resource layout; and
+- exact civilization-specific starting coordinates.
+
+Those concerns must be independent. A recognizable Earth map can support balanced starts, while a player who explicitly wants true historical starts can accept their inherent density.
+
+Modern Civilization games expose ordinary Earth and True Start Location Earth as separate experiences. General start allocation first creates sufficiently separated regions and then applies civilization biases. Civilization I's true-start Earth map did not eliminate European crowding; contemporary descriptions explicitly note that crowding enabled immediate settler or chariot conquest. Conquestoria should preserve true starts as an option without treating their compromises as the default balanced experience.
+
+### Large hot-seat maps preserve or increase roster density
+
+Hot-seat setup currently interprets map capacity as a target. After the humans choose civilizations, it automatically appends enough AI civilizations to fill every remaining slot. Two humans on a large map therefore receive six AI opponents.
+
+The AI list is populated in civilization-definition order, without considering:
+
+- selected human civilizations;
+- historical start proximity;
+- map script;
+- placement mode; or
+- proximity among selected AI civilizations.
+
+Increasing map size therefore does not necessarily increase breathing room. It can add more opponents and select a geographically clustered roster.
+
+### Elimination state is not part of turn cycling
+
+The shared city-capture path correctly sets `Civilization.isEliminated` when the final city is removed. Hot-seat cycling still reads only the static `HotSeatConfig.players` list. `getHumanPlayers`, `getNextPlayer`, and `isRoundComplete` cannot observe elimination.
+
+The completed-round handoff also computes `nextSlotId` before AI and world simulation. Even a state-aware pre-simulation choice could become stale if the expected next human is eliminated during the hidden simulation.
+
+### Elimination is only a flag, not a complete lifecycle transition
+
+The final-city capture path can leave remaining units and linked records behind. Once turn cycling correctly skips the owner, those units would become inert map blockers. Diplomacy, espionage, treaty, transport-cargo, and opponent-planning state can also retain references to an actor the game considers eliminated.
+
+The rule is already encoded in `Civilization.isEliminated`: losing the final city eliminates a major civilization. The mutation must apply that rule atomically across all owned state.
+
+## Goals
+
+1. Guarantee at least 9 wrapped hexes between every major-civilization start in balanced placement.
+2. Keep Earth, Old World, and New World geography available without forcing exact historical starts.
+3. Keep exact known historical starts as an explicit placement mode.
+4. Select AI civilizations deterministically with awareness of humans, map, placement mode, and the partial AI roster.
+5. Let hot-seat users choose AI count independently of human count and map capacity.
+6. Prevent balanced generation from silently accepting an invalid close fallback.
+7. Make final-city loss a canonical, actor-complete elimination transition.
+8. Ensure eliminated humans never receive another handoff.
+9. End a hot-seat campaign cleanly when no active human civilizations remain.
+10. Preserve existing saves and accurately describe the placement semantics under which they were created.
+
+## Non-Goals
+
+- Rebalancing combat strength, city defenses, or AI aggression.
+- Changing the fixed historical anchor tables themselves except to correct independently verified bad coordinates.
+- Guaranteeing fair spacing in exact historical mode.
+- Adding team starts, allied starts, or online multiplayer.
+- Changing the nine-hex balanced-start constant.
+- Removing historical civilization identity from geographic maps.
+
+## Domain Model
+
+### Placement mode
+
+Add:
+
+```ts
+export type StartPlacementMode = 'balanced' | 'historical';
+```
+
+`SoloSetupConfig` and `HotSeatConfig` accept an optional `startPlacementMode`. New setup UI always supplies it. Direct callers default as follows:
+
+- Geographic scripts (`earth`, `old-world`, `new-world`): `balanced`
+- Generated scripts (`balanced`, `single-continent`, legacy `procedural`): `balanced`
+
+`GameState` persists the resolved mode. Save normalization assigns:
+
+- missing mode + geographic map: `historical`
+- missing mode + generated map: `balanced`
+
+This migration records how legacy geographic games were actually created; it does not move existing units or cities.
+
+### Game-over reason
+
+Add a persisted terminal reason:
+
+```ts
+export type GameOverReason = 'domination' | 'all-humans-eliminated';
+```
+
+New terminal transitions populate `gameOverReason`. Save normalization infers `domination` when a legacy save has `gameOver === true` and a winner. `all-humans-eliminated` permits `winner === null` when multiple AI civilizations remain.
+
+### Static setup versus authoritative activity
+
+`HotSeatConfig.players` remains the immutable record of configured seats. It is not the source of current turn eligibility.
+
+An active human is a configured human player whose civilization:
+
+- still exists in `state.civilizations`; and
+- does not have `isEliminated === true`.
+
+Do not infer elimination from `cities.length === 0`; every civilization begins before founding its first city.
+
+## Start Placement Architecture
+
+### Separate geography from placement
+
+`MapScript` continues to choose terrain and geographic layout. `StartPlacementMode` chooses how major civilizations enter that map.
+
+For geographic maps:
+
+- `balanced` selects anonymous fair sites, then assigns civilizations with historical anchors used as soft preferences.
+- `historical` uses exact anchors for known civilizations and balanced fallback sites for unknown or custom civilizations.
+
+For generated maps, placement is always balanced.
+
+### Balanced candidate generation
+
+A candidate start must:
+
+- exist on the map;
+- be valid passable founding terrain;
+- remain outside excluded polar rows where applicable;
+- have workable terrain in its two-hex neighborhood; and
+- satisfy any map-specific candidate constraint, such as the generated single continent.
+
+Each candidate receives deterministic quality data:
+
+- immediate workable-tile count;
+- local terrain fertility/yield score;
+- expansion-room score; and
+- stable seeded tie rank.
+
+Distance and quality are separate concerns. Quality may rank two feasible solutions, but it can never override minimum distance.
+
+### Balanced site selection
+
+Select the requested number of anonymous sites before assigning civilizations.
+
+1. Run deterministic multi-start farthest-point selection.
+2. At each step, discard candidates within 9 wrapped hexes of any chosen site.
+3. Rank remaining candidates lexicographically by:
+   - minimum distance to chosen sites;
+   - weakest selected-site quality after adding the candidate;
+   - total selected-site quality; and
+   - seeded stable tie rank.
+4. Keep the best complete solution across starts.
+5. If greedy multi-start cannot complete, use bounded deterministic backtracking over the remaining conflict graph.
+6. If no complete solution exists, return an explicit placement failure.
+
+Balanced placement must never substitute a closer `bestFallback`. Game creation handles failure as a setup error and does not create a partial state.
+
+### Civilization-to-site assignment
+
+After balanced sites are fixed, assign civilizations to them.
+
+- A known civilization on a geographic map has a historical anchor.
+- Assignment cost is wrapped distance from that anchor to the candidate site.
+- Unknown and custom civilizations use a neutral cost plus deterministic tie rank.
+- Enumerate site permutations for the maximum supported roster of eight and choose the minimum total cost.
+- Ties resolve deterministically from the game seed and civilization ID.
+
+This preserves recognizable affinity where the spacing contract permits it. Historical affinity is a soft objective; it never changes the selected sites or weakens spacing.
+
+### Historical placement
+
+Known civilizations receive exact table anchors.
+
+Unknown, custom, or out-of-region civilizations receive deterministic balanced fallback sites selected against all already claimed exact anchors and other fallback sites. A fallback must use a valid unoccupied tile, but exact known anchors are allowed to violate the balanced spacing minimum.
+
+Setup must compute the actual minimum pairwise distance for the final historical roster. A result below 9 is a visible warning, not a hidden condition.
+
+## Roster-Aware AI Selection
+
+AI selection is a shared seeded helper used by solo and hot-seat creation.
+
+Inputs:
+
+- playable civilization definitions;
+- selected human civilization IDs;
+- requested AI count;
+- map script and size;
+- placement mode;
+- map candidate/anchor data where relevant; and
+- game seed.
+
+Invariants:
+
+- never duplicate a selected human or AI civilization;
+- never exceed requested count or map capacity;
+- never depend on catalog iteration order for the final choice;
+- produce the same roster for the same inputs and seed.
+
+For geographic maps, construct the roster incrementally:
+
+1. Seed the selected set with all human historical anchors that exist.
+2. For each available AI candidate with an anchor, calculate:
+   - minimum anchor distance to the selected set;
+   - total anchor distance to the selected set; and
+   - seeded stable tie rank.
+3. Choose the candidate maximizing those values lexicographically.
+4. Repeat until the requested count is reached.
+5. Consider anchorless custom or out-of-region candidates through their deterministic fallback-site score rather than treating them as colocated or infinitely distant.
+
+For balanced placement, roster selection improves historical diversity while the independent site selector guarantees actual spacing. For historical placement, it directly chooses the least-crowded available exact roster.
+
+If selected humans already have historical anchors closer than 9, roster selection cannot hide or repair that fact. Historical setup surfaces the warning and requires explicit confirmation.
+
+## Setup Experience
+
+### Solo setup
+
+When a geographic map is selected, show placement cards:
+
+- **Balanced** — recommended; guarantees separated viable starts.
+- **True Start** — uses exact known homelands; close starts may occur.
+
+Existing opponent-count selection remains explicit. Before enabling Start Campaign in historical mode, compute the roster-aware AI preview and surface a warning when its minimum distance is below 9. Starting a crowded historical game requires an explicit confirmation action.
+
+### Hot-seat setup
+
+Use these stages:
+
+1. Map size
+2. Map geography
+3. Placement mode when a geographic map is selected
+4. Human-player count
+5. AI-opponent count, bounded by remaining map capacity
+6. Human names
+7. Human civilization choices
+8. Final review
+
+The final review shows:
+
+- map size and geography;
+- placement mode;
+- selected human civilizations;
+- requested AI count;
+- roster-aware AI civilization preview;
+- minimum pairwise historical distance in True Start mode;
+- which civilizations require fallback placement; and
+- a crowding warning when the minimum is below 9.
+
+Balanced mode does not show a false warning because actual placement is guaranteed. True Start requires an explicit “start crowded historical game” confirmation when warned.
+
+The default hot-seat AI count is one, not “fill every remaining slot.” The user can intentionally increase it up to capacity.
+
+### Failure handling
+
+Balanced site-selection failure:
+
+- does not construct or persist a partial `GameState`;
+- leaves setup choices intact;
+- shows an actionable message to reduce player count or choose another map/size; and
+- logs deterministic diagnostic details for development without exposing internal coordinates as the only user feedback.
+
+Historical missing-anchor fallback is not an error. The final review identifies it before game creation.
+
+## Canonical Major-Civilization Elimination
+
+Create a single shared transition used whenever a major civilization loses its final city.
+
+The transition:
+
+1. Verifies the civilization exists, is not already eliminated, and owns no remaining city.
+2. Sets `isEliminated: true` and preserves the civilization record for history, score, logs, and save compatibility.
+3. Removes all remaining owned units through canonical unit lifecycle operations.
+4. Removes transported cargo and linked transport state consistently.
+5. Removes or resolves owned spy and espionage records without leaving captives or missions attached to a dead actor.
+6. Clears opponent AI portfolios and assignments for the actor.
+7. Scrubs the actor from other civilizations' relationships, `atWarWith`, active treaties, embargoes, and defensive leagues as required by existing diplomacy lifecycle rules.
+8. Returns explicit transition metadata identifying removed entities and the eliminating actor.
+
+City capture composes this transition after ownership mutation when the previous owner has no cities. Human combat, AI combat, turn processing, occupation, and raze callers therefore share the same consequence.
+
+`civ:eliminated` is emitted from the returned transition metadata. Repeating capture/event processing against an already eliminated civilization is a no-op and does not re-emit.
+
+## State-Aware Hot-Seat Cycling
+
+Replace config-only cycling with state-aware pure helpers:
+
+- `getActiveHumanPlayers(state)`
+- `getNextActiveHumanPlayerId(state, currentSlotId): string | null`
+- `isActiveHumanRoundComplete(state, currentSlotId): boolean`
+
+Configured order remains authoritative among surviving humans.
+
+### Intermediate handoff
+
+When a human ends a turn and another active human remains later in the current round:
+
+- choose the next active human from current state;
+- never show or persist an eliminated recipient;
+- preserve existing privacy and autosave behavior.
+
+If eliminating a later human makes the current human the last active seat in configured order, the current turn completes the human round immediately.
+
+### Completed-round handoff
+
+Do not finalize `nextSlotId` before AI/world simulation.
+
+1. Enter a generic privacy overlay and suppress round presentation.
+2. Run the completed-round transaction.
+3. Apply AI/world mutations, including elimination.
+4. Resolve domination and all-human-elimination outcomes.
+5. Derive the next active human from the resulting authoritative state.
+6. Persist the completed state with that recipient.
+7. Populate the handoff UI with the correct surviving player's identity only after the recipient is known.
+
+This prevents a player eliminated during hidden AI simulation from appearing as the next handoff target.
+
+### No active humans
+
+If no active human remains:
+
+- set `gameOver = true`;
+- set `gameOverReason = 'all-humans-eliminated'`;
+- leave `winner = null` unless normal domination has identified one surviving civilization;
+- persist the terminal state; and
+- show a Defeat panel instead of a handoff.
+
+Normal domination takes precedence when exactly one major civilization with cities remains.
+
+## End-State Presentation
+
+Generalize the existing terminal panel contract to support:
+
+- victory for the current human winner;
+- defeat when another civilization wins domination; and
+- defeat when all human civilizations are eliminated before AI domination resolves.
+
+The panel remains blocking, identifies the outcome and turn, and offers New Game. It must not label an AI winner as “Victory!” to a defeated human viewer.
+
+Loading a terminal save immediately restores the correct terminal panel from `gameOver`, `winner`, and `gameOverReason`.
+
+## Testing Strategy
+
+### Map placement
+
+Add regressions that prove:
+
+- the large Earth England/Germany/Rome roster in balanced mode has every pair at least 9 wrapped hexes apart;
+- every geographic script, supported size, and supported player count returns the requested number of balanced starts;
+- representative seed sweeps preserve pairwise spacing;
+- identical seed/configuration produces identical sites and assignments;
+- all selected tiles are valid and have workable surroundings;
+- resource guarantees apply around final assigned sites;
+- historical mode preserves exact known anchors;
+- unknown/custom historical starts use valid deterministic fallback sites;
+- a synthetic impossible map returns explicit failure rather than a close fallback;
+- historical affinity assignment never changes the already valid balanced site set.
+
+### Roster selection
+
+Prove:
+
+- no duplicate or human-selected civilization appears in the AI roster;
+- requested AI count is honored;
+- selection is deterministic;
+- catalog order changes do not change a seeded result;
+- for the reported humans/map, roster-aware selection has a strictly better minimum historical distance than the old first-available roster;
+- partial roster scoring accounts for distance from humans and among AIs;
+- anchorless candidates receive deterministic fallback scoring.
+
+### Setup UI
+
+Prove:
+
+- geographic maps default to Balanced;
+- generated maps do not show an irrelevant historical-placement choice;
+- AI count is independent from human count and bounded by capacity;
+- final hot-seat config contains the exact selected counts and placement mode;
+- final review displays roster and fallback information;
+- only crowded True Start configurations show the warning;
+- crowded True Start cannot begin without explicit confirmation;
+- Balanced setup failure remains on setup with an actionable message;
+- all player-visible options remain reachable through the live setup flow.
+
+### Elimination
+
+Add shared-system and integration coverage for:
+
+- final-city occupation and raze by a human;
+- final-city capture by AI/non-human processing;
+- no elimination while another owned city remains;
+- remaining unit and cargo cleanup;
+- linked spy, diplomacy, treaty, embargo, league, and AI-plan cleanup;
+- immutable input state;
+- exactly-once elimination event emission;
+- idempotent repeated calls.
+
+### Hot-seat lifecycle
+
+Prove:
+
+- zero-city pre-founding humans remain active;
+- eliminated humans are skipped in configured order;
+- round completion changes correctly when a later seat is eliminated;
+- intermediate handoff never targets an eliminated seat;
+- completed-round simulation recomputes the recipient after an AI eliminates the provisional next human;
+- no-active-human state produces persistent Defeat rather than an invalid handoff;
+- domination still records and renders the actual winner;
+- loading terminal saves restores the correct outcome.
+
+### Verification
+
+Before PR creation:
+
+1. Run `scripts/check-src-rule-violations.sh` for every changed `src/` file.
+2. Run all mirrored tests for changed source files in one targeted Vitest invocation.
+3. Run relevant setup, capture, handoff, save migration, and terminal UI integration tests.
+4. Run the production build.
+5. Run the complete test suite.
+6. Exercise both setup modes and terminal outcomes in the browser.
+7. Capture setup screenshots for the PR.
+8. Inspect `git diff origin/main...HEAD` and the uncommitted diff in full.
+9. Perform an inline code review for correctness, state completeness, determinism, privacy, test fidelity, and misleading UI.
+10. Fix every finding and rerun affected verification before pushing.
+
+## Acceptance Criteria
+
+- A new Balanced large Earth game containing England, Germany, and Rome cannot place any pair within 9 wrapped hexes.
+- New geographic games default to Balanced placement.
+- True Start preserves exact known anchors and visibly warns before a crowded game begins.
+- AI rosters are deterministic, map-aware, human-aware, and partial-roster-aware.
+- Hot-seat map size no longer silently determines AI count.
+- Balanced generation never silently relaxes minimum spacing.
+- Losing the final city atomically eliminates the civilization and removes all remaining owned active state.
+- Eliminated humans never receive another hot-seat turn.
+- AI-round elimination cannot leave a stale handoff recipient.
+- A campaign with no active humans reaches a persistent Defeat state.
+- Legacy geographic saves load without relocation and are labeled historical.
+- Build, complete tests, targeted regressions, source-policy checks, browser verification, and final diff review all pass.
+
+## Research References
+
+- [Civilization VI Earth and True Start Location Earth](https://civilization.fandom.com/wiki/Earth_%28map%29_%28Civ6%29)
+- [Civilization VI starting biases and region allocation](https://civilization.fandom.com/wiki/Starting_bias_%28Civ6%29)
+- [Civilization V `AssignStartingPlots` API](https://modiki.civfanatics.com/index.php/AssignStartingPlots_%28Civ5_Type%29)
+- [Civilization I Earth start crowding](https://civilization.fandom.com/wiki/Earth_%28map%29_%28Civ1%29)
+- [Historical-start configuration and fallback practices](https://www.keengamer.com/articles/guides/the-ultimate-civ-6-settings-for-historical-starts/)
+- [Constructive strategy-game map generation with explicit fairness constraints](https://www.sciencedirect.com/science/article/abs/pii/S1875952124002544)

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -1,4 +1,4 @@
-import type { GameState, Civilization, Unit, HotSeatConfig, GameSettings, SoloSetupConfig, MapScript, GameMap, HexCoord, OpponentChallenge } from './types';
+import type { GameState, Civilization, Unit, HotSeatConfig, GameSettings, SoloSetupConfig, MapScript, GameMap, HexCoord, OpponentChallenge, StartPlacementMode } from './types';
 import { generateMap, findStartPositions, createRng, guaranteeStartResources } from '@/systems/map-generator';
 import { loadGeoMap } from '@/systems/geo-map-loader';
 import { EARTH_TILES, EARTH_START_POSITIONS, EARTH_RIVERS } from '@/systems/earth-map-data';
@@ -24,6 +24,8 @@ import { placeMinorCivs } from '@/systems/minor-civ-system';
 import { initializeEspionage } from '@/systems/espionage-system';
 import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presentation';
 import { createEmptyOpponentAIState } from './opponent-ai-state';
+import { placeCivilizationStarts } from '@/systems/start-placement-system';
+import { selectAIRoster } from '@/systems/ai-roster-selection';
 
 function hashSeed(s: string): number {
   let h = 0;
@@ -38,6 +40,53 @@ export const MAP_DIMENSIONS = {
   medium: { width: 50, height: 50, maxPlayers: 5 },
   large: { width: 80, height: 80, maxPlayers: 8 },
 } as const;
+
+export class GameCreationError extends Error {
+  readonly code = 'start-placement-failed';
+
+  constructor(
+    readonly requested: number,
+    readonly available: number,
+  ) {
+    super(
+      `Could not find ${requested} starts at least 9 hexes apart (${available} fit). `
+      + 'Reduce the roster or choose another map size.',
+    );
+    this.name = 'GameCreationError';
+  }
+}
+
+function resolveStartPlacementMode(
+  mapScript: MapScript,
+  requested?: StartPlacementMode,
+): StartPlacementMode {
+  const geographic = mapScript === 'earth' || mapScript === 'old-world' || mapScript === 'new-world';
+  return geographic ? (requested ?? 'balanced') : 'balanced';
+}
+
+function placeStartsOrThrow(
+  map: GameMap,
+  civilizationTypeIds: string[],
+  mapScript: MapScript,
+  mapSize: 'small' | 'medium' | 'large',
+  placementMode: StartPlacementMode,
+  seed: string,
+  candidateHexes?: Set<string>,
+): HexCoord[] {
+  const result = placeCivilizationStarts({
+    map,
+    civilizationTypeIds,
+    mapScript,
+    mapSize,
+    mode: placementMode,
+    seed,
+    candidateHexes,
+  });
+  if (!result.ok) {
+    throw new GameCreationError(result.requested, result.available);
+  }
+  return result.positions;
+}
 
 export function createDefaultSettings(
   actualSize: 'small' | 'medium' | 'large',
@@ -97,6 +146,7 @@ function normalizeSoloSetupConfig(
       settingsOverrides: arg1.settingsOverrides,
       customCivilizations: arg1.customCivilizations,
       mapScript: arg1.mapScript,
+      startPlacementMode: arg1.startPlacementMode,
       opponentChallenge: arg1.opponentChallenge,
     };
   }
@@ -127,6 +177,7 @@ export function createNewGame(
   const gameSeed = config.seed ?? `game-${Date.now()}`;
   const resolvedGameTitle = config.gameTitle.trim() || 'Solo Campaign';
   const mapScript: MapScript = config.mapScript ?? 'procedural';
+  const startPlacementMode = resolveStartPlacementMode(mapScript, config.startPlacementMode);
 
   // Determine civ types before map generation so findStartPositions can use real civ IDs
   const settings = createDefaultSettings(actualSize, {
@@ -134,13 +185,19 @@ export function createNewGame(
     customCivilizations: config.customCivilizations,
   });
   const playerCivDef = resolveCivDefinition({ settings }, config.civType ?? '');
-  const aiCivPool = [...getPlayableCivDefinitions(settings).filter(c => c.id !== (config.civType ?? ''))];
-  const civSelectRng = createRng(gameSeed + '-civ-select');
-  for (let i = aiCivPool.length - 1; i > 0; i--) {
-    const j = Math.floor(civSelectRng() * (i + 1));
-    [aiCivPool[i], aiCivPool[j]] = [aiCivPool[j], aiCivPool[i]];
-  }
-  const aiCivDefs = aiCivPool.slice(0, boundedOpponentCount);
+  const playableCivs = getPlayableCivDefinitions(settings);
+  const aiSelection = selectAIRoster({
+    definitions: playableCivs,
+    humanCivilizationTypeIds: [config.civType ?? 'generic'],
+    count: boundedOpponentCount,
+    mapScript,
+    mapSize: actualSize,
+    placementMode: startPlacementMode,
+    seed: gameSeed,
+  });
+  const aiCivDefs = aiSelection.civilizationTypeIds
+    .map(id => playableCivs.find(definition => definition.id === id))
+    .filter((definition): definition is NonNullable<typeof definition> => definition !== undefined);
   const allCivIds = ['player', ...aiCivDefs.map((_, index) => `ai-${index + 1}`)];
   const playerStartBonus = getDiplomacyStartBonus(settings, config.civType);
 
@@ -153,15 +210,15 @@ export function createNewGame(
   switch (mapScript) {
     case 'earth':
       map = loadGeoMap(EARTH_TILES[actualSize], EARTH_RIVERS[actualSize], dims, true);
-      startPositions = findStartPositions(map, civTypeIds, 'earth', actualSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'earth', actualSize, startPlacementMode, gameSeed);
       break;
     case 'old-world':
       map = loadGeoMap(OLD_WORLD_TILES[actualSize], OLD_WORLD_RIVERS[actualSize], dims, false);
-      startPositions = findStartPositions(map, civTypeIds, 'old-world', actualSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'old-world', actualSize, startPlacementMode, gameSeed);
       break;
     case 'new-world':
       map = loadGeoMap(NEW_WORLD_TILES[actualSize], NEW_WORLD_RIVERS[actualSize], dims, false);
-      startPositions = findStartPositions(map, civTypeIds, 'new-world', actualSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'new-world', actualSize, startPlacementMode, gameSeed);
       break;
     case 'balanced': {
       const result = generateBalancedMap(dims.width, dims.height, gameSeed, civTypeIds.length);
@@ -172,12 +229,12 @@ export function createNewGame(
     case 'single-continent': {
       const result = generateContinentMap(dims.width, dims.height, gameSeed);
       map = result.map;
-      startPositions = findStartPositions(map, civTypeIds, 'single-continent', actualSize, result.continentHexes);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'single-continent', actualSize, startPlacementMode, gameSeed, result.continentHexes);
       break;
     }
     default: // 'procedural' and old saves
       map = generateMap(dims.width, dims.height, gameSeed);
-      startPositions = findStartPositions(map, civTypeIds, 'procedural', actualSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'procedural', actualSize, startPlacementMode, gameSeed);
       break;
   }
 
@@ -299,6 +356,7 @@ export function createNewGame(
     pendingDiplomacyRequests: [],
     settings,
     mapScript,
+    startPlacementMode,
   };
 
   // Place minor civilizations
@@ -330,6 +388,7 @@ export function createHotSeatGame(
   const resolvedGameTitle = gameTitle?.trim() || 'Hot Seat Campaign';
   const dims = MAP_DIMENSIONS[config.mapSize];
   const mapScript: MapScript = config.mapScript ?? 'procedural';
+  const startPlacementMode = resolveStartPlacementMode(mapScript, config.startPlacementMode);
   const civTypeIds = config.players.map(p => p.civType);
 
   let map: GameMap;
@@ -338,15 +397,15 @@ export function createHotSeatGame(
   switch (mapScript) {
     case 'earth':
       map = loadGeoMap(EARTH_TILES[config.mapSize], EARTH_RIVERS[config.mapSize], dims, true);
-      startPositions = findStartPositions(map, civTypeIds, 'earth', config.mapSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'earth', config.mapSize, startPlacementMode, gameSeed);
       break;
     case 'old-world':
       map = loadGeoMap(OLD_WORLD_TILES[config.mapSize], OLD_WORLD_RIVERS[config.mapSize], dims, false);
-      startPositions = findStartPositions(map, civTypeIds, 'old-world', config.mapSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'old-world', config.mapSize, startPlacementMode, gameSeed);
       break;
     case 'new-world':
       map = loadGeoMap(NEW_WORLD_TILES[config.mapSize], NEW_WORLD_RIVERS[config.mapSize], dims, false);
-      startPositions = findStartPositions(map, civTypeIds, 'new-world', config.mapSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'new-world', config.mapSize, startPlacementMode, gameSeed);
       break;
     case 'balanced': {
       const result = generateBalancedMap(dims.width, dims.height, gameSeed, civTypeIds.length);
@@ -357,12 +416,12 @@ export function createHotSeatGame(
     case 'single-continent': {
       const result = generateContinentMap(dims.width, dims.height, gameSeed);
       map = result.map;
-      startPositions = findStartPositions(map, civTypeIds, 'single-continent', config.mapSize, result.continentHexes);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'single-continent', config.mapSize, startPlacementMode, gameSeed, result.continentHexes);
       break;
     }
     default: // 'procedural' and old saves
       map = generateMap(dims.width, dims.height, gameSeed);
-      startPositions = findStartPositions(map, civTypeIds, 'procedural', config.mapSize);
+      startPositions = placeStartsOrThrow(map, civTypeIds, 'procedural', config.mapSize, startPlacementMode, gameSeed);
       break;
   }
 
@@ -459,6 +518,7 @@ export function createHotSeatGame(
     pendingDiplomacyRequests: [],
     settings,
     mapScript,
+    startPlacementMode,
   };
 
   // Place minor civilizations

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -1,9 +1,9 @@
 import type { GameState, Civilization, Unit, HotSeatConfig, GameSettings, SoloSetupConfig, MapScript, GameMap, HexCoord, OpponentChallenge, StartPlacementMode } from './types';
 import { generateMap, findStartPositions, createRng, guaranteeStartResources } from '@/systems/map-generator';
 import { loadGeoMap } from '@/systems/geo-map-loader';
-import { EARTH_TILES, EARTH_START_POSITIONS, EARTH_RIVERS } from '@/systems/earth-map-data';
-import { OLD_WORLD_TILES, OLD_WORLD_START_POSITIONS, OLD_WORLD_RIVERS } from '@/systems/old-world-map-data';
-import { NEW_WORLD_TILES, NEW_WORLD_START_POSITIONS, NEW_WORLD_RIVERS } from '@/systems/new-world-map-data';
+import { EARTH_TILES, EARTH_RIVERS } from '@/systems/earth-map-data';
+import { OLD_WORLD_TILES, OLD_WORLD_RIVERS } from '@/systems/old-world-map-data';
+import { NEW_WORLD_TILES, NEW_WORLD_RIVERS } from '@/systems/new-world-map-data';
 import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { generateContinentMap } from '@/systems/continent-map-generator';
 import { createUnit } from '@/systems/unit-system';
@@ -179,7 +179,7 @@ export function createNewGame(
   const mapScript: MapScript = config.mapScript ?? 'procedural';
   const startPlacementMode = resolveStartPlacementMode(mapScript, config.startPlacementMode);
 
-  // Determine civ types before map generation so findStartPositions can use real civ IDs
+  // Determine civ types before map generation so placement can use real civ IDs.
   const settings = createDefaultSettings(actualSize, {
     ...config.settingsOverrides,
     customCivilizations: config.customCivilizations,
@@ -229,12 +229,12 @@ export function createNewGame(
     case 'single-continent': {
       const result = generateContinentMap(dims.width, dims.height, gameSeed);
       map = result.map;
-      startPositions = placeStartsOrThrow(map, civTypeIds, 'single-continent', actualSize, startPlacementMode, gameSeed, result.continentHexes);
+      startPositions = findStartPositions(map, civTypeIds, 'single-continent', actualSize, result.continentHexes);
       break;
     }
     default: // 'procedural' and old saves
       map = generateMap(dims.width, dims.height, gameSeed);
-      startPositions = placeStartsOrThrow(map, civTypeIds, 'procedural', actualSize, startPlacementMode, gameSeed);
+      startPositions = findStartPositions(map, civTypeIds, 'procedural', actualSize);
       break;
   }
 
@@ -416,12 +416,12 @@ export function createHotSeatGame(
     case 'single-continent': {
       const result = generateContinentMap(dims.width, dims.height, gameSeed);
       map = result.map;
-      startPositions = placeStartsOrThrow(map, civTypeIds, 'single-continent', config.mapSize, startPlacementMode, gameSeed, result.continentHexes);
+      startPositions = findStartPositions(map, civTypeIds, 'single-continent', config.mapSize, result.continentHexes);
       break;
     }
     default: // 'procedural' and old saves
       map = generateMap(dims.width, dims.height, gameSeed);
-      startPositions = placeStartsOrThrow(map, civTypeIds, 'procedural', config.mapSize, startPlacementMode, gameSeed);
+      startPositions = findStartPositions(map, civTypeIds, 'procedural', config.mapSize);
       break;
   }
 

--- a/src/core/hotseat-outcome.ts
+++ b/src/core/hotseat-outcome.ts
@@ -1,0 +1,40 @@
+import type { GameState } from '@/core/types';
+import {
+  getActiveHumanPlayers,
+  getNextActiveHumanPlayerId,
+} from '@/core/turn-cycling';
+
+export interface HotSeatPostSimulationResult {
+  state: GameState;
+  nextHumanId: string | null;
+}
+
+export function resolveHotSeatPostSimulation(
+  state: GameState,
+  previousHumanId: string,
+): HotSeatPostSimulationResult {
+  if (state.gameOver) {
+    return {
+      state: state.gameOverReason || !state.winner
+        ? state
+        : { ...state, gameOverReason: 'domination' },
+      nextHumanId: null,
+    };
+  }
+  if (getActiveHumanPlayers(state).length === 0) {
+    return {
+      state: {
+        ...state,
+        gameOver: true,
+        winner: null,
+        gameOverReason: 'all-humans-eliminated',
+      },
+      nextHumanId: null,
+    };
+  }
+  const nextHumanId = getNextActiveHumanPlayerId(state, previousHumanId);
+  return {
+    state: nextHumanId ? { ...state, currentPlayer: nextHumanId } : state,
+    nextHumanId,
+  };
+}

--- a/src/core/turn-cycling.ts
+++ b/src/core/turn-cycling.ts
@@ -1,4 +1,4 @@
-import type { HotSeatConfig, HotSeatPlayer } from './types';
+import type { GameState, HotSeatConfig, HotSeatPlayer } from './types';
 
 export function getHumanPlayers(config: HotSeatConfig): HotSeatPlayer[] {
   return config.players.filter(p => p.isHuman);
@@ -18,4 +18,37 @@ export function getNextPlayer(config: HotSeatConfig, currentSlotId: string): str
 export function isRoundComplete(config: HotSeatConfig, currentSlotId: string): boolean {
   const humans = getHumanPlayers(config);
   return humans[humans.length - 1].slotId === currentSlotId;
+}
+
+export function getActiveHumanPlayers(state: GameState): HotSeatPlayer[] {
+  return (state.hotSeat?.players ?? []).filter(player => {
+    if (!player.isHuman) return false;
+    const civilization = state.civilizations[player.slotId];
+    return civilization !== undefined && civilization.isEliminated !== true;
+  });
+}
+
+export function getNextActiveHumanPlayerId(
+  state: GameState,
+  currentSlotId: string,
+): string | null {
+  const configured = state.hotSeat?.players ?? [];
+  const active = getActiveHumanPlayers(state);
+  if (active.length === 0) return null;
+  const currentIndex = configured.findIndex(player => player.slotId === currentSlotId);
+  const later = active.find(player =>
+    configured.findIndex(candidate => candidate.slotId === player.slotId) > currentIndex,
+  );
+  return (later ?? active[0]).slotId;
+}
+
+export function isActiveHumanRoundComplete(
+  state: GameState,
+  currentSlotId: string,
+): boolean {
+  const configured = state.hotSeat?.players ?? [];
+  const currentIndex = configured.findIndex(player => player.slotId === currentSlotId);
+  return !getActiveHumanPlayers(state).some(player =>
+    configured.findIndex(candidate => candidate.slotId === player.slotId) > currentIndex,
+  );
 }

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -1267,6 +1267,7 @@ export function processTurn(
     if (victorId !== null) {
       newState.gameOver = true;
       newState.winner = victorId;
+      newState.gameOverReason = 'domination';
     }
   }
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1018,6 +1018,9 @@ export type MapScript =
   | 'balanced'
   | 'single-continent';
 
+export type StartPlacementMode = 'balanced' | 'historical';
+export type GameOverReason = 'domination' | 'all-humans-eliminated';
+
 // --- Game Modes ---
 
 export type GameMode = 'solo' | 'hotseat';
@@ -1034,6 +1037,7 @@ export interface HotSeatConfig {
   mapSize: 'small' | 'medium' | 'large';
   /** Keep map generation fields in sync with SoloSetupConfig. */
   mapScript?: MapScript;
+  startPlacementMode?: StartPlacementMode;
   players: HotSeatPlayer[];
   customCivilizations?: CustomCivDefinition[];
 }
@@ -1048,6 +1052,7 @@ export interface SoloSetupConfig {
   seed?: string;
   customCivilizations?: CustomCivDefinition[];
   mapScript?: MapScript;
+  startPlacementMode?: StartPlacementMode;
 }
 
 export interface GameEvent {
@@ -1360,6 +1365,7 @@ export interface GameState {
   currentPlayer: string;     // civ ID whose turn it is
   gameOver: boolean;
   winner: string | null;
+  gameOverReason?: GameOverReason;
   settings: GameSettings;
   marketplace?: MarketplaceState;
   economyStatusByCiv?: Record<string, EconomyStatus>;
@@ -1387,6 +1393,7 @@ export interface GameState {
   pendingDiplomacyRequests?: PendingDiplomaticRequest[];
   territoryFrontiers?: Record<string, TerritoryFrontierState>;
   mapScript?: MapScript;  // undefined on old saves → treat as 'procedural'
+  startPlacementMode?: StartPlacementMode;
 }
 
 export interface GameSettings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -4319,6 +4319,7 @@ function showGameModeSelection(): void {
             // Merge: persisted A/V settings first, then per-game setup choices (e.g. beastsMode) win
             settingsOverrides: { ...getPersistedSettingsOverrides(), ...config.settingsOverrides },
             customCivilizations: config.customCivilizations,
+            seed: config.seed,
             mapScript: config.mapScript,
             startPlacementMode: config.startPlacementMode,
             opponentChallenge: config.opponentChallenge,

--- a/src/main.ts
+++ b/src/main.ts
@@ -116,7 +116,11 @@ import { visitVillage } from '@/systems/village-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs, getEffectiveTechCost } from '@/systems/tech-system';
-import { getNextPlayer, isRoundComplete } from '@/core/turn-cycling';
+import {
+  getNextActiveHumanPlayerId,
+  isActiveHumanRoundComplete,
+} from '@/core/turn-cycling';
+import { resolveHotSeatPostSimulation } from '@/core/hotseat-outcome';
 import {
   acknowledgeTurnHandoffSummary,
   showTurnHandoff,
@@ -3093,13 +3097,18 @@ function handleHexLongPress(rawCoord: HexCoord): void {
 }
 
 function handleVictoryIfNeeded(): boolean {
-  if (!gameState.gameOver || !gameState.winner) return false;
-  const winnerCiv = gameState.civilizations[gameState.winner];
-  const winnerName = winnerCiv?.name ?? gameState.winner;
+  if (!gameState.gameOver) return false;
+  const winnerCiv = gameState.winner
+    ? gameState.civilizations[gameState.winner]
+    : undefined;
+  const winnerName = winnerCiv?.name ?? gameState.winner ?? '';
+  const outcome = gameState.winner === gameState.currentPlayer ? 'victory' : 'defeat';
   setBlockingOverlay('victory');
   showVictoryPanel(uiLayer, {
     winnerName,
-    victoryType: 'Domination Victory',
+    victoryType: outcome === 'victory' ? 'Domination Victory' : 'Campaign Defeat',
+    outcome,
+    reason: gameState.gameOverReason ?? 'domination',
     turn: gameState.turn,
     onNewGame: () => {
       document.getElementById('victory-panel')?.remove();
@@ -3191,8 +3200,11 @@ async function beginHotSeatHandoff(
   completesRound: boolean,
 ): Promise<void> {
   const preSimulationState = gameState;
-  const nextSlotId = getNextPlayer(hotSeat, preSimulationState.currentPlayer);
-  const nextPlayer = hotSeat.players.find(player => player.slotId === nextSlotId);
+  const previousHumanId = preSimulationState.currentPlayer;
+  let resolvedNextSlotId = completesRound
+    ? null
+    : getNextActiveHumanPlayerId(preSimulationState, previousHumanId);
+  const nextPlayer = hotSeat.players.find(player => player.slotId === resolvedNextSlotId);
   closePirateWatersPanels(uiLayer);
   renderLoop.setSelectedPirateFactionId(null);
   audio.stopPirateAmbience('player-changed');
@@ -3202,15 +3214,16 @@ async function beginHotSeatHandoff(
   const controller = showTurnHandoff(
     uiLayer,
     preSimulationState,
-    nextSlotId,
-    nextPlayer?.name ?? 'Player',
+    resolvedNextSlotId,
+    resolvedNextSlotId ? (nextPlayer?.name ?? 'Player') : null,
     {
       initiallyReady: false,
       preparingLabel: 'Preparing next turn…',
       onReady: async summary => {
+        if (!resolvedNextSlotId) return;
         const acknowledgement = acknowledgeTurnHandoffSummary(
           gameState,
-          nextSlotId,
+          resolvedNextSlotId,
           summary,
         );
         gameState = acknowledgement.state;
@@ -3220,10 +3233,10 @@ async function beginHotSeatHandoff(
         } catch {
           acknowledgementFailed = true;
         }
-        releaseHandoffToViewer(nextSlotId);
+        releaseHandoffToViewer(resolvedNextSlotId);
         if (acknowledgement.playStrategicWarningAudio) {
           bus.emit('ai:strategic-warning-audio', {
-            viewerId: nextSlotId,
+            viewerId: resolvedNextSlotId,
             turn: summary.turn,
           });
         }
@@ -3255,7 +3268,13 @@ async function beginHotSeatHandoff(
   };
 
   if (!completesRound) {
-    gameState = { ...preSimulationState, currentPlayer: nextSlotId };
+    if (!resolvedNextSlotId) {
+      gameState = resolveHotSeatPostSimulation(preSimulationState, previousHumanId).state;
+      controller.remove();
+      handleVictoryIfNeeded();
+      return;
+    }
+    gameState = { ...preSimulationState, currentPlayer: resolvedNextSlotId };
     void persistIntermediateHandoff();
     return;
   }
@@ -3263,7 +3282,8 @@ async function beginHotSeatHandoff(
   const transaction = createCompletedRoundHandoffTransaction({
     initialState: preSimulationState,
     runCompletedRound: runCurrentCompletedRound,
-    prepareCompletedState: state => ({ ...state, currentPlayer: nextSlotId }),
+    prepareCompletedState: state =>
+      resolveHotSeatPostSimulation(state, previousHumanId).state,
     eventTarget: bus,
     adoptState: state => {
       gameState = state;
@@ -3279,7 +3299,14 @@ async function beginHotSeatHandoff(
   const persistCompletedHandoff = async (): Promise<void> => {
     const outcome = await transaction.persistCompletedRoundHandoff();
     if (outcome.status === 'ready') {
-      controller.setReady(outcome.state);
+      if (outcome.state.gameOver) {
+        controller.remove();
+        handleVictoryIfNeeded();
+        return;
+      }
+      resolvedNextSlotId = outcome.state.currentPlayer;
+      const recipient = hotSeat.players.find(player => player.slotId === resolvedNextSlotId);
+      controller.setRecipient(outcome.state, resolvedNextSlotId, recipient?.name ?? 'Player');
       return;
     }
     controller.setError(
@@ -3313,7 +3340,14 @@ async function beginHotSeatHandoff(
       );
       return;
     }
-    controller.setReady(outcome.state);
+    if (outcome.state.gameOver) {
+      controller.remove();
+      handleVictoryIfNeeded();
+      return;
+    }
+    resolvedNextSlotId = outcome.state.currentPlayer;
+    const recipient = hotSeat.players.find(player => player.slotId === resolvedNextSlotId);
+    controller.setRecipient(outcome.state, resolvedNextSlotId, recipient?.name ?? 'Player');
   };
   void simulate();
 }
@@ -3336,7 +3370,10 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
     const hotSeat = gameState.hotSeat;
 
     if (hotSeat) {
-      await beginHotSeatHandoff(hotSeat, isRoundComplete(hotSeat, gameState.currentPlayer));
+      await beginHotSeatHandoff(
+        hotSeat,
+        isActiveHumanRoundComplete(gameState, gameState.currentPlayer),
+      );
     } else {
       // --- Solo Mode ---
       const result = runCurrentCompletedRound(gameState);

--- a/src/main.ts
+++ b/src/main.ts
@@ -4043,6 +4043,11 @@ function enterCampaign(
   document.getElementById('save-panel')?.remove();
   gameState = state;
   migrateLegacySave();
+  if (gameState.gameOver) {
+    startGame();
+    handleVictoryIfNeeded();
+    return;
+  }
   if (!gameState.hotSeat) {
     startGame();
     showNotification(message, 'info');
@@ -4315,6 +4320,7 @@ function showGameModeSelection(): void {
             settingsOverrides: { ...getPersistedSettingsOverrides(), ...config.settingsOverrides },
             customCivilizations: config.customCivilizations,
             mapScript: config.mapScript,
+            startPlacementMode: config.startPlacementMode,
             opponentChallenge: config.opponentChallenge,
           });
           if (persistedSettings?.councilTalkLevel) {

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -769,6 +769,17 @@ export function normalizeLoadedState(state: GameState): NormalizedGameState {
   normalizedCityState.pirates = normalizePirateState(normalizedCityState);
   normalizedCityState.notificationLog = normalizeNotificationLog(normalizedCityState.notificationLog);
   normalizedCityState.idCounters = normalizeIdCounters(normalizedCityState);
+  const usesGeographicMap = normalizedCityState.mapScript === 'earth'
+    || normalizedCityState.mapScript === 'old-world'
+    || normalizedCityState.mapScript === 'new-world';
+  normalizedCityState.startPlacementMode ??= usesGeographicMap ? 'historical' : 'balanced';
+  if (
+    normalizedCityState.gameOver
+    && normalizedCityState.winner
+    && !normalizedCityState.gameOverReason
+  ) {
+    normalizedCityState.gameOverReason = 'domination';
+  }
   if (!isOpponentChallenge(normalizedCityState.opponentChallenge)) {
     delete normalizedCityState.opponentChallenge;
   }

--- a/src/systems/ai-roster-selection.ts
+++ b/src/systems/ai-roster-selection.ts
@@ -123,10 +123,11 @@ export function selectAIRoster(input: AIRosterSelectionInput): AIRosterSelection
     }
   }
 
+  const allCivilizationTypeIds = [...input.humanCivilizationTypeIds, ...selected];
   return {
     civilizationTypeIds: selected,
     minimumHistoricalDistance,
-    fallbackCivilizationTypeIds: selected
+    fallbackCivilizationTypeIds: allCivilizationTypeIds
       .filter(id => locationFor(id, input).fallback),
   };
 }

--- a/src/systems/ai-roster-selection.ts
+++ b/src/systems/ai-roster-selection.ts
@@ -1,0 +1,132 @@
+import type {
+  CivDefinition,
+  HexCoord,
+  MapScript,
+  StartPlacementMode,
+} from '@/core/types';
+import {
+  getGeographicStartAnchor,
+  getStartPositionDistance,
+  type GeographicMapScript,
+} from '@/systems/map-generator';
+
+export interface AIRosterSelectionInput {
+  definitions: readonly CivDefinition[];
+  humanCivilizationTypeIds: readonly string[];
+  count: number;
+  mapScript: MapScript;
+  mapSize: 'small' | 'medium' | 'large';
+  placementMode: StartPlacementMode;
+  seed: string;
+}
+
+export interface AIRosterSelection {
+  civilizationTypeIds: string[];
+  minimumHistoricalDistance: number | null;
+  fallbackCivilizationTypeIds: string[];
+}
+
+const MAP_WIDTHS = { small: 30, medium: 50, large: 80 } as const;
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function isGeographic(script: MapScript): script is GeographicMapScript {
+  return script === 'earth' || script === 'old-world' || script === 'new-world';
+}
+
+function virtualFallback(
+  civilizationTypeId: string,
+  input: AIRosterSelectionInput,
+): HexCoord {
+  const width = MAP_WIDTHS[input.mapSize];
+  const hash = stableHash(`${input.seed}:fallback:${civilizationTypeId}`);
+  return {
+    q: hash % width,
+    r: Math.floor(hash / width) % width,
+  };
+}
+
+function locationFor(
+  civilizationTypeId: string,
+  input: AIRosterSelectionInput,
+): { coord: HexCoord; fallback: boolean } {
+  const anchor = isGeographic(input.mapScript)
+    ? getGeographicStartAnchor(input.mapScript, input.mapSize, civilizationTypeId)
+    : null;
+  return anchor
+    ? { coord: anchor, fallback: false }
+    : { coord: virtualFallback(civilizationTypeId, input), fallback: true };
+}
+
+function distance(
+  a: HexCoord,
+  b: HexCoord,
+  input: AIRosterSelectionInput,
+): number {
+  return getStartPositionDistance({
+    width: MAP_WIDTHS[input.mapSize],
+    wrapsHorizontally: input.mapScript === 'earth' || !isGeographic(input.mapScript),
+  }, a, b);
+}
+
+export function selectAIRoster(input: AIRosterSelectionInput): AIRosterSelection {
+  const excluded = new Set(input.humanCivilizationTypeIds);
+  const available = [...input.definitions]
+    .filter(definition => !excluded.has(definition.id))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const selected: string[] = [];
+  const selectedLocations = input.humanCivilizationTypeIds.map(id => locationFor(id, input).coord);
+  const requested = Math.max(0, Math.min(input.count, available.length));
+
+  while (selected.length < requested) {
+    const next = available
+      .filter(definition => !selected.includes(definition.id))
+      .map(definition => {
+        const location = locationFor(definition.id, input).coord;
+        const distances = selectedLocations.map(existing => distance(location, existing, input));
+        return {
+          id: definition.id,
+          location,
+          minimum: distances.length > 0 ? Math.min(...distances) : Infinity,
+          total: distances.reduce((sum, value) => sum + value, 0),
+          tie: stableHash(`${input.seed}:roster:${definition.id}`),
+        };
+      })
+      .sort((a, b) =>
+        b.minimum - a.minimum
+        || b.total - a.total
+        || a.tie - b.tie
+        || a.id.localeCompare(b.id),
+      )[0];
+    if (!next) break;
+    selected.push(next.id);
+    selectedLocations.push(next.location);
+  }
+
+  let minimumHistoricalDistance: number | null = null;
+  if (selectedLocations.length > 1) {
+    minimumHistoricalDistance = Infinity;
+    for (let i = 0; i < selectedLocations.length; i++) {
+      for (let j = i + 1; j < selectedLocations.length; j++) {
+        minimumHistoricalDistance = Math.min(
+          minimumHistoricalDistance,
+          distance(selectedLocations[i], selectedLocations[j], input),
+        );
+      }
+    }
+  }
+
+  return {
+    civilizationTypeIds: selected,
+    minimumHistoricalDistance,
+    fallbackCivilizationTypeIds: selected
+      .filter(id => locationFor(id, input).fallback),
+  };
+}

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -22,6 +22,7 @@ import { executeUnitMove } from '@/systems/unit-movement-system';
 import { buildUnitOccupancy, getUnitIdsAtCoord } from '@/systems/unit-occupancy';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
+import { eliminateCivilization } from '@/systems/civilization-elimination-system';
 
 export type MajorCityCaptureDisposition = 'occupy' | 'raze';
 
@@ -30,6 +31,12 @@ export interface MajorCityCaptureResult {
   outcome: 'occupied' | 'razed';
   goldAwarded: number;
   territoryEvents: GameEvents['territory:tile-flipped'][];
+  elimination?: {
+    civId: string;
+    eliminatedBy: string;
+    removedUnitIds: string[];
+    removedSpyIds: string[];
+  };
 }
 
 export function emitMajorCityCaptureEvents(
@@ -53,13 +60,10 @@ export function emitMajorCityCaptureEvents(
 
   const previousOwnerBefore = before.civilizations[previousOwnerId];
   const previousOwnerAfter = result.state.civilizations[previousOwnerId];
-  if (
-    previousOwnerAfter?.cities.length === 0
-    && (previousOwnerBefore?.cities.length ?? 0) > 0
-  ) {
+  if (result.elimination) {
     bus.emit('civ:eliminated', {
-      civId: previousOwnerId,
-      eliminatedBy: newOwnerId,
+      civId: result.elimination.civId,
+      eliminatedBy: result.elimination.eliminatedBy,
     });
   } else if (
     previousOwnerBefore?.nearDefeat !== true
@@ -309,6 +313,7 @@ function buildCaptureResult(
   outcome: MajorCityCaptureResult['outcome'],
   goldAwarded: number,
   capturedCityId?: string,
+  elimination?: MajorCityCaptureResult['elimination'],
 ): MajorCityCaptureResult {
   const postWorkState = capturedCityId
     ? normalizeCityWorkAfterTerritoryChange(territoryResult.state, capturedCityId).state
@@ -322,6 +327,7 @@ function buildCaptureResult(
       postWorkState,
       territoryResult.resolutions,
     ),
+    elimination,
   };
 }
 
@@ -401,7 +407,6 @@ export function resolveMajorCityCapture(
             // nearDefeat flag: true when previous owner now has ≤ 1 city
             // Used by audio system and handoff payload computation
             nearDefeat: previousOwner.cities.filter(id => id !== cityId).length <= 1,
-            isEliminated: previousOwner.cities.filter(id => id !== cityId).length === 0,
           },
         } : {}),
         [newOwnerId]: {
@@ -417,12 +422,26 @@ export function resolveMajorCityCapture(
         newOwnerId,
       ),
     };
-    const territoryResult = recalculateTerritory(nextState, {
+    const elimination = eliminateCivilization(nextState, previousOwnerId, newOwnerId);
+    const stateAfterElimination = elimination.state;
+    const territoryResult = recalculateTerritory(stateAfterElimination, {
       reason: 'capture',
       preserveCurrentHolderOnTie: true,
     });
 
-    return buildCaptureResult(nextState, territoryResult, 'occupied', 0, cityId);
+    return buildCaptureResult(
+      stateAfterElimination,
+      territoryResult,
+      'occupied',
+      0,
+      cityId,
+      elimination.eliminated ? {
+        civId: elimination.civId,
+        eliminatedBy: elimination.eliminatedBy,
+        removedUnitIds: elimination.removedUnitIds,
+        removedSpyIds: elimination.removedSpyIds,
+      } : undefined,
+    );
   }
 
   const goldAwarded = computeRazeGold(city);
@@ -435,7 +454,6 @@ export function resolveMajorCityCapture(
         diplomacy: modifyRelationship(previousOwner.diplomacy, newOwnerId, -40),
         // nearDefeat flag: true when previous owner now has ≤ 1 city (raze path)
         nearDefeat: previousOwner.cities.filter(id => id !== cityId).length <= 1,
-        isEliminated: previousOwner.cities.filter(id => id !== cityId).length === 0,
       },
     } : {}),
     [newOwnerId]: {
@@ -453,12 +471,26 @@ export function resolveMajorCityCapture(
     civilizations: nextCivilizations,
     legendaryWonderProjects: removeLegendaryWonderProjectsForCity(state.legendaryWonderProjects, cityId),
   };
-  const territoryResult = recalculateTerritory(nextState, {
+  const elimination = eliminateCivilization(nextState, previousOwnerId, newOwnerId);
+  const stateAfterElimination = elimination.state;
+  const territoryResult = recalculateTerritory(stateAfterElimination, {
     reason: 'raze',
     preserveCurrentHolderOnTie: true,
   });
 
-  return buildCaptureResult(nextState, territoryResult, 'razed', goldAwarded, cityId);
+  return buildCaptureResult(
+    stateAfterElimination,
+    territoryResult,
+    'razed',
+    goldAwarded,
+    cityId,
+    elimination.eliminated ? {
+      civId: elimination.civId,
+      eliminatedBy: elimination.eliminatedBy,
+      removedUnitIds: elimination.removedUnitIds,
+      removedSpyIds: elimination.removedSpyIds,
+    } : undefined,
+  );
 }
 
 export function transferCapturedCityOwnership(
@@ -513,7 +545,8 @@ export function transferCapturedCityOwnership(
       },
     },
   };
-  return recalculateTerritory(nextState, {
+  const eliminatedState = eliminateCivilization(nextState, previousOwnerId, newOwnerId).state;
+  return recalculateTerritory(eliminatedState, {
     reason: 'capture',
     preserveCurrentHolderOnTie: true,
   }).state;

--- a/src/systems/civilization-elimination-system.ts
+++ b/src/systems/civilization-elimination-system.ts
@@ -111,6 +111,9 @@ export function eliminateCivilization(
     .filter(league => league.members.length >= 2);
   next.pendingDiplomacyRequests = (next.pendingDiplomacyRequests ?? [])
     .filter(request => request.fromCivId !== civId && request.toCivId !== civId);
+  if (next.pendingEvents) {
+    delete next.pendingEvents[civId];
+  }
 
   const removedSpyIds = Object.keys(next.espionage?.[civId]?.spies ?? {});
   if (next.espionage) {

--- a/src/systems/civilization-elimination-system.ts
+++ b/src/systems/civilization-elimination-system.ts
@@ -1,0 +1,169 @@
+import type {
+  AIStrategicPlan,
+  GameState,
+  MajorCivPlanPortfolio,
+} from '@/core/types';
+
+export type CivilizationEliminationResult =
+  | { state: GameState; eliminated: false }
+  | {
+      state: GameState;
+      eliminated: true;
+      civId: string;
+      eliminatedBy: string;
+      removedUnitIds: string[];
+      removedSpyIds: string[];
+    };
+
+function removeAssignedUnits(
+  plan: AIStrategicPlan | null,
+  removed: Set<string>,
+): AIStrategicPlan | null {
+  return plan
+    ? { ...plan, assignedUnitIds: plan.assignedUnitIds.filter(id => !removed.has(id)) }
+    : null;
+}
+
+function scrubPortfolio(
+  portfolio: MajorCivPlanPortfolio,
+  removed: Set<string>,
+): MajorCivPlanPortfolio {
+  return {
+    ...portfolio,
+    primaryPlan: removeAssignedUnits(portfolio.primaryPlan, removed),
+    defensePlansByCityId: Object.fromEntries(
+      Object.entries(portfolio.defensePlansByCityId).map(([id, plan]) => [
+        id,
+        removeAssignedUnits(plan, removed)!,
+      ]),
+    ),
+    upgradeRoutesByUnitId: Object.fromEntries(
+      Object.entries(portfolio.upgradeRoutesByUnitId)
+        .filter(([unitId]) => !removed.has(unitId)),
+    ),
+  };
+}
+
+export function eliminateCivilization(
+  state: GameState,
+  civId: string,
+  eliminatedBy: string,
+): CivilizationEliminationResult {
+  const civilization = state.civilizations[civId];
+  if (!civilization || civilization.isEliminated || civilization.cities.length > 0) {
+    return { state, eliminated: false };
+  }
+
+  const next = structuredClone(state);
+  const removedUnitIds = Object.values(next.units)
+    .filter(unit => unit.owner === civId)
+    .map(unit => unit.id);
+  const removedUnits = new Set(removedUnitIds);
+  for (const unitId of removedUnitIds) {
+    delete next.units[unitId];
+  }
+  next.civilizations[civId] = {
+    ...next.civilizations[civId],
+    units: [],
+    isEliminated: true,
+    nearDefeat: false,
+  };
+
+  for (const [otherId, other] of Object.entries(next.civilizations)) {
+    if (otherId === civId) continue;
+    const relationships = { ...other.diplomacy.relationships };
+    delete relationships[civId];
+    const satelliteSurveillanceTargets = { ...other.satelliteSurveillanceTargets };
+    delete satelliteSurveillanceTargets[civId];
+    next.civilizations[otherId] = {
+      ...other,
+      satelliteSurveillanceTargets,
+      diplomacy: {
+        ...other.diplomacy,
+        relationships,
+        atWarWith: other.diplomacy.atWarWith.filter(id => id !== civId),
+        treaties: other.diplomacy.treaties.filter(
+          treaty => treaty.civA !== civId && treaty.civB !== civId,
+        ),
+        events: other.diplomacy.events.filter(event => event.otherCiv !== civId),
+        vassalage: {
+          ...other.diplomacy.vassalage,
+          overlord: other.diplomacy.vassalage.overlord === civId
+            ? null
+            : other.diplomacy.vassalage.overlord,
+          vassals: other.diplomacy.vassalage.vassals.filter(id => id !== civId),
+          protectionTimers: other.diplomacy.vassalage.protectionTimers
+            .filter(timer => timer.attackerCivId !== civId),
+        },
+      },
+    };
+  }
+
+  next.embargoes = next.embargoes
+    .filter(embargo => embargo.targetCivId !== civId)
+    .map(embargo => ({
+      ...embargo,
+      participants: embargo.participants.filter(id => id !== civId),
+    }))
+    .filter(embargo => embargo.participants.length > 0);
+  next.defensiveLeagues = next.defensiveLeagues
+    .map(league => ({ ...league, members: league.members.filter(id => id !== civId) }))
+    .filter(league => league.members.length >= 2);
+  next.pendingDiplomacyRequests = (next.pendingDiplomacyRequests ?? [])
+    .filter(request => request.fromCivId !== civId && request.toCivId !== civId);
+
+  const removedSpyIds = Object.keys(next.espionage?.[civId]?.spies ?? {});
+  if (next.espionage) {
+    delete next.espionage[civId];
+    for (const espionage of Object.values(next.espionage)) {
+      for (const [spyId, spy] of Object.entries(espionage.spies)) {
+        if (spy.targetCivId !== civId) continue;
+        espionage.spies[spyId] = {
+          ...spy,
+          targetCivId: null,
+          targetCityId: null,
+          infiltrationCityId: null,
+          currentMission: null,
+          status: 'idle',
+          position: null,
+        };
+      }
+      espionage.detectedThreats = Object.fromEntries(
+        Object.entries(espionage.detectedThreats ?? {})
+          .filter(([, threat]) => threat.foreignCivId !== civId),
+      );
+      espionage.activeInterrogations = Object.fromEntries(
+        Object.entries(espionage.activeInterrogations ?? {})
+          .filter(([, interrogation]) => interrogation.spyOwner !== civId),
+      );
+    }
+  }
+
+  if (next.opponentAI) {
+    delete next.opponentAI.majorCivs[civId];
+    delete next.opponentAI.pressureByHuman[civId];
+    for (const [otherId, portfolio] of Object.entries(next.opponentAI.majorCivs)) {
+      next.opponentAI.majorCivs[otherId] = scrubPortfolio(portfolio, removedUnits);
+    }
+    next.opponentAI.barbarianHomeCampByUnitId = Object.fromEntries(
+      Object.entries(next.opponentAI.barbarianHomeCampByUnitId)
+        .filter(([unitId]) => !removedUnits.has(unitId)),
+    );
+  }
+
+  if (next.marketplace) {
+    next.marketplace.tradeRoutes = next.marketplace.tradeRoutes
+      .filter(route => route.foreignCivId !== civId);
+    next.marketplace.purchasedResources = (next.marketplace.purchasedResources ?? [])
+      .filter(entry => entry.civId !== civId);
+  }
+
+  return {
+    state: next,
+    eliminated: true,
+    civId,
+    eliminatedBy,
+    removedUnitIds,
+    removedSpyIds,
+  };
+}

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -501,8 +501,6 @@ export function findStartPositions(
 
     let bestCandidate: HexCoord | null = null;
     let bestMinDist = -1;
-    let bestFallback: HexCoord | null = null;
-    let bestFallbackDist = -1;
 
     for (const c of allCandidates) {
       if (used.has(hexKey(c))) continue;
@@ -510,22 +508,23 @@ export function findStartPositions(
         ? Infinity
         : Math.min(...placedPositions.map(p => getStartPositionDistance(map, c, p)));
 
-      if (minDist > bestFallbackDist) {
-        bestFallbackDist = minDist;
-        bestFallback = c;
-      }
       if (minDist >= minimumDistance && minDist > bestMinDist) {
         bestMinDist = minDist;
         bestCandidate = c;
       }
     }
 
-    const selected = bestCandidate ?? bestFallback;
-    if (!selected) break;
+    const selected = bestCandidate;
+    if (!selected) {
+      throw new Error(
+        `[findStartPositions] Could not place ${count} civilizations at least `
+        + `${minimumDistance} hexes apart; placed ${placedPositions.length}.`,
+      );
+    }
     positions[i] = selected;
     used.add(hexKey(selected));
     placedPositions.push(selected);
   }
 
-  return positions.filter(Boolean) as HexCoord[];
+  return positions as HexCoord[];
 }

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -411,6 +411,17 @@ const GEO_START_TABLES: Partial<Record<MapScript, Record<'small' | 'medium' | 'l
   'new-world': NEW_WORLD_START_POSITIONS,
 };
 
+export type GeographicMapScript = 'earth' | 'old-world' | 'new-world';
+
+export function getGeographicStartAnchor(
+  mapScript: GeographicMapScript,
+  size: 'small' | 'medium' | 'large',
+  civilizationTypeId: string,
+): HexCoord | null {
+  const anchor = GEO_START_TABLES[mapScript]?.[size]?.[civilizationTypeId];
+  return anchor ? { ...anchor } : null;
+}
+
 /**
  * Find start positions for all civs. Returns positions in the same order as civTypeIds.
  *

--- a/src/systems/start-placement-system.ts
+++ b/src/systems/start-placement-system.ts
@@ -1,0 +1,305 @@
+import type {
+  GameMap,
+  HexCoord,
+  MapScript,
+  StartPlacementMode,
+} from '@/core/types';
+import { hexKey } from '@/systems/hex-utils';
+import {
+  getGeographicStartAnchor,
+  getStartPositionDistance,
+  MIN_MAJOR_CIV_START_DISTANCE,
+  type GeographicMapScript,
+} from '@/systems/map-generator';
+import { isValidStartTile } from '@/systems/map-validation';
+
+export interface StartAssignment {
+  civilizationTypeId: string;
+  position: HexCoord;
+  historicalAnchor: HexCoord | null;
+  usedFallback: boolean;
+}
+
+export type StartPlacementResult =
+  | {
+      ok: true;
+      positions: HexCoord[];
+      assignments: StartAssignment[];
+      minimumDistance: number | null;
+      fallbackCivilizationTypeIds: string[];
+    }
+  | {
+      ok: false;
+      reason: 'insufficient-separated-sites';
+      requested: number;
+      available: number;
+    };
+
+export interface StartPlacementInput {
+  map: GameMap;
+  civilizationTypeIds: string[];
+  mapScript: MapScript;
+  mapSize: 'small' | 'medium' | 'large';
+  mode: StartPlacementMode;
+  seed: string;
+  candidateHexes?: Set<string>;
+}
+
+interface Candidate {
+  coord: HexCoord;
+  quality: number;
+  tieRank: number;
+}
+
+function isGeographicMapScript(script: MapScript): script is GeographicMapScript {
+  return script === 'earth' || script === 'old-world' || script === 'new-world';
+}
+
+function stableHash(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function candidateQuality(map: GameMap, coord: HexCoord): number {
+  let workable = 0;
+  let fertility = 0;
+  for (const tile of Object.values(map.tiles)) {
+    if (getStartPositionDistance(map, coord, tile.coord) > 2) continue;
+    if (!isValidStartTile(tile)) continue;
+    workable++;
+    if (tile.terrain === 'grassland' || tile.terrain === 'forest' || tile.terrain === 'jungle') {
+      fertility += 2;
+    } else {
+      fertility += 1;
+    }
+  }
+  return workable * 10 + fertility;
+}
+
+function collectCandidates(input: StartPlacementInput): Candidate[] {
+  const valid = Object.values(input.map.tiles)
+    .filter(tile => isValidStartTile(tile))
+    .filter(tile => !input.candidateHexes || input.candidateHexes.has(hexKey(tile.coord)))
+    .map(tile => ({
+      coord: tile.coord,
+      quality: candidateQuality(input.map, tile.coord),
+      tieRank: stableHash(`${input.seed}:${hexKey(tile.coord)}`),
+    }));
+  const preferred = valid.filter(candidate =>
+    candidate.coord.r > 3
+    && candidate.coord.r < input.map.height - 4
+    && candidate.quality >= 70,
+  );
+  return (preferred.length >= input.civilizationTypeIds.length ? preferred : valid)
+    .sort((a, b) =>
+      b.quality - a.quality
+      || a.tieRank - b.tieRank
+      || a.coord.r - b.coord.r
+      || a.coord.q - b.coord.q,
+    );
+}
+
+function compareSolutions(a: Candidate[], b: Candidate[], map: GameMap): number {
+  const aMinimum = minimumDistance(a.map(candidate => candidate.coord), map) ?? Infinity;
+  const bMinimum = minimumDistance(b.map(candidate => candidate.coord), map) ?? Infinity;
+  if (aMinimum !== bMinimum) return aMinimum - bMinimum;
+  const aWeakest = Math.min(...a.map(candidate => candidate.quality));
+  const bWeakest = Math.min(...b.map(candidate => candidate.quality));
+  if (aWeakest !== bWeakest) return aWeakest - bWeakest;
+  return a.reduce((sum, candidate) => sum + candidate.quality, 0)
+    - b.reduce((sum, candidate) => sum + candidate.quality, 0);
+}
+
+function selectBalancedSites(
+  map: GameMap,
+  candidates: Candidate[],
+  count: number,
+): { sites: Candidate[] | null; maximumPlaced: number } {
+  if (count === 0) return { sites: [], maximumPlaced: 0 };
+  let best: Candidate[] | null = null;
+  let maximumPlaced = 0;
+  const firstChoices = candidates.slice(0, Math.min(candidates.length, 128));
+
+  for (const first of firstChoices) {
+    const selected = [first];
+    while (selected.length < count) {
+      const remaining = candidates
+        .filter(candidate => !selected.includes(candidate))
+        .map(candidate => ({
+          candidate,
+          distance: Math.min(...selected.map(existing =>
+            getStartPositionDistance(map, candidate.coord, existing.coord),
+          )),
+        }))
+        .filter(entry => entry.distance >= MIN_MAJOR_CIV_START_DISTANCE)
+        .sort((a, b) =>
+          b.distance - a.distance
+          || b.candidate.quality - a.candidate.quality
+          || a.candidate.tieRank - b.candidate.tieRank,
+        );
+      if (!remaining[0]) break;
+      selected.push(remaining[0].candidate);
+    }
+    maximumPlaced = Math.max(maximumPlaced, selected.length);
+    if (selected.length === count && (!best || compareSolutions(selected, best, map) > 0)) {
+      best = selected;
+    }
+  }
+  return { sites: best, maximumPlaced };
+}
+
+function minimumDistance(positions: HexCoord[], map: GameMap): number | null {
+  if (positions.length < 2) return null;
+  let result = Infinity;
+  for (let i = 0; i < positions.length; i++) {
+    for (let j = i + 1; j < positions.length; j++) {
+      result = Math.min(result, getStartPositionDistance(map, positions[i], positions[j]));
+    }
+  }
+  return result;
+}
+
+function assignBalancedSites(
+  input: StartPlacementInput,
+  sites: Candidate[],
+): StartAssignment[] {
+  const anchors = input.civilizationTypeIds.map(civ =>
+    isGeographicMapScript(input.mapScript)
+      ? getGeographicStartAnchor(input.mapScript, input.mapSize, civ)
+      : null,
+  );
+  let bestPositions: HexCoord[] | null = null;
+  let bestCost = Infinity;
+  let bestTie = Infinity;
+
+  const visit = (remaining: Candidate[], assigned: HexCoord[], index: number, cost: number) => {
+    if (cost > bestCost) return;
+    if (index === anchors.length) {
+      const tie = stableHash(`${input.seed}:${assigned.map(hexKey).join('|')}`);
+      if (cost < bestCost || (cost === bestCost && tie < bestTie)) {
+        bestCost = cost;
+        bestTie = tie;
+        bestPositions = assigned.map(coord => ({ ...coord }));
+      }
+      return;
+    }
+    for (let i = 0; i < remaining.length; i++) {
+      const site = remaining[i];
+      const anchor = anchors[index];
+      visit(
+        [...remaining.slice(0, i), ...remaining.slice(i + 1)],
+        [...assigned, site.coord],
+        index + 1,
+        cost + (anchor ? getStartPositionDistance(input.map, anchor, site.coord) : 0),
+      );
+    }
+  };
+  visit(sites, [], 0, 0);
+
+  return input.civilizationTypeIds.map((civilizationTypeId, index) => ({
+    civilizationTypeId,
+    position: bestPositions![index],
+    historicalAnchor: anchors[index],
+    usedFallback: anchors[index] === null,
+  }));
+}
+
+function placeHistorical(
+  input: StartPlacementInput,
+  candidates: Candidate[],
+): StartPlacementResult {
+  const positions: Array<HexCoord | null> = input.civilizationTypeIds.map(civ =>
+    isGeographicMapScript(input.mapScript)
+      ? getGeographicStartAnchor(input.mapScript, input.mapSize, civ)
+      : null,
+  );
+  const fallbackCivilizationTypeIds: string[] = [];
+  const used = new Set(
+    positions.filter((coord): coord is HexCoord => coord !== null).map(hexKey),
+  );
+
+  for (let index = 0; index < positions.length; index++) {
+    const exact = positions[index];
+    if (exact && input.map.tiles[hexKey(exact)] && isValidStartTile(input.map.tiles[hexKey(exact)])) {
+      continue;
+    }
+    const placed = positions.filter((coord): coord is HexCoord => coord !== null);
+    const fallback = candidates
+      .filter(candidate => !used.has(hexKey(candidate.coord)))
+      .map(candidate => ({
+        candidate,
+        distance: placed.length === 0
+          ? Infinity
+          : Math.min(...placed.map(coord =>
+            getStartPositionDistance(input.map, candidate.coord, coord),
+          )),
+      }))
+      .sort((a, b) =>
+        b.distance - a.distance
+        || b.candidate.quality - a.candidate.quality
+        || a.candidate.tieRank - b.candidate.tieRank,
+      )[0]?.candidate;
+    if (!fallback) {
+      return {
+        ok: false,
+        reason: 'insufficient-separated-sites',
+        requested: input.civilizationTypeIds.length,
+        available: used.size,
+      };
+    }
+    positions[index] = fallback.coord;
+    used.add(hexKey(fallback.coord));
+    fallbackCivilizationTypeIds.push(input.civilizationTypeIds[index]);
+  }
+
+  const resolved = positions as HexCoord[];
+  return {
+    ok: true,
+    positions: resolved,
+    assignments: input.civilizationTypeIds.map((civilizationTypeId, index) => ({
+      civilizationTypeId,
+      position: resolved[index],
+      historicalAnchor: isGeographicMapScript(input.mapScript)
+        ? getGeographicStartAnchor(input.mapScript, input.mapSize, civilizationTypeId)
+        : null,
+      usedFallback: fallbackCivilizationTypeIds.includes(civilizationTypeId),
+    })),
+    minimumDistance: minimumDistance(resolved, input.map),
+    fallbackCivilizationTypeIds,
+  };
+}
+
+export function placeCivilizationStarts(input: StartPlacementInput): StartPlacementResult {
+  const candidates = collectCandidates(input);
+  if (input.mode === 'historical' && isGeographicMapScript(input.mapScript)) {
+    return placeHistorical(input, candidates);
+  }
+  const selection = selectBalancedSites(
+    input.map,
+    candidates,
+    input.civilizationTypeIds.length,
+  );
+  if (!selection.sites) {
+    return {
+      ok: false,
+      reason: 'insufficient-separated-sites',
+      requested: input.civilizationTypeIds.length,
+      available: selection.maximumPlaced,
+    };
+  }
+  const assignments = assignBalancedSites(input, selection.sites);
+  const positions = assignments.map(assignment => assignment.position);
+  return {
+    ok: true,
+    positions,
+    assignments,
+    minimumDistance: minimumDistance(positions, input.map),
+    fallbackCivilizationTypeIds: assignments
+      .filter(assignment => assignment.usedFallback)
+      .map(assignment => assignment.civilizationTypeId),
+  };
+}

--- a/src/systems/start-placement-system.ts
+++ b/src/systems/start-placement-system.ts
@@ -4,7 +4,7 @@ import type {
   MapScript,
   StartPlacementMode,
 } from '@/core/types';
-import { hexKey } from '@/systems/hex-utils';
+import { getWrappedHexesInRange, hexesInRange, hexKey } from '@/systems/hex-utils';
 import {
   getGeographicStartAnchor,
   getStartPositionDistance,
@@ -67,8 +67,12 @@ function stableHash(value: string): number {
 function candidateQuality(map: GameMap, coord: HexCoord): number {
   let workable = 0;
   let fertility = 0;
-  for (const tile of Object.values(map.tiles)) {
-    if (getStartPositionDistance(map, coord, tile.coord) > 2) continue;
+  const neighborhood = map.wrapsHorizontally
+    ? getWrappedHexesInRange(coord, 2, map.width)
+    : hexesInRange(coord, 2);
+  for (const nearby of neighborhood) {
+    const tile = map.tiles[hexKey(nearby)];
+    if (!tile) continue;
     if (!isValidStartTile(tile)) continue;
     workable++;
     if (tile.terrain === 'grassland' || tile.terrain === 'forest' || tile.terrain === 'jungle') {
@@ -89,18 +93,12 @@ function collectCandidates(input: StartPlacementInput): Candidate[] {
       quality: candidateQuality(input.map, tile.coord),
       tieRank: stableHash(`${input.seed}:${hexKey(tile.coord)}`),
     }));
-  const preferred = valid.filter(candidate =>
-    candidate.coord.r > 3
-    && candidate.coord.r < input.map.height - 4
-    && candidate.quality >= 70,
-  );
-  return (preferred.length >= input.civilizationTypeIds.length ? preferred : valid)
-    .sort((a, b) =>
+  return valid.sort((a, b) =>
       b.quality - a.quality
       || a.tieRank - b.tieRank
       || a.coord.r - b.coord.r
       || a.coord.q - b.coord.q,
-    );
+  );
 }
 
 function compareSolutions(a: Candidate[], b: Candidate[], map: GameMap): number {
@@ -122,7 +120,7 @@ function selectBalancedSites(
   if (count === 0) return { sites: [], maximumPlaced: 0 };
   let best: Candidate[] | null = null;
   let maximumPlaced = 0;
-  const firstChoices = candidates.slice(0, Math.min(candidates.length, 128));
+  const firstChoices = candidates.slice(0, Math.min(candidates.length, 256));
 
   for (const first of firstChoices) {
     const selected = [first];
@@ -148,6 +146,34 @@ function selectBalancedSites(
     if (selected.length === count && (!best || compareSolutions(selected, best, map) > 0)) {
       best = selected;
     }
+  }
+  if (!best) {
+    const selected: Candidate[] = [];
+    let visited = 0;
+    const visit = (startIndex: number): Candidate[] | null => {
+      maximumPlaced = Math.max(maximumPlaced, selected.length);
+      if (selected.length === count) return [...selected];
+      if (visited >= 100_000 || candidates.length - startIndex < count - selected.length) {
+        return null;
+      }
+      for (let index = startIndex; index < candidates.length; index++) {
+        const candidate = candidates[index];
+        if (selected.some(existing =>
+          getStartPositionDistance(map, candidate.coord, existing.coord)
+            < MIN_MAJOR_CIV_START_DISTANCE,
+        )) {
+          continue;
+        }
+        visited++;
+        selected.push(candidate);
+        const result = visit(index + 1);
+        if (result) return result;
+        selected.pop();
+        if (visited >= 100_000) break;
+      }
+      return null;
+    };
+    best = visit(0);
   }
   return { sites: best, maximumPlaced };
 }

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -1,5 +1,5 @@
-import type { BeastsMode, CustomCivDefinition, SoloSetupConfig, MapScript, OpponentChallenge } from '@/core/types';
-import { MAP_DIMENSIONS } from '@/core/game-state';
+import type { BeastsMode, CustomCivDefinition, SoloSetupConfig, MapScript, OpponentChallenge, StartPlacementMode } from '@/core/types';
+import { GameCreationError, MAP_DIMENSIONS } from '@/core/game-state';
 import { createCivSelectPanel } from '@/ui/civ-select';
 import { createCustomCivPanel } from '@/ui/custom-civ-panel';
 import { getPlayableCivDefinitions } from '@/systems/civ-registry';
@@ -9,6 +9,7 @@ import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { createSetupSection, createSetupShell } from '@/ui/setup-shell';
 import { createGameButton, setButtonDisabled } from '@/ui/ui-kit';
 import { createOpponentChallengeSelector } from '@/ui/opponent-challenge-selector';
+import { selectAIRoster } from '@/systems/ai-roster-selection';
 
 export interface CampaignSetupCallbacks {
   onStartSolo: (config: SoloSetupConfig) => void;
@@ -131,15 +132,15 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   const MAP_SCRIPT_LABELS: Record<string, { emoji: string; label: string; description: string }> = {
     earth: {
       emoji: '🌍', label: 'Earth',
-      description: 'Real-world geography. Civilizations start near their historical homelands; fantasy and out-of-region civs get good constrained starts. Resources follow real-world distribution.',
+      description: 'Real-world geography with your choice of separated Balanced starts or exact True Starts.',
     },
     'old-world': {
       emoji: '🗺️', label: 'Old World',
-      description: 'Europe, Asia, and Africa. Historical civilizations start at their homelands. Best for Old World civs — Aztec gets a constrained random start. Resources follow real-world distribution.',
+      description: 'Europe, Asia, and Africa with Balanced or exact True Start placement.',
     },
     'new-world': {
       emoji: '🌎', label: 'New World',
-      description: 'North and South America. Aztec starts in Central Mexico. England and France land on the eastern seaboard; Spain lands on the Gulf of Mexico; Viking land in Newfoundland. Other civs get a constrained random start.',
+      description: 'North and South America with Balanced or exact True Start placement.',
     },
     balanced: {
       emoji: '⚖️', label: 'Balanced',
@@ -188,6 +189,43 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
   });
   mapSection.content.appendChild(mapDescEl);
 
+  let selectedPlacementMode: StartPlacementMode = 'balanced';
+  const placementRow = document.createElement('div');
+  placementRow.dataset.role = 'campaign-placement-options';
+  placementRow.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;margin:0 0 8px;';
+  const balancedPlacement = createChoiceButton('Balanced (Recommended)');
+  balancedPlacement.dataset.placementMode = 'balanced';
+  const historicalPlacement = createChoiceButton('True Start');
+  historicalPlacement.dataset.placementMode = 'historical';
+  placementRow.append(balancedPlacement, historicalPlacement);
+  mapSection.content.appendChild(placementRow);
+  const placementHelp = document.createElement('p');
+  placementHelp.dataset.role = 'campaign-placement-description';
+  placementHelp.style.cssText = 'font-size:12px;opacity:0.82;margin:0 0 10px;line-height:1.45;';
+  mapSection.content.appendChild(placementHelp);
+
+  const syncPlacement = (): void => {
+    const geographic = mapScriptSelect.value === 'earth'
+      || mapScriptSelect.value === 'old-world'
+      || mapScriptSelect.value === 'new-world';
+    placementRow.hidden = !geographic;
+    placementHelp.hidden = !geographic;
+    if (!geographic) selectedPlacementMode = 'balanced';
+    syncChoiceButtonState(balancedPlacement, selectedPlacementMode === 'balanced');
+    syncChoiceButtonState(historicalPlacement, selectedPlacementMode === 'historical');
+    placementHelp.textContent = selectedPlacementMode === 'balanced'
+      ? 'Separated viable starts are guaranteed; homelands are soft preferences.'
+      : 'Exact known homelands are used. Close neighboring starts may occur.';
+  };
+  balancedPlacement.addEventListener('click', () => {
+    selectedPlacementMode = 'balanced';
+    syncPlacement();
+  });
+  historicalPlacement.addEventListener('click', () => {
+    selectedPlacementMode = 'historical';
+    syncPlacement();
+  });
+
   const mapScriptCards = new Map<MapScriptKey, HTMLButtonElement>();
 
   const syncMapScriptCards = (): void => {
@@ -196,6 +234,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       syncChoiceButtonState(btn, script === current);
     }
     mapDescEl.textContent = MAP_SCRIPT_LABELS[current]?.description ?? '';
+    syncPlacement();
   };
 
   for (const script of MAP_SCRIPT_ORDER) {
@@ -225,7 +264,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
 
   const startSpacingNote = document.createElement('p');
   startSpacingNote.dataset.role = 'start-spacing-note';
-  startSpacingNote.textContent = 'Balanced starts keep rival civilizations from beginning next door, including across the wrapped map edge.';
+  startSpacingNote.textContent = 'Balanced mode guarantees separated starts. True Start uses exact homelands and may place neighbors close together.';
   Object.assign(startSpacingNote.style, {
     margin: '0',
     fontSize: '12px',
@@ -407,6 +446,8 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     const isDisabled = !selectedCivId || !gameTitle;
     setButtonDisabled(startButton, isDisabled);
     startButton.dataset.ready = isDisabled ? 'false' : 'true';
+    delete startButton.dataset.confirmedHistorical;
+    startButton.textContent = 'Start Campaign';
   };
 
   const replaceSetupOverlay = (render: () => void): void => {
@@ -487,20 +528,53 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     if (!gameTitle) {
       return;
     }
-    panel.remove();
-    callbacks.onStartSolo({
-      civType: selectedCivId,
-      mapSize: mapSizeField.select.value as 'small' | 'medium' | 'large',
-      opponentCount: Number(opponentsField.select.value),
-      gameTitle,
-      customCivilizations,
-      mapScript: mapScriptSelect.value as MapScript,
-      opponentChallenge: selectedOpponentChallenge,
-      settingsOverrides: { beastsMode: beastsModeSelected },
+    const mapScript = mapScriptSelect.value as MapScript;
+    const mapSize = mapSizeField.select.value as 'small' | 'medium' | 'large';
+    const preview = selectAIRoster({
+      definitions: civDefinitions,
+      humanCivilizationTypeIds: [selectedCivId],
+      count: Number(opponentsField.select.value),
+      mapScript,
+      mapSize,
+      placementMode: selectedPlacementMode,
+      seed: 'solo-roster-preview',
     });
+    const crowded = selectedPlacementMode === 'historical'
+      && preview.minimumHistoricalDistance !== null
+      && preview.minimumHistoricalDistance < 9;
+    if (crowded && startButton.dataset.confirmedHistorical !== 'true') {
+      startButton.dataset.confirmedHistorical = 'true';
+      startButton.textContent = 'Start Crowded Historical Game';
+      historicalWarning.hidden = false;
+      historicalWarning.textContent = `Warning: previewed historical starts are only ${preview.minimumHistoricalDistance} hexes apart. Press again to confirm.`;
+      return;
+    }
+    try {
+      callbacks.onStartSolo({
+        civType: selectedCivId,
+        mapSize,
+        opponentCount: Number(opponentsField.select.value),
+        gameTitle,
+        customCivilizations,
+        mapScript,
+        startPlacementMode: selectedPlacementMode,
+        opponentChallenge: selectedOpponentChallenge,
+        settingsOverrides: { beastsMode: beastsModeSelected },
+      });
+      panel.remove();
+    } catch (error) {
+      if (!(error instanceof GameCreationError)) throw error;
+      historicalWarning.hidden = false;
+      historicalWarning.textContent = error.message;
+    }
   });
   buttonRow.appendChild(startButton);
 
+  const historicalWarning = document.createElement('p');
+  historicalWarning.dataset.role = 'campaign-historical-warning';
+  historicalWarning.hidden = true;
+  historicalWarning.style.cssText = 'color:#ffb870;font-size:12px;font-weight:bold;margin:0 0 8px;';
+  shell.actions.appendChild(historicalWarning);
   shell.actions.appendChild(buttonRow);
 
   titleInput.addEventListener('input', syncCampaignReadiness);

--- a/src/ui/campaign-setup.ts
+++ b/src/ui/campaign-setup.ts
@@ -73,6 +73,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
     subtitle: 'Choose your civilization, world size, and rival count before your people settle their first city.',
   });
   const panel = shell.surface;
+  const setupSeed = `solo-setup-${Date.now()}`;
 
   const hero = document.createElement('div');
   hero.dataset.role = 'setup-hero';
@@ -537,7 +538,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
       mapScript,
       mapSize,
       placementMode: selectedPlacementMode,
-      seed: 'solo-roster-preview',
+      seed: setupSeed,
     });
     const crowded = selectedPlacementMode === 'historical'
       && preview.minimumHistoricalDistance !== null
@@ -556,6 +557,7 @@ export function showCampaignSetup(container: HTMLElement, callbacks: CampaignSet
         opponentCount: Number(opponentsField.select.value),
         gameTitle,
         customCivilizations,
+        seed: setupSeed,
         mapScript,
         startPlacementMode: selectedPlacementMode,
         opponentChallenge: selectedOpponentChallenge,

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -1,5 +1,5 @@
-import type { CustomCivDefinition, HotSeatConfig, HotSeatPlayer, MapScript, OpponentChallenge } from '@/core/types';
-import { MAP_DIMENSIONS } from '@/core/game-state';
+import type { CustomCivDefinition, HotSeatConfig, HotSeatPlayer, MapScript, OpponentChallenge, StartPlacementMode } from '@/core/types';
+import { GameCreationError, MAP_DIMENSIONS } from '@/core/game-state';
 import { createCivSelectPanel } from './civ-select';
 import { createCustomCivPanel } from './custom-civ-panel';
 import { createDefaultSettings } from '@/core/game-state';
@@ -8,6 +8,7 @@ import { buildCustomCivId, customCivDefinitionsEqual, mergeCustomCivDefinitions 
 import { loadSettings, saveSettings } from '@/storage/save-manager';
 import { createOpponentChallengeSelector } from '@/ui/opponent-challenge-selector';
 import { createGameButton } from '@/ui/ui-kit';
+import { selectAIRoster } from '@/systems/ai-roster-selection';
 
 export interface HotSeatSetupCallbacks {
   onComplete: (config: HotSeatConfig, opponentChallenge?: OpponentChallenge) => void;
@@ -33,8 +34,10 @@ export function showHotSeatSetup(
 
   let selectedMapSize: 'small' | 'medium' | 'large' | null = null;
   let selectedMapScript: MapScript = 'earth';
+  let selectedPlacementMode: StartPlacementMode = 'balanced';
   let selectedOpponentChallenge: OpponentChallenge = 'standard';
   let playerCount = 0;
+  let aiCount = 1;
   const players: HotSeatPlayer[] = [];
   const chosenCivs: string[] = [];
   let customCivilizations: CustomCivDefinition[] = [...(options?.initialCustomCivilizations ?? [])];
@@ -110,17 +113,17 @@ export function showHotSeatSetup(
       earth: {
         emoji: '🌍',
         label: 'Earth',
-        description: 'Real-world geography. Civilizations start near their historical homelands; fantasy and out-of-region civs get good constrained starts. Resources follow real-world distribution.',
+        description: 'Real-world geography with your choice of separated Balanced starts or exact True Starts.',
       },
       'old-world': {
         emoji: '🗺️',
         label: 'Old World',
-        description: 'Europe, Asia, and Africa. Historical civilizations start at their homelands. Best for Old World civs — Aztec gets a constrained random start.',
+        description: 'Europe, Asia, and Africa with Balanced or exact True Start placement.',
       },
       'new-world': {
         emoji: '🌎',
         label: 'New World',
-        description: 'North and South America. Aztec starts in Central Mexico. England and France land on the eastern seaboard; Spain lands on the Gulf of Mexico.',
+        description: 'North and South America with Balanced or exact True Start placement.',
       },
       balanced: {
         emoji: '⚖️',
@@ -156,6 +159,47 @@ export function showHotSeatSetup(
     descEl.style.cssText = 'font-size:12px;opacity:0.82;margin:12px 0;text-align:center;max-width:420px;line-height:1.45;';
     panel.appendChild(descEl);
 
+    const placement = document.createElement('div');
+    placement.dataset.role = 'start-placement-options';
+    placement.style.cssText = 'display:flex;gap:8px;flex-wrap:wrap;justify-content:center;max-width:480px;';
+    const balancedPlacement = createGameButton('Balanced (Recommended)', 'secondary');
+    balancedPlacement.dataset.placementMode = 'balanced';
+    const historicalPlacement = createGameButton('True Start', 'secondary');
+    historicalPlacement.dataset.placementMode = 'historical';
+    placement.append(balancedPlacement, historicalPlacement);
+    panel.appendChild(placement);
+
+    const placementDescription = document.createElement('p');
+    placementDescription.dataset.role = 'start-placement-description';
+    placementDescription.style.cssText = 'font-size:12px;opacity:0.82;margin:8px 0;text-align:center;max-width:420px;line-height:1.45;';
+    panel.appendChild(placementDescription);
+
+    const syncPlacement = (): void => {
+      const geographic = selectedMapScript === 'earth'
+        || selectedMapScript === 'old-world'
+        || selectedMapScript === 'new-world';
+      placement.hidden = !geographic;
+      placementDescription.hidden = !geographic;
+      if (!geographic) selectedPlacementMode = 'balanced';
+      for (const button of [balancedPlacement, historicalPlacement]) {
+        button.dataset.selected = button.dataset.placementMode === selectedPlacementMode
+          ? 'true'
+          : 'false';
+        button.style.outline = button.dataset.selected === 'true' ? '2px solid #e8c170' : 'none';
+      }
+      placementDescription.textContent = selectedPlacementMode === 'balanced'
+        ? 'Separated viable starts are guaranteed; historical regions are soft preferences.'
+        : 'Exact known homelands are used. Nearby civilizations may begin close together.';
+    };
+    balancedPlacement.addEventListener('click', () => {
+      selectedPlacementMode = 'balanced';
+      syncPlacement();
+    });
+    historicalPlacement.addEventListener('click', () => {
+      selectedPlacementMode = 'historical';
+      syncPlacement();
+    });
+
     const buttons = new Map<MapScriptKey, HTMLButtonElement>();
 
     const syncCards = (current: MapScriptKey): void => {
@@ -167,6 +211,7 @@ export function showHotSeatSetup(
         btn.style.color = sel ? '#f7f1d7' : '#f4f1e8';
       }
       descEl.textContent = MAP_SCRIPT_LABELS[current].description;
+      syncPlacement();
     };
 
     for (const script of MAP_SCRIPT_ORDER) {
@@ -310,6 +355,18 @@ export function showHotSeatSetup(
     panel.innerHTML = `
       <h1 style="font-size:22px;color:#e8c170;margin:24px 0 8px;text-align:center;">Player Names</h1>
       <p style="font-size:13px;opacity:0.6;margin-bottom:16px;text-align:center;">Enter names for each player</p>
+      <div data-role="ai-count-options" style="margin-bottom:16px;text-align:center;">
+        <div style="font-size:13px;color:#e8c170;margin-bottom:8px;">AI opponents</div>
+        <div style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap;">
+          ${Array.from(
+            { length: MAP_DIMENSIONS[selectedMapSize!].maxPlayers - playerCount },
+            (_, index) => index + 1,
+          ).map(count => `
+            <button type="button" data-ai-count="${count}" style="min-height:44px;min-width:44px;padding:8px;background:rgba(255,255,255,0.08);color:white;border:1px solid rgba(255,255,255,0.2);border-radius:8px;">${count}</button>
+          `).join('')}
+        </div>
+        <p style="font-size:11px;opacity:0.65;margin:6px 0 0;">Choose independently; map capacity is a limit, not a target.</p>
+      </div>
       <div style="max-width:300px;width:100%;display:flex;flex-direction:column;gap:10px;">
         ${defaultNames.map((_name, i) => `
           <input class="player-name-input" data-idx="${i}" type="text"
@@ -321,6 +378,25 @@ export function showHotSeatSetup(
         <button id="hs-names-next" style="padding:10px 24px;background:rgba(232,193,112,0.3);border:2px solid #e8c170;border-radius:8px;color:#e8c170;cursor:pointer;font-size:14px;font-weight:bold;">Next</button>
       </div>
     `;
+
+    aiCount = Math.max(1, Math.min(
+      aiCount,
+      MAP_DIMENSIONS[selectedMapSize!].maxPlayers - playerCount,
+    ));
+    const syncAICount = (): void => {
+      panel.querySelectorAll<HTMLButtonElement>('[data-ai-count]').forEach(button => {
+        const selected = Number(button.dataset.aiCount) === aiCount;
+        button.dataset.selected = selected ? 'true' : 'false';
+        button.style.borderColor = selected ? '#e8c170' : 'rgba(255,255,255,0.2)';
+      });
+    };
+    panel.querySelectorAll<HTMLButtonElement>('[data-ai-count]').forEach(button => {
+      button.addEventListener('click', () => {
+        aiCount = Number(button.dataset.aiCount);
+        syncAICount();
+      });
+    });
+    syncAICount();
 
     // Set placeholder and value via DOM properties (not attributes) to avoid XSS
     const inputs = panel.querySelectorAll('.player-name-input') as NodeListOf<HTMLInputElement>;
@@ -415,7 +491,7 @@ export function showHotSeatSetup(
           if (playerIdx + 1 < players.length) {
             showCivPickStage(playerIdx + 1);
           } else {
-            finalize();
+            showFinalReview();
           }
         },
         onCreateCustomCiv: () => {
@@ -430,30 +506,110 @@ export function showHotSeatSetup(
     });
   }
 
-  function finalize() {
-    // Add AI players to fill remaining map slots
-    const max = MAP_DIMENSIONS[selectedMapSize!].maxPlayers;
-    const aiCount = Math.max(1, max - playerCount); // at least 1 AI
-    const availableCivs = civDefinitions.filter(c => !chosenCivs.includes(c.id));
-
-    for (let i = 0; i < aiCount && i < availableCivs.length; i++) {
-      players.push({
-        name: availableCivs[i].name,
-        slotId: `ai-${i + 1}`,
-        civType: availableCivs[i].id,
+  function buildFinalConfig(): {
+    config: HotSeatConfig;
+    minimumHistoricalDistance: number | null;
+    fallbackCivilizationTypeIds: string[];
+  } {
+    const humanPlayers = players.filter(player => player.isHuman);
+    const selection = selectAIRoster({
+      definitions: civDefinitions,
+      humanCivilizationTypeIds: humanPlayers.map(player => player.civType),
+      count: aiCount,
+      mapScript: selectedMapScript,
+      mapSize: selectedMapSize!,
+      placementMode: selectedPlacementMode,
+      seed: 'hotseat-roster-preview',
+    });
+    const aiPlayers = selection.civilizationTypeIds.map((id, index) => {
+      const definition = civDefinitions.find(candidate => candidate.id === id);
+      return {
+        name: definition?.name ?? id,
+        slotId: `ai-${index + 1}`,
+        civType: id,
         isHuman: false,
-      });
-    }
-
-    const config: HotSeatConfig = {
-      playerCount: players.length,
+      };
+    });
+    return {
+      config: {
+      playerCount: humanPlayers.length + aiPlayers.length,
       mapSize: selectedMapSize!,
       mapScript: selectedMapScript,
-      players,
+      startPlacementMode: selectedPlacementMode,
+      players: [...humanPlayers, ...aiPlayers],
       customCivilizations,
+      },
+      minimumHistoricalDistance: selection.minimumHistoricalDistance,
+      fallbackCivilizationTypeIds: selection.fallbackCivilizationTypeIds,
     };
+  }
 
-    panel.remove();
-    callbacks.onComplete(config, selectedOpponentChallenge);
+  function showFinalReview() {
+    const review = buildFinalConfig();
+    const humans = review.config.players.filter(player => player.isHuman);
+    const ais = review.config.players.filter(player => !player.isHuman);
+    const crowded = selectedPlacementMode === 'historical'
+      && review.minimumHistoricalDistance !== null
+      && review.minimumHistoricalDistance < 9;
+    panel.replaceChildren();
+    const title = document.createElement('h1');
+    title.textContent = 'Review Campaign';
+    title.style.cssText = 'font-size:22px;color:#e8c170;margin:24px 0 12px;text-align:center;';
+    panel.appendChild(title);
+    const summary = document.createElement('div');
+    summary.dataset.role = 'hotseat-final-review';
+    summary.style.cssText = 'max-width:520px;width:100%;background:rgba(255,255,255,0.06);border-radius:12px;padding:16px;line-height:1.6;';
+    const lines = [
+      `Map: ${selectedMapSize} ${selectedMapScript}`,
+      `Starts: ${selectedPlacementMode === 'balanced' ? 'Balanced' : 'True Start'}`,
+      `Humans: ${humans.map(player => `${player.name} (${player.civType})`).join(', ')}`,
+      `AI opponents (${ais.length}): ${ais.map(player => player.civType).join(', ')}`,
+    ];
+    for (const line of lines) {
+      const row = document.createElement('p');
+      row.textContent = line;
+      row.style.margin = '0 0 6px';
+      summary.appendChild(row);
+    }
+    if (review.fallbackCivilizationTypeIds.length > 0) {
+      const fallback = document.createElement('p');
+      fallback.textContent = `Fallback starts: ${review.fallbackCivilizationTypeIds.join(', ')}`;
+      fallback.style.margin = '0 0 6px';
+      summary.appendChild(fallback);
+    }
+    if (crowded) {
+      const warning = document.createElement('p');
+      warning.dataset.role = 'historical-crowding-warning';
+      warning.textContent = `Warning: this roster has historical starts only ${review.minimumHistoricalDistance} hexes apart.`;
+      warning.style.cssText = 'color:#ffb870;font-weight:bold;margin:10px 0 0;';
+      summary.appendChild(warning);
+    }
+    panel.appendChild(summary);
+
+    const start = createGameButton(
+      crowded ? 'Review Crowding Risk' : 'Start Game',
+      'primary',
+    );
+    start.id = 'hs-review-start';
+    start.style.marginTop = '16px';
+    start.addEventListener('click', () => {
+      if (crowded && start.dataset.confirmed !== 'true') {
+        start.dataset.confirmed = 'true';
+        start.textContent = 'Start Crowded Historical Game';
+        return;
+      }
+      try {
+        callbacks.onComplete(review.config, selectedOpponentChallenge);
+        panel.remove();
+      } catch (error) {
+        if (!(error instanceof GameCreationError)) throw error;
+        const message = document.createElement('p');
+        message.dataset.role = 'setup-error';
+        message.textContent = error.message;
+        message.style.cssText = 'color:#ffb4ab;font-size:12px;font-weight:bold;margin:10px 0 0;';
+        summary.appendChild(message);
+      }
+    });
+    panel.appendChild(start);
   }
 }

--- a/src/ui/hotseat-setup.ts
+++ b/src/ui/hotseat-setup.ts
@@ -313,11 +313,11 @@ export function showHotSeatSetup(
   function showPlayerCountStage() {
     const max = MAP_DIMENSIONS[selectedMapSize!].maxPlayers;
 
-    const counts = Array.from({ length: max - 1 }, (_, i) => i + 2);
+    const counts = Array.from({ length: Math.max(1, max - 2) }, (_, i) => i + 2);
 
     panel.innerHTML = `
       <h1 style="font-size:22px;color:#e8c170;margin:24px 0 8px;text-align:center;">How Many Players?</h1>
-      <p style="font-size:13px;opacity:0.6;margin-bottom:16px;text-align:center;">Human players (AI opponents will fill remaining slots)</p>
+      <p style="font-size:13px;opacity:0.6;margin-bottom:16px;text-align:center;">Human players (choose AI opponents separately on the next screen)</p>
       <div style="display:flex;gap:12px;flex-wrap:wrap;justify-content:center;">
         ${counts.map(n => `
           <div class="count-card" data-count="${n}" style="background:rgba(255,255,255,0.08);border:2px solid transparent;border-radius:12px;padding:16px 24px;cursor:pointer;text-align:center;transition:border-color 0.2s;">

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -15,6 +15,7 @@ export interface TurnHandoffOptions {
 }
 
 export interface TurnHandoffController {
+  setRecipient(state: GameState, nextCivId: string, playerName: string): void;
   setReady(state: GameState): void;
   setError(
     message: string,
@@ -80,19 +81,27 @@ function appendText(
 export function showTurnHandoff(
   container: HTMLElement,
   state: GameState,
-  nextCivId: string,
-  playerName: string,
+  nextCivId: string | null,
+  playerName: string | null,
   options: TurnHandoffOptions,
 ): TurnHandoffController {
   activeHandoffController?.remove();
 
   let currentState = state;
+  let currentNextCivId = nextCivId;
+  let currentPlayerName = playerName;
   let ready = options.initiallyReady;
   let removed = false;
   let controller: TurnHandoffController;
-  const civ = state.civilizations[nextCivId];
-  const civDef = resolveCivDefinition(state, civ?.civType ?? '');
-  const color = civ?.color ?? civDef?.color ?? '#e8c170';
+  let color = '#e8c170';
+  const updateColor = (): void => {
+    const civ = currentNextCivId
+      ? currentState.civilizations[currentNextCivId]
+      : undefined;
+    const civDef = resolveCivDefinition(currentState, civ?.civType ?? '');
+    color = civ?.color ?? civDef?.color ?? '#e8c170';
+  };
+  updateColor();
   const accessibilityRoot = container.closest<HTMLElement>('#game-shell') ?? container;
   const previousAriaHidden = accessibilityRoot.getAttribute('aria-hidden');
   const previousInert = Boolean(accessibilityRoot.inert);
@@ -188,16 +197,24 @@ export function showTurnHandoff(
 
   const renderPassTo = (): void => {
     card.replaceChildren();
+    if (!currentNextCivId || !currentPlayerName) {
+      const title = appendText(card, 'h2', options.preparingLabel ?? 'Preparing next turn…');
+      title.id = 'turn-handoff-title';
+      title.tabIndex = -1;
+      title.style.cssText = 'font-size:20px;margin:0;color:#e8c170;';
+      title.focus();
+      return;
+    }
     const avatar = appendText(card, 'div', '👤');
     avatar.style.cssText = `width:60px;height:60px;border-radius:50%;background:${color};margin:0 auto 16px;display:flex;align-items:center;justify-content:center;font-size:24px;`;
     const title = appendText(card, 'h2', 'Pass to');
     title.id = 'turn-handoff-title';
     title.tabIndex = -1;
     title.style.cssText = 'font-size:20px;margin:0 0 8px;color:#e8c170;';
-    const name = appendText(card, 'h1', playerName);
+    const name = appendText(card, 'h1', currentPlayerName);
     name.style.cssText = `font-size:clamp(22px, 7vw, 30px);margin:0 0 24px;color:${color};`;
     confirmButton = createGameButton(
-      ready ? `I'm ${playerName}` : (options.preparingLabel ?? 'Preparing next turn…'),
+      ready ? `I'm ${currentPlayerName}` : (options.preparingLabel ?? 'Preparing next turn…'),
       'primary',
       { disabled: !ready },
     );
@@ -212,13 +229,14 @@ export function showTurnHandoff(
   };
 
   const renderSummary = (): void => {
-    const summary = generateSummary(currentState, nextCivId);
-    const summaryCiv = currentState.civilizations[nextCivId];
+    if (!currentNextCivId || !currentPlayerName) return;
+    const summary = generateSummary(currentState, currentNextCivId);
+    const summaryCiv = currentState.civilizations[currentNextCivId];
     const warNames = summary.atWarWith.map(id => currentState.civilizations[id]?.name ?? id);
     const allyNames = summary.allies.map(id => currentState.civilizations[id]?.name ?? id);
     card.replaceChildren();
 
-    const title = appendText(card, 'h2', playerName);
+    const title = appendText(card, 'h2', currentPlayerName);
     title.id = 'turn-handoff-title';
     title.style.cssText = `font-size:20px;color:${color};margin:0 0 4px;`;
     appendText(card, 'p', `Turn ${summary.turn} · Era ${summary.era}`)
@@ -332,11 +350,19 @@ export function showTurnHandoff(
   renderPassTo();
 
   controller = {
+    setRecipient(updatedState, recipientId, recipientName) {
+      currentState = updatedState;
+      currentNextCivId = recipientId;
+      currentPlayerName = recipientName;
+      ready = true;
+      updateColor();
+      renderPassTo();
+    },
     setReady(updatedState) {
       currentState = updatedState;
       ready = true;
       if (confirmButton?.isConnected) {
-        confirmButton.textContent = `I'm ${playerName}`;
+        confirmButton.textContent = `I'm ${currentPlayerName ?? 'Player'}`;
         setButtonDisabled(confirmButton, false);
         confirmButton.focus();
       } else {

--- a/src/ui/victory-panel.ts
+++ b/src/ui/victory-panel.ts
@@ -1,6 +1,11 @@
+import type { GameOverReason } from '@/core/types';
+import { createGameButton } from '@/ui/ui-kit';
+
 export interface VictoryPanelOptions {
   winnerName: string;
   victoryType: string;
+  outcome?: 'victory' | 'defeat';
+  reason?: GameOverReason;
   turn: number;
   onNewGame: () => void;
 }
@@ -18,11 +23,12 @@ export function showVictoryPanel(container: HTMLElement, options: VictoryPanelOp
   ].join('');
 
   const trophy = document.createElement('div');
-  trophy.textContent = '🏆';
+  const isDefeat = options.outcome === 'defeat';
+  trophy.textContent = isDefeat ? '⚔️' : '🏆';
   trophy.style.cssText = 'font-size:64px;margin-bottom:16px;';
 
   const title = document.createElement('h1');
-  title.textContent = 'Victory!';
+  title.textContent = isDefeat ? 'Defeat' : 'Victory!';
   title.style.cssText = 'font-size:32px;color:#e8c170;margin:0 0 8px;';
 
   const type = document.createElement('h2');
@@ -31,21 +37,18 @@ export function showVictoryPanel(container: HTMLElement, options: VictoryPanelOp
 
   const winner = document.createElement('p');
   winner.style.cssText = 'font-size:22px;color:white;margin:0 0 8px;';
-  winner.textContent = options.winnerName;
+  winner.textContent = options.reason === 'all-humans-eliminated'
+    ? 'No human civilizations remain.'
+    : options.winnerName;
 
   const turnLine = document.createElement('p');
   turnLine.style.cssText = 'font-size:14px;color:#aaa;margin:0 0 32px;';
   turnLine.textContent = `Turn ${options.turn}`;
 
-  const btn = document.createElement('button');
+  const btn = createGameButton('New Game', 'primary');
   btn.id = 'victory-new-game-btn';
   btn.type = 'button';
-  btn.textContent = 'New Game';
-  btn.style.cssText = [
-    'padding:14px 40px;border-radius:10px;',
-    'background:#e8c170;border:none;',
-    'color:#1a1a2e;font-weight:bold;font-size:16px;cursor:pointer;',
-  ].join('');
+  btn.style.padding = '14px 40px';
   btn.addEventListener('click', options.onNewGame);
 
   overlay.appendChild(trophy);

--- a/tests/core/game-state.test.ts
+++ b/tests/core/game-state.test.ts
@@ -446,4 +446,39 @@ describe('createHotSeatGame — mapScript', () => {
     expect(state.map.width).toBe(30);
     expect(state.mapScript).toBe('earth');
   });
+
+  it('defaults new geographic games to balanced placement', () => {
+    const state = createHotSeatGame({
+      playerCount: 2,
+      mapSize: 'large',
+      mapScript: 'earth',
+      players: [
+        { name: 'England', slotId: 'player-1', civType: 'england', isHuman: true },
+        { name: 'Germany', slotId: 'player-2', civType: 'germany', isHuman: true },
+        { name: 'Rome', slotId: 'ai-1', civType: 'rome', isHuman: false },
+      ],
+    }, 'issue-439-balanced-creation');
+
+    expect(state.startPlacementMode).toBe('balanced');
+    expectMajorStartsToRespectSpacing(state);
+  });
+
+  it('preserves exact known anchors only when historical placement is requested', () => {
+    const state = createHotSeatGame({
+      playerCount: 2,
+      mapSize: 'large',
+      mapScript: 'earth',
+      startPlacementMode: 'historical',
+      players: [
+        { name: 'England', slotId: 'player-1', civType: 'england', isHuman: true },
+        { name: 'Germany', slotId: 'player-2', civType: 'germany', isHuman: true },
+        { name: 'Rome', slotId: 'ai-1', civType: 'rome', isHuman: false },
+      ],
+    }, 'issue-439-historical-creation');
+
+    expect(state.startPlacementMode).toBe('historical');
+    expect(getStartingSettlerByOwner(state, 'player-1')).toEqual({ q: 41, r: 15 });
+    expect(getStartingSettlerByOwner(state, 'player-2')).toEqual({ q: 46, r: 14 });
+    expect(getStartingSettlerByOwner(state, 'ai-1')).toEqual({ q: 44, r: 17 });
+  });
 });

--- a/tests/core/hotseat-outcome.test.ts
+++ b/tests/core/hotseat-outcome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { createHotSeatGame } from '@/core/game-state';
+import { resolveHotSeatPostSimulation } from '@/core/hotseat-outcome';
+
+function state() {
+  return createHotSeatGame({
+    playerCount: 2,
+    mapSize: 'medium',
+    players: [
+      { name: 'Alice', slotId: 'player-1', civType: 'england', isHuman: true },
+      { name: 'Bob', slotId: 'player-2', civType: 'germany', isHuman: true },
+      { name: 'AI Rome', slotId: 'ai-1', civType: 'rome', isHuman: false },
+      { name: 'AI Greece', slotId: 'ai-2', civType: 'greece', isHuman: false },
+    ],
+  }, 'hotseat-outcome');
+}
+
+describe('post-simulation hot-seat outcome', () => {
+  it('chooses the next human from authoritative post-simulation state', () => {
+    const game = state();
+    game.civilizations['player-2'].isEliminated = true;
+
+    const result = resolveHotSeatPostSimulation(game, 'player-1');
+
+    expect(result.nextHumanId).toBe('player-1');
+    expect(result.state.currentPlayer).toBe('player-1');
+  });
+
+  it('persists defeat when no active humans remain', () => {
+    const game = state();
+    game.civilizations['player-1'].isEliminated = true;
+    game.civilizations['player-2'].isEliminated = true;
+
+    const result = resolveHotSeatPostSimulation(game, 'player-2');
+
+    expect(result.nextHumanId).toBeNull();
+    expect(result.state.gameOver).toBe(true);
+    expect(result.state.winner).toBeNull();
+    expect(result.state.gameOverReason).toBe('all-humans-eliminated');
+  });
+
+  it('preserves an already resolved domination winner before all-human defeat', () => {
+    const game = state();
+    game.civilizations['player-1'].isEliminated = true;
+    game.civilizations['player-2'].isEliminated = true;
+    game.gameOver = true;
+    game.winner = 'ai-1';
+    game.gameOverReason = 'domination';
+
+    const result = resolveHotSeatPostSimulation(game, 'player-2');
+
+    expect(result.nextHumanId).toBeNull();
+    expect(result.state.winner).toBe('ai-1');
+    expect(result.state.gameOverReason).toBe('domination');
+  });
+});

--- a/tests/core/turn-cycling.test.ts
+++ b/tests/core/turn-cycling.test.ts
@@ -4,8 +4,12 @@ import {
   getAIPlayers,
   getNextPlayer,
   isRoundComplete,
+  getActiveHumanPlayers,
+  getNextActiveHumanPlayerId,
+  isActiveHumanRoundComplete,
 } from '@/core/turn-cycling';
 import type { HotSeatConfig } from '@/core/types';
+import { createHotSeatGame } from '@/core/game-state';
 
 const config: HotSeatConfig = {
   playerCount: 3,
@@ -56,6 +60,53 @@ describe('turn-cycling', () => {
 
     it('returns false for non-last human player', () => {
       expect(isRoundComplete(config, 'player-1')).toBe(false);
+    });
+  });
+
+  describe('state-aware hot-seat turns', () => {
+    function state() {
+      return createHotSeatGame({
+        playerCount: 3,
+        mapSize: 'medium',
+        players: [
+          { name: 'Alice', slotId: 'player-1', civType: 'egypt', isHuman: true },
+          { name: 'Bob', slotId: 'player-2', civType: 'rome', isHuman: true },
+          { name: 'Cara', slotId: 'player-3', civType: 'england', isHuman: true },
+          { name: 'AI', slotId: 'ai-1', civType: 'greece', isHuman: false },
+        ],
+      }, 'state-aware-turns');
+    }
+
+    it('keeps zero-city pre-founding humans active', () => {
+      const game = state();
+      expect(Object.values(game.civilizations).every(civ => civ.cities.length === 0)).toBe(true);
+      expect(getActiveHumanPlayers(game).map(player => player.slotId))
+        .toEqual(['player-1', 'player-2', 'player-3']);
+    });
+
+    it('skips eliminated humans while preserving configured order', () => {
+      const game = state();
+      game.civilizations['player-2'].isEliminated = true;
+
+      expect(getNextActiveHumanPlayerId(game, 'player-1')).toBe('player-3');
+      expect(getNextActiveHumanPlayerId(game, 'player-3')).toBe('player-1');
+    });
+
+    it('completes the round when every later configured human is eliminated', () => {
+      const game = state();
+      game.civilizations['player-2'].isEliminated = true;
+      game.civilizations['player-3'].isEliminated = true;
+
+      expect(isActiveHumanRoundComplete(game, 'player-1')).toBe(true);
+    });
+
+    it('returns null when no active humans remain', () => {
+      const game = state();
+      for (const player of game.hotSeat!.players.filter(player => player.isHuman)) {
+        game.civilizations[player.slotId].isEliminated = true;
+      }
+
+      expect(getNextActiveHumanPlayerId(game, 'player-1')).toBeNull();
     });
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -18,6 +18,18 @@ describe('campaign entry wiring', () => {
     expect(main).not.toContain('loadAutoSave()');
     expect(main).not.toContain('loadGame(slotId)');
   });
+
+  it('restores terminal saves before entering a hot-seat handoff', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const entry = main.slice(
+      main.indexOf('function enterCampaign('),
+      main.indexOf('async function showStartSavePanel'),
+    );
+
+    expect(entry.indexOf('if (gameState.gameOver)'))
+      .toBeLessThan(entry.indexOf('if (!gameState.hotSeat)'));
+    expect(entry).toContain('handleVictoryIfNeeded()');
+  });
 });
 
 describe('land-unit water recovery wiring', () => {

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -68,10 +68,24 @@ describe('completed-round AI wiring', () => {
 
     expect(handoff).toContain('onReady: async summary =>');
     expect(handoff).toMatch(
-      /acknowledgeTurnHandoffSummary\(\s*gameState,\s*nextSlotId,\s*summary,\s*\)/,
+      /acknowledgeTurnHandoffSummary\(\s*gameState,\s*resolvedNextSlotId,\s*summary,\s*\)/,
     );
-    expect(handoff.indexOf('releaseHandoffToViewer(nextSlotId)'))
+    expect(handoff.indexOf('releaseHandoffToViewer(resolvedNextSlotId)'))
       .toBeLessThan(handoff.indexOf("bus.emit('ai:strategic-warning-audio'"));
+  });
+
+  it('keeps completed-round handoff anonymous and resolves its recipient after simulation', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const handoff = main.slice(
+      main.indexOf('async function beginHotSeatHandoff'),
+      main.indexOf('async function endTurn'),
+    );
+
+    expect(handoff).toContain('const previousHumanId = preSimulationState.currentPlayer');
+    expect(handoff).toContain('const nextPlayer = hotSeat.players.find');
+    expect(handoff).toContain('resolveHotSeatPostSimulation(state, previousHumanId).state');
+    expect(handoff).toContain('resolvedNextSlotId = outcome.state.currentPlayer');
+    expect(handoff).toContain('controller.setRecipient(outcome.state, resolvedNextSlotId');
   });
 });
 

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -57,6 +57,47 @@ function makeLocalStorageMock() {
   };
 }
 
+describe('save-manager setup and outcome migration', () => {
+  it('labels legacy geographic games historical without moving units or cities', () => {
+    const legacy = createNewGame(undefined, 'legacy-geographic-placement', 'small');
+    legacy.mapScript = 'earth';
+    delete legacy.startPlacementMode;
+    const unitPositions = Object.fromEntries(
+      Object.entries(legacy.units).map(([id, unit]) => [id, structuredClone(unit.position)]),
+    );
+    const cityPositions = Object.fromEntries(
+      Object.entries(legacy.cities).map(([id, city]) => [id, structuredClone(city.position)]),
+    );
+
+    const normalized = normalizeLoadedStateForTest(legacy);
+
+    expect(normalized.startPlacementMode).toBe('historical');
+    expect(Object.fromEntries(
+      Object.entries(normalized.units).map(([id, unit]) => [id, unit.position]),
+    )).toEqual(unitPositions);
+    expect(Object.fromEntries(
+      Object.entries(normalized.cities).map(([id, city]) => [id, city.position]),
+    )).toEqual(cityPositions);
+  });
+
+  it('labels legacy generated games balanced', () => {
+    const legacy = createNewGame(undefined, 'legacy-generated-placement', 'small');
+    legacy.mapScript = 'single-continent';
+    delete legacy.startPlacementMode;
+
+    expect(normalizeLoadedStateForTest(legacy).startPlacementMode).toBe('balanced');
+  });
+
+  it('infers domination for legacy terminal saves with a winner', () => {
+    const legacy = createNewGame(undefined, 'legacy-terminal-outcome', 'small');
+    legacy.gameOver = true;
+    legacy.winner = 'player';
+    delete legacy.gameOverReason;
+
+    expect(normalizeLoadedStateForTest(legacy).gameOverReason).toBe('domination');
+  });
+});
+
 describe('save-manager autosave listing', () => {
   beforeEach(() => {
     dbState.clear();

--- a/tests/systems/ai-roster-selection.test.ts
+++ b/tests/systems/ai-roster-selection.test.ts
@@ -60,4 +60,14 @@ describe('roster-aware AI selection', () => {
       historicalMinimum(['england', ...result.civilizationTypeIds]),
     );
   });
+
+  it('reports anchorless humans as fallback starts in the reviewed roster', () => {
+    const result = selectAIRoster({
+      ...input,
+      humanCivilizationTypeIds: ['custom-sunfolk'],
+      count: 1,
+    });
+
+    expect(result.fallbackCivilizationTypeIds).toContain('custom-sunfolk');
+  });
 });

--- a/tests/systems/ai-roster-selection.test.ts
+++ b/tests/systems/ai-roster-selection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
+import { getGeographicStartAnchor, getStartPositionDistance } from '@/systems/map-generator';
+import { selectAIRoster } from '@/systems/ai-roster-selection';
+import { MAP_DIMENSIONS } from '@/core/game-state';
+
+function historicalMinimum(ids: string[]): number {
+  const map = {
+    width: MAP_DIMENSIONS.large.width,
+    wrapsHorizontally: true,
+  };
+  const anchors = ids.map(id => getGeographicStartAnchor('earth', 'large', id));
+  let minimum = Infinity;
+  for (let i = 0; i < anchors.length; i++) {
+    for (let j = i + 1; j < anchors.length; j++) {
+      const first = anchors[i];
+      const second = anchors[j];
+      if (first && second) {
+        minimum = Math.min(minimum, getStartPositionDistance(map, first, second));
+      }
+    }
+  }
+  return minimum;
+}
+
+describe('roster-aware AI selection', () => {
+  const input = {
+    definitions: CIV_DEFINITIONS,
+    humanCivilizationTypeIds: ['england'],
+    count: 2,
+    mapScript: 'earth' as const,
+    mapSize: 'large' as const,
+    placementMode: 'historical' as const,
+    seed: 'issue-439',
+  };
+
+  it('selects the exact count without duplicating humans or AI civilizations', () => {
+    const result = selectAIRoster(input);
+
+    expect(result.civilizationTypeIds).toHaveLength(2);
+    expect(new Set(result.civilizationTypeIds).size).toBe(2);
+    expect(result.civilizationTypeIds).not.toContain('england');
+  });
+
+  it('is deterministic and independent of catalog order', () => {
+    expect(selectAIRoster({ ...input, definitions: [...CIV_DEFINITIONS].reverse() }))
+      .toEqual(selectAIRoster(input));
+  });
+
+  it('improves historical breathing room over the old clustered roster', () => {
+    const result = selectAIRoster(input);
+
+    expect(historicalMinimum(['england', ...result.civilizationTypeIds]))
+      .toBeGreaterThan(historicalMinimum(['england', 'germany', 'rome']));
+  });
+
+  it('accounts for previously selected AIs rather than scoring only against humans', () => {
+    const result = selectAIRoster({ ...input, count: 3 });
+    expect(result.minimumHistoricalDistance).toBe(
+      historicalMinimum(['england', ...result.civilizationTypeIds]),
+    );
+  });
+});

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -502,20 +502,27 @@ describe('city-capture-system', () => {
 
   it('sets isEliminated on the previous owner when their last city is occupied', () => {
     const state = makeExposedCityCaptureState({ population: 4, buildings: [] });
+    const defeatedUnits = [...state.civilizations['ai-1'].units];
     // ai-1 starts with only 'athens'
     expect(state.civilizations['ai-1'].cities).toEqual(['athens']);
 
     const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
 
     expect(result.state.civilizations['ai-1'].isEliminated).toBe(true);
+    expect(result.state.civilizations['ai-1'].units).toEqual([]);
+    expect(defeatedUnits.every(id => result.state.units[id] === undefined)).toBe(true);
+    expect(result.elimination?.civId).toBe('ai-1');
   });
 
   it('sets isEliminated on the previous owner when their last city is razed', () => {
     const state = makeExposedCityCaptureState({ population: 4, buildings: [] });
+    const defeatedUnits = [...state.civilizations['ai-1'].units];
 
     const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
 
     expect(result.state.civilizations['ai-1'].isEliminated).toBe(true);
+    expect(defeatedUnits.every(id => result.state.units[id] === undefined)).toBe(true);
+    expect(result.elimination?.civId).toBe('ai-1');
   });
 
   it('does not set isEliminated when the previous owner still has other cities', () => {

--- a/tests/systems/civilization-elimination-system.test.ts
+++ b/tests/systems/civilization-elimination-system.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { createHotSeatGame } from '@/core/game-state';
+import { eliminateCivilization } from '@/systems/civilization-elimination-system';
+
+function stateWithDefeatedActor() {
+  const state = createHotSeatGame({
+    playerCount: 2,
+    mapSize: 'small',
+    players: [
+      { name: 'Winner', slotId: 'player-1', civType: 'england', isHuman: true },
+      { name: 'Defeated', slotId: 'player-2', civType: 'germany', isHuman: true },
+    ],
+  }, 'elimination-fixture');
+  state.civilizations['player-1'].diplomacy.relationships['player-2'] = -80;
+  state.civilizations['player-1'].diplomacy.atWarWith = ['player-2'];
+  state.civilizations['player-1'].diplomacy.treaties = [{
+    type: 'open_borders',
+    civA: 'player-1',
+    civB: 'player-2',
+    turnsRemaining: 5,
+  }];
+  state.embargoes = [{
+    id: 'embargo-1',
+    targetCivId: 'player-2',
+    participants: ['player-1'],
+    proposedTurn: 1,
+  }];
+  state.defensiveLeagues = [{
+    id: 'league-1',
+    members: ['player-1', 'player-2'],
+    formedTurn: 1,
+  }];
+  state.pendingDiplomacyRequests = [{
+    id: 'peace-1',
+    type: 'peace',
+    fromCivId: 'player-2',
+    toCivId: 'player-1',
+    turnIssued: 1,
+  }];
+  state.opponentAI!.majorCivs['player-2'] = {
+    primaryPlan: null,
+    defensePlansByCityId: {},
+    upgradeRoutesByUnitId: {},
+    modernizationDemand: 0,
+    researchTargetTechId: null,
+    lastPlannedTurn: 0,
+    lastExecutedTurn: 0,
+  };
+  return state;
+}
+
+describe('civilization elimination', () => {
+  it('atomically removes owned pieces and live cross-system references', () => {
+    const state = stateWithDefeatedActor();
+    const defeatedUnitIds = [...state.civilizations['player-2'].units];
+    const before = structuredClone(state);
+
+    const result = eliminateCivilization(state, 'player-2', 'player-1');
+
+    expect(result.eliminated).toBe(true);
+    if (!result.eliminated) return;
+    expect(result.removedUnitIds.sort()).toEqual(defeatedUnitIds.sort());
+    expect(result.state.civilizations['player-2'].isEliminated).toBe(true);
+    expect(result.state.civilizations['player-2'].units).toEqual([]);
+    expect(defeatedUnitIds.every(id => result.state.units[id] === undefined)).toBe(true);
+    expect(result.state.civilizations['player-1'].diplomacy.relationships['player-2'])
+      .toBeUndefined();
+    expect(result.state.civilizations['player-1'].diplomacy.atWarWith)
+      .not.toContain('player-2');
+    expect(result.state.civilizations['player-1'].diplomacy.treaties).toEqual([]);
+    expect(result.state.embargoes).toEqual([]);
+    expect(result.state.defensiveLeagues).toEqual([]);
+    expect(result.state.pendingDiplomacyRequests).toEqual([]);
+    expect(result.state.opponentAI?.majorCivs['player-2']).toBeUndefined();
+    expect(state).toEqual(before);
+  });
+
+  it('does not eliminate an actor that still owns a city', () => {
+    const state = stateWithDefeatedActor();
+    state.civilizations['player-2'].cities = ['city-1'];
+
+    const result = eliminateCivilization(state, 'player-2', 'player-1');
+
+    expect(result).toEqual({ state, eliminated: false });
+  });
+
+  it('is idempotent after the first transition', () => {
+    const first = eliminateCivilization(stateWithDefeatedActor(), 'player-2', 'player-1');
+    expect(first.eliminated).toBe(true);
+    if (!first.eliminated) return;
+
+    expect(eliminateCivilization(first.state, 'player-2', 'player-1')).toEqual({
+      state: first.state,
+      eliminated: false,
+    });
+  });
+});

--- a/tests/systems/start-placement-system.test.ts
+++ b/tests/systems/start-placement-system.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 import type { GameMap, HexTile } from '@/core/types';
 import { MAP_DIMENSIONS } from '@/core/game-state';
 import { EARTH_RIVERS, EARTH_TILES } from '@/systems/earth-map-data';
+import { OLD_WORLD_RIVERS, OLD_WORLD_TILES } from '@/systems/old-world-map-data';
+import { NEW_WORLD_RIVERS, NEW_WORLD_TILES } from '@/systems/new-world-map-data';
 import { loadGeoMap } from '@/systems/geo-map-loader';
 import {
   getGeographicStartAnchor,
   getStartPositionDistance,
+  findStartPositions,
   MIN_MAJOR_CIV_START_DISTANCE,
 } from '@/systems/map-generator';
 import { placeCivilizationStarts } from '@/systems/start-placement-system';
@@ -106,6 +109,8 @@ describe('civilization start placement', () => {
       requested: 2,
       available: 1,
     });
+    expect(() => findStartPositions(map, ['a', 'b'], 'procedural', 'small'))
+      .toThrow(/at least 9 hexes apart/);
   });
 
   it('is deterministic and preserves input civilization alignment', () => {
@@ -125,5 +130,45 @@ describe('civilization start placement', () => {
     expect(second).toEqual(first);
     expect(first.ok && first.assignments.map(assignment => assignment.civilizationTypeId))
       .toEqual(input.civilizationTypeIds);
+  });
+
+  it('finds strict starts at every supported geographic map capacity', () => {
+    const scripts = [
+      { id: 'earth' as const, tiles: EARTH_TILES, rivers: EARTH_RIVERS, wraps: true },
+      { id: 'old-world' as const, tiles: OLD_WORLD_TILES, rivers: OLD_WORLD_RIVERS, wraps: false },
+      { id: 'new-world' as const, tiles: NEW_WORLD_TILES, rivers: NEW_WORLD_RIVERS, wraps: false },
+    ];
+    for (const script of scripts) {
+      for (const size of ['small', 'medium', 'large'] as const) {
+        const dimensions = MAP_DIMENSIONS[size];
+        const map = loadGeoMap(
+          script.tiles[size],
+          script.rivers[size],
+          dimensions,
+          script.wraps,
+        );
+        const result = placeCivilizationStarts({
+          map,
+          civilizationTypeIds: Array.from(
+            { length: dimensions.maxPlayers },
+            (_, index) => `custom-${index}`,
+          ),
+          mapScript: script.id,
+          mapSize: size,
+          mode: 'balanced',
+          seed: `capacity-${script.id}-${size}`,
+        });
+
+        expect(result.ok, `${script.id} ${size}`).toBe(true);
+        if (!result.ok) continue;
+        expect(result.positions).toHaveLength(dimensions.maxPlayers);
+        for (let i = 0; i < result.positions.length; i++) {
+          for (let j = i + 1; j < result.positions.length; j++) {
+            expect(getStartPositionDistance(map, result.positions[i], result.positions[j]))
+              .toBeGreaterThanOrEqual(MIN_MAJOR_CIV_START_DISTANCE);
+          }
+        }
+      }
+    }
   });
 });

--- a/tests/systems/start-placement-system.test.ts
+++ b/tests/systems/start-placement-system.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { GameMap, HexTile } from '@/core/types';
+import { MAP_DIMENSIONS } from '@/core/game-state';
+import { EARTH_RIVERS, EARTH_TILES } from '@/systems/earth-map-data';
+import { loadGeoMap } from '@/systems/geo-map-loader';
+import {
+  getGeographicStartAnchor,
+  getStartPositionDistance,
+  MIN_MAJOR_CIV_START_DISTANCE,
+} from '@/systems/map-generator';
+import { placeCivilizationStarts } from '@/systems/start-placement-system';
+
+function largeEarth(): GameMap {
+  return loadGeoMap(
+    EARTH_TILES.large,
+    EARTH_RIVERS.large,
+    MAP_DIMENSIONS.large,
+    true,
+  );
+}
+
+function tile(q: number, r: number): HexTile {
+  return {
+    coord: { q, r },
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+  };
+}
+
+describe('civilization start placement', () => {
+  it('separates the reported England, Germany, and Rome roster on balanced large Earth', () => {
+    const map = largeEarth();
+
+    const result = placeCivilizationStarts({
+      map,
+      civilizationTypeIds: ['england', 'germany', 'rome'],
+      mapScript: 'earth',
+      mapSize: 'large',
+      mode: 'balanced',
+      seed: 'issue-439',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.positions).toHaveLength(3);
+    for (let i = 0; i < result.positions.length; i++) {
+      for (let j = i + 1; j < result.positions.length; j++) {
+        expect(getStartPositionDistance(map, result.positions[i], result.positions[j]))
+          .toBeGreaterThanOrEqual(MIN_MAJOR_CIV_START_DISTANCE);
+      }
+    }
+  });
+
+  it('keeps exact known anchors in historical mode and reports their crowding', () => {
+    const map = largeEarth();
+    const civs = ['england', 'germany', 'rome'];
+
+    const result = placeCivilizationStarts({
+      map,
+      civilizationTypeIds: civs,
+      mapScript: 'earth',
+      mapSize: 'large',
+      mode: 'historical',
+      seed: 'issue-439',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.positions).toEqual(civs.map(civ =>
+      getGeographicStartAnchor('earth', 'large', civ),
+    ));
+    expect(result.minimumDistance).toBe(3);
+    expect(result.fallbackCivilizationTypeIds).toEqual([]);
+  });
+
+  it('returns an explicit failure rather than weakening spacing', () => {
+    const tiles = Object.fromEntries([
+      tile(0, 0),
+      tile(1, 0),
+      tile(2, 0),
+    ].map(value => [`${value.coord.q},${value.coord.r}`, value]));
+    const map: GameMap = {
+      width: 3,
+      height: 1,
+      wrapsHorizontally: false,
+      tiles,
+      rivers: [],
+    };
+
+    expect(placeCivilizationStarts({
+      map,
+      civilizationTypeIds: ['a', 'b'],
+      mapScript: 'procedural',
+      mapSize: 'small',
+      mode: 'balanced',
+      seed: 'impossible',
+    })).toEqual({
+      ok: false,
+      reason: 'insufficient-separated-sites',
+      requested: 2,
+      available: 1,
+    });
+  });
+
+  it('is deterministic and preserves input civilization alignment', () => {
+    const map = largeEarth();
+    const input = {
+      map,
+      civilizationTypeIds: ['rome', 'england', 'germany'],
+      mapScript: 'earth' as const,
+      mapSize: 'large' as const,
+      mode: 'balanced' as const,
+      seed: 'repeatable',
+    };
+
+    const first = placeCivilizationStarts(input);
+    const second = placeCivilizationStarts(input);
+
+    expect(second).toEqual(first);
+    expect(first.ok && first.assignments.map(assignment => assignment.civilizationTypeId))
+      .toEqual(input.civilizationTypeIds);
+  });
+});

--- a/tests/systems/victory-system.test.ts
+++ b/tests/systems/victory-system.test.ts
@@ -111,6 +111,7 @@ describe('processTurn victory wiring', () => {
 
     expect(result.gameOver).toBe(true);
     expect(result.winner).toBe('player');
+    expect(result.gameOverReason).toBe('domination');
   });
 
   it('does NOT set gameOver when both civs have cities', () => {

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -143,7 +143,7 @@ describe('campaign-setup', () => {
     expect(Array.from(document.querySelectorAll('[data-opponent-count]')).map(card => card.getAttribute('data-opponent-count'))).toEqual(['1', '2', '3', '4']);
     expect(opponentsSelect.value).toBe('1');
     expect(document.querySelector('[data-role="start-spacing-note"]')?.textContent)
-      .toContain('Balanced starts keep rival civilizations from beginning next door');
+      .toContain('Balanced mode guarantees separated starts');
 
     click(document, '[data-size="large"]');
 
@@ -541,6 +541,8 @@ describe('map type selection', () => {
     const desc = document.querySelector('[data-role="map-description"]') as HTMLElement;
     expect(desc).not.toBeNull();
     expect(desc.textContent).toContain('Real-world geography');
+    expect(document.querySelector('[data-placement-mode="balanced"]')?.getAttribute('data-selected'))
+      .toBe('true');
   });
 
   it('updates description when a different map type is clicked', () => {
@@ -549,6 +551,8 @@ describe('map type selection', () => {
     balancedBtn.click();
     const desc = document.querySelector('[data-role="map-description"]') as HTMLElement;
     expect(desc.textContent).toContain('algorithmically fair');
+    expect((document.querySelector('[data-role="campaign-placement-options"]') as HTMLElement).hidden)
+      .toBe(true);
   });
 
   it('includes mapScript in the GameConfig passed to onStartSolo', async () => {
@@ -577,6 +581,24 @@ describe('map type selection', () => {
     expect(onStartSolo).toHaveBeenCalled();
     const config = onStartSolo.mock.calls[0][0];
     expect(config.mapScript).toBe('single-continent');
+    expect(config.startPlacementMode).toBe('balanced');
+  });
+
+  it('passes an explicit true-start choice for geographic maps', async () => {
+    const onStartSolo = vi.fn();
+    showCampaignSetup(document.body, { onStartSolo, onCancel: vi.fn() });
+    click(document, '[data-placement-mode="historical"]');
+    clickButtonWithText('Choose civilization');
+    await flushAsyncWork();
+    (document.querySelector('.civ-card') as HTMLElement)
+      .dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    click(document, '#civ-start');
+    clickButtonWithText('Start Campaign');
+    const confirmation = Array.from(document.querySelectorAll('button'))
+      .find(button => button.textContent === 'Start Crowded Historical Game') as HTMLButtonElement | undefined;
+    confirmation?.click();
+
+    expect(onStartSolo.mock.calls[0]?.[0].startPlacementMode).toBe('historical');
   });
 });
 

--- a/tests/ui/campaign-setup.test.ts
+++ b/tests/ui/campaign-setup.test.ts
@@ -582,6 +582,7 @@ describe('map type selection', () => {
     const config = onStartSolo.mock.calls[0][0];
     expect(config.mapScript).toBe('single-continent');
     expect(config.startPlacementMode).toBe('balanced');
+    expect(config.seed).toMatch(/^solo-setup-/);
   });
 
   it('passes an explicit true-start choice for geographic maps', async () => {

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -45,6 +45,8 @@ function advanceThroughMapType(): void {
 function chooseCiv(civId: string): void {
   click(`.civ-card[data-civ-id="${civId}"]`);
   click('#civ-start');
+  const reviewStart = document.querySelector<HTMLElement>('#hs-review-start');
+  if (reviewStart) reviewStart.click();
 }
 
 function primaryCivActionLabel(): string {
@@ -85,6 +87,66 @@ beforeEach(() => {
 });
 
 describe('hotseat-setup', () => {
+  it('defaults geographic maps to balanced placement and hides the choice for generated maps', () => {
+    showHotSeatSetup(document.body, {
+      onComplete: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    click('[data-size="small"]');
+    expect(document.querySelector('[data-placement-mode="balanced"]')?.getAttribute('data-selected'))
+      .toBe('true');
+    click('[data-map-script="balanced"]');
+    expect((document.querySelector('[data-role="start-placement-options"]') as HTMLElement).hidden)
+      .toBe(true);
+  });
+
+  it('chooses AI count independently and previews exactly that many roster-aware opponents', () => {
+    const onComplete = vi.fn();
+    showHotSeatSetup(document.body, { onComplete, onCancel: vi.fn() });
+
+    click('[data-size="medium"]');
+    advanceThroughMapType();
+    click('[data-count="2"]');
+    click('[data-ai-count="2"]');
+    click('#hs-names-next');
+    chooseCiv('england');
+    click('#hs-civ-ready');
+    click('.civ-card[data-civ-id="germany"]');
+    click('#civ-start');
+
+    expect(document.querySelector('[data-role="hotseat-final-review"]')?.textContent)
+      .toContain('AI opponents (2)');
+    click('#hs-review-start');
+
+    const config = onComplete.mock.calls[0]![0];
+    expect(config.players.filter((player: { isHuman: boolean }) => !player.isHuman)).toHaveLength(2);
+    expect(config.startPlacementMode).toBe('balanced');
+  });
+
+  it('requires explicit confirmation for a crowded true-start roster', () => {
+    const onComplete = vi.fn();
+    showHotSeatSetup(document.body, { onComplete, onCancel: vi.fn() });
+
+    click('[data-size="large"]');
+    click('[data-placement-mode="historical"]');
+    advanceThroughMapType();
+    click('[data-count="2"]');
+    click('#hs-names-next');
+    chooseCiv('england');
+    click('#hs-civ-ready');
+    click('.civ-card[data-civ-id="germany"]');
+    click('#civ-start');
+
+    expect(document.querySelector('[data-role="historical-crowding-warning"]')).not.toBeNull();
+    click('#hs-review-start');
+    expect(onComplete).not.toHaveBeenCalled();
+    expect(document.querySelector('#hs-review-start')?.textContent)
+      .toContain('Start Crowded Historical Game');
+    click('#hs-review-start');
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
   it('always routes through opponent challenge selection after launch', () => {
     showHotSeatSetup(document.body, {
       onComplete: vi.fn(),
@@ -186,6 +248,7 @@ describe('hotseat-setup', () => {
     expect(secondPlayerCiv).toBeTruthy();
     secondPlayerCiv?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     click('#civ-start');
+    click('#hs-review-start');
 
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
@@ -231,6 +294,7 @@ describe('hotseat-setup', () => {
     expect(secondPlayerCiv).toBeTruthy();
     secondPlayerCiv?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     click('#civ-start');
+    click('#hs-review-start');
 
     expect(onComplete).toHaveBeenCalledTimes(1);
     expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({

--- a/tests/ui/hotseat-setup.test.ts
+++ b/tests/ui/hotseat-setup.test.ts
@@ -124,6 +124,16 @@ describe('hotseat-setup', () => {
     expect(config.startPlacementMode).toBe('balanced');
   });
 
+  it('reserves capacity for an explicitly chosen AI instead of offering every seat to humans', () => {
+    showHotSeatSetup(document.body, { onComplete: vi.fn(), onCancel: vi.fn() });
+    click('[data-size="large"]');
+    advanceThroughMapType();
+
+    expect(document.body.textContent).toContain('choose AI opponents separately');
+    expect(document.querySelector('[data-count="7"]')).not.toBeNull();
+    expect(document.querySelector('[data-count="8"]')).toBeNull();
+  });
+
   it('requires explicit confirmation for a crowded true-start roster', () => {
     const onComplete = vi.fn();
     showHotSeatSetup(document.body, { onComplete, onCancel: vi.fn() });

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -29,6 +29,23 @@ function makeFixture() {
 afterEach(() => document.body.replaceChildren());
 
 describe('turn handoff', () => {
+  it('keeps completed-round preparation anonymous until the authoritative recipient is bound', () => {
+    const { state, layer } = makeFixture();
+    const controller = showTurnHandoff(layer, state, null, null, {
+      initiallyReady: false,
+      onReady: vi.fn(),
+    });
+
+    expect(document.body.textContent).toContain('Preparing next turn…');
+    expect(document.body.textContent).not.toContain('Alice');
+    expect(document.body.textContent).not.toContain('Bob');
+
+    controller.setRecipient(state, 'player-2', 'Bob');
+    expect(document.body.textContent).toContain('Pass to');
+    expect(document.body.textContent).toContain('Bob');
+    expect(document.querySelector<HTMLButtonElement>('#handoff-confirm')?.disabled).toBe(false);
+  });
+
   it('acknowledges multiple warning rows with one post-handoff cue and does not replay after reload', () => {
     const { state } = makeFixture();
     state.opponentAI = createEmptyOpponentAIState();

--- a/tests/ui/victory-panel.test.ts
+++ b/tests/ui/victory-panel.test.ts
@@ -55,4 +55,35 @@ describe('showVictoryPanel', () => {
     expect((window as unknown as Record<string, unknown>).__xss).toBeUndefined();
     expect(container.querySelector('#victory-panel')!.textContent).toContain('<script>');
   });
+
+  it('renders defeat instead of victory when every human is eliminated', () => {
+    const container = document.createElement('div');
+    showVictoryPanel(container, {
+      winnerName: '',
+      victoryType: 'Campaign Defeat',
+      outcome: 'defeat',
+      reason: 'all-humans-eliminated',
+      turn: 12,
+      onNewGame: () => {},
+    });
+
+    expect(container.textContent).toContain('Defeat');
+    expect(container.textContent).toContain('No human civilizations remain');
+    expect(container.textContent).not.toContain('Victory!');
+  });
+
+  it('identifies the conquering civilization when another actor wins', () => {
+    const container = document.createElement('div');
+    showVictoryPanel(container, {
+      winnerName: 'Rome',
+      victoryType: 'Domination',
+      outcome: 'defeat',
+      reason: 'domination',
+      turn: 20,
+      onNewGame: () => {},
+    });
+
+    expect(container.textContent).toContain('Defeat');
+    expect(container.textContent).toContain('Rome');
+  });
 });


### PR DESCRIPTION
## Summary

- separate geographic map shape from start policy, defaulting new geographic games to strict Balanced placement while retaining opt-in True Start
- choose AI civilizations deterministically with awareness of selected humans and the partial AI roster; hot-seat now defaults to one explicit AI instead of filling map capacity
- centralize civilization elimination cleanup and derive hot-seat recipients from post-simulation state, including persistent Defeat when no humans survive
- migrate legacy geographic saves as historical without moving existing units or cities

## Root cause

Geographic anchor tables bypassed the nine-hex spacing invariant (England, Germany, and Rome are only 3–5 wrapped hexes apart on Large Earth). Hot-seat setup also filled every unused map slot from catalog order, increasing density. Separately, turn cycling read static setup seats rather than Civilization.isEliminated, and the completed-round handoff chose its recipient before hidden AI/world simulation.

## Gameplay and UI impact

- Balanced Earth/Old World/New World starts guarantee at least nine wrapped hexes between major civilizations.
- True Start preserves exact known homelands and visibly requires a second confirmation when the reviewed roster is crowded.
- Human and AI counts are independent; the final review shows the exact roster-aware AI preview.
- Final-city loss removes remaining units and live diplomacy, espionage, embargo, league, pending-event, marketplace, and AI-planning references through one transition.
- Eliminated humans are skipped, late AI-round elimination cannot leak a stale handoff identity, and terminal saves restore Victory or Defeat directly.

## Validation

- scripts/check-src-rule-violations.sh on every changed source path
- targeted regression run: 281 tests passed
- production build: passed
- full suite: 352 files passed; 5,281 tests passed; 2 skipped
- live browser replay: Balanced default, explicit AI count, roster review, England/Germany 5-hex True Start warning, and two-click confirmation gate
- reviewed both origin/main...HEAD and the final uncommitted delta; all review findings fixed

Closes #439