### PR TITLE
feat(era13-mr2): deliver industrial-to-future resources

### DIFF
--- a/src/ai/ai-production.ts
+++ b/src/ai/ai-production.ts
@@ -289,6 +289,7 @@ function generateWithResidual(
       era: state.era,
       completedTechs: civ.techState.completed,
       activeNationalProjects,
+      availableResources: resources,
     });
     const productionTurns = Math.max(1, Math.ceil(cost / productionPerTurn));
     const roleDemandScore = fulfilled.missing * 40 + fulfilled.priority / 5;
@@ -345,6 +346,7 @@ function generateWithResidual(
       era: state.era,
       completedTechs: civ.techState.completed,
       activeNationalProjects,
+      availableResources: resources,
     });
     const productionTurns = Math.max(1, Math.ceil(cost / productionPerTurn));
     const personalityScore = weightProductionRoles(personality, []);

--- a/src/ai/ai-resource-marketplace.ts
+++ b/src/ai/ai-resource-marketplace.ts
@@ -1,10 +1,18 @@
 import type { GameState, ResourceType } from '@/core/types';
-import { BUILDINGS, getProductionCostForItem, TRAINABLE_UNITS } from '@/systems/city-system';
+import {
+  BUILDINGS,
+  getAvailableBuildings,
+  getProductionCostForItem,
+  getTrainableUnitsForCity,
+  TRAINABLE_UNITS,
+} from '@/systems/city-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
+import { getReservedNationalProjectKeys } from '@/systems/national-project-system';
 import {
   canBuyResourceAccess,
   getCivAvailableResources,
+  getResourceAccessCost,
   performBuyResourceAccess,
 } from '@/systems/resource-acquisition-system';
 
@@ -16,9 +24,38 @@ function getRequiredResources(itemId: string): readonly ResourceType[] {
     ?? [];
 }
 
+function getResourcePurchaseCandidates(state: GameState, civId: string, cityId: string): string[] {
+  const civ = state.civilizations[civId];
+  const city = state.cities[cityId];
+  if (!civ || !city) return [];
+  if (city.productionQueue.length > 0) return [city.productionQueue[0]];
+
+  const reservedNationalProjects = getReservedNationalProjectKeys(state, civId);
+  return [
+    ...getAvailableBuildings(
+      city,
+      civ.techState.completed,
+      state.map,
+      undefined,
+      state.era,
+      reservedNationalProjects,
+      civId,
+    ).map(building => building.id),
+    ...getTrainableUnitsForCity(
+      city,
+      civ.techState.completed,
+      state.map,
+      civ.civType,
+      undefined,
+    ).map(unit => unit.type),
+  ].sort();
+}
+
 /**
  * Gives a major AI one deterministic, player-rule-equivalent resource purchase
- * for a queued hard input that can actually finish before temporary access expires.
+ * for a queued item or an idle-city hard-gated candidate that can finish before
+ * temporary access expires. The latter runs before normal AI production chooses
+ * a candidate, so hard requirements are reachable instead of filtered forever.
  */
 export function processAIResourceMarketplace(state: GameState, civId: string): GameState {
   const civ = state.civilizations[civId];
@@ -28,33 +65,34 @@ export function processAIResourceMarketplace(state: GameState, civId: string): G
   for (const cityId of [...civ.cities].sort()) {
     const city = working.cities[cityId];
     const currentCiv = working.civilizations[civId];
-    const itemId = city?.productionQueue[0];
-    if (!city || !currentCiv || !itemId) continue;
+    if (!city || !currentCiv) continue;
     const available = getCivAvailableResources(working, civId);
-    const missing = getRequiredResources(itemId).filter(resource => !available.has(resource));
-    if (missing.length !== 1) continue;
+    for (const itemId of getResourcePurchaseCandidates(working, civId, cityId)) {
+      const missing = getRequiredResources(itemId).filter(resource => !available.has(resource));
+      if (missing.length !== 1) continue;
 
-    const cost = getProductionCostForItem(itemId, {
-      city,
-      era: working.era,
-      completedTechs: currentCiv.techState.completed,
-      availableResources: available,
-    });
-    const output = Math.max(1, calculateProjectedCityYields(
-      working,
-      cityId,
-      resolveCivDefinition(working, currentCiv.civType)?.bonusEffect,
-    ).production);
-    if (Math.ceil(Math.max(0, cost - city.productionProgress) / output) > ACCESS_DURATION_TURNS) continue;
+      const cost = getProductionCostForItem(itemId, {
+        city,
+        era: working.era,
+        completedTechs: currentCiv.techState.completed,
+        availableResources: available,
+      });
+      const output = Math.max(1, calculateProjectedCityYields(
+        working,
+        cityId,
+        resolveCivDefinition(working, currentCiv.civType)?.bonusEffect,
+      ).production);
+      if (Math.ceil(Math.max(0, cost - city.productionProgress) / output) > ACCESS_DURATION_TURNS) continue;
 
-    const resource = missing[0];
-    const price = (working.marketplace?.prices[resource] ?? 0) * 3;
-    if (price <= 0 || currentCiv.gold < price) continue;
-    const seller = Object.keys(currentCiv.diplomacy.relationships)
-      .sort()
-      .find(sellerId => canBuyResourceAccess(working, civId, sellerId, resource));
-    if (!seller) continue;
-    return performBuyResourceAccess(working, civId, seller, resource);
+      const resource = missing[0];
+      const price = getResourceAccessCost(working, resource);
+      if (currentCiv.gold < price) continue;
+      const seller = Object.keys(currentCiv.diplomacy.relationships)
+        .sort()
+        .find(sellerId => canBuyResourceAccess(working, civId, sellerId, resource));
+      if (!seller) continue;
+      return performBuyResourceAccess(working, civId, seller, resource);
+    }
   }
   return working;
 }

--- a/src/ai/ai-resource-marketplace.ts
+++ b/src/ai/ai-resource-marketplace.ts
@@ -1,0 +1,60 @@
+import type { GameState, ResourceType } from '@/core/types';
+import { BUILDINGS, getProductionCostForItem, TRAINABLE_UNITS } from '@/systems/city-system';
+import { calculateProjectedCityYields } from '@/systems/city-work-system';
+import { resolveCivDefinition } from '@/systems/civ-registry';
+import {
+  canBuyResourceAccess,
+  getCivAvailableResources,
+  performBuyResourceAccess,
+} from '@/systems/resource-acquisition-system';
+
+const ACCESS_DURATION_TURNS = 10;
+
+function getRequiredResources(itemId: string): readonly ResourceType[] {
+  return BUILDINGS[itemId]?.resourceRequired
+    ?? TRAINABLE_UNITS.find(unit => unit.type === itemId)?.resourceRequired
+    ?? [];
+}
+
+/**
+ * Gives a major AI one deterministic, player-rule-equivalent resource purchase
+ * for a queued hard input that can actually finish before temporary access expires.
+ */
+export function processAIResourceMarketplace(state: GameState, civId: string): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ || !state.marketplace) return state;
+  let working = state;
+
+  for (const cityId of [...civ.cities].sort()) {
+    const city = working.cities[cityId];
+    const currentCiv = working.civilizations[civId];
+    const itemId = city?.productionQueue[0];
+    if (!city || !currentCiv || !itemId) continue;
+    const available = getCivAvailableResources(working, civId);
+    const missing = getRequiredResources(itemId).filter(resource => !available.has(resource));
+    if (missing.length !== 1) continue;
+
+    const cost = getProductionCostForItem(itemId, {
+      city,
+      era: working.era,
+      completedTechs: currentCiv.techState.completed,
+      availableResources: available,
+    });
+    const output = Math.max(1, calculateProjectedCityYields(
+      working,
+      cityId,
+      resolveCivDefinition(working, currentCiv.civType)?.bonusEffect,
+    ).production);
+    if (Math.ceil(Math.max(0, cost - city.productionProgress) / output) > ACCESS_DURATION_TURNS) continue;
+
+    const resource = missing[0];
+    const price = (working.marketplace?.prices[resource] ?? 0) * 3;
+    if (price <= 0 || currentCiv.gold < price) continue;
+    const seller = Object.keys(currentCiv.diplomacy.relationships)
+      .sort()
+      .find(sellerId => canBuyResourceAccess(working, civId, sellerId, resource));
+    if (!seller) continue;
+    return performBuyResourceAccess(working, civId, seller, resource);
+  }
+  return working;
+}

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -94,6 +94,7 @@ import { isAIHostileOwner } from './ai-hostility';
 import { hasAICombatRole } from './ai-unit-roles';
 import { applyAIProduction } from './ai-production';
 import { applyAIResearch } from './ai-research';
+import { processAIResourceMarketplace } from './ai-resource-marketplace';
 
 function addAlwaysHostileOwners(
   state: GameState,
@@ -651,6 +652,7 @@ function processAITurnInternal(
     preparedForTurn,
     bus,
   ).state;
+  newState = processAIResourceMarketplace(newState, civId);
   civ = newState.civilizations[civId];
   const administrativePerception = preparedForTurn.perception;
 

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -26,6 +26,7 @@ import { refreshLastSeenPresentationsForCiv } from '@/systems/last-seen-presenta
 import { createEmptyOpponentAIState } from './opponent-ai-state';
 import { placeCivilizationStarts } from '@/systems/start-placement-system';
 import { selectAIRoster } from '@/systems/ai-roster-selection';
+import { placeLateResources } from '@/systems/late-resource-placement';
 
 function hashSeed(s: string): number {
   let h = 0;
@@ -241,6 +242,7 @@ export function createNewGame(
   // Place wonders and villages
   guaranteeStartResources(map, startPositions, createRng(gameSeed + '-resource-guarantee'));
   placeWonders(map, startPositions, actualSize, gameSeed);
+  placeLateResources(map.tiles, createRng(gameSeed + '-late-resources'), startPositions, civTypeIds.length);
   const tribalVillages = placeVillages(map, startPositions, actualSize, gameSeed);
   const beastsMode = settings.beastsMode ?? 'wild';
   const beastLairs = beastsMode === 'off'
@@ -433,6 +435,7 @@ export function createHotSeatGame(
   // Place wonders and villages
   guaranteeStartResources(map, startPositions, createRng(gameSeed + '-resource-guarantee'));
   placeWonders(map, startPositions, config.mapSize, gameSeed);
+  placeLateResources(map.tiles, createRng(gameSeed + '-late-resources'), startPositions, civTypeIds.length);
   const tribalVillages = placeVillages(map, startPositions, config.mapSize, gameSeed);
   const hotSeatSettings = createDefaultSettings(config.mapSize);
   const beastsModeHotSeat = hotSeatSettings.beastsMode ?? 'wild';

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -212,7 +212,7 @@ export function processTurn(
         food:       Math.floor((baseYields.food       + (wonderCityBonuses.food       ?? 0) + resourceYieldBonus.food       + (npCivBonuses.food       ?? 0) + empireFlatFoodForCity + resilienceBonus) * unrestMultiplier),
         production: Math.floor((baseYields.production + (wonderCityBonuses.production ?? 0) + resourceYieldBonus.production + (npCivBonuses.production ?? 0) + empireFlatProductionForCity + resilienceBonus) * unrestMultiplier * (1 + (empireTechPercents.production ?? 0) / 100)),
         gold:       Math.floor((baseYields.gold       + (wonderCityBonuses.gold       ?? 0) + resourceYieldBonus.gold)       * unrestMultiplier * (1 + (empireTechPercents.gold ?? 0) / 100)),
-        science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0) + networkGovernanceScienceForCity) * unrestMultiplier * (1 + (empireTechPercents.science ?? 0) / 100)),
+        science:    Math.floor((baseYields.science    + (wonderCityBonuses.science    ?? 0) + resourceYieldBonus.science + networkGovernanceScienceForCity) * unrestMultiplier * (1 + (empireTechPercents.science ?? 0) / 100)),
       };
       totalScience += yields.science;
       totalGold += yields.gold;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -229,7 +229,7 @@ export interface TribalVillage {
 export type VisibilityState = 'unexplored' | 'fog' | 'visible';
 
 export type ImprovementType = 'farm' | 'mine' | 'lumber_camp' | 'watermill'
-  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'resource_outpost' | 'none';
+  | 'plantation' | 'pasture' | 'camp' | 'quarry' | 'oil_well' | 'resource_outpost' | 'none';
 // resource_outpost is excluded: only Expeditions can establish outposts, not Workers
 export type BuildableImprovementType = Exclude<ImprovementType, 'none' | 'resource_outpost'>;
 export type WorkerActionType = BuildableImprovementType | 'drain_swamp' | 'build_road' | 'restore_land';
@@ -1290,7 +1290,8 @@ export interface OpponentAIState {
 
 export type LuxuryResource = 'silk' | 'wine' | 'spices' | 'gems' | 'ivory' | 'incense'
   | 'gold' | 'silver' | 'furs' | 'sheep';
-export type StrategicResource = 'copper' | 'iron' | 'horses' | 'stone' | 'cattle' | 'salt';
+export type StrategicResource = 'copper' | 'iron' | 'horses' | 'stone' | 'cattle' | 'salt'
+  | 'coal' | 'oil' | 'aluminum' | 'uranium' | 'rare-earth-elements' | 'battery-minerals';
 export type ResourceType = LuxuryResource | StrategicResource;
 
 export interface TradeRoute {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -438,6 +438,8 @@ export interface City {
   buildings: string[];       // building IDs
   productionQueue: string[]; // what's being built (building or unit ID)
   productionProgress: number;
+  /** One-time save-migration exemption for pre-resource-gate queued items. */
+  legacyResourceGrace?: string[];
   ownedTiles: HexCoord[];    // city territory/control, not active citizen assignment
   workedTiles: HexCoord[];
   focus: CityFocus;

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -23,6 +23,7 @@ export const IMPROVEMENT_ICONS: Record<string, string> = {
   pasture: '🐂',
   camp: '⛺',
   quarry: '⚒️',
+  oil_well: '🛢️',
   resource_outpost: '🚩',  // emoji fallback; SVG drawn via getOutpostMarkerImage when loaded
 };
 

--- a/src/renderer/improvements/improvement-treatment.ts
+++ b/src/renderer/improvements/improvement-treatment.ts
@@ -16,6 +16,7 @@ const TREATMENT_FAMILIES: Record<string, ImprovementTreatmentFamily> = {
   plantation: 'orchard-rows',
   pasture: 'fence-lines',
   camp: 'small-camp',
+  oil_well: 'worked-rock',
 };
 
 export function getImprovementTreatmentFamily(improvement: string): ImprovementTreatmentFamily | null {
@@ -92,6 +93,16 @@ export function drawImprovementTreatment(
         ctx.fillStyle = `rgba(${174 + step * 15},${166 + step * 15},${150 + step * 16},0.78)`;
         ctx.fill();
       }
+      break;
+    case 'oil_well':
+      ctx.fillStyle = 'rgba(35,38,42,0.92)';
+      ctx.fillRect(cx - size * 0.05, cy - size * 0.32, size * 0.1, size * 0.54);
+      ctx.strokeStyle = 'rgba(205,185,110,0.9)';
+      ctx.lineWidth = Math.max(1, size * 0.035);
+      ctx.beginPath();
+      ctx.moveTo(cx - size * 0.22, cy - size * 0.12);
+      ctx.lineTo(cx + size * 0.22, cy - size * 0.12);
+      ctx.stroke();
       break;
     case 'lumber_camp':
       ctx.strokeStyle = 'rgba(91,57,31,0.9)';

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -2,6 +2,7 @@ import type { GameState } from '@/core/types';
 import { createRng } from '@/systems/map-generator';
 import { placeLateResources } from '@/systems/late-resource-placement';
 import { createMarketplaceState } from '@/systems/trade-system';
+import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 
 export const CURRENT_SAVE_SCHEMA_VERSION = 2;
 
@@ -119,7 +120,18 @@ function migrateLateResources(state: GameState): GameState {
     }
     : defaults;
 
-  return { ...state, gameId, map: { ...state.map, tiles }, marketplace };
+  const cities = Object.fromEntries(Object.entries(state.cities ?? {}).map(([cityId, city]) => {
+    const grandfathered = city.productionQueue.filter(item => {
+      const building = BUILDINGS[item];
+      const unit = TRAINABLE_UNITS.find(candidate => candidate.type === item);
+      return (building?.resourceRequired?.length ?? unit?.resourceRequired?.length ?? 0) > 0;
+    });
+    return [cityId, grandfathered.length > 0
+      ? { ...city, legacyResourceGrace: [...new Set([...(city.legacyResourceGrace ?? []), ...grandfathered])] }
+      : city];
+  }));
+
+  return { ...state, gameId, map: { ...state.map, tiles }, marketplace, cities };
 }
 
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -1,6 +1,9 @@
 import type { GameState } from '@/core/types';
+import { createRng } from '@/systems/map-generator';
+import { placeLateResources } from '@/systems/late-resource-placement';
+import { createMarketplaceState } from '@/systems/trade-system';
 
-export const CURRENT_SAVE_SCHEMA_VERSION = 1;
+export const CURRENT_SAVE_SCHEMA_VERSION = 2;
 
 export type SaveMigration = (state: GameState) => GameState;
 
@@ -97,8 +100,27 @@ function migrateToEra13Foundation(state: GameState): GameState {
   return remapPersistedTechReferences(withStableIdentity);
 }
 
+function migrateLateResources(state: GameState): GameState {
+  const gameId = state.gameId ?? stableLegacyGameId(state);
+  const tiles = Object.fromEntries(Object.entries(state.map?.tiles ?? {}).map(([key, tile]) => [key, { ...tile }]));
+  placeLateResources(tiles, createRng(`${gameId}-late-resources`));
+
+  const defaults = createMarketplaceState();
+  const marketplace = state.marketplace
+    ? {
+      ...state.marketplace,
+      prices: { ...defaults.prices, ...state.marketplace.prices },
+      priceHistory: { ...defaults.priceHistory, ...state.marketplace.priceHistory },
+      purchasedResources: state.marketplace.purchasedResources ?? [],
+    }
+    : defaults;
+
+  return { ...state, gameId, map: { ...state.map, tiles }, marketplace };
+}
+
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   1: migrateToEra13Foundation,
+  2: migrateLateResources,
 };
 
 function readSchemaVersion(raw: Record<string, unknown>): number {

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -103,7 +103,11 @@ function migrateToEra13Foundation(state: GameState): GameState {
 function migrateLateResources(state: GameState): GameState {
   const gameId = state.gameId ?? stableLegacyGameId(state);
   const tiles = Object.fromEntries(Object.entries(state.map?.tiles ?? {}).map(([key, tile]) => [key, { ...tile }]));
-  placeLateResources(tiles, createRng(`${gameId}-late-resources`));
+  placeLateResources(
+    tiles,
+    createRng(`${gameId}-late-resources`),
+    Object.values(state.cities ?? {}).map(city => city.position),
+  );
 
   const defaults = createMarketplaceState();
   const marketplace = state.marketplace

--- a/src/systems/balanced-map-generator.ts
+++ b/src/systems/balanced-map-generator.ts
@@ -8,7 +8,6 @@ import {
 } from './map-generator';
 import { hexKey, hexDistance } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
-import { placeLateResources } from './late-resource-placement';
 
 // S2a: extended with all 10 luxury resources so the hotspot/equalization passes
 // treat new luxuries the same as the original 6.
@@ -136,7 +135,6 @@ export function generateBalancedMap(
   // Standard resource placement (skips tiles with existing resources)
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
-  placeLateResources(tiles, createRng(seed + '-late-resources'), startPositions, civCount);
 
   // Post-placement zone equalization: bring under-served zones up to 75% of mean density
   const postCounts = new Array(civCount).fill(0);

--- a/src/systems/balanced-map-generator.ts
+++ b/src/systems/balanced-map-generator.ts
@@ -136,7 +136,7 @@ export function generateBalancedMap(
   // Standard resource placement (skips tiles with existing resources)
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
-  placeLateResources(tiles, createRng(seed + '-late-resources'), startPositions);
+  placeLateResources(tiles, createRng(seed + '-late-resources'), startPositions, civCount);
 
   // Post-placement zone equalization: bring under-served zones up to 75% of mean density
   const postCounts = new Array(civCount).fill(0);

--- a/src/systems/balanced-map-generator.ts
+++ b/src/systems/balanced-map-generator.ts
@@ -8,6 +8,7 @@ import {
 } from './map-generator';
 import { hexKey, hexDistance } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
+import { placeLateResources } from './late-resource-placement';
 
 // S2a: extended with all 10 luxury resources so the hotspot/equalization passes
 // treat new luxuries the same as the original 6.
@@ -135,6 +136,7 @@ export function generateBalancedMap(
   // Standard resource placement (skips tiles with existing resources)
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
+  placeLateResources(tiles, createRng(seed + '-late-resources'));
 
   // Post-placement zone equalization: bring under-served zones up to 75% of mean density
   const postCounts = new Array(civCount).fill(0);

--- a/src/systems/balanced-map-generator.ts
+++ b/src/systems/balanced-map-generator.ts
@@ -136,7 +136,7 @@ export function generateBalancedMap(
   // Standard resource placement (skips tiles with existing resources)
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
-  placeLateResources(tiles, createRng(seed + '-late-resources'));
+  placeLateResources(tiles, createRng(seed + '-late-resources'), startPositions);
 
   // Post-placement zone equalization: bring under-served zones up to 75% of mean density
   const postCounts = new Array(civCount).fill(0);

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1837,6 +1837,7 @@ export function processCity(
   let newProgress = city.productionProgress;
   const newQueue = [...city.productionQueue];
   const newBuildings = [...city.buildings];
+  const legacyResourceGrace = new Set(city.legacyResourceGrace ?? []);
   const droppedProductionItems: DroppedProductionItem[] = [];
 
   // Drop queued items that are no longer available (tech lost, resource lost)
@@ -1852,7 +1853,7 @@ export function processCity(
           droppedProductionItems.push({ itemId: item, itemKind: 'building', reason: 'obsoleted' });
           return false;
         }
-        if (building?.resourceRequired?.length && availableResources !== undefined) {
+        if (building?.resourceRequired?.length && availableResources !== undefined && !legacyResourceGrace.has(item)) {
           if (!building.resourceRequired.every(r => availableResources!.has(r))) {
             droppedProductionItems.push({ itemId: item, itemKind: 'building', reason: 'resource-lost' });
             return false;
@@ -1873,7 +1874,8 @@ export function processCity(
         // reasons applying (see the musketeer save-compat test above) — so a third, honest
         // fallback reason covers that residual case instead of misreporting it as resource-lost.
         const obsoleted = unit.obsoletedByTech != null && completedTechs.includes(unit.obsoletedByTech);
-        const resourceLost = (unit.resourceRequired?.length ?? 0) > 0
+        const resourceLost = !legacyResourceGrace.has(unit.type)
+          && (unit.resourceRequired?.length ?? 0) > 0
           && availableResources !== undefined
           && !unit.resourceRequired!.every(r => availableResources.has(r));
         const reason: ProductionDropReason = obsoleted
@@ -1957,6 +1959,7 @@ export function processCity(
       newBuildings.length = 0;
       newBuildings.push(...completion.city.buildings);
       newProgress = completion.city.productionProgress;
+      legacyResourceGrace.delete(currentItem);
       completedBuilding = completion.completedBuilding;
       completedUnit = completion.completedUnit;
     }
@@ -1980,6 +1983,7 @@ export function processCity(
     productionProgress: newProgress,
     productionQueue: newQueue,
     buildings: newBuildings,
+    ...(legacyResourceGrace.size > 0 ? { legacyResourceGrace: [...legacyResourceGrace] } : { legacyResourceGrace: undefined }),
   };
 
   return {

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -1843,7 +1843,10 @@ export function processCity(
   // Drop queued items that are no longer available (tech lost, resource lost)
   if ((completedTechs.length > 0 || availableResources) && newQueue.length > 0) {
     const trainable = getTrainableUnitsForCiv(completedTechs, civType, availableResources);
-    const trainableTypes = new Set(trainable.map(u => u.type));
+    const trainableTypes = new Set([
+      ...trainable.map(u => u.type),
+      ...[...legacyResourceGrace].filter(item => TRAINABLE_UNITS.some(unit => unit.type === item)),
+    ]);
     const BUILDING_IDS = new Set(Object.keys(BUILDINGS));
     const filtered = newQueue.filter(item => {
       if (item.startsWith('legendary:')) return true;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -5,6 +5,7 @@ import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
 import { TECH_COST_DISCOUNTS, getFoundingBonusFood } from './tech-yield-definitions';
 import { UNIT_CLASS_BY_TYPE, type UnitClass } from './unit-modifier-definitions';
+import { getResourceAdvantageMultiplier } from './resource-advantages';
 import {
   getLegendaryWonderDisplayName,
   getLegendaryWonderProductionCost,
@@ -619,7 +620,7 @@ export const BUILDINGS: Record<string, Building> = {
     id: 'oil_refinery', name: 'Oil Refinery', category: 'production',
     yields: { food: 0, production: 3, gold: 0, science: 0 }, productionCost: 185,
     description: 'Petroleum extraction and refining. +3 production per turn.',
-    techRequired: 'petroleum-industry',
+    techRequired: 'petroleum-industry', resourceRequired: ['oil'],
   },
   assembly_line: {
     id: 'assembly_line', name: 'Assembly Line', category: 'production',
@@ -720,7 +721,7 @@ export const BUILDINGS: Record<string, Building> = {
     id: 'nuclear_arsenal', name: 'Nuclear Arsenal', category: 'military',
     yields: { food: 0, production: 3, gold: 0, science: 0 }, productionCost: 195,
     description: 'Atomic weapon stockpile. +3 production per turn.',
-    techRequired: 'nuclear-weapons',
+    techRequired: 'nuclear-weapons', resourceRequired: ['uranium'],
     pacing: { band: 'power-spike', role: 'late-military-production', impact: 1.4, scope: 'city', snowball: 1.3, urgency: 1.1, situationality: 1.1, unlockBreadth: 1 },
   },
   central_bank: {
@@ -776,7 +777,7 @@ export const BUILDINGS: Record<string, Building> = {
     id: 'nuclear_power_plant', name: 'Nuclear Power Plant', category: 'production',
     yields: { food: 0, production: 5, gold: 0, science: 0 }, productionCost: 200,
     description: 'Atomic reactor generating electricity without fuel costs. +5 production per turn.',
-    techRequired: 'nuclear-power',
+    techRequired: 'nuclear-power', resourceRequired: ['uranium'],
     pacing: { band: 'marquee', role: 'late-power-production', impact: 1.6, scope: 'city', snowball: 1.5, urgency: 1.2, situationality: 1.0, unlockBreadth: 1 },
   },
   television_station: {
@@ -800,7 +801,7 @@ export const BUILDINGS: Record<string, Building> = {
     // Single key: production 6 ≤ 9 (era 7+ ceiling) ✓
     yields: { food: 0, production: 6, gold: 0, science: 0 }, productionCost: 310,
     description: 'Total war weapons programme. +6 production empire-wide.',
-    techRequired: 'nuclear-weapons',
+    techRequired: 'nuclear-weapons', resourceRequired: ['uranium'],
     pacing: { band: 'marquee', role: 'national-project', impact: 1.6, scope: 'empire', snowball: 1.5, urgency: 1.2, situationality: 1.3, unlockBreadth: 1 },
     uniquePerEmpire: true, nationalProject: { homeEra: 10 },
     civYieldBonus: { production: 6 },
@@ -1124,7 +1125,7 @@ export const TRAINABLE_UNITS: Array<TrainableUnitEntry & { pacing?: Building['pa
   { type: 'destroyer',           name: 'Destroyer',           cost: 210, techRequired: 'carrier-warfare', coastalRequired: true, pacing: { band: 'power-spike', role: 'naval-escort-apex', impact: 1.55, scope: 'military', snowball: 1.45, urgency: 1.2, situationality: 1.5, unlockBreadth: 1 } },
   // Era 11 units
   { type: 'attack_helicopter', name: 'Attack Helicopter', cost: 230, techRequired: 'helicopter-warfare', pacing: { band: 'marquee', role: 'air-assault', impact: 1.55, scope: 'military', snowball: 1.4, urgency: 1.2, situationality: 1.3, unlockBreadth: 1 } },
-  { type: 'missile_submarine', name: 'Missile Submarine', cost: 250, techRequired: 'nuclear-submarines', coastalRequired: true, pacing: { band: 'marquee', role: 'naval-deterrent', impact: 1.6, scope: 'military', snowball: 1.5, urgency: 1.2, situationality: 1.5, unlockBreadth: 1 } },
+  { type: 'missile_submarine', name: 'Missile Submarine', cost: 250, techRequired: 'nuclear-submarines', coastalRequired: true, resourceRequired: ['uranium'], pacing: { band: 'marquee', role: 'naval-deterrent', impact: 1.6, scope: 'military', snowball: 1.5, urgency: 1.2, situationality: 1.5, unlockBreadth: 1 } },
   // Era 12 units
   { type: 'cyber_unit', name: 'Cyber Unit', cost: 338, techRequired: 'cyber-warfare', pacing: { band: 'marquee', role: 'cyber-saboteur', impact: 1.4, scope: 'military', snowball: 1.2, urgency: 1.1, situationality: 1.4, unlockBreadth: 1 } },
   { type: 'stealth_bomber', name: 'Stealth Bomber', cost: 360, techRequired: 'stealth-technology', trainedFromBuilding: 'stealth_airbase', pacing: { band: 'marquee', role: 'stealth-strike', impact: 1.7, scope: 'military', snowball: 1.5, urgency: 1.3, situationality: 1.5, unlockBreadth: 1 } },
@@ -1311,6 +1312,7 @@ export function getProductionCostForItem(
     era?: number;
     completedTechs?: string[];
     activeNationalProjects?: ActiveNationalProjectRef[];
+    availableResources?: ReadonlySet<ResourceType>;
   } = {},
 ): number {
   const baseCost = getCatalogProductionCost(itemId, options.era);
@@ -1334,7 +1336,8 @@ export function getProductionCostForItem(
     unit != null,
     options.activeNationalProjects ?? [],
   );
-  const discountMultiplier = buildingDiscountMultiplier * techDiscountMultiplier * npDiscountMultiplier;
+  const resourceAdvantageMultiplier = getResourceAdvantageMultiplier(itemId, options.availableResources ?? new Set());
+  const discountMultiplier = buildingDiscountMultiplier * techDiscountMultiplier * npDiscountMultiplier * resourceAdvantageMultiplier;
   const effective = baseCost * civMultiplier * discountMultiplier;
   return discountMultiplier < 1 ? Math.ceil(effective) : Math.round(effective);
 }
@@ -1936,7 +1939,13 @@ export function processCity(
     const currentItem = newQueue[0];
 
     const unitDef = TRAINABLE_UNITS.find(u => u.type === currentItem);
-    const currentItemCost = getProductionCostForItem(currentItem, { city, bonusEffect, era });
+    const currentItemCost = getProductionCostForItem(currentItem, {
+      city,
+      bonusEffect,
+      era,
+      completedTechs,
+      availableResources,
+    });
     if ((BUILDINGS[currentItem] || unitDef) && newProgress >= currentItemCost) {
       const completion = completeCityProductionItem(
         { ...city, productionQueue: newQueue, productionProgress: newProgress, buildings: newBuildings },

--- a/src/systems/city-work-system.ts
+++ b/src/systems/city-work-system.ts
@@ -2,6 +2,7 @@ import type { CityFocus, CivBonusEffect, GameState, HexCoord, ResourceYield } fr
 import { hexKey } from './hex-utils';
 import { calculateCityYields } from './resource-system';
 import { getTileYield } from './tile-yield';
+import { getCivResourceYieldBonus } from './resource-acquisition-system';
 import {
   buildCityWorkClaimIndex,
   canonicalizeCityCoord,
@@ -209,13 +210,20 @@ export function calculateProjectedCityYields(
   const projectedCity = workResult.state.cities[cityId] ?? city;
   const completedTechs = workResult.state.civilizations?.[projectedCity.owner]?.techState.completed ?? [];
   const baseYields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect, completedTechs, {}, state.turn);
+  // City-work helpers also support lightweight presentation fixtures that omit
+  // civilization records; those have no resource access to aggregate.
+  const resourceBonus = workResult.state.civilizations
+    ? getCivResourceYieldBonus(workResult.state, projectedCity.owner)
+    : { food: 0, production: 0, gold: 0, science: 0 };
   // Catastrophe-crisis recovery reward — must match turn-manager.ts's own +1/+1 so the
   // displayed projection never diverges from what processTurn actually applies.
   const resilienceBonus = (city.resilienceBonusUntilTurn ?? 0) > state.turn ? 1 : 0;
   const yields = {
     ...baseYields,
-    food: baseYields.food + resilienceBonus,
-    production: baseYields.production + resilienceBonus,
+    food: baseYields.food + resourceBonus.food + resilienceBonus,
+    production: baseYields.production + resourceBonus.production + resilienceBonus,
+    gold: baseYields.gold + resourceBonus.gold,
+    science: baseYields.science + resourceBonus.science,
   };
 
   if (city.productionQueue.length === 0 && city.idleProduction) {

--- a/src/systems/continent-map-generator.ts
+++ b/src/systems/continent-map-generator.ts
@@ -3,6 +3,7 @@ import { getLandTerrain, placeResources, createRng, createNoise } from './map-ge
 import { hexKey } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
 import { tagLandmassRegions } from './landmass-tagger';
+import { placeLateResources } from './late-resource-placement';
 
 const ISLAND_RESOURCES = ['gems', 'ivory', 'spices'] as const;
 
@@ -165,6 +166,7 @@ export function generateContinentMap(
   }
   const resourceRng = createRng(seed + '-resources');
   placeResources(continentTiles, resourceRng);
+  placeLateResources(continentTiles, createRng(seed + '-late-resources'));
 
   // Island bonus resources
   for (const key of islandHexes) {

--- a/src/systems/continent-map-generator.ts
+++ b/src/systems/continent-map-generator.ts
@@ -3,7 +3,6 @@ import { getLandTerrain, placeResources, createRng, createNoise } from './map-ge
 import { hexKey } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
 import { tagLandmassRegions } from './landmass-tagger';
-import { placeLateResources } from './late-resource-placement';
 
 const ISLAND_RESOURCES = ['gems', 'ivory', 'spices'] as const;
 
@@ -166,7 +165,6 @@ export function generateContinentMap(
   }
   const resourceRng = createRng(seed + '-resources');
   placeResources(continentTiles, resourceRng);
-  placeLateResources(continentTiles, createRng(seed + '-late-resources'));
 
   // Island bonus resources
   for (const key of islandHexes) {

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -17,7 +17,7 @@ import { processTradeRouteIncome } from './trade-system';
 import { getClaimedTrophyGoldPerTurn } from './beast-system';
 import { createUnit, UNIT_DEFINITIONS } from './unit-system';
 import { resolveCivDefinition } from './civ-registry';
-import { getCivHappinessFromResources } from './resource-acquisition-system';
+import { getCivAvailableResources, getCivHappinessFromResources } from './resource-acquisition-system';
 import {
   getEmpireTechPercents,
   getCivLuxuryTechGold,
@@ -722,6 +722,7 @@ export function getRushBuyQuote(state: GameState, civId: string, cityId: string)
     era: state.era,
     completedTechs: civ.techState.completed,
     activeNationalProjects: getActiveNationalProjectsForCiv(state, civId),
+    availableResources: getCivAvailableResources(state, civId),
   });
   if (cost <= 0) {
     return { available: false, itemId, cost: 0, reason: 'invalid-active-item', message: 'This production item cannot be bought.', status: ownerStatus };

--- a/src/systems/improvement-system.ts
+++ b/src/systems/improvement-system.ts
@@ -139,6 +139,17 @@ export const IMPROVEMENT_DEFINITIONS: Record<BuildableImprovementType, Improveme
     preservesTerrain: true,
     resourceMode: 'generic-or-resource',
   },
+  oil_well: {
+    type: 'oil_well',
+    name: 'Oil Well',
+    buildTurns: 5,
+    validTerrains: ['plains', 'desert'],
+    requiresRiver: false,
+    requiredTech: 'petroleum-industry',
+    yieldBonus: { food: 0, production: 0, gold: 0, science: 0 },
+    preservesTerrain: true,
+    resourceMode: 'resource-only',
+  },
 };
 
 export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
@@ -150,6 +161,7 @@ export const IMPROVEMENT_BUILD_TURNS: Record<ImprovementType, number> = {
   pasture: IMPROVEMENT_DEFINITIONS.pasture.buildTurns,
   camp: IMPROVEMENT_DEFINITIONS.camp.buildTurns,
   quarry: IMPROVEMENT_DEFINITIONS.quarry.buildTurns,
+  oil_well: IMPROVEMENT_DEFINITIONS.oil_well.buildTurns,
   resource_outpost: 0,  // set by Expedition unit, not by Worker
   none: 0,
 };

--- a/src/systems/late-resource-placement.ts
+++ b/src/systems/late-resource-placement.ts
@@ -1,0 +1,44 @@
+import type { HexTile, ResourceType } from '@/core/types';
+import { RESOURCE_DEFINITIONS } from './resource-definitions';
+
+const LATE_RESOURCE_DENSITIES: Readonly<Record<string, number>> = {
+  coal: 0.04,
+  oil: 0.04,
+  aluminum: 0.04,
+  uranium: 0.04,
+  'rare-earth-elements': 0.02,
+  'battery-minerals': 0.02,
+};
+
+function isEligible(tile: HexTile, terrains: readonly string[]): boolean {
+  return tile.resource === null
+    && tile.improvement === 'none'
+    && tile.wonder === null
+    && terrains.includes(tile.terrain);
+}
+
+function chooseCandidates<T>(candidates: T[], count: number, rng: () => number): T[] {
+  const shuffled = [...candidates];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(rng() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled.slice(0, count);
+}
+
+/** Places late resources after the existing early resource pass without replacing map state. */
+export function placeLateResources(tiles: Record<string, HexTile>, rng: () => number): void {
+  const orderedTiles = Object.entries(tiles).sort(([left], [right]) => left.localeCompare(right));
+  for (const definition of RESOURCE_DEFINITIONS) {
+    const density = LATE_RESOURCE_DENSITIES[definition.id];
+    if (!density) continue;
+    const terrains = Array.isArray(definition.terrain) ? definition.terrain : [definition.terrain];
+    const candidates = orderedTiles
+      .map(([, tile]) => tile)
+      .filter(tile => isEligible(tile, terrains));
+    const target = Math.max(1, Math.round(candidates.length * density));
+    for (const tile of chooseCandidates(candidates, target, rng)) {
+      tile.resource = definition.id as ResourceType;
+    }
+  }
+}

--- a/src/systems/late-resource-placement.ts
+++ b/src/systems/late-resource-placement.ts
@@ -33,6 +33,7 @@ export function placeLateResources(
   tiles: Record<string, HexTile>,
   rng: () => number,
   protectedCoords: readonly HexCoord[] = [],
+  minimumUraniumDeposits = 1,
 ): void {
   const protectedTileKeys = new Set(protectedCoords.map(hexKey));
   const orderedTiles = Object.entries(tiles).sort(([left], [right]) => left.localeCompare(right));
@@ -43,7 +44,9 @@ export function placeLateResources(
     const candidates = orderedTiles
       .map(([, tile]) => tile)
       .filter(tile => isEligible(tile, terrains, protectedTileKeys));
-    const target = Math.max(1, Math.round(candidates.length * density));
+    const target = definition.id === 'uranium'
+      ? Math.max(minimumUraniumDeposits, Math.round(candidates.length * density))
+      : Math.max(1, Math.round(candidates.length * density));
     for (const tile of chooseCandidates(candidates, target, rng)) {
       tile.resource = definition.id as ResourceType;
     }

--- a/src/systems/late-resource-placement.ts
+++ b/src/systems/late-resource-placement.ts
@@ -1,4 +1,5 @@
-import type { HexTile, ResourceType } from '@/core/types';
+import type { HexCoord, HexTile, ResourceType } from '@/core/types';
+import { hexKey } from './hex-utils';
 import { RESOURCE_DEFINITIONS } from './resource-definitions';
 
 const LATE_RESOURCE_DENSITIES: Readonly<Record<string, number>> = {
@@ -10,10 +11,11 @@ const LATE_RESOURCE_DENSITIES: Readonly<Record<string, number>> = {
   'battery-minerals': 0.02,
 };
 
-function isEligible(tile: HexTile, terrains: readonly string[]): boolean {
+function isEligible(tile: HexTile, terrains: readonly string[], protectedTileKeys: ReadonlySet<string>): boolean {
   return tile.resource === null
     && tile.improvement === 'none'
     && tile.wonder === null
+    && !protectedTileKeys.has(hexKey(tile.coord))
     && terrains.includes(tile.terrain);
 }
 
@@ -27,7 +29,12 @@ function chooseCandidates<T>(candidates: T[], count: number, rng: () => number):
 }
 
 /** Places late resources after the existing early resource pass without replacing map state. */
-export function placeLateResources(tiles: Record<string, HexTile>, rng: () => number): void {
+export function placeLateResources(
+  tiles: Record<string, HexTile>,
+  rng: () => number,
+  protectedCoords: readonly HexCoord[] = [],
+): void {
+  const protectedTileKeys = new Set(protectedCoords.map(hexKey));
   const orderedTiles = Object.entries(tiles).sort(([left], [right]) => left.localeCompare(right));
   for (const definition of RESOURCE_DEFINITIONS) {
     const density = LATE_RESOURCE_DENSITIES[definition.id];
@@ -35,7 +42,7 @@ export function placeLateResources(tiles: Record<string, HexTile>, rng: () => nu
     const terrains = Array.isArray(definition.terrain) ? definition.terrain : [definition.terrain];
     const candidates = orderedTiles
       .map(([, tile]) => tile)
-      .filter(tile => isEligible(tile, terrains));
+      .filter(tile => isEligible(tile, terrains, protectedTileKeys));
     const target = Math.max(1, Math.round(candidates.length * density));
     for (const tile of chooseCandidates(candidates, target, rng)) {
       tile.resource = definition.id as ResourceType;

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -263,7 +263,9 @@ export function guaranteeStartResources(
     RESOURCE_DEFINITIONS.filter(def => def.type === 'luxury').map(def => def.id),
   );
   const strategicIds = new Set<ResourceType>(
-    RESOURCE_DEFINITIONS.filter(def => def.type === 'strategic').map(def => def.id),
+    RESOURCE_DEFINITIONS
+      .filter(def => def.type === 'strategic' && !LATE_STRATEGIC_RESOURCE_IDS.has(def.id))
+      .map(def => def.id),
   );
 
   for (const start of startPositions) {

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -8,6 +8,7 @@ import {
 } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
 import { RESOURCE_DEFINITIONS } from './trade-system';
+import { placeLateResources } from './late-resource-placement';
 import { LEGENDARY_WONDER_DEFINITIONS } from './legendary-wonder-definitions';
 // Geo data imports — populated by `yarn generate-maps`. Placeholder empty exports are safe.
 import { EARTH_START_POSITIONS } from './earth-map-data';
@@ -197,6 +198,7 @@ export function generateMap(width: number, height: number, seed: string): GameMa
   const tiles = generateBaseTerrain(width, height, seed);
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
+  placeLateResources(tiles, createRng(seed + '-late-resources'));
   const mapResult: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
   const rivers = generateRivers(mapResult, seed);
   applyRiversToMap(mapResult, rivers);
@@ -211,11 +213,21 @@ const TERRAIN_PROBABILITIES: Record<string, number> = {
 };
 const DEFAULT_RESOURCE_PROBABILITY = 0.20;
 
+export const LATE_STRATEGIC_RESOURCE_IDS = new Set<ResourceType>([
+  'coal',
+  'oil',
+  'aluminum',
+  'uranium',
+  'rare-earth-elements',
+  'battery-minerals',
+]);
+
 // Derived at module load from RESOURCE_DEFINITIONS — eliminates dual-maintenance.
 // terrain field is string | string[]; we expand multi-terrain entries here.
 function buildTerrainResourceMap(): Record<string, ResourceType[]> {
   const map: Record<string, ResourceType[]> = {};
   for (const def of RESOURCE_DEFINITIONS) {
+    if (LATE_STRATEGIC_RESOURCE_IDS.has(def.id)) continue;
     const terrains = Array.isArray(def.terrain) ? def.terrain : [def.terrain];
     for (const t of terrains) {
       (map[t] ??= []).push(def.id);

--- a/src/systems/map-generator.ts
+++ b/src/systems/map-generator.ts
@@ -8,7 +8,6 @@ import {
 } from './hex-utils';
 import { generateRivers, applyRiversToMap } from './river-system';
 import { RESOURCE_DEFINITIONS } from './trade-system';
-import { placeLateResources } from './late-resource-placement';
 import { LEGENDARY_WONDER_DEFINITIONS } from './legendary-wonder-definitions';
 // Geo data imports — populated by `yarn generate-maps`. Placeholder empty exports are safe.
 import { EARTH_START_POSITIONS } from './earth-map-data';
@@ -198,7 +197,6 @@ export function generateMap(width: number, height: number, seed: string): GameMa
   const tiles = generateBaseTerrain(width, height, seed);
   const resourceRng = createRng(seed + '-resources');
   placeResources(tiles, resourceRng);
-  placeLateResources(tiles, createRng(seed + '-late-resources'));
   const mapResult: GameMap = { width, height, tiles, wrapsHorizontally: true, rivers: [] };
   const rivers = generateRivers(mapResult, seed);
   applyRiversToMap(mapResult, rivers);

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -6,6 +6,7 @@ import { resolveBuildingPacingBand, resolveUnitPacingBand } from '@/systems/paci
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { getQueueableResearchIds } from '@/systems/tech-progression';
 import { getActiveNationalProjectsForCiv, getReservedNationalProjectKeys } from '@/systems/national-project-system';
+import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
 
 const MAX_CITY_QUEUE_ITEMS = 4;
 const MAX_RESEARCH_QUEUE_ITEMS = 3;
@@ -172,6 +173,7 @@ export function getRecommendedIdleCityChoice(
   const completedTechs = civ.techState.completed ?? [];
   const reservedNationalProjects = getReservedNationalProjectKeys(state, civId);
   const activeNationalProjects = getActiveNationalProjectsForCiv(state, civId);
+  const availableResources = getCivAvailableResources(state, civId);
   const bonusEffect = resolveCivDefinition(state, civ.civType)?.bonusEffect;
   const productionPerTurn = Math.max(1, calculateProjectedCityYields(state, cityId, bonusEffect).production);
   const candidates = [
@@ -184,7 +186,7 @@ export function getRecommendedIdleCityChoice(
       reservedNationalProjects,
       civId,
     ) : []).map(building => {
-      const cost = getProductionCostForItem(building.id, { city, bonusEffect, era: state.era, completedTechs, activeNationalProjects });
+      const cost = getProductionCostForItem(building.id, { city, bonusEffect, era: state.era, completedTechs, activeNationalProjects, availableResources });
       return {
         itemId: building.id,
         label: building.name,
@@ -195,7 +197,7 @@ export function getRecommendedIdleCityChoice(
     }),
     ...getTrainableUnitsForCiv(completedTechs, civ.civType)
       .map(unit => {
-        const cost = getProductionCostForItem(unit.type, { city, bonusEffect, era: state.era, completedTechs, activeNationalProjects });
+        const cost = getProductionCostForItem(unit.type, { city, bonusEffect, era: state.era, completedTechs, activeNationalProjects, availableResources });
         return {
           itemId: unit.type,
           label: unit.name,

--- a/src/systems/planning-system.ts
+++ b/src/systems/planning-system.ts
@@ -128,6 +128,7 @@ export function getIdleCityIds(state: GameState, civId: string): string[] {
 
   const completedTechs = civ.techState.completed ?? [];
   const reservedNationalProjects = getReservedNationalProjectKeys(state, civId);
+  const availableResources = getCivAvailableResources(state, civId);
   return Object.values(state.cities)
     .filter(city => city.owner === civId)
     .filter(city => city.productionQueue.length === 0)
@@ -137,12 +138,12 @@ export function getIdleCityIds(state: GameState, civId: string): string[] {
         city,
         completedTechs,
         state.map,
-        undefined,
+        availableResources,
         state.era,
         reservedNationalProjects,
         civId,
       ).length > 0;
-      const buildableUnits = getTrainableUnitsForCiv(completedTechs, civ.civType).length > 0;
+      const buildableUnits = getTrainableUnitsForCiv(completedTechs, civ.civType, availableResources).length > 0;
       return buildableBuildings || buildableUnits;
     })
     .map(city => city.id);
@@ -181,7 +182,7 @@ export function getRecommendedIdleCityChoice(
       city,
       completedTechs,
       state.map,
-      undefined,
+      availableResources,
       state.era,
       reservedNationalProjects,
       civId,
@@ -195,7 +196,7 @@ export function getRecommendedIdleCityChoice(
         priority: resolveBuildingPacingBand(building) === 'starter' ? 0 : 1,
       };
     }),
-    ...getTrainableUnitsForCiv(completedTechs, civ.civType)
+    ...getTrainableUnitsForCiv(completedTechs, civ.civType, availableResources)
       .map(unit => {
         const cost = getProductionCostForItem(unit.type, { city, bonusEffect, era: state.era, completedTechs, activeNationalProjects, availableResources });
         return {

--- a/src/systems/quest-objective-system.ts
+++ b/src/systems/quest-objective-system.ts
@@ -76,12 +76,13 @@ function queueCostBeforeCaravan(state: GameState, cityId: string): number | null
   if (!city || !civ) return null;
   const bonusEffect = resolveCivDefinition(state, civ.civType)?.bonusEffect;
   const activeNationalProjects = getActiveNationalProjectsForCiv(state, city.owner);
+  const availableResources = getCivAvailableResources(state, city.owner);
   let remaining = 0;
   let foundCaravan = false;
 
   for (let index = 0; index < city.productionQueue.length; index++) {
     const itemId = city.productionQueue[index];
-    const cost = getProductionCostForItem(itemId, { city, bonusEffect, era: state.era, completedTechs: civ.techState.completed, activeNationalProjects });
+    const cost = getProductionCostForItem(itemId, { city, bonusEffect, era: state.era, completedTechs: civ.techState.completed, activeNationalProjects, availableResources });
     remaining += index === 0 ? Math.max(0, cost - city.productionProgress) : cost;
     if (itemId === 'caravan') {
       foundCaravan = true;
@@ -90,7 +91,7 @@ function queueCostBeforeCaravan(state: GameState, cityId: string): number | null
   }
 
   if (!foundCaravan) {
-    remaining += getProductionCostForItem('caravan', { city, bonusEffect, era: state.era, completedTechs: civ.techState.completed, activeNationalProjects });
+    remaining += getProductionCostForItem('caravan', { city, bonusEffect, era: state.era, completedTechs: civ.techState.completed, activeNationalProjects, availableResources });
   }
   return remaining;
 }

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -54,16 +54,17 @@ export function getCivAvailableResources(
 
   const completedTechs = new Set(civ.techState.completed);
   const resourceDefMap = new Map(RESOURCE_DEFINITIONS.map(d => [d.id, d]));
+  const mapTiles = state.map?.tiles ?? {};
 
-  for (const cityId of civ.cities) {
+  for (const cityId of civ.cities ?? []) {
     const city = state.cities[cityId];
     if (!city) continue;
 
     const cityKey = hexKey(city.position);
 
-    for (const coord of city.ownedTiles) {
+    for (const coord of city.ownedTiles ?? []) {
       const key = hexKey(coord);
-      const tile = state.map.tiles[key];
+      const tile = mapTiles[key];
       if (!tile?.resource) continue;
 
       const def = resourceDefMap.get(tile.resource as ResourceType);
@@ -90,7 +91,7 @@ export function getCivAvailableResources(
 
   // Pass 2 — resource outpost tiles owned by this civ (outside city territory)
   // Linear scan over all tiles: 60×40 = 2,400 tiles maximum.
-  for (const tile of Object.values(state.map.tiles)) {
+  for (const tile of Object.values(mapTiles)) {
     if (
       tile.improvement !== 'resource_outpost' ||
       tile.improvementTurnsLeft !== 0 ||
@@ -271,6 +272,8 @@ export function canBuyResourceAccess(
 ): boolean {
   const buyer = state.civilizations[buyerCivId];
   if (!buyer) return false;
+  const definition = RESOURCE_DEFINITIONS.find(def => def.id === resource);
+  if (!definition || !buyer.techState.completed.includes(definition.tech)) return false;
 
   // Must have met the seller (key present in relationships map)
   if (!(sellerCivId in buyer.diplomacy.relationships)) return false;
@@ -290,7 +293,14 @@ export function canBuyResourceAccess(
   const buyerResources = getCivAvailableResources(state, buyerCivId);
   if (buyerResources.has(resource)) return false;
 
+  if (buyer.gold < getResourceAccessCost(state, resource)) return false;
+
   return true;
+}
+
+export function getResourceAccessCost(state: GameState, resource: ResourceType): number {
+  const definition = RESOURCE_DEFINITIONS.find(def => def.id === resource);
+  return (state.marketplace?.prices[resource] ?? definition?.basePrice ?? 5) * 3;
 }
 
 /**
@@ -301,13 +311,11 @@ export function canBuyResourceAccess(
 export function performBuyResourceAccess(
   state: GameState,
   buyerCivId: string,
-  _sellerCivId: string,   // reserved: future diplomatic impact on relationship score
+  sellerCivId: string,
   resource: ResourceType,
 ): GameState {
-  if (!state.marketplace) return state;
-
-  const def = RESOURCE_DEFINITIONS.find(d => d.id === resource);
-  const cost = (state.marketplace.prices[resource] ?? def?.basePrice ?? 5) * 3;
+  if (!state.marketplace || !canBuyResourceAccess(state, buyerCivId, sellerCivId, resource)) return state;
+  const cost = getResourceAccessCost(state, resource);
 
   const buyer = state.civilizations[buyerCivId];
   if (!buyer) return state;

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -144,6 +144,7 @@ export function getCivResourceYieldBonus(
       case 'gold':       bonus.gold       += def.effect.amount; break;
       case 'production': bonus.production += def.effect.amount; break;
       case 'food':       bonus.food       += def.effect.amount; break;
+      case 'science':    bonus.science    += def.effect.amount; break;
     }
   }
 

--- a/src/systems/resource-acquisition-system.ts
+++ b/src/systems/resource-acquisition-system.ts
@@ -294,7 +294,7 @@ export function canBuyResourceAccess(
 }
 
 /**
- * Deducts 3× basePrice gold from the buyer and adds a 10-turn purchasedResources entry.
+ * Deducts 3× the current marketplace price from the buyer and adds a 10-turn purchasedResources entry.
  * Precondition: canBuyResourceAccess(state, buyerCivId, sellerCivId, resource) === true.
  * Returns a new GameState (immutable spread-copy). Returns state unchanged if marketplace absent.
  */
@@ -307,7 +307,7 @@ export function performBuyResourceAccess(
   if (!state.marketplace) return state;
 
   const def = RESOURCE_DEFINITIONS.find(d => d.id === resource);
-  const cost = (def?.basePrice ?? 5) * 3;
+  const cost = (state.marketplace.prices[resource] ?? def?.basePrice ?? 5) * 3;
 
   const buyer = state.civilizations[buyerCivId];
   if (!buyer) return state;

--- a/src/systems/resource-advantages.ts
+++ b/src/systems/resource-advantages.ts
@@ -1,0 +1,30 @@
+import type { ResourceType } from '@/core/types';
+
+export interface ResourceAdvantageDefinition {
+  resource: ResourceType;
+  discount: number;
+  itemIds: readonly string[];
+}
+
+export const RESOURCE_ADVANTAGES: readonly ResourceAdvantageDefinition[] = [
+  { resource: 'coal', discount: 0.20, itemIds: ['factory', 'steamship', 'ironclad'] },
+  { resource: 'oil', discount: 0.15, itemIds: ['tank', 'biplane', 'bomber', 'carrier', 'attack_helicopter'] },
+  { resource: 'aluminum', discount: 0.15, itemIds: ['jet_fighter', 'stealth_bomber', 'combat_drone'] },
+  { resource: 'rare-earth-elements', discount: 0.15, itemIds: ['combat_drone', 'drone_controller', 'autonomous_frigate', 'electronic_warfare_array', 'network_operations_center'] },
+  { resource: 'battery-minerals', discount: 0.15, itemIds: ['combat_drone', 'exosuit_infantry', 'smart_grid', 'drone_fabricator', 'circular_fabricator'] },
+];
+
+export function getResourceAdvantagesForItem(itemId: string): readonly ResourceAdvantageDefinition[] {
+  return RESOURCE_ADVANTAGES.filter(advantage => advantage.itemIds.includes(itemId));
+}
+
+/** Shared soft-material cost multiplier. Hard requirements remain catalog eligibility. */
+export function getResourceAdvantageMultiplier(itemId: string, availableResources: ReadonlySet<ResourceType>): number {
+  let multiplier = 1;
+  for (const advantage of RESOURCE_ADVANTAGES) {
+    if (availableResources.has(advantage.resource) && advantage.itemIds.includes(itemId)) {
+      multiplier *= 1 - advantage.discount;
+    }
+  }
+  return Math.max(0.75, multiplier);
+}

--- a/src/systems/resource-definitions.ts
+++ b/src/systems/resource-definitions.ts
@@ -1,8 +1,20 @@
 import type { BuildableImprovementType, ResourceType } from '@/core/types';
 
 export interface ResourceEffect {
-  type: 'happiness' | 'gold' | 'production' | 'food';
+  type: 'happiness' | 'gold' | 'production' | 'food' | 'science';
   amount: number;
+}
+
+export type ResourceMaterialFamily =
+  | 'industrial'
+  | 'petroleum'
+  | 'aluminum'
+  | 'nuclear'
+  | 'rare-earth'
+  | 'battery';
+
+export interface ResourceCodexMetadata {
+  summary: string;
 }
 
 export interface ResourceDefinition {
@@ -15,6 +27,8 @@ export interface ResourceDefinition {
   icon: string;
   requiredImprovement: BuildableImprovementType;
   effect: ResourceEffect | null;
+  materialFamily?: ResourceMaterialFamily;
+  codex?: ResourceCodexMetadata;
 }
 
 export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
@@ -34,4 +48,10 @@ export const RESOURCE_DEFINITIONS: ResourceDefinition[] = [
   { id: 'iron', name: 'Iron', type: 'strategic', terrain: 'hills', basePrice: 8, tech: 'bronze-working', icon: '⚙️', requiredImprovement: 'mine', effect: null },
   { id: 'horses', name: 'Horses', type: 'strategic', terrain: 'plains', basePrice: 7, tech: 'animal-husbandry', icon: '🐎', requiredImprovement: 'pasture', effect: null },
   { id: 'stone', name: 'Stone', type: 'strategic', terrain: 'mountain', basePrice: 4, tech: 'gathering', icon: '🪨', requiredImprovement: 'quarry', effect: null },
+  { id: 'coal', name: 'Coal', type: 'strategic', terrain: 'hills', basePrice: 7, tech: 'steam-power', icon: '◼️', requiredImprovement: 'mine', effect: { type: 'production', amount: 1 }, materialFamily: 'industrial', codex: { summary: 'A dense industrial fuel used to power factories, railways, and steamships.' } },
+  { id: 'oil', name: 'Oil', type: 'strategic', terrain: ['plains', 'desert'], basePrice: 12, tech: 'petroleum-industry', icon: '🛢️', requiredImprovement: 'oil_well', effect: { type: 'production', amount: 1 }, materialFamily: 'petroleum', codex: { summary: 'Crude petroleum powers modern industry, armored forces, and aircraft.' } },
+  { id: 'aluminum', name: 'Aluminum', type: 'strategic', terrain: ['hills', 'desert'], basePrice: 10, tech: 'aluminium-smelting', icon: '🔩', requiredImprovement: 'mine', effect: null, materialFamily: 'aluminum', codex: { summary: 'A lightweight metal used for aircraft, aerospace, and advanced fabrication.' } },
+  { id: 'uranium', name: 'Uranium', type: 'strategic', terrain: ['hills', 'tundra', 'desert'], basePrice: 16, tech: 'nuclear-physics', icon: '☢️', requiredImprovement: 'mine', effect: { type: 'science', amount: 1 }, materialFamily: 'nuclear', codex: { summary: 'A radioactive fuel that supports nuclear research, power, and strategic arsenals.' } },
+  { id: 'rare-earth-elements', name: 'Rare Earth Elements', type: 'strategic', terrain: ['hills', 'desert'], basePrice: 14, tech: 'nanomaterials', icon: '🧲', requiredImprovement: 'mine', effect: { type: 'science', amount: 1 }, materialFamily: 'rare-earth', codex: { summary: 'A family of seventeen elements used in magnets, sensors, and advanced electronics.' } },
+  { id: 'battery-minerals', name: 'Battery Minerals', type: 'strategic', terrain: ['hills', 'desert', 'plains'], basePrice: 13, tech: 'smart-cities', icon: '🔋', requiredImprovement: 'mine', effect: { type: 'production', amount: 1 }, materialFamily: 'battery', codex: { summary: 'Lithium, nickel, cobalt, graphite, and related materials abstracted for energy storage.' } },
 ];

--- a/src/systems/tech-definitions-eras10.ts
+++ b/src/systems/tech-definitions-eras10.ts
@@ -23,7 +23,7 @@ const ERA_10_TECHS: Tech[] = [
   // SCIENCE (2)
   { id: 'nuclear-physics', name: 'Nuclear Physics', track: 'science', cost: 1895,
     prerequisites: ['quantum-theory', 'tungsten-alloys'],
-    unlocks: ['+3 science in cities with a research institute; atomic science reaches critical mass'],
+    unlocks: ['+3 science in cities with a research institute; atomic science reaches critical mass', 'Reveal Uranium resource'],
     unlocksBuildings: ['atomic_laboratory'], era: 10 },
   // MR10: re-homed from a stub — nuclear-theory is no longer a legendary-wonder gate.
   // Give it a real effect instead of sitting inert as pure flavor text (see cityFlat

--- a/src/systems/tech-definitions-eras12.ts
+++ b/src/systems/tech-definitions-eras12.ts
@@ -84,7 +84,7 @@ const ERA_12_TECHS: Tech[] = [
   // METALLURGY (2)
   { id: 'nanomaterials', name: 'Nanomaterials', track: 'metallurgy', cost: 1780,
     prerequisites: ['carbon-fiber', 'precision-engineering'],
-    unlocks: ['All units gain +3 strength'],
+    unlocks: ['All units gain +3 strength', 'Reveal Rare Earth Elements resource'],
     era: 12 },
   { id: '3d-printing', name: '3D Printing', track: 'metallurgy', cost: 1925,
     prerequisites: ['precision-engineering', 'megastructures'],
@@ -94,7 +94,7 @@ const ERA_12_TECHS: Tech[] = [
   // CONSTRUCTION (2)
   { id: 'smart-cities', name: 'Smart Cities', track: 'construction', cost: 2780,
     prerequisites: ['megastructures', 'offshore-platforms'],
-    unlocks: ['Cities with both a factory and a semiconductor fab generate +2 production and +1 science per turn from smart-grid integration'],
+    unlocks: ['Cities with both a factory and a semiconductor fab generate +2 production and +1 science per turn from smart-grid integration', 'Reveal Battery Minerals resource'],
     unlocksBuildings: ['smart_grid'], era: 12 },
   { id: 'green-architecture', name: 'Green Architecture', track: 'construction', cost: 1330,
     prerequisites: ['offshore-platforms', 'green-revolution-crops'],

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -273,7 +273,7 @@ const ERA_7_TECHS: Tech[] = [
   // ECONOMY (2)
   { id: 'steam-power', name: 'Steam Power', track: 'economy', cost: 200,
     prerequisites: ['joint-stock-companies', 'precision-casting'],
-    unlocks: ['Factory unlocked — steam-driven industrial production building'], unlocksBuildings: ['factory'], era: 7 },
+    unlocks: ['Factory unlocked — steam-driven industrial production building', 'Reveal Coal resource'], unlocksBuildings: ['factory'], era: 7 },
   { id: 'mass-production', name: 'Mass Production', track: 'economy', cost: 210,
     prerequisites: ['mercantilism', 'aqueduct-expansion'],
     unlocks: ['+10% production empire-wide; unit training costs reduced 5%'], era: 7 },

--- a/src/systems/tech-definitions-eras9.ts
+++ b/src/systems/tech-definitions-eras9.ts
@@ -19,7 +19,7 @@ const ERA_9_TECHS: Tech[] = [
   // ECONOMY (2)
   { id: 'petroleum-industry', name: 'Petroleum Industry', track: 'economy', cost: 190,
     prerequisites: ['industrial-monopoly', 'structural-engineering'],
-    unlocks: ['Crude oil extraction and refining; fuel powers the modern economy'],
+    unlocks: ['Crude oil extraction and refining; fuel powers the modern economy', 'Reveal Oil resource'],
     unlocksBuildings: ['oil_refinery'], era: 9 },
   { id: 'fordist-manufacturing', name: 'Fordist Manufacturing', track: 'economy', cost: 270,
     prerequisites: ['industrial-monopoly', 'bessemer-steel'],
@@ -98,7 +98,7 @@ const ERA_9_TECHS: Tech[] = [
   // METALLURGY (2)
   { id: 'aluminium-smelting', name: 'Aluminium Smelting', track: 'metallurgy', cost: 190,
     prerequisites: ['bessemer-steel', 'structural-engineering'],
-    unlocks: ['+1 production all cities; lightweight aluminium enables aviation and modern machinery'], era: 9 },
+    unlocks: ['+1 production all cities; lightweight aluminium enables aviation and modern machinery', 'Reveal Aluminum resource'], era: 9 },
   { id: 'tungsten-alloys', name: 'Tungsten Alloys', track: 'metallurgy', cost: 270,
     prerequisites: ['bessemer-steel', 'reinforced-concrete'],
     unlocks: ['+2 strength all military units; heat-resistant tungsten forges harder weapons and armor'], era: 9 },

--- a/src/systems/unit-upgrade-system.ts
+++ b/src/systems/unit-upgrade-system.ts
@@ -1,9 +1,9 @@
 import type { Unit, UnitType, City, GameState, ResourceType } from '@/core/types';
-import { TRAINABLE_UNITS, getCatalogProductionCost } from './city-system';
+import { TRAINABLE_UNITS, getProductionCostForItem } from './city-system';
 import { getCivAvailableResources } from './resource-acquisition-system';
 
-export function getUpgradeCost(targetType: UnitType): number {
-  const cost = getCatalogProductionCost(targetType, 1);
+export function getUpgradeCost(targetType: UnitType, availableResources?: ReadonlySet<ResourceType>): number {
+  const cost = getProductionCostForItem(targetType, { availableResources });
   return cost > 0 ? Math.ceil(cost * 0.5) : 0;
 }
 
@@ -24,11 +24,11 @@ export function canUpgradeUnit(
   if (!targetType) {
     const targetInPrinciple = getCanonicalUpgradeTarget(unit, completedTechs, undefined, availableResources);
     if (targetInPrinciple) {
-      return { canUpgrade: false, targetType: null, cost: getUpgradeCost(targetInPrinciple), reason: 'missing-building' };
+      return { canUpgrade: false, targetType: null, cost: getUpgradeCost(targetInPrinciple, availableResources), reason: 'missing-building' };
     }
     return { canUpgrade: false, targetType: null, cost: 0 };
   }
-  const cost = getUpgradeCost(targetType);
+  const cost = getUpgradeCost(targetType, availableResources);
   if (civGold !== undefined && civGold < cost) return { canUpgrade: false, targetType: null, cost };
   return { canUpgrade: true, targetType, cost };
 }
@@ -122,7 +122,7 @@ export function applyUnitUpgradeToState(
   if (canonicalTarget !== targetType) {
     return { state, upgraded: false, reason: 'invalid-target' };
   }
-  const cost = getUpgradeCost(targetType);
+  const cost = getUpgradeCost(targetType, getCivAvailableResources(state, unit.owner));
   if (civ.gold < cost) {
     return { state, upgraded: false, reason: 'insufficient-gold' };
   }

--- a/src/ui/advisor-system.ts
+++ b/src/ui/advisor-system.ts
@@ -816,7 +816,7 @@ export function fireResourceDiscoveredTip(
   if (hasTech) {
     const impMap: Record<string, string> = {
       mine: 'Mine', pasture: 'Pasture', camp: 'Camp',
-      plantation: 'Plantation', quarry: 'Quarry',
+      plantation: 'Plantation', quarry: 'Quarry', oil_well: 'Oil Well',
     };
     const reqImp = resourceDef?.requiredImprovement;
     const impName = reqImp ? (impMap[reqImp] ?? reqImp) : 'improvement';

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -163,6 +163,7 @@ export function createCityPanel(
       case 'gold': return '+1 gold/turn';
       case 'production': return '+1 production/turn';
       case 'food': return '+1 food/turn';
+      case 'science': return '+1 science/turn';
       default: return '';
     }
   }

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -10,6 +10,7 @@ import {
 } from '@/systems/city-system';
 import { getCivAvailableResources } from '@/systems/resource-acquisition-system';
 import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+import { getResourceAdvantagesForItem, getResourceAdvantageMultiplier } from '@/systems/resource-advantages';
 import { SESSION_SHOWN_TIPS } from '@/ui/advisor-system';
 import { hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
 import { createGameButton } from './ui-kit';
@@ -203,7 +204,21 @@ export function createCityPanel(
     era: state.era,
     completedTechs: currentCiv.techState.completed,
     activeNationalProjects,
+    availableResources: playerResources,
   });
+  const resourceRequirementLine = (itemId: string, required: readonly ResourceType[] = []): string => {
+    const requiredNames = required.map(id => RESOURCE_DEFINITIONS.find(def => def.id === id)?.name ?? id);
+    const advantages = getResourceAdvantagesForItem(itemId);
+    const fasterNames = advantages.map(advantage => RESOURCE_DEFINITIONS.find(def => def.id === advantage.resource)?.name ?? advantage.resource);
+    const multiplier = getResourceAdvantageMultiplier(itemId, playerResources);
+    const parts: string[] = [];
+    if (requiredNames.length) parts.push(`Required: ${requiredNames.join(', ')}`);
+    if (fasterNames.length) {
+      const saved = Math.round((1 - multiplier) * 100);
+      parts.push(`Faster with: ${fasterNames.join(', ')}${saved > 0 ? ` (${saved}% discount)` : ''}`);
+    }
+    return parts.length ? `<div style="font-size:10px;opacity:0.72;">${parts.join(' · ')}</div>` : '';
+  };
   const builtNPKeys = getReservedNationalProjectKeys(state, city.owner);
   const availableBuildings = getAvailableBuildings(
     city,
@@ -405,6 +420,7 @@ export function createCityPanel(
     buildItemPlaceholders += `<div class="build-item" data-item-id="${b.id}" style="background:rgba(255,255,255,0.1);${npBorder}border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
       <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(b.id)} <span data-text="build-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">${yieldStr}${turns} turns${upkeepStr}${deadline}</div>
+      ${resourceRequirementLine(b.id, b.resourceRequired)}
       <div style="font-size:10px;opacity:0.5;" data-text="build-desc-${idx}"></div>
     </div>`;
   }
@@ -483,6 +499,7 @@ export function createCityPanel(
     unitPlaceholders += `<div class="build-item" data-item-id="${u.type}" style="background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:8px;padding:10px;margin-bottom:6px;cursor:pointer;">
       <div style="font-weight:bold;font-size:13px;">${getProductionIconForItem(u.type)} <span data-text="unit-name-${idx}"></span></div>
       <div style="font-size:11px;opacity:0.7;">Cost: ${cost} · ${turns} turns</div>
+      ${resourceRequirementLine(u.type, u.resourceRequired)}
     </div>`;
   }
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -433,7 +433,7 @@ export function createCityPanel(
     })),
   ];
 
-  const IMPROVEMENT_LABELS: Record<string, string> = { mine: 'Mine', pasture: 'Pasture', quarry: 'Quarry', plantation: 'Plantation', camp: 'Camp' };
+  const IMPROVEMENT_LABELS: Record<string, string> = { mine: 'Mine', pasture: 'Pasture', quarry: 'Quarry', plantation: 'Plantation', camp: 'Camp', oil_well: 'Oil Well' };
 
   function buildLockedItemReason(resourceId: ResourceType, techs: string[]): string {
     const def = RESOURCE_DEFINITIONS.find(d => d.id === resourceId);

--- a/src/ui/marketplace-panel.ts
+++ b/src/ui/marketplace-panel.ts
@@ -41,6 +41,13 @@ export function createMarketplacePanel(
   const strategicOwned = knownDefs
     .filter(d => d.type === 'strategic' && ownedResources.has(d.id as ResourceType))
     .map(d => d.name);
+  const temporaryAccess = (marketplace.purchasedResources ?? [])
+    .filter(entry => entry.civId === state.currentPlayer && entry.expiresOnTurn > state.turn)
+    .map(entry => ({
+      name: knownDefs.find(def => def.id === entry.resource)?.name,
+      turns: entry.expiresOnTurn - state.turn,
+    }))
+    .filter((entry): entry is { name: string; turns: number } => entry.name !== undefined);
 
   const yourResourcesHtml = `
     <div style="background:rgba(255,255,255,0.04);border-radius:8px;padding:10px 12px;margin-bottom:12px;">
@@ -130,6 +137,7 @@ export function createMarketplacePanel(
         case 'gold':        effectText = '$ +1 gold/turn'; break;
         case 'production':  effectText = '⚙ +1 production/turn'; break;
         case 'food':        effectText = '🌾 +1 food/turn'; break;
+        case 'science':     effectText = '🔬 +1 science/turn'; break;
         default:            effectText = '';
       }
     }
@@ -152,6 +160,12 @@ export function createMarketplacePanel(
       strLine.textContent = `Strategic (${strategicOwned.length}): ${strategicOwned.length > 0 ? strategicOwned.join(', ') : '—'}`;
       bodyEl.appendChild(luxLine);
       bodyEl.appendChild(strLine);
+      if (temporaryAccess.length > 0) {
+        const temporaryLine = document.createElement('div');
+        temporaryLine.style.cssText = 'font-size:12px;color:#e8c170;margin-top:4px;';
+        temporaryLine.textContent = `Temporary access: ${temporaryAccess.map(entry => `${entry.name} (${entry.turns} turns left)`).join(', ')}`;
+        bodyEl.appendChild(temporaryLine);
+      }
     }
   }
 
@@ -312,7 +326,7 @@ function buildKnownCivResourceSection(
     const sellerColor = sellerCivDef?.color ?? '#888888';
     const score = playerDip.relationships[sellerCivId] ?? -100;
     const atWar = isAtWar(playerDip, sellerCivId);
-    const cost = def.basePrice * 3;
+    const cost = (state.marketplace?.prices[resource] ?? def.basePrice) * 3;
 
     const row = document.createElement('div');
     row.style.cssText =

--- a/src/ui/marketplace-panel.ts
+++ b/src/ui/marketplace-panel.ts
@@ -1,6 +1,6 @@
 import type { GameState, ResourceType } from '@/core/types';
 import { RESOURCE_DEFINITIONS, getEffectiveGoldPerTurn, getRouteCapacity, getRouteTechGoldBonus } from '@/systems/trade-system';
-import { getCivAvailableResources, canBuyResourceAccess } from '@/systems/resource-acquisition-system';
+import { getCivAvailableResources, canBuyResourceAccess, getResourceAccessCost } from '@/systems/resource-acquisition-system';
 import { isAtWar } from '@/systems/diplomacy-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createGameButton } from './ui-kit';
@@ -300,9 +300,11 @@ function buildKnownCivResourceSection(
   // Rows where player already owns the resource show "Already have this" instead of buy button.
   type Row = { sellerCivId: string; resource: ResourceType };
   const rows: Row[] = [];
+  const viewerTechs = new Set(civ.techState.completed);
   for (const sellerCivId of knownCivIds) {
     const sellerResources = getCivAvailableResources(state, sellerCivId);
     for (const def of RESOURCE_DEFINITIONS) {
+      if (!viewerTechs.has(def.tech)) continue;
       const resource = def.id as ResourceType;
       if (!sellerResources.has(resource)) continue;
       rows.push({ sellerCivId, resource });
@@ -326,7 +328,7 @@ function buildKnownCivResourceSection(
     const sellerColor = sellerCivDef?.color ?? '#888888';
     const score = playerDip.relationships[sellerCivId] ?? -100;
     const atWar = isAtWar(playerDip, sellerCivId);
-    const cost = (state.marketplace?.prices[resource] ?? def.basePrice) * 3;
+    const cost = getResourceAccessCost(state, resource);
 
     const row = document.createElement('div');
     row.style.cssText =

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -123,6 +123,7 @@ function nextTierLabel(currentLabel: string): string | null {
 const WORKER_ACTIONS: ImprovementWorkerActionType[] = [
   'farm', 'mine', 'lumber_camp', 'watermill',
   'plantation', 'pasture', 'camp', 'quarry',
+  'oil_well',
   'drain_swamp',
 ];
 

--- a/tests/ai/ai-resource-marketplace.test.ts
+++ b/tests/ai/ai-resource-marketplace.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { foundCity } from '@/systems/city-system';
+import { hexKey } from '@/systems/hex-utils';
+import { processAIResourceMarketplace } from '@/ai/ai-resource-marketplace';
+
+describe('processAIResourceMarketplace', () => {
+  it('buys a missing hard input for an otherwise eligible idle-city candidate', () => {
+    const state = createNewGame(undefined, 'ai-resource-candidate', 'small');
+    const ai = state.civilizations['ai-1'];
+    const player = state.civilizations.player;
+    const aiSettler = ai.units.map(id => state.units[id]).find(unit => unit?.type === 'settler');
+    const playerSettler = player.units.map(id => state.units[id]).find(unit => unit?.type === 'settler');
+    if (!aiSettler || !playerSettler || !state.marketplace) throw new Error('missing setup state');
+
+    const aiCity = foundCity(ai.id, aiSettler.position, state.map, state.idCounters);
+    aiCity.productionProgress = 180;
+    state.cities[aiCity.id] = aiCity;
+    ai.cities = [aiCity.id];
+    ai.gold = 100;
+    ai.techState.completed = ['petroleum-industry'];
+    state.map.tiles[hexKey(aiCity.position)].resource = null;
+
+    const sellerCity = foundCity(player.id, playerSettler.position, state.map, state.idCounters);
+    state.cities[sellerCity.id] = sellerCity;
+    player.cities = [sellerCity.id];
+    player.techState.completed = ['petroleum-industry'];
+    const sellerTile = state.map.tiles[hexKey(sellerCity.position)];
+    sellerTile.resource = 'oil';
+    sellerTile.improvement = 'none';
+    sellerTile.improvementTurnsLeft = 0;
+    ai.diplomacy.relationships[player.id] = 10;
+    state.marketplace.prices.oil = 12;
+
+    const result = processAIResourceMarketplace(state, ai.id);
+
+    expect(result.marketplace?.purchasedResources).toContainEqual({
+      civId: ai.id,
+      resource: 'oil',
+      expiresOnTurn: state.turn + 10,
+    });
+    expect(result.civilizations[ai.id].gold).toBe(64);
+  });
+});

--- a/tests/core/game-state.test.ts
+++ b/tests/core/game-state.test.ts
@@ -37,6 +37,9 @@ const LUXURY_IDS = new Set<ResourceType>(
 const STRATEGIC_IDS = new Set<ResourceType>(
   RESOURCE_DEFINITIONS.filter(def => def.type === 'strategic').map(def => def.id),
 );
+const LATE_STRATEGIC_IDS = new Set<ResourceType>([
+  'coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals',
+]);
 
 function getStartingSettlerByOwner(state: GameState, owner: string): HexCoord {
   const settler = Object.values(state.units).find(unit => unit.owner === owner && unit.type === 'settler');
@@ -91,6 +94,31 @@ describe('createNewGame', () => {
     expect(state.map.height).toBe(30);
     expect(Object.keys(state.map.tiles).length).toBe(900);
   });
+
+  it.each(['procedural', 'balanced', 'single-continent'] as const)(
+    'places late resources only after protected %s-map setup',
+    mapScript => {
+      const state = createNewGame({
+        civType: 'rome',
+        seed: `late-resource-finalization-${mapScript}`,
+        mapSize: 'small',
+        opponentCount: 2,
+        gameTitle: 'Late Resource Finalization',
+        mapScript,
+      });
+      const starts = new Set(getMajorSettlerStarts(state).map(hexKey));
+
+      const placed = new Set<ResourceType>();
+      for (const tile of Object.values(state.map.tiles)) {
+        if (tile.resource && LATE_STRATEGIC_IDS.has(tile.resource as ResourceType)) {
+          placed.add(tile.resource as ResourceType);
+          expect(starts.has(hexKey(tile.coord))).toBe(false);
+          expect(tile.wonder).toBeNull();
+        }
+      }
+      expect(placed).toEqual(LATE_STRATEGIC_IDS);
+    },
+  );
 
   it('places barbarian camps', () => {
     const state = createNewGame(undefined, 'test-seed');

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { City, GameMap, GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { migrateLegacyCoastalData } from '@/storage/save-manager';
+import { CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
 
 const dbState = new Map<string, unknown>();
 
@@ -65,7 +66,7 @@ describe('save-manager setup and outcome migration', () => {
 
     const normalized = normalizeLoadedStateForTest(legacy);
 
-    expect(normalized.saveSchemaVersion).toBe(1);
+    expect(normalized.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
     expect(normalized.gameId).toMatch(/^legacy-/);
   });
 

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -114,4 +114,14 @@ describe('save migrations', () => {
     }
     expect(loadedAgain).toEqual(migrated);
   });
+
+  it('grandfathers a schema-v1 hard-resource queue once', () => {
+    const legacySave = createNewGame('rome', 'legacy-resource-queue', 'small');
+    legacySave.saveSchemaVersion = 1;
+    const city = Object.values(legacySave.cities)[0]!;
+    city.productionQueue = ['oil_refinery'];
+
+    const migrated = migrateSaveToCurrent(legacySave);
+    expect(migrated.cities[city.id].legacyResourceGrace).toEqual(['oil_refinery']);
+  });
 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -88,4 +88,30 @@ describe('save migrations', () => {
 
     expect(() => migrateSaveToCurrent(legacySave)).not.toThrow();
   });
+
+  it('migrates schema-v1 maps and marketplace prices deterministically for late resources', () => {
+    const legacySave = createNewGame('rome', 'late-resource-migration', 'small');
+    legacySave.saveSchemaVersion = 1;
+    for (const tile of Object.values(legacySave.map.tiles)) {
+      if (['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals'].includes(tile.resource ?? '')) {
+        tile.resource = null;
+      }
+    }
+    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
+      delete legacySave.marketplace!.prices[resource];
+      delete legacySave.marketplace!.priceHistory[resource];
+    }
+
+    const migrated = migrateSaveToCurrent(legacySave);
+    const loadedAgain = migrateSaveToCurrent(migrated);
+    const resources = new Set(Object.values(migrated.map.tiles).map(tile => tile.resource));
+
+    expect(migrated.saveSchemaVersion).toBe(2);
+    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
+      expect(resources).toContain(resource);
+      expect(migrated.marketplace!.prices[resource]).toBeGreaterThan(0);
+      expect(migrated.marketplace!.priceHistory[resource]).toEqual([migrated.marketplace!.prices[resource]]);
+    }
+    expect(loadedAgain).toEqual(migrated);
+  });
 });

--- a/tests/systems/balanced-map-generator.test.ts
+++ b/tests/systems/balanced-map-generator.test.ts
@@ -11,6 +11,12 @@ describe('generateBalancedMap', () => {
     }
   });
 
+  it('guarantees at least one Uranium deposit per major civilization when terrain permits', () => {
+    const { map } = generateBalancedMap(30, 30, 'balanced-uranium-guarantee', 3);
+    const uraniumCount = Object.values(map.tiles).filter(tile => tile.resource === 'uranium').length;
+    expect(uraniumCount).toBeGreaterThanOrEqual(3);
+  });
+
   it('returns startPositions.length === civCount', () => {
     const { startPositions } = generateBalancedMap(30, 30, 'bal-test-1', 3);
     expect(startPositions).toHaveLength(3);

--- a/tests/systems/balanced-map-generator.test.ts
+++ b/tests/systems/balanced-map-generator.test.ts
@@ -3,18 +3,10 @@ import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { hexKey } from '@/systems/hex-utils';
 
 describe('generateBalancedMap', () => {
-  it('places late strategic resources through the shared late pass', () => {
+  it('leaves late strategic resources until game setup knows every protected tile', () => {
     const { map } = generateBalancedMap(30, 30, 'balanced-late-resources', 3);
-    const resources = new Set(Object.values(map.tiles).map(tile => tile.resource));
-    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
-      expect(resources).toContain(resource);
-    }
-  });
-
-  it('guarantees at least one Uranium deposit per major civilization when terrain permits', () => {
-    const { map } = generateBalancedMap(30, 30, 'balanced-uranium-guarantee', 3);
-    const uraniumCount = Object.values(map.tiles).filter(tile => tile.resource === 'uranium').length;
-    expect(uraniumCount).toBeGreaterThanOrEqual(3);
+    const lateResources = new Set(['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']);
+    expect(Object.values(map.tiles).some(tile => lateResources.has(tile.resource ?? ''))).toBe(false);
   });
 
   it('returns startPositions.length === civCount', () => {

--- a/tests/systems/balanced-map-generator.test.ts
+++ b/tests/systems/balanced-map-generator.test.ts
@@ -3,6 +3,14 @@ import { generateBalancedMap } from '@/systems/balanced-map-generator';
 import { hexKey } from '@/systems/hex-utils';
 
 describe('generateBalancedMap', () => {
+  it('places late strategic resources through the shared late pass', () => {
+    const { map } = generateBalancedMap(30, 30, 'balanced-late-resources', 3);
+    const resources = new Set(Object.values(map.tiles).map(tile => tile.resource));
+    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
+      expect(resources).toContain(resource);
+    }
+  });
+
   it('returns startPositions.length === civCount', () => {
     const { startPositions } = generateBalancedMap(30, 30, 'bal-test-1', 3);
     expect(startPositions).toHaveLength(3);

--- a/tests/systems/continent-map-generator.test.ts
+++ b/tests/systems/continent-map-generator.test.ts
@@ -3,12 +3,10 @@ import { generateContinentMap } from '@/systems/continent-map-generator';
 import { hexKey } from '@/systems/hex-utils';
 
 describe('generateContinentMap', () => {
-  it('places late strategic resources through the shared late pass', () => {
+  it('leaves late strategic resources until game setup knows every protected tile', () => {
     const { map } = generateContinentMap(30, 30, 'continent-late-resources');
-    const resources = new Set(Object.values(map.tiles).map(tile => tile.resource));
-    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
-      expect(resources).toContain(resource);
-    }
+    const lateResources = new Set(['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']);
+    expect(Object.values(map.tiles).some(tile => lateResources.has(tile.resource ?? ''))).toBe(false);
   });
 
   it('sets wrapsHorizontally to true', () => {

--- a/tests/systems/continent-map-generator.test.ts
+++ b/tests/systems/continent-map-generator.test.ts
@@ -3,6 +3,14 @@ import { generateContinentMap } from '@/systems/continent-map-generator';
 import { hexKey } from '@/systems/hex-utils';
 
 describe('generateContinentMap', () => {
+  it('places late strategic resources through the shared late pass', () => {
+    const { map } = generateContinentMap(30, 30, 'continent-late-resources');
+    const resources = new Set(Object.values(map.tiles).map(tile => tile.resource));
+    for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
+      expect(resources).toContain(resource);
+    }
+  });
+
   it('sets wrapsHorizontally to true', () => {
     const { map } = generateContinentMap(30, 30, 'cont-1');
     expect(map.wrapsHorizontally).toBe(true);

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -202,14 +202,11 @@ describe('placeResources', () => {
 });
 
 describe('late resource placement', () => {
-  it('adds every late strategic resource deterministically after early placement', () => {
-    const first = generateMap(30, 30, 'late-resource-pass');
-    const second = generateMap(30, 30, 'late-resource-pass');
-    const expected = ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals'];
-    const placed = new Set(Object.values(first.tiles).map(tile => tile.resource));
+  it('leaves late strategic placement until game setup knows starts and wonders', () => {
+    const map = generateMap(30, 30, 'late-resource-pass');
+    const lateResources = new Set(['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']);
 
-    expect(first).toEqual(second);
-    for (const resource of expected) expect(placed).toContain(resource);
+    expect(Object.values(map.tiles).some(tile => lateResources.has(tile.resource ?? ''))).toBe(false);
   });
 });
 

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -187,6 +187,30 @@ describe('placeResources', () => {
     placeResources(tiles, createRng('resource-rng'));
     expect(grassTile.resource).toBe('horses');
   });
+
+  it('keeps late strategic resources out of the early terrain-probability pass', () => {
+    const tiles = generateBaseTerrain(1, 1, 'early-resource-catalog');
+    const tile = Object.values(tiles)[0];
+    tile.terrain = 'hills';
+
+    const rolls = [0, 0.999];
+    placeResources(tiles, () => rolls.shift() ?? 0);
+
+    expect(['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals'])
+      .not.toContain(tile.resource);
+  });
+});
+
+describe('late resource placement', () => {
+  it('adds every late strategic resource deterministically after early placement', () => {
+    const first = generateMap(30, 30, 'late-resource-pass');
+    const second = generateMap(30, 30, 'late-resource-pass');
+    const expected = ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals'];
+    const placed = new Set(Object.values(first.tiles).map(tile => tile.resource));
+
+    expect(first).toEqual(second);
+    for (const resource of expected) expect(placed).toContain(resource);
+  });
 });
 
 describe('findStartPositions', () => {
@@ -318,7 +342,7 @@ describe('S2a resource catalog coverage in placeResources', () => {
     expect(tiles['0,0'].resource).not.toBeNull();
   });
 
-  it('every resource in RESOURCE_DEFINITIONS appears on its declared terrain after placeResources', () => {
+  it('every early resource appears on its declared terrain after placeResources', () => {
     // Build a tile set with 30 tiles of each relevant terrain
     const terrainSet: TerrainType[] = ['grassland', 'plains', 'jungle', 'hills', 'forest', 'desert', 'mountain', 'tundra'];
     const tiles: Record<string, HexTile> = {};
@@ -330,7 +354,7 @@ describe('S2a resource catalog coverage in placeResources', () => {
       }
     }
 
-    for (const def of RESOURCE_DEFINITIONS) {
+    for (const def of RESOURCE_DEFINITIONS.filter(def => !['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals'].includes(def.id))) {
       const declaredTerrains = Array.isArray(def.terrain) ? def.terrain : [def.terrain];
       const validTerrains = declaredTerrains.filter(t => terrainSet.includes(t as TerrainType));
       if (validTerrains.length === 0) continue;

--- a/tests/systems/map-generator.test.ts
+++ b/tests/systems/map-generator.test.ts
@@ -400,6 +400,21 @@ describe('guaranteeStartResources', () => {
     }
   });
 
+  it('does not use late resources to satisfy a start strategic-resource guarantee', () => {
+    const map = makeSmallMap();
+    for (const tile of Object.values(map.tiles)) tile.resource = null;
+    const start = { q: 5, r: 5 };
+    guaranteeStartResources(map, [start], createRng('early-start-resource-only'));
+    const nearby = getWrappedHexesInRange(start, 5, map.width)
+      .map(coord => map.tiles[hexKey(coord)]?.resource);
+    expect(nearby).not.toContain('coal');
+    expect(nearby).not.toContain('oil');
+    expect(nearby).not.toContain('aluminum');
+    expect(nearby).not.toContain('uranium');
+    expect(nearby).not.toContain('rare-earth-elements');
+    expect(nearby).not.toContain('battery-minerals');
+  });
+
   it('does not overwrite existing resources', () => {
     const map = makeSmallMap();
     for (const tile of Object.values(map.tiles)) tile.resource = null;

--- a/tests/systems/production-costs.test.ts
+++ b/tests/systems/production-costs.test.ts
@@ -7,8 +7,22 @@ import {
   getSettlerProductionCost,
 } from '@/systems/city-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getResourceAdvantageMultiplier } from '@/systems/resource-advantages';
 
 describe('production cost catalog', () => {
+  it('keeps the five intrinsic Oil/Uranium inputs hard-gated', () => {
+    expect(BUILDINGS.oil_refinery.resourceRequired).toEqual(['oil']);
+    expect(BUILDINGS.nuclear_power_plant.resourceRequired).toEqual(['uranium']);
+    expect(BUILDINGS.nuclear_arsenal.resourceRequired).toEqual(['uranium']);
+    expect(BUILDINGS.manhattan_project.resourceRequired).toEqual(['uranium']);
+    expect(TRAINABLE_UNITS.find(unit => unit.type === 'missile_submarine')?.resourceRequired).toEqual(['uranium']);
+  });
+
+  it('applies generic resource advantages multiplicatively with a 25% cap', () => {
+    expect(getResourceAdvantageMultiplier('tank', new Set(['oil']))).toBe(0.85);
+    expect(getResourceAdvantageMultiplier('combat_drone', new Set(['aluminum', 'rare-earth-elements', 'battery-minerals']))).toBe(0.75);
+    expect(getProductionCostForItem('tank', { availableResources: new Set(['oil']) })).toBe(Math.ceil(185 * 0.85));
+  });
   it('keeps Herbalist in the Era 1 starter window for a new capital', () => {
     expect(BUILDINGS.herbalist.productionCost).toBe(16);
     expect(BUILDINGS.herbalist.pacing?.band).toBe('starter');

--- a/tests/systems/resource-acquisition-system.test.ts
+++ b/tests/systems/resource-acquisition-system.test.ts
@@ -869,6 +869,10 @@ describe('canBuyResourceAccess', () => {
   it('returns false when buyer already owns the resource', () => {
     expect(canBuyResourceAccess(makeBuyState({ buyerAlreadyOwns: true }), 'buyer', 'seller', 'iron')).toBe(false);
   });
+
+  it('returns false when the buyer cannot afford the current access price', () => {
+    expect(canBuyResourceAccess(makeBuyState({ buyerGold: 23 }), 'buyer', 'seller', 'iron')).toBe(false);
+  });
 });
 
 describe('performBuyResourceAccess', () => {
@@ -879,14 +883,29 @@ describe('performBuyResourceAccess', () => {
 
     return {
       turn: 5,
-      map: { width: 10, height: 10, tiles: {}, wrapsHorizontally: false, rivers: [] },
-      cities: {},
       civilizations: {
         buyer: {
           id: 'buyer', cities: [], units: [], gold: 100,
-          techState: { completed: [], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
-          diplomacy: { relationships: {}, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
+          techState: { completed: ['bronze-working'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+          diplomacy: { relationships: { seller: 10 }, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
         } as unknown as never,
+        seller: {
+          id: 'seller', cities: ['seller-city'], units: [], gold: 0,
+          techState: { completed: ['bronze-working'], currentResearch: null, researchQueue: [], researchProgress: 0, trackPriorities: {} },
+          diplomacy: { relationships: { buyer: 10 }, treaties: [], events: [], atWarWith: [], treacheryScore: 0, vassalage: { overlord: null, vassals: [], protectionScore: 100, protectionTimers: [], peakCities: 0, peakMilitary: 0 } },
+        } as unknown as never,
+      },
+      cities: {
+        'seller-city': {
+          id: 'seller-city', owner: 'seller', position: { q: 5, r: 5 }, ownedTiles: [{ q: 5, r: 5 }],
+          population: 1, food: 0, production: 0, gold: 0, buildings: [], productionQueue: [], workedTiles: [], specialistSlots: [], garrisonUnitId: null, hp: 100, maxHp: 100,
+        } as unknown as never,
+      },
+      map: {
+        width: 10, height: 10, wrapsHorizontally: false, rivers: [],
+        tiles: {
+          '5,5': { coord: { q: 5, r: 5 }, terrain: 'hills', elevation: 'lowland', resource: 'iron', improvement: 'none', improvementTurnsLeft: 0, hasRiver: false, wonder: null, owner: 'seller' },
+        },
       },
       marketplace: { prices, priceHistory, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [], purchasedResources: [] },
     } as unknown as GameState;

--- a/tests/systems/resource-effects.test.ts
+++ b/tests/systems/resource-effects.test.ts
@@ -143,6 +143,15 @@ describe('RESOURCE_DEFINITIONS catalog', () => {
       expect(def.effect, `${def.id} is missing effect field`).not.toBeUndefined();
     }
   });
+
+  it('adds science from improved Uranium and Rare Earth deposits', () => {
+    const state = makeMultiResourceState([
+      { resource: 'uranium', improvement: 'mine', tech: 'nuclear-physics', terrain: 'hills' },
+      { resource: 'rare-earth-elements', improvement: 'mine', tech: 'nanomaterials', terrain: 'desert' },
+    ]);
+
+    expect(getCivResourceYieldBonus(state, 'player').science).toBe(2);
+  });
 });
 
 // ── getCivHappinessFromResources ──────────────────────────────────────────────

--- a/tests/systems/trade-system.test.ts
+++ b/tests/systems/trade-system.test.ts
@@ -96,10 +96,41 @@ function makeMinimalState(overrides: Partial<{
 
 describe('trade-system', () => {
   describe('RESOURCE_DEFINITIONS', () => {
-    it('defines 16 resources (10 luxury + 6 strategic)', () => {
-      expect(RESOURCE_DEFINITIONS).toHaveLength(16);
+    it('defines 22 resources (10 luxury + 12 strategic)', () => {
+      expect(RESOURCE_DEFINITIONS).toHaveLength(22);
       expect(RESOURCE_DEFINITIONS.filter(r => r.type === 'luxury')).toHaveLength(10);
-      expect(RESOURCE_DEFINITIONS.filter(r => r.type === 'strategic')).toHaveLength(6);
+      expect(RESOURCE_DEFINITIONS.filter(r => r.type === 'strategic')).toHaveLength(12);
+    });
+
+    it('defines the industrial-to-future resources with stable, distinct material metadata', () => {
+      const expected = {
+        coal: { price: 7, tech: 'steam-power', terrain: ['hills'], improvement: 'mine', effect: { type: 'production', amount: 1 } },
+        oil: { price: 12, tech: 'petroleum-industry', terrain: ['plains', 'desert'], improvement: 'oil_well', effect: { type: 'production', amount: 1 } },
+        aluminum: { price: 10, tech: 'aluminium-smelting', terrain: ['hills', 'desert'], improvement: 'mine', effect: null },
+        uranium: { price: 16, tech: 'nuclear-physics', terrain: ['hills', 'tundra', 'desert'], improvement: 'mine', effect: { type: 'science', amount: 1 } },
+        'rare-earth-elements': { price: 14, tech: 'nanomaterials', terrain: ['hills', 'desert'], improvement: 'mine', effect: { type: 'science', amount: 1 } },
+        'battery-minerals': { price: 13, tech: 'smart-cities', terrain: ['hills', 'desert', 'plains'], improvement: 'mine', effect: { type: 'production', amount: 1 } },
+      } as const;
+
+      for (const [id, expectedDefinition] of Object.entries(expected)) {
+        const definition = RESOURCE_DEFINITIONS.find(resource => resource.id === id);
+        expect(definition, `missing resource ${id}`).toBeDefined();
+        expect(definition?.basePrice).toBe(expectedDefinition.price);
+        expect(definition?.tech).toBe(expectedDefinition.tech);
+        expect([...(Array.isArray(definition?.terrain) ? definition.terrain : [definition?.terrain])].sort())
+          .toEqual([...expectedDefinition.terrain].sort());
+        expect(definition?.requiredImprovement).toBe(expectedDefinition.improvement);
+        expect(definition?.effect).toEqual(expectedDefinition.effect);
+        expect((definition as { materialFamily?: string } | undefined)?.materialFamily).toBeTruthy();
+        expect((definition as { codex?: { summary?: string } } | undefined)?.codex?.summary).toBeTruthy();
+
+        const revealTech = TECH_TREE.find(tech => tech.id === expectedDefinition.tech);
+        expect(revealTech?.unlocks).toContain(`Reveal ${definition?.name} resource`);
+      }
+
+      const rareEarth = RESOURCE_DEFINITIONS.find(resource => resource.id === 'rare-earth-elements') as { materialFamily?: string } | undefined;
+      const battery = RESOURCE_DEFINITIONS.find(resource => resource.id === 'battery-minerals') as { materialFamily?: string } | undefined;
+      expect(rareEarth?.materialFamily).not.toBe(battery?.materialFamily);
     });
 
     it('each resource has a positive base price', () => {
@@ -172,7 +203,7 @@ describe('trade-system', () => {
     });
 
     it('requiredImprovement values are valid BuildableImprovementTypes', () => {
-      const valid = new Set(['farm', 'mine', 'lumber_camp', 'watermill', 'plantation', 'pasture', 'camp', 'quarry']);
+      const valid = new Set(['farm', 'mine', 'lumber_camp', 'watermill', 'plantation', 'pasture', 'camp', 'quarry', 'oil_well']);
       for (const r of RESOURCE_DEFINITIONS) {
         const imp = (r as unknown as Record<string, unknown>).requiredImprovement as string | undefined;
         expect(valid.has(imp ?? ''), `${r.id}.requiredImprovement "${imp}" is not a valid BuildableImprovementType`).toBe(true);

--- a/tests/ui/city-panel-resources.test.ts
+++ b/tests/ui/city-panel-resources.test.ts
@@ -86,6 +86,16 @@ function makeStateNoResources(): GameState {
 }
 
 describe('city panel resource bonus section', () => {
+  it('labels optional resource discounts as Faster with rather than Required', () => {
+    const state = makeLegendaryWonderFixture({ completedTechs: ['steam-power', 'philosophy', 'sacred-sites'] });
+    const city = state.cities['city-river'];
+    const container = document.getElementById('panel-root')!;
+    createCityPanel(container, city, state, noopCallbacks);
+
+    expect(container.textContent).toContain('Faster with: Coal');
+    expect(container.textContent).not.toContain('Required: Coal');
+  });
+
   it('test 21: silk owned → "Empire bonuses" header and "Silk" text with "+1 happiness"', () => {
     const state = makeStateWithSilk();
     const city = state.cities['city-river'];

--- a/tests/ui/marketplace-panel-effects.test.ts
+++ b/tests/ui/marketplace-panel-effects.test.ts
@@ -72,4 +72,14 @@ describe('marketplace panel effect badges', () => {
     createMarketplacePanel(container, state, { onClose: () => {} });
     expect(container.textContent).toContain('+1 food/turn');
   });
+
+  it('Uranium row contains a science badge when Nuclear Physics is known', () => {
+    const container = document.getElementById('mp-root')!;
+    const state = makeMarketState();
+    (state.civilizations.player.techState.completed as string[]).push('nuclear-physics');
+    state.marketplace!.prices.uranium = 16;
+    state.marketplace!.priceHistory.uranium = [16];
+    createMarketplacePanel(container, state, { onClose: () => {} });
+    expect(container.textContent).toContain('+1 science/turn');
+  });
 });

--- a/tests/ui/marketplace-panel.test.ts
+++ b/tests/ui/marketplace-panel.test.ts
@@ -407,11 +407,11 @@ describe('createMarketplacePanel', () => {
     expect(text).toContain('research');
   });
 
-  it('footer count is correct: 14 hidden when viewer has only mining-tech (unlocks 2 of 16)', () => {
+  it('footer count is correct: 20 hidden when viewer has only mining-tech (unlocks 2 of 22)', () => {
     const state = buildState({ currentPlayer: 'p1', civTechs: ['mining-tech'] });
     createMarketplacePanel(container, state, { onClose: vi.fn() });
     const text = document.getElementById('marketplace-panel')?.textContent ?? '';
-    expect(text).toContain('14 more resources');
+    expect(text).toContain('20 more resources');
   });
 
   it('resource type badge shows capitalized label (Luxury / Strategic, not luxury / strategic)', () => {
@@ -590,8 +590,8 @@ describe('createMarketplacePanel', () => {
       const state = buildStateWithKnownCiv();
       createMarketplacePanel(container, state, { onClose: vi.fn() });
       const section = container.querySelector('[data-section="known-civs"]') as HTMLElement;
-      // iron basePrice=8, cost=24
-      expect(section.textContent).toContain('24');
+      // Current marketplace price is 5, so temporary access costs 15.
+      expect(section.textContent).toContain('15');
       expect(section.textContent).toContain('10 turns');
     });
 


### PR DESCRIPTION
## Gameplay impact
Adds Coal, Oil, Aluminum, Uranium, Rare Earth Elements, and Battery Minerals with deterministic late placement and schema-v2 migration. Oil and Uranium enforce their five intrinsic hard inputs; soft material advantages use one data-driven multiplicative evaluator capped at 25 percent. Legacy queued hard-input items receive one-time migration grace rather than being silently dropped.

## Player-facing behavior
Oil Well is reachable through the worker flow and renders on the map. City production separates Required from Faster with, including active discounts and recalculated cost/ETA. Marketplace shows science effects, live purchase prices, temporary-access expiry, and only resources revealed to the active viewer.

## AI, solo, and hot seat
AI, planning, rush estimates, quest ETAs, and upgrades use the same production evaluator as players. AI can buy an affordable hard input through public marketplace rules for a queued item or a viable idle-city candidate, only when it can finish during the 10-turn access window. Resource access and marketplace presentation are scoped to the current player for hot seat.

## Save and map safety
Late resources are placed after start and wonder placement in solo and hot-seat setup, never overwrite early resources, starts, wonders, cities, or improvements, and never satisfy early-start guarantees. Migration repairs marketplace data, deterministically normalizes legacy maps, and is idempotent.

## Final review fixes
- Protected late-resource placement ordering across procedural, balanced, continent, solo, and hot-seat setup.
- Canonical affordability and discovery validation for temporary access, with viewer-safe marketplace rows.
- Resource bonuses now affect runtime science and projected yields; planning, quest ETA, and upgrade cost paths use the same access/cost rules.
- Legacy/lightweight state compatibility retained for UI and tutorial callers.

## Verification
- Production build passed.
- Source-rule validation passed.
- Full suite: 373 files passed, 5,967 tests passed, 2 skipped.
- Targeted resource, map, AI, UI, save, planning, upgrade, and hook-smoke tests passed.
- Independent final code review found no actionable P0/P1/P2 findings.

Closes #512