### PR TITLE
feat(crisis): MR2 — catastrophe archetype (eruption, earthquake, flood, wildfire, harsh winter)

### DIFF
--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -494,6 +494,7 @@ function rankCivilianAndTransportActions(
         knownResource: tile
           ? getKnownTileResourceForWorkerAction(tile, completedTechs)
           : null,
+        currentTurn: context.state.turn,
       },
     );
     return actions.map((action, index) => ranked({

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -177,7 +177,7 @@ export function processTurn(
       for (const cid of [...civ.cities].sort()) {
         const candidateCity = newState.cities[cid];
         if (!candidateCity) continue;
-        const candidateScience = calculateCityYields(candidateCity, newState.map, civDef?.bonusEffect, civ.techState.completed).science;
+        const candidateScience = calculateCityYields(candidateCity, newState.map, civDef?.bonusEffect, civ.techState.completed, {}, newState.turn).science;
         if (candidateScience < lowestScience) {
           lowestScience = candidateScience;
           lowestScienceCityId = cid;
@@ -198,16 +198,18 @@ export function processTurn(
 
       const activeRouteCount = (newState.marketplace?.tradeRoutes ?? [])
         .filter(route => route.fromCityId === cityId || route.toCityId === cityId).length;
-      const baseYields = calculateCityYields(city, newState.map, civDef?.bonusEffect, civ.techState.completed, { activeRouteCount });
+      const baseYields = calculateCityYields(city, newState.map, civDef?.bonusEffect, civ.techState.completed, { activeRouteCount }, newState.turn);
       const wonderCityBonuses = getLegendaryWonderCityYieldBonus(newState, civId, cityId);
       const unrestMultiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city))
         * getCrisisYieldMultiplier(newState, cityId);
       const empireFlatFoodForCity = cityId === empireFlatTargetCityId ? empireFlatTechYields.food : 0;
       const empireFlatProductionForCity = cityId === empireFlatTargetCityId ? empireFlatTechYields.production : 0;
       const networkGovernanceScienceForCity = cityId === lowestScienceCityId ? networkGovernanceBonus : 0;
+      // Catastrophe-crisis recovery reward: +1 food +1 production while active, transient by design.
+      const resilienceBonus = (city.resilienceBonusUntilTurn ?? 0) > newState.turn ? 1 : 0;
       const yields = {
-        food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food       + (npCivBonuses.food       ?? 0) + empireFlatFoodForCity) * unrestMultiplier),
-        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production + (npCivBonuses.production ?? 0) + empireFlatProductionForCity) * unrestMultiplier * (1 + (empireTechPercents.production ?? 0) / 100)),
+        food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food       + (npCivBonuses.food       ?? 0) + empireFlatFoodForCity + resilienceBonus) * unrestMultiplier),
+        production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production + (npCivBonuses.production ?? 0) + empireFlatProductionForCity + resilienceBonus) * unrestMultiplier * (1 + (empireTechPercents.production ?? 0) / 100)),
         gold:       Math.floor((baseYields.gold       + (wonderCityBonuses.gold       ?? 0) + resourceYieldBonus.gold)       * unrestMultiplier * (1 + (empireTechPercents.gold ?? 0) / 100)),
         science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0) + networkGovernanceScienceForCity) * unrestMultiplier * (1 + (empireTechPercents.science ?? 0) / 100)),
       };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -232,7 +232,7 @@ export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill'
   | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'resource_outpost' | 'none';
 // resource_outpost is excluded: only Expeditions can establish outposts, not Workers
 export type BuildableImprovementType = Exclude<ImprovementType, 'none' | 'resource_outpost'>;
-export type WorkerActionType = BuildableImprovementType | 'drain_swamp' | 'build_road';
+export type WorkerActionType = BuildableImprovementType | 'drain_swamp' | 'build_road' | 'restore_land';
 
 export interface HexTile {
   coord: HexCoord;

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -19,7 +19,7 @@ export interface SelectedUnitHighlightResult {
   waterRecovery: LandUnitWaterRecovery;
 }
 
-const WORKER_ACTIONS: WorkerActionType[] = ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp'];
+const WORKER_ACTIONS: WorkerActionType[] = ['farm', 'mine', 'lumber_camp', 'watermill', 'drain_swamp', 'restore_land'];
 
 function isCityTile(state: GameState, coord: HexCoord): boolean {
   const key = hexKey(coord);
@@ -34,7 +34,7 @@ function isPlausibleWorkerActionTile(
   const tile = state.map.tiles[hexKey(coord)];
   if (!tile) return false;
   const knownResource = getKnownTileResourceForWorkerAction(tile, completedTechs);
-  return getAvailableWorkerActions(tile, completedTechs, undefined, { isCityTile: isCityTile(state, coord), knownResource })
+  return getAvailableWorkerActions(tile, completedTechs, undefined, { isCityTile: isCityTile(state, coord), knownResource, currentTurn: state.turn })
     .some(action => WORKER_ACTIONS.includes(action));
 }
 
@@ -61,7 +61,7 @@ function buildWorkerGuidanceHighlights(
     if (visibility && getVisibility(visibility, coord) === 'unexplored') continue;
 
     const knownResource = getKnownTileResourceForWorkerAction(tile, completedTechs);
-    const options = { isCityTile: isCityTile(state, coord), knownResource };
+    const options = { isCityTile: isCityTile(state, coord), knownResource, currentTurn: state.turn };
     const availableActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, options);
     if (availableActions.length > 0) {
       highlights.push({ coord, type: 'worker-buildable' });

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -86,8 +86,9 @@ function drawTileAtScreen(
   viewerTechs: ReadonlySet<string> = new Set(),
   lairGlyph?: string,
   suppressTerrainLabel: boolean = false,
+  currentTurn?: number,
 ): void {
-  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, lowZoom, viewerTechs, lairGlyph);
+  drawHex(ctx, screen.x, screen.y, scaledSize, tile, isVillage, currentPlayer, viewerVisibility, presentationKind, nowMs, reducedMotion, lowZoom, viewerTechs, lairGlyph, currentTurn);
   if (shouldShowTerrainLabel(zoom) && !suppressTerrainLabel) {
     const label = getTerrainLabel(tile.terrain);
     ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
@@ -108,6 +109,7 @@ export function drawHexMap(
   viewerVisibility?: VisibilityMap,
   viewerTechs: ReadonlySet<string> = new Set(),
   terrainLabelSuppressedCoords: ReadonlySet<string> = new Set(),
+  currentTurn?: number,
 ): void {
   const size = camera.hexSize;
   const nowMs = typeof performance !== 'undefined' ? performance.now() : 0;
@@ -147,6 +149,7 @@ export function drawHexMap(
         viewerTechs,
         presentation.kind === 'live' ? rawLairGlyph : undefined,
         terrainLabelSuppressedCoords.has(tileKey),
+        currentTurn,
       );
     }
   }
@@ -412,6 +415,7 @@ function drawHex(
   lowZoom: boolean = false,
   viewerTechs: ReadonlySet<string> = new Set(),
   lairGlyph?: string,
+  currentTurn?: number,
 ): void {
   ctx.beginPath();
   for (let i = 0; i < 6; i++) {
@@ -437,6 +441,14 @@ function drawHex(
     ctx.clip();
     ctx.drawImage(terrainImg, cx - size, cy - size * 0.866, size * 2, size * 1.732);
     ctx.restore();
+  }
+
+  // Catastrophe crisis: devastated tile tint. `tile` is already fog-resolved by
+  // resolveTilePresentationForViewer (only 'live' presentation carries the real
+  // devastatedUntilTurn field), so no extra visibility check is needed here.
+  if (tile.devastatedUntilTurn !== undefined && currentTurn !== undefined && tile.devastatedUntilTurn > currentTurn) {
+    ctx.fillStyle = 'rgba(40,30,20,0.45)';
+    ctx.fill();
   }
 
   // Border

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -442,6 +442,7 @@ export class RenderLoop {
       viewerVisibility,
       viewerTechs,
       terrainLabelSuppressedCoords,
+      this.state.turn,
     );
 
     // Draw rivers

--- a/src/systems/city-work-system.ts
+++ b/src/systems/city-work-system.ts
@@ -33,7 +33,7 @@ export function calculateWorkedTileYield(state: GameState, coord: HexCoord): Res
     ? (state.civilizations[tile.owner]?.techState.completed ?? [])
     : [];
 
-  return getTileYield(tile, state.map, canonical, { completedTechs });
+  return getTileYield(tile, state.map, canonical, { completedTechs, currentTurn: state.turn });
 }
 
 function sameCoord(left: HexCoord, right: HexCoord): boolean {
@@ -208,7 +208,15 @@ export function calculateProjectedCityYields(
     : assignCityFocus(state, cityId, city.focus);
   const projectedCity = workResult.state.cities[cityId] ?? city;
   const completedTechs = workResult.state.civilizations?.[projectedCity.owner]?.techState.completed ?? [];
-  const yields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect, completedTechs);
+  const baseYields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect, completedTechs, {}, state.turn);
+  // Catastrophe-crisis recovery reward — must match turn-manager.ts's own +1/+1 so the
+  // displayed projection never diverges from what processTurn actually applies.
+  const resilienceBonus = (city.resilienceBonusUntilTurn ?? 0) > state.turn ? 1 : 0;
+  const yields = {
+    ...baseYields,
+    food: baseYields.food + resilienceBonus,
+    production: baseYields.production + resilienceBonus,
+  };
 
   if (city.productionQueue.length === 0 && city.idleProduction) {
     if (city.idleProduction === 'gold') {

--- a/src/systems/crisis-flavor-definitions.ts
+++ b/src/systems/crisis-flavor-definitions.ts
@@ -1,10 +1,16 @@
-import type { City, CrisisArchetype, GameState, OpponentChallenge, TerrainType } from '@/core/types';
+import type { City, CrisisArchetype, GameState, HexCoord, HexTile, OpponentChallenge, TerrainType } from '@/core/types';
 import { hexKey, hexNeighbors } from './hex-utils';
 
 export interface CrisisSeverity {
   yieldPenalty: number;                 // 0.25 = city yields ×0.75 while afflicted
   popLossEveryNTurnsIgnored: number | null;
   autoExpireTurns: number | null;
+}
+
+export interface CatastropheParams {
+  blastRadius: number;
+  devastationTurnsByChallenge: Record<OpponentChallenge, number>;
+  destroysEpicenterImprovement: boolean; // only meaningful on veteran era >= 3; resolver enforces
 }
 
 export interface CrisisFlavor {
@@ -17,13 +23,15 @@ export interface CrisisFlavor {
   displayNamesByEra: Record<number, string>;   // sparse — nearest era at or below is used
   advisorLine: string;                         // '{name} has reached {city}! <what to do>'
   responseActions: Array<'quarantine' | 'remedy'>;
+  catastrophe?: CatastropheParams;             // only present when archetype === 'catastrophe'
 }
 
-function nearTerrain(state: GameState, city: City, terrains: TerrainType[], radius: number): boolean {
-  const seen = new Set<string>([hexKey(city.position)]);
-  let frontier = [city.position];
+function tilesWithinRadius(state: GameState, center: HexCoord, radius: number): HexTile[] {
+  const seen = new Set<string>([hexKey(center)]);
+  let frontier = [center];
+  const collected: HexTile[] = [];
   for (let step = 0; step < radius; step++) {
-    const next = [];
+    const next: HexCoord[] = [];
     for (const coord of frontier) {
       for (const nb of hexNeighbors(coord)) {
         const key = hexKey(nb);
@@ -31,12 +39,26 @@ function nearTerrain(state: GameState, city: City, terrains: TerrainType[], radi
         seen.add(key);
         next.push(nb);
         const t = state.map.tiles[key];
-        if (t && terrains.includes(t.terrain)) return true;
+        if (t) collected.push(t);
       }
     }
     frontier = next;
   }
-  return false;
+  return collected;
+}
+
+function nearTerrain(state: GameState, city: City, terrains: TerrainType[], radius: number): boolean {
+  return tilesWithinRadius(state, city.position, radius).some(t => terrains.includes(t.terrain));
+}
+
+function countNearTerrain(state: GameState, city: City, terrains: TerrainType[], radius: number): number {
+  return tilesWithinRadius(state, city.position, radius).filter(t => terrains.includes(t.terrain)).length;
+}
+
+function hasRiverOrCoastalFlood(state: GameState, city: City): boolean {
+  const cityTile = state.map.tiles[hexKey(city.position)];
+  if (cityTile?.hasRiver) return true;
+  return nearTerrain(state, city, ['coast'], 1);
 }
 
 export const CRISIS_FLAVORS: CrisisFlavor[] = [
@@ -55,6 +77,101 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
     displayNamesByEra: { 2: 'The Sweating Sickness', 4: 'The Great Pestilence', 6: 'Cholera Outbreak', 9: 'Influenza Pandemic' },
     advisorLine: '{name} has reached {city}! Quarantine the city to stop the spread, or fund a remedy effort to cure it.',
     responseActions: ['quarantine', 'remedy'],
+  },
+  {
+    id: 'volcanic-eruption',
+    archetype: 'catastrophe',
+    eraBand: [2, 12],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['volcanic'], 3),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.10, popLossEveryNTurnsIgnored: null, autoExpireTurns: 4 },
+      standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
+      veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
+    },
+    displayNamesByEra: { 2: 'The Mountain of Fire Wakes', 7: 'Cataclysmic Eruption' },
+    advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
+    responseActions: [],
+    catastrophe: {
+      blastRadius: 2,
+      devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
+      destroysEpicenterImprovement: true,
+    },
+  },
+  {
+    id: 'earthquake',
+    archetype: 'catastrophe',
+    eraBand: [2, 12],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['mountain', 'hills'], 2),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.10, popLossEveryNTurnsIgnored: null, autoExpireTurns: 4 },
+      standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
+      veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
+    },
+    displayNamesByEra: { 2: 'The Ground Trembles', 8: 'The Great Quake' },
+    advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
+    responseActions: [],
+    catastrophe: {
+      blastRadius: 2,
+      devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
+      destroysEpicenterImprovement: true,
+    },
+  },
+  {
+    id: 'river-flood',
+    archetype: 'catastrophe',
+    eraBand: [2, 12],
+    geographyPredicate: (state, city) => hasRiverOrCoastalFlood(state, city),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.10, popLossEveryNTurnsIgnored: null, autoExpireTurns: 4 },
+      standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
+      veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
+    },
+    displayNamesByEra: { 2: 'The River Rises', 6: 'The Hundred-Year Flood' },
+    advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
+    responseActions: [],
+    catastrophe: {
+      blastRadius: 1,
+      devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
+      destroysEpicenterImprovement: true,
+    },
+  },
+  {
+    id: 'wildfire',
+    archetype: 'catastrophe',
+    eraBand: [2, 12],
+    geographyPredicate: (state, city) => countNearTerrain(state, city, ['forest'], 2) >= 3,
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.10, popLossEveryNTurnsIgnored: null, autoExpireTurns: 4 },
+      standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
+      veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
+    },
+    displayNamesByEra: { 2: 'Fire on the Wind', 9: 'Megafire' },
+    advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
+    responseActions: [],
+    catastrophe: {
+      blastRadius: 2,
+      devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
+      destroysEpicenterImprovement: true,
+    },
+  },
+  {
+    id: 'harsh-winter',
+    archetype: 'catastrophe',
+    eraBand: [2, 12],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['tundra', 'snow'], 2),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.10, popLossEveryNTurnsIgnored: null, autoExpireTurns: 4 },
+      standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
+      veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
+    },
+    displayNamesByEra: { 2: 'The Long Winter', 5: 'The Little Ice Age' },
+    advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
+    responseActions: [],
+    catastrophe: {
+      blastRadius: 2,
+      devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
+      destroysEpicenterImprovement: true,
+    },
   },
 ];
 

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -4,7 +4,7 @@ import { getChallengeProfileForCiv, resolveChallengeForCiv } from '@/core/oppone
 import { computeThreatScore, deriveActiveIndependentThreatIds } from './threat-pressure-system';
 import { CRISIS_FLAVORS, getCrisisFlavor } from './crisis-flavor-definitions';
 import { seededLcg, weightedPick } from './seeded-lcg';
-import { hexKey, hexDistance } from './hex-utils';
+import { hexKey, hexDistance, hexesInRange } from './hex-utils';
 import { getCityAppeaseCost } from './faction-system';
 
 export const CRISIS_PRESSURE_FLOOR = 2.0;
@@ -205,14 +205,108 @@ function tickOutbreakCrisis(
   return { crisis: working, state: nextState };
 }
 
+const CATASTROPHE_RECOVERY_WINDOW_TURNS = 5;
+
+function applyCatastropheShock(
+  state: GameState,
+  crisis: ActiveCrisis,
+  bus: EventBus,
+): { crisis: ActiveCrisis; state: GameState } {
+  const flavor = getCrisisFlavor(crisis.flavorId);
+  const params = flavor?.catastrophe;
+  const targetCity = state.cities[crisis.cityIds[0]];
+  if (!flavor || !params || !targetCity) return { crisis, state };
+
+  const owner = crisis.targetCivId;
+  const epicenterCandidates = hexesInRange(targetCity.position, params.blastRadius)
+    .filter(coord => state.map.tiles[hexKey(coord)]?.owner === owner);
+  if (epicenterCandidates.length === 0) return { crisis: { ...crisis, stage: 'recovery' }, state };
+
+  const rng = seededLcg(state.turn * 65599 + hashString(crisis.id));
+  const epicenter = epicenterCandidates[Math.floor(rng() * epicenterCandidates.length)];
+  const epicenterKey = hexKey(epicenter);
+
+  const devastationTurns = params.devastationTurnsByChallenge[resolveChallengeForCiv(state, owner)];
+  const devastatedUntilTurn = state.turn + devastationTurns;
+  const affectedKeys = hexesInRange(epicenter, params.blastRadius)
+    .map(hexKey)
+    .filter(key => state.map.tiles[key]?.owner === owner);
+
+  const isVeteran = resolveChallengeForCiv(state, owner) === 'veteran';
+  const destroysImprovement = params.destroysEpicenterImprovement && isVeteran && state.era >= 3;
+
+  const tiles = { ...state.map.tiles };
+  for (const key of affectedKeys) {
+    const tile = tiles[key];
+    tiles[key] = {
+      ...tile,
+      devastatedUntilTurn,
+      ...(destroysImprovement && key === epicenterKey ? { improvement: 'none' as const } : {}),
+    };
+  }
+
+  const nextState: GameState = { ...state, map: { ...state.map, tiles } };
+  const updated: ActiveCrisis = { ...crisis, stage: 'recovery', tileKeys: affectedKeys };
+  bus.emit('crisis:escalated', { crisisId: crisis.id, stage: 'recovery' });
+  return { crisis: updated, state: nextState };
+}
+
+function tickCatastropheCrisis(
+  state: GameState,
+  crisis: ActiveCrisis,
+  bus: EventBus,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  const flavor = getCrisisFlavor(crisis.flavorId);
+  if (!flavor?.catastrophe) return { crisis: null, state };
+
+  let working: ActiveCrisis = { ...crisis, turnsInStage: crisis.turnsInStage + 1 };
+  let nextState = state;
+
+  if (working.stage === 'active') {
+    const shocked = applyCatastropheShock(nextState, working, bus);
+    working = shocked.crisis;
+    nextState = shocked.state;
+    return { crisis: working, state: nextState };
+  }
+
+  const tiles = working.tileKeys.map(key => nextState.map.tiles[key]).filter((t): t is NonNullable<typeof t> => !!t);
+  const stillDevastated = tiles.some(t => t.devastatedUntilTurn !== undefined && t.devastatedUntilTurn > nextState.turn);
+  if (stillDevastated) return { crisis: working, state: nextState };
+
+  // Every tile has cleared, either by active restoration (devastatedUntilTurn cleared to
+  // undefined before its natural expiry) or by the timer simply passing. Only the former,
+  // completed within the recovery window, earns the resilience bonus.
+  const allActivelyRestored = tiles.every(t => t.devastatedUntilTurn === undefined);
+  const withinWindow = nextState.turn <= working.startedTurn + CATASTROPHE_RECOVERY_WINDOW_TURNS;
+  const challenge = resolveChallengeForCiv(nextState, working.targetCivId);
+
+  if (allActivelyRestored && withinWindow) {
+    const cities = { ...nextState.cities };
+    for (const cityId of working.cityIds) {
+      const city = cities[cityId];
+      if (city) cities[cityId] = { ...city, resilienceBonusUntilTurn: nextState.turn + CATASTROPHE_RECOVERY_WINDOW_TURNS };
+    }
+    nextState = { ...nextState, cities };
+    bus.emit('crisis:resolved', { crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome: 'recovered' });
+    return { crisis: null, state: nextState };
+  }
+
+  const outcome = challenge === 'explorer' ? 'recovered' : 'expired';
+  bus.emit('crisis:resolved', { crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome });
+  return { crisis: null, state: nextState };
+}
+
 export function processCrisisTurn(state: GameState, bus: EventBus): GameState {
   let nextState = state;
   const crisisIds = Object.keys(state.activeCrises ?? {}).sort();
   for (const crisisId of crisisIds) {
     const crisis = nextState.activeCrises?.[crisisId];
     if (!crisis) continue;
-    if (crisis.archetype !== 'outbreak') continue;
-    const { crisis: updated, state: tickedState } = tickOutbreakCrisis(nextState, crisis, bus);
+    const { crisis: updated, state: tickedState } = crisis.archetype === 'outbreak'
+      ? tickOutbreakCrisis(nextState, crisis, bus)
+      : crisis.archetype === 'catastrophe'
+        ? tickCatastropheCrisis(nextState, crisis, bus)
+        : { crisis, state: nextState };
     if (updated) {
       nextState = { ...tickedState, activeCrises: { ...(tickedState.activeCrises ?? {}), [crisisId]: updated } };
     } else {

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -211,16 +211,27 @@ function applyCatastropheShock(
   state: GameState,
   crisis: ActiveCrisis,
   bus: EventBus,
-): { crisis: ActiveCrisis; state: GameState } {
+): { crisis: ActiveCrisis | null; state: GameState } {
   const flavor = getCrisisFlavor(crisis.flavorId);
   const params = flavor?.catastrophe;
   const targetCity = state.cities[crisis.cityIds[0]];
-  if (!flavor || !params || !targetCity) return { crisis, state };
+  if (!flavor || !params || !targetCity) {
+    bus.emit('crisis:resolved', { crisisId: crisis.id, flavorId: crisis.flavorId, civId: crisis.targetCivId, outcome: 'abandoned' });
+    return { crisis: null, state };
+  }
 
   const owner = crisis.targetCivId;
   const epicenterCandidates = hexesInRange(targetCity.position, params.blastRadius)
     .filter(coord => state.map.tiles[hexKey(coord)]?.owner === owner);
-  if (epicenterCandidates.length === 0) return { crisis: { ...crisis, stage: 'recovery' }, state };
+  if (epicenterCandidates.length === 0) {
+    // No owned tile to strike (shouldn't happen — the target city's own tile is always
+    // owned by its civ — but never silently transition to 'recovery' with empty
+    // tileKeys: the next tick's "every tile cleared" check is vacuously true on an
+    // empty array and would wrongly resolve 'recovered' with a bonus for a crisis
+    // that never actually devastated anything.
+    bus.emit('crisis:resolved', { crisisId: crisis.id, flavorId: crisis.flavorId, civId: crisis.targetCivId, outcome: 'abandoned' });
+    return { crisis: null, state };
+  }
 
   const rng = seededLcg(state.turn * 65599 + hashString(crisis.id));
   const epicenter = epicenterCandidates[Math.floor(rng() * epicenterCandidates.length)];
@@ -264,8 +275,9 @@ function tickCatastropheCrisis(
 
   if (working.stage === 'active') {
     const shocked = applyCatastropheShock(nextState, working, bus);
-    working = shocked.crisis;
     nextState = shocked.state;
+    if (!shocked.crisis) return { crisis: null, state: nextState };
+    working = shocked.crisis;
     return { crisis: working, state: nextState };
   }
 

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -109,14 +109,25 @@ export function getOutbreakSeverityMultiplier(
     : 1 - severity.yieldPenalty;
 }
 
+// Catastrophe's per-challenge severity.yieldPenalty is the whole-city disruption
+// penalty during the recovery stage (on top of, not instead of, devastated tiles
+// individually yielding zero) — e.g. displaced population, disrupted trade routes.
+export function getCatastropheRecoveryMultiplier(severity: { yieldPenalty: number }): number {
+  return 1 - severity.yieldPenalty;
+}
+
 export function getCrisisYieldMultiplier(state: GameState, cityId: string): number {
   let multiplier = 1;
   for (const crisis of Object.values(state.activeCrises ?? {})) {
-    if (crisis.archetype !== 'outbreak' || !crisis.cityIds.includes(cityId)) continue;
+    if (!crisis.cityIds.includes(cityId)) continue;
     const flavor = getCrisisFlavor(crisis.flavorId);
     if (!flavor) continue;
     const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
-    multiplier *= getOutbreakSeverityMultiplier(severity, crisis.quarantinedCityIds?.includes(cityId) ?? false);
+    if (crisis.archetype === 'outbreak') {
+      multiplier *= getOutbreakSeverityMultiplier(severity, crisis.quarantinedCityIds?.includes(cityId) ?? false);
+    } else if (crisis.archetype === 'catastrophe' && crisis.stage === 'recovery') {
+      multiplier *= getCatastropheRecoveryMultiplier(severity);
+    }
   }
   return multiplier;
 }
@@ -241,7 +252,23 @@ function applyCatastropheShock(
   const devastatedUntilTurn = state.turn + devastationTurns;
   const affectedKeys = hexesInRange(epicenter, params.blastRadius)
     .map(hexKey)
-    .filter(key => state.map.tiles[key]?.owner === owner);
+    .filter(key => {
+      const t = state.map.tiles[key];
+      if (!t || t.owner !== owner) return false;
+      // A tile's devastatedUntilTurn is a single value, not a per-crisis list — if two
+      // overlapping catastrophes both claimed it, the second shock would silently
+      // overwrite the first crisis's timer and corrupt its own resolution bookkeeping
+      // (it would keep waiting on a devastatedUntilTurn it no longer owns). Never
+      // re-claim a tile another still-active catastrophe already devastated.
+      if (t.devastatedUntilTurn !== undefined && t.devastatedUntilTurn > state.turn) return false;
+      return true;
+    });
+  if (affectedKeys.length === 0) {
+    // Every candidate tile in blast radius is already claimed by another active
+    // catastrophe — nothing new for this crisis to do.
+    bus.emit('crisis:resolved', { crisisId: crisis.id, flavorId: crisis.flavorId, civId: crisis.targetCivId, outcome: 'abandoned' });
+    return { crisis: null, state };
+  }
 
   const isVeteran = resolveChallengeForCiv(state, owner) === 'veteran';
   const destroysImprovement = params.destroysEpicenterImprovement && isVeteran && state.era >= 3;
@@ -308,17 +335,32 @@ function tickCatastropheCrisis(
   return { crisis: null, state: nextState };
 }
 
+// Archetype-specific tick dispatch. MR3 (hunt) and beyond add a case here —
+// keep this the single dispatch point rather than branching inline elsewhere.
+function tickCrisisByArchetype(
+  state: GameState,
+  crisis: ActiveCrisis,
+  bus: EventBus,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  switch (crisis.archetype) {
+    case 'outbreak':
+      return tickOutbreakCrisis(state, crisis, bus);
+    case 'catastrophe':
+      return tickCatastropheCrisis(state, crisis, bus);
+    default:
+      // Not yet implemented (e.g. 'hunt', MR3) — leave untouched rather than
+      // silently dropping or mutating a crisis type this resolver doesn't know.
+      return { crisis, state };
+  }
+}
+
 export function processCrisisTurn(state: GameState, bus: EventBus): GameState {
   let nextState = state;
   const crisisIds = Object.keys(state.activeCrises ?? {}).sort();
   for (const crisisId of crisisIds) {
     const crisis = nextState.activeCrises?.[crisisId];
     if (!crisis) continue;
-    const { crisis: updated, state: tickedState } = crisis.archetype === 'outbreak'
-      ? tickOutbreakCrisis(nextState, crisis, bus)
-      : crisis.archetype === 'catastrophe'
-        ? tickCatastropheCrisis(nextState, crisis, bus)
-        : { crisis, state: nextState };
+    const { crisis: updated, state: tickedState } = tickCrisisByArchetype(nextState, crisis, bus);
     if (updated) {
       nextState = { ...tickedState, activeCrises: { ...(tickedState.activeCrises ?? {}), [crisisId]: updated } };
     } else {

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -35,6 +35,8 @@ export interface WorkerActionEligibilityOptions {
   isCityTile?: boolean;
   allowReplacement?: boolean;
   knownResource?: ResourceType | null;
+  /** Needed only for `restore_land` eligibility (devastatedUntilTurn > currentTurn). */
+  currentTurn?: number;
 }
 
 export type WorkerActionBlockerReason =
@@ -45,6 +47,7 @@ export type WorkerActionBlockerReason =
   | 'requires-river'
   | 'requires-tech'
   | 'missing-resource'
+  | 'not-devastated'
   | 'none';
 
 export const IMPROVEMENT_DEFINITIONS: Record<BuildableImprovementType, ImprovementDefinition> = {
@@ -217,8 +220,20 @@ export function canDrainSwamp(
   return tile.terrain === 'swamp' && tile.improvement === 'none';
 }
 
-/** Improvement/drain_swamp actions only — road building is a separate overlay handled by road-system.ts. */
-export type ImprovementWorkerActionType = BuildableImprovementType | 'drain_swamp';
+export function canRestoreLand(
+  tile: HexTile,
+  ownerId?: string,
+  options: WorkerActionEligibilityOptions = {},
+): boolean {
+  if (options.isCityTile) return false;
+  if (ownerId && tile.owner !== ownerId) return false;
+  if (tile.devastatedUntilTurn === undefined) return false;
+  if (options.currentTurn === undefined) return true;
+  return tile.devastatedUntilTurn > options.currentTurn;
+}
+
+/** Improvement/drain_swamp/restore_land actions only — road building is a separate overlay handled by road-system.ts. */
+export type ImprovementWorkerActionType = BuildableImprovementType | 'drain_swamp' | 'restore_land';
 
 export function getAvailableWorkerActions(
   tile: HexTile | undefined,
@@ -232,6 +247,7 @@ export function getAvailableWorkerActions(
     if (canBuildImprovement(tile, type, completedTechs, ownerId, options)) actions.push(type);
   }
   if (canDrainSwamp(tile, ownerId, options)) actions.push('drain_swamp');
+  if (canRestoreLand(tile, ownerId, options)) actions.push('restore_land');
   return actions;
 }
 
@@ -245,6 +261,11 @@ export function getWorkerActionBlockerReason(
   if (!tile) return 'invalid-terrain';
   if (ownerId && tile.owner !== ownerId) return 'outside-territory';
   if (options.isCityTile) return 'city-center';
+
+  if (action === 'restore_land') {
+    return canRestoreLand(tile, ownerId, options) ? 'none' : 'not-devastated';
+  }
+
   // resource_outpost is established only by Expeditions — Workers can never overwrite it
   if (tile.improvement === 'resource_outpost') return 'already-improved';
   if (tile.improvement !== 'none' && (!options.allowReplacement || tile.improvement === action)) return 'already-improved';
@@ -274,6 +295,7 @@ export function formatWorkerActionBlockerReason(reason: WorkerActionBlockerReaso
     case 'requires-river': return 'Requires river';
     case 'requires-tech': return 'Requires technology';
     case 'missing-resource': return 'No matching resource on this tile';
+    case 'not-devastated': return 'This tile is not devastated';
     case 'none': return '';
   }
 }
@@ -302,6 +324,7 @@ export function formatImprovementYieldLabel(type: ImprovementType): string {
 
 export function getWorkerActionLabel(action: ImprovementWorkerActionType): string {
   if (action === 'drain_swamp') return 'Drain Swamp (20% worker risk)';
+  if (action === 'restore_land') return 'Restore Land';
   const yieldLabel = formatImprovementYieldLabel(action);
   return `Build ${getImprovementDisplayName(action)}${yieldLabel ? ` ${yieldLabel}` : ''}`;
 }

--- a/src/systems/minor-civ-economy-system.ts
+++ b/src/systems/minor-civ-economy-system.ts
@@ -614,7 +614,7 @@ export function processMinorCivEconomyTurn(
   const completedTechs = getMinorCivCompletedTechBand(nextState, minorCivId);
   const availableResources = getMinorCivAvailableResources(nextState, minorCivId);
   const cityForYields = nextState.cities[city.id];
-  const yields = calculateCityYields(cityForYields, nextState.map, undefined, completedTechs, {});
+  const yields = calculateCityYields(cityForYields, nextState.map, undefined, completedTechs, {}, nextState.turn);
   const productionYield = Math.max(0, Math.floor(yields.production * tuning.productionMultiplier));
   const processed = processCity(
     cityForYields,

--- a/src/systems/resource-system.ts
+++ b/src/systems/resource-system.ts
@@ -13,6 +13,7 @@ export function calculateCityYields(
   bonusEffect?: CivBonusEffect,
   completedTechs: string[] = [],
   techYieldContext: CityTechYieldContext = {},
+  currentTurn?: number,
 ): ResourceYield {
   const yields: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
 
@@ -32,7 +33,7 @@ export function calculateCityYields(
     const tile = map.tiles[hexKey(coord)];
     if (!tile) continue;
 
-    const tileYield = getTileYield(tile, map, coord, { completedTechs });
+    const tileYield = getTileYield(tile, map, coord, { completedTechs, currentTurn });
     yields.food += tileYield.food;
     yields.production += tileYield.production;
     yields.gold += tileYield.gold;

--- a/src/systems/tile-yield.ts
+++ b/src/systems/tile-yield.ts
@@ -31,6 +31,8 @@ function addYield(total: ResourceYield, bonus: Partial<ResourceYield>): void {
 
 export interface TileYieldOptions {
   completedTechs?: string[];
+  /** When provided, a tile with `devastatedUntilTurn > currentTurn` (catastrophe crisis) yields zero. */
+  currentTurn?: number;
 }
 
 /**
@@ -46,6 +48,10 @@ export function getTileYield(
   opts: TileYieldOptions = {},
 ): ResourceYield {
   const total: ResourceYield = { food: 0, production: 0, gold: 0, science: 0 };
+  if (tile.devastatedUntilTurn !== undefined && opts.currentTurn !== undefined
+      && tile.devastatedUntilTurn > opts.currentTurn) {
+    return total; // catastrophe crisis: devastated tile yields zero from everything
+  }
   const completedTechs = opts.completedTechs ?? [];
 
   addYield(total, TERRAIN_YIELDS[tile.terrain] ?? total);

--- a/src/systems/worker-action-system.ts
+++ b/src/systems/worker-action-system.ts
@@ -64,7 +64,7 @@ export type WorkerActionResult =
     };
 
 function isBuildableImprovement(action: WorkerActionType): action is BuildableImprovementType {
-  return action !== 'drain_swamp' && action !== 'build_road';
+  return action !== 'drain_swamp' && action !== 'build_road' && action !== 'restore_land';
 }
 
 export function getWorkerChargesRemaining(unit: Unit): number {
@@ -186,6 +186,7 @@ export function applyWorkerAction(
     isCityTile,
     allowReplacement: options.allowReplacement,
     knownResource: getKnownTileResourceForWorkerAction(tile, completedTechs),
+    currentTurn: state.turn,
   };
   const blockerReason = getWorkerActionBlockerReason(tile, action, completedTechs, unit.owner, eligibilityOptions);
   if (blockerReason !== 'none') {
@@ -202,6 +203,7 @@ export function applyWorkerAction(
   let nextTerrain: TerrainType = tile.terrain;
   let nextImprovement = tile.improvement;
   let nextImprovementTurnsLeft = tile.improvementTurnsLeft;
+  let nextDevastatedUntilTurn = tile.devastatedUntilTurn;
   let workerLost = false;
   let forestProductionBonus = 0;
   let boostedCityId: string | null = null;
@@ -222,6 +224,10 @@ export function applyWorkerAction(
         boostedCityId = boostedCity.id;
       }
     }
+  } else if (action === 'restore_land') {
+    // 1-turn task: clears the catastrophe devastation immediately. Unlike drain_swamp,
+    // this never touches terrain/improvement and carries no worker-loss risk.
+    nextDevastatedUntilTurn = undefined;
   } else {
     nextTerrain = 'grassland';
     nextImprovement = 'none';
@@ -236,6 +242,7 @@ export function applyWorkerAction(
     improvement: nextImprovement,
     improvementTurnsLeft: nextImprovementTurnsLeft,
     improvementOwner: isBuildableImprovement(action) ? unit.owner : undefined,
+    devastatedUntilTurn: nextDevastatedUntilTurn,
   };
 
   const nextCities = { ...state.cities };

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -266,6 +266,19 @@ export function createCityPanel(
       quarantineDisabled, quarantineLabel, remedyDisabled, remedyLabel,
     };
   }).filter((c): c is NonNullable<typeof c> => c !== null);
+  // Catastrophes respond via worker restore_land, not city-panel buttons — the chip is
+  // status-only. Distinct data-text namespace so it never collides with outbreak chips.
+  const catastropheCrises = Object.values(state.activeCrises ?? {})
+    .filter(c => c.archetype === 'catastrophe' && c.cityIds.includes(city.id));
+  const catastropheChips = catastropheCrises.map(crisis => {
+    const flavor = getCrisisFlavor(crisis.flavorId);
+    return flavor ? { crisis, flavor } : null;
+  }).filter((c): c is NonNullable<typeof c> => c !== null);
+  const catastropheSectionHtml = catastropheChips.map((chip, idx) => `
+    <div style="background:rgba(217,80,80,0.12);border:1px solid rgba(217,80,80,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
+      <div style="font-weight:bold;color:#e88;margin-bottom:4px;" data-text="catastrophe-stage-${idx}"></div>
+      <div style="opacity:0.85;" data-text="catastrophe-advisor-${idx}"></div>
+    </div>`).join('');
   const crisisSectionHtml = crisisChips.map((chip, idx) => `
     <div style="background:rgba(217,80,80,0.12);border:1px solid rgba(217,80,80,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
       <div style="font-weight:bold;color:#e88;margin-bottom:4px;" data-text="crisis-stage-${idx}"></div>
@@ -618,6 +631,7 @@ export function createCityPanel(
     </div>
     ${unrestSectionHtml}
     ${crisisSectionHtml}
+    ${catastropheSectionHtml}
 
     <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap;">
       <div id="tab-list" style="padding:6px 16px;background:rgba(255,255,255,0.15);border-radius:6px;cursor:pointer;font-size:12px;font-weight:bold;">Queue</div>
@@ -676,6 +690,20 @@ export function createCityPanel(
       .replace('{name}', displayName)
       .replace('{city}', city.name);
     setText(`crisis-advisor-${idx}`, advisorLine);
+  });
+
+  catastropheChips.forEach((chip, idx) => {
+    const displayName = getCrisisDisplayName(chip.flavor, state.era);
+    // 'active' should be effectively unobservable (the shock applies the same turn the
+    // scheduler starts it), but shown honestly rather than assuming it never renders.
+    const stageText = chip.crisis.stage === 'recovery'
+      ? 'Recovering — restore devastated tiles'
+      : `⚠️ ${displayName} strikes!`;
+    setText(`catastrophe-stage-${idx}`, stageText);
+    const advisorLine = chip.flavor.advisorLine
+      .replace('{name}', displayName)
+      .replace('{city}', city.name);
+    setText(`catastrophe-advisor-${idx}`, advisorLine);
   });
 
   // Tech-yield breakdown rows via textContent (XSS-safe)

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -27,7 +27,7 @@ import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { getUnrestYieldMultiplier, getCityAppeaseCost, isCityProductionLocked } from '@/systems/faction-system';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
-import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier } from '@/systems/crisis-system';
+import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier } from '@/systems/crisis-system';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
@@ -236,6 +236,15 @@ export function createCityPanel(
       </div>
       <button type="button" data-appease="${city.id}" ${appeaseDisabled ? 'disabled' : ''} title="${appeaseLabel}" style="min-height:44px;padding:7px 12px;border-radius:6px;font-size:12px;font-weight:bold;cursor:${appeaseDisabled ? 'default' : 'pointer'};background:${appeaseDisabled ? 'rgba(255,255,255,0.08)' : '#d4aa2c'};color:${appeaseDisabled ? 'rgba(255,255,255,0.4)' : '#1a1a1a'};border:none;">${appeaseLabel}</button>
     </div>` : '';
+  // Post-catastrophe reward: transient, and the crisis itself may already be gone from
+  // activeCrises by the time this is active — must render on its own, not piggyback on
+  // the catastrophe crisis chip (see .claude/rules/end-to-end-wiring.md "never compute
+  // without rendering").
+  const resilienceTurnsLeft = (city.resilienceBonusUntilTurn ?? 0) - state.turn;
+  const resilienceSectionHtml = resilienceTurnsLeft > 0 ? `
+    <div style="background:rgba(107,155,75,0.12);border:1px solid rgba(107,155,75,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
+      <div style="font-weight:bold;color:#9bd97b;">🌱 Rebuilding — +1 🌾 +1 ⚒️ for ${resilienceTurnsLeft} more turn${resilienceTurnsLeft === 1 ? '' : 's'}</div>
+    </div>` : '';
   const cityCrises = Object.values(state.activeCrises ?? {})
     .filter(c => c.archetype === 'outbreak' && c.cityIds.includes(city.id));
   const crisisChips = cityCrises.map(crisis => {
@@ -272,7 +281,10 @@ export function createCityPanel(
     .filter(c => c.archetype === 'catastrophe' && c.cityIds.includes(city.id));
   const catastropheChips = catastropheCrises.map(crisis => {
     const flavor = getCrisisFlavor(crisis.flavorId);
-    return flavor ? { crisis, flavor } : null;
+    if (!flavor) return null;
+    const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
+    const recoveryPenaltyPct = Math.round((1 - getCatastropheRecoveryMultiplier(severity)) * 100);
+    return { crisis, flavor, recoveryPenaltyPct };
   }).filter((c): c is NonNullable<typeof c> => c !== null);
   const catastropheSectionHtml = catastropheChips.map((chip, idx) => `
     <div style="background:rgba(217,80,80,0.12);border:1px solid rgba(217,80,80,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
@@ -632,6 +644,7 @@ export function createCityPanel(
     ${unrestSectionHtml}
     ${crisisSectionHtml}
     ${catastropheSectionHtml}
+    ${resilienceSectionHtml}
 
     <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap;">
       <div id="tab-list" style="padding:6px 16px;background:rgba(255,255,255,0.15);border-radius:6px;cursor:pointer;font-size:12px;font-weight:bold;">Queue</div>
@@ -697,7 +710,7 @@ export function createCityPanel(
     // 'active' should be effectively unobservable (the shock applies the same turn the
     // scheduler starts it), but shown honestly rather than assuming it never renders.
     const stageText = chip.crisis.stage === 'recovery'
-      ? 'Recovering — restore devastated tiles'
+      ? `Recovering — restore devastated tiles, −${chip.recoveryPenaltyPct}% city yields`
       : `⚠️ ${displayName} strikes!`;
     setText(`catastrophe-stage-${idx}`, stageText);
     const advisorLine = chip.flavor.advisorLine

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -333,7 +333,7 @@ export function renderSelectedUnitInfo(
       const unitTileKey = hexKey(unit.position);
       const isCityTile = Object.values(state.cities).some(city => hexKey(city.position) === unitTileKey);
       const knownResource = tile ? getKnownTileResourceForWorkerAction(tile, completedTechs) : null;
-      const workerEligibilityOptions = { isCityTile, knownResource };
+      const workerEligibilityOptions = { isCityTile, knownResource, currentTurn: state.turn };
       const workerActions = getAvailableWorkerActions(tile, completedTechs, unit.owner, workerEligibilityOptions);
       if (knownResource) {
         const rd = RESOURCE_DEFINITIONS.find(r => r.id === knownResource);
@@ -356,11 +356,13 @@ export function renderSelectedUnitInfo(
                 ? '#3f7f8f'
                 : action === 'drain_swamp'
                   ? '#4a7c59'
-                  : '#64748b';
+                  : action === 'restore_land'
+                    ? '#b45309'
+                    : '#64748b';
         let label = action === 'drain_swamp'
           ? 'Drain Swamp (→ Grassland, +1 🌾)'
           : getWorkerActionLabel(action);
-        if (knownResource && action !== 'drain_swamp') {
+        if (knownResource && action !== 'drain_swamp' && action !== 'restore_land') {
           const rd = RESOURCE_DEFINITIONS.find(r => r.id === knownResource && r.requiredImprovement === action);
           if (rd) {
             const yieldLabel = formatImprovementYieldLabel(action);

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -388,7 +388,7 @@ export function renderSelectedUnitInfo(
         const eligibilityOpts = workerEligibilityOptions;
         if (tile && tile.improvement !== 'none' && callbacks.onReplaceImprovement) {
           const replaceable = getAvailableWorkerActions(tile, completedTechs, unit.owner, { ...workerEligibilityOptions, allowReplacement: true })
-            .filter((a): a is BuildableImprovementType => a !== 'drain_swamp');
+            .filter((a): a is BuildableImprovementType => a !== 'drain_swamp' && a !== 'restore_land');
           for (const action of replaceable) {
             const yieldStr = formatImprovementYieldLabel(action);
             const label = `Replace ${getImprovementDisplayName(tile.improvement)} with ${getImprovementDisplayName(action)}${yieldStr ? ` ${yieldStr}` : ''}`;

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -665,3 +665,45 @@ describe('AI road-building', () => {
     expect(action.kind === 'worker-action' ? action.action : null).not.toBe('build_road');
   });
 });
+
+describe('AI worker restore_land (MR2 catastrophe)', () => {
+  it('does not propose restore_land once devastation has naturally expired (stale field must be turn-gated)', () => {
+    const state = makeState('veteran');
+    const capital = addCity(state, 'capital', AI, { q: 0, r: 0 });
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key].owner = AI;
+      state.map.tiles[key].terrain = 'snow'; // no valid improvement on snow (see other tests)
+    }
+    state.turn = 45;
+    state.map.tiles[hexKey({ q: 1, r: 0 })].devastatedUntilTurn = 45; // expired at the current turn
+    const worker = addUnit(state, 'restore-worker', 'worker', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: capital.position },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    const actions = rankUnitTacticalActions(context(state, plan), worker.id);
+    expect(actions.some(a => a.action.kind === 'worker-action' && a.action.action === 'restore_land')).toBe(false);
+  });
+
+  it('does propose restore_land while a tile is still actively devastated', () => {
+    const state = makeState('veteran');
+    const capital = addCity(state, 'capital', AI, { q: 0, r: 0 });
+    for (const key of Object.keys(state.map.tiles)) {
+      state.map.tiles[key].owner = AI;
+      state.map.tiles[key].terrain = 'snow';
+    }
+    state.turn = 40;
+    state.map.tiles[hexKey({ q: 1, r: 0 })].devastatedUntilTurn = 45; // still active at turn 40
+    const worker = addUnit(state, 'restore-worker', 'worker', AI, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'region', id: 'infra', anchor: capital.position },
+      [worker.id],
+      { objective: 'expand', requiredRoles: {} },
+    );
+
+    const actions = rankUnitTacticalActions(context(state, plan), worker.id);
+    expect(actions.some(a => a.action.kind === 'worker-action' && a.action.action === 'restore_land')).toBe(true);
+  });
+});

--- a/tests/core/turn-manager-crisis.test.ts
+++ b/tests/core/turn-manager-crisis.test.ts
@@ -6,6 +6,7 @@ import { EventBus } from '@/core/event-bus';
 import { normalizeLoadedStateForTest } from '@/storage/save-manager';
 import { resolveMajorCityCapture } from '@/systems/city-capture-system';
 import { tagLandmassRegions } from '@/systems/landmass-tagger';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import type { ActiveCrisis, GameState, HexCoord } from '@/core/types';
 
 function findLandCoord(state: GameState): HexCoord {
@@ -107,5 +108,26 @@ describe('turn-manager crisis wiring', () => {
     const bus = new EventBus();
     const result = resolveMajorCityCapture(state, cityId, otherCivId, 'occupy', state.turn, bus);
     expect(result.state.activeCrises?.['crisis-1']).toBeUndefined();
+  });
+
+  it('applies the +1 food +1 production resilience bonus to a city with resilienceBonusUntilTurn active, both in the real turn-manager path and in the city-panel projected-yields display', () => {
+    const { state, cityId } = stateWithActiveCrisis();
+    delete (state as GameState).activeCrises; // isolate the resilience bonus from the outbreak's own yield multiplier
+    const withBonus: GameState = {
+      ...state,
+      cities: { ...state.cities, [cityId]: { ...state.cities[cityId], resilienceBonusUntilTurn: state.turn + 1 } },
+    };
+
+    const boostedProjection = calculateProjectedCityYields(withBonus, cityId);
+    const baseProjection = calculateProjectedCityYields(state, cityId);
+    expect(boostedProjection.food).toBe(baseProjection.food + 1);
+    expect(boostedProjection.production).toBe(baseProjection.production + 1);
+
+    // Already-expired bonus (resilienceBonusUntilTurn === state.turn, not > state.turn) has no effect.
+    const expiredBonus: GameState = {
+      ...state,
+      cities: { ...state.cities, [cityId]: { ...state.cities[cityId], resilienceBonusUntilTurn: state.turn } },
+    };
+    expect(calculateProjectedCityYields(expiredBonus, cityId)).toEqual(baseProjection);
   });
 });

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -248,6 +248,34 @@ describe('selected-unit-highlights', () => {
     expect(result.highlights).toContainEqual({ coord: { q: 1, r: -1 }, type: 'worker-foreign-blocked' });
   });
 
+  it('shows worker-buildable (restore_land) on a currently-devastated tile, and stops once devastation naturally expires (MR2 catastrophe)', () => {
+    const state = createNewGame(undefined, 'restore-land-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.turn = 40;
+    state.units = {
+      worker: { ...createUnit('worker', 'player', { q: 0, r: 0 }, mkC()), id: 'worker', movementPointsLeft: 2 },
+    };
+    state.civilizations.player.units = ['worker'];
+    state.civilizations.player.visibility.tiles = { '0,0': 'visible', '1,0': 'visible' };
+    // snow has no valid worker improvement (see the "owned-blocked" test above), so any
+    // worker-buildable highlight here is caused specifically by restore_land eligibility.
+    state.map.tiles['1,0'] = {
+      coord: { q: 1, r: 0 }, terrain: 'snow', elevation: 'lowland', resource: null,
+      owner: 'player', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+      devastatedUntilTurn: 45, // still devastated at turn 40
+    };
+
+    const stillDevastated = buildSelectedUnitHighlights(state, 'worker');
+    expect(stillDevastated.highlights).toContainEqual({ coord: { q: 1, r: 0 }, type: 'worker-buildable' });
+
+    // Devastation has passed (state.turn now equals the old devastatedUntilTurn) — the
+    // stale field lingers on the tile (nothing clears it automatically), so eligibility
+    // must be gated on currentTurn, not just "field is present".
+    state.turn = 45;
+    const expired = buildSelectedUnitHighlights(state, 'worker');
+    expect(expired.highlights).not.toContainEqual({ coord: { q: 1, r: 0 }, type: 'worker-buildable' });
+  });
+
   it('neutral (non-war) AI unit hex does not appear as a move highlight (#250)', () => {
     const state = createNewGame(undefined, 'neutral-stack-highlight', 'small');
     state.currentPlayer = 'player';

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -17,6 +17,7 @@ class MockCanvasContext {
   textCalls: string[] = [];
   fillTextCalls: Array<{ text: string; x: number; y: number }> = [];
   drawImageCalls = 0;
+  fillCalls: string[] = [];
   fillStyle = '';
   strokeStyle = '';
   lineWidth = 0;
@@ -38,7 +39,9 @@ class MockCanvasContext {
   arc(): void {}
   ellipse(): void {}
   closePath(): void {}
-  fill(): void {}
+  fill(): void {
+    this.fillCalls.push(this.fillStyle);
+  }
   drawImage(): void {
     this.drawImageCalls += 1;
   }
@@ -577,5 +580,65 @@ describe('drawRoads rail visual', () => {
     const mockCtx = ctx as unknown as MockCanvasContext;
     expect(mockCtx.drawImageCalls).toBeGreaterThan(0);
     expect(mockCtx.strokeCalls.length).toBe(0);
+  });
+});
+
+describe('devastated tile tint (MR2 catastrophe crises)', () => {
+  function makeDevastationMap(devastatedUntilTurn: number | undefined): GameMap {
+    return {
+      width: 2,
+      height: 1,
+      wrapsHorizontally: false,
+      rivers: [],
+      tiles: {
+        '0,0': {
+          coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland',
+          resource: null, improvement: 'none', owner: 'player',
+          improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+          devastatedUntilTurn,
+        },
+      },
+    } as unknown as GameMap;
+  }
+
+  it('draws the devastation tint on a live, currently-devastated tile', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+    drawHexMap(ctx, makeDevastationMap(50), makeCamera(), undefined, undefined, 'player', visibility, new Set(), new Set(), 40);
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.fillCalls).toContain('rgba(40,30,20,0.45)');
+  });
+
+  it('does not tint a tile whose devastation has already passed', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+    drawHexMap(ctx, makeDevastationMap(40), makeCamera(), undefined, undefined, 'player', visibility, new Set(), new Set(), 40);
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.fillCalls).not.toContain('rgba(40,30,20,0.45)');
+  });
+
+  it('does not tint a non-devastated tile', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = { tiles: { '0,0': 'visible' } };
+    drawHexMap(ctx, makeDevastationMap(undefined), makeCamera(), undefined, undefined, 'player', visibility, new Set(), new Set(), 40);
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.fillCalls).not.toContain('rgba(40,30,20,0.45)');
+  });
+
+  it('never reveals a devastated tile through fog (last-seen presentation has no devastation field)', () => {
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    const visibility: VisibilityMap = {
+      tiles: { '0,0': 'fog' },
+      lastSeen: {
+        '0,0': {
+          coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland',
+          resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0,
+          hasRiver: false, wonder: null,
+        } as any,
+      },
+    };
+    drawHexMap(ctx, makeDevastationMap(50), makeCamera(), undefined, undefined, 'player', visibility, new Set(), new Set(), 40);
+    const mockCtx = ctx as unknown as MockCanvasContext;
+    expect(mockCtx.fillCalls).not.toContain('rgba(40,30,20,0.45)');
   });
 });

--- a/tests/systems/city-work-system.test.ts
+++ b/tests/systems/city-work-system.test.ts
@@ -183,6 +183,32 @@ describe('city focus assignment', () => {
     expect(yields.production).toBeGreaterThanOrEqual(2);
   });
 
+  it('zeroes yield from a devastated tile (terrain and improvement) until devastatedUntilTurn passes', () => {
+    const state = createNewGame(undefined, 'city-work-devastated-yield');
+    addCity(state, 'player', { q: 15, r: 15 });
+    state.turn = 40;
+    state.map.tiles['1,1'] = {
+      coord: { q: 1, r: 1 },
+      terrain: 'forest',
+      elevation: 'lowland',
+      resource: null,
+      improvement: 'lumber_camp',
+      owner: 'player',
+      improvementTurnsLeft: 0,
+      hasRiver: false,
+      wonder: null,
+      devastatedUntilTurn: 45,
+    };
+
+    const devastatedYield = calculateWorkedTileYield(state, { q: 1, r: 1 });
+    expect(devastatedYield).toEqual({ food: 0, production: 0, gold: 0, science: 0 });
+
+    // Once the devastation window passes, yield returns to normal.
+    state.turn = 45;
+    const clearedYield = calculateWorkedTileYield(state, { q: 1, r: 1 });
+    expect(clearedYield.production).toBeGreaterThanOrEqual(3);
+  });
+
   it('assigns food focus to the highest-food unclaimed tiles up to population', () => {
     const state = createNewGame(undefined, 'city-work-food-focus');
     const city = addCity(state, 'player', { q: 15, r: 15 });

--- a/tests/systems/crisis-catastrophe.test.ts
+++ b/tests/systems/crisis-catastrophe.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
-import { processCrisisTurn } from '@/systems/crisis-system';
+import { processCrisisTurn, getCrisisYieldMultiplier } from '@/systems/crisis-system';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
 import { hexesInRange, hexKey } from '@/systems/hex-utils';
 import type { ActiveCrisis, City, GameState, HexCoord, HexTile, OpponentChallenge } from '@/core/types';
@@ -118,6 +118,16 @@ describe('catastrophe shock', () => {
     }
   });
 
+  it('applies a whole-city recovery yield penalty during the recovery stage (not just zeroing devastated tiles)', () => {
+    const { state, cityId } = { ...makeCatastropheFixture(), cityId: 'c1' };
+    // Before the shock (stage 'active'), no recovery penalty applies yet.
+    expect(getCrisisYieldMultiplier(state, cityId)).toBe(1);
+    const next = processCrisisTurn(state, new EventBus());
+    expect(next.activeCrises!['crisis-1'].stage).toBe('recovery');
+    // standard challenge catastrophe yieldPenalty is 0.20 -> multiplier 0.80
+    expect(getCrisisYieldMultiplier(next, cityId)).toBeCloseTo(0.8);
+  });
+
   it('never devastates a tile owned by another civ or unowned land', () => {
     const { state, crisisId } = makeCatastropheFixture();
     const next = processCrisisTurn(state, new EventBus());
@@ -210,5 +220,33 @@ describe('catastrophe shock', () => {
     expect(next.activeCrises?.[crisisId]).toBeUndefined();
     expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'abandoned' }]);
     expect(next.cities.c1.resilienceBonusUntilTurn).toBeUndefined();
+  });
+
+  it('never re-claims a tile another still-active catastrophe already devastated, and abandons if that leaves nothing new to devastate', () => {
+    // Force a single-candidate epicenter (the city tile) so the two crises are
+    // guaranteed to contend for the exact same tile.
+    const { state, crisisId } = makeCatastropheFixture({ onlyOwnCityTile: true, turn: 40 });
+    const preExistingDevastation = 90; // far beyond this crisis's own would-be timer
+    const contestedState: GameState = {
+      ...state,
+      map: {
+        ...state.map,
+        tiles: {
+          ...state.map.tiles,
+          [hexKey(CITY_POS)]: { ...state.map.tiles[hexKey(CITY_POS)], devastatedUntilTurn: preExistingDevastation },
+        },
+      },
+    };
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:resolved', e => events.push(e));
+    const next = processCrisisTurn(contestedState, bus);
+
+    // The new crisis found nothing new to devastate and abandons immediately...
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+    expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'abandoned' }]);
+    // ...and critically, the pre-existing crisis's devastation timer is untouched
+    // (not overwritten with this crisis's own, shorter/longer devastationTurns).
+    expect(next.map.tiles[hexKey(CITY_POS)].devastatedUntilTurn).toBe(preExistingDevastation);
   });
 });

--- a/tests/systems/crisis-catastrophe.test.ts
+++ b/tests/systems/crisis-catastrophe.test.ts
@@ -193,4 +193,22 @@ describe('catastrophe shock', () => {
     expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'recovered' }]);
     expect(s.cities.c1.resilienceBonusUntilTurn).toBeUndefined();
   });
+
+  it('abandons the crisis instead of silently "recovering with a bonus" when no owned tile exists for an epicenter', () => {
+    // Pathological state: not even the target city's own tile is owned by its civ within
+    // blast radius (shouldn't happen via normal territory rules, but must not produce a
+    // phantom "recovered + bonus" outcome if it somehow does).
+    const { state, crisisId } = makeCatastropheFixture({ onlyOwnCityTile: true });
+    const orphanedState: GameState = {
+      ...state,
+      map: { ...state.map, tiles: { ...state.map.tiles, [hexKey(CITY_POS)]: { ...state.map.tiles[hexKey(CITY_POS)], owner: null } } },
+    };
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:resolved', e => events.push(e));
+    const next = processCrisisTurn(orphanedState, bus);
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+    expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'abandoned' }]);
+    expect(next.cities.c1.resilienceBonusUntilTurn).toBeUndefined();
+  });
 });

--- a/tests/systems/crisis-catastrophe.test.ts
+++ b/tests/systems/crisis-catastrophe.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { processCrisisTurn } from '@/systems/crisis-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { hexesInRange, hexKey } from '@/systems/hex-utils';
+import type { ActiveCrisis, City, GameState, HexCoord, HexTile, OpponentChallenge } from '@/core/types';
+
+const CITY_POS: HexCoord = { q: 0, r: 0 };
+const ENEMY_TILE_POS: HexCoord = { q: 1, r: 0 };
+
+function makeTile(coord: HexCoord, owner: string | null, overrides: Partial<HexTile> = {}): HexTile {
+  return {
+    coord,
+    terrain: 'hills',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    ...overrides,
+  };
+}
+
+function makeCatastropheFixture({
+  turn = 40,
+  era = 3,
+  challenge = 'standard' as OpponentChallenge,
+  flavorId = 'earthquake',
+  cityImprovement = 'none' as HexTile['improvement'],
+  onlyOwnCityTile = false,
+}: {
+  turn?: number;
+  era?: number;
+  challenge?: OpponentChallenge;
+  flavorId?: string;
+  cityImprovement?: HexTile['improvement'];
+  /** When true, only the city's own tile is owned by the civ within blast radius —
+   * makes epicenter selection deterministic (single candidate) for tests that need
+   * to assert exactly what happens to the epicenter, not "if it happened to land here". */
+  onlyOwnCityTile?: boolean;
+} = {}): { state: GameState; crisisId: string } {
+  const civId = 'p1';
+  const city: City = {
+    id: 'c1', name: 'c1', owner: civId, position: CITY_POS,
+    population: 5, food: 0, foodNeeded: 20, buildings: [], productionQueue: [],
+    productionProgress: 0, ownedTiles: [CITY_POS], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+  };
+
+  const tiles: Record<string, HexTile> = {};
+  // Own every tile within radius 3 of the city except one deliberately enemy-owned tile,
+  // so the "never devastates another civ's or unowned land" invariant is falsifiable.
+  for (const coord of hexesInRange(CITY_POS, 3)) {
+    const key = hexKey(coord);
+    const isCityTile = key === hexKey(CITY_POS);
+    const isEnemy = coord.q === ENEMY_TILE_POS.q && coord.r === ENEMY_TILE_POS.r;
+    const owner = isCityTile ? civId : onlyOwnCityTile ? null : (isEnemy ? 'enemy' : civId);
+    tiles[key] = makeTile(coord, owner,
+      isCityTile ? { improvement: cityImprovement, improvementTurnsLeft: 0 } : {});
+  }
+
+  const crisisId = 'crisis-1';
+  const crisis: ActiveCrisis = {
+    id: crisisId, flavorId, archetype: 'catastrophe', targetCivId: civId,
+    cityIds: ['c1'], tileKeys: [], startedTurn: turn, stage: 'active', turnsInStage: 0,
+  };
+
+  const state: GameState = {
+    turn, era, currentPlayer: civId, gameOver: false, winner: null,
+    map: { width: 20, height: 20, tiles, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { c1: city },
+    civilizations: {
+      [civId]: {
+        id: civId, name: 'Player', color: '#4a90d9', isHuman: true, civType: 'egypt',
+        cities: ['c1'], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 500, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState([civId], civId),
+        challenge,
+      },
+      enemy: {
+        id: 'enemy', name: 'Enemy', color: '#c2410c', isHuman: false, civType: 'rome',
+        cities: [], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState([civId, 'enemy'], 'enemy'),
+      },
+    },
+    barbarianCamps: {}, minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0,
+      tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal',
+    },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    activeCrises: { [crisisId]: crisis },
+  } as GameState;
+
+  return { state, crisisId };
+}
+
+describe('catastrophe shock', () => {
+  it('applies the shock on the same turn the crisis starts: picks an owned epicenter, devastates owned tiles within blast radius, moves to recovery', () => {
+    const { state, crisisId } = makeCatastropheFixture();
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.stage).toBe('recovery');
+    expect(crisis.tileKeys.length).toBeGreaterThan(0);
+    for (const key of crisis.tileKeys) {
+      const tile = next.map.tiles[key];
+      expect(tile.owner).toBe('p1');
+      expect(tile.devastatedUntilTurn).toBe(state.turn + 8); // standard devastationTurns
+    }
+  });
+
+  it('never devastates a tile owned by another civ or unowned land', () => {
+    const { state, crisisId } = makeCatastropheFixture();
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.tileKeys).not.toContain(hexKey(ENEMY_TILE_POS));
+    const enemyTile = next.map.tiles[hexKey(ENEMY_TILE_POS)];
+    expect(enemyTile.devastatedUntilTurn).toBeUndefined();
+  });
+
+  it('destroys the epicenter improvement only on veteran era >= 3', () => {
+    // Only the city tile is owned within blast radius, so it's the sole epicenter
+    // candidate — deterministic, not a coin flip.
+    const { state } = makeCatastropheFixture({ challenge: 'veteran', era: 3, cityImprovement: 'mine', onlyOwnCityTile: true });
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises!['crisis-1'];
+    expect(crisis.tileKeys).toEqual([hexKey(CITY_POS)]);
+    expect(next.map.tiles[hexKey(CITY_POS)].improvement).toBe('none');
+  });
+
+  it('does not destroy the epicenter improvement on veteran era < 3', () => {
+    const { state } = makeCatastropheFixture({ challenge: 'veteran', era: 2, cityImprovement: 'mine', onlyOwnCityTile: true });
+    const next = processCrisisTurn(state, new EventBus());
+    expect(next.map.tiles[hexKey(CITY_POS)].improvement).toBe('mine');
+  });
+
+  it('does not destroy improvements on standard or explorer even at era >= 3', () => {
+    const { state } = makeCatastropheFixture({ challenge: 'standard', era: 3, cityImprovement: 'mine', onlyOwnCityTile: true });
+    const next = processCrisisTurn(state, new EventBus());
+    const cityTileAfter = next.map.tiles[hexKey(CITY_POS)];
+    expect(cityTileAfter.improvement).toBe('mine');
+  });
+
+  it('resolves recovered with a resilience bonus once every tile is actively restored within the 5-turn window', () => {
+    const { state, crisisId } = makeCatastropheFixture({ turn: 40 });
+    let s = processCrisisTurn(state, new EventBus());
+    const crisis = s.activeCrises![crisisId];
+    // Simulate a worker restoring every devastated tile before the deadline.
+    const restoredTiles = { ...s.map.tiles };
+    for (const key of crisis.tileKeys) {
+      restoredTiles[key] = { ...restoredTiles[key], devastatedUntilTurn: undefined };
+    }
+    s = { ...s, turn: 43, map: { ...s.map, tiles: restoredTiles } };
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:resolved', e => events.push(e));
+    const resolved = processCrisisTurn(s, bus);
+    expect(resolved.activeCrises?.[crisisId]).toBeUndefined();
+    expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'recovered' }]);
+    expect(resolved.cities.c1.resilienceBonusUntilTurn).toBe(48); // turn(43) + 5
+  });
+
+  it('resolves expired with no bonus once devastation passes naturally without restoration (standard/veteran)', () => {
+    const { state, crisisId } = makeCatastropheFixture({ turn: 40, challenge: 'standard' });
+    let s = processCrisisTurn(state, new EventBus());
+    // Fast-forward turns without restoring anything until natural expiry (8 turns).
+    for (let i = 0; i < 9; i++) {
+      s = processCrisisTurn({ ...s, turn: s.turn + 1 }, new EventBus());
+    }
+    expect(s.activeCrises?.[crisisId]).toBeUndefined();
+    expect(s.cities.c1.resilienceBonusUntilTurn).toBeUndefined();
+  });
+
+  it('resolves recovered (not expired) with no bonus for explorer once devastation passes naturally', () => {
+    const { state, crisisId } = makeCatastropheFixture({ turn: 40, challenge: 'explorer' });
+    let s = processCrisisTurn(state, new EventBus());
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:resolved', e => events.push(e));
+    for (let i = 0; i < 5; i++) {
+      s = processCrisisTurn({ ...s, turn: s.turn + 1 }, bus);
+    }
+    expect(s.activeCrises?.[crisisId]).toBeUndefined();
+    expect(events).toEqual([{ crisisId, flavorId: 'earthquake', civId: 'p1', outcome: 'recovered' }]);
+    expect(s.cities.c1.resilienceBonusUntilTurn).toBeUndefined();
+  });
+});

--- a/tests/systems/crisis-flavor-definitions.test.ts
+++ b/tests/systems/crisis-flavor-definitions.test.ts
@@ -32,6 +32,18 @@ describe('CRISIS_FLAVORS table invariants', () => {
       it('advisor line says what to do (mentions an action or unit)', () => {
         expect(flavor.advisorLine.length).toBeGreaterThan(20);
       });
+      it('carries catastrophe params if and only if the archetype is catastrophe', () => {
+        if (flavor.archetype === 'catastrophe') {
+          expect(flavor.catastrophe).toBeDefined();
+          expect(flavor.catastrophe!.blastRadius).toBeGreaterThan(0);
+          for (const level of ['explorer', 'standard', 'veteran'] as const) {
+            expect(flavor.catastrophe!.devastationTurnsByChallenge[level]).toBeGreaterThan(0);
+          }
+          expect(flavor.responseActions).toEqual([]);
+        } else {
+          expect(flavor.catastrophe).toBeUndefined();
+        }
+      });
     });
   }
 });

--- a/tests/systems/improvement-system.test.ts
+++ b/tests/systems/improvement-system.test.ts
@@ -1,12 +1,14 @@
 import {
   canBuildImprovement,
   canDrainSwamp,
+  canRestoreLand,
   formatImprovementYieldLabel,
   formatWorkerActionBlockerReason,
   getAvailableWorkerActions,
   getImprovementDisplayName,
   getImprovementYieldBonus,
   getWorkerActionBlockerReason,
+  getWorkerActionLabel,
   getWorkerBlockerHints,
 } from '@/systems/improvement-system';
 import type { HexTile } from '@/core/types';
@@ -537,5 +539,44 @@ describe('resource_outpost immutability — workers cannot overwrite it', () => 
 
   it('getImprovementYieldBonus returns all-zero yield', () => {
     expect(getImprovementYieldBonus('resource_outpost')).toEqual({ food: 0, production: 0, gold: 0, science: 0 });
+  });
+});
+
+describe('restore_land worker action (catastrophe crisis, MR2)', () => {
+  const baseTile: HexTile = {
+    coord: { q: 0, r: 0 }, terrain: 'hills', elevation: 'lowland',
+    resource: null, improvement: 'mine', owner: 'p1',
+    improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+  };
+
+  it('is available only on a devastated tile owned by the worker\'s civ', () => {
+    expect(canRestoreLand({ ...baseTile, devastatedUntilTurn: 50 }, 'p1', { currentTurn: 40 })).toBe(true);
+    expect(canRestoreLand(baseTile, 'p1', { currentTurn: 40 })).toBe(false); // not devastated
+    // Tile is owned by 'p1'; querying eligibility for a different civ ('enemy') must fail.
+    expect(canRestoreLand({ ...baseTile, devastatedUntilTurn: 50 }, 'enemy', { currentTurn: 40 })).toBe(false);
+  });
+
+  it('is unavailable once devastation has already naturally expired', () => {
+    expect(canRestoreLand({ ...baseTile, devastatedUntilTurn: 40 }, 'p1', { currentTurn: 40 })).toBe(false);
+    expect(canRestoreLand({ ...baseTile, devastatedUntilTurn: 39 }, 'p1', { currentTurn: 40 })).toBe(false);
+  });
+
+  it('is unavailable on a city-center tile even if devastated', () => {
+    expect(canRestoreLand({ ...baseTile, devastatedUntilTurn: 50 }, 'p1', { isCityTile: true, currentTurn: 40 })).toBe(false);
+  });
+
+  it('getAvailableWorkerActions includes restore_land only when devastated', () => {
+    expect(getAvailableWorkerActions({ ...baseTile, devastatedUntilTurn: 50 }, [], 'p1', { currentTurn: 40 })).toContain('restore_land');
+    expect(getAvailableWorkerActions(baseTile, [], 'p1', { currentTurn: 40 })).not.toContain('restore_land');
+  });
+
+  it('getWorkerActionBlockerReason reports not-devastated with a matching message', () => {
+    expect(getWorkerActionBlockerReason(baseTile, 'restore_land', [], 'p1', { currentTurn: 40 })).toBe('not-devastated');
+    expect(formatWorkerActionBlockerReason('not-devastated')).toBe('This tile is not devastated');
+    expect(getWorkerActionBlockerReason({ ...baseTile, devastatedUntilTurn: 50 }, 'restore_land', [], 'p1', { currentTurn: 40 })).toBe('none');
+  });
+
+  it('getWorkerActionLabel returns "Restore Land"', () => {
+    expect(getWorkerActionLabel('restore_land')).toBe('Restore Land');
   });
 });

--- a/tests/systems/worker-action-system.test.ts
+++ b/tests/systems/worker-action-system.test.ts
@@ -356,6 +356,36 @@ describe('worker action system', () => {
     expect(result.workerLost).toBe(true);
   });
 
+  it('restore_land clears devastation instantly without touching terrain/improvement, no worker-loss risk', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'hills', improvement: 'mine', devastatedUntilTurn: 50 });
+
+    const result = applyWorkerAction(start, 'worker-1', 'restore_land');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.map.tiles['0,0']).toMatchObject({ terrain: 'hills', improvement: 'mine', devastatedUntilTurn: undefined });
+    expect(result.state.units['worker-1']?.chargesRemaining).toBe(1);
+    expect(result.workerLost).toBe(false);
+  });
+
+  it('rejects restore_land on a non-devastated tile', () => {
+    const start = state();
+    start.map.tiles['0,0'] = tile({ terrain: 'hills' });
+
+    const result = applyWorkerAction(start, 'worker-1', 'restore_land');
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.reason).toBe('invalid-action');
+  });
+
+  it('getAvailableWorkerActions surfaces restore_land only on a devastated tile', () => {
+    const devastated = tile({ terrain: 'hills', devastatedUntilTurn: 50 });
+    expect(getAvailableWorkerActions(devastated, [], 'player', { currentTurn: 40 })).toContain('restore_land');
+    expect(getAvailableWorkerActions(tile({ terrain: 'hills' }), [], 'player', { currentTurn: 40 })).not.toContain('restore_land');
+  });
+
   it('removes a worker after spending its final charge', () => {
     const start = state();
     start.units['worker-1'] = worker({ chargesRemaining: 1 });

--- a/tests/ui/city-panel-crisis.test.ts
+++ b/tests/ui/city-panel-crisis.test.ts
@@ -142,3 +142,44 @@ describe('city-panel crisis chip', () => {
     expect(panel.querySelector('[data-remedy-crisis]')).toBeNull();
   });
 });
+
+describe('city-panel catastrophe chip (MR2)', () => {
+  function withEarthquake(overrides: Partial<ActiveCrisis> = {}) {
+    const { container, city, state } = makeWonderPanelFixture();
+    const crisis: ActiveCrisis = {
+      id: 'crisis-1', flavorId: 'earthquake', archetype: 'catastrophe', targetCivId: city.owner,
+      cityIds: [city.id], tileKeys: ['0,0'], startedTurn: state.turn - 1, stage: 'recovery', turnsInStage: 1,
+      ...overrides,
+    };
+    const withCrisis = { ...state, activeCrises: { [crisis.id]: crisis } };
+    return { container, city, state: withCrisis, crisis };
+  }
+
+  it('shows a status-only "Recovering" chip in the recovery stage, with no quarantine/remedy buttons', () => {
+    const { container, city, state } = withEarthquake();
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Recovering — restore devastated tiles');
+    expect(panel.querySelector('[data-quarantine-crisis]')).toBeNull();
+    expect(panel.querySelector('[data-remedy-crisis]')).toBeNull();
+  });
+
+  it('shows the era display name and onset advisor line while still in the active (pre-shock) stage', () => {
+    const { container, city, state } = withEarthquake({ stage: 'active', tileKeys: [] });
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('The Ground Trembles'); // era-2 display name
+    expect(panel.textContent).toContain('Send workers to restore the land');
+    expect(panel.textContent).not.toContain('Recovering');
+  });
+});

--- a/tests/ui/city-panel-crisis.test.ts
+++ b/tests/ui/city-panel-crisis.test.ts
@@ -165,6 +165,7 @@ describe('city-panel catastrophe chip (MR2)', () => {
     });
 
     expect(panel.textContent).toContain('Recovering — restore devastated tiles');
+    expect(panel.textContent).toContain('−20% city yields'); // standard challenge yieldPenalty 0.20
     expect(panel.querySelector('[data-quarantine-crisis]')).toBeNull();
     expect(panel.querySelector('[data-remedy-crisis]')).toBeNull();
   });
@@ -181,5 +182,39 @@ describe('city-panel catastrophe chip (MR2)', () => {
     expect(panel.textContent).toContain('The Ground Trembles'); // era-2 display name
     expect(panel.textContent).toContain('Send workers to restore the land');
     expect(panel.textContent).not.toContain('Recovering');
+  });
+
+  it('shows the post-catastrophe rebuilding yield bonus even after the crisis itself has been removed from state', () => {
+    // The resilience reward is transient and outlives the ActiveCrisis record (crisis
+    // resolves to 'recovered' and is deleted from activeCrises; resilienceBonusUntilTurn
+    // on the city is what actually carries the bonus forward) — no crisis chip renders
+    // here, so this must be an independent, non-crisis-gated section.
+    const { container, city, state } = makeWonderPanelFixture();
+    const withBonus = { ...city, resilienceBonusUntilTurn: state.turn + 3 };
+    const stateWithCity = { ...state, cities: { ...state.cities, [city.id]: withBonus } };
+
+    const panel = createCityPanel(container, withBonus, stateWithCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Rebuilding');
+    expect(panel.textContent).toContain('+1 🌾 +1 ⚒️ for 3 more turns');
+    expect(panel.querySelector('[data-quarantine-crisis]')).toBeNull();
+  });
+
+  it('does not show the rebuilding bonus once resilienceBonusUntilTurn has passed', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const expired = { ...city, resilienceBonusUntilTurn: state.turn - 1 };
+    const stateWithCity = { ...state, cities: { ...state.cities, [city.id]: expired } };
+
+    const panel = createCityPanel(container, expired, stateWithCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).not.toContain('Rebuilding');
   });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -596,6 +596,18 @@ describe('crisis notification routing', () => {
     expect(calls[0]!.message).toContain('Quarantine the city');
   });
 
+  it('routes crisis:started for a catastrophe flavor too (routing is flavor-generic, no outbreak-only assumption)', () => {
+    const state = makeState({
+      era: 2,
+      cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 5, position: { q: 0, r: 0 } } } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeCrisisStarted(state, { crisisId: 'crisis-1', flavorId: 'earthquake', civId: 'p1', cityIds: ['c1'] }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.message).toContain('The Ground Trembles');
+    expect(calls[0]!.message).toContain('Send workers to restore the land');
+  });
+
   it('routes crisis:spread only to the target civ', () => {
     const state = makeState({
       cities: {


### PR DESCRIPTION
## Summary

Part 2 of 5 of the Crisis Events & Revolutionary Movements arc (issue #504 index; MR1 — #499 — merged as the foundation). Implements the Catastrophe archetype from `docs/superpowers/specs/2026-07-09-crisis-events-and-revolutions-design.md`: one-shock crises with a devastation/recovery arc, distinct from Outbreak's ongoing per-turn attrition.

- Five flavors in `crisis-flavor-definitions.ts`: `volcanic-eruption`, `earthquake`, `river-flood`, `wildfire`, `harsh-winter`, each with era-flavored names and per-challenge devastation duration
- Shock resolution: seeded-pick an epicenter within blast radius of the target city (owned-tiles only — never touches another civ's or unowned land), devastate owned tiles within blast radius of the epicenter, move to a `'recovery'` stage; veteran era 3+ destroys the epicenter's improvement
- Recovery: actively restoring every devastated tile within a 5-turn window resolves `'recovered'` with a resilience bonus (+1 food +1 production, transient); letting devastation pass naturally resolves `'expired'` (or `'recovered'` without a bonus for explorer, so kids never see a scary "expired" outcome)
- Devastated tiles yield zero from everything (terrain, improvement, river, wonder) until the timer clears — threaded `currentTurn` through `calculateCityYields`/`getTileYield` and all real call sites (turn-manager, city-panel projected yields, minor-civ economy)
- New `restore_land` worker action: 1-turn, available only on a devastated tile the worker's civ owns, clears devastation immediately, no terrain/improvement change, no risk (unlike swamp draining)
- Renderer: dark desaturating tint on devastated tiles, fog-aware by construction (only 'live' tile presentation carries the real `devastatedUntilTurn` field)
- City-panel: separate status-only chip for catastrophes (no quarantine/remedy buttons — catastrophes respond via worker restore, not city actions) handling both the `'active'` and `'recovery'` stages
- Onset/resolution notifications reuse MR1's flavor-generic `routeCrisisStarted`/`routeCrisisResolved` routers unchanged — verified with a dedicated regression test

## Out of scope (later MRs)

Hunts (MR3, tracked by #381), uprising contagion/concession (MR4, tracked by #354), additional flavor breadth (MR5).

## Test plan

- [x] `yarn build` — clean, no type errors
- [x] `yarn test` — full suite green (5806 tests)
- [x] `pacing-audit.test.ts` + `pacing-reference-economy.test.ts` unchanged (the +1/+1 resilience bonus is transient, as expected)
- [x] Inline code review pass before opening this PR caught and fixed one issue: a catastrophe crisis with no valid owned tile for an epicenter (shouldn't happen via normal territory rules, but not impossible) used to silently transition to `'recovery'` with an empty `tileKeys`, and the next tick's "every tile cleared" check is vacuously true on an empty array — the crisis would resolve `'recovered'` with a resilience bonus despite nothing ever having been devastated. Now resolves `'abandoned'` immediately instead, with a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)