### PR TITLE
feat(crisis): MR5 — flavor breadth pass (blight, locusts, red tide, dire pack, kraken)

### DIFF
--- a/src/systems/crisis-flavor-definitions.ts
+++ b/src/systems/crisis-flavor-definitions.ts
@@ -76,6 +76,15 @@ function isCoastalCity(state: GameState, city: City): boolean {
   return nearTerrain(state, city, ['ocean', 'coast'], 1);
 }
 
+function countFarmsInTerritory(state: GameState, city: City): number {
+  return city.ownedTiles.filter(coord => state.map.tiles[hexKey(coord)]?.improvement === 'farm').length;
+}
+
+function isPlainsOrGrasslandCity(state: GameState, city: City): boolean {
+  const cityTile = state.map.tiles[hexKey(city.position)];
+  return cityTile?.terrain === 'plains' || cityTile?.terrain === 'grassland';
+}
+
 // No severity-driven yield penalty, pop loss, or auto-expiry for Hunt flavors — the
 // archetype resolves via combat (the foe dying), not attrition or a timer. Shared
 // across all three hunt flavors since none of them vary this by challenge level;
@@ -99,7 +108,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.25, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
       veteran:  { yieldPenalty: 0.35, popLossEveryNTurnsIgnored: 3,    autoExpireTurns: null },
     },
-    displayNamesByEra: { 2: 'The Sweating Sickness', 4: 'The Great Pestilence', 6: 'Cholera Outbreak', 9: 'Influenza Pandemic' },
+    displayNamesByEra: { 2: 'The Sweating Sickness', 4: 'The Great Pestilence', 6: 'Cholera Outbreak', 9: 'Influenza Pandemic', 11: 'The Novel Contagion' },
     advisorLine: '{name} has reached {city}! Quarantine the city to stop the spread, or fund a remedy effort to cure it.',
     responseActions: ['quarantine', 'remedy'],
   },
@@ -113,7 +122,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
       veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
     },
-    displayNamesByEra: { 2: 'The Mountain of Fire Wakes', 7: 'Cataclysmic Eruption' },
+    displayNamesByEra: { 2: 'The Mountain of Fire Wakes', 5: 'The Fire Below Stirs', 7: 'Cataclysmic Eruption', 10: 'The Ash-Choked Sky' },
     advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
     responseActions: [],
     catastrophe: {
@@ -132,7 +141,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
       veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
     },
-    displayNamesByEra: { 2: 'The Ground Trembles', 8: 'The Great Quake' },
+    displayNamesByEra: { 2: 'The Ground Trembles', 5: 'The Shaking Earth', 8: 'The Great Quake', 11: 'The Seismic Collapse' },
     advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
     responseActions: [],
     catastrophe: {
@@ -151,7 +160,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
       veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
     },
-    displayNamesByEra: { 2: 'The River Rises', 6: 'The Hundred-Year Flood' },
+    displayNamesByEra: { 2: 'The River Rises', 6: 'The Hundred-Year Flood', 9: 'The Levee Breaks' },
     advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
     responseActions: [],
     catastrophe: {
@@ -170,7 +179,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
       veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
     },
-    displayNamesByEra: { 2: 'Fire on the Wind', 9: 'Megafire' },
+    displayNamesByEra: { 2: 'Fire on the Wind', 5: 'The Dry Season Burns', 9: 'Megafire' },
     advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
     responseActions: [],
     catastrophe: {
@@ -189,7 +198,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       standard: { yieldPenalty: 0.20, popLossEveryNTurnsIgnored: null, autoExpireTurns: 8 },
       veteran:  { yieldPenalty: 0.30, popLossEveryNTurnsIgnored: null, autoExpireTurns: 10 },
     },
-    displayNamesByEra: { 2: 'The Long Winter', 5: 'The Little Ice Age' },
+    displayNamesByEra: { 2: 'The Long Winter', 5: 'The Little Ice Age', 8: 'The Killing Frost' },
     advisorLine: '{name} strikes near {city}! Send workers to restore the land within 5 turns for a resilience bonus.',
     responseActions: [],
     catastrophe: {
@@ -208,7 +217,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
       // save mid-migration), not "on by default".
       !!state.beasts && state.beasts.mode !== 'off' && nearTerrain(state, city, ['forest', 'mountain', 'jungle'], 4),
     severityByChallenge: NO_ATTRITION_SEVERITY,
-    displayNamesByEra: { 2: 'Beast Awakening' },
+    displayNamesByEra: { 2: 'Beast Awakening', 4: 'The Old Terror Wakes', 6: 'The Ancient Stirring' },
     advisorLine: '{name} has awoken near {city}! Slay it to end the threat — any civilization may claim the hunt.',
     responseActions: [],
     hunt: { spawnKind: 'beast' },
@@ -219,7 +228,7 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
     eraBand: [2, 8],
     geographyPredicate: () => true,
     severityByChallenge: NO_ATTRITION_SEVERITY,
-    displayNamesByEra: { 2: 'Bandit Uprising' },
+    displayNamesByEra: { 2: 'Bandit Uprising', 4: 'The Highway Robbers', 6: 'The Outlaw Gang' },
     advisorLine: '{name} has raised a bandit camp near {city}! Slay it to end the threat — any civilization may claim the hunt.',
     responseActions: [],
     hunt: { spawnKind: 'barbarian-camp' },
@@ -230,10 +239,90 @@ export const CRISIS_FLAVORS: CrisisFlavor[] = [
     eraBand: [4, 12],
     geographyPredicate: (state, city) => isCoastalCity(state, city),
     severityByChallenge: NO_ATTRITION_SEVERITY,
-    displayNamesByEra: { 4: 'Corsair Armada' },
+    displayNamesByEra: { 4: 'Corsair Armada', 7: 'The Buccaneer Fleet', 10: 'The Iron-Clad Raiders' },
     advisorLine: '{name} raids the waters near {city}! Slay it to end the threat — any civilization may claim the hunt.',
     responseActions: [],
     hunt: { spawnKind: 'pirate' },
+  },
+  {
+    id: 'crop-blight',
+    archetype: 'outbreak',
+    // Grace-period floor is era 2 for standard/veteran, era 3 for explorer (see
+    // opponent-challenge.ts crisisGraceMaxEra) — an era-1 band start would never
+    // actually be reachable, so this starts at era 2 like the other outbreaks/
+    // catastrophes rather than shipping unreachable era-1 display-name content.
+    eraBand: [2, 10],
+    geographyPredicate: (state, city) =>
+      countFarmsInTerritory(state, city) >= 2 || isPlainsOrGrasslandCity(state, city),
+    spreadBoostPredicate: (state, city) => nearTerrain(state, city, ['plains'], 2),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.15, popLossEveryNTurnsIgnored: null, autoExpireTurns: 5 },
+      standard: { yieldPenalty: 0.25, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+      veteran:  { yieldPenalty: 0.35, popLossEveryNTurnsIgnored: 3,    autoExpireTurns: null },
+    },
+    displayNamesByEra: { 2: 'The Withering', 4: 'The Blackened Rows', 6: 'The Potato Blight', 9: 'The Rust Fungus' },
+    advisorLine: '{name} has struck the fields near {city}! Quarantine the city to stop the spread, or fund a remedy effort to cure it.',
+    responseActions: ['quarantine', 'remedy'],
+  },
+  {
+    id: 'locust-swarm',
+    archetype: 'outbreak',
+    eraBand: [2, 8],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['plains', 'grassland'], 2),
+    spreadBoostPredicate: (state, city) => nearTerrain(state, city, ['plains', 'grassland'], 2),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.15, popLossEveryNTurnsIgnored: null, autoExpireTurns: 5 },
+      standard: { yieldPenalty: 0.25, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+      veteran:  { yieldPenalty: 0.35, popLossEveryNTurnsIgnored: 3,    autoExpireTurns: null },
+    },
+    displayNamesByEra: { 2: 'The Devouring Cloud', 5: 'The Locust Storm' },
+    advisorLine: '{name} descends on the farmland near {city}! Quarantine the city to stop the spread, or fund a remedy effort to cure it.',
+    responseActions: ['quarantine', 'remedy'],
+  },
+  {
+    id: 'red-tide',
+    archetype: 'outbreak',
+    eraBand: [3, 12],
+    geographyPredicate: (state, city) => isCoastalCity(state, city),
+    spreadBoostPredicate: (state, city) => nearTerrain(state, city, ['coast', 'ocean'], 1),
+    severityByChallenge: {
+      explorer: { yieldPenalty: 0.15, popLossEveryNTurnsIgnored: null, autoExpireTurns: 5 },
+      standard: { yieldPenalty: 0.25, popLossEveryNTurnsIgnored: null, autoExpireTurns: null },
+      veteran:  { yieldPenalty: 0.35, popLossEveryNTurnsIgnored: 3,    autoExpireTurns: null },
+    },
+    displayNamesByEra: { 3: 'The Crimson Waters', 7: 'The Poisoned Tide', 11: 'The Algal Bloom' },
+    advisorLine: '{name} fouls the harbor near {city}! Quarantine the city to stop the spread, or fund a remedy effort to cure it.',
+    responseActions: ['quarantine', 'remedy'],
+  },
+  {
+    id: 'dire-pack',
+    archetype: 'hunt',
+    eraBand: [2, 4],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['forest', 'tundra'], 3),
+    severityByChallenge: NO_ATTRITION_SEVERITY,
+    displayNamesByEra: { 2: 'Dire Pack' },
+    advisorLine: '{name} stalks the wilds near {city}! Slay it to end the threat — any civilization may claim the hunt.',
+    responseActions: [],
+    hunt: { spawnKind: 'beast' },
+  },
+  {
+    id: 'kraken-sighting',
+    archetype: 'hunt',
+    // Uses spawnKind: 'beast' rather than a pirate sea-monster name pool — the
+    // `sea_serpent` entry (habitatTerrains: ['ocean'], awakenEra: 3) already exists in
+    // beast-definitions.ts, so no new spawn mechanism was needed (per MR5 scope: data
+    // rows only, no resolver changes). Note for reviewers: spawnBeastHunt in
+    // crisis-system.ts picks its spawned beast at random from all era-eligible
+    // BEAST_DEFINITIONS regardless of which flavor triggered the hunt (pre-existing
+    // behavior shared with beast-awakening/dire-pack) — this flavor's geography gate
+    // guarantees an ocean-adjacent city, not that the sea_serpent specifically spawns.
+    eraBand: [5, 12],
+    geographyPredicate: (state, city) => nearTerrain(state, city, ['ocean'], 3),
+    severityByChallenge: NO_ATTRITION_SEVERITY,
+    displayNamesByEra: { 5: 'Kraken Sighting', 8: 'The Deep Stirs' },
+    advisorLine: '{name} has been sighted off the coast near {city}! Slay it to end the threat — any civilization may claim the hunt.',
+    responseActions: [],
+    hunt: { spawnKind: 'beast' },
   },
 ];
 

--- a/tests/systems/crisis-system.test.ts
+++ b/tests/systems/crisis-system.test.ts
@@ -9,14 +9,16 @@ describe('crisis scheduler', () => {
     const next = processCrisisSchedulerForHumans(state, new EventBus());
     const crises = Object.values(next.activeCrises ?? {});
     expect(crises).toHaveLength(1);
-    // This fixture's city (population 5, no forest/mountain/coast/jungle terrain) is
-    // geography-eligible for both 'plague' (population >= 4) and 'bandit-uprising'
-    // (any land city, MR3) — both start with equal anti-repeat weight, and this seed's
-    // weighted pick lands on bandit-uprising. The point of this test is the grace/cooldown
-    // gate and history bookkeeping, not which specific flavor wins the pick.
-    expect(crises[0].flavorId).toBe('bandit-uprising');
+    // This fixture's city (population 5, grassland, no forest/mountain/coast/jungle
+    // terrain) is geography-eligible for 'plague' (population >= 4), 'bandit-uprising'
+    // (any land city, MR3), and 'crop-blight' (grassland city, MR5) — all start with
+    // equal anti-repeat weight, and this seed's weighted pick lands on crop-blight
+    // (was bandit-uprising before MR5 added a new equally-weighted grassland-eligible
+    // candidate). The point of this test is the grace/cooldown gate and history
+    // bookkeeping, not which specific flavor wins the pick.
+    expect(crises[0].flavorId).toBe('crop-blight');
     expect(next.civilizations.p1.lastCrisisOnsetTurn).toBe(40);
-    expect(next.civilizations.p1.recentCrisisHistory).toEqual(['bandit-uprising']);
+    expect(next.civilizations.p1.recentCrisisHistory).toEqual(['crop-blight']);
   });
 
   it('respects era grace: no crisis in era 1 for anyone, era 2 for explorer', () => {


### PR DESCRIPTION
## Summary

Part 5 of 5 of the [Crisis Events & Revolutionary Movements arc](https://github.com/a1flecke/conquestoria/issues/504). Adds five new rows to `CRISIS_FLAVORS` (`src/systems/crisis-flavor-definitions.ts`):

- **Outbreaks:** `crop-blight` (≥2 farms in territory or grassland/plains city, plains spread boost, era 2–10), `locust-swarm` (plains/grassland within 2, era 2–8), `red-tide` (coastal, era 3–12).
- **Hunts:** `dire-pack` (era 2–4, forest/tundra), `kraken-sighting` (era 5–12, ocean within 3).

Also fills in additional era-scaled display names across all 9 pre-existing flavors (plague, the four elemental catastrophes, the three original hunts) so repeat play stays varied deeper into the game, not just for the new rows.

**`kraken-sighting` deviation from the issue text (documented in a code comment):** rather than adding a new pirate sea-monster name pool, it reuses `spawnKind: 'beast'` — `sea_serpent` (habitatTerrains: `['ocean']`, awakenEra 3) already exists in `beast-definitions.ts`, so no new spawn path was needed. Reviewer note: `spawnBeastHunt` in `crisis-system.ts` picks its spawned beast at random from *all* era-eligible beasts regardless of which flavor triggered the hunt (pre-existing behavior shared with `beast-awakening`/`dire-pack`) — this flavor's geography gate guarantees an ocean-adjacent city, not that `sea_serpent` specifically spawns. Flagged as out of scope since MR5 is data-rows-only (no resolver changes per the issue).

**Fix beyond the issue text:** `crop-blight`'s initial era band was `[1, 10]`, but the crisis scheduler's grace period floor (`crisisGraceMaxEra` in `opponent-challenge.ts`) means no crisis can ever start before era 2 (standard/veteran) or era 3 (explorer) — an era-1 band start would ship an unreachable display name. Changed to `[2, 10]` to match every other flavor's convention.

## Review pass (inline, no subagents)

Went through balance/fun, ages 7–43, play styles, difficulty modes, AI usage, UI/UX, architecture/extensibility, data, SFX, save compatibility, solo/hotseat, and testing:

- **Architecture:** confirmed via grep that nothing outside `crisis-flavor-definitions.ts` hardcodes a flavor-id list — scheduler eligibility (`crisis-system.ts`), SFX hooks (`audio-system.ts`), and notification text (`notification-routing.ts`) are all generic over `CRISIS_FLAVORS`/archetype, so the 5 new rows are fully wired with zero additional code.
- **Balance:** all severities reuse the existing 0.15/0.25/0.35 (outbreak) tiers with explorer auto-expiry — no new ceiling introduced; ran the pacing-audit/reference-economy/wonder/national-project balance suites explicitly (all green, snapshots unchanged).
- **Found and fixed one pinned-test drift:** `crisis-system.test.ts`'s scheduler test hardcoded a specific seeded-RNG flavor pick (`bandit-uprising`); adding `crop-blight` as a new equally-weighted grassland-eligible candidate legitimately shifted that seed's pick to `crop-blight`. Updated the assertion and comment (not a bug — the test's own comment says it's about grace/cooldown gating, not which flavor wins).
- **Found and fixed the era-1 dead-content issue** described above.
- **Saves/hotseat:** no new fields, no schema change — full existing save-compat and hotseat-privacy suites pass untouched.

## Test plan

- [x] `yarn build` — exit 0
- [x] `yarn test` — exit 0 (5906 passed, 2 skipped, including hook smoke tests)
- [x] `pacing-audit`, `pacing-reference-economy`, `wonder-definitions`, `national-project-balance` suites re-run explicitly — all green, no snapshot drift
- [x] `crisis-flavor-definitions.test.ts` — 80/80 passing (generic table invariants auto-cover all 14 flavors)
- [x] Diff scope: only `src/systems/crisis-flavor-definitions.ts` + `tests/systems/crisis-system.test.ts` touched, matching the issue's "zero diff outside crisis-flavor-definitions.ts, name pools, copy, and tests" requirement

Closes #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)