### PR TITLE
feat(crisis): MR3 — hunt archetype (beast awakening, bandit uprising, corsair armada)

### DIFF
--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -360,7 +360,9 @@ export class AudioSystem {
         this.director.setCrisisActiveForCurrentPlayer(
           currentState ? this.hasActiveCrisisFor(this.currentPlayerId, currentState) : false,
         );
-        if (p.outcome === 'contained' || p.outcome === 'recovered') {
+        // 'hunted' (MR3) is just as much a triumphant resolution as containing an
+        // outbreak or recovering from a catastrophe — the player slew the foe.
+        if (p.outcome === 'contained' || p.outcome === 'recovered' || p.outcome === 'hunted') {
           this.director.handleCrisisResolved();
         }
       }),

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -854,6 +854,7 @@ export interface Civilization {
   pendingChallenge?: OpponentChallenge; // applied at the start of this civ's next turn
   recentCrisisHistory?: string[]; // last 4 crisis flavor ids, for anti-repeat weighting
   lastCrisisOnsetTurn?: number;
+  feastUntilTurn?: number; // beast-slayer's feast (hunt crisis): +2 happiness while active
 }
 
 export interface BreakawayMetadata {
@@ -1737,9 +1738,16 @@ export interface GameEvents {
   // Crisis events & revolutionary movements (#381, #354)
   'crisis:started':   { crisisId: string; flavorId: string; civId: string; cityIds: string[] };
   'crisis:spread':    { crisisId: string; fromCityId: string; toCityId: string };
-  'crisis:escalated': { crisisId: string; stage: CrisisStage };
+  // civId/foeName are populated for Hunt transitions (spawn -> menacing, menacing ->
+  // assaulting) — carried directly rather than re-read from state because both are set
+  // for the first time in the same tick this event fires, and the listener may run
+  // against a state snapshot from before this tick's processing (see
+  // .claude/rules/end-to-end-wiring.md "Transition Events must be transition-owned").
+  'crisis:escalated': { crisisId: string; stage: CrisisStage; civId?: string; foeName?: string };
   'crisis:response':  { crisisId: string; civId: string; action: string };
-  'crisis:resolved':  { crisisId: string; flavorId: string; civId: string; outcome: CrisisOutcome };
+  // foeName/killerCivId populated for Hunt's 'hunted' outcome, for the same
+  // same-tick-freshness reason as crisis:escalated above.
+  'crisis:resolved':  { crisisId: string; flavorId: string; civId: string; outcome: CrisisOutcome; foeName?: string; killerCivId?: string };
 }
 
 // --- Crisis Events & Revolutionary Movements ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -218,6 +218,7 @@ import {
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
+  routeCrisisEscalated,
   routeCrisisResolved,
   type NotificationSink,
 } from '@/ui/notification-routing';
@@ -3979,6 +3980,10 @@ bus.on('crisis:started', event => {
 
 bus.on('crisis:spread', event => {
   routeCrisisSpread(gameState, event, appendToCivLog);
+});
+
+bus.on('crisis:escalated', event => {
+  routeCrisisEscalated(gameState, event, appendToCivLog);
 });
 
 bus.on('crisis:resolved', event => {

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -23,6 +23,7 @@ import {
 import { selectDefenderForAttack } from './combat-system';
 import { applyQuestGameplayAction, type ChainTransition } from './quest-chain-system';
 import { UNIT_DEFINITIONS } from './unit-system';
+import { recordHuntCampKillerIfApplicable } from './hunt-crisis-linkage';
 
 // Seeded LCG — avoids Math.random() per project rules
 function lcg(seed: number): () => number {
@@ -103,7 +104,8 @@ export function applyCampDestruction(
   const progress = applyQuestGameplayAction(nextState, {
     type: 'camp_destroyed', actorCivId: civId, campId, position: camp.position, turn,
   });
-  return { state: progress.state, reward, questTransitions: progress.transitions };
+  const withHuntAttribution = recordHuntCampKillerIfApplicable(progress.state, campId, civId);
+  return { state: withHuntAttribution, reward, questTransitions: progress.transitions };
 }
 
 export function applyCampDestructionAtTarget(

--- a/src/systems/combat-reward-system.ts
+++ b/src/systems/combat-reward-system.ts
@@ -3,6 +3,7 @@ import { cleanupDeadSpyUnit } from '@/systems/espionage-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { applyQuestGameplayAction, type ChainTransition } from '@/systems/quest-chain-system';
 import { canReceiveCivilizationCombatRewards, isPirateOwner } from '@/core/owner-kind';
+import { recordHuntKillerIfApplicable } from '@/systems/hunt-crisis-linkage';
 import {
   breakPirateTributeOnAttack,
   destroyPirateFaction,
@@ -428,6 +429,13 @@ export function applyCombatOutcomeToState(
     });
     nextState = destruction.state;
     pirateEvents.push(...destruction.events);
+  }
+
+  if (defenderActuallyDefeated) {
+    nextState = recordHuntKillerIfApplicable(nextState, defenderBefore.id, defenderBefore.owner, attackerBefore.owner);
+  }
+  if (attackerActuallyDefeated) {
+    nextState = recordHuntKillerIfApplicable(nextState, attackerBefore.id, attackerBefore.owner, defenderBefore.owner);
   }
 
   return {

--- a/src/systems/crisis-flavor-definitions.ts
+++ b/src/systems/crisis-flavor-definitions.ts
@@ -13,6 +13,14 @@ export interface CatastropheParams {
   destroysEpicenterImprovement: boolean; // only meaningful on veteran era >= 3; resolver enforces
 }
 
+export interface HuntParams {
+  spawnKind: 'beast' | 'barbarian-camp' | 'pirate';
+  // Deviation from the original plan's `namePoolKey`: the spawner picks the named-foe
+  // pool by the target civ's own civType (matches BANDIT_LORD_NAMES's existing
+  // civType-keyed shape) rather than a fixed pool key — more thematic, and civType is
+  // already known at spawn time, so a separate key would be redundant.
+}
+
 export interface CrisisFlavor {
   id: string;
   archetype: CrisisArchetype;
@@ -24,6 +32,7 @@ export interface CrisisFlavor {
   advisorLine: string;                         // '{name} has reached {city}! <what to do>'
   responseActions: Array<'quarantine' | 'remedy'>;
   catastrophe?: CatastropheParams;             // only present when archetype === 'catastrophe'
+  hunt?: HuntParams;                            // only present when archetype === 'hunt'
 }
 
 function tilesWithinRadius(state: GameState, center: HexCoord, radius: number): HexTile[] {
@@ -60,6 +69,22 @@ function hasRiverOrCoastalFlood(state: GameState, city: City): boolean {
   if (cityTile?.hasRiver) return true;
   return nearTerrain(state, city, ['coast'], 1);
 }
+
+function isCoastalCity(state: GameState, city: City): boolean {
+  const cityTile = state.map.tiles[hexKey(city.position)];
+  if (cityTile?.terrain === 'coast') return true;
+  return nearTerrain(state, city, ['ocean', 'coast'], 1);
+}
+
+// No severity-driven yield penalty, pop loss, or auto-expiry for Hunt flavors — the
+// archetype resolves via combat (the foe dying), not attrition or a timer. Shared
+// across all three hunt flavors since none of them vary this by challenge level;
+// challenge instead governs veteran-only escalation (see tickHuntCrisis).
+const NO_ATTRITION_SEVERITY: Record<OpponentChallenge, CrisisSeverity> = {
+  explorer: { yieldPenalty: 0, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+  standard: { yieldPenalty: 0, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+  veteran: { yieldPenalty: 0, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+};
 
 export const CRISIS_FLAVORS: CrisisFlavor[] = [
   {
@@ -172,6 +197,43 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       devastationTurnsByChallenge: { explorer: 4, standard: 8, veteran: 10 },
       destroysEpicenterImprovement: true,
     },
+  },
+  {
+    id: 'beast-awakening',
+    archetype: 'hunt',
+    eraBand: [2, 6],
+    geographyPredicate: (state, city) =>
+      // Matches turn-manager.ts's own beast-processing gate: `state.beasts` must exist
+      // AND not be 'off' — undefined means beasts were never initialized (e.g. a legacy
+      // save mid-migration), not "on by default".
+      !!state.beasts && state.beasts.mode !== 'off' && nearTerrain(state, city, ['forest', 'mountain', 'jungle'], 4),
+    severityByChallenge: NO_ATTRITION_SEVERITY,
+    displayNamesByEra: { 2: 'Beast Awakening' },
+    advisorLine: '{name} has awoken near {city}! Slay it to end the threat — any civilization may claim the hunt.',
+    responseActions: [],
+    hunt: { spawnKind: 'beast' },
+  },
+  {
+    id: 'bandit-uprising',
+    archetype: 'hunt',
+    eraBand: [2, 8],
+    geographyPredicate: () => true,
+    severityByChallenge: NO_ATTRITION_SEVERITY,
+    displayNamesByEra: { 2: 'Bandit Uprising' },
+    advisorLine: '{name} has raised a bandit camp near {city}! Slay it to end the threat — any civilization may claim the hunt.',
+    responseActions: [],
+    hunt: { spawnKind: 'barbarian-camp' },
+  },
+  {
+    id: 'corsair-armada',
+    archetype: 'hunt',
+    eraBand: [4, 12],
+    geographyPredicate: (state, city) => isCoastalCity(state, city),
+    severityByChallenge: NO_ATTRITION_SEVERITY,
+    displayNamesByEra: { 4: 'Corsair Armada' },
+    advisorLine: '{name} raids the waters near {city}! Slay it to end the threat — any civilization may claim the hunt.',
+    responseActions: [],
+    hunt: { spawnKind: 'pirate' },
   },
 ];
 

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -1,11 +1,16 @@
-import type { ActiveCrisis, City, CrisisOutcome, GameState } from '@/core/types';
+import type { ActiveCrisis, BeastLair, City, CrisisOutcome, GameState, HexCoord } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { getChallengeProfileForCiv, resolveChallengeForCiv } from '@/core/opponent-challenge';
-import { computeThreatScore, deriveActiveIndependentThreatIds } from './threat-pressure-system';
-import { CRISIS_FLAVORS, getCrisisFlavor } from './crisis-flavor-definitions';
+import { computeThreatScore, deriveActiveIndependentThreatIds, createPirateFleetNear, pickBanditName } from './threat-pressure-system';
+import { CRISIS_FLAVORS, getCrisisFlavor, type CrisisFlavor } from './crisis-flavor-definitions';
 import { seededLcg, weightedPick } from './seeded-lcg';
 import { hexKey, hexDistance, hexesInRange } from './hex-utils';
 import { getCityAppeaseCost } from './faction-system';
+import { spawnBarbarianCamp } from './barbarian-system';
+import { BEAST_DEFINITIONS } from './beast-definitions';
+import { BEAST_OWNER, isTerrainPassableForBeast } from './beast-system';
+import { createUnit } from './unit-system';
+import { buildUnitOccupancy, getUnitIdsAtCoord } from './unit-occupancy';
 
 export const CRISIS_PRESSURE_FLOOR = 2.0;
 export const EXTERNAL_THREAT_RECENCY_TURNS = 5;
@@ -335,6 +340,203 @@ function tickCatastropheCrisis(
   return { crisis: null, state: nextState };
 }
 
+// ── Hunt resolver ────────────────────────────────────────────────────────────
+
+const HUNT_ESCALATION_TURNS = 5;
+
+// 3-5 tiles from the target city, never inside the target civ's own territory,
+// on terrain the foe can actually occupy, and never stacking on another unit —
+// same spawn-occupancy contract as every other entity-spawn path in the game.
+function findHuntSpawnHex(
+  state: GameState,
+  targetCity: City,
+  owner: string,
+  isPassable: (terrain: string) => boolean,
+  rng: () => number,
+): HexCoord | null {
+  const occupancy = buildUnitOccupancy(state.units);
+  const candidates = hexesInRange(targetCity.position, 5)
+    .filter(coord => hexDistance(coord, targetCity.position) >= 3)
+    .filter(coord => {
+      const tile = state.map.tiles[hexKey(coord)];
+      if (!tile) return false;
+      if (tile.owner === owner) return false;
+      if (!isPassable(tile.terrain)) return false;
+      return getUnitIdsAtCoord(occupancy, coord).length === 0;
+    });
+  if (candidates.length === 0) return null;
+  return candidates[Math.floor(rng() * candidates.length)];
+}
+
+function spawnBeastHunt(
+  state: GameState,
+  crisis: ActiveCrisis,
+  targetCity: City,
+  rng: () => number,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  const eligible = Object.values(BEAST_DEFINITIONS).filter(d => d.awakenEra <= state.era);
+  if (eligible.length === 0) return { crisis: null, state };
+  const def = eligible[Math.floor(rng() * eligible.length)];
+
+  const spawnHex = findHuntSpawnHex(
+    state, targetCity, crisis.targetCivId,
+    terrain => isTerrainPassableForBeast(def.unitType, terrain), rng,
+  );
+  if (!spawnHex) return { crisis: null, state };
+
+  const beastUnit = createUnit(def.unitType, BEAST_OWNER, spawnHex, state.idCounters);
+  const lairId = `hunt-lair-${crisis.id}`;
+  const lair: BeastLair = {
+    id: lairId, beastId: def.id, position: { ...spawnHex }, status: 'awake',
+    strength: 0, awakenedTurn: state.turn, unitIds: [beastUnit.id],
+  };
+  const existingBeasts = state.beasts ?? { mode: 'wild' as const, lairs: {}, sightingsByCiv: {} };
+
+  const nextState: GameState = {
+    ...state,
+    units: { ...state.units, [beastUnit.id]: beastUnit },
+    beasts: { ...existingBeasts, lairs: { ...existingBeasts.lairs, [lairId]: lair } },
+  };
+  return {
+    crisis: { ...crisis, stage: 'menacing', huntEntityId: beastUnit.id, foeName: def.name },
+    state: nextState,
+  };
+}
+
+function spawnBarbarianHunt(
+  state: GameState,
+  crisis: ActiveCrisis,
+  rng: () => number,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  const civ = state.civilizations[crisis.targetCivId];
+  const cityPositions = Object.values(state.cities).map(c => c.position);
+  const existingCamps = Object.values(state.barbarianCamps);
+  const seed = Math.floor(rng() * 2147483647);
+  const camp = spawnBarbarianCamp(state.map, cityPositions, existingCamps, seed, state.idCounters);
+  if (!camp) return { crisis: null, state };
+
+  const foeName = pickBanditName(civ?.civType ?? 'generic', seed + 1);
+  const namedCamp = { ...camp, banditLordName: foeName };
+  const nextState: GameState = {
+    ...state,
+    barbarianCamps: { ...state.barbarianCamps, [namedCamp.id]: namedCamp },
+  };
+  return {
+    crisis: { ...crisis, stage: 'menacing', huntEntityId: namedCamp.id, foeName },
+    state: nextState,
+  };
+}
+
+function spawnPirateHunt(
+  state: GameState,
+  crisis: ActiveCrisis,
+  targetCity: City,
+  rng: () => number,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  const civ = state.civilizations[crisis.targetCivId];
+  const landmassId = state.map.tiles[hexKey(targetCity.position)]?.regionKey;
+  if (!landmassId) return { crisis: null, state };
+  const seed = Math.floor(rng() * 2147483647);
+  const { state: nextState, fleetId } = createPirateFleetNear(state, crisis.targetCivId, landmassId, targetCity, seed);
+  if (!fleetId) return { crisis: null, state };
+
+  const foeName = pickBanditName(civ?.civType ?? 'generic', seed + 1);
+  return {
+    crisis: { ...crisis, stage: 'menacing', huntEntityId: fleetId, foeName },
+    state: nextState,
+  };
+}
+
+function huntEntityExists(state: GameState, crisis: ActiveCrisis, flavor: CrisisFlavor): boolean {
+  const entityId = crisis.huntEntityId;
+  if (!entityId) return false;
+  switch (flavor.hunt?.spawnKind) {
+    case 'beast': return !!state.units[entityId];
+    case 'barbarian-camp': return !!state.barbarianCamps[entityId];
+    case 'pirate': {
+      // huntEntityId stores the fleetId, but nothing in the pirate system currently
+      // prunes state.pirateFleets when the fleet's ship dies in combat — checking the
+      // fleet record would make this hunt un-resolvable forever. The underlying unit
+      // IS reliably removed from state.units by every combat path (shared
+      // applyCombatOutcomeToState), so key existence off that instead.
+      const fleet = state.pirateFleets?.[entityId];
+      return !!fleet && !!state.units[fleet.unitId];
+    }
+    default: return false;
+  }
+}
+
+function tickHuntCrisis(
+  state: GameState,
+  crisis: ActiveCrisis,
+  bus: EventBus,
+): { crisis: ActiveCrisis | null; state: GameState } {
+  const flavor = getCrisisFlavor(crisis.flavorId);
+  if (!flavor?.hunt) return { crisis: null, state };
+
+  let working: ActiveCrisis = { ...crisis, turnsInStage: crisis.turnsInStage + 1 };
+  let nextState = state;
+
+  if (working.stage === 'active') {
+    const targetCity = state.cities[working.cityIds[0]];
+    if (!targetCity) {
+      bus.emit('crisis:resolved', { crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome: 'abandoned' });
+      return { crisis: null, state: nextState };
+    }
+    const rng = seededLcg(state.turn * 65599 + hashString(working.id));
+    const spawned = flavor.hunt.spawnKind === 'beast'
+      ? spawnBeastHunt(nextState, working, targetCity, rng)
+      : flavor.hunt.spawnKind === 'barbarian-camp'
+        ? spawnBarbarianHunt(nextState, working, rng)
+        : spawnPirateHunt(nextState, working, targetCity, rng);
+    nextState = spawned.state;
+    if (!spawned.crisis) {
+      // No legal spawn hex / no candidate — nothing for this hunt to menace with.
+      bus.emit('crisis:resolved', { crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome: 'abandoned' });
+      return { crisis: null, state: nextState };
+    }
+    bus.emit('crisis:escalated', {
+      crisisId: spawned.crisis.id, stage: 'menacing',
+      civId: spawned.crisis.targetCivId, foeName: spawned.crisis.foeName,
+    });
+    return { crisis: spawned.crisis, state: nextState };
+  }
+
+  if (huntEntityExists(nextState, working, flavor)) {
+    const challenge = resolveChallengeForCiv(nextState, working.targetCivId);
+    if (challenge === 'veteran' && working.stage === 'menacing' && working.turnsInStage >= HUNT_ESCALATION_TURNS) {
+      working = { ...working, stage: 'assaulting' };
+      bus.emit('crisis:escalated', {
+        crisisId: working.id, stage: 'assaulting',
+        civId: working.targetCivId, foeName: working.foeName,
+      });
+    }
+    return { crisis: working, state: nextState };
+  }
+
+  // The foe is gone — resolve 'hunted' regardless of who claimed the kill. The
+  // beast-slayer's feast (feastUntilTurn on the killer civ) is applied by whichever
+  // combat/camp-destruction path recorded lastHuntKillerCivId on this crisis; if none
+  // did (e.g. the entity was removed by some other path), fall back to the target civ
+  // per the plan's "fall back to the target civ if unattributed" rule.
+  const killerCivId = working.lastHuntKillerCivId ?? working.targetCivId;
+  const killerCiv = nextState.civilizations[killerCivId];
+  if (killerCiv) {
+    nextState = {
+      ...nextState,
+      civilizations: {
+        ...nextState.civilizations,
+        [killerCivId]: { ...killerCiv, feastUntilTurn: nextState.turn + 5 },
+      },
+    };
+  }
+  bus.emit('crisis:resolved', {
+    crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome: 'hunted',
+    foeName: working.foeName, killerCivId,
+  });
+  return { crisis: null, state: nextState };
+}
+
 // Archetype-specific tick dispatch. MR3 (hunt) and beyond add a case here —
 // keep this the single dispatch point rather than branching inline elsewhere.
 function tickCrisisByArchetype(
@@ -347,9 +549,12 @@ function tickCrisisByArchetype(
       return tickOutbreakCrisis(state, crisis, bus);
     case 'catastrophe':
       return tickCatastropheCrisis(state, crisis, bus);
+    case 'hunt':
+      return tickHuntCrisis(state, crisis, bus);
     default:
-      // Not yet implemented (e.g. 'hunt', MR3) — leave untouched rather than
-      // silently dropping or mutating a crisis type this resolver doesn't know.
+      // Not yet implemented (MR4's uprising lives in faction-system.ts, not here) —
+      // leave untouched rather than silently dropping or mutating a crisis type this
+      // resolver doesn't know.
       return { crisis, state };
   }
 }

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -344,13 +344,15 @@ function tickCatastropheCrisis(
 
 const HUNT_ESCALATION_TURNS = 5;
 
-// 3-5 tiles from the target city, never inside the target civ's own territory,
-// on terrain the foe can actually occupy, and never stacking on another unit —
-// same spawn-occupancy contract as every other entity-spawn path in the game.
+// 3-5 tiles from the target city, in unclaimed wilderness (not just "not the target's
+// own territory" — a rival civ's nearby garrison could otherwise kill the foe before the
+// target player gets a turn, handing them the reward and defeating the "go fight it"
+// loop for the player the hunt was actually scheduled for), on terrain the foe can
+// actually occupy, and never stacking on another unit — same spawn-occupancy contract
+// as every other entity-spawn path in the game.
 function findHuntSpawnHex(
   state: GameState,
   targetCity: City,
-  owner: string,
   isPassable: (terrain: string) => boolean,
   rng: () => number,
 ): HexCoord | null {
@@ -360,7 +362,7 @@ function findHuntSpawnHex(
     .filter(coord => {
       const tile = state.map.tiles[hexKey(coord)];
       if (!tile) return false;
-      if (tile.owner === owner) return false;
+      if (tile.owner !== null) return false;
       if (!isPassable(tile.terrain)) return false;
       return getUnitIdsAtCoord(occupancy, coord).length === 0;
     });
@@ -379,7 +381,7 @@ function spawnBeastHunt(
   const def = eligible[Math.floor(rng() * eligible.length)];
 
   const spawnHex = findHuntSpawnHex(
-    state, targetCity, crisis.targetCivId,
+    state, targetCity,
     terrain => isTerrainPassableForBeast(def.unitType, terrain), rng,
   );
   if (!spawnHex) return { crisis: null, state };
@@ -529,6 +531,17 @@ function tickHuntCrisis(
         [killerCivId]: { ...killerCiv, feastUntilTurn: nextState.turn + 5 },
       },
     };
+  }
+  if (flavor.hunt.spawnKind === 'beast' && nextState.beasts) {
+    // The ephemeral hunt lair (registered only so recordBeastSlain's hoard-gold path
+    // fires normally) has no map-generation meaning once the hunt is over — unlike an
+    // organic lair, its position is an arbitrary frontier spawn point, not a discovered
+    // landmark. Leaving it in state.beasts.lairs forever would both bloat the save and
+    // permanently clutter the map with a 🏆 marker (render-loop.ts draws one for every
+    // 'slain'/'claimed' lair) at that arbitrary spot — and since hunts can recur every
+    // 5-12 turns per human for the rest of the game, that accumulation is unbounded.
+    const { [`hunt-lair-${working.id}`]: _removedLair, ...lairs } = nextState.beasts.lairs;
+    nextState = { ...nextState, beasts: { ...nextState.beasts, lairs } };
   }
   bus.emit('crisis:resolved', {
     crisisId: working.id, flavorId: working.flavorId, civId: working.targetCivId, outcome: 'hunted',

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -199,8 +199,10 @@ export function processFactionTurn(state: GameState, bus: EventBus): GameState {
 
   // Pre-compute happiness per civ to avoid O(cities²) tile scans inside the city loop
   const civHappiness: Record<string, number> = {};
-  for (const civId of Object.keys(nextState.civilizations)) {
-    civHappiness[civId] = getCivHappinessFromResources(nextState, civId);
+  for (const [civId, civ] of Object.entries(nextState.civilizations)) {
+    // Beast-slayer's feast (Hunt crisis, MR3): +2 happiness while feastUntilTurn is active.
+    const feasting = (civ.feastUntilTurn ?? 0) > nextState.turn;
+    civHappiness[civId] = getCivHappinessFromResources(nextState, civId) + (feasting ? 2 : 0);
   }
 
   for (const cityId of Object.keys(nextState.cities)) {

--- a/src/systems/hunt-crisis-linkage.ts
+++ b/src/systems/hunt-crisis-linkage.ts
@@ -1,11 +1,19 @@
 import type { GameState } from '@/core/types';
-import { classifyOwner } from '@/core/owner-kind';
+import { classifyOwner, isMajorCivOwner } from '@/core/owner-kind';
 
 // Shared by combat-reward-system.ts (beast/pirate kills) and barbarian-system.ts (camp
 // destruction) to record which civ actually slew a Hunt crisis's foe — "any civilization
 // may claim the hunt" per the crisis design. Deliberately its own leaf module (only
 // depends on core/types + owner-kind) so both of those systems can call it without
 // creating an import cycle through crisis-system.ts, which already depends on both.
+//
+// killerCivId must be an actual major-civ id (isMajorCivOwner) or we deliberately leave
+// lastHuntKillerCivId untouched. Hostility rules allow barbarians/beasts/pirates/minor
+// civs to fight each other, so a hunt's foe can in principle be killed by a non-major
+// entity; recording that id here would make `state.civilizations[lastHuntKillerCivId]`
+// undefined in crisis-system.ts's resolution step, silently dropping BOTH the feast
+// reward and the "fall back to the target civ" rule (the fallback only triggers when
+// lastHuntKillerCivId is `undefined`, not when it's set to something invalid).
 
 export function recordHuntKillerIfApplicable(
   state: GameState,
@@ -15,6 +23,7 @@ export function recordHuntKillerIfApplicable(
 ): GameState {
   const kind = classifyOwner(defeatedOwnerId);
   if (kind !== 'beast' && kind !== 'pirate') return state;
+  if (!isMajorCivOwner(killerCivId)) return state;
   for (const [crisisId, crisis] of Object.entries(state.activeCrises ?? {})) {
     if (crisis.archetype !== 'hunt' || !crisis.huntEntityId) continue;
     const isMatch = kind === 'beast'
@@ -34,6 +43,7 @@ export function recordHuntCampKillerIfApplicable(
   campId: string,
   killerCivId: string,
 ): GameState {
+  if (!isMajorCivOwner(killerCivId)) return state;
   for (const [crisisId, crisis] of Object.entries(state.activeCrises ?? {})) {
     if (crisis.archetype === 'hunt' && crisis.huntEntityId === campId) {
       return {

--- a/src/systems/hunt-crisis-linkage.ts
+++ b/src/systems/hunt-crisis-linkage.ts
@@ -1,0 +1,46 @@
+import type { GameState } from '@/core/types';
+import { classifyOwner } from '@/core/owner-kind';
+
+// Shared by combat-reward-system.ts (beast/pirate kills) and barbarian-system.ts (camp
+// destruction) to record which civ actually slew a Hunt crisis's foe — "any civilization
+// may claim the hunt" per the crisis design. Deliberately its own leaf module (only
+// depends on core/types + owner-kind) so both of those systems can call it without
+// creating an import cycle through crisis-system.ts, which already depends on both.
+
+export function recordHuntKillerIfApplicable(
+  state: GameState,
+  defeatedUnitId: string,
+  defeatedOwnerId: string,
+  killerCivId: string,
+): GameState {
+  const kind = classifyOwner(defeatedOwnerId);
+  if (kind !== 'beast' && kind !== 'pirate') return state;
+  for (const [crisisId, crisis] of Object.entries(state.activeCrises ?? {})) {
+    if (crisis.archetype !== 'hunt' || !crisis.huntEntityId) continue;
+    const isMatch = kind === 'beast'
+      ? crisis.huntEntityId === defeatedUnitId
+      : state.pirateFleets?.[crisis.huntEntityId]?.unitId === defeatedUnitId;
+    if (!isMatch) continue;
+    return {
+      ...state,
+      activeCrises: { ...state.activeCrises, [crisisId]: { ...crisis, lastHuntKillerCivId: killerCivId } },
+    };
+  }
+  return state;
+}
+
+export function recordHuntCampKillerIfApplicable(
+  state: GameState,
+  campId: string,
+  killerCivId: string,
+): GameState {
+  for (const [crisisId, crisis] of Object.entries(state.activeCrises ?? {})) {
+    if (crisis.archetype === 'hunt' && crisis.huntEntityId === campId) {
+      return {
+        ...state,
+        activeCrises: { ...state.activeCrises, [crisisId]: { ...crisis, lastHuntKillerCivId: killerCivId } },
+      };
+    }
+  }
+  return state;
+}

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -389,7 +389,7 @@ const BANDIT_LORD_NAMES: Record<string, string[]> = {
   isengard: ['Saruman', 'Grima Wormtongue', 'Uglúk', 'Grishnákh', 'Mauhúr'],
 };
 
-function pickBanditName(civType: string, seed: number): string {
+export function pickBanditName(civType: string, seed: number): string {
   const pool = BANDIT_LORD_NAMES[civType] ?? BANDIT_LORD_NAMES['generic'];
   const rng = seededLcg(seed);
   return pool[Math.floor(rng() * pool.length)];
@@ -517,6 +517,78 @@ function pirateUnitType(era: number): 'galley' | 'trireme' {
   return era >= 3 ? 'trireme' : 'galley';
 }
 
+function findPirateSpawnTile(state: GameState, landmassId: string): HexCoord | null {
+  const cityPositions = Object.values(state.cities).map(c => c.position);
+  const candidates = Object.values(state.map.tiles).filter(tile => {
+    if (tile.terrain !== 'ocean') return false;
+    // Must be adjacent to a land tile on the target landmass
+    const nearLandmass = hexNeighbors(tile.coord).some(nb => {
+      const t = state.map.tiles[hexKey(nb)];
+      return t?.regionKey === landmassId;
+    });
+    if (!nearLandmass) return false;
+    // Must be ≥ 5 tiles from any city
+    for (const pos of cityPositions) {
+      if (hexDistance(tile.coord, pos) < 5) return false;
+    }
+    return true;
+  });
+  return candidates.length > 0 ? candidates[0].coord : null;
+}
+
+// Core fleet-creation shared by the organic (threshold-gated) spawn below and any
+// forced spawn (e.g. a Hunt crisis's corsair-armada flavor) — no threshold/cooldown
+// checks here; callers are responsible for those. `targetCity` is whichever coastal
+// city the caller has already chosen as the fleet's raid target.
+export function createPirateFleetNear(
+  state: GameState,
+  civId: string,
+  landmassId: string,
+  targetCity: City,
+  seed: number,
+): { state: GameState; fleetId: string | null } {
+  const cityPositions = Object.values(state.cities).map(c => c.position);
+  const rng = seededLcg(seed);
+
+  const spawnCandidates = Object.values(state.map.tiles).filter(tile => {
+    if (tile.terrain !== 'ocean') return false;
+    const nearLandmass = hexNeighbors(tile.coord).some(nb => {
+      const t = state.map.tiles[hexKey(nb)];
+      return t?.regionKey === landmassId;
+    });
+    if (!nearLandmass) return false;
+    for (const pos of cityPositions) {
+      if (hexDistance(tile.coord, pos) < 5) return false;
+    }
+    return true;
+  });
+
+  if (spawnCandidates.length === 0) return { state, fleetId: null };
+
+  const spawnTile = spawnCandidates[Math.floor(rng() * spawnCandidates.length)];
+
+  const unitType = pirateUnitType(state.era);
+  const pirateUnit = createUnit(unitType, PIRATE_OWNER, spawnTile.coord, state.idCounters);
+  const fleetId = `fleet-${pirateUnit.id}`;
+  const fleet: PirateFleet = {
+    id: fleetId,
+    unitId: pirateUnit.id,
+    targetCivId: civId,
+    targetCityId: targetCity.id,
+    landmassId,
+    era: state.era,
+    plunderCooldown: 0,
+  };
+
+  const updatedState: GameState = {
+    ...state,
+    units: { ...state.units, [pirateUnit.id]: pirateUnit },
+    pirateFleets: { ...(state.pirateFleets ?? {}), [fleetId]: fleet },
+  };
+
+  return { state: updatedState, fleetId };
+}
+
 export function processPirateSpawn(
   state: GameState,
   civId: string,
@@ -554,58 +626,24 @@ export function processPirateSpawn(
   });
   if (coastalCities.length === 0) return state;
 
-  // Find spawn tile: ocean tile adjacent to landmass coastline, ≥ 5 tiles from any city
-  const cityPositions = Object.values(state.cities).map(c => c.position);
-  const spawnSeed = state.turn * 73937 + civId.charCodeAt(0) * 13 + landmassId.charCodeAt(0) * 5;
-  const rng = seededLcg(spawnSeed);
+  // Find spawn tile: ocean tile adjacent to landmass coastline, ≥ 5 tiles from any city.
+  // Target-city selection depends on it (nearest coastal city to the spawn point), so
+  // probe with a lightweight lookup before delegating fleet creation to the shared helper.
+  const spawnTile = findPirateSpawnTile(state, landmassId);
+  if (!spawnTile) return state;
 
-  const spawnCandidates = Object.values(state.map.tiles).filter(tile => {
-    if (tile.terrain !== 'ocean') return false;
-    // Must be adjacent to a land tile on the target landmass
-    const nearLandmass = hexNeighbors(tile.coord).some(nb => {
-      const t = state.map.tiles[hexKey(nb)];
-      return t?.regionKey === landmassId;
-    });
-    if (!nearLandmass) return false;
-    // Must be ≥ 5 tiles from any city
-    for (const pos of cityPositions) {
-      if (hexDistance(tile.coord, pos) < 5) return false;
-    }
-    return true;
-  });
-
-  if (spawnCandidates.length === 0) return state;
-
-  const spawnTile = spawnCandidates[Math.floor(rng() * spawnCandidates.length)];
-
-  // Pick nearest coastal city as target
   const targetCity = coastalCities.reduce((nearest, city) => {
-    const d1 = hexDistance(city.position, spawnTile.coord);
-    const d2 = hexDistance(nearest.position, spawnTile.coord);
+    const d1 = hexDistance(city.position, spawnTile);
+    const d2 = hexDistance(nearest.position, spawnTile);
     return d1 < d2 ? city : nearest;
   });
 
-  const unitType = pirateUnitType(state.era);
-  const pirateUnit = createUnit(unitType, PIRATE_OWNER, spawnTile.coord, state.idCounters);
-  const fleetId = `fleet-${pirateUnit.id}`;
-  const fleet: PirateFleet = {
-    id: fleetId,
-    unitId: pirateUnit.id,
-    targetCivId: civId,
-    targetCityId: targetCity.id,
-    landmassId,
-    era: state.era,
-    plunderCooldown: 0,
-  };
-
-  const updatedState: GameState = {
-    ...state,
-    units: { ...state.units, [pirateUnit.id]: pirateUnit },
-    pirateFleets: { ...(state.pirateFleets ?? {}), [fleetId]: fleet },
-  };
+  const spawnSeed = state.turn * 73937 + civId.charCodeAt(0) * 13 + landmassId.charCodeAt(0) * 5;
+  const { state: updatedState, fleetId } = createPirateFleetNear(state, civId, landmassId, targetCity, spawnSeed);
+  if (!fleetId) return state;
 
   bus.emit('threat:pirate-fleet-spawned', {
-    fleetId, civId, landmassId, position: spawnTile.coord,
+    fleetId, civId, landmassId, position: spawnTile,
   });
 
   return updatedState;

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -398,6 +398,11 @@ export function routeCrisisStarted(
 ): void {
   const flavor = getCrisisFlavor(event.flavorId);
   if (!flavor) return;
+  // Hunt's onset notification fires later, at spawn time (routeCrisisEscalated, stage
+  // 'menacing') — the foe doesn't have a name yet when the crisis record is first
+  // scheduled, so announcing here would either use a generic category name or duplicate
+  // the real announcement a moment later.
+  if (flavor.archetype === 'hunt') return;
   const cityId = event.cityIds[0];
   const city = cityId ? state.cities[cityId] : undefined;
   const name = getCrisisDisplayName(flavor, state.era);
@@ -409,6 +414,37 @@ export function routeCrisisStarted(
     coord: { ...city.position },
     label: name,
   } : undefined);
+}
+
+export function routeCrisisEscalated(
+  state: GameState,
+  event: GameEvents['crisis:escalated'],
+  sink: NotificationSink,
+): void {
+  // civId/foeName come from the event, not re-read from state: this fires mid-turn,
+  // in the same tick the foe first gets a name, and the caller's state snapshot may
+  // predate that (see the GameEvents['crisis:escalated'] doc comment in core/types.ts).
+  if (!event.civId || !event.foeName) return;
+  const crisis = state.activeCrises?.[event.crisisId];
+  const flavor = crisis ? getCrisisFlavor(crisis.flavorId) : undefined;
+  // cityIds is set once at crisis creation and never changes afterward, so it's safe
+  // to read from a possibly-stale snapshot even though foeName/civId are not.
+  const city = crisis ? state.cities[crisis.cityIds[0]] : undefined;
+  const target = city ? { kind: 'map' as const, coord: { ...city.position }, label: event.foeName } : undefined;
+
+  if (event.stage === 'menacing' && flavor) {
+    const message = flavor.advisorLine
+      .replace('{name}', event.foeName)
+      .replace('{city}', city?.name ?? 'a city');
+    sink(event.civId, message, 'warning', target);
+  } else if (event.stage === 'assaulting') {
+    sink(
+      event.civId,
+      `${event.foeName} now assaults ${city?.name ?? 'your city'}! Slay it before it breaches the walls.`,
+      'warning',
+      target,
+    );
+  }
 }
 
 export function routeCrisisSpread(
@@ -435,6 +471,19 @@ export function routeCrisisResolved(
   event: GameEvents['crisis:resolved'],
   sink: NotificationSink,
 ): void {
+  // Hunt's 'hunted' outcome gets its own two-sided messaging (killer civ + target civ,
+  // using the foe's real name) rather than the generic per-outcome line below — both
+  // foeName and killerCivId are carried on the event itself for the same
+  // same-tick-freshness reason as crisis:escalated (see core/types.ts).
+  if (event.outcome === 'hunted' && event.foeName) {
+    const killerCivId = event.killerCivId ?? event.civId;
+    sink(killerCivId, `The beast-slayer's feast begins! (+2 happiness, 5 turns)`, 'success');
+    if (killerCivId !== event.civId) {
+      sink(event.civId, `${event.foeName} has been slain by ${state.civilizations[killerCivId]?.name ?? 'another civilization'}.`, 'success');
+    }
+    return;
+  }
+
   const outcomeMessage: Record<typeof event.outcome, string> = {
     contained: 'has been contained.',
     expired: 'has run its course.',

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -142,6 +142,20 @@ function chooseWorkerBlockerReason(
   return fallback;
 }
 
+// A Hunt crisis's foe is a real, named world entity ("any civilization may fight it") —
+// surface its name whenever the player selects the actual beast/ship unit. Camps have no
+// equivalent selectable-unit tap target (consistent with barbarian camps generally having
+// no inspection panel today), so bandit-uprising hunts aren't covered here.
+function findHuntFoeNameForUnit(state: GameState, unitId: string): string | undefined {
+  for (const crisis of Object.values(state.activeCrises ?? {})) {
+    if (crisis.archetype !== 'hunt' || !crisis.huntEntityId || !crisis.foeName) continue;
+    if (crisis.huntEntityId === unitId) return crisis.foeName;
+    const fleet = state.pirateFleets?.[crisis.huntEntityId];
+    if (fleet?.unitId === unitId) return crisis.foeName;
+  }
+  return undefined;
+}
+
 export function renderSelectedUnitInfo(
   container: HTMLElement,
   state: GameState,
@@ -198,6 +212,14 @@ export function renderSelectedUnitInfo(
 
   wrapper.appendChild(topRow);
   wrapper.appendChild(descDiv);
+
+  const huntFoeName = findHuntFoeNameForUnit(state, unitId);
+  if (huntFoeName) {
+    const huntLine = document.createElement('div');
+    huntLine.style.cssText = 'margin-top:6px;padding:6px 8px;border-radius:6px;background:rgba(122,31,43,0.25);border:1px solid rgba(122,31,43,0.5);font-size:11px;font-weight:700;color:#e88;';
+    huntLine.textContent = `⚔ ${huntFoeName} — slay it to end the threat. Any civilization may claim the hunt.`;
+    wrapper.appendChild(huntLine);
+  }
 
   const waterRecovery = presentation.waterRecovery;
   const waterRecoveryMessage = waterRecovery

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -436,4 +436,26 @@ describe('AudioSystem integration', () => {
 
     expect(ctx.transcript.some(e => e.op === 'stop')).toBe(true);
   });
+
+  it('a Hunt crisis resolving "hunted" (MR3) gets the same triumphant resolution stinger as contained/recovered outcomes', () => {
+    system.start(makeState(), busHelper.bus);
+    const handleCrisisResolved = vi.spyOn((system as any).director, 'handleCrisisResolved');
+
+    busHelper.emit('crisis:resolved', {
+      crisisId: 'crisis-1', flavorId: 'beast-awakening', civId: 'rome', outcome: 'hunted',
+    });
+
+    expect(handleCrisisResolved).toHaveBeenCalled();
+  });
+
+  it('crisis:resolved "abandoned" does not play the triumphant resolution stinger', () => {
+    system.start(makeState(), busHelper.bus);
+    const handleCrisisResolved = vi.spyOn((system as any).director, 'handleCrisisResolved');
+
+    busHelper.emit('crisis:resolved', {
+      crisisId: 'crisis-1', flavorId: 'beast-awakening', civId: 'rome', outcome: 'abandoned',
+    });
+
+    expect(handleCrisisResolved).not.toHaveBeenCalled();
+  });
 });

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -78,6 +78,24 @@ describe('destroyCamp', () => {
     expect(result.reward).toBeGreaterThan(0);
   });
 
+  it('records the killer civ on a Hunt crisis (MR3) when its bandit camp is destroyed', () => {
+    const state = createNewGame('egypt', 'hunt-camp-attribution', 'small');
+    state.barbarianCamps['camp-1'] = {
+      id: 'camp-1', position: { q: 4, r: 4 }, strength: 5, spawnCooldown: 0, banditLordName: 'Test Lord',
+    };
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'bandit-uprising', archetype: 'hunt', targetCivId: 'ai-1',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'camp-1', foeName: 'Test Lord',
+      },
+    };
+
+    const result = applyCampDestruction(state, 'player', 'camp-1', state.turn);
+
+    expect(result.state.activeCrises!['crisis-1'].lastHuntKillerCivId).toBe('player');
+  });
+
   it('completes the matching camp quest at the destruction source', () => {
     const state = createNewGame('egypt', 'camp-quest-source', 'small');
     const minorCivId = Object.keys(state.minorCivs)[0];

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -255,6 +255,56 @@ describe('applyCombatOutcomeToState', () => {
       .not.toContainEqual(expect.objectContaining({ type: 'military_attacked' }));
   });
 
+  it('records the killer civ on a Hunt crisis (MR3) when its beast defender is defeated', () => {
+    const state = makeRewardState();
+    state.units.defender.owner = 'beasts';
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'ai-1',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'defender', foeName: 'Test Beast',
+      },
+    };
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.activeCrises!['crisis-1'].lastHuntKillerCivId).toBe('player');
+  });
+
+  it('does not record hunt-killer attribution for an ordinary (non-hunt) unit kill', () => {
+    const state = makeRewardState();
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'ai-1',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'some-other-unit', foeName: 'Test Beast',
+      },
+    };
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+    expect(applied.state.activeCrises!['crisis-1'].lastHuntKillerCivId).toBeUndefined();
+  });
+
   it('records a recent aggressor in minor-civ diplomacy at the combat source', () => {
     const state = makeRewardState();
     state.units.defender.owner = 'mc-test';

--- a/tests/systems/combat-reward-system.test.ts
+++ b/tests/systems/combat-reward-system.test.ts
@@ -281,6 +281,33 @@ describe('applyCombatOutcomeToState', () => {
     expect(applied.state.activeCrises!['crisis-1'].lastHuntKillerCivId).toBe('player');
   });
 
+  it('does not attribute a hunt kill to a non-major-civ killer (e.g. a barbarian), leaving lastHuntKillerCivId unset so the target-civ fallback still applies at resolution', () => {
+    const state = makeRewardState();
+    state.units.attacker.owner = 'barbarian';
+    state.units.defender.owner = 'beasts';
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'ai-1',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'defender', foeName: 'Test Beast',
+      },
+    };
+    const result: CombatResult = {
+      attackerId: 'attacker',
+      defenderId: 'defender',
+      attackerDamage: 5,
+      defenderDamage: 5,
+      attackerSurvived: true,
+      defenderSurvived: false,
+      attackerPosition: { q: 0, r: 0 },
+      defenderPosition: { q: 1, r: 0 },
+    };
+
+    const applied = applyCombatOutcomeToState(state, result, 64);
+    expect(applied.defenderDefeated).toBe(true);
+    expect(applied.state.activeCrises!['crisis-1'].lastHuntKillerCivId).toBeUndefined();
+  });
+
   it('does not record hunt-killer attribution for an ordinary (non-hunt) unit kill', () => {
     const state = makeRewardState();
     state.activeCrises = {

--- a/tests/systems/crisis-flavor-definitions.test.ts
+++ b/tests/systems/crisis-flavor-definitions.test.ts
@@ -20,10 +20,15 @@ describe('CRISIS_FLAVORS table invariants', () => {
           expect(s.yieldPenalty).toBeLessThanOrEqual(0.5); // balance ceiling
         }
       });
-      it('explorer severity always auto-expires and never costs population', () => {
-        expect(flavor.severityByChallenge.explorer.autoExpireTurns).not.toBeNull();
-        expect(flavor.severityByChallenge.explorer.popLossEveryNTurnsIgnored).toBeNull();
-      });
+      if (flavor.archetype !== 'hunt') {
+        // Hunt flavors resolve via combat (the foe dying), never a turn-count timer or
+        // population attrition, on any challenge level — this invariant is specific to
+        // the attrition/shock archetypes (outbreak, catastrophe).
+        it('explorer severity always auto-expires and never costs population', () => {
+          expect(flavor.severityByChallenge.explorer.autoExpireTurns).not.toBeNull();
+          expect(flavor.severityByChallenge.explorer.popLossEveryNTurnsIgnored).toBeNull();
+        });
+      }
       it('resolves a display name for every era in its band', () => {
         for (let era = flavor.eraBand[0]; era <= flavor.eraBand[1]; era++) {
           expect(getCrisisDisplayName(flavor, era)).toBeTruthy();

--- a/tests/systems/crisis-hunt.test.ts
+++ b/tests/systems/crisis-hunt.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { processCrisisTurn } from '@/systems/crisis-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { hexesInRange, hexKey, hexDistance } from '@/systems/hex-utils';
+import { BEAST_OWNER } from '@/systems/beast-system';
+import type { ActiveCrisis, City, GameState, HexCoord, HexTile, OpponentChallenge } from '@/core/types';
+
+const CITY_POS: HexCoord = { q: 0, r: 0 };
+const LANDMASS = 'landmass-1';
+
+function makeTile(coord: HexCoord, overrides: Partial<HexTile> = {}): HexTile {
+  return {
+    coord,
+    terrain: 'grassland',
+    elevation: 'lowland',
+    resource: null,
+    improvement: 'none',
+    owner: null,
+    improvementTurnsLeft: 0,
+    hasRiver: false,
+    wonder: null,
+    regionKey: LANDMASS,
+    ...overrides,
+  };
+}
+
+function makeHuntFixture({
+  turn = 40,
+  era = 4,
+  challenge = 'standard' as OpponentChallenge,
+  flavorId = 'beast-awakening',
+  stage = 'active' as ActiveCrisis['stage'],
+  turnsInStage = 0,
+  huntEntityId,
+  foeName,
+  lastHuntKillerCivId,
+  includeBarbarianCamp = false,
+  includePirateFleet = false,
+}: {
+  turn?: number;
+  era?: number;
+  challenge?: OpponentChallenge;
+  flavorId?: string;
+  stage?: ActiveCrisis['stage'];
+  turnsInStage?: number;
+  huntEntityId?: string;
+  foeName?: string;
+  lastHuntKillerCivId?: string;
+  includeBarbarianCamp?: boolean;
+  includePirateFleet?: boolean;
+} = {}): { state: GameState; crisisId: string } {
+  const civId = 'p1';
+  const city: City = {
+    id: 'c1', name: 'c1', owner: civId, position: CITY_POS,
+    population: 5, food: 0, foodNeeded: 20, buildings: [], productionQueue: [],
+    productionProgress: 0, ownedTiles: [CITY_POS], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+  };
+
+  const tiles: Record<string, HexTile> = {};
+  // Territory: owned out to distance 2. Distance 3-5 west (forest, unowned) is the
+  // beast-awakening spawn ring. Distance 6+ east is ocean (with a coastal fringe at 5-6)
+  // for the corsair-armada spawn ring, far enough from the city to satisfy the pirate
+  // spawner's own >=5-tiles-from-any-city rule.
+  for (const coord of hexesInRange(CITY_POS, 12)) {
+    const key = hexKey(coord);
+    const dist = hexDistance(coord, CITY_POS);
+    if (dist === 0) {
+      tiles[key] = makeTile(coord, { owner: civId });
+    } else if (dist <= 2) {
+      tiles[key] = makeTile(coord, { owner: civId });
+    } else if (coord.q < 0 && dist <= 6) {
+      tiles[key] = makeTile(coord, { terrain: 'forest' });
+    } else if (coord.q >= 0 && dist >= 6) {
+      tiles[key] = makeTile(coord, { terrain: 'ocean', regionKey: undefined });
+    } else {
+      tiles[key] = makeTile(coord);
+    }
+  }
+
+  const crisisId = 'crisis-1';
+  const crisis: ActiveCrisis = {
+    id: crisisId, flavorId, archetype: 'hunt', targetCivId: civId,
+    cityIds: ['c1'], tileKeys: [], startedTurn: turn - turnsInStage, stage, turnsInStage,
+    ...(huntEntityId ? { huntEntityId } : {}),
+    ...(foeName ? { foeName } : {}),
+    ...(lastHuntKillerCivId ? { lastHuntKillerCivId } : {}),
+  };
+
+  const state: GameState = {
+    turn, era, currentPlayer: civId, gameOver: false, winner: null,
+    map: { width: 40, height: 40, tiles, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: { c1: city },
+    civilizations: {
+      [civId]: {
+        id: civId, name: 'Player', color: '#4a90d9', isHuman: true, civType: 'egypt',
+        cities: ['c1'], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 500, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState([civId, 'killer'], civId),
+        challenge,
+      },
+      killer: {
+        id: 'killer', name: 'Killer', color: '#c2410c', isHuman: false, civType: 'rome',
+        cities: [], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState([civId, 'killer'], 'killer'),
+      },
+    },
+    barbarianCamps: includeBarbarianCamp
+      ? { 'camp-1': { id: 'camp-1', position: { q: -8, r: 8 }, strength: 5, spawnCooldown: 0, banditLordName: 'Old Lord' } }
+      : {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0,
+      tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal',
+    },
+    tribalVillages: {}, discoveredWonders: {}, wonderDiscoverers: {},
+    embargoes: [], defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 2, nextQuestId: 1 },
+    beasts: { mode: 'wild', lairs: {}, sightingsByCiv: {} },
+    activeCrises: { [crisisId]: crisis },
+    ...(includePirateFleet ? { pirateFleets: {} } : {}),
+  } as GameState;
+
+  return { state, crisisId };
+}
+
+describe('hunt crisis — spawn orchestration (MR3)', () => {
+  it('beast-awakening: spawns a beast unit 3-5 tiles from the city, outside its territory, and transitions to menacing', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.stage).toBe('menacing');
+    expect(crisis.huntEntityId).toBeDefined();
+    expect(crisis.foeName).toBeTruthy();
+
+    const beast = next.units[crisis.huntEntityId!];
+    expect(beast).toBeDefined();
+    expect(beast.owner).toBe(BEAST_OWNER);
+    const dist = hexDistance(beast.position, CITY_POS);
+    expect(dist).toBeGreaterThanOrEqual(3);
+    expect(dist).toBeLessThanOrEqual(5);
+    expect(next.map.tiles[hexKey(beast.position)].owner).not.toBe('p1');
+  });
+
+  it('beast-awakening: never spawns on a tile occupied by another unit', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    // Occupy every tile in the legal ring except one, forcing a specific deterministic pick.
+    let occupied = 0;
+    const units: GameState['units'] = {};
+    for (const coord of hexesInRange(CITY_POS, 5)) {
+      const dist = hexDistance(coord, CITY_POS);
+      if (dist < 3 || dist > 5) continue;
+      const tile = state.map.tiles[hexKey(coord)];
+      if (tile?.terrain !== 'forest') continue;
+      occupied += 1;
+      if (occupied <= 5) {
+        const id = `blocker-${occupied}`;
+        units[id] = {
+          id, type: 'warrior', owner: 'killer', position: coord, health: 100,
+          movementPointsLeft: 1, experience: 0,
+        } as GameState['units'][string];
+      }
+    }
+    const blockedState: GameState = { ...state, units };
+    const next = processCrisisTurn(blockedState, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.huntEntityId).toBeDefined();
+    const beast = next.units[crisis.huntEntityId!];
+    for (const blocker of Object.values(units)) {
+      expect(hexKey(blocker.position)).not.toBe(hexKey(beast.position));
+    }
+  });
+
+  it('is deterministic for a fixed seed: same turn/state produces the same spawn position and beast', () => {
+    const { state } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    const a = processCrisisTurn(state, new EventBus());
+    const b = processCrisisTurn(state, new EventBus());
+    const crisisA = a.activeCrises!['crisis-1'];
+    const crisisB = b.activeCrises!['crisis-1'];
+    expect(crisisA.foeName).toBe(crisisB.foeName);
+    expect(a.units[crisisA.huntEntityId!].position).toEqual(b.units[crisisB.huntEntityId!].position);
+  });
+
+  it('bandit-uprising: spawns a barbarian camp with a named lord and transitions to menacing', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'bandit-uprising' });
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.stage).toBe('menacing');
+    expect(crisis.huntEntityId).toBeDefined();
+    expect(crisis.foeName).toBeTruthy();
+    expect(next.barbarianCamps[crisis.huntEntityId!]).toBeDefined();
+    expect(next.barbarianCamps[crisis.huntEntityId!].banditLordName).toBe(crisis.foeName);
+  });
+
+  it('corsair-armada: spawns a pirate fleet with a named captain and transitions to menacing', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'corsair-armada', includePirateFleet: true });
+    const next = processCrisisTurn(state, new EventBus());
+    const crisis = next.activeCrises![crisisId];
+    expect(crisis.stage).toBe('menacing');
+    expect(crisis.huntEntityId).toBeDefined();
+    expect(crisis.foeName).toBeTruthy();
+    const fleet = next.pirateFleets![crisis.huntEntityId!];
+    expect(fleet).toBeDefined();
+    expect(next.units[fleet.unitId]).toBeDefined();
+  });
+
+  it('abandons the hunt when the target city no longer exists', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    const { c1: _removed, ...rest } = state.cities;
+    const cityless: GameState = { ...state, cities: rest };
+    const next = processCrisisTurn(cityless, new EventBus());
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+  });
+});
+
+describe('hunt crisis — resolution, feast, escalation (MR3)', () => {
+  it('resolves "hunted" once the spawned entity is gone, crediting the recorded killer with a feast', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    // Entity already absent from state.units — simulates it having been slain this turn.
+    const next = processCrisisTurn(state, new EventBus());
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+    expect(next.civilizations.killer.feastUntilTurn).toBe(state.turn + 5);
+  });
+
+  it('falls back to the target civ for the feast when no killer was ever attributed', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast',
+    });
+    const next = processCrisisTurn(state, new EventBus());
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+    expect(next.civilizations.p1.feastUntilTurn).toBe(state.turn + 5);
+  });
+
+  it('stays menacing (not resolved) while the spawned beast is still alive', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1, huntEntityId: 'unit-alive',
+    });
+    const alive: GameState = {
+      ...state,
+      units: {
+        'unit-alive': {
+          id: 'unit-alive', type: 'beast_boar', owner: BEAST_OWNER, position: { q: -4, r: 0 },
+          health: 100, movementPointsLeft: 1, experience: 0,
+        } as GameState['units'][string],
+      },
+    };
+    const next = processCrisisTurn(alive, new EventBus());
+    expect(next.activeCrises?.[crisisId]).toBeDefined();
+    expect(next.activeCrises![crisisId].stage).toBe('menacing');
+  });
+
+  it('escalates menacing -> assaulting only on veteran, after 5 turns', () => {
+    const aliveUnits = (): GameState['units'] => ({
+      'unit-alive': {
+        id: 'unit-alive', type: 'beast_boar', owner: BEAST_OWNER, position: { q: -4, r: 0 },
+        health: 100, movementPointsLeft: 1, experience: 0,
+      } as GameState['units'][string],
+    });
+
+    const veteran = makeHuntFixture({
+      flavorId: 'beast-awakening', challenge: 'veteran', stage: 'menacing', turnsInStage: 5, huntEntityId: 'unit-alive',
+    });
+    const veteranState: GameState = { ...veteran.state, units: aliveUnits() };
+    const veteranNext = processCrisisTurn(veteranState, new EventBus());
+    expect(veteranNext.activeCrises![veteran.crisisId].stage).toBe('assaulting');
+
+    const standard = makeHuntFixture({
+      flavorId: 'beast-awakening', challenge: 'standard', stage: 'menacing', turnsInStage: 5, huntEntityId: 'unit-alive',
+    });
+    const standardState: GameState = { ...standard.state, units: aliveUnits() };
+    const standardNext = processCrisisTurn(standardState, new EventBus());
+    expect(standardNext.activeCrises![standard.crisisId].stage).toBe('menacing');
+  });
+});

--- a/tests/systems/crisis-hunt.test.ts
+++ b/tests/systems/crisis-hunt.test.ts
@@ -177,6 +177,27 @@ describe('hunt crisis — spawn orchestration (MR3)', () => {
     }
   });
 
+  it('beast-awakening: never spawns inside a rival civ\'s territory (would otherwise let the rival kill it before the target player gets a turn)', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    // Claim every tile in the entire 3-5 spawn ring for a rival civ — with the old
+    // "only exclude the target's own territory" rule this would all still be legal
+    // (it's not the target's land), but a hunt should never spawn on ANY claimed land.
+    const rivalClaimed: GameState['map']['tiles'] = { ...state.map.tiles };
+    for (const coord of hexesInRange(CITY_POS, 5)) {
+      const dist = hexDistance(coord, CITY_POS);
+      if (dist < 3 || dist > 5) continue;
+      const key = hexKey(coord);
+      const tile = rivalClaimed[key];
+      if (tile && tile.terrain !== 'ocean') {
+        rivalClaimed[key] = { ...tile, owner: 'rival' };
+      }
+    }
+    const rivalState: GameState = { ...state, map: { ...state.map, tiles: rivalClaimed } };
+    const next = processCrisisTurn(rivalState, new EventBus());
+    // No unowned land left in the ring -> abandoned, not spawned onto rival territory.
+    expect(next.activeCrises?.[crisisId]).toBeUndefined();
+  });
+
   it('is deterministic for a fixed seed: same turn/state produces the same spawn position and beast', () => {
     const { state } = makeHuntFixture({ flavorId: 'beast-awakening' });
     const a = processCrisisTurn(state, new EventBus());
@@ -229,6 +250,23 @@ describe('hunt crisis — resolution, feast, escalation (MR3)', () => {
     const next = processCrisisTurn(state, new EventBus());
     expect(next.activeCrises?.[crisisId]).toBeUndefined();
     expect(next.civilizations.killer.feastUntilTurn).toBe(state.turn + 5);
+  });
+
+  it('removes the ephemeral beast lair once the hunt resolves, so map trophy markers do not accumulate forever across many hunts', () => {
+    const { state, crisisId } = makeHuntFixture({ flavorId: 'beast-awakening' });
+    const spawned = processCrisisTurn(state, new EventBus());
+    const crisis = spawned.activeCrises![crisisId];
+    const lairId = `hunt-lair-${crisisId}`;
+    expect(spawned.beasts!.lairs[lairId]).toBeDefined();
+
+    // Simulate the beast being slain: remove its unit (as recordBeastSlain's caller
+    // would after combat), leaving the lair's bookkeeping otherwise untouched.
+    const { [crisis.huntEntityId!]: _removedUnit, ...remainingUnits } = spawned.units;
+    const slainState: GameState = { ...spawned, units: remainingUnits };
+    const resolved = processCrisisTurn(slainState, new EventBus());
+
+    expect(resolved.activeCrises?.[crisisId]).toBeUndefined();
+    expect(resolved.beasts!.lairs[lairId]).toBeUndefined();
   });
 
   it('falls back to the target civ for the feast when no killer was ever attributed', () => {

--- a/tests/systems/crisis-system.test.ts
+++ b/tests/systems/crisis-system.test.ts
@@ -4,14 +4,19 @@ import { processCrisisSchedulerForHumans, countActiveCrisesForCiv, countUnrestGr
 import { makeCrisisFixture } from './helpers/crisis-fixture';
 
 describe('crisis scheduler', () => {
-  it('fires a plague for an idle human past grace', () => {
+  it('fires a crisis for an idle human past grace', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40, challenge: 'standard' });
     const next = processCrisisSchedulerForHumans(state, new EventBus());
     const crises = Object.values(next.activeCrises ?? {});
     expect(crises).toHaveLength(1);
-    expect(crises[0].flavorId).toBe('plague');
+    // This fixture's city (population 5, no forest/mountain/coast/jungle terrain) is
+    // geography-eligible for both 'plague' (population >= 4) and 'bandit-uprising'
+    // (any land city, MR3) — both start with equal anti-repeat weight, and this seed's
+    // weighted pick lands on bandit-uprising. The point of this test is the grace/cooldown
+    // gate and history bookkeeping, not which specific flavor wins the pick.
+    expect(crises[0].flavorId).toBe('bandit-uprising');
     expect(next.civilizations.p1.lastCrisisOnsetTurn).toBe(40);
-    expect(next.civilizations.p1.recentCrisisHistory).toEqual(['plague']);
+    expect(next.civilizations.p1.recentCrisisHistory).toEqual(['bandit-uprising']);
   });
 
   it('respects era grace: no crisis in era 1 for anyone, era 2 for explorer', () => {

--- a/tests/systems/faction-happiness.test.ts
+++ b/tests/systems/faction-happiness.test.ts
@@ -126,4 +126,25 @@ describe('processFactionTurn with happiness', () => {
     const bus = new EventBus();
     expect(() => processFactionTurn(state, bus)).not.toThrow();
   });
+
+  it('beast-slayer\'s feast (MR3 hunt crisis): +2 happiness -> -4 pressure is enough to prevent unrest at a borderline threshold', () => {
+    // Engineered so base pressure (distance 20 capped + war 24 capped = 44) sits just
+    // above UNREST_TRIGGER_PRESSURE (40) — the feast's -4 pressure should be the
+    // difference between unrest starting and not.
+    const base = makeMinimalState({ cityCount: 1, cityPosition: { q: 20, r: 0 }, atWarCount: 3, era: 2 });
+    const bus = new EventBus();
+
+    const withoutFeast = processFactionTurn(base, bus);
+    expect(withoutFeast.cities['city-1'].unrestLevel).toBe(1);
+
+    const withFeast: GameState = {
+      ...base,
+      civilizations: {
+        ...base.civilizations,
+        player: { ...base.civilizations.player, feastUntilTurn: base.turn + 5 },
+      },
+    };
+    const result = processFactionTurn(withFeast, bus);
+    expect(result.cities['city-1'].unrestLevel).toBe(0);
+  });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -20,6 +20,7 @@ import {
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
+  routeCrisisEscalated,
   routeCrisisResolved,
   type NotificationSink,
 } from '@/ui/notification-routing';
@@ -645,5 +646,87 @@ describe('crisis notification routing', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]!.message).toContain('A crisis');
     expect(calls[0]!.type).toBe('info');
+  });
+
+  it('does not route crisis:started for a hunt flavor — the onset announcement waits for the foe to have a name', () => {
+    const state = makeState({
+      era: 2,
+      cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 5, position: { q: 0, r: 0 } } } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeCrisisStarted(state, { crisisId: 'crisis-1', flavorId: 'beast-awakening', civId: 'p1', cityIds: ['c1'] }, sink);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('routes crisis:escalated (stage menacing) as the hunt onset announcement, using the real foe name', () => {
+    const state = makeState({
+      era: 2,
+      cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 5, position: { q: 0, r: 0 } } } as any,
+      activeCrises: {
+        'crisis-1': {
+          id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'p1',
+          cityIds: ['c1'], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 0,
+          huntEntityId: 'unit-1', foeName: 'Giant Boar',
+        },
+      },
+    } as any);
+    const { sink, calls } = makeSink();
+    routeCrisisEscalated(state, { crisisId: 'crisis-1', stage: 'menacing', civId: 'p1', foeName: 'Giant Boar' }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.civId).toBe('p1');
+    expect(calls[0]!.message).toContain('Giant Boar');
+    expect(calls[0]!.message).toContain('Thebes');
+  });
+
+  it('routes crisis:escalated (stage assaulting) as the veteran escalation warning', () => {
+    const state = makeState({
+      cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', population: 5, position: { q: 0, r: 0 } } } as any,
+      activeCrises: {
+        'crisis-1': {
+          id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'p1',
+          cityIds: ['c1'], tileKeys: [], startedTurn: 1, stage: 'assaulting', turnsInStage: 5,
+          huntEntityId: 'unit-1', foeName: 'Giant Boar',
+        },
+      },
+    } as any);
+    const { sink, calls } = makeSink();
+    routeCrisisEscalated(state, { crisisId: 'crisis-1', stage: 'assaulting', civId: 'p1', foeName: 'Giant Boar' }, sink);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.message).toContain('Giant Boar');
+    expect(calls[0]!.message).toContain('assaults');
+  });
+
+  it('routes crisis:resolved (hunted) with two-sided messaging: feast to the killer, notice to the target civ', () => {
+    const state = makeState({
+      civilizations: {
+        p1: { id: 'p1', name: 'Rome' },
+        p2: { id: 'p2', name: 'Egypt' },
+      } as any,
+    });
+    const { sink, calls } = makeSink();
+    routeCrisisResolved(
+      state,
+      { crisisId: 'crisis-1', flavorId: 'beast-awakening', civId: 'p1', outcome: 'hunted', foeName: 'Giant Boar', killerCivId: 'p2' },
+      sink,
+    );
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.civId).toBe('p2');
+    expect(calls[0]!.message).toContain('feast');
+    expect(calls[1]!.civId).toBe('p1');
+    expect(calls[1]!.message).toContain('Giant Boar');
+    expect(calls[1]!.message).toContain('Egypt');
+  });
+
+  it('routes crisis:resolved (hunted) with a single message when the target civ claimed its own hunt', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+    routeCrisisResolved(
+      state,
+      { crisisId: 'crisis-1', flavorId: 'beast-awakening', civId: 'p1', outcome: 'hunted', foeName: 'Giant Boar', killerCivId: 'p1' },
+      sink,
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.civId).toBe('p1');
+    expect(calls[0]!.message).toContain('feast');
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -259,6 +259,78 @@ function makeWorkerState(tileOverrides: Record<string, unknown>, unitOverrides: 
   } as unknown as GameState;
 }
 
+describe('renderSelectedUnitInfo — hunt crisis foe label (MR3)', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows the named foe when the selected unit is a hunt crisis\'s spawned beast', () => {
+    const state = createNewGame(undefined, 'hunt-foe-label-beast', 'small');
+    const beast = {
+      ...createUnit('beast_boar', 'beasts', { q: 3, r: 0 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'beast-1',
+    };
+    state.units = { 'beast-1': beast };
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'beast-awakening', archetype: 'hunt', targetCivId: 'player',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'beast-1', foeName: 'Giant Boar',
+      },
+    };
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'beast-1', {});
+
+    const text = collectAllText(container).join(' ');
+    expect(text).toContain('Giant Boar');
+    expect(text).toContain('Any civilization may claim the hunt');
+  });
+
+  it('shows no hunt foe label for a beast unrelated to any active hunt', () => {
+    const state = createNewGame(undefined, 'hunt-foe-label-none', 'small');
+    const beast = {
+      ...createUnit('beast_boar', 'beasts', { q: 3, r: 0 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'beast-1',
+    };
+    state.units = { 'beast-1': beast };
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'beast-1', {});
+
+    expect(collectAllText(container).join(' ')).not.toContain('claim the hunt');
+  });
+
+  it('shows the named foe when the selected unit is a hunt crisis\'s spawned pirate ship', () => {
+    const state = createNewGame(undefined, 'hunt-foe-label-pirate', 'small');
+    const ship = {
+      ...createUnit('galley', 'pirate', { q: 3, r: 0 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'ship-1',
+    };
+    state.units = { 'ship-1': ship };
+    state.pirateFleets = {
+      'fleet-1': { id: 'fleet-1', unitId: 'ship-1', targetCivId: 'player', targetCityId: 'c1', landmassId: 'l1', era: 1, plunderCooldown: 0 },
+    };
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'corsair-armada', archetype: 'hunt', targetCivId: 'player',
+        cityIds: [], tileKeys: [], startedTurn: 1, stage: 'menacing', turnsInStage: 1,
+        huntEntityId: 'fleet-1', foeName: 'The Reaver',
+      },
+    };
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'ship-1', {});
+
+    expect(collectAllText(container).join(' ')).toContain('The Reaver');
+  });
+});
+
 describe('renderSelectedUnitInfo — spy disguise buttons', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);


### PR DESCRIPTION
## Summary

Part 3 of 5 of the Crisis Events & Revolutionary Movements arc (index #504; MR1 #499 and MR2 #500 merged). Adds the "fight it" archetype: a named foe spawns near a player's borders as a crisis, and any civilization may resolve it by killing the foe — 100% existing beast/barbarian/pirate spawn and combat machinery, no new foe AI.

**Closes #381** — with MR1 (plague/outbreak) + MR2 (catastrophe) + MR3 (hunt) merged, every crisis type from that issue (plague, famine-class outbreaks, eruption/earthquake/flood/wildfire/winter, and now beast/bandit/corsair hunts) is playable. Rebellious-province was deliberately folded into the existing faction/unrest system per the original design doc, not a separate crisis type.

## What's in

- **Three hunt flavors** in `crisis-flavor-definitions.ts`: `beast-awakening` (era 2–6, forest/mountain/jungle within 4 of a city), `bandit-uprising` (era 2–8, any land city), `corsair-armada` (era 4–12, coastal city). All resolve via combat, not a timer — no auto-expiry/pop-loss severity knobs apply.
- **Spawn orchestration** in `crisis-system.ts`, 3–5 tiles from the target city, outside its territory, occupancy-respected, deterministic for a fixed seed:
  - Beast: an era-appropriate beast unit is registered under an ephemeral `BeastLair` so the existing hoard-gold-on-slay path fires normally.
  - Barbarian camp: `spawnBarbarianCamp` with a guaranteed named lord (reusing the existing `BANDIT_LORD_NAMES` pool via a newly-exported `pickBanditName`).
  - Pirate: a fleet via `createPirateFleetNear`, extracted from the organic pirate spawner (`threat-pressure-system.ts`) so both the scheduled and forced paths share one implementation.
- **Resolution**: hunt resolves `hunted` once the foe is gone, regardless of who killed it. Killer attribution lives in a new leaf module `hunt-crisis-linkage.ts`, hooked into the single shared combat-outcome choke point (`combat-reward-system.ts`, covers every combat source — human, AI, beast counter-attack) and into `applyCampDestruction` — deliberately its own module (not imported from `crisis-system.ts`) to avoid an import cycle (`crisis-system.ts` → `beast-system.ts` → `combat-reward-system.ts`).
- **Beast-slayer's feast**: +2 happiness for 5 turns on the killer civ, threaded into `processFactionTurn`'s happiness precompute (−4 pressure via the existing `pressure -= happiness*2` formula).
- **Veteran-only escalation**: `menacing` → `assaulting` after 5 turns alive; explorer/standard never escalate. Target-civ elimination mid-hunt resolves `abandoned` via the same city-capture → `handleCityLeftCiv` path MR1 already wired (no new code needed there).
- **UI**: hunt's onset notification fires at spawn time (`crisis:escalated`, stage `menacing`) rather than `crisis:started`, since the foe doesn't have a name yet when the crisis is first scheduled — carrying `civId`/`foeName` directly on the event payload rather than re-reading from state, since both are set for the first time in the same tick the event fires (mid-turn state snapshots can be stale for that). Resolution notifies the killer civ (feast) and, if different, the target civ (by name). Tapping the spawned beast or pirate ship in `selected-unit-info.ts` shows the named foe.

## Out of scope (later MRs)

- MR4: revolutionary movements (contagion + ideological concession).
- MR5: additional outbreak/hunt flavor breadth.
- A persistent map banner for the foe's name (spec mentions this) — the notification and selected-unit-info paths above satisfy "identify the foe" without a new always-on renderer overlay; organic (non-hunt) bandit lords have no equivalent map label today either, so this isn't a regression.

## Test plan

- [x] `yarn build` — clean, no type errors
- [x] `yarn test` — 5850 passed, 2 skipped, 369 files
- [x] Pacing gate (`pacing-audit.test.ts` + `pacing-reference-economy.test.ts`) — 39 passed, no snapshot drift
- [x] New `tests/systems/crisis-hunt.test.ts` — spawn legality (territory, occupancy, determinism) for all three spawn kinds, abandonment, resolution/feast/escalation
- [x] Killer-attribution regressions in `combat-reward-system.test.ts` and `barbarian-system.test.ts`
- [x] Feast pressure regression in `faction-happiness.test.ts` (engineered borderline-pressure scenario)
- [x] Notification-routing regressions for the new onset/resolution/escalation messages
- [x] Selected-unit-info regressions for the named-foe label

🤖 Generated with [Claude Code](https://claude.com/claude-code)