### PR TITLE
feat(faction): MR4 — uprising contagion + ideological concession

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1723,6 +1723,8 @@ export interface GameEvents {
   'faction:breakaway-established': { civId: string; originOwnerId: string };
   'faction:breakaway-reabsorbed': { civId: string; ownerId: string; cityId: string };
   'faction:critical-status': { cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string };
+  'faction:contagion-spread': { fromCityId: string; toCityId: string; owner: string };
+  'faction:concession-made': { cityId: string; owner: string; concessionType: 'charter' };
   'espionage:spy-promoted': { civId: string; spyId: string; promotion: SpyPromotion };
   'espionage:advisor-assassinated': { targetCivId: string; advisorType: AdvisorType; disabledUntilTurn: number };
   'espionage:documents-forged': { civA: string; civB: string; relationshipPenalty: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,7 +233,7 @@ import { beginCampaignEntry } from '@/ui/campaign-entry-flow';
 import { showLegacyOpponentChallengePrompt } from '@/ui/legacy-opponent-challenge-prompt';
 import { updateAndRefreshVisibility, reconstructLastSeenFromMap } from '@/systems/last-seen-presentation';
 import { calculateCivEconomy, formatGoldHudText, rushBuyActiveProduction } from '@/systems/economy-system';
-import { appeaseFaction } from '@/systems/faction-system';
+import { appeaseFaction, concedeToMovement } from '@/systems/faction-system';
 import { applyQuarantine, applyRemedy } from '@/systems/crisis-system';
 import { createTreasuryDrawer, type TreasuryDrawer } from '@/ui/treasury-drawer';
 import { getCivHappinessFromResources, getCivAvailableResources, canEstablishOutpost, performEstablishOutpost, canBuyResourceAccess, performBuyResourceAccess } from '@/systems/resource-acquisition-system';
@@ -1212,6 +1212,26 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
         return gameState;
       }
       gameState = result.state;
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      showNotification(result.message, 'success');
+      return gameState;
+    },
+    onConcedeToMovement: (cityId) => {
+      const targetCity = gameState.cities[cityId];
+      if (!targetCity) return gameState;
+      const result = concedeToMovement(gameState, cityId, gameState.currentPlayer);
+      if (!result.success) {
+        showNotification(result.message, 'warning');
+        return gameState;
+      }
+      gameState = result.state;
+      // concedeToMovement clears unrestLevel immediately, bypassing the normal
+      // processFactionTurn scan that would emit faction:unrest-resolved — without this,
+      // the music director's unrestCityCount (incremented on faction:unrest-started)
+      // never decrements for this city, leaving the unrest music layer stuck on.
+      bus.emit('faction:unrest-resolved', { cityId, owner: gameState.currentPlayer });
+      bus.emit('faction:concession-made', { cityId, owner: gameState.currentPlayer, concessionType: 'charter' });
       renderLoop.setGameState(gameState);
       updateHUD();
       showNotification(result.message, 'success');
@@ -3960,6 +3980,10 @@ bus.on('faction:revolt-started', event => {
 
 bus.on('faction:unrest-resolved', event => {
   routeFactionTransition(gameState, { type: 'faction:unrest-resolved', ...event }, appendFactionNotice);
+});
+
+bus.on('faction:concession-made', event => {
+  routeFactionTransition(gameState, { type: 'faction:concession-made', ...event }, appendFactionNotice);
 });
 
 bus.on('faction:breakaway-started', event => {

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -8,6 +8,8 @@ import { createBreakawayFromCity } from './breakaway-system';
 import { getEconomyStatusForCiv } from './economy-system';
 import { getCivHappinessFromResources } from './resource-acquisition-system';
 import { getCapitalCity } from './capital-system';
+import { getChallengeProfileForCiv } from '../core/opponent-challenge';
+import { TECH_TREE } from './tech-definitions';
 
 // --- Thresholds ---
 const UNREST_TRIGGER_PRESSURE = 40;
@@ -15,12 +17,20 @@ export const REVOLT_UNREST_TURNS = 5;        // turns at unrest before revolt es
 export const BREAKAWAY_REVOLT_TURNS = 10;    // turns at revolt before breakaway
 const CONQUEST_UNREST_DURATION = 15;         // turns until conquestTurn is cleared
 const GOLD_APPEASE_COST_PER_POP = 15;
+export const CONCESSION_IMMUNITY_TURNS = 15; // uprising: turns of no-new-unrest after conceding
 
 // Pressure caps per category
 const MAX_PRESSURE_EMPIRE = 30;
 const MAX_PRESSURE_DISTANCE = 20;
 const MAX_PRESSURE_WAR = 24;
 const MAX_PRESSURE_ECONOMY = 20;
+
+// Uprising contagion (MR4, issue #354): a same-owner city in open revolt radiates
+// unrest pressure to nearby cities. Garrisoning or concession immunity blocks the
+// *receiving* city from being affected entirely (see getContagionSpread).
+export const CONTAGION_GROUP_RANGE = 3;
+const CONTAGION_PRESSURE_PER_NEIGHBOR = 8;
+const MAX_PRESSURE_CONTAGION = 16;
 
 // --- Pressure computation ---
 
@@ -68,6 +78,8 @@ export function computeUnrestPressure(cityId: string, state: GameState, ownerHap
   // Happiness from luxury resources reduces unrest pressure (2 pressure per happiness point)
   pressure -= ownerHappiness * 2;
 
+  pressure += getContagionSpread(cityId, state).pressure;
+
   return Math.min(100, Math.max(0, pressure));
 }
 
@@ -81,8 +93,93 @@ export function canGarrisonCity(cityId: string, state: GameState): boolean {
   );
 }
 
+// Uprising contagion (MR4): a same-owner city at unrestLevel 2 (revolt) within
+// CONTAGION_GROUP_RANGE hexes radiates pressure to this city, scaled by the
+// *owner's* per-civ challenge profile (resolveChallengeForCiv already resolves AI
+// owners to the game-wide challenge). Skipped entirely — not just reduced — when
+// this city is garrisoned or under concession immunity, matching the spec's
+// "immune to incoming spread" contract.
+export function getContagionSpread(
+  cityId: string,
+  state: GameState,
+): { pressure: number; nearestCityId: string | null } {
+  const city = state.cities[cityId];
+  if (!city) return { pressure: 0, nearestCityId: null };
+  if (canGarrisonCity(cityId, state)) return { pressure: 0, nearestCityId: null };
+  if ((city.concessionImmunityUntilTurn ?? 0) > state.turn) return { pressure: 0, nearestCityId: null };
+
+  const profile = getChallengeProfileForCiv(state, city.owner);
+  let total = 0;
+  let nearestCityId: string | null = null;
+  let nearestDistance = Infinity;
+  for (const [otherId, other] of Object.entries(state.cities)) {
+    if (otherId === cityId || other.owner !== city.owner || other.unrestLevel !== 2) continue;
+    const distance = hexDistance(city.position, other.position);
+    if (distance > CONTAGION_GROUP_RANGE) continue;
+    total += CONTAGION_PRESSURE_PER_NEIGHBOR * profile.crisisSeverityMultiplier;
+    if (distance < nearestDistance) {
+      nearestDistance = distance;
+      nearestCityId = otherId;
+    }
+  }
+  return { pressure: Math.min(MAX_PRESSURE_CONTAGION, total), nearestCityId };
+}
+
 export function getCityAppeaseCost(city: City): number {
   return city.population * GOLD_APPEASE_COST_PER_POP;
+}
+
+// Ideological concession (MR4, issue #354): a permanent resolution alongside gold
+// appeasement. 2x the appeasement cost, halved to 1x if the owner has researched
+// any civics-track tech of the *current* era (rewards civics investment without
+// requiring a specific tech id, so future civics techs qualify automatically).
+export function getConcessionCost(state: GameState, city: City): number {
+  const base = getCityAppeaseCost(city);
+  return hasCurrentEraCivicsTech(state, city.owner) ? base : base * 2;
+}
+
+function hasCurrentEraCivicsTech(state: GameState, civId: string): boolean {
+  const civ = state.civilizations[civId];
+  if (!civ) return false;
+  const completed = new Set(civ.techState.completed);
+  return TECH_TREE.some(tech => tech.track === 'civics' && tech.era === state.era && completed.has(tech.id));
+}
+
+export function concedeToMovement(
+  state: GameState,
+  cityId: string,
+  civId: string,
+): { success: boolean; state: GameState; message: string } {
+  const city = state.cities[cityId];
+  if (!city || city.unrestLevel === 0) {
+    return { success: false, state, message: 'This city has no unrest to concede to.' };
+  }
+  const cost = getConcessionCost(state, city);
+  const civ = state.civilizations[civId];
+  if (!civ || civ.gold < cost) {
+    return { success: false, state, message: `Not enough gold — conceding to ${city.name} costs ${cost}.` };
+  }
+  return {
+    success: true,
+    message: `${city.name} granted a charter for ${cost} gold — immune to unrest for ${CONCESSION_IMMUNITY_TURNS} turns.`,
+    state: {
+      ...state,
+      civilizations: {
+        ...state.civilizations,
+        [civId]: { ...civ, gold: civ.gold - cost },
+      },
+      cities: {
+        ...state.cities,
+        [cityId]: {
+          ...city,
+          unrestLevel: 0,
+          unrestTurns: 0,
+          spyUnrestBonus: 0,
+          concessionImmunityUntilTurn: state.turn + CONCESSION_IMMUNITY_TURNS,
+        },
+      },
+    },
+  };
 }
 
 export function appeaseFaction(
@@ -232,13 +329,22 @@ export function processFactionTurn(state: GameState, bus: EventBus): GameState {
     let updated = { ...currentCity };
 
     if (updated.unrestLevel === 0) {
-      if (pressure > UNREST_TRIGGER_PRESSURE) {
+      const immune = (updated.concessionImmunityUntilTurn ?? 0) > nextState.turn;
+      if (pressure > UNREST_TRIGGER_PRESSURE && !immune) {
         updated = { ...updated, unrestLevel: 1, unrestTurns: 0 };
         nextState = {
           ...nextState,
           cities: { ...nextState.cities, [cityId]: updated },
         };
         bus.emit('faction:unrest-started', { cityId, owner: city.owner });
+        const contagion = getContagionSpread(cityId, nextState);
+        if (contagion.pressure > 0 && contagion.nearestCityId) {
+          bus.emit('faction:contagion-spread', {
+            fromCityId: contagion.nearestCityId,
+            toCityId: cityId,
+            owner: city.owner,
+          });
+        }
       }
     } else if (updated.unrestLevel === 1) {
       const garrisoned = canGarrisonCity(cityId, nextState);

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -25,7 +25,13 @@ import {
 import { getLegendaryLandmarkPreviewViewForCity } from '@/systems/legendary-wonder-landmark-presentation';
 import { canUpgradeUnit, getUpgradeCost } from '@/systems/unit-upgrade-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { getUnrestYieldMultiplier, getCityAppeaseCost, isCityProductionLocked } from '@/systems/faction-system';
+import {
+  getUnrestYieldMultiplier,
+  getCityAppeaseCost,
+  isCityProductionLocked,
+  getContagionSpread,
+  getConcessionCost,
+} from '@/systems/faction-system';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier } from '@/systems/crisis-system';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
@@ -60,6 +66,7 @@ export interface CityPanelCallbacks {
   onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => void;
   onRushBuyActiveProduction?: (cityId: string) => GameState | void;
   onAppeaseFaction?: (cityId: string) => GameState | void;
+  onConcedeToMovement?: (cityId: string) => GameState | void;
   onQuarantineCrisis?: (crisisId: string, cityId: string) => GameState | void;
   onRemedyCrisis?: (crisisId: string, cityId: string) => GameState | void;
   onFindResources?: (
@@ -223,18 +230,41 @@ export function createCityPanel(
   const civGoldForAppease = state.civilizations[city.owner]?.gold ?? 0;
   const appeasedThisTurn = city.appeasedOnTurn === state.turn;
   const canAffordAppease = civGoldForAppease >= appeaseCost;
-  const appeaseDisabled = !canAffordAppease || appeasedThisTurn || !callbacks.onAppeaseFaction;
+  const concessionImmuneTurnsLeft = (city.concessionImmunityUntilTurn ?? 0) - state.turn;
+  const isConcessionImmune = concessionImmuneTurnsLeft > 0;
+  const appeaseDisabled = !canAffordAppease || appeasedThisTurn || isConcessionImmune || !callbacks.onAppeaseFaction;
   const appeaseLabel = appeasedThisTurn
     ? 'Already appeased this turn'
     : !canAffordAppease
       ? `Not enough gold (needs ${appeaseCost})`
       : `Appease (${appeaseCost} gold)`;
+  const concessionCost = getConcessionCost(state, city);
+  const canAffordConcession = civGoldForAppease >= concessionCost;
+  const concedeDisabled = !canAffordConcession || isConcessionImmune || !callbacks.onConcedeToMovement;
+  const concedeLabel = !canAffordConcession
+    ? `Not enough gold (needs ${concessionCost})`
+    : `Concede (${concessionCost} gold)`;
+  // Uprising contagion (MR4): only shown when the term is actually > 0 for THIS city —
+  // garrisoning or concession immunity zero out getContagionSpread entirely, so this
+  // stays honest rather than a blanket "any revolting civ city" check.
+  const contagionSpread = getContagionSpread(city.id, state);
+  const contagionSourceCity = contagionSpread.nearestCityId ? state.cities[contagionSpread.nearestCityId] : null;
+  const showSpreadWarning = contagionSpread.pressure > 0 && contagionSourceCity !== null;
+  const spreadWarningHtml = showSpreadWarning ? `
+    <div style="background:rgba(217,80,80,0.10);border:1px solid rgba(217,80,80,0.3);border-radius:8px;padding:8px 12px;margin-bottom:16px;font-size:12px;color:#e88;" data-text="contagion-spread-warning"></div>` : '';
+  const immunitySectionHtml = isConcessionImmune ? `
+    <div style="background:rgba(74,144,217,0.12);border:1px solid rgba(74,144,217,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
+      <div style="font-weight:bold;color:#7fb3e8;">🕊️ Immune to unrest for ${concessionImmuneTurnsLeft} more turn${concessionImmuneTurnsLeft === 1 ? '' : 's'}</div>
+    </div>` : '';
   const unrestSectionHtml = city.unrestLevel > 0 ? `
     <div style="background:rgba(217,80,80,0.12);border:1px solid rgba(217,80,80,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
       <div style="font-weight:bold;color:#e88;margin-bottom:4px;">
         ${city.unrestLevel === 2 ? '⚠️ Revolt' : '⚠️ Unrest'} — yields reduced${isCityProductionLocked(city) ? ', production locked' : ''}
       </div>
-      <button type="button" data-appease="${city.id}" ${appeaseDisabled ? 'disabled' : ''} title="${appeaseLabel}" style="min-height:44px;padding:7px 12px;border-radius:6px;font-size:12px;font-weight:bold;cursor:${appeaseDisabled ? 'default' : 'pointer'};background:${appeaseDisabled ? 'rgba(255,255,255,0.08)' : '#d4aa2c'};color:${appeaseDisabled ? 'rgba(255,255,255,0.4)' : '#1a1a1a'};border:none;">${appeaseLabel}</button>
+      <div style="display:flex;gap:8px;flex-wrap:wrap;">
+        <button type="button" data-appease="${city.id}" ${appeaseDisabled ? 'disabled' : ''} title="${appeaseLabel}" style="min-height:44px;padding:7px 12px;border-radius:6px;font-size:12px;font-weight:bold;cursor:${appeaseDisabled ? 'default' : 'pointer'};background:${appeaseDisabled ? 'rgba(255,255,255,0.08)' : '#d4aa2c'};color:${appeaseDisabled ? 'rgba(255,255,255,0.4)' : '#1a1a1a'};border:none;">${appeaseLabel}</button>
+        <button type="button" data-concede="${city.id}" ${concedeDisabled ? 'disabled' : ''} title="${concedeLabel}" style="min-height:44px;padding:7px 12px;border-radius:6px;font-size:12px;font-weight:bold;cursor:${concedeDisabled ? 'default' : 'pointer'};background:${concedeDisabled ? 'rgba(255,255,255,0.08)' : '#4a90d9'};color:${concedeDisabled ? 'rgba(255,255,255,0.4)' : '#fff'};border:none;">${concedeLabel}</button>
+      </div>
     </div>` : '';
   // Post-catastrophe reward: transient, and the crisis itself may already be gone from
   // activeCrises by the time this is active — must render on its own, not piggyback on
@@ -641,6 +671,8 @@ export function createCityPanel(
       <span>Net treasury: ${economyStatus.netGoldPerTurn >= 0 ? '+' : ''}${economyStatus.netGoldPerTurn}/turn</span>
       ${economyStatus.strainLevel !== 'none' ? '<span style="color:#d9a25c;" data-text="economy-strain"></span>' : ''}
     </div>
+    ${immunitySectionHtml}
+    ${spreadWarningHtml}
     ${unrestSectionHtml}
     ${crisisSectionHtml}
     ${catastropheSectionHtml}
@@ -690,6 +722,13 @@ export function createCityPanel(
   setText('yield-prod', String(yields.production));
   setText('yield-gold', String(yields.gold));
   setText('yield-science', String(yields.science));
+
+  if (showSpreadWarning && contagionSourceCity) {
+    setText(
+      'contagion-spread-warning',
+      `Unrest is spreading from ${contagionSourceCity.name} (+${Math.round(contagionSpread.pressure)} pressure/turn) — garrison a unit to block it.`,
+    );
+  }
 
   crisisChips.forEach((chip, idx) => {
     const displayName = getCrisisDisplayName(chip.flavor, state.era);
@@ -1056,6 +1095,14 @@ export function createCityPanel(
     btn.addEventListener('click', () => {
       if (btn.disabled) return;
       const nextState = callbacks.onAppeaseFaction?.(city.id);
+      rerenderPanel(nextState);
+    });
+  });
+
+  panel.querySelectorAll<HTMLButtonElement>('[data-concede]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (btn.disabled) return;
+      const nextState = callbacks.onConcedeToMovement?.(city.id);
       rerenderPanel(nextState);
     });
   });

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -3,7 +3,7 @@ import { collectEvent } from '@/core/hotseat-events';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
-import { REVOLT_UNREST_TURNS, BREAKAWAY_REVOLT_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
+import { REVOLT_UNREST_TURNS, BREAKAWAY_REVOLT_TURNS, CONCESSION_IMMUNITY_TURNS, getCityAppeaseCost } from '@/systems/faction-system';
 import { getLegendaryWonderNotification } from '@/ui/legendary-wonder-notifications';
 import { describeDroppedProductionItem } from '@/systems/city-system';
 import type { NotificationEntry } from '@/core/notification-log';
@@ -23,7 +23,8 @@ type FactionTransitionEvent =
   | { type: 'faction:unrest-resolved'; cityId: string; owner: string }
   | { type: 'faction:breakaway-started'; cityId: string; oldOwner: string; breakawayId: string }
   | { type: 'faction:breakaway-established'; civId: string; originOwnerId: string }
-  | { type: 'faction:critical-status'; cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string };
+  | { type: 'faction:critical-status'; cityId: string; owner: string; status: 'unrest' | 'revolt' | 'breakaway'; breakawayId?: string }
+  | { type: 'faction:concession-made'; cityId: string; owner: string; concessionType: 'charter' };
 
 type TerritoryTileFlippedRoutingEvent =
   GameEvents['territory:tile-flipped'] & { type: 'territory:tile-flipped' };
@@ -140,6 +141,16 @@ export function routeFactionTransition(
       event.owner,
       `${city?.name ?? 'A city'} is still in secession${turnsLeft > 0 ? ` (${turnsLeft} turns before establishment)` : ''}.`,
       'warning',
+    );
+    return;
+  }
+
+  if (event.type === 'faction:concession-made') {
+    const city = state.cities[event.cityId];
+    sink(
+      event.owner,
+      `${city?.name ?? 'A city'} has been granted a charter — immune to unrest for ${CONCESSION_IMMUNITY_TURNS} turns.`,
+      'success',
     );
     return;
   }

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -5,10 +5,14 @@ import { createDiplomacyState } from '@/systems/diplomacy-system';
 import {
   REVOLT_UNREST_TURNS,
   BREAKAWAY_REVOLT_TURNS,
+  CONCESSION_IMMUNITY_TURNS,
   appeaseFaction,
   canGarrisonCity,
   computeUnrestPressure,
+  concedeToMovement,
   getCityAppeaseCost,
+  getConcessionCost,
+  getContagionSpread,
   getUnrestYieldMultiplier,
   isCityProductionLocked,
   processFactionTurn,
@@ -609,5 +613,237 @@ describe('faction-system constant exports and era-gating', () => {
     const result = processFactionTurn(state, bus);
     // With pressure > 40 and no garrison, city stays in unrest (not cleared by clearEraOneUnrest)
     expect(result.cities['city-1']?.unrestLevel).not.toBe(0);
+  });
+});
+
+describe('faction-system — MR4 uprising contagion + concession', () => {
+  // city-1 sits at {q:0,r:0}; adds a same-owner neighbor at {q:2,r:0} (hex distance 2,
+  // within CONTAGION_GROUP_RANGE=3) already in revolt, so city-1 is the contagion receiver.
+  function withRevoltingNeighbor(state: GameState, overrides: Partial<City> = {}): GameState {
+    const neighbor: City = {
+      id: 'city-2',
+      name: 'city-2',
+      owner: 'player',
+      position: { q: 2, r: 0 },
+      population: 4,
+      food: 0,
+      foodNeeded: 20,
+      buildings: [],
+      productionQueue: [],
+      productionProgress: 0,
+      ownedTiles: [],
+      workedTiles: [],
+      focus: 'balanced',
+      maturity: 'outpost',
+      unrestLevel: 2,
+      unrestTurns: 5,
+      spyUnrestBonus: 0,
+      ...overrides,
+    };
+    return {
+      ...state,
+      cities: { ...state.cities, [neighbor.id]: neighbor },
+      civilizations: {
+        ...state.civilizations,
+        player: { ...state.civilizations['player'], cities: [...state.civilizations['player'].cities, neighbor.id] },
+      },
+    };
+  }
+
+  describe('getContagionSpread / computeUnrestPressure contagion term', () => {
+    it('adds pressure from a same-owner revolting neighbor within range', () => {
+      const state = withRevoltingNeighbor(makeState({ era: 2 }));
+      const spread = getContagionSpread('city-1', state);
+      expect(spread.pressure).toBeGreaterThan(0);
+      expect(spread.nearestCityId).toBe('city-2');
+      // standard challenge: 8 * 1.0 multiplier = 8
+      expect(spread.pressure).toBe(8);
+    });
+
+    it('is skipped entirely when the receiving city is garrisoned', () => {
+      const state = withRevoltingNeighbor(
+        makeState({ era: 2, unitPositions: [{ q: 0, r: 0 }] }),
+      );
+      const spread = getContagionSpread('city-1', state);
+      expect(spread.pressure).toBe(0);
+      expect(spread.nearestCityId).toBeNull();
+    });
+
+    it('is skipped entirely during concession immunity', () => {
+      let state = withRevoltingNeighbor(makeState({ era: 2 }));
+      state = {
+        ...state,
+        cities: {
+          ...state.cities,
+          'city-1': { ...state.cities['city-1'], concessionImmunityUntilTurn: state.turn + 5 },
+        },
+      };
+      const spread = getContagionSpread('city-1', state);
+      expect(spread.pressure).toBe(0);
+      expect(spread.nearestCityId).toBeNull();
+    });
+
+    it('halves the term for an explorer-challenge owner', () => {
+      let state = withRevoltingNeighbor(makeState({ era: 2 }));
+      state = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          player: { ...state.civilizations['player'], challenge: 'explorer' },
+        },
+      };
+      const spread = getContagionSpread('city-1', state);
+      // explorer multiplier 0.5: 8 * 0.5 = 4
+      expect(spread.pressure).toBe(4);
+    });
+
+    it('resolves AI-owned cities to the game-wide challenge, not a per-civ setting', () => {
+      let state = withRevoltingNeighbor(makeState({ era: 2 }), { owner: 'ai-1' });
+      state = {
+        ...state,
+        cities: {
+          ...state.cities,
+          'city-1': { ...state.cities['city-1'], owner: 'ai-1' },
+        },
+        opponentChallenge: 'veteran',
+      };
+      const spread = getContagionSpread('city-1', state);
+      // ai-1 is not human, so it must resolve to state.opponentChallenge ('veteran': 1.3x)
+      // rather than any per-civ `challenge` field, even if one were set on it.
+      expect(spread.pressure).toBeCloseTo(8 * 1.3, 5);
+    });
+
+    it('contributes to computeUnrestPressure total', () => {
+      const withNeighbor = withRevoltingNeighbor(makeState({ era: 2 }));
+      const withoutNeighbor = makeState({ era: 2 });
+      expect(computeUnrestPressure('city-1', withNeighbor)).toBe(
+        computeUnrestPressure('city-1', withoutNeighbor) + 8,
+      );
+    });
+
+    it('emits faction:contagion-spread exactly once on crossing into unrest, not every turn', () => {
+      const bus = new EventBus();
+      const events: Array<{ fromCityId: string; toCityId: string }> = [];
+      bus.on('faction:contagion-spread', payload => events.push(payload));
+
+      // conquestTurn:0 + spyUnrestBonus:20 alone already crosses the trigger threshold
+      // (same recipe as the "starts unrest" test above: 25 + 20 = 45 > 40); contagion
+      // (+8) rides along on the same crossing rather than being required to cause it.
+      const state = withRevoltingNeighbor(
+        makeState({ era: 2, conquestTurn: 0, spyUnrestBonus: 20 }),
+      );
+      const afterFirstTurn = processFactionTurn(state, bus);
+      expect(afterFirstTurn.cities['city-1'].unrestLevel).toBe(1);
+      expect(events).toEqual([{ fromCityId: 'city-2', toCityId: 'city-1', owner: 'player' }]);
+
+      // Second turn: city-1 is already at unrestLevel 1 (not crossing from 0), so no
+      // second contagion-spread event should fire even though the neighbor still radiates.
+      const afterSecondTurn = processFactionTurn(afterFirstTurn, bus);
+      expect(afterSecondTurn.cities['city-1'].unrestLevel).not.toBe(0);
+      expect(events).toEqual([{ fromCityId: 'city-2', toCityId: 'city-1', owner: 'player' }]);
+    });
+
+    it('blocks new unrest from starting entirely while a city is under concession immunity', () => {
+      const bus = new EventBus();
+      let state = makeState({ era: 2, conquestTurn: 0, spyUnrestBonus: 20 });
+      state = {
+        ...state,
+        cities: {
+          ...state.cities,
+          'city-1': { ...state.cities['city-1'], concessionImmunityUntilTurn: state.turn + 5 },
+        },
+      };
+      const result = processFactionTurn(state, bus);
+      expect(result.cities['city-1'].unrestLevel).toBe(0);
+    });
+  });
+
+  describe('getConcessionCost / concedeToMovement', () => {
+    it('costs 2x the appeasement cost by default', () => {
+      const state = makeState({ unrestLevel: 2 });
+      const city = state.cities['city-1'];
+      expect(getConcessionCost(state, city)).toBe(getCityAppeaseCost(city) * 2);
+    });
+
+    it('halves to 1x when the owner has completed a current-era civics tech', () => {
+      let state = makeState({ era: 3, unrestLevel: 2 });
+      state = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          player: {
+            ...state.civilizations['player'],
+            techState: { ...state.civilizations['player'].techState, completed: ['civil-service'] },
+          },
+        },
+      };
+      const city = state.cities['city-1'];
+      expect(getConcessionCost(state, city)).toBe(getCityAppeaseCost(city));
+    });
+
+    it('does not discount for a civics tech from a different era', () => {
+      let state = makeState({ era: 2, unrestLevel: 2 });
+      state = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          // civil-service is era 3, but the civ is currently era 2
+          player: {
+            ...state.civilizations['player'],
+            techState: { ...state.civilizations['player'].techState, completed: ['civil-service'] },
+          },
+        },
+      };
+      const city = state.cities['city-1'];
+      expect(getConcessionCost(state, city)).toBe(getCityAppeaseCost(city) * 2);
+    });
+
+    it('fully clears unrest and sets immunity on success', () => {
+      let state = makeState({ unrestLevel: 2, unrestTurns: 8, spyUnrestBonus: 12 });
+      // Concession costs 2x appeasement (120 for a pop-4 city) — the default 100 gold isn't enough.
+      state = { ...state, civilizations: { ...state.civilizations, player: { ...state.civilizations['player'], gold: 1000 } } };
+      const result = concedeToMovement(state, 'city-1', 'player');
+      expect(result.success).toBe(true);
+      const city = result.state.cities['city-1'];
+      expect(city.unrestLevel).toBe(0);
+      expect(city.unrestTurns).toBe(0);
+      expect(city.spyUnrestBonus).toBe(0);
+      expect(city.concessionImmunityUntilTurn).toBe(state.turn + CONCESSION_IMMUNITY_TURNS);
+    });
+
+    it('fails with no unrest to concede', () => {
+      const state = makeState({ unrestLevel: 0 });
+      const result = concedeToMovement(state, 'city-1', 'player');
+      expect(result.success).toBe(false);
+    });
+
+    it('fails when the civ cannot afford the cost', () => {
+      let state = makeState({ unrestLevel: 2 });
+      state = {
+        ...state,
+        civilizations: { ...state.civilizations, player: { ...state.civilizations['player'], gold: 0 } },
+      };
+      const result = concedeToMovement(state, 'city-1', 'player');
+      expect(result.success).toBe(false);
+    });
+
+    it('prevents new unrest from starting again while immunity is active (integration)', () => {
+      const bus = new EventBus();
+      let state = makeState({ unrestLevel: 2, unrestTurns: 8, cityCount: 21, atWarCount: 3 });
+      state = { ...state, civilizations: { ...state.civilizations, player: { ...state.civilizations['player'], gold: 1000 } } };
+      const conceded = concedeToMovement(state, 'city-1', 'player');
+      expect(conceded.success).toBe(true);
+      const result = processFactionTurn(conceded.state, bus);
+      expect(result.cities['city-1'].unrestLevel).toBe(0);
+    });
+
+    it('leaves appeasement available and unchanged (still suppresses, not permanent)', () => {
+      const state = makeState({ unrestLevel: 2, unrestTurns: 5 });
+      const result = appeaseFaction(state, 'city-1', 'player');
+      expect(result.success).toBe(true);
+      // Appease only downgrades revolt to unrest — it does not fully clear it or set immunity.
+      expect(result.state.cities['city-1'].unrestLevel).toBe(1);
+      expect(result.state.cities['city-1'].concessionImmunityUntilTurn).toBeUndefined();
+    });
   });
 });

--- a/tests/ui/city-panel-uprising.test.ts
+++ b/tests/ui/city-panel-uprising.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createCityPanel } from '@/ui/city-panel';
+import { concedeToMovement, getCityAppeaseCost, getConcessionCost } from '@/systems/faction-system';
+import { makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
+import type { City, GameState } from '@/core/types';
+
+function clickElement(element: Element | null | undefined): void {
+  expect(element).toBeTruthy();
+  element!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+// city-river sits at {q:2,r:2}; adds a same-owner neighbor at {q:4,r:2} (hex distance 2,
+// within contagion range) already in open revolt, so city-river is the spread receiver.
+function withRevoltingNeighbor(state: GameState, city: City) {
+  const neighbor: City = {
+    ...city,
+    id: 'city-neighbor',
+    name: 'Neighborton',
+    position: { q: 4, r: 2 },
+    unrestLevel: 2,
+    unrestTurns: 5,
+  };
+  return {
+    ...state,
+    cities: { ...state.cities, [neighbor.id]: neighbor },
+    civilizations: {
+      ...state.civilizations,
+      [city.owner]: {
+        ...state.civilizations[city.owner],
+        cities: [...state.civilizations[city.owner].cities, neighbor.id],
+      },
+    },
+  };
+}
+
+describe('city-panel uprising contagion + concession (MR4)', () => {
+  it('shows a spread warning naming the revolting neighbor when this city is stable and ungarrisoned', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const withNeighbor = withRevoltingNeighbor(state, city);
+
+    const panel = createCityPanel(container, city, withNeighbor, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Unrest is spreading from Neighborton');
+    expect(panel.textContent).toContain('garrison a unit to block it');
+  });
+
+  it('does not show a spread warning when this city is garrisoned (negative test)', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const withNeighbor = withRevoltingNeighbor(state, city);
+    const garrisoned = {
+      ...withNeighbor,
+      units: {
+        ...withNeighbor.units,
+        'unit-garrison': {
+          id: 'unit-garrison', type: 'warrior' as const, owner: city.owner, position: city.position,
+          movementPointsLeft: 2, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+        },
+      },
+    };
+
+    const panel = createCityPanel(container, city, garrisoned, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).not.toContain('Unrest is spreading');
+  });
+
+  it('does not show a spread warning when this city is under concession immunity (negative test)', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const withNeighbor = withRevoltingNeighbor(state, city);
+    const immuneCity = { ...city, concessionImmunityUntilTurn: withNeighbor.turn + 5 };
+    const withImmunity = { ...withNeighbor, cities: { ...withNeighbor.cities, [city.id]: immuneCity } };
+
+    const panel = createCityPanel(container, immuneCity, withImmunity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).not.toContain('Unrest is spreading');
+  });
+
+  it('shows both Appease and Concede buttons on a revolting city, with cost labels', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const revolting = { ...city, unrestLevel: 2 as const, unrestTurns: 6 };
+    const withCity = { ...state, cities: { ...state.cities, [city.id]: revolting } };
+    withCity.civilizations[city.owner].gold = 1000;
+
+    const panel = createCityPanel(container, revolting, withCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onAppeaseFaction: vi.fn(() => withCity),
+      onConcedeToMovement: vi.fn(() => withCity),
+    });
+
+    const appeaseCost = getCityAppeaseCost(revolting);
+    const concedeCost = getConcessionCost(withCity, revolting);
+    expect(panel.textContent).toContain(`Appease (${appeaseCost} gold)`);
+    expect(panel.textContent).toContain(`Concede (${concedeCost} gold)`);
+  });
+
+  it('disables Concede with a gold-specific reason when unaffordable', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const revolting = { ...city, unrestLevel: 2 as const, unrestTurns: 6 };
+    const withCity = { ...state, cities: { ...state.cities, [city.id]: revolting } };
+    withCity.civilizations[city.owner].gold = 0;
+
+    const panel = createCityPanel(container, revolting, withCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onConcedeToMovement: vi.fn(() => withCity),
+    });
+
+    const btn = panel.querySelector<HTMLButtonElement>('[data-concede]');
+    expect(btn?.disabled).toBe(true);
+    expect(panel.textContent).toContain('Not enough gold');
+  });
+
+  it('tapping Concede clears the unrest chip, deducts gold, and shows the immunity note', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const revolting = { ...city, unrestLevel: 2 as const, unrestTurns: 6 };
+    let withCity = { ...state, cities: { ...state.cities, [city.id]: revolting } };
+    withCity.civilizations[city.owner].gold = 1000;
+    const onConcedeToMovement = vi.fn((cityId: string) => {
+      const result = concedeToMovement(withCity, cityId, city.owner);
+      withCity = result.state;
+      return result.state;
+    });
+
+    const panel = createCityPanel(container, revolting, withCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onConcedeToMovement,
+    });
+
+    clickElement(panel.querySelector('[data-concede]'));
+    expect(onConcedeToMovement).toHaveBeenCalledWith(city.id);
+
+    const rerendered = container.querySelector('[id="city-panel"]')!;
+    expect(rerendered.textContent).toContain('Immune to unrest for 15 more turns');
+    expect(rerendered.querySelector('[data-appease]')).toBeNull();
+    expect(rerendered.querySelector('[data-concede]')).toBeNull();
+    expect(withCity.civilizations[city.owner].gold).toBeLessThan(1000);
+  });
+
+  it('hides both Appease and Concede, and shows the immunity note, while under concession immunity', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    const immuneCity = { ...city, unrestLevel: 0 as const, concessionImmunityUntilTurn: state.turn + 10 };
+    const withCity = { ...state, cities: { ...state.cities, [city.id]: immuneCity } };
+
+    const panel = createCityPanel(container, immuneCity, withCity, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onAppeaseFaction: vi.fn(() => withCity),
+      onConcedeToMovement: vi.fn(() => withCity),
+    });
+
+    expect(panel.textContent).toContain('Immune to unrest for 10 more turns');
+    expect(panel.querySelector('[data-appease]')).toBeNull();
+    expect(panel.querySelector('[data-concede]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Part 4 of 5 of the Crisis Events & Revolutionary Movements arc (#504). The two pieces of #354 not already covered by the existing unrest→revolt→breakaway pipeline: same-owner city-to-city contagion and a permanent ideological-concession resolution path. No second unrest score — extends `faction-system.ts` directly, per spec Key Decision 1.

## Changes

- **Contagion pressure term** (`computeUnrestPressure` + new `getContagionSpread`): each same-owner city at `unrestLevel === 2` within 3 hexes adds `+8 × owner's crisisSeverityMultiplier` pressure, capped at 16. Fully skipped (not just reduced) when the receiving city is garrisoned or under concession immunity. `processFactionTurn` emits `faction:contagion-spread` once on crossing into unrest (the existing `faction:unrest-started` still fires — music unrest counters stay correct automatically).
- **Ideological concession** (`getConcessionCost` + `concedeToMovement`): 2× the appeasement cost, halved to 1× if the civ has completed any `track === 'civics'` tech of the current era. Fully clears `unrestLevel`/`unrestTurns`/`spyUnrestBonus` and sets `concessionImmunityUntilTurn = turn + 15`; `processFactionTurn` now blocks new unrest from starting on an immune city. Appeasement is unchanged — still the cheap suppress-only option.
- **City panel**: incoming-spread warning shown only when the contagion term is actually `> 0` for that city (negative tests for garrison + immunity boundaries), a Concede button next to Appease with cost/disabled-reason, and a standalone immunity note (Appease and Concede both absent while immune).
- **Audio consistency fix**: `concedeToMovement` clears unrest immediately, bypassing the per-turn scan that normally emits `faction:unrest-resolved`. Without also emitting that event from `main.ts`'s `onConcedeToMovement`, the music director's `unrestCityCount` (incremented on `faction:unrest-started`) would never decrement for a conceded city, leaving the unrest music layer stuck on. Fixed by emitting both `faction:unrest-resolved` and `faction:concession-made`.

## Test plan

- [x] `tests/systems/faction-system.test.ts` — contagion term (adds for revolt-neighbor, garrison-immune, concession-immune, explorer multiplier halves it, AI-owner resolves to game-wide challenge, contributes to `computeUnrestPressure`, fires once on crossing not every turn), concession (2x/1x cost, full clear + immunity, no-unrest/no-gold failure paths, immunity blocks new unrest end-to-end, appease unchanged)
- [x] `tests/ui/city-panel-uprising.test.ts` — full player truth table: spread warning shown/hidden (garrison + immunity negatives), Appease+Concede cost labels, Concede disabled when unaffordable, clicking Concede clears the chip + deducts gold + shows the immunity note + hides both buttons, immunity-alone state hides both buttons
- [x] `yarn build` — passes
- [x] `yarn test` — 370 files, 5878 passed, 2 skipped (full suite, no regressions)

Closes #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)