### PR TITLE
MR14 — Rail visual: directional SVG track segment for rail-upgraded roads

### DIFF
--- a/.claude/rules/sprites.md
+++ b/.claude/rules/sprites.md
@@ -39,6 +39,24 @@ See `docs/sprite-design-system.md` for the full asset inventory, placeholder lis
 2. SVG format: `viewBox="0 0 48 48"`, no palette, no animation, `stroke-linecap="round"` throughout.
 3. Replace the emoji entry in `IMPROVEMENT_ICONS` in `hex-renderer.ts` with an image-draw call using the new SVG (follow the `resource_outpost` pattern once it's implemented).
 
+## Extension Recipe — Rail Segment (edge sprite, not a tile marker)
+
+The rail segment (`src/renderer/improvements/rail-segment-marker.ts`) is the one visual asset in
+this codebase that doesn't cleanly fit Unit/Building, Terrain Tile, or Improvement Marker. It is
+closest to an Improvement Marker but differs in three ways — document any future edge-sprite the
+same way:
+
+1. **`viewBox 0 0 48 48`, no palette, no animation** — same as a standard Improvement Marker.
+2. **Drawn per road *segment*, not per tile.** `hex-renderer.ts`'s `drawRailSegment` rotates and
+   stretches the image along the line between two hex centers (`ctx.translate` to the segment
+   midpoint, `ctx.rotate` by `Math.atan2(dy, dx)`, then `ctx.drawImage` sized to the segment
+   length) — it is never drawn centered on a single hex the way `resource_outpost` is.
+3. **Both-endpoints-required gate.** The sprite only renders when *both* tiles bounding the edge
+   resolve `hasRail: true` (see `resolveTileHasRail` in `road-network.ts`); a segment with only
+   one qualifying endpoint falls back to the plain road line — there is no half-rail asset. Any
+   future edge sprite with a similar gated-pair condition should follow this same fallback
+   pattern rather than rendering a degraded/partial variant.
+
 ---
 
 ## Hard Rules

--- a/docs/claude-design-sprites-prompt.md
+++ b/docs/claude-design-sprites-prompt.md
@@ -1112,3 +1112,60 @@ Before finalising each sprite, verify:
 - [ ] Wolf silhouette reads as "wolf" at 32 px; basilisk reads as "big lizard" at 32 px
 - [ ] Wolf and basilisk are visually distinct from the boar — different shape language, different palette, different animations
 </style_checklist>
+
+---
+
+## 2026-07-06 addendum — Rail Segment (MR14, issue #483)
+
+### Developer instructions (do not copy into Claude)
+
+This is a **non-standard Improvement Marker** — a single reusable edge sprite drawn rotated along
+a road segment (see `.claude/rules/sprites.md` → "Extension Recipe — Rail Segment") rather than
+centered on a hex. For this MR the SVG was hand-authored directly in
+`src/renderer/improvements/rail-segment-marker.ts` following the checklist below rather than
+round-tripped through Claude Design, since the change needed to ship in the same session. Use
+this prompt if a future pass wants a higher-fidelity replacement asset.
+
+### Prompt (copy everything below this line)
+
+<role>
+You are a senior SVG sprite artist specializing in hand-crafted game graphics. You write clean, geometric SVG — no photorealism, no gradient meshes, no blur filters.
+</role>
+
+<context>
+**Project**: Conquestoria — HTML5 Canvas + DOM strategy game, medieval/ancient theme (Eras 1–4), mobile-first. This asset represents a rail-upgraded road (unlocked by the "Railway Expansion" tech, era 7+).
+</context>
+
+<reference_files>
+1. Hex renderer (road/rail draw calls): https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/renderer/hex-renderer.ts
+2. Existing improvement marker for style reference: https://raw.githubusercontent.com/a1flecke/conquestoria/main/src/renderer/improvements/resource-outpost-marker.ts
+</reference_files>
+
+<sprites>
+## IMPROVEMENT — RailSegmentSvg (edge sprite, not a tile-centered marker)
+
+**Create file**: `src/renderer/improvements/rail-segment-marker.ts`
+**Replaces**: the plain `#8a6a3a` road line drawn by `drawRoads`/`drawWrapGhostRoads` in `hex-renderer.ts`, but only on segments where both endpoint tiles are rail-upgraded.
+
+### Concept
+A short straight length of railway track: two steel rails running the full width of the tile with wooden ties (sleepers) crossing perpendicular beneath them. Drawn along the X axis of the viewBox (length axis) so the renderer can rotate it to match any hex-to-hex edge direction.
+
+### Key requirements
+- viewBox="0 0 48 48", no palette prop, no animation, no JSX
+- Rails run horizontally (length axis), ties run vertical/perpendicular — the renderer stretches this along the edge and rotates it, so the "length" direction must be the sprite's horizontal axis
+- Wood ties: `#5e3f24`, evenly spaced, 5 ties across the 48-unit width
+- Steel rails: `#8a929b` with a thin `#e8edf2` highlight line at ~50% opacity for a metallic sheen
+- `stroke-linecap="round"` and `stroke-linejoin="round"` throughout
+- Tone: industrial, functional, distinct at a glance from the plain brown road line
+</sprites>
+
+<output_format>
+Output a single `export function getRailSegmentSvg(): string` returning the SVG string, matching the shape of `resource-outpost-marker.ts`'s exported constant/loader pair.
+</output_format>
+
+<style_checklist>
+- [ ] viewBox="0 0 48 48"
+- [ ] No palette prop, no animation, no JSX
+- [ ] Rails run along the horizontal (length) axis; ties perpendicular
+- [ ] Reads clearly as "railway track" at 24–32px when stretched along a hex edge
+</style_checklist>

--- a/docs/sprite-design-system.md
+++ b/docs/sprite-design-system.md
@@ -146,7 +146,16 @@ Canvas-drawn emoji icons. Target: replace with proper SVG marker images.
 
 Roads are **not** an improvement marker — they're a tile overlay (`HexTile.hasRoad`) drawn as
 programmatic canvas lines between hex centers in `src/renderer/hex-renderer.ts` → `drawRoads`,
-the same technique used for rivers (`drawRivers`). No sprite art exists or is planned yet.
+the same technique used for rivers (`drawRivers`). Plain (non-rail) segments still use this
+line-draw technique.
+
+### Rail Segment — `src/renderer/improvements/rail-segment-marker.ts`
+✅ SVG marker (steel rails + wooden ties, `src/renderer/improvements/rail-segment-loader.ts` for the
+cached `HTMLImageElement`). Drawn by `drawRoads`/`drawWrapGhostRoads` in place of the plain road
+line on any segment where **both** endpoint tiles resolve `hasRail: true` (owner has completed
+`railway-expansion` — see `resolveTileHasRail` in `src/systems/road-network.ts`). This is a
+non-standard extension of the Improvement Marker contract — see the "Rail Segment" recipe in
+`.claude/rules/sprites.md` for the differences (per-edge rotation, both-endpoints-required).
 
 ### Legendary Wonders — `src/systems/legendary-wonder-definitions.ts`
 No map sprites yet. Production queue falls back to `'🏗️'`. Codex images exist in `public/images/wonders/codex/*.jpg` (lore art only, not map sprites).

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -305,6 +305,7 @@ export interface LastSeenTilePresentation {
   hasRiver: boolean;
   wonder: string | null;
   hasRoad?: boolean;
+  hasRail?: boolean;
   city?: LastSeenCityPresentation;
   observedTurn?: number;
   source?: 'observed' | 'legacy-reconstructed';

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { processNonHumanMajorRound } from '@/ai/ai-round-scheduler';
 import { RenderLoop } from '@/renderer/render-loop';
 import { initSprites } from '@/renderer/sprites/sprite-loader';
 import { preloadOutpostMarker } from '@/renderer/improvements/resource-outpost-marker';
+import { preloadRailSegment } from '@/renderer/improvements/rail-segment-loader';
 import { preloadTerrainTiles } from '@/renderer/terrain/terrain-tile-loader';
 import { preloadNaturalWonderTiles } from '@/renderer/terrain/wonder-tile-loader';
 import { TouchHandler, type InputCallbacks } from '@/input/touch-handler';
@@ -4396,6 +4397,7 @@ function startGame(): void {
   }
   initSprites(civColors);
   preloadOutpostMarker().catch(() => {});
+  preloadRailSegment().catch(() => {});
   preloadTerrainTiles().catch(() => {});
   preloadNaturalWonderTiles().catch(() => {});
 

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -8,6 +8,7 @@ import { drawNaturalWonderLandmark } from './wonders/natural-wonder-renderer';
 import { RESOURCE_ICONS, RESOURCE_TECH } from '@/systems/trade-system';
 import { LOD_SPRITE_ZOOM_THRESHOLD } from '@/renderer/sprites/sprite-system';
 import { getOutpostMarkerImage } from './improvements/resource-outpost-marker';
+import { getRailSegmentImage } from './improvements/rail-segment-loader';
 import { getTerrainTileImage } from './terrain/terrain-tile-loader';
 import { drawImprovementTreatment } from './improvements/improvement-treatment';
 
@@ -220,7 +221,8 @@ function canRenderRiverEndpoint(map: GameMap, visibility: VisibilityMap | undefi
   return presentation.kind === 'live' || presentation.kind === 'last-seen';
 }
 
-// --- Roads (drawn as programmatic lines, like rivers — no sprite art yet) ---
+// --- Roads (programmatic line, like rivers) and rail (directional sprite once
+// both segment endpoints qualify — see `resolveTileHasRail` in road-network.ts) ---
 
 function roadConnects(
   map: GameMap,
@@ -231,6 +233,15 @@ function roadConnects(
   const presentation = resolveTilePresentationForViewer(map, visibility, coord);
   if (presentation.kind !== 'live' && presentation.kind !== 'last-seen') return false;
   return Boolean(presentation.tile.hasRoad) || cityTileKeys.has(hexKey(coord));
+}
+
+function endpointHasRail(
+  map: GameMap,
+  visibility: VisibilityMap | undefined,
+  completedTechsByCiv: Record<string, string[]>,
+  coord: HexCoord,
+): boolean {
+  return resolveTilePresentationForViewer(map, visibility, coord, completedTechsByCiv).hasRail;
 }
 
 function drawRoadSegment(
@@ -247,6 +258,37 @@ function drawRoadSegment(
   ctx.moveTo(fromScreen.x, fromScreen.y);
   ctx.lineTo(toScreen.x, toScreen.y);
   ctx.stroke();
+}
+
+function drawRailSegment(
+  ctx: CanvasRenderingContext2D,
+  camera: Camera,
+  from: HexCoord,
+  to: HexCoord,
+): boolean {
+  const railImg = getRailSegmentImage();
+  if (!railImg) return false;
+
+  const fromPixel = hexToPixel(from, camera.hexSize);
+  const toPixel = hexToPixel(to, camera.hexSize);
+  const fromScreen = camera.worldToScreen(fromPixel.x, fromPixel.y);
+  const toScreen = camera.worldToScreen(toPixel.x, toPixel.y);
+  const dx = toScreen.x - fromScreen.x;
+  const dy = toScreen.y - fromScreen.y;
+  const length = Math.sqrt(dx * dx + dy * dy);
+  if (length === 0) return false;
+
+  const midX = (fromScreen.x + toScreen.x) / 2;
+  const midY = (fromScreen.y + toScreen.y) / 2;
+  const angle = Math.atan2(dy, dx);
+  const width = 8 * camera.zoom;
+
+  ctx.save();
+  ctx.translate(midX, midY);
+  ctx.rotate(angle);
+  ctx.drawImage(railImg, -length / 2, -width / 2, length, width);
+  ctx.restore();
+  return true;
 }
 
 function forEachRoadSegment(
@@ -271,12 +313,28 @@ function forEachRoadSegment(
   }
 }
 
+function drawRoadOrRailSegment(
+  ctx: CanvasRenderingContext2D,
+  map: GameMap,
+  camera: Camera,
+  visibility: VisibilityMap | undefined,
+  completedTechsByCiv: Record<string, string[]>,
+  from: HexCoord,
+  to: HexCoord,
+): void {
+  const isRail = endpointHasRail(map, visibility, completedTechsByCiv, from)
+    && endpointHasRail(map, visibility, completedTechsByCiv, to);
+  if (isRail && drawRailSegment(ctx, camera, from, to)) return;
+  drawRoadSegment(ctx, camera, from, to);
+}
+
 export function drawRoads(
   ctx: CanvasRenderingContext2D,
   map: GameMap,
   camera: Camera,
   cityTileKeys: ReadonlySet<string>,
   viewerVisibility?: VisibilityMap,
+  completedTechsByCiv: Record<string, string[]> = {},
 ): void {
   ctx.strokeStyle = '#8a6a3a';
   ctx.lineWidth = 3 * camera.zoom;
@@ -284,12 +342,12 @@ export function drawRoads(
 
   forEachRoadSegment(map, viewerVisibility, cityTileKeys, (from, to) => {
     if (camera.isHexVisible(from) || camera.isHexVisible(to)) {
-      drawRoadSegment(ctx, camera, from, to);
+      drawRoadOrRailSegment(ctx, map, camera, viewerVisibility, completedTechsByCiv, from, to);
     }
   });
 
   if (map.wrapsHorizontally) {
-    drawWrapGhostRoads(ctx, map, camera, cityTileKeys, viewerVisibility);
+    drawWrapGhostRoads(ctx, map, camera, cityTileKeys, viewerVisibility, completedTechsByCiv);
   }
 }
 
@@ -299,13 +357,14 @@ export function drawWrapGhostRoads(
   camera: Camera,
   cityTileKeys: ReadonlySet<string>,
   viewerVisibility?: VisibilityMap,
+  completedTechsByCiv: Record<string, string[]> = {},
 ): void {
   forEachRoadSegment(map, viewerVisibility, cityTileKeys, (from, to) => {
     for (const offset of getHorizontalWrapOffsetsForRiver(from, to, map.width)) {
       const ghostFrom: HexCoord = { q: from.q + offset, r: from.r };
       const ghostTo: HexCoord = { q: to.q + offset, r: to.r };
       if (!camera.isHexVisible(ghostFrom) && !camera.isHexVisible(ghostTo)) continue;
-      drawRoadSegment(ctx, camera, ghostFrom, ghostTo);
+      drawRoadOrRailSegment(ctx, map, camera, viewerVisibility, completedTechsByCiv, ghostFrom, ghostTo);
     }
   });
 }

--- a/src/renderer/improvements/rail-segment-loader.ts
+++ b/src/renderer/improvements/rail-segment-loader.ts
@@ -1,0 +1,18 @@
+import { getRailSegmentSvg } from './rail-segment-marker';
+
+let cachedImage: HTMLImageElement | null = null;
+
+export async function preloadRailSegment(): Promise<void> {
+  const blob = new Blob([getRailSegmentSvg()], { type: 'image/svg+xml' });
+  const url = URL.createObjectURL(blob);
+  await new Promise<void>((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => { URL.revokeObjectURL(url); cachedImage = img; resolve(); };
+    img.onerror = () => { URL.revokeObjectURL(url); reject(); };
+    img.src = url;
+  });
+}
+
+export function getRailSegmentImage(): HTMLImageElement | null {
+  return cachedImage;
+}

--- a/src/renderer/improvements/rail-segment-marker.ts
+++ b/src/renderer/improvements/rail-segment-marker.ts
@@ -1,0 +1,30 @@
+// Directional SVG track segment drawn along a road edge once BOTH endpoint
+// tiles resolve `hasRail: true` (see `resolveTileHasRail` in
+// `road-network.ts`). Rendered rotated per-edge in `hex-renderer.ts`, not
+// centered on a hex like a standard Improvement Marker — steel-gray rails on
+// wooden ties, faction-neutral, no animation. Replaces the plain brown line
+// segment used before Railway Expansion is completed.
+
+const RAIL_SEGMENT_SVG = `<svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+  <g stroke-linecap="round" stroke-linejoin="round">
+    <g stroke="#5e3f24" stroke-width="5">
+      <path d="M6,14 L6,34"/>
+      <path d="M15,10 L15,38"/>
+      <path d="M24,7 L24,41"/>
+      <path d="M33,10 L33,38"/>
+      <path d="M42,14 L42,34"/>
+    </g>
+    <g stroke="#8a929b" stroke-width="2.4">
+      <path d="M4,18 L44,18"/>
+      <path d="M4,30 L44,30"/>
+    </g>
+    <g stroke="#e8edf2" stroke-width="0.8" opacity="0.5">
+      <path d="M4,17 L44,17"/>
+      <path d="M4,29 L44,29"/>
+    </g>
+  </g>
+</svg>`;
+
+export function getRailSegmentSvg(): string {
+  return RAIL_SEGMENT_SVG;
+}

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -449,7 +449,10 @@ export class RenderLoop {
 
     // Draw roads (overlay, drawn under units — see drawUnits below)
     const cityTileKeys = new Set(Object.values(this.state.cities).map(city => hexKey(city.position)));
-    drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility);
+    const completedTechsByCiv = Object.fromEntries(
+      Object.entries(this.state.civilizations).map(([id, civ]) => [id, civ.techState?.completed ?? []]),
+    );
+    drawRoads(this.ctx, this.state.map, this.camera, cityTileKeys, viewerVisibility, completedTechsByCiv);
 
     // Draw minor civ territory
     if (this.state.minorCivs) {

--- a/src/renderer/tile-presentation.ts
+++ b/src/renderer/tile-presentation.ts
@@ -1,12 +1,14 @@
 import type { GameMap, HexCoord, HexTile, LastSeenTilePresentation, VisibilityMap } from '@/core/types';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexKey, wrapHexCoord } from '@/systems/hex-utils';
+import { resolveTileHasRail } from '@/systems/road-network';
 
 export type TilePresentationKind = 'live' | 'last-seen' | 'unknown-fog' | 'unexplored';
 
 export interface TilePresentation {
   kind: TilePresentationKind;
   tile: HexTile;
+  hasRail: boolean;
 }
 
 function unknownTile(coord: HexCoord): HexTile {
@@ -42,16 +44,24 @@ export function resolveTilePresentationForViewer(
   map: GameMap,
   visibility: VisibilityMap | undefined,
   renderCoord: HexCoord,
+  completedTechsByCiv: Record<string, string[]> = {},
 ): TilePresentation {
   const coord = map.wrapsHorizontally ? wrapHexCoord(renderCoord, map.width) : renderCoord;
   const key = hexKey(coord);
   const liveTile = map.tiles[key] ?? unknownTile(coord);
   const state = visibility ? getVisibility(visibility, coord) : 'visible';
 
-  if (state === 'visible') return { kind: 'live', tile: liveTile };
-  if (state === 'unexplored') return { kind: 'unexplored', tile: unknownTile(coord) };
+  if (state === 'visible') {
+    const hasRail = resolveTileHasRail(
+      Boolean(liveTile.hasRoad),
+      liveTile.owner,
+      liveTile.owner ? completedTechsByCiv[liveTile.owner] : undefined,
+    );
+    return { kind: 'live', tile: liveTile, hasRail };
+  }
+  if (state === 'unexplored') return { kind: 'unexplored', tile: unknownTile(coord), hasRail: false };
 
   const snapshot = visibility?.lastSeen?.[key];
-  if (snapshot) return { kind: 'last-seen', tile: lastSeenToTile(snapshot) };
-  return { kind: 'unknown-fog', tile: unknownTile(coord) };
+  if (snapshot) return { kind: 'last-seen', tile: lastSeenToTile(snapshot), hasRail: snapshot.hasRail ?? false };
+  return { kind: 'unknown-fog', tile: unknownTile(coord), hasRail: false };
 }

--- a/src/systems/last-seen-presentation.ts
+++ b/src/systems/last-seen-presentation.ts
@@ -10,6 +10,7 @@ import type {
 import { getVisibility, isForestConcealedUnit, updateVisibility } from '@/systems/fog-of-war';
 import { getActiveNationalProjectsForCiv } from '@/systems/national-project-system';
 import { getVisionBonus } from '@/systems/unit-modifier-system';
+import { resolveTileHasRail } from '@/systems/road-network';
 import { hexKey, parseHexKey, wrapHexCoord } from '@/systems/hex-utils';
 import { canInspectUnitForViewer } from './viewer-intel';
 import { getVisibleUnitsForPlayer } from './espionage-stealth';
@@ -85,6 +86,11 @@ function createTilePresentation(
 ): LastSeenTilePresentation {
   const tileKey = hexKey(tile.coord);
   const city = Object.values(state.cities).find(candidate => hexKey(candidate.position) === tileKey);
+  const hasRail = resolveTileHasRail(
+    Boolean(tile.hasRoad),
+    tile.owner,
+    tile.owner ? state.civilizations[tile.owner]?.techState.completed : undefined,
+  );
   return {
     coord: { ...tile.coord },
     terrain: tile.terrain,
@@ -96,6 +102,7 @@ function createTilePresentation(
     hasRiver: tile.hasRiver,
     wonder: tile.wonder,
     hasRoad: tile.hasRoad,
+    hasRail,
     city: city
       ? { id: city.id, name: city.name, owner: city.owner, population: city.population }
       : undefined,

--- a/src/systems/road-network.ts
+++ b/src/systems/road-network.ts
@@ -49,6 +49,22 @@ export function getCitiesConnectedToCapital(state: GameState, civId: string): Se
   return connected;
 }
 
+/**
+ * Whether a road tile should render with rail visuals: it must have a road,
+ * be owned, and that owner must have completed Railway Expansion. Purely
+ * presentational — no gameplay effect. Used identically by live-tile
+ * resolution (`tile-presentation.ts`) and last-seen snapshot capture
+ * (`last-seen-presentation.ts`) so fog/last-seen tiles freeze rail status at
+ * observation time instead of re-deriving the rival's current tech state.
+ */
+export function resolveTileHasRail(
+  hasRoad: boolean,
+  owner: string | null,
+  ownerCompletedTechs: string[] | undefined,
+): boolean {
+  return hasRoad && owner != null && (ownerCompletedTechs ?? []).includes('railway-expansion');
+}
+
 export function getOwnedRoadTileCount(state: GameState, civId: string): number {
   let count = 0;
   for (const tile of Object.values(state.map.tiles)) {

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { Camera } from '@/renderer/camera';
 import {
   drawHexHighlight,
@@ -8,10 +8,15 @@ import {
 } from '@/renderer/hex-renderer';
 import type { GameMap, VisibilityMap } from '@/core/types';
 
+vi.mock('@/renderer/improvements/rail-segment-loader', () => ({
+  getRailSegmentImage: () => ({} as HTMLImageElement),
+}));
+
 class MockCanvasContext {
   strokeCalls: string[] = [];
   textCalls: string[] = [];
   fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
+  drawImageCalls = 0;
   fillStyle = '';
   strokeStyle = '';
   lineWidth = 0;
@@ -24,6 +29,8 @@ class MockCanvasContext {
 
   save(): void {}
   restore(): void {}
+  translate(): void {}
+  rotate(): void {}
   beginPath(): void {}
   moveTo(): void {}
   lineTo(): void {}
@@ -32,6 +39,9 @@ class MockCanvasContext {
   ellipse(): void {}
   closePath(): void {}
   fill(): void {}
+  drawImage(): void {
+    this.drawImageCalls += 1;
+  }
   fillText(text: string, x: number = 0, y: number = 0): void {
     this.textCalls.push(text);
     this.fillTextCalls.push({ text, x, y });
@@ -501,5 +511,71 @@ describe('drawRoads', () => {
     const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
     drawRoads(ctx, map, makeCamera(), new Set());
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBe(0);
+  });
+});
+
+describe('drawRoads rail visual', () => {
+  function makeRailMap(secondTileOwner: string | null, secondTileHasRoad: boolean): GameMap {
+    return {
+      width: 2,
+      height: 1,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+        '1,0': { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: secondTileOwner, improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: secondTileHasRoad },
+      },
+    } as unknown as GameMap;
+  }
+
+  it('draws rail art (drawImage) when both segment endpoints are rail', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, makeRailMap('player', true), makeCamera(), new Set(), undefined, {
+      player: ['railway-expansion'],
+    });
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.drawImageCalls).toBeGreaterThan(0);
+    expect(mockCtx.strokeCalls.length).toBe(0);
+  });
+
+  it('falls back to the plain road line when only one endpoint qualifies (mixed-tech boundary, negative)', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    // '1,0' has no road at all, so it can never be rail regardless of tech.
+    drawRoads(ctx, makeRailMap('player', false), makeCamera(), new Set(['1,0']), undefined, {
+      player: ['railway-expansion'],
+    });
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.drawImageCalls).toBe(0);
+    expect(mockCtx.strokeCalls.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the plain road line when neither tile has a road at all (negative)', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const map = makeMap();
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, map, makeCamera(), new Set(['0,0', '1,0']), undefined, { player: ['railway-expansion'] });
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.drawImageCalls).toBe(0);
+  });
+
+  it('renders rail art identically on the wrap-ghost pass on a wrapping map', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const wrapMap: GameMap = {
+      width: 2,
+      height: 1,
+      wrapsHorizontally: true,
+      rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+        '1,0': { coord: { q: 1, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+      },
+    } as unknown as GameMap;
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    drawRoads(ctx, wrapMap, makeCamera(), new Set(), undefined, { player: ['railway-expansion'] });
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.drawImageCalls).toBeGreaterThan(0);
+    expect(mockCtx.strokeCalls.length).toBe(0);
   });
 });

--- a/tests/renderer/tile-presentation.test.ts
+++ b/tests/renderer/tile-presentation.test.ts
@@ -83,3 +83,55 @@ describe('tile-presentation', () => {
     });
   });
 });
+
+describe('tile-presentation hasRail', () => {
+  const railMap = {
+    width: 4,
+    height: 3,
+    wrapsHorizontally: false,
+    rivers: [],
+    tiles: { '0,0': { ...liveTile, hasRoad: true, owner: 'ai-1' } },
+  } as unknown as GameMap;
+
+  it('live tile resolves hasRail true when the owner has completed railway-expansion', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+    const result = resolveTilePresentationForViewer(railMap, visibility, { q: 0, r: 0 }, {
+      'ai-1': ['railway-expansion'],
+    });
+    expect(result.hasRail).toBe(true);
+  });
+
+  it('live tile resolves hasRail false when the owner lacks railway-expansion (negative)', () => {
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+    const result = resolveTilePresentationForViewer(railMap, visibility, { q: 0, r: 0 }, {
+      'ai-1': ['road-building'],
+    });
+    expect(result.hasRail).toBe(false);
+  });
+
+  it('last-seen tile reads the frozen hasRail snapshot rather than re-deriving from live tech state (negative)', () => {
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 },
+          terrain: 'plains',
+          elevation: 'lowland',
+          resource: null,
+          improvement: 'none',
+          improvementTurnsLeft: 0,
+          owner: 'ai-1',
+          hasRiver: false,
+          wonder: null,
+          hasRoad: true,
+          hasRail: false,
+        },
+      },
+    };
+    // Rival has since completed railway-expansion, but the viewer hasn't re-observed the tile.
+    const result = resolveTilePresentationForViewer(railMap, visibility, { q: 0, r: 0 }, {
+      'ai-1': ['railway-expansion'],
+    });
+    expect(result.hasRail).toBe(false);
+  });
+});

--- a/tests/systems/last-seen-presentation.test.ts
+++ b/tests/systems/last-seen-presentation.test.ts
@@ -62,6 +62,29 @@ describe('last-seen-presentation', () => {
     expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot);
   });
 
+  it('bakes hasRail true at capture time for a road tile owned by a civ with railway-expansion', () => {
+    const state = createNewGame(undefined, 'last-seen-rail-upgraded', 'small');
+    const tile = state.map.tiles['0,0'];
+    tile.owner = 'player';
+    tile.hasRoad = true;
+    state.civilizations['player'].techState.completed.push('railway-expansion');
+
+    const snapshot = createLastSeenTilePresentation(state, 'player', tile);
+
+    expect(snapshot.hasRail).toBe(true);
+  });
+
+  it('bakes hasRail false at capture time for a road tile without railway-expansion (negative)', () => {
+    const state = createNewGame(undefined, 'last-seen-rail-not-upgraded', 'small');
+    const tile = state.map.tiles['0,0'];
+    tile.owner = 'player';
+    tile.hasRoad = true;
+
+    const snapshot = createLastSeenTilePresentation(state, 'player', tile);
+
+    expect(snapshot.hasRail).toBe(false);
+  });
+
   it('updates only currently visible tiles for the viewer', () => {
     const state = createNewGame(undefined, 'last-seen-refresh', 'small');
     state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'fog' };

--- a/tests/systems/road-network.test.ts
+++ b/tests/systems/road-network.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { City, GameState, HexTile } from '@/core/types';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
-import { getCitiesConnectedToCapital, getOwnedRoadTileCount, getRoadBuildTarget } from '@/systems/road-network';
+import { getCitiesConnectedToCapital, getOwnedRoadTileCount, getRoadBuildTarget, resolveTileHasRail } from '@/systems/road-network';
 
 function tile(overrides: Partial<HexTile>): HexTile {
   return {
@@ -217,5 +217,27 @@ describe('getRoadBuildTarget', () => {
       },
     });
     expect(getRoadBuildTarget(s, 'player')).toBeNull();
+  });
+});
+
+describe('resolveTileHasRail', () => {
+  it('is true only with a road, an owner, and railway-expansion completed', () => {
+    expect(resolveTileHasRail(true, 'player', ['railway-expansion'])).toBe(true);
+  });
+
+  it('is false without a road (negative)', () => {
+    expect(resolveTileHasRail(false, 'player', ['railway-expansion'])).toBe(false);
+  });
+
+  it('is false without an owner (negative)', () => {
+    expect(resolveTileHasRail(true, null, ['railway-expansion'])).toBe(false);
+  });
+
+  it('is false when the owner has not completed railway-expansion (negative)', () => {
+    expect(resolveTileHasRail(true, 'player', ['road-building'])).toBe(false);
+  });
+
+  it('is false when completed techs is undefined (negative)', () => {
+    expect(resolveTileHasRail(true, 'player', undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds a directional steel-rail-and-ties SVG segment (`src/renderer/improvements/rail-segment-marker.ts` + `rail-segment-loader.ts`) drawn by `drawRoads`/`drawWrapGhostRoads` in place of the plain brown road line, whenever **both** endpoint tiles of a road segment resolve `hasRail: true`.
- `hasRail` is fully derived, never persisted: `resolveTileHasRail(hasRoad, owner, ownerCompletedTechs)` in `src/systems/road-network.ts` returns true only when a road tile is owned by a civ that has completed `railway-expansion`. No new `HexTile` field, no save migration.
- `TilePresentation` (`src/renderer/tile-presentation.ts`) gains a `hasRail` field for live tiles; `LastSeenTilePresentation` (`src/core/types.ts`) gains an optional `hasRail` baked in at observation time by `createTilePresentation` (`src/systems/last-seen-presentation.ts`). Fog/last-seen tiles read the frozen snapshot value and never re-derive the rival's current tech state — a regression test proves a remembered tile stays a plain road even after the rival later completes Railway Expansion.
- Rendering-only change: no effect on movement costs, income effects, or AI road-building behavior from MR7 (#466).
- Docs updated: `docs/sprite-design-system.md` (asset entry), `.claude/rules/sprites.md` (new "Rail Segment" extension recipe — this asset doesn't fit the standard Unit/Building, Terrain Tile, or Improvement Marker contracts since it's a per-edge rotated sprite gated on both segment endpoints), `docs/claude-design-sprites-prompt.md` (Claude Design prompt addendum for a future higher-fidelity replacement).

## Test plan

- [x] `tests/systems/road-network.test.ts` — `resolveTileHasRail` positive + 4 negative cases (no road, no owner, wrong/missing tech)
- [x] `tests/renderer/tile-presentation.test.ts` — live tile resolves `hasRail` from current owner tech; last-seen tile reads the frozen snapshot even after the rival's tech state changes post-observation (negative/privacy regression)
- [x] `tests/systems/last-seen-presentation.test.ts` — `createTilePresentation` bakes `hasRail` correctly at capture time for upgraded and non-upgraded road tiles
- [x] `tests/renderer/hex-renderer.test.ts` — `drawRoads` draws rail art when both endpoints qualify; falls back to the plain line on a mixed-tech boundary and when neither tile has a road; wrap-ghost pass renders rail art identically to the live pass
- [x] `bash scripts/run-with-mise.sh yarn build` — green
- [x] `bash scripts/run-with-mise.sh yarn test` — green (5619 passed, 2 skipped)
- [x] Verified in browser preview: app boots with no console/server errors after the change

Closes #483