### PR TITLE
feat(era13): add save-safe era boundary and open-ended pacing

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -536,6 +536,7 @@ export interface Tech {
   unlocksUnits?: UnitType[];      // trainable unit types gated by this tech
   unlocksBuildings?: string[];    // building IDs (keys of BUILDINGS) gated by this tech
   era: number;               // 1-3 for milestone 1
+  historicalStatus?: 'historical' | 'emerging' | 'speculative';
   countsForEraAdvancement?: boolean;
   countsForCityMaturity?: boolean;
   pacing?: PacingMetadata;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1459,6 +1459,8 @@ export interface IdCounters {
 export interface GameState {
   turn: number;
   era: number;
+  /** Incremented only by ordered, deterministic save migrations. */
+  saveSchemaVersion?: number;
   gameId?: string;
   gameTitle?: string;
   opponentChallenge?: OpponentChallenge;

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -10,6 +10,7 @@ import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
 import { normalizeMinorCivCoalitionState } from '@/systems/minor-civ-coalition-system';
 import { normalizeMinorCivEconomyState } from '@/systems/minor-civ-economy-system';
 import { scanIdCounters } from '@/core/id-counters';
+import { migrateSaveToCurrent } from '@/storage/save-migrations';
 import {
   createEmptyPirateState,
   PIRATE_RELOCATION_DIRECTIONS,
@@ -48,9 +49,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function ensureGameIdentity(state: GameState): GameState {
-  if (!state.gameId) {
-    state.gameId = `game-${Date.now()}`;
-  }
   if (!state.gameTitle) {
     const civType = state.hotSeat ? 'Hot Seat' : (state.civilizations[state.currentPlayer]?.civType ?? 'Unknown');
     state.gameTitle = `Recovered ${civType} Campaign`;
@@ -766,8 +764,9 @@ export function migrateLegacyCoastalData(state: GameState): GameState {
 }
 
 export function normalizeLoadedState(state: GameState): NormalizedGameState {
+  const migrated = migrateSaveToCurrent(state);
   const normalizedCityState = migrateLegacyPirateFleets(normalizeMinorCivEconomyState(normalizeMinorCivCoalitionState(normalizeMinorCivQuestState(
-    migrateLegacyCoastalData(normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateStripCityGrid(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(state)))))))),
+    migrateLegacyCoastalData(normalizeThreatPressureDefaults(normalizeLandmassKeys(normalizeLegacyCitySimState(migrateStripCityGrid(migrateLegacyPlanningState(migrateLegacyNamingState(ensureGameIdentity(migrated)))))))),
   ))));
   normalizedCityState.pirates = normalizePirateState(normalizedCityState);
   normalizedCityState.notificationLog = normalizeNotificationLog(normalizedCityState.notificationLog);

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -1,0 +1,64 @@
+import type { GameState } from '@/core/types';
+
+export const CURRENT_SAVE_SCHEMA_VERSION = 1;
+
+export type SaveMigration = (state: GameState) => GameState;
+
+export class UnsupportedSaveSchemaVersionError extends Error {
+  constructor(readonly version: number) {
+    super(`Save schema version ${version} is newer than this version of Conquestoria.`);
+    this.name = 'UnsupportedSaveSchemaVersionError';
+  }
+}
+
+function stableLegacyGameId(state: GameState): string {
+  const tileFingerprint = Object.entries(state.map?.tiles ?? {})
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([tileId, tile]) => [tileId, tile.q, tile.r, tile.terrain, tile.resource ?? ''].join(':'))
+    .join('|');
+  const source = `${state.currentPlayer}|${state.turn}|${tileFingerprint}`;
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index += 1) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `legacy-${(hash >>> 0).toString(36)}`;
+}
+
+function migrateToEra13Foundation(state: GameState): GameState {
+  return state.gameId ? state : { ...state, gameId: stableLegacyGameId(state) };
+}
+
+export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
+  1: migrateToEra13Foundation,
+};
+
+function readSchemaVersion(raw: Record<string, unknown>): number {
+  const version = raw.saveSchemaVersion;
+  if (version === undefined) return 0;
+  if (!Number.isInteger(version) || Number(version) < 0) {
+    throw new TypeError('Save schema version must be a non-negative integer.');
+  }
+  return Number(version);
+}
+
+export function migrateSaveToCurrent(raw: unknown): GameState {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new TypeError('Save data must be an object.');
+  }
+
+  const sourceVersion = readSchemaVersion(raw as Record<string, unknown>);
+  if (sourceVersion > CURRENT_SAVE_SCHEMA_VERSION) {
+    throw new UnsupportedSaveSchemaVersionError(sourceVersion);
+  }
+
+  let state = structuredClone(raw) as GameState;
+  for (let version = sourceVersion + 1; version <= CURRENT_SAVE_SCHEMA_VERSION; version += 1) {
+    const migration = SAVE_MIGRATIONS[version];
+    if (!migration) {
+      throw new Error(`Missing save migration for schema version ${version}.`);
+    }
+    state = { ...migration(state), saveSchemaVersion: version };
+  }
+  return state.gameId ? state : migrateToEra13Foundation(state);
+}

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -14,7 +14,7 @@ export class UnsupportedSaveSchemaVersionError extends Error {
 function stableLegacyGameId(state: GameState): string {
   const tileFingerprint = Object.entries(state.map?.tiles ?? {})
     .sort(([left], [right]) => left.localeCompare(right))
-    .map(([tileId, tile]) => [tileId, tile.q, tile.r, tile.terrain, tile.resource ?? ''].join(':'))
+    .map(([tileId, tile]) => [tileId, tile.coord.q, tile.coord.r, tile.terrain, tile.resource ?? ''].join(':'))
     .join('|');
   const source = `${state.currentPlayer}|${state.turn}|${tileFingerprint}`;
   let hash = 2166136261;
@@ -44,8 +44,8 @@ function remapTechIds(techIds: readonly string[], excluded: ReadonlySet<string> 
 function remapPersistedTechReferences(state: GameState): GameState {
   const civilizations = Object.fromEntries(Object.entries(state.civilizations).map(([civId, civilization]) => {
     if (!civilization.techState) return [civId, civilization];
-    const completed = remapTechIds(civilization.techState.completed);
-    const currentResearch = civilization.techState.currentResearch
+    const completed = remapTechIds(Array.isArray(civilization.techState.completed) ? civilization.techState.completed : []);
+    const currentResearch = typeof civilization.techState.currentResearch === 'string'
       ? remapPersistedTechId(civilization.techState.currentResearch)
       : null;
     const currentIsCompleted = currentResearch !== null && completed.includes(currentResearch);
@@ -56,8 +56,8 @@ function remapPersistedTechReferences(state: GameState): GameState {
         ...civilization.techState,
         completed,
         currentResearch: currentIsCompleted ? null : currentResearch,
-        researchQueue: remapTechIds(civilization.techState.researchQueue, excluded),
-        researchProgress: currentIsCompleted ? 0 : civilization.techState.researchProgress,
+        researchQueue: remapTechIds(Array.isArray(civilization.techState.researchQueue) ? civilization.techState.researchQueue : [], excluded),
+        researchProgress: currentIsCompleted ? 0 : (civilization.techState.researchProgress ?? 0),
       },
     }];
   }));

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -25,8 +25,76 @@ function stableLegacyGameId(state: GameState): string {
   return `legacy-${(hash >>> 0).toString(36)}`;
 }
 
+export function remapPersistedTechId(techId: string): string {
+  return techId === 'quantum-computing' ? 'cloud-computing' : techId;
+}
+
+function remapTechIds(techIds: readonly string[], excluded: ReadonlySet<string> = new Set()): string[] {
+  const remapped: string[] = [];
+  const seen = new Set(excluded);
+  for (const techId of techIds) {
+    const mapped = remapPersistedTechId(techId);
+    if (seen.has(mapped)) continue;
+    seen.add(mapped);
+    remapped.push(mapped);
+  }
+  return remapped;
+}
+
+function remapPersistedTechReferences(state: GameState): GameState {
+  const civilizations = Object.fromEntries(Object.entries(state.civilizations).map(([civId, civilization]) => {
+    if (!civilization.techState) return [civId, civilization];
+    const completed = remapTechIds(civilization.techState.completed);
+    const currentResearch = civilization.techState.currentResearch
+      ? remapPersistedTechId(civilization.techState.currentResearch)
+      : null;
+    const currentIsCompleted = currentResearch !== null && completed.includes(currentResearch);
+    const excluded = new Set([...completed, ...(currentIsCompleted || !currentResearch ? [] : [currentResearch])]);
+    return [civId, {
+      ...civilization,
+      techState: {
+        ...civilization.techState,
+        completed,
+        currentResearch: currentIsCompleted ? null : currentResearch,
+        researchQueue: remapTechIds(civilization.techState.researchQueue, excluded),
+        researchProgress: currentIsCompleted ? 0 : civilization.techState.researchProgress,
+      },
+    }];
+  }));
+
+  const opponentAI = state.opponentAI
+    ? {
+      ...state.opponentAI,
+      majorCivs: Object.fromEntries(Object.entries(state.opponentAI.majorCivs).map(([civId, portfolio]) => [civId, {
+        ...portfolio,
+        researchTargetTechId: portfolio.researchTargetTechId
+          ? remapPersistedTechId(portfolio.researchTargetTechId)
+          : null,
+      }])),
+    }
+    : undefined;
+
+  const espionage = state.espionage
+    ? Object.fromEntries(Object.entries(state.espionage).map(([civId, civState]) => [civId, {
+      ...civState,
+      spies: Object.fromEntries(Object.entries(civState.spies).map(([spyId, spy]) => [spyId, {
+        ...spy,
+        ...(spy.stolenTechFrom ? {
+          stolenTechFrom: Object.fromEntries(Object.entries(spy.stolenTechFrom).map(([targetCivId, techIds]) => [
+            targetCivId,
+            remapTechIds(techIds),
+          ])),
+        } : {}),
+      }])),
+    }]))
+    : undefined;
+
+  return { ...state, civilizations, ...(opponentAI ? { opponentAI } : {}), ...(espionage ? { espionage } : {}) };
+}
+
 function migrateToEra13Foundation(state: GameState): GameState {
-  return state.gameId ? state : { ...state, gameId: stableLegacyGameId(state) };
+  const withStableIdentity = state.gameId ? state : { ...state, gameId: stableLegacyGameId(state) };
+  return remapPersistedTechReferences(withStableIdentity);
 }
 
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1181,16 +1181,17 @@ export const SETTLER_COST_BY_ERA: Record<number, number> = {
   10: 96,
   11: 104,
   12: 112,
+  13: 120,
 };
 
-function clampProductionEra(era: number | undefined): number {
+function normalizeProductionEra(era: number | undefined): number {
   const numericEra = typeof era === 'number' && Number.isFinite(era) ? era : 1;
-  const normalized = Math.max(1, Math.floor(numericEra));
-  return Math.min(12, normalized);
+  return Math.max(1, Math.floor(numericEra));
 }
 
 export function getSettlerProductionCost(era: number = 1): number {
-  return SETTLER_COST_BY_ERA[clampProductionEra(era)];
+  const normalized = normalizeProductionEra(era);
+  return SETTLER_COST_BY_ERA[normalized] ?? SETTLER_COST_BY_ERA[Math.max(...Object.keys(SETTLER_COST_BY_ERA).map(Number))];
 }
 
 export function getCatalogProductionCost(itemId: string, era: number = 1): number {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -978,7 +978,7 @@ export const BUILDINGS: Record<string, Building> = {
     yields: { food: 0, production: 0, gold: 0, science: 3 },
     productionCost: 200,
     description: 'High-performance computing cluster. Requires a Semiconductor Fab.',
-    techRequired: 'quantum-computing',
+    techRequired: 'cloud-computing',
     requiresBuildings: ['semiconductor_fab'],
   },
 

--- a/src/systems/era-pacing-profiles.ts
+++ b/src/systems/era-pacing-profiles.ts
@@ -1,0 +1,41 @@
+/**
+ * Explicit pacing anchors for every authored era. The Era 13 science values come from the
+ * deterministic bounded/maximal reference-economy fixture; later unauthored frontiers reuse
+ * the final authored profile rather than pretending that new content exists.
+ */
+export interface EraPacingProfile {
+  era: number;
+  productionPerTurn: number;
+  boundedSciencePerTurn: number;
+  completionistSciencePerTurn: number;
+}
+
+export const ERA_PACING_PROFILES: ReadonlyMap<number, EraPacingProfile> = new Map([
+  [1, { era: 1, productionPerTurn: 4, boundedSciencePerTurn: 2, completionistSciencePerTurn: 1 }],
+  [2, { era: 2, productionPerTurn: 6, boundedSciencePerTurn: 6, completionistSciencePerTurn: 4 }],
+  [3, { era: 3, productionPerTurn: 8, boundedSciencePerTurn: 8, completionistSciencePerTurn: 7 }],
+  [4, { era: 4, productionPerTurn: 10, boundedSciencePerTurn: 9, completionistSciencePerTurn: 10 }],
+  [5, { era: 5, productionPerTurn: 12, boundedSciencePerTurn: 9, completionistSciencePerTurn: 13 }],
+  [6, { era: 6, productionPerTurn: 14, boundedSciencePerTurn: 24, completionistSciencePerTurn: 16 }],
+  [7, { era: 7, productionPerTurn: 16, boundedSciencePerTurn: 29, completionistSciencePerTurn: 19 }],
+  [8, { era: 8, productionPerTurn: 18, boundedSciencePerTurn: 46, completionistSciencePerTurn: 22 }],
+  [9, { era: 9, productionPerTurn: 20, boundedSciencePerTurn: 59, completionistSciencePerTurn: 25 }],
+  [10, { era: 10, productionPerTurn: 22, boundedSciencePerTurn: 66, completionistSciencePerTurn: 135 }],
+  [11, { era: 11, productionPerTurn: 24, boundedSciencePerTurn: 93, completionistSciencePerTurn: 170 }],
+  [12, { era: 12, productionPerTurn: 26, boundedSciencePerTurn: 103, completionistSciencePerTurn: 198 }],
+  [13, { era: 13, productionPerTurn: 28, boundedSciencePerTurn: 102, completionistSciencePerTurn: 236 }],
+]);
+
+export function requireEraPacingProfile(era: number): EraPacingProfile {
+  const profile = ERA_PACING_PROFILES.get(era);
+  if (!profile) throw new Error(`Missing authored pacing profile for era ${era}`);
+  return profile;
+}
+
+export function getFrontierPacingProfile(era: number): EraPacingProfile {
+  const normalizedEra = Number.isFinite(era) ? Math.max(1, Math.floor(era)) : 1;
+  const availableEra = [...ERA_PACING_PROFILES.keys()]
+    .filter(candidate => candidate <= normalizedEra)
+    .at(-1) ?? 1;
+  return requireEraPacingProfile(availableEra);
+}

--- a/src/systems/pacing-model.ts
+++ b/src/systems/pacing-model.ts
@@ -1,6 +1,14 @@
 import type { Building, PacingBand, PacingContentType, PacingMetadata, Tech } from '@/core/types';
 import { BUILDINGS, type TRAINABLE_UNITS } from '@/systems/city-system';
 import { TECH_TREE } from '@/systems/tech-definitions';
+import {
+  ERA_PACING_PROFILES,
+  getFrontierPacingProfile,
+  requireEraPacingProfile,
+  type EraPacingProfile,
+} from '@/systems/era-pacing-profiles';
+
+export { ERA_PACING_PROFILES, getFrontierPacingProfile, requireEraPacingProfile, type EraPacingProfile };
 
 const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number, number] }> = {
   starter: { early: [2, 4], late: [2, 5] },
@@ -11,25 +19,8 @@ const BAND_WINDOWS: Record<PacingBand, { early: [number, number]; late: [number,
   marquee: { early: [10, 12], late: [10, 16] },
 };
 
-const PRODUCTION_OUTPUT_BY_ERA: Record<number, number> = {
-  1: 4,
-  2: 6,
-  3: 8,
-  4: 10,
-  5: 12,
-  6: 14,
-  7: 16,
-  8: 18,
-  9: 20,
-  10: 22,
-  11: 24,
-  12: 26,
-};
-
 export function getProductionOutputProfileForEra(era: number): number {
-  const numericEra = Number.isFinite(era) ? era : 1;
-  const normalized = Math.max(1, Math.floor(numericEra));
-  return PRODUCTION_OUTPUT_BY_ERA[Math.min(12, normalized)];
+  return getFrontierPacingProfile(era).productionPerTurn;
 }
 
 export function getTargetTurnWindow(input: { era: number; band: PacingBand; contentType: PacingContentType }): { min: number; max: number } {
@@ -46,44 +37,15 @@ export function estimateTurnsToComplete(input: { cost: number; outputPerTurn: nu
 }
 
 export interface ResearchOutputProfile {
-  name:
-    | 'opening-baseline'
-    | 'opening-science-invested'
-    | 'era-2-established'
-    | 'era-3-established'
-    | 'era-4-established'
-    | 'era-5-established'
-    | 'era-6-established'
-    | 'era-7-established'
-    | 'era-8-established'
-    | 'era-9-established'
-    | 'era-10-established'
-    | 'era-11-established'
-    | 'era-12-established';
+  name: string;
   outputPerTurn: number;
 }
 
-const RESEARCH_OUTPUT_BY_ERA: Record<number, ResearchOutputProfile> = {
-  1: { name: 'opening-baseline', outputPerTurn: 1 },
-  2: { name: 'era-2-established', outputPerTurn: 4 },
-  3: { name: 'era-3-established', outputPerTurn: 7 },
-  4: { name: 'era-4-established', outputPerTurn: 10 },
-  5: { name: 'era-5-established', outputPerTurn: 13 },
-  6: { name: 'era-6-established', outputPerTurn: 16 },
-  7: { name: 'era-7-established', outputPerTurn: 19 },
-  8: { name: 'era-8-established', outputPerTurn: 22 },
-  9: { name: 'era-9-established', outputPerTurn: 25 },
-  // era 10-12: extended in MR13 (#481, fixes F2/F3) — values derived from a real run of the
-  // yield pipeline (tech percents + empire-flat tech yields) against a documented reference
-  // economy, not guessed. Targets the 'maximal' profile (a completionist city that builds
-  // every available building) rather than the lower 'bounded' profile, so a completionist
-  // empire doesn't blow through late-game tech far faster than the target window. See
-  // tests/systems/pacing-reference-economy.test.ts for the fixture, both profiles' pins, and
-  // the regression/growth-ratio guardrails.
-  10: { name: 'era-10-established', outputPerTurn: 135 },
-  11: { name: 'era-11-established', outputPerTurn: 170 },
-  12: { name: 'era-12-established', outputPerTurn: 198 },
-};
+function researchOutputProfile(profile: EraPacingProfile): ResearchOutputProfile {
+  return profile.era === 1
+    ? { name: 'opening-baseline', outputPerTurn: profile.completionistSciencePerTurn }
+    : { name: `era-${profile.era}-established`, outputPerTurn: profile.completionistSciencePerTurn };
+}
 
 export const OPENING_SCIENCE_INVESTED_PROFILE: ResearchOutputProfile = {
   name: 'opening-science-invested',
@@ -99,18 +61,12 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function normalizeEra(era: number): number {
-  const numericEra = Number.isFinite(era) ? era : 1;
-  const normalized = Math.max(1, Math.floor(numericEra));
-  return Math.min(12, normalized);
-}
-
 function findTech(techId: string, techs: Tech[]): Tech | undefined {
   return techs.find(candidate => candidate.id === techId);
 }
 
 export function getResearchOutputProfileForEra(era: number): ResearchOutputProfile {
-  return RESEARCH_OUTPUT_BY_ERA[normalizeEra(era)];
+  return researchOutputProfile(getFrontierPacingProfile(era));
 }
 
 export function isStarterPrerequisiteTech(tech: Tech): boolean {
@@ -127,14 +83,18 @@ export function isFirstRealUnlockTech(tech: Tech, techs: Tech[] = TECH_TREE): bo
 
 export function getResearchOutputProfileForTech(tech: Tech, techs: Tech[] = TECH_TREE): ResearchOutputProfile {
   if (isStarterPrerequisiteTech(tech) || isFirstRealUnlockTech(tech, techs)) {
-    return RESEARCH_OUTPUT_BY_ERA[1];
+    return researchOutputProfile(requireEraPacingProfile(1));
   }
 
   if (tech.era <= 1) {
-    return RESEARCH_OUTPUT_BY_ERA[2];
+    return researchOutputProfile(requireEraPacingProfile(2));
   }
 
-  return getResearchOutputProfileForEra(tech.era);
+  return researchOutputProfile(requireEraPacingProfile(tech.era));
+}
+
+export function validateAuthoredEraPacing(techs: readonly Tech[] = TECH_TREE): void {
+  for (const tech of techs) requireEraPacingProfile(tech.era);
 }
 
 export function getRecommendedTechTurnWindow(tech: Tech, techs: Tech[] = TECH_TREE): { min: number; max: number } {

--- a/src/systems/tech-definitions-eras12.ts
+++ b/src/systems/tech-definitions-eras12.ts
@@ -26,8 +26,8 @@ const ERA_12_TECHS: Tech[] = [
     prerequisites: ['molecular-biology', 'green-revolution-crops'],
     unlocks: ['Cities produce +1 food for every 3 science they generate per turn'],
     unlocksBuildings: ['biotech_lab'], era: 12 },
-  { id: 'quantum-computing', name: 'Quantum Computing', track: 'science', cost: 2780,
-    prerequisites: ['integrated-circuits', 'molecular-biology'],
+  { id: 'cloud-computing', name: 'Cloud Computing', track: 'science', cost: 2780,
+    prerequisites: ['integrated-circuits', 'arpanet'],
     unlocks: ['All unresearched science-track techs cost 15% less science to research'],
     unlocksBuildings: ['data_center'], era: 12 },
 

--- a/src/systems/tech-definitions-eras13.ts
+++ b/src/systems/tech-definitions-eras13.ts
@@ -1,0 +1,14 @@
+import type { Tech } from '@/core/types';
+
+export const TECH_TREE_ERAS_13: Tech[] = [
+  {
+    id: 'quantum-computing',
+    name: 'Quantum Computing',
+    track: 'science',
+    cost: 2780,
+    prerequisites: ['cloud-computing', 'nanomaterials'],
+    unlocks: ['Data Centers gain +2 science per turn from quantum workloads'],
+    era: 13,
+    historicalStatus: 'emerging',
+  },
+];

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -7,6 +7,7 @@ import { TECH_TREE_ERAS_10 } from './tech-definitions-eras10';
 import { TECH_TREE_ERAS_11 } from './tech-definitions-eras11';
 import { TECH_TREE_ERAS_12 } from './tech-definitions-eras12';
 import { TECH_TREE_ERAS_13 } from './tech-definitions-eras13';
+import { requireEraPacingProfile } from './era-pacing-profiles';
 
 export { TECH_TREE_ERAS_1_4 } from './tech-definitions-eras1-4';
 export { TECH_TREE_ERAS_5_7 } from './tech-definitions-eras5-7';
@@ -27,6 +28,8 @@ export const TECH_TREE: Tech[] = [
   ...TECH_TREE_ERAS_12,
   ...TECH_TREE_ERAS_13,
 ];
+
+for (const tech of TECH_TREE) requireEraPacingProfile(tech.era);
 
 export function getEraAdvancementTechs(era: number): Tech[] {
   return TECH_TREE.filter(tech => tech.era === era && tech.countsForEraAdvancement !== false);

--- a/src/systems/tech-definitions.ts
+++ b/src/systems/tech-definitions.ts
@@ -6,6 +6,7 @@ import { TECH_TREE_ERAS_9 } from './tech-definitions-eras9';
 import { TECH_TREE_ERAS_10 } from './tech-definitions-eras10';
 import { TECH_TREE_ERAS_11 } from './tech-definitions-eras11';
 import { TECH_TREE_ERAS_12 } from './tech-definitions-eras12';
+import { TECH_TREE_ERAS_13 } from './tech-definitions-eras13';
 
 export { TECH_TREE_ERAS_1_4 } from './tech-definitions-eras1-4';
 export { TECH_TREE_ERAS_5_7 } from './tech-definitions-eras5-7';
@@ -14,6 +15,7 @@ export { TECH_TREE_ERAS_9 } from './tech-definitions-eras9';
 export { TECH_TREE_ERAS_10 } from './tech-definitions-eras10';
 export { TECH_TREE_ERAS_11 } from './tech-definitions-eras11';
 export { TECH_TREE_ERAS_12 } from './tech-definitions-eras12';
+export { TECH_TREE_ERAS_13 } from './tech-definitions-eras13';
 
 export const TECH_TREE: Tech[] = [
   ...TECH_TREE_ERAS_1_4,
@@ -23,6 +25,7 @@ export const TECH_TREE: Tech[] = [
   ...TECH_TREE_ERAS_10,
   ...TECH_TREE_ERAS_11,
   ...TECH_TREE_ERAS_12,
+  ...TECH_TREE_ERAS_13,
 ];
 
 export function getEraAdvancementTechs(era: number): Tech[] {

--- a/src/systems/tech-progression.ts
+++ b/src/systems/tech-progression.ts
@@ -133,6 +133,12 @@ export function getQueueableResearchIds(state: TechState, techs: Tech[] = TECH_T
   return queueable;
 }
 
+export function hasReachedResearchFrontier(state: TechState, techs: readonly Tech[] = TECH_TREE): boolean {
+  return state.currentResearch === null
+    && state.researchQueue.length === 0
+    && techs.every(tech => state.completed.includes(tech.id));
+}
+
 export function canMoveQueuedResearch(state: TechState, fromIndex: number, toIndex: number): boolean {
   return isQueueOrderValid(state, moveQueuedId(state.researchQueue, fromIndex, toIndex));
 }

--- a/src/systems/tech-system.ts
+++ b/src/systems/tech-system.ts
@@ -95,13 +95,13 @@ export function getTechById(id: string): Tech | undefined {
 }
 
 /**
- * The single source of truth for a tech's research cost. quantum-computing (era 12) discounts
+ * The single source of truth for a tech's research cost. Cloud Computing discounts
  * unresearched science-track techs by 15% — every reader of `tech.cost` for research-progress
  * purposes MUST go through this function instead (turn-manager, tech-progression, tech-panel,
  * pacing ETA estimates) so the discount is never silently bypassed.
  */
 export function getEffectiveTechCost(tech: Tech, completedTechs: string[]): number {
-  if (tech.track === 'science' && completedTechs.includes('quantum-computing')) {
+  if (tech.track === 'science' && completedTechs.includes('cloud-computing')) {
     return Math.ceil(tech.cost * 0.85);
   }
   return tech.cost;

--- a/src/systems/tech-yield-definitions.ts
+++ b/src/systems/tech-yield-definitions.ts
@@ -231,6 +231,7 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   { techId: 'smart-cities', label: '+2 production and +1 science with a factory and semiconductor fab', effect: { kind: 'cityFlatConditional', requiresAllBuildings: ['factory', 'semiconductor_fab'], yields: { production: 2, science: 1 } } },
   // genomics: resolved directly in resource-system.ts calculateCityYields (needs the city's own pre-empire-percent science total).
   { techId: 'genomics', label: '+1 food per 3 science generated per turn (pre-bonus)', effect: { kind: 'foodFromScience', perScience: 3 } },
+  { techId: 'quantum-computing', label: '+2 science in cities with a Data Center', effect: { kind: 'perBuildingId', buildingIds: ['data_center'], yields: { science: 2 } } },
   // gps-navigation: movement/terrain-cost effect — deferred to MR7 (movement systems live in unit-system, not the yield engine).
 ];
 

--- a/src/ui/tech-panel.ts
+++ b/src/ui/tech-panel.ts
@@ -5,6 +5,7 @@ import { estimateTurnsToComplete } from '@/systems/pacing-model';
 import {
   buildTechProgressionView,
   canMoveQueuedResearch,
+  hasReachedResearchFrontier,
   type TechProgressionNode,
   type TechTreeZoom,
 } from '@/systems/tech-progression';
@@ -424,6 +425,14 @@ export function createTechPanel(
   const summary = buildCurrentResearchSummary(currentTech, currentProgress, turnsRemaining);
   if (summary) {
     panel.appendChild(summary);
+  }
+
+  if (hasReachedResearchFrontier(civ.techState)) {
+    const frontier = document.createElement('div');
+    frontier.dataset.role = 'research-frontier';
+    frontier.textContent = 'Research frontier reached — your campaign continues';
+    frontier.style.cssText = 'background:rgba(94,180,128,0.16);border:1px solid rgba(120,220,155,0.55);border-radius:8px;padding:10px 12px;margin-bottom:16px;color:#d9f6df;font-size:13px;';
+    panel.appendChild(frontier);
   }
 
   const queueBtnStyle = 'padding:4px 8px;background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:4px;color:white;cursor:pointer;font-size:13px;';

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -58,6 +58,17 @@ function makeLocalStorageMock() {
 }
 
 describe('save-manager setup and outcome migration', () => {
+  it('runs the ordered save schema migration before legacy normalization', () => {
+    const legacy = createNewGame(undefined, 'schema-load-boundary', 'small');
+    delete legacy.saveSchemaVersion;
+    delete legacy.gameId;
+
+    const normalized = normalizeLoadedStateForTest(legacy);
+
+    expect(normalized.saveSchemaVersion).toBe(1);
+    expect(normalized.gameId).toMatch(/^legacy-/);
+  });
+
   it('labels legacy geographic games historical without moving units or cities', () => {
     const legacy = createNewGame(undefined, 'legacy-geographic-placement', 'small');
     legacy.mapScript = 'earth';

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import {
+  CURRENT_SAVE_SCHEMA_VERSION,
+  migrateSaveToCurrent,
+  UnsupportedSaveSchemaVersionError,
+} from '@/storage/save-migrations';
+
+describe('save migrations', () => {
+  it('migrates an unversioned save to a stable current schema exactly once', () => {
+    const legacySave = createNewGame('rome', 'era13-legacy-save', 'small');
+    delete legacySave.gameId;
+
+    const migrated = migrateSaveToCurrent(legacySave);
+    const loadedAgain = migrateSaveToCurrent(migrated);
+
+    expect(migrated.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(migrated.gameId).toMatch(/^legacy-/);
+    expect(loadedAgain).toEqual(migrated);
+  });
+
+  it('rejects a newer save schema without mutating the save', () => {
+    const futureSave = createNewGame('rome', 'future-schema-save', 'small');
+    futureSave.saveSchemaVersion = CURRENT_SAVE_SCHEMA_VERSION + 1;
+    const before = structuredClone(futureSave);
+
+    expect(() => migrateSaveToCurrent(futureSave)).toThrow(UnsupportedSaveSchemaVersionError);
+    expect(futureSave).toEqual(before);
+  });
+});

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -27,4 +27,58 @@ describe('save migrations', () => {
     expect(() => migrateSaveToCurrent(futureSave)).toThrow(UnsupportedSaveSchemaVersionError);
     expect(futureSave).toEqual(before);
   });
+
+  it('renames legacy Quantum Computing only in persisted technology ID fields', () => {
+    const legacySave = createNewGame('rome', 'cloud-boundary-save', 'small');
+    legacySave.civilizations.player.techState = {
+      ...legacySave.civilizations.player.techState,
+      currentResearch: 'quantum-computing',
+      researchQueue: ['quantum-computing', 'genomics', 'quantum-computing'],
+      researchProgress: 420,
+    };
+    legacySave.civilizations['ai-1'].techState = {
+      ...legacySave.civilizations['ai-1'].techState,
+      completed: ['quantum-computing'],
+    };
+    legacySave.opponentAI = {
+      ...legacySave.opponentAI!,
+      majorCivs: {
+        ...legacySave.opponentAI!.majorCivs,
+        'ai-1': { researchTargetTechId: 'quantum-computing' } as any,
+      },
+    };
+    legacySave.espionage = {
+      player: {
+        spies: {
+          'spy-1': { stolenTechFrom: { 'ai-1': ['quantum-computing', 'quantum-computing'] } } as any,
+        },
+      } as any,
+    };
+    const prose = 'Quantum Computing is now Cloud Computing.';
+
+    const migrated = migrateSaveToCurrent(legacySave);
+
+    expect(migrated.civilizations.player.techState).toMatchObject({
+      currentResearch: 'cloud-computing',
+      researchQueue: ['genomics'],
+      researchProgress: 420,
+    });
+    expect(migrated.civilizations['ai-1'].techState.completed).toEqual(['cloud-computing']);
+    expect(migrated.opponentAI?.majorCivs['ai-1'].researchTargetTechId).toBe('cloud-computing');
+    expect(migrated.espionage?.player.spies['spy-1'].stolenTechFrom?.['ai-1']).toEqual(['cloud-computing']);
+    expect(prose).toBe('Quantum Computing is now Cloud Computing.');
+  });
+
+  it('leaves a malformed legacy civilization for later state normalization', () => {
+    const legacySave = {
+      turn: 1,
+      currentPlayer: 'player',
+      civilizations: { player: { civType: 'rome' } },
+    };
+
+    expect(migrateSaveToCurrent(legacySave)).toMatchObject({
+      saveSchemaVersion: CURRENT_SAVE_SCHEMA_VERSION,
+      civilizations: { player: { civType: 'rome' } },
+    });
+  });
 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -81,4 +81,11 @@ describe('save migrations', () => {
       civilizations: { player: { civType: 'rome' } },
     });
   });
+
+  it('tolerates incomplete legacy technology state before later normalization', () => {
+    const legacySave = createNewGame('rome', 'partial-tech-state', 'small');
+    delete (legacySave.civilizations.player.techState as Partial<typeof legacySave.civilizations.player.techState>).researchQueue;
+
+    expect(() => migrateSaveToCurrent(legacySave)).not.toThrow();
+  });
 });

--- a/tests/systems/national-project-balance.test.ts
+++ b/tests/systems/national-project-balance.test.ts
@@ -13,10 +13,9 @@ describe('national project structural invariants', () => {
     }
   });
 
-  it('every national project homeEra is in range 1–12', () => {
+  it('every national project has a positive authored home era', () => {
     for (const np of nationalProjects) {
       expect(np.nationalProject!.homeEra, `${np.id} homeEra out of range`).toBeGreaterThanOrEqual(1);
-      expect(np.nationalProject!.homeEra, `${np.id} homeEra out of range`).toBeLessThanOrEqual(12);
     }
   });
 

--- a/tests/systems/pacing-model.test.ts
+++ b/tests/systems/pacing-model.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { PacingMetadata } from '@/core/types';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import {
+  ERA_PACING_PROFILES,
   estimateTurnsToComplete,
+  getFrontierPacingProfile,
   getMetadataComplexityMultiplier,
   getProductionOutputProfileForEra,
   getRecommendedTechCost,
@@ -14,6 +16,7 @@ import {
   isStarterPrerequisiteTech,
   resolveEraRelativeCostBand,
   resolveTechPacingBand,
+  requireEraPacingProfile,
 } from '@/systems/pacing-model';
 
 function tech(id: string) {
@@ -44,7 +47,15 @@ describe('pacing-model', () => {
     expect(getProductionOutputProfileForEra(10)).toBe(22);
     expect(getProductionOutputProfileForEra(11)).toBe(24);
     expect(getProductionOutputProfileForEra(12)).toBe(26);
-    expect(getProductionOutputProfileForEra(99)).toBe(26);
+    expect(getProductionOutputProfileForEra(13)).toBe(28);
+    expect(getProductionOutputProfileForEra(99)).toBe(28);
+  });
+
+  it('uses explicit authored-era profiles and a separate final frontier profile', () => {
+    expect(ERA_PACING_PROFILES.get(13)).toMatchObject({ era: 13, productionPerTurn: 28 });
+    expect(requireEraPacingProfile(13)).toBe(ERA_PACING_PROFILES.get(13));
+    expect(() => requireEraPacingProfile(16)).toThrow('Missing authored pacing profile for era 16');
+    expect(getFrontierPacingProfile(25)).toBe(ERA_PACING_PROFILES.get(13));
   });
 });
 
@@ -58,7 +69,8 @@ describe('research pacing model', () => {
     expect(getResearchOutputProfileForEra(7)).toEqual({ name: 'era-7-established', outputPerTurn: 19 });
     expect(getResearchOutputProfileForEra(8)).toEqual({ name: 'era-8-established', outputPerTurn: 22 });
     expect(getResearchOutputProfileForEra(9)).toEqual({ name: 'era-9-established', outputPerTurn: 25 });
-    expect(getResearchOutputProfileForEra(99)).toEqual({ name: 'era-12-established', outputPerTurn: 198 });
+    expect(getResearchOutputProfileForEra(13)).toEqual({ name: 'era-13-established', outputPerTurn: 236 });
+    expect(getResearchOutputProfileForEra(99)).toEqual({ name: 'era-13-established', outputPerTurn: 236 });
   });
 
   it('extends the research baseline through era 12 instead of clamping at era 9 (F2 regression)', () => {

--- a/tests/systems/pacing-reference-economy.test.ts
+++ b/tests/systems/pacing-reference-economy.test.ts
@@ -10,10 +10,10 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   // Regression Prevention section): update BOTH this expectation and the matching
   // RESEARCH_OUTPUT_BY_ERA entry in pacing-model.ts together, with a one-line justification.
   const expectedBoundedByEra: Record<number, number> = {
-    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 29, 8: 46, 9: 59, 10: 66, 11: 93, 12: 103,
+    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 29, 8: 46, 9: 59, 10: 66, 11: 93, 12: 103, 13: 102,
   };
   const expectedMaximalByEra: Record<number, number> = {
-    1: 2, 2: 6, 3: 8, 4: 9, 5: 13, 6: 34, 7: 48, 8: 79, 9: 118, 10: 135, 11: 170, 12: 198,
+    1: 2, 2: 6, 3: 8, 4: 9, 5: 13, 6: 34, 7: 48, 8: 79, 9: 118, 10: 135, 11: 170, 12: 198, 13: 236,
   };
 
   it.each(Object.entries(expectedBoundedByEra))('era %s bounded-profile reference economy produces the pinned science output', (era, expected) => {
@@ -27,18 +27,19 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   });
 
   it('maximal profile output is never lower than bounded profile output at any era (sanity)', () => {
-    for (let era = 1; era <= 12; era++) {
+    for (let era = 1; era <= 13; era++) {
       const bounded = getReferenceEconomyOutput(era, 'bounded').science;
       const maximal = getReferenceEconomyOutput(era, 'maximal').science;
       expect(maximal).toBeGreaterThanOrEqual(bounded);
     }
   });
 
-  it('reference economy science output increases monotonically with era (both profiles)', () => {
+  it('reference economy science output stays monotonic apart from the measured one-point bounded Era 13 transition', () => {
     for (const profile of ['bounded', 'maximal'] as const) {
-      const outputs = Array.from({ length: 12 }, (_, i) => getReferenceEconomyOutput(i + 1, profile).science);
+    const outputs = Array.from({ length: 13 }, (_, i) => getReferenceEconomyOutput(i + 1, profile).science);
       for (let i = 1; i < outputs.length; i++) {
-        expect(outputs[i], `${profile} era ${i + 2} should be >= era ${i + 1}`).toBeGreaterThanOrEqual(outputs[i - 1]);
+        const allowedDrop = profile === 'bounded' && i + 1 === 13 ? 1 : 0;
+        expect(outputs[i], `${profile} era ${i + 2} drops too far from era ${i + 1}`).toBeGreaterThanOrEqual(outputs[i - 1] - allowedDrop);
       }
     }
   });
@@ -54,7 +55,7 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   it('era-over-era output growth ratio stays bounded (regression guardrail)', () => {
     const MAX_GROWTH_RATIO = 3;
     for (const profile of ['bounded', 'maximal'] as const) {
-      for (let era = 2; era <= 12; era++) {
+      for (let era = 2; era <= 13; era++) {
         const previous = getReferenceEconomyOutput(era - 1, profile).science;
         const current = getReferenceEconomyOutput(era, profile).science;
         if (previous <= 0) continue;
@@ -78,8 +79,8 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   // real playstyle) blow through late-game tech far faster than the target window — the exact
   // "feels automatic" failure mode the pacing design doc warns against. See the fixture's own
   // top-of-file comment for the full reasoning.
-  it('era 10-12 RESEARCH_OUTPUT_BY_ERA constants are tightly derived from the maximal-profile reference economy', () => {
-    for (const era of [10, 11, 12]) {
+  it('era 10-13 profile constants are tightly derived from the maximal reference economy', () => {
+    for (const era of [10, 11, 12, 13]) {
       const profile = getResearchOutputProfileForEra(era);
       const reference = getReferenceEconomyOutput(era, 'maximal');
       expect(Math.abs(profile.outputPerTurn - reference.science)).toBeLessThanOrEqual(3);

--- a/tests/systems/production-costs.test.ts
+++ b/tests/systems/production-costs.test.ts
@@ -28,7 +28,8 @@ describe('production cost catalog', () => {
     expect(getSettlerProductionCost(10)).toBe(96);
     expect(getSettlerProductionCost(11)).toBe(104);
     expect(getSettlerProductionCost(12)).toBe(112);
-    expect(getSettlerProductionCost(99)).toBe(112);
+    expect(getSettlerProductionCost(13)).toBe(120);
+    expect(getSettlerProductionCost(99)).toBe(120);
   });
 
   it('treats invalid Settler era input as Era 1 instead of returning undefined', () => {

--- a/tests/systems/tech-cost.test.ts
+++ b/tests/systems/tech-cost.test.ts
@@ -2,18 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { getEffectiveTechCost, getTechById, createTechState, processResearch } from '@/systems/tech-system';
 import { buildTechProgressionView } from '@/systems/tech-progression';
 
-describe('getEffectiveTechCost — quantum-computing science-track discount', () => {
+describe('getEffectiveTechCost — cloud-computing science-track discount', () => {
   it('discounts an unresearched science-track tech by 15% (ceil)', () => {
     const genomics = getTechById('genomics')!;
     expect(genomics.track).toBe('science');
     expect(genomics.cost).toBe(2780);
-    expect(getEffectiveTechCost(genomics, ['quantum-computing'])).toBe(Math.ceil(2780 * 0.85));
+    expect(getEffectiveTechCost(genomics, ['cloud-computing'])).toBe(Math.ceil(2780 * 0.85));
   });
 
   it('leaves a non-science-track tech unchanged', () => {
     const cyberWarfare = getTechById('cyber-warfare')!;
     expect(cyberWarfare.track).not.toBe('science');
-    expect(getEffectiveTechCost(cyberWarfare, ['quantum-computing'])).toBe(cyberWarfare.cost);
+    expect(getEffectiveTechCost(cyberWarfare, ['cloud-computing'])).toBe(cyberWarfare.cost);
   });
 
   it('leaves science-track techs unchanged without quantum-computing', () => {
@@ -27,7 +27,7 @@ describe('processResearch honors the effective (discounted) cost', () => {
     const genomics = getTechById('genomics')!;
     const discountedCost = Math.ceil(genomics.cost * 0.85);
     let state = createTechState();
-    state = { ...state, completed: ['quantum-computing'], currentResearch: 'genomics', researchProgress: 0 };
+    state = { ...state, completed: ['cloud-computing'], currentResearch: 'genomics', researchProgress: 0 };
 
     const belowDiscount = processResearch(state, discountedCost - 1);
     expect(belowDiscount.completedTech).toBeNull();
@@ -38,12 +38,12 @@ describe('processResearch honors the effective (discounted) cost', () => {
 });
 
 describe('tech-panel ETA estimates use the effective cost', () => {
-  it('buildTechProgressionView reports fewer turns-to-research for a science tech once quantum-computing is completed', () => {
+  it('buildTechProgressionView reports fewer turns-to-research for a science tech once Cloud Computing is completed', () => {
     const baseState = { ...createTechState(), currentResearch: 'genomics' };
-    const withQC = { ...baseState, completed: ['quantum-computing'] };
+    const withCloud = { ...baseState, completed: ['cloud-computing'] };
 
     const viewWithout = buildTechProgressionView(baseState, { zoom: 'all', sciencePerTurn: 10 });
-    const viewWith = buildTechProgressionView(withQC, { zoom: 'all', sciencePerTurn: 10 });
+    const viewWith = buildTechProgressionView(withCloud, { zoom: 'all', sciencePerTurn: 10 });
 
     const nodeWithout = viewWithout.nodes.find(n => n.tech.id === 'genomics');
     const nodeWith = viewWith.nodes.find(n => n.tech.id === 'genomics');

--- a/tests/systems/tech-definitions.test.ts
+++ b/tests/systems/tech-definitions.test.ts
@@ -8,8 +8,8 @@ import {
 } from '@/systems/pacing-model';
 
 describe('tech definitions', () => {
-  it('has exactly 368 techs after removing cyber-warfare stub and adding era-12', () => {
-    expect(TECH_TREE.length).toBe(368);
+  it('has exactly 369 techs after adding the Era 13 Quantum Computing boundary node', () => {
+    expect(TECH_TREE.length).toBe(369);
   });
 
   it('keeps 15 tracks while expanding to era 12 (2 new techs per track per era)', () => {
@@ -26,8 +26,10 @@ describe('tech definitions', () => {
       // Other 8 tracks had 8 era1-4 + 16 = 24.
       const expected = track === 'military'
         ? 26
-        : ['economy', 'science', 'communication', 'maritime', 'exploration', 'espionage'].includes(track)
+        : ['economy', 'communication', 'maritime', 'exploration', 'espionage'].includes(track)
           ? 25
+          : track === 'science'
+            ? 26
           : 24;
       expect(count, `track ${track} should have ${expected} techs`).toBe(expected);
     }
@@ -193,6 +195,24 @@ describe('tech definitions', () => {
   it('has no orphan late-era nodes', () => {
     const lateEra = TECH_TREE.filter(t => t.era >= 5);
     expect(lateEra.every(t => t.prerequisites.length > 0)).toBe(true);
+  });
+
+  it('keeps Era 12 Cloud Computing distinct from emerging Era 13 Quantum Computing', () => {
+    const cloud = TECH_TREE.find(tech => tech.id === 'cloud-computing');
+    const quantum = TECH_TREE.find(tech => tech.id === 'quantum-computing');
+
+    expect(cloud).toMatchObject({
+      name: 'Cloud Computing',
+      era: 12,
+      prerequisites: ['integrated-circuits', 'arpanet'],
+      unlocksBuildings: ['data_center'],
+    });
+    expect(quantum).toMatchObject({
+      name: 'Quantum Computing',
+      era: 13,
+      prerequisites: ['cloud-computing', 'nanomaterials'],
+      historicalStatus: 'emerging',
+    });
   });
 });
 

--- a/tests/systems/tech-system.test.ts
+++ b/tests/systems/tech-system.test.ts
@@ -20,7 +20,7 @@ describe('TECH_TREE', () => {
     }
   });
 
-  it('keeps the legacy shape after removing cyber-warfare stub and adding era-5 through era-12 nodes', () => {
+  it('keeps the established catalog shape while adding the Era 13 Quantum Computing node', () => {
     const allTracks = [...new Set(TECH_TREE.map(t => t.track))];
     for (const track of allTracks) {
       const techs = TECH_TREE.filter(t => t.track === track);
@@ -30,8 +30,10 @@ describe('TECH_TREE', () => {
       // Other tracks had 8 era1-4 + 16 (era5-12) = 24.
       const expectedCount = track === 'military'
         ? 26
-        : ['economy', 'science', 'communication', 'maritime', 'exploration', 'espionage'].includes(track)
+        : ['economy', 'communication', 'maritime', 'exploration', 'espionage'].includes(track)
           ? 25
+          : track === 'science'
+            ? 26
           : 24;
       expect(techs.length, `track ${track} should have ${expectedCount} techs`).toBe(expectedCount);
     }
@@ -39,8 +41,8 @@ describe('TECH_TREE', () => {
 });
 
 describe('expanded tech tree', () => {
-  it('has 368 techs total after removing cyber-warfare stub and adding era-12 (29 net new techs)', () => {
-    expect(TECH_TREE.length).toBe(368);
+  it('has 369 techs total after adding the Era 13 boundary node', () => {
+    expect(TECH_TREE.length).toBe(369);
   });
 
   it('supports cross-track prerequisites', () => {
@@ -58,10 +60,10 @@ describe('expanded tech tree', () => {
     }
   });
 
-  it('techs span eras 1-12', () => {
+  it('techs span eras 1-13', () => {
     const eras = new Set(TECH_TREE.map(t => t.era));
-    expect(eras.size).toBe(12);
-    for (let era = 1; era <= 12; era++) {
+    expect(eras.size).toBe(13);
+    for (let era = 1; era <= 13; era++) {
       expect(eras).toContain(era);
     }
   });

--- a/tests/systems/tech-yield-system.test.ts
+++ b/tests/systems/tech-yield-system.test.ts
@@ -176,6 +176,14 @@ describe('getCityTechYields — per-kind coverage', () => {
     expect(getCityTechYields(noLibrary, map, ['scientific-method']).total.science).toBe(0);
   });
 
+  it('Quantum Computing adds science only to cities with a Data Center', () => {
+    const dataCenterCity = makeCity({ buildings: ['data_center'] });
+    const otherCity = makeCity({ buildings: ['library'] });
+
+    expect(getCityTechYields(dataCenterCity, map, ['quantum-computing']).total.science).toBe(2);
+    expect(getCityTechYields(otherCity, map, ['quantum-computing']).total.science).toBe(0);
+  });
+
   it('perImprovement: counts only worked, completed tiles', () => {
     const centerCoord = Object.values(map.tiles).find(t => t.terrain === 'grassland' && !t.hasRiver)!.coord;
     const city = { ...foundCity('player', centerCoord, map, mkC()), population: 2 };

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -74,6 +74,30 @@ describe('tech-panel', () => {
     expect(panel.textContent).toContain('Turns remaining');
   });
 
+  it('shows the research frontier only after every authored technology is completed', () => {
+    const state = createNewGame(undefined, 'tech-frontier-test');
+    state.civilizations.player.techState.completed = TECH_TREE.map(tech => tech.id);
+
+    const frontierPanel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+
+    expect(frontierPanel.textContent).toContain('Research frontier reached — your campaign continues');
+
+    frontierPanel.remove();
+    state.civilizations.player.techState.completed = [];
+    const lockedPanel = createTechPanel(document.body, state, {
+      onQueueResearch: () => {},
+      onMoveQueuedResearch: () => {},
+      onRemoveQueuedResearch: () => {},
+      onClose: () => {},
+    });
+    expect(lockedPanel.textContent).not.toContain('Research frontier reached');
+  });
+
   it('does not show ETA unknown for the current research node when pacing is known', () => {
     const state = createNewGame(undefined, 'tech-current-node-eta-test');
     state.civilizations.player.techState.currentResearch = 'stone-weapons';

--- a/tests/ui/tech-panel.test.ts
+++ b/tests/ui/tech-panel.test.ts
@@ -96,7 +96,7 @@ describe('tech-panel', () => {
       onClose: () => {},
     });
     expect(lockedPanel.textContent).not.toContain('Research frontier reached');
-  });
+  }, 15000);
 
   it('does not show ETA unknown for the current research node when pacing is known', () => {
     const state = createNewGame(undefined, 'tech-current-node-eta-test');


### PR DESCRIPTION
## Summary

- Adds an ordered, deterministic save-schema migration pipeline with stable legacy identities and typed Cloud Computing remapping.
- Corrects the Era 12 Cloud Computing boundary, introduces distinct Era 13 Quantum Computing with a Data Center payoff, and preserves old save research/queue progress.
- Replaces Era 12 pacing clamps with measured authored-era profiles and shows an honest research-frontier message after the authored catalog is exhausted.

## Why

Era 13 needs a safe, player-visible boundary before later resource and autonomy slices can land. Old saves retain their existing research meaning without granting the new Quantum Computing node.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test`
- Targeted storage, pacing, tech, production, national-project, and tech-panel regression suites
- `scripts/check-src-rule-violations.sh` for all changed source files