### PR TITLE
feat: add hidden city-state economy

### DIFF
--- a/docs/superpowers/plans/2026-07-08-hidden-city-state-economy.md
+++ b/docs/superpowers/plans/2026-07-08-hidden-city-state-economy.md
@@ -1,0 +1,1793 @@
+# Hidden City-State Economy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This repo forbids subagents in `CLAUDE.md`, so do not use subagent-driven execution even if a generic skill recommends it.
+
+**Goal:** Implement issue #490 by giving active city-states a hidden, production-backed economy that grows, queues safe buildings/units, mobilizes under threat, stays viewer-safe, and composes with existing regional grievance, coalition, reparations, quest, save, solo, hot-seat, web/PWA, and Tauri paths.
+
+**Architecture:** Add a focused `minor-civ-economy-system.ts` that normalizes economy metadata, derives minor-civ-safe tech/resources, selects one legal queue item, processes real city production through existing `processCity`, handles minor-civ unit completion, and exposes viewer-safe presentation summaries. Integrate it from `processMinorCivTurn` before minor-civ planning/movement while changing regional grievance processing to provide a shared mobilization budget instead of independently spawning extra defenders in the same turn.
+
+**Tech Stack:** TypeScript, Vite, Vitest, DOM/CSS UI, existing `EventBus`, existing `processCity`, existing minor-civ coalition/grievance helpers, existing save normalization in `src/storage/save-manager.ts`.
+
+---
+
+## Target Agent
+
+This plan is written for a Sonnet 4.5 coding agent. Keep the spec and this plan open while working. Do not infer missing gameplay rules from taste; implement the exact contracts here and in `docs/superpowers/specs/2026-07-07-hidden-city-state-economy-design.md`.
+
+## Spec And Rule References
+
+- Spec: `docs/superpowers/specs/2026-07-07-hidden-city-state-economy-design.md`
+- Existing related plan: `docs/superpowers/plans/2026-07-07-minor-civ-regional-grievance-mobilization.md`
+- Rules to keep open:
+  - `CLAUDE.md`
+  - `.claude/rules/game-systems.md`
+  - `.claude/rules/strategy-game-mechanics.md`
+  - `.claude/rules/end-to-end-wiring.md`
+  - `.claude/rules/ui-panels.md`
+  - `.claude/rules/spec-fidelity.md`
+  - `.claude/rules/incremental-mr-completion.md`
+  - `docs/superpowers/plans/README.md`
+
+## Concrete Tuning For This Implementation
+
+Use these exact first-pass values. Adjusting them is a balance follow-up, not part of this implementation.
+
+```ts
+export const MINOR_CIV_ECONOMY_TUNING = {
+  explorer: {
+    productionMultiplier: 0.75,
+    queueDecisionInterval: 5,
+    caps: { settled: 1, fortifying: 2, mobilizing: 3, recovering: 1 },
+    recoveryTurns: 8,
+    pendingSpawnMaxAttempts: 3,
+  },
+  standard: {
+    productionMultiplier: 1,
+    queueDecisionInterval: 4,
+    caps: { settled: 2, fortifying: 3, mobilizing: 4, recovering: 2 },
+    recoveryTurns: 6,
+    pendingSpawnMaxAttempts: 3,
+  },
+  veteran: {
+    productionMultiplier: 1.15,
+    queueDecisionInterval: 3,
+    caps: { settled: 2, fortifying: 4, mobilizing: 5, recovering: 2 },
+    recoveryTurns: 5,
+    pendingSpawnMaxAttempts: 4,
+  },
+} as const;
+```
+
+- Militaristic city-states get `+1` cap only while `fortifying` or `mobilizing`.
+- Cultural city-states use the table cap unchanged and prefer culture/science buildings over extra peaceful units.
+- Mercantile city-states use the table cap unchanged and prefer gold/economy buildings before peaceful units.
+- `fortifying` is the default response to regional grievance status `wary`.
+- `mobilizing` is the response to direct war, immediate city threat, regional grievance status `mobilizing` or `coalition-talks`, or an active/forming coalition involving the city-state.
+- `recovering` applies while `economy.localRecoveryUntilTurn > state.turn` or a relevant regional grievance has `recoveryStrainedUntilTurn > state.turn`.
+- Early-game force projection remains local: do not widen `MINOR_OPERATIONAL_RADIUS`.
+
+## Files And Responsibilities
+
+- Modify `src/core/types.ts`: add `MinorCivPosture`, `MinorCivPolicy`, `MinorCivEconomyState`, optional `MinorCivState.economy`, and `minor-civ:production-completed` event.
+- Create `src/systems/minor-civ-economy-system.ts`: economy normalization, tech/resource helpers, candidate filtering/scoring, posture evaluation, unit caps, pending spawn handling, `processMinorCivEconomyTurn`, and viewer-safe presentation helper.
+- Modify `src/systems/minor-civ-coalition-system.ts`: expose a mobilization-budget helper and add an option to process regional grievance without direct defender spawning.
+- Modify `src/systems/minor-civ-system.ts`: call regional grievance pressure processing without direct spawns, process the hidden economy, then run planning/movement/combat/quests/alliance/garrison/relationship logic.
+- Modify `src/storage/save-manager.ts`: normalize minor-civ economy state after quest and coalition normalization, without emitting events or creating units.
+- Modify `src/systems/minor-civ-presentation.ts`: compose economy presentation with existing known/unknown masking.
+- Modify `src/ui/minor-civ-notifications.ts`: add production/mobilization notification drafts with viewer-safe text.
+- Modify `src/ui/minor-civ-notification-listeners.ts`: route `minor-civ:production-completed` to eligible solo and hot-seat viewers.
+- Modify `src/ui/diplomacy-panel.ts`: render broad economy posture with regional grievance as one coherent block, remove exact pressure leakage, and keep gift/festival/reparations/war actions reachable.
+- Tests:
+  - `tests/systems/minor-civ-economy-system.test.ts`
+  - `tests/systems/minor-civ-system.test.ts`
+  - `tests/systems/minor-civ-presentation.test.ts`
+  - `tests/storage/save-persistence.test.ts`
+  - `tests/ui/minor-civ-notifications.test.ts`
+  - `tests/ui/minor-civ-notification-listeners.test.ts`
+  - `tests/ui/diplomacy-panel.test.ts`
+
+## Player Truth Table
+
+| Before | Action | Internal State | Immediate Visible Result |
+|---|---|---|---|
+| Discovered peaceful city-state row shows relationship, quest, gift, festival, war/peace actions | Advance turns until the hidden economy completes a safe building | City-state city gains the building and `economy.recentProductionSummary` records a building class | No raw queue or ETA appears; row can show broad `Quiet` or `Prosperous`; existing actions remain reachable |
+| Discovered city-state has regional grievance `wary` | Open diplomacy | Economy posture resolves to `fortifying` through shared presentation | Row shows one coherent warning such as `Regional grievance: Wary · Fortifying`, without exact pressure numbers |
+| City-state is mobilizing and completes a unit | End turn | Unit is added to `state.units` and `mc.units`, with `movementPointsLeft = 0`, `hasMoved = true`, and `hasActed = true` | Eligible viewer may receive a broad warning; no same-turn hidden attack occurs |
+| Production completes while city and adjacent tiles are occupied | End turn | `economy.pendingUnitSpawn` stores the completed unit and no unit is created | No notification claims a unit exists; next turn retries if a legal tile opens |
+| Hot-seat player A knows Sparta; player B does not | Economy event fires for Sparta | Event routes by viewer eligibility | Player A gets pending/log notification; player B gets no name, color, location, posture, or queue hint |
+| Solo player has not discovered Sparta | Economy event fires for Sparta | Event exists in hidden state only | No notification/log text leaks Sparta or the event |
+| Player pays reparations from an open diplomacy panel | Click `Pay Reparations` | Regional pressure cools; economy posture recomputes from the cooled grievance | Open panel rerenders; exact pressure is still hidden; reparations cannot be double-clicked from stale DOM |
+
+## Misleading UI Risks
+
+- `Mobilizing` must not appear after reparations if the shared regional grievance helper has cooled the pressure below mobilization.
+- `Prosperous` must not imply exact queue details. It means recent building/economy completion or peaceful growth only.
+- `Training defenders` must not appear for a blocked `pendingUnitSpawn`; use `Recovering` or no production hint until a unit actually exists.
+- Exact hidden pressure values such as `(55)` must not render in `diplomacy-panel.ts`.
+- Undiscovered city-state names, colors, map targets, and production classes must not render in notifications or diplomacy rows.
+- A default focused economy hint must not remove gift, festival, reparations, or war/peace actions.
+
+## Interaction Replay Checklist
+
+- Open diplomacy with a discovered city-state in `wary` regional grievance.
+- Pay reparations once and assert panel rerenders with cooled posture.
+- Repeat-click the old reparations button reference and assert gold is not deducted twice.
+- Reopen diplomacy and assert broad posture persists without exact pressure.
+- Open hot-seat as another current player and assert hidden city-state economy details do not leak.
+- Trigger a production-completed notification in solo and assert undiscovered city-states remain silent.
+
+## Queue And ETA Checklist
+
+This implementation does not add a player-visible production queue for city-states. The hidden queue lives on the existing `City.productionQueue`, but the player sees only broad posture and coarse production class hints when visibility allows it. Tests must assert that exact queue item ids and ETA text are not rendered.
+
+## Task 1: Types, Save Normalization, And Event Skeleton
+
+**Files:**
+- Modify: `src/core/types.ts`
+- Create: `src/systems/minor-civ-economy-system.ts`
+- Modify: `src/storage/save-manager.ts`
+- Test: `tests/storage/save-persistence.test.ts`
+- Test: `tests/systems/minor-civ-economy-system.test.ts`
+
+- [ ] **Step 1: Write failing type/normalization tests**
+
+Add to `tests/storage/save-persistence.test.ts`:
+
+```ts
+it('normalizes missing hidden minor-civ economy state after coalition state', () => {
+  const state = createNewGame(undefined, 'minor-economy-legacy', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  delete (minorCiv as any).economy;
+  minorCiv.regionalGrievanceByCiv = {
+    player: {
+      targetCivId: 'player',
+      pressure: 55,
+      status: 'mobilizing',
+      lastUpdatedTurn: state.turn,
+      causes: [],
+      mobilizationProgress: 12,
+    },
+  };
+
+  const loaded = normalizeLoadedStateForTest(state);
+
+  expect(loaded.minorCivs[minorCiv.id].economy).toMatchObject({
+    policy: 'balanced',
+    posture: 'settled',
+    lastProcessedTurn: Math.max(0, state.turn - 1),
+  });
+  expect(loaded.minorCivs[minorCiv.id].regionalGrievanceByCiv?.player).toMatchObject({
+    pressure: 55,
+    status: 'mobilizing',
+    mobilizationProgress: 12,
+  });
+});
+
+it('drops malformed pending minor-civ economy spawns without creating units on load', () => {
+  const state = createNewGame(undefined, 'minor-economy-bad-pending', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const unitCountBefore = Object.keys(state.units).length;
+  (minorCiv as any).economy = {
+    policy: 'balanced',
+    posture: 'settled',
+    lastProcessedTurn: state.turn,
+    pendingUnitSpawn: { unitType: 'settler', completedTurn: 'bad', attempts: -1 },
+  };
+
+  const loaded = normalizeLoadedStateForTest(state);
+
+  expect(loaded.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toBeUndefined();
+  expect(Object.keys(loaded.units)).toHaveLength(unitCountBefore);
+});
+```
+
+Create `tests/systems/minor-civ-economy-system.test.ts` with:
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
+
+describe('minor-civ economy normalization', () => {
+  it('does not change city queue, production progress, units, or regional grievance', () => {
+    const state = createNewGame(undefined, 'minor-economy-normalize-system', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0]!;
+    const city = state.cities[minorCiv.cityId];
+    city.productionQueue = ['walls'];
+    city.productionProgress = 7;
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 45,
+        status: 'mobilizing',
+        lastUpdatedTurn: state.turn,
+        causes: [],
+      },
+    };
+    const beforeUnits = structuredClone(state.units);
+
+    const result = normalizeMinorCivEconomyState(state);
+
+    expect(result.cities[city.id].productionQueue).toEqual(['walls']);
+    expect(result.cities[city.id].productionProgress).toBe(7);
+    expect(result.units).toEqual(beforeUnits);
+    expect(result.minorCivs[minorCiv.id].regionalGrievanceByCiv).toEqual(minorCiv.regionalGrievanceByCiv);
+    expect(result.minorCivs[minorCiv.id].economy).toMatchObject({ policy: 'balanced', posture: 'settled' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/storage/save-persistence.test.ts tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: FAIL because `normalizeMinorCivEconomyState` and `MinorCivState.economy` do not exist.
+
+- [ ] **Step 3: Add types and event**
+
+In `src/core/types.ts`, add near the existing minor-civ types:
+
+```ts
+export type MinorCivPosture = 'settled' | 'fortifying' | 'mobilizing' | 'recovering';
+export type MinorCivPolicy = 'balanced' | 'defense' | 'economy' | 'knowledge' | 'recovery';
+
+export interface MinorCivEconomyState {
+  policy: MinorCivPolicy;
+  posture: MinorCivPosture;
+  lastProcessedTurn: number;
+  lastPostureChangeTurn?: number;
+  localRecoveryUntilTurn?: number;
+  lastQueueDecisionTurn?: number;
+  pendingUnitSpawn?: {
+    unitType: UnitType;
+    completedTurn: number;
+    attempts: number;
+  };
+  recentProductionSummary?: {
+    itemId: string;
+    itemClass: 'building' | 'unit' | 'idle';
+    completedTurn: number;
+  };
+}
+```
+
+Add `economy?: MinorCivEconomyState;` to `MinorCivState`.
+
+Add this event to `GameEvents` near the other `minor-civ:*` events:
+
+```ts
+'minor-civ:production-completed': {
+  minorCivId: string;
+  cityId: string;
+  itemId: string;
+  itemClass: 'building' | 'unit';
+  state?: GameState;
+};
+```
+
+- [ ] **Step 4: Implement normalization skeleton**
+
+Create `src/systems/minor-civ-economy-system.ts`:
+
+```ts
+import type { GameState, MinorCivEconomyState, MinorCivPolicy, MinorCivPosture, UnitType } from '@/core/types';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+
+const POLICIES = new Set<MinorCivPolicy>(['balanced', 'defense', 'economy', 'knowledge', 'recovery']);
+const POSTURES = new Set<MinorCivPosture>(['settled', 'fortifying', 'mobilizing', 'recovering']);
+const SAFE_UNIT_TYPES = new Set<UnitType>(TRAINABLE_UNITS.map(unit => unit.type));
+
+function isFiniteNonNegative(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function normalizePendingSpawn(value: unknown, completedTurnFallback: number): MinorCivEconomyState['pendingUnitSpawn'] {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.unitType !== 'string') return undefined;
+  if (!SAFE_UNIT_TYPES.has(record.unitType as UnitType)) return undefined;
+  if (!isFiniteNonNegative(record.completedTurn)) return undefined;
+  if (!isFiniteNonNegative(record.attempts)) return undefined;
+  if (record.completedTurn > completedTurnFallback) return undefined;
+  return {
+    unitType: record.unitType as UnitType,
+    completedTurn: record.completedTurn,
+    attempts: record.attempts,
+  };
+}
+
+export function createDefaultMinorCivEconomyState(state: Pick<GameState, 'turn'>): MinorCivEconomyState {
+  return {
+    policy: 'balanced',
+    posture: 'settled',
+    lastProcessedTurn: Math.max(0, state.turn - 1),
+  };
+}
+
+function normalizeEconomy(value: unknown, state: Pick<GameState, 'turn'>): MinorCivEconomyState {
+  const defaults = createDefaultMinorCivEconomyState(state);
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return defaults;
+  const record = value as Record<string, unknown>;
+  const economy: MinorCivEconomyState = {
+    policy: typeof record.policy === 'string' && POLICIES.has(record.policy as MinorCivPolicy)
+      ? record.policy as MinorCivPolicy
+      : defaults.policy,
+    posture: typeof record.posture === 'string' && POSTURES.has(record.posture as MinorCivPosture)
+      ? record.posture as MinorCivPosture
+      : defaults.posture,
+    lastProcessedTurn: isFiniteNonNegative(record.lastProcessedTurn)
+      ? record.lastProcessedTurn
+      : defaults.lastProcessedTurn,
+  };
+  if (isFiniteNonNegative(record.lastPostureChangeTurn)) economy.lastPostureChangeTurn = record.lastPostureChangeTurn;
+  if (isFiniteNonNegative(record.localRecoveryUntilTurn)) economy.localRecoveryUntilTurn = record.localRecoveryUntilTurn;
+  if (isFiniteNonNegative(record.lastQueueDecisionTurn)) economy.lastQueueDecisionTurn = record.lastQueueDecisionTurn;
+  const pending = normalizePendingSpawn(record.pendingUnitSpawn, state.turn);
+  if (pending) economy.pendingUnitSpawn = pending;
+  if (typeof record.recentProductionSummary === 'object' && record.recentProductionSummary !== null && !Array.isArray(record.recentProductionSummary)) {
+    const summary = record.recentProductionSummary as Record<string, unknown>;
+    if (
+      typeof summary.itemId === 'string'
+      && (summary.itemClass === 'building' || summary.itemClass === 'unit' || summary.itemClass === 'idle')
+      && isFiniteNonNegative(summary.completedTurn)
+    ) {
+      economy.recentProductionSummary = {
+        itemId: summary.itemId,
+        itemClass: summary.itemClass,
+        completedTurn: summary.completedTurn,
+      };
+    }
+  }
+  return economy;
+}
+
+export function normalizeMinorCivEconomyState(state: GameState): GameState {
+  const minorCivs = { ...(state.minorCivs ?? {}) };
+  for (const [minorCivId, minorCiv] of Object.entries(minorCivs)) {
+    if (minorCiv.isDestroyed) {
+      minorCivs[minorCivId] = { ...minorCiv, economy: normalizeEconomy(minorCiv.economy, state) };
+      continue;
+    }
+    minorCivs[minorCivId] = { ...minorCiv, economy: normalizeEconomy(minorCiv.economy, state) };
+  }
+  return { ...state, minorCivs };
+}
+```
+
+- [ ] **Step 5: Wire save normalization**
+
+In `src/storage/save-manager.ts`, import:
+
+```ts
+import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
+```
+
+Wrap the current quest/coalition normalization so economy runs after coalition state and before pirate migration:
+
+```ts
+const normalizedCityState = migrateLegacyPirateFleets(normalizeMinorCivEconomyState(normalizeMinorCivCoalitionState(normalizeMinorCivQuestState(
+  migrateLegacyCoastalData(normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateStripCityGrid(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))))))),
+))));
+```
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/storage/save-persistence.test.ts tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/types.ts src/systems/minor-civ-economy-system.ts src/storage/save-manager.ts tests/storage/save-persistence.test.ts tests/systems/minor-civ-economy-system.test.ts
+git commit -m "feat: normalize hidden city-state economy state"
+```
+
+## Task 2: Minor-Civ-Safe Tech, Resource, Candidate, And Posture Helpers
+
+**Files:**
+- Modify: `src/systems/minor-civ-economy-system.ts`
+- Test: `tests/systems/minor-civ-economy-system.test.ts`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Add to `tests/systems/minor-civ-economy-system.test.ts`:
+
+```ts
+import {
+  chooseMinorCivQueueItem,
+  evaluateMinorCivEconomyPosture,
+  getMinorCivAvailableResources,
+  getMinorCivBuildCandidates,
+  getMinorCivCompletedTechBand,
+  getMinorCivUnitCap,
+} from '@/systems/minor-civ-economy-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { hexKey } from '@/systems/hex-utils';
+
+it('derives minor-civ tech bands by era without needing a Civilization record', () => {
+  const state = createNewGame(undefined, 'minor-economy-tech-band', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  state.era = 2;
+
+  const techs = getMinorCivCompletedTechBand(state, minorCiv.id);
+
+  expect(state.civilizations[minorCiv.id]).toBeUndefined();
+  expect(techs).toContain('bronze-working');
+  expect(techs.every(techId => typeof techId === 'string')).toBe(true);
+});
+
+it('reads city-state resources from owned improved tiles and does not use major-civ resource lookup', () => {
+  const state = createNewGame(undefined, 'minor-economy-resource-band', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  const resourceTile = city.ownedTiles.find(coord => hexKey(coord) !== hexKey(city.position)) ?? city.position;
+  const key = hexKey(resourceTile);
+  state.map.tiles[key] = {
+    ...state.map.tiles[key],
+    owner: minorCiv.id,
+    resource: 'copper',
+    improvement: 'mine',
+    improvementTurnsLeft: 0,
+  };
+  state.era = 1;
+
+  expect(getCivAvailableResources(state, minorCiv.id).has('copper')).toBe(false);
+  expect(getMinorCivAvailableResources(state, minorCiv.id).has('copper')).toBe(true);
+});
+
+it('does not reveal resource-gated candidates before the era band reveals their resource', () => {
+  const state = createNewGame(undefined, 'minor-economy-resource-negative', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  state.era = 1;
+  state.map.tiles[hexKey(city.position)] = {
+    ...state.map.tiles[hexKey(city.position)],
+    owner: minorCiv.id,
+    resource: 'iron',
+  };
+
+  const candidates = getMinorCivBuildCandidates(state, minorCiv.id);
+
+  expect(candidates.units.map(unit => unit.type)).not.toContain('swordsman');
+});
+
+it('filters city-state unsafe candidates', () => {
+  const state = createNewGame(undefined, 'minor-economy-safe-candidates', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+
+  const candidates = getMinorCivBuildCandidates(state, minorCiv.id);
+  const ids = [...candidates.buildings.map(building => building.id), ...candidates.units.map(unit => unit.type)];
+
+  expect(ids).not.toContain('settler');
+  expect(ids).not.toContain('worker');
+  expect(ids).not.toContain('spy_scout');
+  expect(ids).not.toContain('caravan');
+  expect(candidates.buildings.every(building => !building.nationalProject && !building.uniquePerEmpire)).toBe(true);
+});
+
+it('maps regional grievance and recovery strain into economy posture', () => {
+  const state = createNewGame(undefined, 'minor-economy-posture', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  minorCiv.regionalGrievanceByCiv = {
+    player: {
+      targetCivId: 'player',
+      pressure: 50,
+      status: 'mobilizing',
+      lastUpdatedTurn: state.turn,
+      recoveryStrainedUntilTurn: state.turn + 3,
+      causes: [],
+    },
+  };
+
+  expect(evaluateMinorCivEconomyPosture(state, minorCiv.id)).toBe('recovering');
+});
+
+it('uses challenge, posture, and archetype for unit caps', () => {
+  const state = createNewGame(undefined, 'minor-economy-caps', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  minorCiv.definitionId = 'sparta';
+  state.opponentChallenge = 'veteran';
+
+  expect(getMinorCivUnitCap(state, minorCiv.id, 'mobilizing')).toBe(6);
+});
+
+it('chooses a deterministic single queue item', () => {
+  const state = createNewGame(undefined, 'minor-economy-queue-choice', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  state.minorCivs[minorCiv.id].economy = { policy: 'defense', posture: 'fortifying', lastProcessedTurn: 0 };
+
+  expect(chooseMinorCivQueueItem(state, minorCiv.id)).toEqual(chooseMinorCivQueueItem(state, minorCiv.id));
+});
+
+it('treats low cooled wary pressure as settled when no local threat exists', () => {
+  const state = createNewGame(undefined, 'minor-economy-cooled-wary', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  minorCiv.regionalGrievanceByCiv = {
+    player: {
+      targetCivId: 'player',
+      pressure: 5,
+      status: 'wary',
+      lastUpdatedTurn: state.turn,
+      causes: [],
+    },
+  };
+
+  expect(evaluateMinorCivEconomyPosture(state, minorCiv.id)).toBe('settled');
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: FAIL because the helper functions do not exist.
+
+- [ ] **Step 3: Implement helper exports**
+
+In `src/systems/minor-civ-economy-system.ts`, extend imports:
+
+```ts
+import type { Building, MinorCivArchetype, ResourceType, TrainableUnitEntry } from '@/core/types';
+import { resolveOpponentChallenge } from '@/core/opponent-challenge';
+import { getAvailableBuildings, getTrainableUnitsForCity } from '@/systems/city-system';
+import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
+import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { hexKey, hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
+```
+
+Add these helpers:
+
+```ts
+export const MINOR_CIV_ECONOMY_TUNING = {
+  explorer: {
+    productionMultiplier: 0.75,
+    queueDecisionInterval: 5,
+    caps: { settled: 1, fortifying: 2, mobilizing: 3, recovering: 1 },
+    recoveryTurns: 8,
+    pendingSpawnMaxAttempts: 3,
+  },
+  standard: {
+    productionMultiplier: 1,
+    queueDecisionInterval: 4,
+    caps: { settled: 2, fortifying: 3, mobilizing: 4, recovering: 2 },
+    recoveryTurns: 6,
+    pendingSpawnMaxAttempts: 3,
+  },
+  veteran: {
+    productionMultiplier: 1.15,
+    queueDecisionInterval: 3,
+    caps: { settled: 2, fortifying: 4, mobilizing: 5, recovering: 2 },
+    recoveryTurns: 5,
+    pendingSpawnMaxAttempts: 4,
+  },
+} as const;
+
+const UNSAFE_UNIT_TYPES = new Set<UnitType>([
+  'settler',
+  'worker',
+  'spy_scout',
+  'spy_informant',
+  'spy_agent',
+  'spy_operative',
+  'spy_hacker',
+  'caravan',
+  'transport',
+  'troop_transport',
+]);
+const UNSAFE_BUILDING_IDS = new Set<string>();
+
+function getMinorCivDefinition(minorCivId: string, state: GameState) {
+  const minorCiv = state.minorCivs[minorCivId];
+  return minorCiv ? MINOR_CIV_DEFINITIONS.find(definition => definition.id === minorCiv.definitionId) : undefined;
+}
+
+function distance(state: GameState, left: { q: number; r: number }, right: { q: number; r: number }): number {
+  return state.map.wrapsHorizontally ? wrappedHexDistance(left, right, state.map.width) : hexDistance(left, right);
+}
+
+export function getMinorCivCompletedTechBand(state: GameState, minorCivId: string): string[] {
+  if (!state.minorCivs[minorCivId]) return [];
+  return TECH_TREE
+    .filter(tech => tech.era <= state.era)
+    .map(tech => tech.id)
+    .sort();
+}
+
+export function getMinorCivAvailableResources(state: GameState, minorCivId: string): Set<ResourceType> {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city) return new Set();
+  const completedTechs = new Set(getMinorCivCompletedTechBand(state, minorCivId));
+  const definitions = new Map(RESOURCE_DEFINITIONS.map(definition => [definition.id, definition]));
+  const resources = new Set<ResourceType>();
+  const cityKey = hexKey(city.position);
+  for (const coord of city.ownedTiles) {
+    const key = hexKey(coord);
+    const tile = state.map.tiles[key];
+    if (!tile?.resource) continue;
+    const definition = definitions.get(tile.resource as ResourceType);
+    if (!definition || !completedTechs.has(definition.tech)) continue;
+    if (key === cityKey) {
+      resources.add(tile.resource as ResourceType);
+      continue;
+    }
+    if (tile.improvement === definition.requiredImprovement && tile.improvementTurnsLeft === 0) {
+      resources.add(tile.resource as ResourceType);
+    }
+  }
+  return resources;
+}
+
+export function getMinorCivBuildCandidates(state: GameState, minorCivId: string): { buildings: Building[]; units: TrainableUnitEntry[] } {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city || city.owner !== minorCiv.id || minorCiv.isDestroyed) {
+    return { buildings: [], units: [] };
+  }
+  const completedTechs = getMinorCivCompletedTechBand(state, minorCivId);
+  const resources = getMinorCivAvailableResources(state, minorCivId);
+  const buildings = getAvailableBuildings(city, completedTechs, state.map, resources, state.era)
+    .filter(building => !building.nationalProject && !building.uniquePerEmpire && !UNSAFE_BUILDING_IDS.has(building.id));
+  const units = getTrainableUnitsForCity(city, completedTechs, state.map, undefined, resources)
+    .filter(unit => !UNSAFE_UNIT_TYPES.has(unit.type));
+  return { buildings, units };
+}
+
+function hasImmediateCityThreat(state: GameState, minorCivId: string): boolean {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city) return false;
+  return Object.values(state.units).some(unit => (
+    unit.owner !== minorCiv.id
+    && !unit.transportId
+    && distance(state, city.position, unit.position) <= 2
+    && (minorCiv.diplomacy.atWarWith.includes(unit.owner) || unit.owner === 'barbarian')
+  ));
+}
+
+export function evaluateMinorCivEconomyPosture(state: GameState, minorCivId: string): MinorCivPosture {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv || minorCiv.isDestroyed) return 'settled';
+  const economy = minorCiv.economy;
+  if ((economy?.localRecoveryUntilTurn ?? 0) > state.turn) return 'recovering';
+  const grievances = Object.values(minorCiv.regionalGrievanceByCiv ?? {});
+  if (grievances.some(grievance => (grievance.recoveryStrainedUntilTurn ?? 0) > state.turn)) return 'recovering';
+  if (minorCiv.diplomacy.atWarWith.length > 0 || hasImmediateCityThreat(state, minorCivId)) return 'mobilizing';
+  if (grievances.some(grievance => grievance.status === 'mobilizing' || grievance.status === 'coalition-talks')) return 'mobilizing';
+  if (Object.values(state.minorCivCoalitions ?? {}).some(coalition => coalition.memberIds.includes(minorCivId) && (coalition.status === 'forming' || coalition.status === 'active'))) return 'mobilizing';
+  if (grievances.some(grievance => grievance.status === 'wary' && grievance.pressure >= 20) || minorCiv.units.filter(unitId => state.units[unitId]).length === 0) return 'fortifying';
+  return 'settled';
+}
+
+export function getMinorCivUnitCap(state: GameState, minorCivId: string, posture: MinorCivPosture): number {
+  const challenge = resolveOpponentChallenge(state);
+  const tuning = MINOR_CIV_ECONOMY_TUNING[challenge];
+  const definition = getMinorCivDefinition(minorCivId, state);
+  const archetypeBonus = definition?.archetype === 'militaristic' && (posture === 'fortifying' || posture === 'mobilizing') ? 1 : 0;
+  return Math.max(1, tuning.caps[posture] + archetypeBonus);
+}
+```
+
+Add candidate scoring:
+
+```ts
+function scoreBuilding(building: Building, archetype: MinorCivArchetype | undefined, posture: MinorCivPosture): number {
+  let score = 20;
+  if (posture === 'fortifying' || posture === 'mobilizing') {
+    if (building.id === 'walls' || building.id === 'barracks' || building.id === 'stable') score += 60;
+  }
+  if (archetype === 'mercantile' && (building.yields.gold > 0 || building.id === 'marketplace')) score += 35;
+  if (archetype === 'cultural' && (building.yields.science > 0 || building.id === 'library' || building.id === 'temple' || building.id === 'monument')) score += 35;
+  if (archetype === 'militaristic' && (building.id === 'walls' || building.id === 'barracks')) score += 35;
+  score += building.yields.food * 3 + building.yields.production * 4 + building.yields.gold * 2 + building.yields.science * 2;
+  return score;
+}
+
+function scoreUnit(unit: TrainableUnitEntry, archetype: MinorCivArchetype | undefined, posture: MinorCivPosture, currentUnits: number, cap: number): number {
+  if (currentUnits >= cap) return -1;
+  let score = posture === 'mobilizing' ? 90 : posture === 'fortifying' ? 60 : 15;
+  if (archetype === 'militaristic') score += 20;
+  if (unit.type === 'scout') score -= 20;
+  return score;
+}
+
+export function chooseMinorCivQueueItem(state: GameState, minorCivId: string): string | null {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv) return null;
+  const definition = getMinorCivDefinition(minorCivId, state);
+  const posture = minorCiv.economy?.posture ?? evaluateMinorCivEconomyPosture(state, minorCivId);
+  const cap = getMinorCivUnitCap(state, minorCivId, posture);
+  const currentUnits = minorCiv.units.filter(unitId => Boolean(state.units[unitId])).length;
+  const candidates = getMinorCivBuildCandidates(state, minorCivId);
+  const scored = [
+    ...candidates.buildings.map(building => ({ id: building.id, score: scoreBuilding(building, definition?.archetype, posture) })),
+    ...candidates.units.map(unit => ({ id: unit.type, score: scoreUnit(unit, definition?.archetype, posture, currentUnits, cap) })),
+  ].filter(candidate => candidate.score >= 0);
+  scored.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+  return scored[0]?.id ?? null;
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/minor-civ-economy-system.ts tests/systems/minor-civ-economy-system.test.ts
+git commit -m "feat: add city-state economy candidate helpers"
+```
+
+## Task 3: Production Processing, Pending Spawns, And No Same-Turn Action
+
+**Files:**
+- Modify: `src/systems/minor-civ-economy-system.ts`
+- Test: `tests/systems/minor-civ-economy-system.test.ts`
+
+- [ ] **Step 1: Write failing production tests**
+
+Add to `tests/systems/minor-civ-economy-system.test.ts`:
+
+```ts
+import { processMinorCivEconomyTurn } from '@/systems/minor-civ-economy-system';
+import { createUnit } from '@/systems/unit-system';
+import { getWrappedHexNeighbors, hexNeighbors } from '@/systems/hex-utils';
+
+it('processes real city production and completes a minor-civ building', () => {
+  const state = createNewGame(undefined, 'minor-economy-building', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.productionQueue = ['walls'];
+  city.productionProgress = 999;
+  minorCiv.economy = { policy: 'defense', posture: 'fortifying', lastProcessedTurn: 0 };
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+  expect(result.state.cities[city.id].buildings).toContain('walls');
+  expect(result.state.minorCivs[minorCiv.id].economy?.recentProductionSummary).toMatchObject({
+    itemId: 'walls',
+    itemClass: 'building',
+    completedTurn: state.turn,
+  });
+});
+
+it('completes a minor-civ unit into state.units and mc.units with no same-turn action', () => {
+  const state = createNewGame(undefined, 'minor-economy-unit', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.productionQueue = ['warrior'];
+  city.productionProgress = 999;
+  minorCiv.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+  const beforeUnitIds = new Set(Object.keys(state.units));
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+  const newUnit = Object.values(result.state.units).find(unit => !beforeUnitIds.has(unit.id))!;
+
+  expect(newUnit.owner).toBe(minorCiv.id);
+  expect(result.state.minorCivs[minorCiv.id].units).toContain(newUnit.id);
+  expect(newUnit.movementPointsLeft).toBe(0);
+  expect(newUnit.hasMoved).toBe(true);
+  expect(newUnit.hasActed).toBe(true);
+});
+
+it('stores pending unit spawn when city and adjacent tiles are occupied', () => {
+  const state = createNewGame(undefined, 'minor-economy-pending-spawn', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.productionQueue = ['warrior'];
+  city.productionProgress = 999;
+  minorCiv.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+  const adjacent = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(city.position, state.map.width)
+    : hexNeighbors(city.position);
+  const occupied = [city.position, ...adjacent];
+  occupied.forEach((coord, index) => {
+    const blocker = createUnit('warrior', 'player', coord, state.idCounters);
+    blocker.id = `spawn-blocker-${index}`;
+    state.units[blocker.id] = blocker;
+  });
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+  expect(result.state.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toMatchObject({
+    unitType: 'warrior',
+    completedTurn: state.turn,
+    attempts: 1,
+  });
+  expect(Object.values(result.state.units).filter(unit => unit.owner === minorCiv.id && unit.type === 'warrior')).toHaveLength(1);
+});
+
+it('retries pending spawns before adding more production progress and clears after creation', () => {
+  const state = createNewGame(undefined, 'minor-economy-pending-retry', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.productionQueue = ['walls'];
+  city.productionProgress = 0;
+  minorCiv.economy = {
+    policy: 'defense',
+    posture: 'mobilizing',
+    lastProcessedTurn: 0,
+    pendingUnitSpawn: { unitType: 'warrior', completedTurn: state.turn - 1, attempts: 1 },
+  };
+  const beforeProgress = city.productionProgress;
+  const beforeUnitIds = new Set(Object.keys(state.units));
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+  const newUnit = Object.values(result.state.units).find(unit => !beforeUnitIds.has(unit.id))!;
+
+  expect(newUnit.owner).toBe(minorCiv.id);
+  expect(result.state.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toBeUndefined();
+  expect(result.state.cities[city.id].productionProgress).toBe(beforeProgress);
+});
+
+it('does not process destroyed or captured city-states', () => {
+  const state = createNewGame(undefined, 'minor-economy-captured-skip', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.owner = 'player';
+  city.productionQueue = ['walls'];
+  city.productionProgress = 999;
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+  expect(result.state.cities[city.id].buildings).not.toContain('walls');
+});
+
+it('does not replace an active legal hidden queue item just because the decision interval elapsed', () => {
+  const state = createNewGame(undefined, 'minor-economy-preserve-queue', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  city.productionQueue = ['walls'];
+  city.productionProgress = 1;
+  minorCiv.economy = {
+    policy: 'balanced',
+    posture: 'settled',
+    lastProcessedTurn: 0,
+    lastQueueDecisionTurn: 0,
+  };
+  state.turn = 20;
+
+  const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+  expect(result.state.cities[city.id].productionQueue[0]).toBe('walls');
+  expect(result.state.cities[city.id].productionProgress).toBeGreaterThan(1);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: FAIL because `processMinorCivEconomyTurn` does not exist.
+
+- [ ] **Step 3: Implement production processing**
+
+In `src/systems/minor-civ-economy-system.ts`, add imports:
+
+```ts
+import type { EventBus } from '@/core/event-bus';
+import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
+import { processCity } from '@/systems/city-system';
+import { calculateCityYields } from '@/systems/resource-system';
+import { getWrappedHexNeighbors, hexNeighbors } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
+```
+
+Add:
+
+```ts
+interface MinorCivEconomyTurnResult {
+  state: GameState;
+  completed?: {
+    minorCivId: string;
+    cityId: string;
+    itemId: string;
+    itemClass: 'building' | 'unit';
+  };
+}
+
+function legalSpawnPositions(state: GameState, minorCivId: string): Array<{ q: number; r: number }> {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!city) return [];
+  const occupied = new Set(Object.values(state.units).filter(unit => !unit.transportId).map(unit => hexKey(unit.position)));
+  const adjacent = state.map.wrapsHorizontally ? getWrappedHexNeighbors(city.position, state.map.width) : hexNeighbors(city.position);
+  return [city.position, ...adjacent]
+    .filter(coord => {
+      const tile = state.map.tiles[hexKey(coord)];
+      return tile && tile.terrain !== 'ocean' && tile.terrain !== 'coast' && tile.terrain !== 'mountain' && !occupied.has(hexKey(coord));
+    })
+    .sort((left, right) => left.q - right.q || left.r - right.r);
+}
+
+function createMinorCivUnit(state: GameState, minorCivId: string, unitType: UnitType): { state: GameState; created: boolean } {
+  const position = legalSpawnPositions(state, minorCivId)[0];
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!position || !minorCiv) return { state, created: false };
+  const unit = createUnit(unitType, minorCivId, position, state.idCounters);
+  unit.movementPointsLeft = 0;
+  unit.hasMoved = true;
+  unit.hasActed = true;
+  return {
+    state: {
+      ...state,
+      units: { ...state.units, [unit.id]: unit },
+      minorCivs: {
+        ...state.minorCivs,
+        [minorCivId]: {
+          ...minorCiv,
+          units: [...minorCiv.units.filter(unitId => Boolean(state.units[unitId])), unit.id],
+        },
+      },
+    },
+    created: true,
+  };
+}
+
+function updateMinorEconomy(state: GameState, minorCivId: string, patch: Partial<MinorCivEconomyState>): GameState {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv) return state;
+  const economy = { ...(minorCiv.economy ?? createDefaultMinorCivEconomyState(state)), ...patch };
+  return {
+    ...state,
+    minorCivs: {
+      ...state.minorCivs,
+      [minorCivId]: { ...minorCiv, economy },
+    },
+  };
+}
+
+function isMinorCivQueueHeadLegal(state: GameState, minorCivId: string, itemId: string | undefined): boolean {
+  if (!itemId) return false;
+  const candidates = getMinorCivBuildCandidates(state, minorCivId);
+  return candidates.buildings.some(building => building.id === itemId)
+    || candidates.units.some(unit => unit.type === itemId);
+}
+```
+
+Implement:
+
+```ts
+export function processMinorCivEconomyTurn(state: GameState, minorCivId: string, bus?: EventBus): MinorCivEconomyTurnResult {
+  let nextState = normalizeMinorCivEconomyState(state);
+  const minorCiv = nextState.minorCivs[minorCivId];
+  const city = minorCiv ? nextState.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || minorCiv.isDestroyed || !city || city.owner !== minorCiv.id) {
+    return { state: nextState };
+  }
+
+  const tuning = MINOR_CIV_ECONOMY_TUNING[resolveOpponentChallenge(nextState)];
+  const economy = minorCiv.economy ?? createDefaultMinorCivEconomyState(nextState);
+  const pending = economy.pendingUnitSpawn;
+  if (pending) {
+    const spawned = createMinorCivUnit(nextState, minorCivId, pending.unitType);
+    if (spawned.created) {
+      nextState = updateMinorEconomy(spawned.state, minorCivId, { pendingUnitSpawn: undefined });
+      return { state: nextState, completed: { minorCivId, cityId: city.id, itemId: pending.unitType, itemClass: 'unit' } };
+    }
+    const attempts = pending.attempts + 1;
+    nextState = updateMinorEconomy(nextState, minorCivId, {
+      pendingUnitSpawn: attempts > tuning.pendingSpawnMaxAttempts ? undefined : { ...pending, attempts },
+    });
+    return { state: nextState };
+  }
+
+  const posture = evaluateMinorCivEconomyPosture(nextState, minorCivId);
+  const policy: MinorCivPolicy = posture === 'mobilizing' || posture === 'fortifying'
+    ? 'defense'
+    : posture === 'recovering' ? 'recovery' : 'balanced';
+  const normalizedWork = city.workedTiles.length > city.population
+    ? normalizeWorkedTilesForCity(nextState, city.id)
+    : assignCityFocus(nextState, city.id, posture === 'recovering' ? 'food' : posture === 'mobilizing' ? 'production' : 'balanced');
+  nextState = normalizedWork.state;
+
+  const currentCity = nextState.cities[city.id];
+  let queue = currentCity.productionQueue;
+  let madeQueueDecision = false;
+  const queueHeadLegal = isMinorCivQueueHeadLegal(nextState, minorCivId, queue[0]);
+  const emptyQueueDecisionReady = queue.length === 0
+    && (economy.lastQueueDecisionTurn ?? -999) + tuning.queueDecisionInterval <= nextState.turn;
+  const invalidQueueHead = queue.length > 0 && !queueHeadLegal;
+  if (emptyQueueDecisionReady || invalidQueueHead) {
+    const chosen = chooseMinorCivQueueItem(nextState, minorCivId);
+    queue = chosen ? [chosen] : [];
+    madeQueueDecision = true;
+    nextState = {
+      ...nextState,
+      cities: {
+        ...nextState.cities,
+        [city.id]: { ...currentCity, productionQueue: queue },
+      },
+    };
+  }
+
+  const completedTechs = getMinorCivCompletedTechBand(nextState, minorCivId);
+  const availableResources = getMinorCivAvailableResources(nextState, minorCivId);
+  const cityForYields = nextState.cities[city.id];
+  const yields = calculateCityYields(cityForYields, nextState.map, undefined, completedTechs, {});
+  const productionYield = Math.max(0, Math.floor(yields.production * tuning.productionMultiplier));
+  const processed = processCity(cityForYields, nextState.map, yields.food, productionYield, undefined, completedTechs, undefined, nextState.era, availableResources);
+  nextState = {
+    ...nextState,
+    cities: { ...nextState.cities, [city.id]: processed.city },
+  };
+
+  let completed: MinorCivEconomyTurnResult['completed'];
+  if (processed.completedUnit) {
+    const spawned = createMinorCivUnit(nextState, minorCivId, processed.completedUnit);
+    if (spawned.created) {
+      nextState = spawned.state;
+      completed = { minorCivId, cityId: city.id, itemId: processed.completedUnit, itemClass: 'unit' };
+    } else {
+      nextState = updateMinorEconomy(nextState, minorCivId, {
+        pendingUnitSpawn: { unitType: processed.completedUnit, completedTurn: nextState.turn, attempts: 1 },
+      });
+    }
+  } else if (processed.completedBuilding) {
+    completed = { minorCivId, cityId: city.id, itemId: processed.completedBuilding, itemClass: 'building' };
+  }
+
+  nextState = updateMinorEconomy(nextState, minorCivId, {
+    posture,
+    policy,
+    lastProcessedTurn: nextState.turn,
+    lastPostureChangeTurn: posture !== economy.posture ? nextState.turn : economy.lastPostureChangeTurn,
+    lastQueueDecisionTurn: madeQueueDecision ? nextState.turn : economy.lastQueueDecisionTurn,
+    recentProductionSummary: completed ? {
+      itemId: completed.itemId,
+      itemClass: completed.itemClass,
+      completedTurn: nextState.turn,
+    } : economy.recentProductionSummary,
+  });
+
+  if (completed) bus?.emit('minor-civ:production-completed', { ...completed, state: nextState });
+  return { state: nextState, completed };
+}
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/minor-civ-economy-system.ts tests/systems/minor-civ-economy-system.test.ts
+git commit -m "feat: process hidden city-state production"
+```
+
+## Task 4: Turn-Loop Integration And Shared Mobilization Budget
+
+**Files:**
+- Modify: `src/systems/minor-civ-coalition-system.ts`
+- Modify: `src/systems/minor-civ-system.ts`
+- Modify: `src/systems/minor-civ-economy-system.ts`
+- Test: `tests/systems/minor-civ-system.test.ts`
+- Test: `tests/systems/minor-civ-economy-system.test.ts`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Add to `tests/systems/minor-civ-system.test.ts`:
+
+```ts
+it('runs hidden economy before minor-civ planning so completed units cannot act same turn', () => {
+  const state = createNewGame(undefined, 'minor-economy-turn-order', 'small');
+  const mcId = Object.keys(state.minorCivs)[0]!;
+  const mc = state.minorCivs[mcId];
+  const city = state.cities[mc.cityId];
+  city.productionQueue = ['warrior'];
+  city.productionProgress = 999;
+  mc.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+  const beforeIds = new Set(Object.keys(state.units));
+
+  const result = processMinorCivTurn(state, new EventBus());
+  const created = Object.values(result.units).find(unit => !beforeIds.has(unit.id))!;
+
+  expect(created.owner).toBe(mcId);
+  expect(created.hasActed).toBe(true);
+  expect(result.opponentAI?.minorCivs[mcId]?.assignedUnitIds).toContain(created.id);
+});
+
+it('does not spawn both economy defender and regional grievance defender in one minor-civ turn', () => {
+  const state = createNewGame(undefined, 'minor-economy-no-double-spawn', 'small');
+  state.era = 2;
+  const mcId = Object.keys(state.minorCivs)[0]!;
+  const mc = state.minorCivs[mcId];
+  const city = state.cities[mc.cityId];
+  city.population = 4;
+  city.productionQueue = ['warrior'];
+  city.productionProgress = 999;
+  mc.regionalGrievanceByCiv = {
+    player: {
+      targetCivId: 'player',
+      pressure: 90,
+      status: 'coalition-talks',
+      lastUpdatedTurn: state.turn,
+      mobilizationProgress: 24,
+      causes: [],
+    },
+  };
+  const beforeMinorUnits = mc.units.filter(unitId => state.units[unitId]).length;
+
+  const result = processMinorCivTurn(state, new EventBus());
+  const afterMinorUnits = result.minorCivs[mcId].units.filter(unitId => result.units[unitId]).length;
+
+  expect(afterMinorUnits - beforeMinorUnits).toBe(1);
+});
+
+it('production-backed defenders stay within local force projection', () => {
+  const state = createNewGame(undefined, 'minor-economy-local-defense', 'small');
+  const mcId = Object.keys(state.minorCivs)[0]!;
+  const mc = state.minorCivs[mcId];
+  const city = state.cities[mc.cityId];
+  const distant = createUnit('warrior', 'barbarian', { q: city.position.q + 9, r: city.position.r }, state.idCounters);
+  distant.id = 'distant-raider';
+  state.units[distant.id] = distant;
+  city.productionQueue = ['warrior'];
+  city.productionProgress = 999;
+  mc.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+
+  const result = processMinorCivTurn(state, new EventBus());
+
+  expect(JSON.stringify(result.opponentAI?.minorCivs[mcId])).not.toContain('distant-raider');
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-system.test.ts tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: FAIL because the turn loop does not call the economy and regional grievance still spawns independently.
+
+- [ ] **Step 3: Add regional grievance spawn control and budget helper**
+
+In `src/systems/minor-civ-coalition-system.ts`, add:
+
+```ts
+export interface MinorCivRegionalGrievanceTurnOptions {
+  allowDefenderSpawns?: boolean;
+}
+
+export interface MinorCivMobilizationBudget {
+  targetCivId: string | null;
+  pressure: number;
+  status: MinorCivRegionalGrievanceStatus | null;
+  wantsDefender: boolean;
+  allowsConscription: boolean;
+  recoveryStrainedUntilTurn?: number;
+  conscriptCooldownUntilTurn?: number;
+}
+
+export function getMinorCivMobilizationBudget(state: GameState, minorCivId: string): MinorCivMobilizationBudget {
+  const minorCiv = state.minorCivs[minorCivId];
+  const grievances = Object.values(minorCiv?.regionalGrievanceByCiv ?? {})
+    .sort((left, right) => right.pressure - left.pressure || left.targetCivId.localeCompare(right.targetCivId));
+  const top = grievances[0];
+  const directWarTarget = minorCiv?.diplomacy.atWarWith.find(targetId => state.civilizations[targetId]);
+  return {
+    targetCivId: top?.targetCivId ?? directWarTarget ?? null,
+    pressure: top?.pressure ?? 0,
+    status: top?.status ?? null,
+    wantsDefender: Boolean(top && (top.status === 'mobilizing' || top.status === 'coalition-talks')),
+    allowsConscription: Boolean(top && (top.pressure >= CONSCRIPTION_PRESSURE || isDirectWarGrievance(state, minorCiv!, top.targetCivId))),
+    recoveryStrainedUntilTurn: top?.recoveryStrainedUntilTurn,
+    conscriptCooldownUntilTurn: top?.conscriptCooldownUntilTurn,
+  };
+}
+```
+
+Change the signature:
+
+```ts
+export function processMinorCivRegionalGrievanceTurn(
+  state: GameState,
+  minorCivId: string,
+  options: MinorCivRegionalGrievanceTurnOptions = {},
+): GameState {
+  const allowDefenderSpawns = options.allowDefenderSpawns ?? true;
+```
+
+Wrap both `spawnRegionalDefender` branches with `allowDefenderSpawns`.
+
+- [ ] **Step 4: Consume budget in economy without direct duplicate spawns**
+
+In `src/systems/minor-civ-economy-system.ts`, import:
+
+```ts
+import { getMinorCivMobilizationBudget } from '@/systems/minor-civ-coalition-system';
+```
+
+Inside `chooseMinorCivQueueItem`, boost defender units when `getMinorCivMobilizationBudget(state, minorCivId).wantsDefender` is true by treating posture as `mobilizing`.
+
+Inside `processMinorCivEconomyTurn`, before queue selection, compute:
+
+```ts
+const budget = getMinorCivMobilizationBudget(nextState, minorCivId);
+```
+
+Use `budget.recoveryStrainedUntilTurn` in posture handling and do not create a separate regional cooldown field. Do not perform emergency conscription in this first pass. The existing regional conscription remains available only through direct callers that use the default `allowDefenderSpawns: true`; the minor-civ turn loop below will pass `false` so #490 does not double-spawn.
+
+- [ ] **Step 5: Wire `processMinorCivTurn`**
+
+In `src/systems/minor-civ-system.ts`, import:
+
+```ts
+import { processMinorCivEconomyTurn } from './minor-civ-economy-system';
+```
+
+Change the per-minor-civ loop order:
+
+```ts
+nextState = processMinorCivRegionalGrievanceTurn(nextState, mcId, { allowDefenderSpawns: false });
+const economyResult = processMinorCivEconomyTurn(nextState, mcId, bus);
+nextState = economyResult.state;
+mc = nextState.minorCivs[mcId];
+```
+
+Place those lines after reset and before `planPurposefulMinorCivTurn`. Remove the later existing `processMinorCivRegionalGrievanceTurn(nextState, mcId)` call from the end of the loop.
+
+Keep `processGarrison` as a temporary backstop but modify it to skip free respawn when `mc.economy` exists and `state.cities[mc.cityId]?.owner === mc.id`:
+
+```ts
+if (mc.economy && state.cities[mc.cityId]?.owner === mc.id) {
+  return { ...state, minorCivs: { ...state.minorCivs, [mc.id]: { ...mc, units: aliveUnits } } };
+}
+```
+
+- [ ] **Step 6: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-system.test.ts tests/systems/minor-civ-economy-system.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/systems/minor-civ-system.ts src/systems/minor-civ-coalition-system.ts src/systems/minor-civ-economy-system.ts tests/systems/minor-civ-system.test.ts tests/systems/minor-civ-economy-system.test.ts
+git commit -m "feat: run city-state economy in minor-civ turns"
+```
+
+## Task 5: Viewer-Safe Presentation, Notifications, And Hot-Seat Routing
+
+**Files:**
+- Modify: `src/systems/minor-civ-presentation.ts`
+- Modify: `src/ui/minor-civ-notifications.ts`
+- Modify: `src/ui/minor-civ-notification-listeners.ts`
+- Test: `tests/systems/minor-civ-presentation.test.ts`
+- Test: `tests/ui/minor-civ-notifications.test.ts`
+- Test: `tests/ui/minor-civ-notification-listeners.test.ts`
+
+- [ ] **Step 1: Write failing presentation and notification tests**
+
+Add to `tests/systems/minor-civ-presentation.test.ts`:
+
+```ts
+import { getMinorCivEconomyPresentationForPlayer } from '@/systems/minor-civ-presentation';
+
+it('masks hidden city-state economy presentation from undiscovered viewers', () => {
+  const state = createNewGame(undefined, 'minor-economy-presentation-hidden', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  minorCiv.economy = {
+    policy: 'defense',
+    posture: 'mobilizing',
+    lastProcessedTurn: state.turn,
+    recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+  };
+
+  const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+  expect(presentation.known).toBe(false);
+  expect(presentation.postureLabel).toBeNull();
+  expect(presentation.hint).toBeNull();
+});
+
+it('shows only broad city-state economy posture to discovered viewers', () => {
+  const state = createNewGame(undefined, 'minor-economy-presentation-known', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'fog';
+  minorCiv.economy = {
+    policy: 'defense',
+    posture: 'mobilizing',
+    lastProcessedTurn: state.turn,
+    recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+  };
+
+  const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+  expect(presentation).toMatchObject({
+    known: true,
+    postureLabel: 'Mobilizing',
+    hint: 'training defenders',
+  });
+  expect(JSON.stringify(presentation)).not.toContain('warrior');
+});
+
+it('recomputes effective posture from cooled grievance state for immediate UI refresh', () => {
+  const state = createNewGame(undefined, 'minor-economy-presentation-cooled', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'fog';
+  minorCiv.regionalGrievanceByCiv = {
+    player: {
+      targetCivId: 'player',
+      pressure: 5,
+      status: 'wary',
+      lastUpdatedTurn: state.turn,
+      causes: [],
+    },
+  };
+  minorCiv.economy = {
+    policy: 'defense',
+    posture: 'mobilizing',
+    lastProcessedTurn: state.turn,
+  };
+
+  const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+  expect(presentation.postureLabel).toBe('Quiet');
+});
+```
+
+Add to `tests/ui/minor-civ-notifications.test.ts`:
+
+```ts
+it('creates viewer-safe production notifications only for discovered city-states', () => {
+  const state = createNewGame(undefined, 'minor-economy-notification', 'small');
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const hidden = getMinorCivNotification(state, 'player', {
+    type: 'minor-civ:production-completed',
+    minorCivId: minorCiv.id,
+    cityId: minorCiv.cityId,
+    itemId: 'warrior',
+    itemClass: 'unit',
+  });
+  expect(hidden).toBeNull();
+
+  state.civilizations.player.visibility.tiles[hexKey(state.cities[minorCiv.cityId].position)] = 'fog';
+  const known = getMinorCivNotification(state, 'player', {
+    type: 'minor-civ:production-completed',
+    minorCivId: minorCiv.id,
+    cityId: minorCiv.cityId,
+    itemId: 'warrior',
+    itemClass: 'unit',
+  });
+
+  expect(known?.message).toContain('is strengthening its defenses');
+  expect(known?.message).not.toContain('warrior');
+});
+```
+
+Add to `tests/ui/minor-civ-notification-listeners.test.ts`:
+
+```ts
+it('routes city-state economy production to eligible hot-seat viewers only', () => {
+  const state = createHotSeatGame({
+    playerCount: 2,
+    mapSize: 'small',
+    players: [
+      { name: 'A', slotId: 'player-1', civType: 'egypt', isHuman: true },
+      { name: 'B', slotId: 'player-2', civType: 'rome', isHuman: true },
+    ],
+  }, 'minor-economy-hotseat-notify');
+  state.pendingEvents = {};
+  const minorCiv = Object.values(state.minorCivs)[0]!;
+  const city = state.cities[minorCiv.cityId];
+  state.civilizations['player-1'].visibility.tiles[hexKey(city.position)] = 'fog';
+  const bus = new EventBus();
+  const log: string[] = [];
+
+  registerMinorCivNotificationListeners(bus, () => state, {
+    appendToCivLog: (civId, message) => { log.push(`${civId}:${message}`); },
+  });
+
+  bus.emit('minor-civ:production-completed', {
+    minorCivId: minorCiv.id,
+    cityId: city.id,
+    itemId: 'warrior',
+    itemClass: 'unit',
+    state,
+  });
+
+  expect(state.pendingEvents?.['player-1']).toHaveLength(1);
+  expect(state.pendingEvents?.['player-2']).toBeUndefined();
+  expect(log.some(entry => entry.startsWith('player-1:'))).toBe(true);
+  expect(log.some(entry => entry.startsWith('player-2:'))).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-presentation.test.ts tests/ui/minor-civ-notifications.test.ts tests/ui/minor-civ-notification-listeners.test.ts`
+
+Expected: FAIL because the new presentation and notification event do not exist.
+
+- [ ] **Step 3: Implement presentation helper**
+
+In `src/systems/minor-civ-presentation.ts`, add:
+
+```ts
+import type { MinorCivPosture } from '@/core/types';
+import { evaluateMinorCivEconomyPosture } from '@/systems/minor-civ-economy-system';
+
+export interface MinorCivEconomyPresentation {
+  known: boolean;
+  postureLabel: string | null;
+  hint: string | null;
+}
+
+const POSTURE_LABELS: Record<MinorCivPosture, string> = {
+  settled: 'Quiet',
+  fortifying: 'Fortifying',
+  mobilizing: 'Mobilizing',
+  recovering: 'Recovering',
+};
+
+export function getMinorCivEconomyPresentationForPlayer(
+  state: GameState,
+  viewerCivId: string,
+  minorCivId: string,
+): MinorCivEconomyPresentation {
+  const base = getMinorCivPresentationForPlayer(state, viewerCivId, minorCivId);
+  if (!base.known) return { known: false, postureLabel: null, hint: null };
+  const economy = state.minorCivs[minorCivId]?.economy;
+  const effectivePosture = evaluateMinorCivEconomyPosture(state, minorCivId);
+  if (!economy) return { known: true, postureLabel: POSTURE_LABELS[effectivePosture], hint: null };
+  const summary = economy.recentProductionSummary;
+  const hint = summary?.itemClass === 'unit'
+    ? 'training defenders'
+    : summary?.itemClass === 'building'
+      ? 'investing locally'
+      : effectivePosture === 'recovering' ? 'recovering from levy' : null;
+  return {
+    known: true,
+    postureLabel: POSTURE_LABELS[effectivePosture],
+    hint,
+  };
+}
+```
+
+- [ ] **Step 4: Implement notification draft and listener routing**
+
+In `src/ui/minor-civ-notifications.ts`, add event union member:
+
+```ts
+| { type: 'minor-civ:production-completed'; minorCivId: string; cityId: string; itemId: string; itemClass: 'building' | 'unit' }
+```
+
+Before the `majorCivId` gate, add:
+
+```ts
+if (event.type === 'minor-civ:production-completed') {
+  const presentation = getTargetedMinorCivPresentation(state, viewerCivId, event.minorCivId);
+  if (!presentation) return null;
+  return {
+    message: event.itemClass === 'unit'
+      ? `${presentation.name} is strengthening its defenses.`
+      : `${presentation.name} is growing more prosperous.`,
+    type: event.itemClass === 'unit' ? 'warning' : 'info',
+    turn: state.turn,
+  };
+}
+```
+
+In `src/ui/minor-civ-notification-listeners.ts`, add listener:
+
+```ts
+bus.on('minor-civ:production-completed', data => {
+  const state = data.state ?? getState();
+  for (const civId of Object.keys(state.civilizations)) {
+    const notification = getMinorCivNotification(state, civId, {
+      type: 'minor-civ:production-completed',
+      minorCivId: data.minorCivId,
+      cityId: data.cityId,
+      itemId: data.itemId,
+      itemClass: data.itemClass,
+    });
+    if (!notification) continue;
+    queueHotSeatEvent(state, civId, { type: 'minor-civ:production-completed', message: notification.message, turn: state.turn });
+    appendToCivLog(civId, notification.message, notification.type);
+  }
+});
+```
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-presentation.test.ts tests/ui/minor-civ-notifications.test.ts tests/ui/minor-civ-notification-listeners.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/minor-civ-presentation.ts src/ui/minor-civ-notifications.ts src/ui/minor-civ-notification-listeners.ts tests/systems/minor-civ-presentation.test.ts tests/ui/minor-civ-notifications.test.ts tests/ui/minor-civ-notification-listeners.test.ts
+git commit -m "feat: route city-state economy presentation safely"
+```
+
+## Task 6: Diplomacy Panel Integration And Exact-Pressure Cleanup
+
+**Files:**
+- Modify: `src/ui/diplomacy-panel.ts`
+- Test: `tests/ui/diplomacy-panel.test.ts`
+
+- [ ] **Step 1: Write failing UI tests**
+
+Update the existing grievance panel test in `tests/ui/diplomacy-panel.test.ts` so it asserts no exact pressure number:
+
+```ts
+expect(panel.textContent).toContain('Regional grievance: Mobilizing');
+expect(panel.textContent).toContain('Mobilizing');
+expect(panel.textContent).not.toContain('(55)');
+```
+
+Add:
+
+```ts
+it('renders broad economy posture without hiding city-state actions', () => {
+  const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+  state.minorCivs['mc-sparta'] = {
+    id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: [],
+    diplomacy: state.civilizations.player.diplomacy,
+    activeQuests: {},
+    chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+    regionalGrievanceByCiv: {
+      player: { targetCivId: 'player', pressure: 55, status: 'mobilizing', lastUpdatedTurn: state.turn, causes: [] },
+    },
+    economy: {
+      policy: 'defense',
+      posture: 'mobilizing',
+      lastProcessedTurn: state.turn,
+      recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+    },
+    isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+  };
+  state.cities['mc-city'] = {
+    ...state.cities['city-border'], id: 'mc-city', owner: 'mc-sparta',
+    position: { q: 6, r: 0 }, ownedTiles: [{ q: 6, r: 0 }],
+  };
+  state.civilizations.player.visibility.tiles['6,0'] = 'fog';
+
+  const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {} });
+
+  expect(panel.textContent).toContain('Regional grievance: Mobilizing');
+  expect(panel.textContent).toContain('training defenders');
+  expect(panel.textContent).not.toContain('warrior');
+  expect(panel.querySelector('.mc-gift')).not.toBeNull();
+  expect(panel.querySelector('.mc-war')).not.toBeNull();
+});
+
+it('rerenders reparations cooling into economy posture without double charging from stale DOM', () => {
+  const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+  state.civilizations.player.gold = 200;
+  state.minorCivs['mc-sparta'] = {
+    id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: [],
+    diplomacy: state.civilizations.player.diplomacy,
+    activeQuests: {},
+    chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+    regionalGrievanceByCiv: {
+      player: { targetCivId: 'player', pressure: 25, status: 'wary', lastUpdatedTurn: state.turn, causes: [] },
+    },
+    economy: { policy: 'defense', posture: 'fortifying', lastProcessedTurn: state.turn },
+    isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+  };
+  state.cities['mc-city'] = { ...state.cities['city-border'], id: 'mc-city', owner: 'mc-sparta', position: { q: 6, r: 0 }, ownedTiles: [{ q: 6, r: 0 }] };
+  state.civilizations.player.visibility.tiles['6,0'] = 'fog';
+  let currentState = state;
+  const render = () => createDiplomacyPanel(container, currentState, {
+    onAction: () => {},
+    onMinorCivReparations: mcId => {
+      currentState.minorCivs[mcId].regionalGrievanceByCiv!.player.pressure = 5;
+      currentState.minorCivs[mcId].regionalGrievanceByCiv!.player.status = 'wary';
+      currentState.minorCivs[mcId].economy = { ...currentState.minorCivs[mcId].economy!, posture: 'settled' };
+      currentState.civilizations.player.gold -= 60;
+      render();
+    },
+    onClose: () => {},
+  });
+
+  const panel = render();
+  const button = panel.querySelector<HTMLButtonElement>('[data-action="pay-reparations"]')!;
+  button.click();
+  button.click();
+  const rerendered = container.querySelector('#diplomacy-panel') as HTMLElement;
+
+  expect(currentState.civilizations.player.gold).toBe(140);
+  expect(rerendered.textContent).not.toContain('Pay Reparations');
+  expect(rerendered.textContent).not.toContain('(25)');
+});
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/ui/diplomacy-panel.test.ts`
+
+Expected: FAIL because the panel still renders exact pressure and does not render economy presentation.
+
+- [ ] **Step 3: Render coherent broad posture**
+
+In `src/ui/diplomacy-panel.ts`, import:
+
+```ts
+import { getMinorCivEconomyPresentationForPlayer } from '@/systems/minor-civ-presentation';
+```
+
+When building `minorCivRows`, compute:
+
+```ts
+const economyPresentation = getMinorCivEconomyPresentationForPlayer(state, state.currentPlayer, mcId);
+const regionalGrievanceText = grievance && grievanceStatusLabel
+  ? `Regional grievance: ${grievanceStatusLabel}${economyPresentation.postureLabel ? ` · ${economyPresentation.postureLabel}` : ''}`
+  : economyPresentation.postureLabel ? `City-state posture: ${economyPresentation.postureLabel}` : null;
+const economyHintText = economyPresentation.hint;
+```
+
+Add `economyHintText` to `MinorCivRowData`.
+
+Replace the current pressure-rendering text:
+
+```ts
+regionalGrievanceText: grievance && grievanceStatusLabel
+  ? `Regional grievance: ${grievanceStatusLabel} (${Math.round(grievance.pressure)})`
+  : null,
+```
+
+with:
+
+```ts
+regionalGrievanceText,
+economyHintText,
+```
+
+Render:
+
+```ts
+if (row.economyHintText !== null) {
+  minorCivsHtml += `<div style="font-size:11px;opacity:0.65;margin-top:4px;" data-text="mc-economy-hint-${row.mcIdx}"></div>`;
+}
+```
+
+Set text:
+
+```ts
+if (row.economyHintText !== null) {
+  setText(`mc-economy-hint-${row.mcIdx}`, row.economyHintText);
+}
+```
+
+Keep existing action buttons unchanged.
+
+Update the reparations click listener to guard stale repeat clicks before invoking the callback:
+
+```ts
+panel.querySelectorAll('.mc-reparations').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const button = btn as HTMLButtonElement;
+    if (button.disabled) return;
+    button.disabled = true;
+    const mcId = button.dataset.mcId!;
+    panel.remove();
+    callbacks.onMinorCivReparations?.(mcId);
+  });
+});
+```
+
+- [ ] **Step 4: Run tests and verify GREEN**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/ui/diplomacy-panel.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/diplomacy-panel.ts tests/ui/diplomacy-panel.test.ts
+git commit -m "feat: show city-state economy posture in diplomacy"
+```
+
+## Task 7: Save, Client Neutrality, Rule Checks, And Full Regression Pass
+
+**Files:**
+- Modify tests only if the verification commands expose a real gap.
+- No platform-specific source file should be modified for this task.
+
+- [ ] **Step 1: Run source rule check for changed `src` files**
+
+Run with the actual changed source file list from `git diff --name-only origin/main...HEAD`:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/minor-civ-economy-system.ts src/systems/minor-civ-coalition-system.ts src/systems/minor-civ-system.ts src/storage/save-manager.ts src/systems/minor-civ-presentation.ts src/ui/minor-civ-notifications.ts src/ui/minor-civ-notification-listeners.ts src/ui/diplomacy-panel.ts
+```
+
+Expected: PASS with no rule violation output.
+
+- [ ] **Step 2: Run targeted tests**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test --run tests/systems/minor-civ-economy-system.test.ts tests/systems/minor-civ-system.test.ts tests/systems/minor-civ-presentation.test.ts tests/storage/save-persistence.test.ts tests/ui/minor-civ-notifications.test.ts tests/ui/minor-civ-notification-listeners.test.ts tests/ui/diplomacy-panel.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build
+```
+
+Expected: PASS. This is required because `yarn test` does not type-check.
+
+- [ ] **Step 4: Run Tauri frontend build**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn build:tauri
+```
+
+Expected: PASS. This verifies the shared frontend compiles for the desktop client after changing shared systems, storage normalization, and UI.
+
+- [ ] **Step 5: Check client-neutral source boundaries**
+
+Run:
+
+```bash
+rg -n "@tauri|__TAURI__|window\\.location|/conquestoria/" src/core/types.ts src/systems/minor-civ-economy-system.ts src/systems/minor-civ-coalition-system.ts src/systems/minor-civ-system.ts src/storage/save-manager.ts src/systems/minor-civ-presentation.ts src/ui/minor-civ-notifications.ts src/ui/minor-civ-notification-listeners.ts src/ui/diplomacy-panel.ts
+```
+
+Expected: no matches. Shared gameplay, save, and UI modules must not branch on web/PWA/Tauri details for #490.
+
+- [ ] **Step 6: Run full tests before push/PR**
+
+Run:
+
+```bash
+./scripts/run-with-mise.sh yarn test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Inspect committed and uncommitted diffs**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- src/core/types.ts src/systems/minor-civ-economy-system.ts src/systems/minor-civ-coalition-system.ts src/systems/minor-civ-system.ts src/storage/save-manager.ts src/systems/minor-civ-presentation.ts src/ui/minor-civ-notifications.ts src/ui/minor-civ-notification-listeners.ts src/ui/diplomacy-panel.ts tests/systems/minor-civ-economy-system.test.ts tests/systems/minor-civ-system.test.ts tests/systems/minor-civ-presentation.test.ts tests/storage/save-persistence.test.ts tests/ui/minor-civ-notifications.test.ts tests/ui/minor-civ-notification-listeners.test.ts tests/ui/diplomacy-panel.test.ts
+git diff
+```
+
+Expected:
+- branch diff shows only the implementation and tests for #490
+- uncommitted diff is empty after final commit
+- no Tauri-specific imports, browser-only globals, or platform path branches in shared gameplay modules
+- no exact hidden pressure values rendered in player-facing city-state economy UI
+
+- [ ] **Step 8: Final commit if verification fixes were needed**
+
+```bash
+git add src tests
+git commit -m "test: cover hidden city-state economy regressions"
+```
+
+Only run this commit if Step 1-5 caused additional changes after Task 6.
+
+## Self-Review Notes
+
+- Spec coverage: data model, normalization, queue selection, city production, unit completion, pending spawn, regional grievance integration, no duplicate defender spawning, presentation, solo/hot-seat routing, save/load, web/PWA/Tauri neutrality, gameplay balance, and regression coverage are each mapped to tasks above.
+- Architecture review: the new economy module owns hidden economy logic; presentation remains a helper boundary; UI does not read raw hidden fields except through presentation helpers.
+- Gameplay balance review: caps and production multipliers are challenge-based, bounded, and local; city-states cannot expand or become hidden full major civs.
+- Hot-seat and solo review: notification tests cover eligible and ineligible viewers; solo tests assert undiscovered silence.
+- Client review: no platform-specific source path is in scope; build verification catches shared TypeScript mistakes for web/PWA/Tauri frontend code.
+- Regression review: targeted tests cover save migration, no same-turn unit action, no double spawn, blocked pending spawn, exact-pressure cleanup, and visible panel rerender behavior.

--- a/docs/superpowers/specs/2026-07-07-hidden-city-state-economy-design.md
+++ b/docs/superpowers/specs/2026-07-07-hidden-city-state-economy-design.md
@@ -1,0 +1,601 @@
+# Hidden City-State Economy Design
+
+**Issue:** [#490](https://github.com/a1flecke/conquestoria/issues/490)
+**Related future designs:** [#496 city-state leagues](https://github.com/a1flecke/conquestoria/issues/496), [#497 minor-civ graduation](https://github.com/a1flecke/conquestoria/issues/497)
+**Status:** Approved design
+**Date:** 2026-07-07
+
+## Summary
+
+City-states should feel like small living polities rather than static quest dispensers. This design adds a hidden, production-backed economy for minor civilizations. A city-state quietly grows, produces buildings and units, changes posture, mobilizes under threat, recovers from emergency levies, and exposes only viewer-safe summaries to the player.
+
+The chosen approach is a hybrid model: reuse real `City` yield, food, production, queue, building, and unit-completion mechanics, but place a city-state-specific policy layer and hard caps on top. City-states remain bounded one-city actors for this design. They do not become hidden full major civilizations.
+
+## Goals
+
+- Make city-states feel alive through real production-backed growth and defenses.
+- Replace or reduce unexplained magic behavior, especially free garrison replacement and era upgrades, where production-backed alternatives exist.
+- Keep minor-civ behavior deterministic, serializable, and testable.
+- Reuse existing city and production helpers instead of duplicating a second economy.
+- Keep city-states bounded so they remain interesting neighbors rather than hidden major powers.
+- Preserve hot-seat privacy and discovery rules through viewer-scoped presentation helpers.
+- Leave explicit extension points for future city-state leagues and rare minor-to-major graduation.
+- Integrate with the existing regional grievance, coalition, and reparations systems instead of creating a parallel mobilization model.
+
+## Non-Goals
+
+- City-state settlers, expansion, or multi-city empires.
+- City-state workers or autonomous tile improvement logic.
+- Full city-state research trees.
+- National projects, legendary wonders, or other unique race content.
+- A full management UI for city-state internals.
+- City-state leagues. Those are split to #496.
+- Probabilistic graduation into major civilizations. That is split to #497.
+- New major-civ diplomacy mechanics beyond what is needed to surface city-state posture and warnings.
+
+## Current Code Context
+
+Current minor civilizations already own real `City` records and real units:
+
+- `placeMinorCivs` creates a `City` with population, buildings, queue fields, and one garrison unit.
+- `MinorCivState` tracks the owning city, units, diplomacy, quests, chain status, garrison cooldown, and last era upgrade.
+- `processMinorCivTurn` currently resets minor-civ units, plans movement/combat, processes quests, applies ally bonuses, processes garrison replacement, and emits relationship threshold events.
+- `minor-civ-coalition-system.ts` already tracks `regionalGrievanceByCiv`, pressure, grievance status, mobilization progress, conscription cooldowns, recovery strain, coalition records, coalition cooldowns, and reparations effects.
+- `processCity` already advances food, growth, production queue progress, building completion, unit completion, idle production, and invalid queued item removal for major-civ cities.
+- The main turn manager only runs the city production loop for `state.civilizations[*].cities`. Minor-civ cities whose owner is `mc-*` do not currently flow through that loop.
+- Presentation and notification paths already use viewer-scoped helpers such as `getMinorCivPresentationForPlayer` and hide undiscovered city-state identities.
+- The diplomacy panel already surfaces regional grievance and reparations for discovered city-states. Economy posture must compose with that surface rather than duplicate or contradict it.
+
+This design adds a minor-civ economy turn inside the minor-civ system rather than treating city-states as entries in `state.civilizations`.
+
+## Core Invariants
+
+1. A city-state economy is authoritative only while the minor civilization is active and owns its city.
+2. The actual production queue, production progress, food, population, and buildings remain on the existing `City` object.
+3. `MinorCivState.economy` stores policy, posture, cooldowns, and summaries, not a duplicate city simulation.
+4. Minor-civ economy processing is deterministic. It must not use `Math.random()`.
+5. Events notify presentation layers; listeners do not mutate city-state economy state.
+6. Completed minor-civ units are added to `state.units` and `MinorCivState.units`, not to any major-civ roster.
+7. Unit creation must respect map occupancy. If no valid spawn tile exists, the spawn is delayed or skipped according to explicit rules.
+8. City-state UI reads through `*ForPlayer` presentation helpers and never directly exposes raw hidden economy state.
+9. Undiscovered city-states do not leak names, colors, locations, postures, queue classes, or economic hints.
+10. Difficulty affects caps, mobilization timing, cooldowns, and policy efficiency, not hidden rule exceptions.
+11. Economy state must not duplicate `regionalGrievanceByCiv`, `minorCivCoalitions`, or `minorCivRegionalCooldowns`. It may read those states and update them only through their existing helpers.
+12. Newly trained or conscripted minor-civ units do not move or attack on the same turn they are created.
+
+## Data Model
+
+Add a small economy state to `MinorCivState`:
+
+```ts
+export type MinorCivPosture =
+  | 'settled'
+  | 'fortifying'
+  | 'mobilizing'
+  | 'recovering';
+
+export type MinorCivPolicy =
+  | 'balanced'
+  | 'defense'
+  | 'economy'
+  | 'knowledge'
+  | 'recovery';
+
+export interface MinorCivEconomyState {
+  policy: MinorCivPolicy;
+  posture: MinorCivPosture;
+  lastProcessedTurn: number;
+  lastPostureChangeTurn?: number;
+  localRecoveryUntilTurn?: number;
+  lastQueueDecisionTurn?: number;
+  pendingUnitSpawn?: {
+    unitType: UnitType;
+    completedTurn: number;
+    attempts: number;
+  };
+  recentProductionSummary?: {
+    itemId: string;
+    itemClass: 'building' | 'unit' | 'idle';
+    completedTurn: number;
+  };
+}
+```
+
+`economy` is optional for save compatibility:
+
+```ts
+export interface MinorCivState {
+  // existing fields
+  economy?: MinorCivEconomyState;
+}
+```
+
+Loaded saves normalize missing economy state into a stable default:
+
+```ts
+{
+  policy: 'balanced',
+  posture: 'settled',
+  lastProcessedTurn: Math.max(0, state.turn - 1),
+}
+```
+
+`lastProcessedTurn` is an audit/idempotence marker, not a reason to skip the next legitimate minor-civ economy turn after loading. Normalization must not change city queues, production progress, units, regional grievance, coalitions, or diplomacy except to add missing default economy metadata.
+
+## Architecture
+
+### 1. Economy module
+
+Add a focused economy module, preferably `src/systems/minor-civ-economy-system.ts`, to keep `minor-civ-system.ts` from growing into a catch-all.
+
+The module owns:
+
+- economy normalization
+- posture evaluation
+- build-policy selection
+- queue maintenance
+- minor-civ production processing
+- minor-civ-specific completion handling
+
+Viewer-safe presentation can live in the same module for the first slice, but it should remain a separate helper boundary. If the implementation grows, split presentation into a small `minor-civ-economy-presentation.ts` rather than letting UI code read raw economy state.
+
+`processMinorCivTurn` remains the orchestrator. It calls the economy helper before planning/movement/combat so the plan sees newly completed units.
+
+### 2. Turn flow
+
+For each active minor civilization:
+
+1. Normalize economy defaults.
+2. Skip processing if the minor civ is destroyed or no longer owns its city.
+3. Reconcile regional grievance pressure for the minor civ, preserving existing pressure/cooldown semantics.
+4. Recalculate posture from current state, including war, local threats, regional grievance, and recovery strain.
+5. Maintain or choose the city production queue when empty or invalid.
+6. Calculate city yields using existing city work/yield helpers plus minor-civ-safe resource and tech-band helpers.
+7. Call `processCity` for food, growth, production, building completion, and unit completion.
+8. Apply city maturity if appropriate for city-states.
+9. Handle completed minor-civ buildings, units, and pending unit spawns.
+10. Update `recentProductionSummary`.
+11. Emit typed economy or mobilization events only from actual state transitions.
+12. Continue existing quest, ally, plan, movement, combat, relationship, coalition, and notification logic. Coalition activation that depends on all member pressure should still run after member-level processing.
+
+Newly created units are included in strength/cap accounting immediately but are marked unable to act until the next minor-civ turn. This keeps production meaningful without producing instant hidden attacks.
+
+### 3. Completion handling
+
+Building completion can use the normal `City.buildings` result from `processCity`. Unit completion needs city-state-specific handling because minor civs are not stored in `state.civilizations`.
+
+When `processCity` reports `completedUnit`:
+
+- choose the city tile or a valid adjacent tile using deterministic ordered coordinates
+- store `economy.pendingUnitSpawn` if every legal tile is occupied or invalid
+- create the unit with owner `mc.id`
+- set the new unit's movement/action state so it cannot move or attack until the next minor-civ turn
+- add it to `state.units`
+- append the unit id to `mc.units`
+- emit a minor-civ economy event if the event is player-relevant through presentation routing
+- clear `economy.pendingUnitSpawn` only after the unit is actually created
+
+The implementation must not emit a major-civ `city:unit-trained` event unless that event is made semantically safe for non-major owners. A dedicated event is clearer:
+
+```ts
+'minor-civ:production-completed': {
+  minorCivId: string;
+  cityId: string;
+  itemId: string;
+  itemClass: 'building' | 'unit';
+  state?: GameState;
+}
+```
+
+The event listener should expand this raw economy event into viewer-specific notifications through the same eligibility checks used by `getMinorCivPresentationForPlayer`; the economy system itself should not decide visibility from `state.currentPlayer` alone.
+
+When `economy.pendingUnitSpawn` exists at the start of a later turn, retry that spawn before adding more production progress to the same queue item. Pending spawns should be capped by attempts or age so a permanently blocked city does not accumulate invisible completed units.
+
+### 4. Existing garrison behavior
+
+Current garrison replacement and regional grievance defender spawning must converge into one production/mobilization budget. During migration, the legacy garrison replacement can remain as a temporary backstop only when a city-state has no functioning economy state or no legal production path. The target behavior is production-backed defense:
+
+- a city-state with no units switches to `mobilizing` or `recovering`
+- it queues a defender if it can legally build one
+- emergency conscription uses the existing regional grievance cooldown/strain fields when the trigger is regional aggression
+- free garrison respawn should not silently produce professional units indefinitely
+- production-backed defenders, regional mobilization defenders, and emergency conscription must not all fire independently in the same turn for the same city-state
+
+## Regional Grievance And Coalition Integration
+
+The current regional grievance system is not a future hook; it is live state. The hidden economy must treat it as an input and gradually move its unit generation into the economy path.
+
+### Source of truth
+
+Keep these fields authoritative for regional aggression:
+
+- `MinorCivState.regionalGrievanceByCiv`
+- `GameState.minorCivCoalitions`
+- `GameState.minorCivRegionalCooldowns`
+
+Do not add separate economy fields for regional pressure, coalition membership, reparations, conscription cooldown, or regional recovery strain. The economy may derive posture and queue scores from those fields.
+
+### Mobilization budget
+
+For each minor civ and turn, compute one mobilization budget from:
+
+- active war with a major civ
+- immediate city threat
+- regional grievance status and pressure
+- coalition status
+- existing living units and unit cap
+- recent conscription or recovery strain
+
+That budget decides whether the city-state:
+
+- queues a defender through normal production
+- stores production priority for future turns
+- performs emergency conscription
+- does nothing because caps, cooldowns, or recovery block action
+
+Tests must prove a city-state cannot receive a trained defender from production and a regional grievance defender from the existing helper in the same turn unless the design explicitly budgets both and the cap permits both.
+
+### Reparations and cooling
+
+Reparations lower regional pressure and should also influence economy posture:
+
+- `coalition-talks` or `mobilizing` can drop to `fortifying` or `settled` only through the shared grievance state.
+- Economy presentation must not show a city-state as `Mobilizing` after reparations if the grievance helper has already cooled the pressure below the mobilization threshold.
+- The diplomacy panel should render regional grievance and economy posture as one coherent block, not two unrelated warnings.
+
+## Posture
+
+Posture is the high-level state shown to players through presentation helpers.
+
+### `settled`
+
+Default peaceful state. The city-state favors economic, archetype, and modest defense investments.
+
+### `fortifying`
+
+Used when the city-state is not at war but has plausible local danger: nearby hostile units, recent conquest pressure, a weak garrison, or a negative relationship trend. It favors walls, barracks-style buildings, and defenders.
+
+Regional grievance status `wary` generally maps to `fortifying` unless the pressure is low and no local threat exists.
+
+### `mobilizing`
+
+Used during war, imminent city threat, severe recent aggression, `regionalGrievanceByCiv` status `mobilizing`/`coalition-talks`, or active/forming minor-civ coalitions. It prioritizes defenders and can consider emergency conscription through the shared mobilization budget.
+
+### `recovering`
+
+Used after conscription, heavy unit losses, siege pressure, city damage, or population loss. It favors food, basic economy, and cooldown. It blocks repeated emergency levies until recovery ends.
+
+Posture transitions should be transition-owned. Tests must prove a warning event fires once on a transition such as `settled -> mobilizing`, not every turn that the state remains `mobilizing`.
+
+## Build Policy
+
+Build policy is definition-driven by archetype plus posture. It should use existing catalogs and eligibility helpers, then filter down to city-state-safe items.
+
+### Shared restrictions
+
+City-states cannot queue:
+
+- settlers
+- workers
+- spies unless a later design explicitly adds city-state espionage
+- caravans or trade-route units unless a later implementation gives city-states explicit route ownership and AI use
+- national projects
+- legendary wonders
+- unique-per-empire projects
+- items whose tech/resource/building/location requirements are not met
+
+City-states should not queue an item they already have unless the catalog allows repeat production, such as units.
+
+### Archetype bias
+
+Militaristic:
+
+- favors defenders and military buildings
+- reaches higher unit caps
+- changes to `fortifying` and `mobilizing` earlier
+- recovers faster from defense losses
+
+Mercantile:
+
+- favors marketplace and economy buildings
+- has modest defenses unless threatened
+- may later feed league or graduation wealth signals
+- values trade-route relationships as an economy hint
+
+Cultural:
+
+- favors library, temple, science, culture, and prestige buildings
+- has lower peaceful unit caps
+- gets resilient institutional growth rather than large armies
+
+### Queue selection
+
+When a city-state needs a queue item:
+
+1. Determine posture.
+2. Build a list of legal city-state-safe buildings and units.
+3. Score each candidate by archetype, posture, current era, existing buildings, unit cap, and difficulty.
+4. Break ties deterministically by score, priority, then stable id.
+5. Queue only the selected item, or maintain a short queue if tests prove order/ETA remains visible through presentation.
+
+Avoid long hidden queues in the first implementation. A single active item is simpler, easier to reason about, and enough to make the economy real.
+
+### Tech and resource eligibility
+
+City-states are not entries in `state.civilizations`, so major-civ helpers that assume a `Civilization` record are unsafe. In particular, `getCivAvailableResources(state, mc.id)` returns an empty set today because minor civs are not major civ records.
+
+Add minor-civ-safe helpers instead:
+
+- `getMinorCivCompletedTechBand(state, minorCivId)` returns a deterministic era-band tech set for production eligibility only.
+- `getMinorCivAvailableResources(state, minorCivId)` reads the city-state city, owned tiles, resource definitions, improvements, and the era-band reveal set without requiring `state.civilizations[minorCivId]`.
+- `getMinorCivBuildCandidates(state, minorCivId)` wraps `getAvailableBuildings` and `getTrainableUnitsForCity`, then applies the city-state-safe restrictions.
+
+These helpers must have negative tests proving they do not call major-civ-only resource paths and do not unlock resources/buildings before the city-state's era band allows them.
+
+## Units And Mobilization
+
+### Unit caps
+
+Unit caps depend on era, posture, archetype, and difficulty. Early peaceful city-states should not flood the map.
+
+Example target shape:
+
+- Explorer: peaceful 1-2, mobilizing 2-3
+- Standard: peaceful 1-2, mobilizing 3-4
+- Veteran: peaceful 2-3, mobilizing 4-5 for militaristic city-states
+
+The exact values should live in a small table and have era coverage tests.
+
+### Unit eligibility
+
+City-states do not use full research. They use `state.era` plus curated unlock bands. The unit set should be derived from existing unit definitions where possible, but the allowed list must be explicitly city-state-safe.
+
+The current `ERA_UNIT_MAP` can seed the first version, but production should eventually train the chosen era-appropriate defender rather than mutating existing units into a new type during era advancement.
+
+### Emergency conscription
+
+Conscription is allowed only through the shared mobilization budget. It is valid only when all of these are true:
+
+1. Posture is `mobilizing`.
+2. The city is under immediate threat, at war with a nearby active target, or has severe regional grievance pressure.
+3. The city-state is below its minimum emergency defender count.
+4. The relevant regional grievance `conscriptCooldownUntilTurn` is absent or has passed, or the non-regional conscription source has an equivalent tested cooldown.
+5. The city has enough population or economy capacity to pay the cost.
+6. A legal spawn tile exists.
+
+Conscription costs one or more of:
+
+- population loss
+- existing regional recovery strain, such as `recoveryStrainedUntilTurn`, when the cause is regional aggression
+- `localRecoveryUntilTurn` for non-regional emergency recovery
+- production progress reset or penalty
+- longer recovery posture
+
+If a militia unit type is introduced later, conscription should create weaker militia. Until then, use the weakest era-appropriate defender with reduced health, no same-turn action, and no bonus experience. Deferring conscription entirely is acceptable only if regional grievance emergency spawning remains in place for that implementation slice and is explicitly marked as temporary.
+
+### Map clutter and force projection
+
+City-state units should mostly defend their home region. Production caps are not enough by themselves; the plan/movement layer must also avoid far-away harassment.
+
+- Peaceful or `fortifying` city-states patrol within the existing minor operational radius.
+- `mobilizing` city-states can pursue direct attackers, local threats, and active war targets but should not chase across the world.
+- Explorer difficulty should bias strongly toward defensive positioning.
+- Tests must cover that production increases local defense without creating distant offensive pressure in early eras.
+
+## Buildings And Era Progression
+
+City-states can build ordinary non-unique buildings that match their archetype and current era band. They do not need the major-civ tech tree, but they must not bypass location, resource, or prerequisite-building rules.
+
+Era advancement should not silently mutate every existing city-state unit into a new unit type as the long-term design. Instead:
+
+- new production unlocks stronger defenders by era band
+- old units remain old unless a future explicit upgrade helper is added
+- city-state population/building growth comes from the economy path
+
+If the legacy era upgrade remains during an incremental implementation, the spec must call it temporary and add tests proving it does not duplicate production-backed upgrades.
+
+## Visibility And UI
+
+Raw economy state is hidden. Player-facing surfaces use viewer-scoped presentation helpers.
+
+### Visibility layers
+
+Undiscovered:
+
+- no diplomacy row
+- no named warnings
+- no color, posture, queue, or economy hints
+
+Discovered:
+
+- city-state name, archetype, relationship, and broad posture
+- possible labels: `Quiet`, `Fortifying`, `Mobilizing`, `Recovering`, `Prosperous`
+
+Friendly, allied, or trade-connected:
+
+- coarse economy hints, such as `building defenses`, `training militia`, `investing in trade`, or `recovering from levy`
+- no exact queue item or ETA unless the design adds an earned intel source
+
+Future spy or earned-intel layer:
+
+- can reveal queue class and rough ETA band
+- is out of scope for #490 unless the implementation plan explicitly adds a narrow earned-intel presentation helper without new espionage mechanics
+
+### Diplomacy panel
+
+The diplomacy panel should show broad posture for discovered city-states. If it shows any derived label such as `Mobilizing`, the label must come from one shared presentation helper and include negative tests proving hidden or non-qualifying states are not surfaced.
+
+Panel actions that can change relationship, war state, or posture must refresh the open panel immediately. Updating only state or HUD is not enough.
+
+### Notifications
+
+Notifications must route per eligible viewer:
+
+- a known target can receive mobilization or conscription warnings
+- undiscovered city-states use generic text or remain hidden, depending on event type
+- hot-seat events are queued only for eligible civs
+- hidden identities, colors, and locations do not leak
+
+## Client And Mode Behavior
+
+The economy is shared gameplay state. It must run identically in the web/PWA build and the Tauri build.
+
+- New economy code belongs under shared `src/` systems, UI, renderer, or storage boundaries.
+- Shared modules must not import Tauri APIs, browser-only globals, or asset-path assumptions.
+- Save/load shape must be identical across web, PWA, and Tauri clients.
+- Any client-specific behavior must enter through existing platform capability boundaries, not through economy-specific branches.
+
+### Solo
+
+Solo play can show eligible notifications immediately through the normal notification/log path for the current player. It must still use viewer-scoped presentation helpers, because the solo player may not have discovered every city-state.
+
+Solo tests should prove undiscovered city-state economy events remain hidden even though there is no hot-seat handoff.
+
+### Hot-seat
+
+Hot-seat must treat economy events the same way as other viewer-scoped state:
+
+- queue eligible notifications through the existing pending-event handoff path
+- do not show another civilization's city-state intelligence during the active player's turn
+- derive viewer eligibility from the event target, discovered city-state state, and current player context
+- never rely on a global human/player assumption when deciding whether to reveal posture, name, location, or queue hints
+
+Hot-seat tests should cover both eligible and ineligible viewers for the same economy transition.
+
+## Difficulty And Balance
+
+Use `resolveOpponentChallenge(state)` and a small minor-civ tuning table.
+
+Explorer:
+
+- lower unit caps
+- slower mobilization
+- longer conscription cooldowns
+- clearer warning thresholds
+- stronger early-game guardrails
+
+Standard:
+
+- balanced production-backed defense
+- occasional emergency levy when clearly threatened
+- moderate recovery time
+
+Veteran:
+
+- faster posture changes
+- better queue scoring
+- higher defensive caps
+- shorter recovery
+- still respects global caps and early-game guardrails
+
+The design should avoid severe early pressure. Before a defined early-game turn or era threshold, city-states can defend themselves but should not project force far from home except against always-hostile actors or direct attackers.
+
+Fun comes from readable consequences, not surprise punishment. City-states should feel tougher because their cities invest, warn, recover, and remember pressure. They should not become frequent chores, hidden raiders, or a second class of full AI empires. Warnings, posture labels, and caps should make escalation understandable before it becomes dangerous.
+
+## Future Extension Points
+
+### City-state leagues (#496)
+
+The hidden economy should expose enough non-UI state for future league coordination:
+
+- posture
+- recent production class
+- threat/recovery state
+- conscription cooldown
+- broad economy strength
+
+Leagues may later bias member production or shared posture, but #490 does not implement league membership or coordination.
+
+### Minor-civ graduation (#497)
+
+The hidden economy should expose enough history for a future 50-turn probabilistic graduation check:
+
+- survival age
+- population and maturity
+- buildings and production output
+- defensive success
+- trade wealth or relationships
+- regional security or opportunity
+
+#490 does not convert city-states into major civilizations. It only makes the future eligibility check grounded in real state.
+
+## Save Migration
+
+Loaded saves must normalize safely:
+
+- add missing `economy` defaults to active city-states after minor-civ quest and coalition state are normalized
+- leave destroyed city-states alone except for shape safety
+- do not modify existing city queues or production progress
+- do not create units during load
+- do not emit events during load
+- round-trip economy state through save/load
+
+If a loaded save has impossible economy data, normalization should fall back to `settled`/`balanced` and preserve the city-state rather than crashing. Invalid `pendingUnitSpawn` records should be dropped unless they name a legal city-state-safe unit type and a sane completion turn. Normalization must not clear `regionalGrievanceByCiv`, `minorCivCoalitions`, or `minorCivRegionalCooldowns`.
+
+## Testing Strategy
+
+### System tests
+
+- Legacy save normalization adds default economy state to active city-states.
+- Destroyed city-states do not process economy.
+- Captured city-state cities stop processing as minor-civ economies.
+- A city-state with an empty queue chooses an archetype-appropriate item deterministically.
+- Queue selection never chooses settlers, workers, national projects, legendary wonders, or unavailable items.
+- Production advances through `processCity` and completes a building.
+- Production advances through `processCity` and completes a unit.
+- Completed units are added to `state.units` and `mc.units`, not a major-civ roster.
+- Unit spawn respects occupancy and delays or skips when no legal tile exists.
+- Pending unit spawns retry when a tile opens, clear only after real creation, and cannot accumulate unlimited hidden completions.
+- Newly trained and conscripted units cannot move or attack on the same turn they are created.
+- Peaceful city-states obey unit caps.
+- Threatened city-states switch to `mobilizing` and prioritize defense.
+- `settled -> mobilizing` warnings fire once per transition, not every steady-state turn.
+- Conscription requires all gating conditions and has negative tests for missing threat, cooldown, insufficient population, and blocked spawn.
+- Regional grievance, reparations, and coalition pressure drive posture through the existing grievance fields.
+- Production-backed defenders and regional grievance defenders cannot both spawn independently in the same turn outside the shared mobilization budget.
+- Reparations that cool grievance also cool economy posture/presentation.
+- Minor-civ resource and tech helpers do not call major-civ-only resource paths and do not reveal locked resources.
+- Early-era production increases local defense without creating distant offensive pressure.
+- Explorer, Standard, and Veteran profiles produce distinct caps or mobilization timing.
+- Existing quest and durable-alliance state keeps working while economy turns run.
+- Human and AI conquest/combat paths interact with the same minor-civ state.
+
+### UI and presentation tests
+
+- Undiscovered city-states do not leak economy, posture, names, colors, or queue hints.
+- Discovered city-states show only broad posture.
+- Friendly/allied/trade-connected city-states show coarse economy hints and no raw queue details.
+- Solo notifications still hide undiscovered city-state economy events.
+- Hot-seat notifications route only to eligible viewers and do not leak during handoff.
+- Diplomacy panel rerenders after actions that change posture or relationship.
+- Derived posture labels come from a shared helper and include negative tests.
+- Web/PWA and Tauri builds share the same economy presentation data without platform-specific branches.
+
+### Save tests
+
+- Missing `economy` state normalizes.
+- Malformed economy state normalizes without changing city queues or units.
+- Existing regional grievance, coalition, and cooldown state survives economy normalization.
+- Malformed `pendingUnitSpawn` is normalized or dropped without creating a unit during load.
+- Economy state round-trips through save/load.
+
+## Implementation Notes
+
+- Prefer adding `minor-civ-economy-system.ts` rather than expanding `minor-civ-system.ts` further.
+- Keep helper boundaries small: posture evaluation, candidate scoring, queue application, production processing, and presentation should be separately testable.
+- Use immutable turn processing patterns where touched code currently mutates nested state.
+- Reuse `processCity`, `calculateCityYields`, `assignCityFocus`, `normalizeWorkedTilesForCity`, and production eligibility helpers where they fit.
+- Do not call major-civ-only helpers that assume `state.civilizations[ownerId]` exists unless they are first made owner-kind safe.
+- If a queue or production event is player-visible, wire the live UI path and tests in the same implementation slice.
+
+## Acceptance Criteria
+
+- Hidden city-state economy state is defined, normalized, saved, and loaded.
+- Active city-states process real food, growth, production, building completion, and unit completion through the hybrid economy.
+- City-state build policy is deterministic, archetype-aware, posture-aware, difficulty-aware, and capped.
+- City-states do not build settlers, workers, national projects, legendary wonders, or unavailable items.
+- Emergency conscription, if included in the first implementation, has explicit costs, cooldowns, and negative gate tests.
+- Player-facing posture and economy hints are viewer-safe and hot-seat safe.
+- The diplomacy panel surfaces discovered broad posture and refreshes after relevant actions.
+- Existing quest, alliance, combat, conquest, and notification behavior remains intact.
+- Future leagues (#496) and graduation (#497) have explicit extension points but no first-implementation behavior in #490.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1029,6 +1029,29 @@ export interface MinorCivRegionalCooldown {
   cooldownUntil: number;
 }
 
+export type MinorCivPosture = 'settled' | 'fortifying' | 'mobilizing' | 'recovering';
+
+export type MinorCivPolicy = 'balanced' | 'defense' | 'economy' | 'knowledge' | 'recovery';
+
+export interface MinorCivEconomyState {
+  policy: MinorCivPolicy;
+  posture: MinorCivPosture;
+  lastProcessedTurn: number;
+  lastPostureChangeTurn?: number;
+  localRecoveryUntilTurn?: number;
+  lastQueueDecisionTurn?: number;
+  pendingUnitSpawn?: {
+    unitType: UnitType;
+    completedTurn: number;
+    attempts: number;
+  };
+  recentProductionSummary?: {
+    itemId: string;
+    itemClass: 'building' | 'unit' | 'idle';
+    completedTurn: number;
+  };
+}
+
 export type QuestAction =
   | { type: 'gift_gold'; actorCivId: string; minorCivId: string; amount: number; turn: number }
   | { type: 'sponsor_festival'; actorCivId: string; minorCivId: string; turn: number }
@@ -1047,6 +1070,7 @@ export interface MinorCivState {
   questCooldownUntilByCiv: Record<string, number>;
   lastNotifiedStatusByCiv: Record<string, MinorCivRelationshipStatus>;
   regionalGrievanceByCiv?: Record<string, MinorCivRegionalGrievance>;
+  economy?: MinorCivEconomyState;
   isDestroyed: boolean;
   garrisonCooldown: number;
   lastEraUpgrade: number;
@@ -1658,6 +1682,13 @@ export interface GameEvents {
   'minor-civ:quest-expired': { minorCivId: string; majorCivId: string; quest: Quest; state?: GameState };
   'minor-civ:coalition-status': { minorCivId: string; targetCivId: string; status: MinorCivRegionalGrievanceStatus; state?: GameState };
   'minor-civ:coalition-war': { coalitionId: string; targetCivId: string; memberIds: string[]; state?: GameState };
+  'minor-civ:production-completed': {
+    minorCivId: string;
+    cityId: string;
+    itemId: string;
+    itemClass: 'building' | 'unit';
+    state?: GameState;
+  };
   'espionage:spy-recruited': { civId: string; spy: Spy };
   'espionage:spy-assigned': { civId: string; spyId: string; targetCivId: string; targetCityId: string };
   'espionage:spy-arrived': { civId: string; spyId: string; targetCityId: string };

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -8,6 +8,7 @@ import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { getQuestChain, getQuestChainForArchetype } from '@/systems/quest-chain-definitions';
 import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
 import { normalizeMinorCivCoalitionState } from '@/systems/minor-civ-coalition-system';
+import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
 import { scanIdCounters } from '@/core/id-counters';
 import {
   createEmptyPirateState,
@@ -764,9 +765,9 @@ export function migrateLegacyCoastalData(state: GameState): GameState {
 }
 
 export function normalizeLoadedState(state: GameState): NormalizedGameState {
-  const normalizedCityState = migrateLegacyPirateFleets(normalizeMinorCivCoalitionState(normalizeMinorCivQuestState(
+  const normalizedCityState = migrateLegacyPirateFleets(normalizeMinorCivEconomyState(normalizeMinorCivCoalitionState(normalizeMinorCivQuestState(
     migrateLegacyCoastalData(normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateStripCityGrid(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))))))),
-  )));
+  ))));
   normalizedCityState.pirates = normalizePirateState(normalizedCityState);
   normalizedCityState.notificationLog = normalizeNotificationLog(normalizedCityState.notificationLog);
   normalizedCityState.idCounters = normalizeIdCounters(normalizedCityState);

--- a/src/systems/minor-civ-coalition-system.ts
+++ b/src/systems/minor-civ-coalition-system.ts
@@ -55,6 +55,20 @@ const COALITION_STATUSES = new Set<MinorCivCoalitionStatus>([
   'cooling',
 ]);
 
+export interface MinorCivRegionalGrievanceTurnOptions {
+  allowDefenderSpawns?: boolean;
+}
+
+export interface MinorCivMobilizationBudget {
+  targetCivId: string | null;
+  pressure: number;
+  status: MinorCivRegionalGrievanceStatus | null;
+  wantsDefender: boolean;
+  allowsConscription: boolean;
+  recoveryStrainedUntilTurn?: number;
+  conscriptCooldownUntilTurn?: number;
+}
+
 function getMinorCivArchetype(minorCiv: MinorCivState) {
   return MINOR_CIV_DEFINITIONS.find(definition => definition.id === minorCiv.definitionId)?.archetype;
 }
@@ -113,6 +127,37 @@ function findRegionalDefenderSpawnPosition(state: GameState, minorCiv: MinorCivS
 function isDirectWarGrievance(state: GameState, minorCiv: MinorCivState, targetCivId: string): boolean {
   return minorCiv.diplomacy.atWarWith.includes(targetCivId)
     || Boolean(state.civilizations[targetCivId]?.diplomacy.atWarWith.includes(minorCiv.id));
+}
+
+export function getMinorCivMobilizationBudget(state: GameState, minorCivId: string): MinorCivMobilizationBudget {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv) {
+    return {
+      targetCivId: null,
+      pressure: 0,
+      status: null,
+      wantsDefender: false,
+      allowsConscription: false,
+    };
+  }
+
+  const grievances = Object.values(minorCiv.regionalGrievanceByCiv ?? {})
+    .sort((left, right) => right.pressure - left.pressure || left.targetCivId.localeCompare(right.targetCivId));
+  const top = grievances[0];
+  const directWarTarget = minorCiv.diplomacy.atWarWith.find(targetId => state.civilizations[targetId]);
+
+  return {
+    targetCivId: top?.targetCivId ?? directWarTarget ?? null,
+    pressure: top?.pressure ?? 0,
+    status: top?.status ?? null,
+    wantsDefender: Boolean(top && (top.status === 'mobilizing' || top.status === 'coalition-talks')),
+    allowsConscription: Boolean(top && (
+      top.pressure >= CONSCRIPTION_PRESSURE
+      || isDirectWarGrievance(state, minorCiv, top.targetCivId)
+    )),
+    recoveryStrainedUntilTurn: top?.recoveryStrainedUntilTurn,
+    conscriptCooldownUntilTurn: top?.conscriptCooldownUntilTurn,
+  };
 }
 
 function spawnRegionalDefender(
@@ -231,10 +276,12 @@ export function applyRegionalGrievanceForMinorCivConquest(
 export function processMinorCivRegionalGrievanceTurn(
   state: GameState,
   minorCivId: string,
+  options: MinorCivRegionalGrievanceTurnOptions = {},
 ): GameState {
   const minorCiv = state.minorCivs[minorCivId];
   if (!minorCiv || minorCiv.isDestroyed) return state;
 
+  const allowDefenderSpawns = options.allowDefenderSpawns ?? true;
   let nextState = state;
   const grievanceByCiv = { ...(minorCiv.regionalGrievanceByCiv ?? {}) };
   for (const [targetCivId, grievance] of Object.entries(minorCiv.regionalGrievanceByCiv ?? {})) {
@@ -272,6 +319,7 @@ export function processMinorCivRegionalGrievanceTurn(
       && city.population >= 3
       && conscriptionReady
       && severeThreat
+      && allowDefenderSpawns
     ) {
       const spawned = spawnRegionalDefender(nextState, currentMinor, 65);
       if (spawned) {
@@ -296,7 +344,9 @@ export function processMinorCivRegionalGrievanceTurn(
     ) {
       const nextProgress = (nextGrievance.mobilizationProgress ?? 0) + mobilizationProgressPerTurn(nextState);
       if (nextProgress >= TRAINED_DEFENDER_PROGRESS) {
-        const spawned = spawnRegionalDefender(nextState, nextState.minorCivs[minorCivId], 100);
+        const spawned = allowDefenderSpawns
+          ? spawnRegionalDefender(nextState, nextState.minorCivs[minorCivId], 100)
+          : null;
         if (spawned) {
           nextState = spawned.state;
           nextGrievance = {

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -1,0 +1,140 @@
+import type {
+  GameState,
+  MinorCivEconomyState,
+  MinorCivPolicy,
+  MinorCivPosture,
+  UnitType,
+} from '@/core/types';
+import { TRAINABLE_UNITS } from '@/systems/city-system';
+
+const MINOR_CIV_POLICIES = new Set<MinorCivPolicy>([
+  'balanced',
+  'defense',
+  'economy',
+  'knowledge',
+  'recovery',
+]);
+
+const MINOR_CIV_POSTURES = new Set<MinorCivPosture>([
+  'settled',
+  'fortifying',
+  'mobilizing',
+  'recovering',
+]);
+
+const SAFE_UNIT_TYPES = new Set<UnitType>(TRAINABLE_UNITS.map(unit => unit.type));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isFiniteNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function normalizePendingSpawn(
+  value: unknown,
+  state: Pick<GameState, 'turn'>,
+): MinorCivEconomyState['pendingUnitSpawn'] {
+  if (!isRecord(value) || typeof value.unitType !== 'string') {
+    return undefined;
+  }
+
+  if (!SAFE_UNIT_TYPES.has(value.unitType as UnitType)) {
+    return undefined;
+  }
+
+  if (
+    !isFiniteNonNegativeNumber(value.completedTurn)
+    || !isFiniteNonNegativeNumber(value.attempts)
+    || value.completedTurn > state.turn
+  ) {
+    return undefined;
+  }
+
+  return {
+    unitType: value.unitType as UnitType,
+    completedTurn: value.completedTurn,
+    attempts: value.attempts,
+  };
+}
+
+function normalizeRecentProductionSummary(value: unknown): MinorCivEconomyState['recentProductionSummary'] {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (
+    typeof value.itemId !== 'string'
+    || (value.itemClass !== 'building' && value.itemClass !== 'unit' && value.itemClass !== 'idle')
+    || !isFiniteNonNegativeNumber(value.completedTurn)
+  ) {
+    return undefined;
+  }
+
+  return {
+    itemId: value.itemId,
+    itemClass: value.itemClass,
+    completedTurn: value.completedTurn,
+  };
+}
+
+export function createDefaultMinorCivEconomyState(state: Pick<GameState, 'turn'>): MinorCivEconomyState {
+  return {
+    policy: 'balanced',
+    posture: 'settled',
+    lastProcessedTurn: Math.max(0, state.turn - 1),
+  };
+}
+
+function normalizeEconomyState(value: unknown, state: Pick<GameState, 'turn'>): MinorCivEconomyState {
+  const defaults = createDefaultMinorCivEconomyState(state);
+  if (!isRecord(value)) {
+    return defaults;
+  }
+
+  const economy: MinorCivEconomyState = {
+    policy: typeof value.policy === 'string' && MINOR_CIV_POLICIES.has(value.policy as MinorCivPolicy)
+      ? value.policy as MinorCivPolicy
+      : defaults.policy,
+    posture: typeof value.posture === 'string' && MINOR_CIV_POSTURES.has(value.posture as MinorCivPosture)
+      ? value.posture as MinorCivPosture
+      : defaults.posture,
+    lastProcessedTurn: isFiniteNonNegativeNumber(value.lastProcessedTurn)
+      ? value.lastProcessedTurn
+      : defaults.lastProcessedTurn,
+  };
+
+  if (isFiniteNonNegativeNumber(value.lastPostureChangeTurn)) {
+    economy.lastPostureChangeTurn = value.lastPostureChangeTurn;
+  }
+  if (isFiniteNonNegativeNumber(value.localRecoveryUntilTurn)) {
+    economy.localRecoveryUntilTurn = value.localRecoveryUntilTurn;
+  }
+  if (isFiniteNonNegativeNumber(value.lastQueueDecisionTurn)) {
+    economy.lastQueueDecisionTurn = value.lastQueueDecisionTurn;
+  }
+
+  const pendingUnitSpawn = normalizePendingSpawn(value.pendingUnitSpawn, state);
+  if (pendingUnitSpawn) {
+    economy.pendingUnitSpawn = pendingUnitSpawn;
+  }
+
+  const recentProductionSummary = normalizeRecentProductionSummary(value.recentProductionSummary);
+  if (recentProductionSummary) {
+    economy.recentProductionSummary = recentProductionSummary;
+  }
+
+  return economy;
+}
+
+export function normalizeMinorCivEconomyState(state: GameState): GameState {
+  const minorCivs = { ...state.minorCivs };
+  for (const [minorCivId, minorCiv] of Object.entries(minorCivs)) {
+    minorCivs[minorCivId] = {
+      ...minorCiv,
+      economy: normalizeEconomyState(minorCiv.economy, state),
+    };
+  }
+  return { ...state, minorCivs };
+}

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -66,8 +66,6 @@ const MINOR_CIV_POSTURES = new Set<MinorCivPosture>([
   'recovering',
 ]);
 
-const SAFE_UNIT_TYPES = new Set<UnitType>(TRAINABLE_UNITS.map(unit => unit.type));
-
 const UNSAFE_UNIT_TYPES = new Set<UnitType>([
   'settler',
   'worker',
@@ -81,6 +79,12 @@ const UNSAFE_UNIT_TYPES = new Set<UnitType>([
   'transport',
   'troop_transport',
 ]);
+
+const SAFE_MINOR_CIV_UNIT_TYPES = new Set<UnitType>(
+  TRAINABLE_UNITS
+    .map(unit => unit.type)
+    .filter(unitType => !UNSAFE_UNIT_TYPES.has(unitType)),
+);
 
 const UNSAFE_BUILDING_IDS = new Set<string>();
 
@@ -123,7 +127,7 @@ function normalizePendingSpawn(
     return undefined;
   }
 
-  if (!SAFE_UNIT_TYPES.has(value.unitType as UnitType)) {
+  if (!SAFE_MINOR_CIV_UNIT_TYPES.has(value.unitType as UnitType)) {
     return undefined;
   }
 
@@ -413,7 +417,7 @@ export function chooseMinorCivQueueItem(state: GameState, minorCivId: string): s
   }
 
   const definition = getMinorCivDefinition(minorCivId, state);
-  const posture = minorCiv.economy?.posture ?? evaluateMinorCivEconomyPosture(state, minorCivId);
+  const posture = evaluateMinorCivEconomyPosture(state, minorCivId);
   const budget = getMinorCivMobilizationBudget(state, minorCivId);
   const effectivePosture = budget.wantsDefender ? 'mobilizing' : posture;
   const cap = getMinorCivUnitCap(state, minorCivId, effectivePosture);

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -10,12 +10,21 @@ import type {
   TrainableUnitEntry,
   UnitType,
 } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
 import { resolveOpponentChallenge } from '@/core/opponent-challenge';
-import { getAvailableBuildings, getTrainableUnitsForCity, TRAINABLE_UNITS } from '@/systems/city-system';
-import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import {
+  getAvailableBuildings,
+  getTrainableUnitsForCity,
+  processCity,
+  TRAINABLE_UNITS,
+} from '@/systems/city-system';
+import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
+import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from '@/systems/hex-utils';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
+import { calculateCityYields } from '@/systems/resource-system';
 import { TECH_TREE } from '@/systems/tech-definitions';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
 
 export const MINOR_CIV_ECONOMY_TUNING = {
   explorer: {
@@ -85,6 +94,16 @@ function distance(state: GameState, left: HexCoord, right: HexCoord): number {
   return state.map.wrapsHorizontally
     ? wrappedHexDistance(left, right, state.map.width)
     : hexDistance(left, right);
+}
+
+export interface MinorCivEconomyTurnResult {
+  state: GameState;
+  completed?: {
+    minorCivId: string;
+    cityId: string;
+    itemId: string;
+    itemClass: 'building' | 'unit';
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -410,4 +429,231 @@ export function chooseMinorCivQueueItem(state: GameState, minorCivId: string): s
 
   scored.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
   return scored[0]?.id ?? null;
+}
+
+function isLegalSpawnTerrain(state: GameState, coord: HexCoord, unitType: UnitType): boolean {
+  const tile = state.map.tiles[hexKey(coord)];
+  if (!tile) {
+    return false;
+  }
+
+  const domain = UNIT_DEFINITIONS[unitType]?.domain ?? 'land';
+  if (domain === 'naval') {
+    return tile.terrain === 'ocean' || tile.terrain === 'coast';
+  }
+  return tile.terrain !== 'ocean' && tile.terrain !== 'coast' && tile.terrain !== 'mountain';
+}
+
+function legalSpawnPositions(state: GameState, minorCivId: string, unitType: UnitType): HexCoord[] {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!city) {
+    return [];
+  }
+
+  const occupied = new Set(
+    Object.values(state.units)
+      .filter(unit => !unit.transportId)
+      .map(unit => hexKey(unit.position)),
+  );
+  const adjacent = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(city.position, state.map.width)
+    : hexNeighbors(city.position);
+
+  return [city.position, ...adjacent]
+    .filter(coord => isLegalSpawnTerrain(state, coord, unitType) && !occupied.has(hexKey(coord)))
+    .sort((left, right) => left.q - right.q || left.r - right.r);
+}
+
+function createMinorCivUnit(
+  state: GameState,
+  minorCivId: string,
+  unitType: UnitType,
+): { state: GameState; created: boolean } {
+  const minorCiv = state.minorCivs[minorCivId];
+  const position = legalSpawnPositions(state, minorCivId, unitType)[0];
+  if (!minorCiv || !position) {
+    return { state, created: false };
+  }
+
+  const unit = createUnit(unitType, minorCivId, position, state.idCounters);
+  unit.movementPointsLeft = 0;
+  unit.hasMoved = true;
+  unit.hasActed = true;
+
+  return {
+    state: {
+      ...state,
+      units: { ...state.units, [unit.id]: unit },
+      minorCivs: {
+        ...state.minorCivs,
+        [minorCivId]: {
+          ...minorCiv,
+          units: [...minorCiv.units.filter(unitId => Boolean(state.units[unitId])), unit.id],
+        },
+      },
+    },
+    created: true,
+  };
+}
+
+function updateMinorEconomy(
+  state: GameState,
+  minorCivId: string,
+  patch: Partial<MinorCivEconomyState>,
+): GameState {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv) {
+    return state;
+  }
+
+  const economy = { ...(minorCiv.economy ?? createDefaultMinorCivEconomyState(state)), ...patch };
+  return {
+    ...state,
+    minorCivs: {
+      ...state.minorCivs,
+      [minorCivId]: { ...minorCiv, economy },
+    },
+  };
+}
+
+function isMinorCivQueueHeadLegal(state: GameState, minorCivId: string, itemId: string | undefined): boolean {
+  if (!itemId) {
+    return false;
+  }
+
+  const candidates = getMinorCivBuildCandidates(state, minorCivId);
+  return candidates.buildings.some(building => building.id === itemId)
+    || candidates.units.some(unit => unit.type === itemId);
+}
+
+export function processMinorCivEconomyTurn(
+  state: GameState,
+  minorCivId: string,
+  bus?: EventBus,
+): MinorCivEconomyTurnResult {
+  let nextState = normalizeMinorCivEconomyState(state);
+  const minorCiv = nextState.minorCivs[minorCivId];
+  const city = minorCiv ? nextState.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || minorCiv.isDestroyed || !city || city.owner !== minorCiv.id) {
+    return { state: nextState };
+  }
+
+  const tuning = MINOR_CIV_ECONOMY_TUNING[resolveOpponentChallenge(nextState)];
+  const economy = minorCiv.economy ?? createDefaultMinorCivEconomyState(nextState);
+  const pending = economy.pendingUnitSpawn;
+  if (pending) {
+    const spawned = createMinorCivUnit(nextState, minorCivId, pending.unitType);
+    if (spawned.created) {
+      const completed = {
+        minorCivId,
+        cityId: city.id,
+        itemId: pending.unitType,
+        itemClass: 'unit' as const,
+      };
+      nextState = updateMinorEconomy(spawned.state, minorCivId, {
+        pendingUnitSpawn: undefined,
+        recentProductionSummary: {
+          itemId: completed.itemId,
+          itemClass: completed.itemClass,
+          completedTurn: nextState.turn,
+        },
+      });
+      bus?.emit('minor-civ:production-completed', { ...completed, state: nextState });
+      return { state: nextState, completed };
+    }
+
+    const attempts = pending.attempts + 1;
+    nextState = updateMinorEconomy(nextState, minorCivId, {
+      pendingUnitSpawn: attempts > tuning.pendingSpawnMaxAttempts ? undefined : { ...pending, attempts },
+    });
+    return { state: nextState };
+  }
+
+  const posture = evaluateMinorCivEconomyPosture(nextState, minorCivId);
+  const policy: MinorCivPolicy = posture === 'mobilizing' || posture === 'fortifying'
+    ? 'defense'
+    : posture === 'recovering'
+      ? 'recovery'
+      : 'balanced';
+  const work = city.workedTiles.length > city.population
+    ? normalizeWorkedTilesForCity(nextState, city.id)
+    : assignCityFocus(nextState, city.id, posture === 'recovering' ? 'food' : posture === 'mobilizing' ? 'production' : 'balanced');
+  nextState = work.state;
+
+  const currentCity = nextState.cities[city.id];
+  let queue = currentCity.productionQueue;
+  let madeQueueDecision = false;
+  const queueHeadLegal = isMinorCivQueueHeadLegal(nextState, minorCivId, queue[0]);
+  const emptyQueueDecisionReady = queue.length === 0
+    && (economy.lastQueueDecisionTurn ?? -999) + tuning.queueDecisionInterval <= nextState.turn;
+  const invalidQueueHead = queue.length > 0 && !queueHeadLegal;
+  if (emptyQueueDecisionReady || invalidQueueHead) {
+    const chosen = chooseMinorCivQueueItem(nextState, minorCivId);
+    queue = chosen ? [chosen] : [];
+    madeQueueDecision = true;
+    nextState = {
+      ...nextState,
+      cities: {
+        ...nextState.cities,
+        [city.id]: { ...currentCity, productionQueue: queue },
+      },
+    };
+  }
+
+  const completedTechs = getMinorCivCompletedTechBand(nextState, minorCivId);
+  const availableResources = getMinorCivAvailableResources(nextState, minorCivId);
+  const cityForYields = nextState.cities[city.id];
+  const yields = calculateCityYields(cityForYields, nextState.map, undefined, completedTechs, {});
+  const productionYield = Math.max(0, Math.floor(yields.production * tuning.productionMultiplier));
+  const processed = processCity(
+    cityForYields,
+    nextState.map,
+    yields.food,
+    productionYield,
+    undefined,
+    completedTechs,
+    undefined,
+    nextState.era,
+    availableResources,
+  );
+  nextState = {
+    ...nextState,
+    cities: { ...nextState.cities, [city.id]: processed.city },
+  };
+
+  let completed: MinorCivEconomyTurnResult['completed'];
+  if (processed.completedUnit) {
+    const spawned = createMinorCivUnit(nextState, minorCivId, processed.completedUnit);
+    if (spawned.created) {
+      nextState = spawned.state;
+      completed = { minorCivId, cityId: city.id, itemId: processed.completedUnit, itemClass: 'unit' };
+    } else {
+      nextState = updateMinorEconomy(nextState, minorCivId, {
+        pendingUnitSpawn: { unitType: processed.completedUnit, completedTurn: nextState.turn, attempts: 1 },
+      });
+    }
+  } else if (processed.completedBuilding) {
+    completed = { minorCivId, cityId: city.id, itemId: processed.completedBuilding, itemClass: 'building' };
+  }
+
+  nextState = updateMinorEconomy(nextState, minorCivId, {
+    posture,
+    policy,
+    lastProcessedTurn: nextState.turn,
+    lastPostureChangeTurn: posture !== economy.posture ? nextState.turn : economy.lastPostureChangeTurn,
+    lastQueueDecisionTurn: madeQueueDecision ? nextState.turn : economy.lastQueueDecisionTurn,
+    recentProductionSummary: completed
+      ? {
+          itemId: completed.itemId,
+          itemClass: completed.itemClass,
+          completedTurn: nextState.turn,
+        }
+      : economy.recentProductionSummary,
+  });
+
+  if (completed) {
+    bus?.emit('minor-civ:production-completed', { ...completed, state: nextState });
+  }
+  return { state: nextState, completed };
 }

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -20,6 +20,7 @@ import {
 } from '@/systems/city-system';
 import { assignCityFocus, normalizeWorkedTilesForCity } from '@/systems/city-work-system';
 import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from '@/systems/hex-utils';
+import { getMinorCivMobilizationBudget } from '@/systems/minor-civ-coalition-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
 import { calculateCityYields } from '@/systems/resource-system';
@@ -413,17 +414,19 @@ export function chooseMinorCivQueueItem(state: GameState, minorCivId: string): s
 
   const definition = getMinorCivDefinition(minorCivId, state);
   const posture = minorCiv.economy?.posture ?? evaluateMinorCivEconomyPosture(state, minorCivId);
-  const cap = getMinorCivUnitCap(state, minorCivId, posture);
+  const budget = getMinorCivMobilizationBudget(state, minorCivId);
+  const effectivePosture = budget.wantsDefender ? 'mobilizing' : posture;
+  const cap = getMinorCivUnitCap(state, minorCivId, effectivePosture);
   const currentUnits = minorCiv.units.filter(unitId => Boolean(state.units[unitId])).length;
   const candidates = getMinorCivBuildCandidates(state, minorCivId);
   const scored = [
     ...candidates.buildings.map(building => ({
       id: building.id,
-      score: scoreBuilding(building, definition?.archetype, posture),
+      score: scoreBuilding(building, definition?.archetype, effectivePosture),
     })),
     ...candidates.units.map(unit => ({
       id: unit.type,
-      score: scoreUnit(unit, definition?.archetype, posture, currentUnits, cap),
+      score: scoreUnit(unit, definition?.archetype, effectivePosture, currentUnits, cap),
     })),
   ].filter(candidate => candidate.score >= 0);
 
@@ -570,7 +573,10 @@ export function processMinorCivEconomyTurn(
     return { state: nextState };
   }
 
-  const posture = evaluateMinorCivEconomyPosture(nextState, minorCivId);
+  const budget = getMinorCivMobilizationBudget(nextState, minorCivId);
+  const posture = (budget.recoveryStrainedUntilTurn ?? 0) > nextState.turn
+    ? 'recovering'
+    : evaluateMinorCivEconomyPosture(nextState, minorCivId);
   const policy: MinorCivPolicy = posture === 'mobilizing' || posture === 'fortifying'
     ? 'defense'
     : posture === 'recovering'

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -1,11 +1,45 @@
 import type {
+  Building,
   GameState,
+  HexCoord,
+  MinorCivArchetype,
   MinorCivEconomyState,
   MinorCivPolicy,
   MinorCivPosture,
+  ResourceType,
+  TrainableUnitEntry,
   UnitType,
 } from '@/core/types';
-import { TRAINABLE_UNITS } from '@/systems/city-system';
+import { resolveOpponentChallenge } from '@/core/opponent-challenge';
+import { getAvailableBuildings, getTrainableUnitsForCity, TRAINABLE_UNITS } from '@/systems/city-system';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
+import { RESOURCE_DEFINITIONS } from '@/systems/resource-definitions';
+import { TECH_TREE } from '@/systems/tech-definitions';
+
+export const MINOR_CIV_ECONOMY_TUNING = {
+  explorer: {
+    productionMultiplier: 0.75,
+    queueDecisionInterval: 5,
+    caps: { settled: 1, fortifying: 2, mobilizing: 3, recovering: 1 },
+    recoveryTurns: 8,
+    pendingSpawnMaxAttempts: 3,
+  },
+  standard: {
+    productionMultiplier: 1,
+    queueDecisionInterval: 4,
+    caps: { settled: 2, fortifying: 3, mobilizing: 4, recovering: 2 },
+    recoveryTurns: 6,
+    pendingSpawnMaxAttempts: 3,
+  },
+  veteran: {
+    productionMultiplier: 1.15,
+    queueDecisionInterval: 3,
+    caps: { settled: 2, fortifying: 4, mobilizing: 5, recovering: 2 },
+    recoveryTurns: 5,
+    pendingSpawnMaxAttempts: 4,
+  },
+} as const;
 
 const MINOR_CIV_POLICIES = new Set<MinorCivPolicy>([
   'balanced',
@@ -23,6 +57,35 @@ const MINOR_CIV_POSTURES = new Set<MinorCivPosture>([
 ]);
 
 const SAFE_UNIT_TYPES = new Set<UnitType>(TRAINABLE_UNITS.map(unit => unit.type));
+
+const UNSAFE_UNIT_TYPES = new Set<UnitType>([
+  'settler',
+  'worker',
+  'spy_scout',
+  'spy_informant',
+  'spy_agent',
+  'spy_operative',
+  'spy_hacker',
+  'caravan',
+  'expedition',
+  'transport',
+  'troop_transport',
+]);
+
+const UNSAFE_BUILDING_IDS = new Set<string>();
+
+function getMinorCivDefinition(minorCivId: string, state: GameState) {
+  const minorCiv = state.minorCivs[minorCivId];
+  return minorCiv
+    ? MINOR_CIV_DEFINITIONS.find(definition => definition.id === minorCiv.definitionId)
+    : undefined;
+}
+
+function distance(state: GameState, left: HexCoord, right: HexCoord): number {
+  return state.map.wrapsHorizontally
+    ? wrappedHexDistance(left, right, state.map.width)
+    : hexDistance(left, right);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -137,4 +200,214 @@ export function normalizeMinorCivEconomyState(state: GameState): GameState {
     };
   }
   return { ...state, minorCivs };
+}
+
+export function getMinorCivCompletedTechBand(state: GameState, minorCivId: string): string[] {
+  if (!state.minorCivs[minorCivId]) {
+    return [];
+  }
+  return TECH_TREE
+    .filter(tech => tech.era <= state.era)
+    .map(tech => tech.id)
+    .sort();
+}
+
+export function getMinorCivAvailableResources(state: GameState, minorCivId: string): Set<ResourceType> {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city) {
+    return new Set();
+  }
+
+  const completedTechs = new Set(getMinorCivCompletedTechBand(state, minorCivId));
+  const resourceDefinitions = new Map(RESOURCE_DEFINITIONS.map(definition => [definition.id, definition]));
+  const resources = new Set<ResourceType>();
+  const cityKey = hexKey(city.position);
+
+  for (const coord of city.ownedTiles) {
+    const key = hexKey(coord);
+    const tile = state.map.tiles[key];
+    if (!tile?.resource || tile.owner !== minorCiv.id) {
+      continue;
+    }
+
+    const resourceType = tile.resource as ResourceType;
+    const definition = resourceDefinitions.get(resourceType);
+    if (!definition || !completedTechs.has(definition.tech)) {
+      continue;
+    }
+
+    if (
+      key === cityKey
+      || (tile.improvement === definition.requiredImprovement && tile.improvementTurnsLeft === 0)
+    ) {
+      resources.add(resourceType);
+    }
+  }
+
+  return resources;
+}
+
+export function getMinorCivBuildCandidates(
+  state: GameState,
+  minorCivId: string,
+): { buildings: Building[]; units: TrainableUnitEntry[] } {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city || city.owner !== minorCiv.id || minorCiv.isDestroyed) {
+    return { buildings: [], units: [] };
+  }
+
+  const completedTechs = getMinorCivCompletedTechBand(state, minorCivId);
+  const resources = getMinorCivAvailableResources(state, minorCivId);
+  const buildings = getAvailableBuildings(city, completedTechs, state.map, resources, state.era)
+    .filter(building => !building.nationalProject && !building.uniquePerEmpire && !UNSAFE_BUILDING_IDS.has(building.id));
+  const units = getTrainableUnitsForCity(city, completedTechs, state.map, undefined, resources)
+    .filter(unit => !UNSAFE_UNIT_TYPES.has(unit.type));
+
+  return { buildings, units };
+}
+
+function hasImmediateCityThreat(state: GameState, minorCivId: string): boolean {
+  const minorCiv = state.minorCivs[minorCivId];
+  const city = minorCiv ? state.cities[minorCiv.cityId] : undefined;
+  if (!minorCiv || !city) {
+    return false;
+  }
+
+  return Object.values(state.units).some(unit => (
+    unit.owner !== minorCiv.id
+    && !unit.transportId
+    && distance(state, city.position, unit.position) <= 2
+    && (minorCiv.diplomacy.atWarWith.includes(unit.owner) || unit.owner === 'barbarian')
+  ));
+}
+
+export function evaluateMinorCivEconomyPosture(state: GameState, minorCivId: string): MinorCivPosture {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv || minorCiv.isDestroyed) {
+    return 'settled';
+  }
+
+  const economy = minorCiv.economy;
+  if ((economy?.localRecoveryUntilTurn ?? 0) > state.turn) {
+    return 'recovering';
+  }
+
+  const grievances = Object.values(minorCiv.regionalGrievanceByCiv ?? {});
+  if (grievances.some(grievance => (grievance.recoveryStrainedUntilTurn ?? 0) > state.turn)) {
+    return 'recovering';
+  }
+
+  if (minorCiv.diplomacy.atWarWith.length > 0 || hasImmediateCityThreat(state, minorCivId)) {
+    return 'mobilizing';
+  }
+
+  if (grievances.some(grievance => grievance.status === 'mobilizing' || grievance.status === 'coalition-talks')) {
+    return 'mobilizing';
+  }
+
+  const isCoalitionMember = Object.values(state.minorCivCoalitions ?? {}).some(coalition => (
+    coalition.memberIds.includes(minorCivId)
+    && (coalition.status === 'forming' || coalition.status === 'active')
+  ));
+  if (isCoalitionMember) {
+    return 'mobilizing';
+  }
+
+  const liveUnitCount = minorCiv.units.filter(unitId => Boolean(state.units[unitId])).length;
+  if (grievances.some(grievance => grievance.status === 'wary' && grievance.pressure >= 20) || liveUnitCount === 0) {
+    return 'fortifying';
+  }
+
+  return 'settled';
+}
+
+export function getMinorCivUnitCap(
+  state: GameState,
+  minorCivId: string,
+  posture: MinorCivPosture,
+): number {
+  const challenge = resolveOpponentChallenge(state);
+  const tuning = MINOR_CIV_ECONOMY_TUNING[challenge];
+  const definition = getMinorCivDefinition(minorCivId, state);
+  const archetypeBonus = definition?.archetype === 'militaristic' && (posture === 'fortifying' || posture === 'mobilizing') ? 1 : 0;
+  return Math.max(1, tuning.caps[posture] + archetypeBonus);
+}
+
+function scoreBuilding(
+  building: Building,
+  archetype: MinorCivArchetype | undefined,
+  posture: MinorCivPosture,
+): number {
+  let score = 20;
+  if (posture === 'fortifying' || posture === 'mobilizing') {
+    if (building.id === 'walls' || building.id === 'barracks' || building.id === 'stable') {
+      score += 60;
+    }
+  }
+  if (archetype === 'mercantile' && (building.yields.gold > 0 || building.id === 'marketplace')) {
+    score += 35;
+  }
+  if (
+    archetype === 'cultural'
+    && (building.yields.science > 0 || building.id === 'library' || building.id === 'temple' || building.id === 'monument')
+  ) {
+    score += 35;
+  }
+  if (archetype === 'militaristic' && (building.id === 'walls' || building.id === 'barracks')) {
+    score += 35;
+  }
+  score += building.yields.food * 3
+    + building.yields.production * 4
+    + building.yields.gold * 2
+    + building.yields.science * 2;
+  return score;
+}
+
+function scoreUnit(
+  unit: TrainableUnitEntry,
+  archetype: MinorCivArchetype | undefined,
+  posture: MinorCivPosture,
+  currentUnits: number,
+  cap: number,
+): number {
+  if (currentUnits >= cap) {
+    return -1;
+  }
+
+  let score = posture === 'mobilizing' ? 90 : posture === 'fortifying' ? 60 : 15;
+  if (archetype === 'militaristic') {
+    score += 20;
+  }
+  if (unit.type === 'scout') {
+    score -= 20;
+  }
+  return score;
+}
+
+export function chooseMinorCivQueueItem(state: GameState, minorCivId: string): string | null {
+  const minorCiv = state.minorCivs[minorCivId];
+  if (!minorCiv) {
+    return null;
+  }
+
+  const definition = getMinorCivDefinition(minorCivId, state);
+  const posture = minorCiv.economy?.posture ?? evaluateMinorCivEconomyPosture(state, minorCivId);
+  const cap = getMinorCivUnitCap(state, minorCivId, posture);
+  const currentUnits = minorCiv.units.filter(unitId => Boolean(state.units[unitId])).length;
+  const candidates = getMinorCivBuildCandidates(state, minorCivId);
+  const scored = [
+    ...candidates.buildings.map(building => ({
+      id: building.id,
+      score: scoreBuilding(building, definition?.archetype, posture),
+    })),
+    ...candidates.units.map(unit => ({
+      id: unit.type,
+      score: scoreUnit(unit, definition?.archetype, posture, currentUnits, cap),
+    })),
+  ].filter(candidate => candidate.score >= 0);
+
+  scored.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+  return scored[0]?.id ?? null;
 }

--- a/src/systems/minor-civ-presentation.ts
+++ b/src/systems/minor-civ-presentation.ts
@@ -1,12 +1,26 @@
-import type { GameState } from '@/core/types';
+import type { GameState, MinorCivPosture } from '@/core/types';
 import { MINOR_CIV_DEFINITIONS } from './minor-civ-definitions';
 import { hasDiscoveredMinorCiv } from './discovery-system';
+import { evaluateMinorCivEconomyPosture } from './minor-civ-economy-system';
 
 export interface MinorCivPresentation {
   known: boolean;
   name: string;
   color: string;
 }
+
+export interface MinorCivEconomyPresentation {
+  known: boolean;
+  postureLabel: string | null;
+  hint: string | null;
+}
+
+const POSTURE_LABELS: Record<MinorCivPosture, string> = {
+  settled: 'Quiet',
+  fortifying: 'Fortifying',
+  mobilizing: 'Mobilizing',
+  recovering: 'Recovering',
+};
 
 export function getMinorCivPresentationForPlayer(
   state: Pick<GameState, 'minorCivs' | 'cities' | 'civilizations'>,
@@ -22,6 +36,42 @@ export function getMinorCivPresentationForPlayer(
     known,
     name: known ? (def?.name ?? unknownName) : unknownName,
     color: known ? (def?.color ?? '#888') : '#888',
+  };
+}
+
+export function getMinorCivEconomyPresentationForPlayer(
+  state: GameState,
+  viewerCivId: string,
+  minorCivId: string,
+): MinorCivEconomyPresentation {
+  const base = getMinorCivPresentationForPlayer(state, viewerCivId, minorCivId);
+  if (!base.known) {
+    return { known: false, postureLabel: null, hint: null };
+  }
+
+  const economy = state.minorCivs[minorCivId]?.economy;
+  const effectivePosture = evaluateMinorCivEconomyPosture(state, minorCivId);
+  const hasRegionalGrievanceContext = Object.keys(state.minorCivs[minorCivId]?.regionalGrievanceByCiv ?? {}).length > 0;
+  const displayPosture = effectivePosture === 'settled' && economy?.posture && !hasRegionalGrievanceContext
+    ? economy.posture
+    : effectivePosture;
+  if (!economy) {
+    return { known: true, postureLabel: POSTURE_LABELS[displayPosture], hint: null };
+  }
+
+  const summary = economy.recentProductionSummary;
+  const hint = summary?.itemClass === 'unit'
+    ? 'training defenders'
+    : summary?.itemClass === 'building'
+      ? 'investing locally'
+      : effectivePosture === 'recovering'
+        ? 'recovering from levy'
+        : null;
+
+  return {
+    known: true,
+    postureLabel: POSTURE_LABELS[displayPosture],
+    hint,
   };
 }
 

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -28,6 +28,7 @@ import { foundCity } from './city-system';
 import { collectUsedCityNames } from './city-name-system';
 import { generateQuest } from './quest-system';
 import { isMinorCivAtWar, isMinorCivHostileToOwner } from './minor-civ-diplomacy';
+import { processMinorCivEconomyTurn } from './minor-civ-economy-system';
 import { resolveCombat } from './combat-system';
 import { hasDiscoveredMinorCiv } from './discovery-system';
 import { canAttackByProfileOnMap } from './attack-targeting';
@@ -209,6 +210,10 @@ export function processMinorCivTurn(
       const unit = nextState.units[unitId];
       if (unit) nextState.units[unitId] = resetUnitTurn(unit);
     }
+    nextState = processMinorCivRegionalGrievanceTurn(nextState, mcId, { allowDefenderSpawns: false });
+    const economyResult = processMinorCivEconomyTurn(nextState, mcId, bus);
+    nextState = economyResult.state;
+    mc = nextState.minorCivs[mcId];
     const planned = planPurposefulMinorCivTurn(nextState, mcId);
     if (planned.plan) {
       nextState.opponentAI!.minorCivs[mcId] = planned.plan;
@@ -221,7 +226,6 @@ export function processMinorCivTurn(
     nextState = applyAllyBonuses(nextState, mc, def);
     mc = nextState.minorCivs[mcId];
     nextState = processGarrison(nextState, mc);
-    nextState = processMinorCivRegionalGrievanceTurn(nextState, mcId);
     emitRelationshipThresholds(nextState, nextState.minorCivs[mcId], bus);
   }
 
@@ -627,6 +631,16 @@ function emitRelationshipThresholds(state: GameState, mc: MinorCivState, bus: Ev
 function processGarrison(state: GameState, mc: MinorCivState): GameState {
   const aliveUnits = mc.units.filter(uid => state.units[uid]);
   mc.units = aliveUnits;
+
+  if (mc.economy && state.cities[mc.cityId]?.owner === mc.id) {
+    return {
+      ...state,
+      minorCivs: {
+        ...state.minorCivs,
+        [mc.id]: { ...mc, units: aliveUnits },
+      },
+    };
+  }
 
   if (aliveUnits.length === 0) {
     if (mc.garrisonCooldown > 0) {

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -10,7 +10,10 @@ import { resolveCivDefinition } from '@/systems/civ-registry';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { hasDiscoveredMinorCiv } from '@/systems/discovery-system';
 import { shouldListMajorCivForViewer } from '@/systems/viewer-intel';
-import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
+import {
+  getMinorCivEconomyPresentationForPlayer,
+  getMinorCivPresentationForPlayer,
+} from '@/systems/minor-civ-presentation';
 import {
   formatQuestReward,
   getMinorCivChainPresentationForPlayer,
@@ -62,6 +65,7 @@ interface MinorCivRowData {
   festivalLabel: string | null;
   festivalDisabledReason: string | null;
   regionalGrievanceText: string | null;
+  economyHintText: string | null;
   reparationsLabel: string | null;
   reparationsDisabledReason: string | null;
   atWar: boolean;
@@ -191,6 +195,13 @@ export function createDiplomacyPanel(
       .split('-')
       .map(part => part[0].toUpperCase() + part.slice(1))
       .join(' ');
+    const economyPresentation = getMinorCivEconomyPresentationForPlayer(state, state.currentPlayer, mcId);
+    const postureSuffix = economyPresentation.postureLabel && economyPresentation.postureLabel !== grievanceStatusLabel
+      ? ` · ${economyPresentation.postureLabel}`
+      : '';
+    const regionalGrievanceText = grievance && grievanceStatusLabel
+      ? `Regional grievance: ${grievanceStatusLabel}${postureSuffix}`
+      : economyPresentation.postureLabel ? `City-state posture: ${economyPresentation.postureLabel}` : null;
     const canOfferReparations = Boolean(grievance && grievance.pressure >= 20);
     const reparationsDisabledReason = !canOfferReparations ? null
       : atWar ? 'Unavailable while at war.'
@@ -211,9 +222,8 @@ export function createDiplomacyPanel(
         ? `Sponsor ${questPresentation?.stepTitle ?? 'Festival'} (${festivalTarget.amount} Gold)`
         : null,
       festivalDisabledReason,
-      regionalGrievanceText: grievance && grievanceStatusLabel
-        ? `Regional grievance: ${grievanceStatusLabel} (${Math.round(grievance.pressure)})`
-        : null,
+      regionalGrievanceText,
+      economyHintText: economyPresentation.hint,
       reparationsLabel: canOfferReparations ? `Pay Reparations (${reparationsCost} Gold)` : null,
       reparationsDisabledReason,
       atWar,
@@ -285,6 +295,9 @@ export function createDiplomacyPanel(
       if (row.regionalGrievanceText !== null) {
         minorCivsHtml += `<div style="font-size:11px;color:#e8c170;margin-top:4px;" data-text="mc-grievance-${row.mcIdx}"></div>`;
       }
+      if (row.economyHintText !== null) {
+        minorCivsHtml += `<div style="font-size:11px;opacity:0.65;margin-top:4px;" data-text="mc-economy-hint-${row.mcIdx}"></div>`;
+      }
       if (row.festivalDisabledReason) {
         minorCivsHtml += `<div style="font-size:10px;color:#e8c170;margin-top:5px;" data-text="mc-festival-reason-${row.mcIdx}"></div>`;
       }
@@ -337,6 +350,9 @@ export function createDiplomacyPanel(
     }
     if (row.regionalGrievanceText !== null) {
       setText(`mc-grievance-${row.mcIdx}`, row.regionalGrievanceText);
+    }
+    if (row.economyHintText !== null) {
+      setText(`mc-economy-hint-${row.mcIdx}`, row.economyHintText);
     }
     if (row.festivalDisabledReason) setText(`mc-festival-reason-${row.mcIdx}`, row.festivalDisabledReason);
     if (row.reparationsDisabledReason) setText(`mc-reparations-reason-${row.mcIdx}`, row.reparationsDisabledReason);
@@ -427,9 +443,12 @@ export function createDiplomacyPanel(
 
   panel.querySelectorAll('.mc-reparations').forEach(btn => {
     btn.addEventListener('click', () => {
-      const mcId = (btn as HTMLElement).dataset.mcId!;
-      callbacks.onMinorCivReparations?.(mcId);
+      const button = btn as HTMLButtonElement;
+      if (button.disabled) return;
+      button.disabled = true;
+      const mcId = button.dataset.mcId!;
       panel.remove();
+      callbacks.onMinorCivReparations?.(mcId);
     });
   });
 

--- a/src/ui/minor-civ-notification-listeners.ts
+++ b/src/ui/minor-civ-notification-listeners.ts
@@ -131,6 +131,26 @@ export function registerMinorCivNotificationListeners(
     appendToCivLog(data.majorCivId, notification.message, notification.type);
   });
 
+  bus.on('minor-civ:production-completed', data => {
+    const state = data.state ?? getState();
+    for (const civId of Object.keys(state.civilizations)) {
+      const notification = getMinorCivNotification(state, civId, {
+        type: 'minor-civ:production-completed',
+        minorCivId: data.minorCivId,
+        cityId: data.cityId,
+        itemId: data.itemId,
+        itemClass: data.itemClass,
+      });
+      if (!notification) continue;
+      queueHotSeatEvent(state, civId, {
+        type: 'minor-civ:production-completed',
+        message: notification.message,
+        turn: state.turn,
+      });
+      appendToCivLog(civId, notification.message, notification.type);
+    }
+  });
+
   bus.on('minor-civ:guerrilla', data => {
     const state = getState();
     const notification = getMinorCivNotification(state, data.targetCivId, {

--- a/src/ui/minor-civ-notifications.ts
+++ b/src/ui/minor-civ-notifications.ts
@@ -20,6 +20,7 @@ export type MinorCivNotificationEvent =
   | { type: 'minor-civ:alliance-broken'; majorCivId: string; minorCivId: string }
   | { type: 'minor-civ:relationship-threshold'; majorCivId: string; minorCivId: string; newStatus: string }
   | { type: 'minor-civ:guerrilla'; targetCivId: string; minorCivId: string }
+  | { type: 'minor-civ:production-completed'; minorCivId: string; cityId: string; itemId: string; itemClass: 'building' | 'unit' }
   | { type: 'minor-civ:quest-expired'; majorCivId: string; minorCivId: string };
 
 function getTargetedMinorCivPresentation(
@@ -64,6 +65,21 @@ export function getMinorCivNotification(
     return {
       message: formatMinorCivEventMessageForPlayer(state, viewerCivId, event.minorCivId, 'guerrilla'),
       type: 'warning',
+      turn: state.turn,
+    };
+  }
+
+  if (event.type === 'minor-civ:production-completed') {
+    const presentation = getTargetedMinorCivPresentation(state, viewerCivId, event.minorCivId);
+    if (!presentation) {
+      return null;
+    }
+
+    return {
+      message: event.itemClass === 'unit'
+        ? `${presentation.name} is strengthening its defenses.`
+        : `${presentation.name} is growing more prosperous.`,
+      type: event.itemClass === 'unit' ? 'warning' : 'info',
       turn: state.turn,
     };
   }

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -370,6 +370,21 @@ describe('save persistence (#38)', () => {
     expect(Object.keys(loaded.units)).toHaveLength(unitCountBefore);
   });
 
+  it('drops valid-looking pending minor-civ economy spawns for unsafe unit types', () => {
+    const state = createNewGame(undefined, 'minor-economy-unsafe-pending', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    (minorCiv as any).economy = {
+      policy: 'balanced',
+      posture: 'settled',
+      lastProcessedTurn: state.turn,
+      pendingUnitSpawn: { unitType: 'settler', completedTurn: state.turn, attempts: 1 },
+    };
+
+    const loaded = normalizeLoadedStateForTest(state);
+
+    expect(loaded.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toBeUndefined();
+  });
+
   it('removes malformed chain metadata without changing treasury or relationship', () => {
     const state = createNewGame(undefined, 'invalid-minor-chain-save', 'small');
     const minorCiv = Object.values(state.minorCivs)[0];

--- a/tests/storage/save-persistence.test.ts
+++ b/tests/storage/save-persistence.test.ts
@@ -324,6 +324,52 @@ describe('save persistence (#38)', () => {
     });
   });
 
+  it('normalizes missing hidden minor-civ economy state after coalition state', () => {
+    const state = createNewGame(undefined, 'minor-economy-legacy', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    delete (minorCiv as any).economy;
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 55,
+        status: 'mobilizing',
+        lastUpdatedTurn: state.turn,
+        causes: [],
+        mobilizationProgress: 12,
+      },
+    };
+
+    const loaded = normalizeLoadedStateForTest(state);
+
+    expect(loaded.minorCivs[minorCiv.id].economy).toMatchObject({
+      policy: 'balanced',
+      posture: 'settled',
+      lastProcessedTurn: Math.max(0, state.turn - 1),
+    });
+    expect(loaded.minorCivs[minorCiv.id].regionalGrievanceByCiv?.player).toMatchObject({
+      pressure: 55,
+      status: 'mobilizing',
+      mobilizationProgress: 12,
+    });
+  });
+
+  it('drops malformed pending minor-civ economy spawns without creating units on load', () => {
+    const state = createNewGame(undefined, 'minor-economy-bad-pending', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const unitCountBefore = Object.keys(state.units).length;
+    (minorCiv as any).economy = {
+      policy: 'balanced',
+      posture: 'settled',
+      lastProcessedTurn: state.turn,
+      pendingUnitSpawn: { unitType: 'settler', completedTurn: 'bad', attempts: -1 },
+    };
+
+    const loaded = normalizeLoadedStateForTest(state);
+
+    expect(loaded.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toBeUndefined();
+    expect(Object.keys(loaded.units)).toHaveLength(unitCountBefore);
+  });
+
   it('removes malformed chain metadata without changing treasury or relationship', () => {
     const state = createNewGame(undefined, 'invalid-minor-chain-save', 'small');
     const minorCiv = Object.values(state.minorCivs)[0];

--- a/tests/systems/minor-civ-economy-system.test.ts
+++ b/tests/systems/minor-civ-economy-system.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
-import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
+import {
+  chooseMinorCivQueueItem,
+  evaluateMinorCivEconomyPosture,
+  getMinorCivAvailableResources,
+  getMinorCivBuildCandidates,
+  getMinorCivCompletedTechBand,
+  getMinorCivUnitCap,
+  normalizeMinorCivEconomyState,
+} from '@/systems/minor-civ-economy-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
+import { hexKey } from '@/systems/hex-utils';
 
 describe('minor-civ economy normalization', () => {
   it('does not change city queue, production progress, units, or regional grievance', () => {
@@ -27,5 +37,118 @@ describe('minor-civ economy normalization', () => {
     expect(result.units).toEqual(beforeUnits);
     expect(result.minorCivs[minorCiv.id].regionalGrievanceByCiv).toEqual(minorCiv.regionalGrievanceByCiv);
     expect(result.minorCivs[minorCiv.id].economy).toMatchObject({ policy: 'balanced', posture: 'settled' });
+  });
+});
+
+describe('minor-civ economy helpers', () => {
+  it('derives minor-civ tech bands by era without needing a Civilization record', () => {
+    const state = createNewGame(undefined, 'minor-economy-tech-band', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    state.era = 2;
+
+    const techs = getMinorCivCompletedTechBand(state, minorCiv.id);
+
+    expect(state.civilizations[minorCiv.id]).toBeUndefined();
+    expect(techs).toContain('bronze-working');
+    expect(techs.every(techId => typeof techId === 'string')).toBe(true);
+  });
+
+  it('reads city-state resources from owned improved tiles and does not use major-civ resource lookup', () => {
+    const state = createNewGame(undefined, 'minor-economy-resource-band', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    const resourceTile = city.ownedTiles.find(coord => hexKey(coord) !== hexKey(city.position)) ?? city.position;
+    const key = hexKey(resourceTile);
+    state.map.tiles[key] = {
+      ...state.map.tiles[key],
+      owner: minorCiv.id,
+      resource: 'copper',
+      improvement: 'mine',
+      improvementTurnsLeft: 0,
+    };
+    state.era = 1;
+
+    expect(getCivAvailableResources(state, minorCiv.id).has('copper')).toBe(false);
+    expect(getMinorCivAvailableResources(state, minorCiv.id).has('copper')).toBe(true);
+  });
+
+  it('does not reveal resource-gated candidates before the era band reveals their resource', () => {
+    const state = createNewGame(undefined, 'minor-economy-resource-negative', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    state.era = 1;
+    state.map.tiles[hexKey(city.position)] = {
+      ...state.map.tiles[hexKey(city.position)],
+      owner: minorCiv.id,
+      resource: 'iron',
+    };
+
+    const candidates = getMinorCivBuildCandidates(state, minorCiv.id);
+
+    expect(candidates.units.map(unit => unit.type)).not.toContain('swordsman');
+  });
+
+  it('filters city-state unsafe candidates', () => {
+    const state = createNewGame(undefined, 'minor-economy-safe-candidates', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+
+    const candidates = getMinorCivBuildCandidates(state, minorCiv.id);
+    const ids = [...candidates.buildings.map(building => building.id), ...candidates.units.map(unit => unit.type)];
+
+    expect(ids).not.toContain('settler');
+    expect(ids).not.toContain('worker');
+    expect(ids).not.toContain('spy_scout');
+    expect(ids).not.toContain('caravan');
+    expect(candidates.buildings.every(building => !building.nationalProject && !building.uniquePerEmpire)).toBe(true);
+  });
+
+  it('maps regional grievance and recovery strain into economy posture', () => {
+    const state = createNewGame(undefined, 'minor-economy-posture', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 50,
+        status: 'mobilizing',
+        lastUpdatedTurn: state.turn,
+        recoveryStrainedUntilTurn: state.turn + 3,
+        causes: [],
+      },
+    };
+
+    expect(evaluateMinorCivEconomyPosture(state, minorCiv.id)).toBe('recovering');
+  });
+
+  it('uses challenge, posture, and archetype for unit caps', () => {
+    const state = createNewGame(undefined, 'minor-economy-caps', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    minorCiv.definitionId = 'sparta';
+    state.opponentChallenge = 'veteran';
+
+    expect(getMinorCivUnitCap(state, minorCiv.id, 'mobilizing')).toBe(6);
+  });
+
+  it('chooses a deterministic single queue item', () => {
+    const state = createNewGame(undefined, 'minor-economy-queue-choice', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    state.minorCivs[minorCiv.id].economy = { policy: 'defense', posture: 'fortifying', lastProcessedTurn: 0 };
+
+    expect(chooseMinorCivQueueItem(state, minorCiv.id)).toEqual(chooseMinorCivQueueItem(state, minorCiv.id));
+  });
+
+  it('treats low cooled wary pressure as settled when no local threat exists', () => {
+    const state = createNewGame(undefined, 'minor-economy-cooled-wary', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 5,
+        status: 'wary',
+        lastUpdatedTurn: state.turn,
+        causes: [],
+      },
+    };
+
+    expect(evaluateMinorCivEconomyPosture(state, minorCiv.id)).toBe('settled');
   });
 });

--- a/tests/systems/minor-civ-economy-system.test.ts
+++ b/tests/systems/minor-civ-economy-system.test.ts
@@ -138,6 +138,19 @@ describe('minor-civ economy helpers', () => {
     expect(chooseMinorCivQueueItem(state, minorCiv.id)).toEqual(chooseMinorCivQueueItem(state, minorCiv.id));
   });
 
+  it('uses live mobilizing posture over stale settled economy when choosing defenders', () => {
+    const state = createNewGame(undefined, 'minor-economy-live-war-choice', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    minorCiv.economy = { policy: 'balanced', posture: 'settled', lastProcessedTurn: state.turn - 1 };
+    minorCiv.diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.atWarWith = [minorCiv.id];
+
+    const chosen = chooseMinorCivQueueItem(state, minorCiv.id);
+    const candidates = getMinorCivBuildCandidates(state, minorCiv.id);
+
+    expect(candidates.units.map(unit => unit.type)).toContain(chosen);
+  });
+
   it('treats low cooled wary pressure as settled when no local threat exists', () => {
     const state = createNewGame(undefined, 'minor-economy-cooled-wary', 'small');
     const minorCiv = Object.values(state.minorCivs)[0];

--- a/tests/systems/minor-civ-economy-system.test.ts
+++ b/tests/systems/minor-civ-economy-system.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
+
+describe('minor-civ economy normalization', () => {
+  it('does not change city queue, production progress, units, or regional grievance', () => {
+    const state = createNewGame(undefined, 'minor-economy-normalize-system', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    city.productionQueue = ['walls'];
+    city.productionProgress = 7;
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 45,
+        status: 'mobilizing',
+        lastUpdatedTurn: state.turn,
+        causes: [],
+      },
+    };
+    const beforeUnits = structuredClone(state.units);
+
+    const result = normalizeMinorCivEconomyState(state);
+
+    expect(result.cities[city.id].productionQueue).toEqual(['walls']);
+    expect(result.cities[city.id].productionProgress).toBe(7);
+    expect(result.units).toEqual(beforeUnits);
+    expect(result.minorCivs[minorCiv.id].regionalGrievanceByCiv).toEqual(minorCiv.regionalGrievanceByCiv);
+    expect(result.minorCivs[minorCiv.id].economy).toMatchObject({ policy: 'balanced', posture: 'settled' });
+  });
+});

--- a/tests/systems/minor-civ-economy-system.test.ts
+++ b/tests/systems/minor-civ-economy-system.test.ts
@@ -8,9 +8,11 @@ import {
   getMinorCivCompletedTechBand,
   getMinorCivUnitCap,
   normalizeMinorCivEconomyState,
+  processMinorCivEconomyTurn,
 } from '@/systems/minor-civ-economy-system';
 import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
-import { hexKey } from '@/systems/hex-utils';
+import { getWrappedHexNeighbors, hexKey, hexNeighbors } from '@/systems/hex-utils';
+import { createUnit } from '@/systems/unit-system';
 
 describe('minor-civ economy normalization', () => {
   it('does not change city queue, production progress, units, or regional grievance', () => {
@@ -150,5 +152,130 @@ describe('minor-civ economy helpers', () => {
     };
 
     expect(evaluateMinorCivEconomyPosture(state, minorCiv.id)).toBe('settled');
+  });
+});
+
+describe('minor-civ hidden production', () => {
+  it('processes real city production and completes a minor-civ building', () => {
+    const state = createNewGame(undefined, 'minor-economy-building', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    const legalBuilding = getMinorCivBuildCandidates(state, minorCiv.id).buildings[0]!.id;
+    city.productionQueue = [legalBuilding];
+    city.productionProgress = 999;
+    minorCiv.economy = { policy: 'defense', posture: 'fortifying', lastProcessedTurn: 0 };
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+    expect(result.state.cities[city.id].buildings).toContain(legalBuilding);
+    expect(result.state.minorCivs[minorCiv.id].economy?.recentProductionSummary).toMatchObject({
+      itemId: legalBuilding,
+      itemClass: 'building',
+      completedTurn: state.turn,
+    });
+  });
+
+  it('completes a minor-civ unit into state.units and mc.units with no same-turn action', () => {
+    const state = createNewGame(undefined, 'minor-economy-unit', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    city.productionQueue = ['warrior'];
+    city.productionProgress = 999;
+    minorCiv.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+    const beforeUnitIds = new Set(Object.keys(state.units));
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+    const newUnit = Object.values(result.state.units).find(unit => !beforeUnitIds.has(unit.id))!;
+
+    expect(newUnit.owner).toBe(minorCiv.id);
+    expect(result.state.minorCivs[minorCiv.id].units).toContain(newUnit.id);
+    expect(newUnit.movementPointsLeft).toBe(0);
+    expect(newUnit.hasMoved).toBe(true);
+    expect(newUnit.hasActed).toBe(true);
+  });
+
+  it('stores pending unit spawn when city and adjacent tiles are occupied', () => {
+    const state = createNewGame(undefined, 'minor-economy-pending-spawn', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    city.productionQueue = ['warrior'];
+    city.productionProgress = 999;
+    minorCiv.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+    const adjacent = state.map.wrapsHorizontally
+      ? getWrappedHexNeighbors(city.position, state.map.width)
+      : hexNeighbors(city.position);
+    const occupied = [city.position, ...adjacent];
+    occupied.forEach((coord, index) => {
+      const blocker = createUnit('warrior', 'player', coord, state.idCounters);
+      blocker.id = `spawn-blocker-${index}`;
+      state.units[blocker.id] = blocker;
+    });
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+    expect(result.state.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toMatchObject({
+      unitType: 'warrior',
+      completedTurn: state.turn,
+      attempts: 1,
+    });
+    expect(Object.values(result.state.units).filter(unit => unit.owner === minorCiv.id && unit.type === 'warrior')).toHaveLength(1);
+  });
+
+  it('retries pending spawns before adding more production progress and clears after creation', () => {
+    const state = createNewGame(undefined, 'minor-economy-pending-retry', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    city.productionQueue = ['walls'];
+    city.productionProgress = 0;
+    minorCiv.economy = {
+      policy: 'defense',
+      posture: 'mobilizing',
+      lastProcessedTurn: 0,
+      pendingUnitSpawn: { unitType: 'warrior', completedTurn: state.turn - 1, attempts: 1 },
+    };
+    const beforeProgress = city.productionProgress;
+    const beforeUnitIds = new Set(Object.keys(state.units));
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+    const newUnit = Object.values(result.state.units).find(unit => !beforeUnitIds.has(unit.id))!;
+
+    expect(newUnit.owner).toBe(minorCiv.id);
+    expect(result.state.minorCivs[minorCiv.id].economy?.pendingUnitSpawn).toBeUndefined();
+    expect(result.state.cities[city.id].productionProgress).toBe(beforeProgress);
+  });
+
+  it('does not process destroyed or captured city-states', () => {
+    const state = createNewGame(undefined, 'minor-economy-captured-skip', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    const legalBuilding = getMinorCivBuildCandidates(state, minorCiv.id).buildings[0]!.id;
+    city.owner = 'player';
+    city.productionQueue = [legalBuilding];
+    city.productionProgress = 999;
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+    expect(result.state.cities[city.id].buildings).not.toContain(legalBuilding);
+  });
+
+  it('does not replace an active legal hidden queue item just because the decision interval elapsed', () => {
+    const state = createNewGame(undefined, 'minor-economy-preserve-queue', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0];
+    const city = state.cities[minorCiv.cityId];
+    const legalBuilding = getMinorCivBuildCandidates(state, minorCiv.id).buildings[0]!.id;
+    city.productionQueue = [legalBuilding];
+    city.productionProgress = 1;
+    minorCiv.economy = {
+      policy: 'balanced',
+      posture: 'settled',
+      lastProcessedTurn: 0,
+      lastQueueDecisionTurn: 0,
+    };
+    state.turn = 20;
+
+    const result = processMinorCivEconomyTurn(state, minorCiv.id);
+
+    expect(result.state.cities[city.id].productionQueue[0]).toBe(legalBuilding);
+    expect(result.state.cities[city.id].productionProgress).toBeGreaterThan(1);
   });
 });

--- a/tests/systems/minor-civ-presentation.test.ts
+++ b/tests/systems/minor-civ-presentation.test.ts
@@ -3,6 +3,7 @@ import { createHotSeatGame, createNewGame } from '@/core/game-state';
 import { hexKey } from '@/systems/hex-utils';
 import {
   formatMinorCivEventMessageForPlayer,
+  getMinorCivEconomyPresentationForPlayer,
   getMinorCivPresentationForPlayer,
 } from '@/systems/minor-civ-presentation';
 
@@ -78,5 +79,69 @@ describe('minor-civ-presentation', () => {
 
     expect(discoveredMsg).not.toBe('City-state guerrilla fighters attack!');
     expect(hiddenMsg).toBe('City-state guerrilla fighters attack!');
+  });
+
+  it('masks hidden city-state economy presentation from undiscovered viewers', () => {
+    const state = createNewGame(undefined, 'minor-economy-presentation-hidden', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0]!;
+    minorCiv.economy = {
+      policy: 'defense',
+      posture: 'mobilizing',
+      lastProcessedTurn: state.turn,
+      recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+    };
+
+    const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+    expect(presentation.known).toBe(false);
+    expect(presentation.postureLabel).toBeNull();
+    expect(presentation.hint).toBeNull();
+  });
+
+  it('shows only broad city-state economy posture to discovered viewers', () => {
+    const state = createNewGame(undefined, 'minor-economy-presentation-known', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0]!;
+    const city = state.cities[minorCiv.cityId];
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'fog';
+    minorCiv.economy = {
+      policy: 'defense',
+      posture: 'mobilizing',
+      lastProcessedTurn: state.turn,
+      recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+    };
+
+    const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+    expect(presentation).toMatchObject({
+      known: true,
+      postureLabel: 'Mobilizing',
+      hint: 'training defenders',
+    });
+    expect(JSON.stringify(presentation)).not.toContain('warrior');
+  });
+
+  it('recomputes effective posture from cooled grievance state for immediate UI refresh', () => {
+    const state = createNewGame(undefined, 'minor-economy-presentation-cooled', 'small');
+    const minorCiv = Object.values(state.minorCivs)[0]!;
+    const city = state.cities[minorCiv.cityId];
+    state.civilizations.player.visibility.tiles[hexKey(city.position)] = 'fog';
+    minorCiv.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 5,
+        status: 'wary',
+        lastUpdatedTurn: state.turn,
+        causes: [],
+      },
+    };
+    minorCiv.economy = {
+      policy: 'defense',
+      posture: 'mobilizing',
+      lastProcessedTurn: state.turn,
+    };
+
+    const presentation = getMinorCivEconomyPresentationForPlayer(state, 'player', minorCiv.id);
+
+    expect(presentation.postureLabel).toBe('Quiet');
   });
 });

--- a/tests/systems/minor-civ-system.test.ts
+++ b/tests/systems/minor-civ-system.test.ts
@@ -6,6 +6,7 @@ import { EventBus } from '@/core/event-bus';
 import { TECH_TREE, getEraAdvancementTechs } from '@/systems/tech-definitions';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { processMinorCivRegionalGrievanceTurn } from '@/systems/minor-civ-coalition-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -97,6 +98,68 @@ describe('minor civ placement', () => {
 });
 
 describe('minor civ turn processing', () => {
+  it('runs hidden economy before minor-civ planning so completed units cannot act same turn', () => {
+    const state = createNewGame(undefined, 'minor-economy-turn-order', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    city.productionQueue = ['warrior'];
+    city.productionProgress = 999;
+    mc.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+    const beforeIds = new Set(Object.keys(state.units));
+
+    const result = processMinorCivTurn(state, new EventBus());
+    const created = Object.values(result.units).find(unit => !beforeIds.has(unit.id))!;
+
+    expect(created.owner).toBe(mcId);
+    expect(created.hasActed).toBe(true);
+    expect(result.opponentAI?.minorCivs[mcId]?.assignedUnitIds).toContain(created.id);
+  });
+
+  it('does not spawn both economy defender and regional grievance defender in one minor-civ turn', () => {
+    const state = createNewGame(undefined, 'minor-economy-no-double-spawn', 'small');
+    state.era = 2;
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    city.population = 4;
+    city.productionQueue = ['warrior'];
+    city.productionProgress = 999;
+    mc.regionalGrievanceByCiv = {
+      player: {
+        targetCivId: 'player',
+        pressure: 90,
+        status: 'coalition-talks',
+        lastUpdatedTurn: state.turn,
+        mobilizationProgress: 24,
+        causes: [],
+      },
+    };
+    const beforeMinorUnits = mc.units.filter(unitId => state.units[unitId]).length;
+
+    const result = processMinorCivTurn(state, new EventBus());
+    const afterMinorUnits = result.minorCivs[mcId].units.filter(unitId => result.units[unitId]).length;
+
+    expect(afterMinorUnits - beforeMinorUnits).toBe(1);
+  });
+
+  it('production-backed defenders stay within local force projection', () => {
+    const state = createNewGame(undefined, 'minor-economy-local-defense', 'small');
+    const mcId = Object.keys(state.minorCivs)[0]!;
+    const mc = state.minorCivs[mcId];
+    const city = state.cities[mc.cityId];
+    const distant = createUnit('warrior', 'barbarian', { q: city.position.q + 9, r: city.position.r }, state.idCounters);
+    distant.id = 'distant-raider';
+    state.units[distant.id] = distant;
+    city.productionQueue = ['warrior'];
+    city.productionProgress = 999;
+    mc.economy = { policy: 'defense', posture: 'mobilizing', lastProcessedTurn: 0 };
+
+    const result = processMinorCivTurn(state, new EventBus());
+
+    expect(JSON.stringify(result.opponentAI?.minorCivs[mcId])).not.toContain('distant-raider');
+  });
+
   it('purposefully intercepts always-hostile units inside its territory', () => {
     const state = createNewGame(undefined, 'mc-purposeful-defense', 'small');
     const mcId = Object.keys(state.minorCivs)[0]!;
@@ -200,7 +263,7 @@ describe('minor civ turn processing', () => {
     expect(peacetime.attackOrders).toEqual([]);
   });
 
-  it('replaces lost garrison after cooldown', () => {
+  it('does not free-replace a lost garrison once the hidden economy manages the city-state', () => {
     const state = createNewGame(undefined, 'mc-garrison', 'small');
     const mcId = Object.keys(state.minorCivs)[0];
     if (!mcId) return;
@@ -213,11 +276,12 @@ describe('minor civ turn processing', () => {
     mc.garrisonCooldown = 1;
 
     const result = processMinorCivTurn(state, bus);
-    expect(result.minorCivs[mcId].garrisonCooldown).toBe(0);
+    expect(result.minorCivs[mcId].garrisonCooldown).toBe(1);
+    expect(result.minorCivs[mcId].units).toHaveLength(0);
 
-    // Next turn should spawn replacement
     const result2 = processMinorCivTurn(result, bus);
-    expect(result2.minorCivs[mcId].units.length).toBeGreaterThanOrEqual(1);
+    expect(result2.minorCivs[mcId].units).toHaveLength(0);
+    expect(result2.minorCivs[mcId].economy).toBeDefined();
   });
 
   it('skips garrison respawn when city hex is occupied by another unit', () => {
@@ -245,7 +309,7 @@ describe('minor civ turn processing', () => {
     expect(result.minorCivs[mcId].units.length).toBe(0);
   });
 
-  it('respawns garrison when city hex is free after cooldown', () => {
+  it('does not free-respawn a garrison on an economy-managed city-state even when city hex is free', () => {
     const state = createNewGame(undefined, 'mc-garrison-free', 'small');
     const mcId = Object.keys(state.minorCivs)[0];
     if (!mcId) return;
@@ -260,8 +324,8 @@ describe('minor civ turn processing', () => {
 
     const result = processMinorCivTurn(state, bus);
 
-    // Garrison should be respawned — hex is free
-    expect(result.minorCivs[mcId].units.length).toBeGreaterThanOrEqual(1);
+    expect(result.minorCivs[mcId].units).toHaveLength(0);
+    expect(result.minorCivs[mcId].economy).toBeDefined();
   });
 
   it('applies ally bonus to allied major civ', () => {
@@ -550,7 +614,7 @@ describe('regional grievance mobilization', () => {
     };
     const beforeUnits = mc.units.length;
 
-    const result = processMinorCivTurn(state, bus);
+    const result = processMinorCivRegionalGrievanceTurn(state, mcId);
     const current = result.minorCivs[mcId];
     const newUnitId = current.units.find(unitId => !mc.units.includes(unitId));
 
@@ -609,6 +673,13 @@ describe('regional grievance mobilization', () => {
     const mc = state.minorCivs[mcId];
     const city = state.cities[mc.cityId];
     city.population = 3;
+    const garrison = state.units[mc.units[0]];
+    const fallbackPosition = Object.values(state.map.tiles)
+      .map(tile => tile.coord)
+      .find(coord =>
+        hexDistance(coord, city.position) > 2
+        && !['ocean', 'coast', 'mountain'].includes(state.map.tiles[hexKey(coord)].terrain))!;
+    garrison.position = fallbackPosition;
     mc.regionalGrievanceByCiv = {
       player: {
         targetCivId: 'player',
@@ -620,14 +691,14 @@ describe('regional grievance mobilization', () => {
       } as any,
     };
 
-    const result = processMinorCivTurn(state, bus);
+    const result = processMinorCivRegionalGrievanceTurn(state, mcId);
     const current = result.minorCivs[mcId];
     const newUnitId = current.units.find(unitId => !mc.units.includes(unitId));
 
     expect(result.cities[mc.cityId].population).toBe(2);
     expect(newUnitId).toBeDefined();
     expect(result.units[newUnitId!]).toMatchObject({ type: 'musketeer', health: 65 });
-    expect(result.units[newUnitId!].position).not.toEqual(state.cities[mc.cityId].position);
+    expect(result.units[newUnitId!].position).toEqual(state.cities[mc.cityId].position);
     expect(current.regionalGrievanceByCiv?.player.conscriptCooldownUntilTurn).toBeGreaterThan(state.turn);
     expect(current.regionalGrievanceByCiv?.player.recoveryStrainedUntilTurn).toBeGreaterThan(state.turn);
   });

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -319,10 +319,87 @@ describe('diplomacy-panel breakaway rows', () => {
     });
     const button = panel.querySelector<HTMLButtonElement>('[data-action="pay-reparations"]');
 
-    expect(panel.textContent).toContain('Regional grievance: Mobilizing (55)');
+    expect(panel.textContent).toContain('Regional grievance: Mobilizing');
+    expect(panel.textContent).not.toContain('(55)');
     expect(button?.textContent).toBe('Pay Reparations (60 Gold)');
     button?.click();
     expect(repaired).toBe('mc-sparta');
+  });
+
+  it('renders broad economy posture without hiding city-state actions', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+    state.minorCivs['mc-sparta'] = {
+      id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: [],
+      diplomacy: state.civilizations.player.diplomacy,
+      activeQuests: {},
+      chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+      regionalGrievanceByCiv: {
+        player: { targetCivId: 'player', pressure: 55, status: 'mobilizing', lastUpdatedTurn: state.turn, causes: [] },
+      },
+      economy: {
+        policy: 'defense',
+        posture: 'mobilizing',
+        lastProcessedTurn: state.turn,
+        recentProductionSummary: { itemId: 'warrior', itemClass: 'unit', completedTurn: state.turn },
+      },
+      isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+    };
+    state.cities['mc-city'] = {
+      ...state.cities['city-border'], id: 'mc-city', owner: 'mc-sparta',
+      position: { q: 6, r: 0 }, ownedTiles: [{ q: 6, r: 0 }],
+    };
+    state.civilizations.player.visibility.tiles['6,0'] = 'fog';
+
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {} });
+
+    expect(panel.textContent).toContain('Regional grievance: Mobilizing');
+    expect(panel.textContent).toContain('training defenders');
+    expect(panel.textContent).not.toContain('warrior');
+    expect(panel.querySelector('.mc-gift')).not.toBeNull();
+    expect(panel.querySelector('.mc-war')).not.toBeNull();
+  });
+
+  it('rerenders reparations cooling into economy posture without double charging from stale DOM', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+    state.civilizations.player.gold = 200;
+    state.minorCivs['mc-sparta'] = {
+      id: 'mc-sparta', definitionId: 'sparta', cityId: 'mc-city', units: [],
+      diplomacy: state.civilizations.player.diplomacy,
+      activeQuests: {},
+      chainStatusByCiv: {}, questCooldownUntilByCiv: {}, lastNotifiedStatusByCiv: {},
+      regionalGrievanceByCiv: {
+        player: { targetCivId: 'player', pressure: 25, status: 'wary', lastUpdatedTurn: state.turn, causes: [] },
+      },
+      economy: { policy: 'defense', posture: 'fortifying', lastProcessedTurn: state.turn },
+      isDestroyed: false, garrisonCooldown: 0, lastEraUpgrade: 1,
+    };
+    state.cities['mc-city'] = {
+      ...state.cities['city-border'], id: 'mc-city', owner: 'mc-sparta',
+      position: { q: 6, r: 0 }, ownedTiles: [{ q: 6, r: 0 }],
+    };
+    state.civilizations.player.visibility.tiles['6,0'] = 'fog';
+    let currentState = state;
+    const render = (): HTMLElement => createDiplomacyPanel(container, currentState, {
+      onAction: () => {},
+      onMinorCivReparations: mcId => {
+        currentState.minorCivs[mcId].regionalGrievanceByCiv!.player.pressure = 5;
+        currentState.minorCivs[mcId].regionalGrievanceByCiv!.player.status = 'wary';
+        currentState.minorCivs[mcId].economy = { ...currentState.minorCivs[mcId].economy!, posture: 'settled' };
+        currentState.civilizations.player.gold -= 60;
+        render();
+      },
+      onClose: () => {},
+    });
+
+    const panel = render();
+    const button = panel.querySelector<HTMLButtonElement>('[data-action="pay-reparations"]')!;
+    button.click();
+    button.click();
+    const rerendered = container.querySelector('#diplomacy-panel') as HTMLElement;
+
+    expect(currentState.civilizations.player.gold).toBe(140);
+    expect(rerendered.textContent).not.toContain('Pay Reparations');
+    expect(rerendered.textContent).not.toContain('(25)');
   });
 
   it('does not render another hot-seat player assignment', () => {

--- a/tests/ui/minor-civ-notification-listeners.test.ts
+++ b/tests/ui/minor-civ-notification-listeners.test.ts
@@ -105,4 +105,39 @@ describe('minor-civ notification listeners', () => {
     expect(stale.pendingEvents?.['player-1']).toBeUndefined();
     expect(next.pendingEvents?.['player-1']).toHaveLength(1);
   });
+
+  it('routes city-state economy production to eligible hot-seat viewers only', () => {
+    const state = createHotSeatGame({
+      playerCount: 2,
+      mapSize: 'small',
+      players: [
+        { name: 'A', slotId: 'player-1', civType: 'egypt', isHuman: true },
+        { name: 'B', slotId: 'player-2', civType: 'rome', isHuman: true },
+      ],
+    }, 'minor-economy-hotseat-notify');
+    state.pendingEvents = {};
+    const minorCivId = getFirstMinorCivId(state);
+    const minorCiv = state.minorCivs[minorCivId];
+    const city = state.cities[minorCiv.cityId];
+    state.civilizations['player-1'].visibility.tiles[hexKey(city.position)] = 'fog';
+    const bus = new EventBus();
+    const log: string[] = [];
+
+    registerMinorCivNotificationListeners(bus, () => state, {
+      appendToCivLog: (civId, message) => { log.push(`${civId}:${message}`); },
+    });
+
+    bus.emit('minor-civ:production-completed', {
+      minorCivId: minorCiv.id,
+      cityId: city.id,
+      itemId: 'warrior',
+      itemClass: 'unit',
+      state,
+    });
+
+    expect(state.pendingEvents?.['player-1']).toHaveLength(1);
+    expect(state.pendingEvents?.['player-2']).toBeUndefined();
+    expect(log.some(entry => entry.startsWith('player-1:'))).toBe(true);
+    expect(log.some(entry => entry.startsWith('player-2:'))).toBe(false);
+  });
 });

--- a/tests/ui/minor-civ-notifications.test.ts
+++ b/tests/ui/minor-civ-notifications.test.ts
@@ -278,4 +278,30 @@ describe('minor-civ-notifications', () => {
     expect(ownerNotification?.message).toMatch(/expired/i);
     expect(otherNotification).toBeNull();
   });
+
+  it('creates viewer-safe production notifications only for discovered city-states', () => {
+    const state = createNewGame(undefined, 'minor-economy-notification', 'small');
+    const minorCivId = getFirstMinorCivId(state);
+    const minorCiv = state.minorCivs[minorCivId];
+    const hidden = getMinorCivNotification(state, 'player', {
+      type: 'minor-civ:production-completed',
+      minorCivId: minorCiv.id,
+      cityId: minorCiv.cityId,
+      itemId: 'warrior',
+      itemClass: 'unit',
+    });
+    expect(hidden).toBeNull();
+
+    discoverMinorCiv(state, 'player', minorCiv.id);
+    const known = getMinorCivNotification(state, 'player', {
+      type: 'minor-civ:production-completed',
+      minorCivId: minorCiv.id,
+      cityId: minorCiv.cityId,
+      itemId: 'warrior',
+      itemClass: 'unit',
+    });
+
+    expect(known?.message).toContain('is strengthening its defenses');
+    expect(known?.message).not.toContain('warrior');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds normalized hidden economy state for minor civs, including posture, policy, production summaries, and safe pending unit spawns.
- Processes city-state production during minor-civ turns with bounded unit caps, safe trainable filters, deterministic queue choice, and spawn retry handling.
- Surfaces city-state economic posture through player-safe presentation data and diplomacy UI without exposing hidden internals.
- Documents the issue #490 design and implementation plan for the hybrid city-state economy approach.

## Gameplay impact
City-states now quietly grow their local economy and defenses over time, with stronger mobilization when threatened while avoiding major-civ behaviors like settlers, workers, spies, trade units, national projects, or empire-unique buildings.

## Validation
- scripts/check-src-rule-violations.sh src/core/types.ts src/storage/save-manager.ts src/systems/minor-civ-coalition-system.ts src/systems/minor-civ-economy-system.ts src/systems/minor-civ-presentation.ts src/systems/minor-civ-system.ts src/ui/diplomacy-panel.ts src/ui/minor-civ-notification-listeners.ts src/ui/minor-civ-notifications.ts
- ./scripts/run-with-mise.sh yarn build
- ./scripts/run-with-mise.sh yarn test

Refs #490