### PR TITLE
fix(combat,city): bombard defense penalty + barbarian city-siege overhaul

### DIFF
--- a/docs/superpowers/specs/2026-07-11-combat-retaliation-and-city-siege-design.md
+++ b/docs/superpowers/specs/2026-07-11-combat-retaliation-and-city-siege-design.md
@@ -1,0 +1,191 @@
+# Combat Retaliation Fix + City Siege Overhaul — Design
+
+Issues: #537 (counter-attack rule matrix), #522 (flat-damage city sieges), part of the
+battle-mechanics arc (#546).
+
+## 1. Counter-attack fix (#537)
+
+**Scope, after working through the four findings against the desired behavior:** the
+existing distance-based retaliation check in `canCounterAttackAtDistance`
+(`src/systems/combat-system.ts:206`) is correct and unchanged. It already produces the
+right outcome for every case:
+
+- L1 (archer attacks adjacent melee warrior): warrior's `kind === 'melee'` and
+  `distance <= 1` → retaliates. **Kept as-is** — a melee unit that gets closed on
+  should be able to swing back regardless of what attacked it.
+- L3 (two ranged units trade at range): unchanged, matches current behavior.
+- Any attacker outranging a numeric-range defender already fails the existing
+  `defenderProfile.range >= distance` check, because an attacker can never attack from
+  farther than its own range — so a defender that's outranged at max range already
+  gets no retaliation today. Closing the distance (e.g. a bombard-range-2 unit
+  attacking a ranged-range-1 defender from 1 hex away) already lets the defender
+  reach back under the existing distance check, and that's the desired behavior — a
+  unit that's attacked at point-blank range should be able to hit back.
+
+**Real fix — L2 and L4, one shared mechanism:** add a defense-strength penalty for
+`bombard`-kind units when they are the defender in `calculateCombatStrengths`
+(`src/systems/combat-system.ts`):
+
+```
+if (UNIT_DEFINITIONS[defender.type].attackProfile?.kind === 'bombard') {
+  defenderStrength *= 0.5;
+}
+```
+
+Applied to `defenderStrength` before the ratio that drives both `defenderDamage` and
+`attackerDamage`, so a bombard-kind defender both takes more damage and deals less
+counter-damage — matching the classic "siege is terrible on defense" convention.
+
+This set is `catapult`, `cannon`, `artillery`, `grenadier`, `bomber`, `stealth_bomber`
+(everything whose `attackProfile.kind === 'bombard'`). Deliberately **not** keyed off
+the `siege` `UnitClass` tag, because that tag includes `ballista` (kind `ranged`,
+more agile — no penalty) and excludes `bomber`/`stealth_bomber` (which do need it).
+This directly answers "should bombers be siege weapons in the air": mechanically,
+yes, via the shared `bombard` kind, not via reusing the ground-only `siege` class
+(which also drives `NP_PRODUCTION_DISCOUNTS` and other ground-specific bonuses that
+shouldn't apply to bombers).
+
+Net effect on the two flagged bugs:
+- **L4** (catapult defends at full strength): now takes 2x damage and deals half
+  counter-damage when defending — no longer "defends like a spear line."
+- **L2** (bomber counter-intercepts a fighter at full bombard strength): still CAN
+  retaliate (its bombard range 3 covers the fighter's ranged range 2), but at half
+  strength, combined with the existing Interceptor class-counter
+  (`CLASS_COUNTERS` in `unit-modifier-definitions.ts`, ×1.5 for `jet_fighter`/`biplane`
+  vs `bomber`) that already favors the fighter. A shot-down bomber still gets one
+  weak "spraying fire on the way down" hit back — not a full-strength exchange, not
+  zero. No new attack-kind-vs-attack-kind special case needed.
+
+No changes needed to the combat preview UI text (`src/ui/combat-preview.ts`) beyond
+what already surfaces via `defenderModifierParts` — this new penalty is a baseline
+rule (not tech/national-project-sourced), so it's surfaced as a new
+`CombatStrengthBreakdown` part alongside terrain/river, not through the modifier-parts
+list. Add one line: `"Siege defends poorly (−50%)"` when applicable.
+
+## 2. City siege overhaul (#522)
+
+### Garrison blocking (full block)
+
+Barbarian and pirate city-siege damage currently applies unconditionally, ignoring any
+defending unit garrisoned on the city tile. New shared helper,
+`resolveCitySiegeDamage` in a new file `src/systems/city-siege-system.ts`:
+
+```ts
+export interface CitySiegeInput {
+  city: City;
+  ownerCiv: Civilization;
+  rawDamage: number;
+  attackerDomain: 'land' | 'naval' | 'air';
+  hasGarrison: boolean;
+  era: number;
+}
+
+export interface CitySiegeResult {
+  hpLost: number;          // 0 if blocked by garrison
+  newHp: number;
+  outcome: 'blocked' | 'damaged' | 'sacked' | 'destroyed';
+}
+```
+
+- `hasGarrison` (a unit with `owner === city.owner` occupying `city.position`) → fully
+  blocks the damage (`outcome: 'blocked'`, `hpLost: 0`). This matches
+  `beginMajorCityAssault`'s existing rule that a defended city tile can't be taken —
+  city HP damage is the barbarian/pirate equivalent of capture, so it gets the same
+  gate.
+- Otherwise, damage is mitigated through the existing `getCityDefenseBreakdown` (walls
+  / Star Fort / Fortification Engineering / Professional Army / Torpedo Warfare):
+  `mitigatedDamage = Math.round(rawDamage / breakdown.multiplier)`. Only the
+  multiplier is reused (not `flatBonus`, which is tuned for unit-strength points, not
+  flat siege HP — reusing it here would need a second, differently-scaled constant
+  table for no real benefit).
+- Since damage is only ever applied when `hasGarrison` is false, HP can only reach 0
+  on an undefended city — "destroy only if ungarrisoned" from the issue is
+  automatically satisfied by the block rule, no extra check needed.
+
+### Barbarian/pirate targeting: attack the garrison first
+
+`processBarbarians`' city-attack branch (`src/systems/barbarian-system.ts:497-500`) and
+the pirate siege loop (`src/systems/threat-pressure-system.ts:768-781`) both need to
+check for a garrison before queuing a city-damage order. If a garrison unit is present,
+redirect to a normal unit-attack order against it (both systems already have unit-vs-unit
+combat paths — barbarians via `attackOrders`, pirates need one added, since currently
+pirates never fight garrisons at all). If the city is undefended, proceed with the
+siege-damage order as before, now routed through `resolveCitySiegeDamage`.
+
+### Zero-HP outcome: difficulty- and era-gated
+
+At 0 HP, whether the city is destroyed or merely "sacked" depends on the human owner's
+resolved `OpponentChallenge` (`resolveChallengeForCiv`, `src/core/opponent-challenge.ts`)
+and the current era — mirroring the existing `crisisGraceMaxEra` pattern (a punishing
+mechanic gated by a per-difficulty era threshold). New field on
+`OpponentChallengeProfile`: `citySiegeDestructionEra`. Destruction is possible once
+`state.era > citySiegeDestructionEra` for that civ's resolved challenge:
+
+| Challenge  | `citySiegeDestructionEra` | Destruction possible from |
+|---|---|---|
+| `explorer` (easiest) | 3 | era 4+ |
+| `standard` (medium)  | 2 | era 3+ |
+| `veteran` (hardest)  | 1 | era 2+ |
+
+- Below the threshold (or always, for AI-owned cities using `resolveOpponentChallenge`
+  at the table default): **sacked**, not destroyed. HP floors at 1 (never 0), a
+  one-time gold plunder applies (`Math.round(ownerCiv.gold * 0.15)`, same style as the
+  existing pirate plunder calc), and the city immediately starts regenerating (below).
+- At/above the threshold: existing destruction path (city removed from `state.cities`
+  and the owner's `civilizations[id].cities`), unchanged from current
+  `turn-manager.ts` logic, just routed through the shared helper's `outcome:
+  'destroyed'` branch instead of being duplicated per-source.
+- Barbarians and pirates share this outcome logic — today pirates never destroy a
+  city at all (asymmetric with barbarians); this makes both sources consistent.
+
+Both call sites keep emitting their existing source-specific events
+(`barbarian:city-attacked`/`barbarian:city-destroyed`, and a new
+`threat:pirate-siege`-adjacent `pirate:city-destroyed`) so existing listeners don't
+need renaming, but both now emit them based on the shared helper's `outcome` instead
+of duplicated inline logic. Add one new shared event, `city:sacked { cityId, source:
+'barbarian' | 'pirate', goldLost }`, fired instead of the destroy event when the
+era/difficulty threshold isn't met.
+
+### HP regeneration
+
+New per-turn step in `turn-manager.ts` (alongside existing per-city turn processing):
++5 HP/turn (same rate as `HEAL_PASSIVE` for units, for consistency) when no hostile
+unit is within 1 hex of the city (hostile = `owner === 'barbarian'`, a pirate-fleet
+unit, or a unit whose owner is at war with the city's owner). Capped at 100.
+
+### UI surfacing
+
+- `city-panel.ts`'s HP display (`city.hp ?? 100`) gets a small
+  `regenerating (+5/turn)` / `under siege — no regen` suffix depending on hostile
+  adjacency, consistent with the "HUD shows per-turn rates, not just totals" rule.
+- `main.ts` notification wiring: add a `threat:pirate-siege` listener mirroring the
+  existing `barbarian:city-attacked` one (today pirates deal HP damage completely
+  silently to the notification log — issue #522 explicitly calls this out). Add
+  listeners for the new `city:sacked` and `pirate:city-destroyed` events, phrased
+  distinctly from straight damage ("X was sacked — city survives at 1 HP!" vs "X was
+  destroyed!") so a losing-a-city moment is never confused with a scarier-but-recoverable
+  one.
+
+## Save compatibility
+
+`City.hp` is already optional (`hp?: number`, defaults to 100 via `?? 100`) — no
+migration needed. The new `citySiegeDestructionEra` field lives on the existing
+`OpponentChallengeProfile` const table, not on saved state, so no migration needed
+there either.
+
+## Testing
+
+- `combat-system.test.ts`: bombard-kind defense penalty — catapult vs melee attacker
+  (L4 regression), bomber vs jet_fighter (L2 regression, verify reduced but nonzero
+  counter-damage), ballista unaffected (control), non-bombard units unaffected
+  (control).
+- New `city-siege-system.test.ts`: garrison fully blocks damage; walls/Star Fort
+  mitigate via the multiplier; sack vs destroy branches by era/challenge; gold
+  plunder amount; HP floors at 1 on sack, removed from state on destroy.
+- `barbarian-system.test.ts` / `threat-pressure-system.test.ts`: garrisoned city is
+  attacked as a unit target, not a city-damage target; undefended city still takes
+  siege damage.
+- `turn-manager.test.ts`: HP regen applies with no hostile adjacent, does not apply
+  with a hostile unit adjacent, caps at 100.
+- Notification/event regression: `city:sacked`, `pirate:city-destroyed`,
+  `threat:pirate-siege` log listener parity with the barbarian path.

--- a/docs/superpowers/specs/2026-07-11-combat-retaliation-and-city-siege-design.md
+++ b/docs/superpowers/specs/2026-07-11-combat-retaliation-and-city-siege-design.md
@@ -62,6 +62,24 @@ rule (not tech/national-project-sourced), so it's surfaced as a new
 `CombatStrengthBreakdown` part alongside terrain/river, not through the modifier-parts
 list. Add one line: `"Siege defends poorly (−50%)"` when applicable.
 
+## Deviation from #522 as written: the pirate half is stale
+
+The issue's code map cites `threat-pressure-system.ts:770-783` (`processPirateFleets`,
+`state.pirateFleets`, `threat:pirate-*` events) as the live pirate-siege path. It is
+not — `tests/systems/pirate-end-to-end.test.ts`'s "pirate feature completion gate"
+explicitly asserts `main.ts` never wires a `bus.on('threat:pirate-'` listener and
+`turn-manager.ts` never calls `processPirateFleets(`, confirming this fleet/siege
+model was deliberately retired in favor of the newer faction-based system
+(`pirate-system.ts` / `pirate-actions.ts`: headquarters, tribute, contracts,
+notoriety). That live system has **no city-HP-damage mechanic at all** — a pirate
+"raid" against a city today only affects contract/exposure bookkeeping, never
+`city.hp`. So there is no live pirate city-siege bug to fix; #522's pirate half
+describes code that no longer runs. This MR implements the garrison/mitigation/
+sack-vs-destroy/regen fix for the barbarian path only, since that's the only live
+city-siege-HP source. Whether pirates should gain an equivalent HP-damage mechanic
+under the new faction system is a separate design question, not a bug fix — flagged
+as a follow-up rather than decided here.
+
 ## 2. City siege overhaul (#522)
 
 ### Garrison blocking (full block)
@@ -102,14 +120,12 @@ export interface CitySiegeResult {
   on an undefended city — "destroy only if ungarrisoned" from the issue is
   automatically satisfied by the block rule, no extra check needed.
 
-### Barbarian/pirate targeting: attack the garrison first
+### Barbarian targeting: attack the garrison first
 
-`processBarbarians`' city-attack branch (`src/systems/barbarian-system.ts:497-500`) and
-the pirate siege loop (`src/systems/threat-pressure-system.ts:768-781`) both need to
-check for a garrison before queuing a city-damage order. If a garrison unit is present,
-redirect to a normal unit-attack order against it (both systems already have unit-vs-unit
-combat paths — barbarians via `attackOrders`, pirates need one added, since currently
-pirates never fight garrisons at all). If the city is undefended, proceed with the
+`processPurposefulBarbarians`' city-attack branch
+(`src/systems/barbarian-system.ts:498-501`) needs to check for a garrison before
+queuing a city-damage order. If a garrison unit is present, redirect to a normal
+unit-attack order against it instead. If the city is undefended, proceed with the
 siege-damage order as before, now routed through `resolveCitySiegeDamage`.
 
 ### Zero-HP outcome: difficulty- and era-gated
@@ -135,36 +151,29 @@ mechanic gated by a per-difficulty era threshold). New field on
   and the owner's `civilizations[id].cities`), unchanged from current
   `turn-manager.ts` logic, just routed through the shared helper's `outcome:
   'destroyed'` branch instead of being duplicated per-source.
-- Barbarians and pirates share this outcome logic — today pirates never destroy a
-  city at all (asymmetric with barbarians); this makes both sources consistent.
-
-Both call sites keep emitting their existing source-specific events
-(`barbarian:city-attacked`/`barbarian:city-destroyed`, and a new
-`threat:pirate-siege`-adjacent `pirate:city-destroyed`) so existing listeners don't
-need renaming, but both now emit them based on the shared helper's `outcome` instead
-of duplicated inline logic. Add one new shared event, `city:sacked { cityId, source:
-'barbarian' | 'pirate', goldLost }`, fired instead of the destroy event when the
-era/difficulty threshold isn't met.
+- `city:sacked { cityId, source: 'barbarian' | 'pirate', goldLost }` is a new shared
+  event, with `source` typed to include `'pirate'` for forward-compat even though only
+  `'barbarian'` is ever emitted today (see deviation note above). Fired instead of
+  `barbarian:city-destroyed` when the era/difficulty threshold isn't met; the existing
+  `barbarian:city-attacked`/`barbarian:city-destroyed` events are kept as-is, now
+  driven by the shared helper's `outcome` instead of duplicated inline logic.
 
 ### HP regeneration
 
 New per-turn step in `turn-manager.ts` (alongside existing per-city turn processing):
 +5 HP/turn (same rate as `HEAL_PASSIVE` for units, for consistency) when no hostile
-unit is within 1 hex of the city (hostile = `owner === 'barbarian'`, a pirate-fleet
-unit, or a unit whose owner is at war with the city's owner). Capped at 100.
+unit is within 1 hex of the city (hostile = barbarian, or a unit whose owner is at war
+with the city's owner, via `isAlwaysHostilePair`/`isAtWar`). Capped at 100.
 
 ### UI surfacing
 
-- `city-panel.ts`'s HP display (`city.hp ?? 100`) gets a small
-  `regenerating (+5/turn)` / `under siege — no regen` suffix depending on hostile
-  adjacency, consistent with the "HUD shows per-turn rates, not just totals" rule.
-- `main.ts` notification wiring: add a `threat:pirate-siege` listener mirroring the
-  existing `barbarian:city-attacked` one (today pirates deal HP damage completely
-  silently to the notification log — issue #522 explicitly calls this out). Add
-  listeners for the new `city:sacked` and `pirate:city-destroyed` events, phrased
-  distinctly from straight damage ("X was sacked — city survives at 1 HP!" vs "X was
-  destroyed!") so a losing-a-city moment is never confused with a scarier-but-recoverable
-  one.
+- `city-panel.ts`'s HP display (`city.hp ?? 100`) gets a `Recovering — X/100 HP
+  (+5/turn)` / `Under siege — X/100 HP (no regen)` label depending on hostile
+  adjacency (`isCityHpRegenerating`), consistent with the "HUD shows per-turn rates,
+  not just totals" rule.
+- `main.ts` notification wiring: add a `city:sacked` listener phrased distinctly from
+  straight damage ("X was sacked — survives at 1 HP" vs "X was destroyed") so a
+  losing-a-city moment is never confused with a scarier-but-recoverable one.
 
 ## Save compatibility
 
@@ -181,11 +190,8 @@ there either.
   (control).
 - New `city-siege-system.test.ts`: garrison fully blocks damage; walls/Star Fort
   mitigate via the multiplier; sack vs destroy branches by era/challenge; gold
-  plunder amount; HP floors at 1 on sack, removed from state on destroy.
-- `barbarian-system.test.ts` / `threat-pressure-system.test.ts`: garrisoned city is
-  attacked as a unit target, not a city-damage target; undefended city still takes
-  siege damage.
-- `turn-manager.test.ts`: HP regen applies with no hostile adjacent, does not apply
-  with a hostile unit adjacent, caps at 100.
-- Notification/event regression: `city:sacked`, `pirate:city-destroyed`,
-  `threat:pirate-siege` log listener parity with the barbarian path.
+  plunder amount; HP floors at 1 on sack, removed from state on destroy; HP
+  regeneration and its hostile-adjacency gate; `isCityHpRegenerating`.
+- `barbarian-system.test.ts`: garrisoned city is attacked as a unit target, not a
+  city-damage target; undefended city still takes siege damage (regression).
+- `city-panel.test.ts`: recovering vs under-siege HP status label.

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -14,6 +14,10 @@ export interface OpponentChallengeProfile {
   crisisGraceMaxEra: number;
   crisisGraceMinTurns: number;
   crisisSeverityMultiplier: number;
+  // Barbarian/pirate city sieges only permanently destroy an undefended city once
+  // state.era exceeds this value for the city owner's resolved challenge; below it,
+  // a city that hits 0 HP is sacked (survives at 1 HP) instead. See #522.
+  citySiegeDestructionEra: number;
 }
 
 export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChallengeProfile> = {
@@ -31,6 +35,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMaxEra: 2,
     crisisGraceMinTurns: 30,
     crisisSeverityMultiplier: 0.5,
+    citySiegeDestructionEra: 3,
   },
   standard: {
     mobilizationRounds: 1,
@@ -46,6 +51,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMaxEra: 1,
     crisisGraceMinTurns: 20,
     crisisSeverityMultiplier: 1.0,
+    citySiegeDestructionEra: 2,
   },
   veteran: {
     mobilizationRounds: 0,
@@ -61,6 +67,7 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMaxEra: 1,
     crisisGraceMinTurns: 10,
     crisisSeverityMultiplier: 1.3,
+    citySiegeDestructionEra: 1,
   },
 };
 

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -76,7 +76,8 @@ import { chargeUnitsOnGeneTherapyResearch, applyGeneTherapyRecharge } from '@/sy
 import { processCyberDrain } from '@/systems/cyber-warfare-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
-import { applyPendingOpponentChallenge } from '@/core/opponent-challenge';
+import { applyPendingOpponentChallenge, resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
@@ -777,18 +778,30 @@ export function processTurn(
     }
   }
 
-  // Barbarian city attacks
+  // Barbarian city attacks — routed through the shared siege helper (#522): a
+  // garrisoned city fully blocks damage, walls/techs mitigate it, and the 0-HP
+  // outcome is sack-vs-destroy gated by era + the owner's resolved difficulty.
   for (const order of barbResult.cityAttackOrders) {
     const city = newState.cities[order.cityId];
     if (!city) continue;
     const currentHp = city.hp ?? 100;
     if (currentHp <= 0) continue; // already at zero (shouldn't persist, but guard against legacy saves)
-    const newHp = Math.max(0, currentHp - order.damage);
-    newState = {
-      ...newState,
-      cities: { ...newState.cities, [order.cityId]: { ...city, hp: newHp } },
-    };
-    bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: currentHp - newHp });
+    const ownerCiv = newState.civilizations[city.owner];
+    if (!ownerCiv) continue;
+
+    const result = resolveCitySiegeDamage({
+      city,
+      ownerCiv,
+      rawDamage: order.damage,
+      attackerDomain: 'land',
+      hasGarrison: getCityGarrisonUnit(newState.units, city) !== undefined,
+      era: newState.era,
+      challenge: resolveChallengeForCiv(newState, city.owner),
+    });
+    newState = applyCitySiegeOutcome(newState, order.cityId, result);
+    if (result.outcome === 'blocked') continue;
+
+    bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: result.hpLost });
     if (newState.opponentAI) {
       const campId = newState.opponentAI.barbarianHomeCampByUnitId[order.attackerUnitId];
       const plan = campId ? newState.opponentAI.barbarianCamps[campId] : undefined;
@@ -801,23 +814,17 @@ export function processTurn(
       }
     }
 
-    if (newHp === 0) {
-      const ownerId = city.owner;
-      const { [order.cityId]: _removed, ...remainingCities } = newState.cities;
-      newState = { ...newState, cities: remainingCities };
-      const ownerCiv = newState.civilizations[ownerId];
-      if (ownerCiv) {
-        newState = {
-          ...newState,
-          civilizations: {
-            ...newState.civilizations,
-            [ownerId]: { ...ownerCiv, cities: ownerCiv.cities.filter((cId: string) => cId !== order.cityId) },
-          },
-        };
-      }
-      bus.emit('barbarian:city-destroyed', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, ownerId });
+    if (result.outcome === 'sacked') {
+      bus.emit('city:sacked', { cityId: order.cityId, source: 'barbarian', goldLost: result.goldLost });
+    } else if (result.outcome === 'destroyed') {
+      bus.emit('barbarian:city-destroyed', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, ownerId: city.owner });
     }
   }
+
+  // City HP regeneration (#522) — +5/turn for any city below max HP with no hostile
+  // unit adjacent, so damage from a raid that didn't destroy the city doesn't linger
+  // forever.
+  newState = applyCityHpRegeneration(newState);
 
   // --- Minor civ turn phase ---
   newState = processMinorCivTurn(newState, bus);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1646,6 +1646,9 @@ export interface GameEvents {
   'threat:pirate-fleet-destroyed': { fleetId: string; civId: string; landmassId: string };
   'barbarian:city-attacked': { attackerUnitId: string; cityId: string; hpLost: number };
   'barbarian:city-destroyed': { attackerUnitId: string; cityId: string; ownerId: string };
+  // 'pirate' source is future-proofed for when the pirate-faction system (pirate-system.ts)
+  // gains a city-HP-damage mechanic; only 'barbarian' is emitted today (turn-manager.ts).
+  'city:sacked': { cityId: string; source: 'barbarian' | 'pirate'; goldLost: number };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3867,6 +3867,23 @@ bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
   appendToCivLog(ownerId, `${cityName} was destroyed by barbarian raiders!`, 'warning');
 });
 
+// A sacked city survives the raid at 1 HP — phrased distinctly from outright
+// destruction so a recoverable loss is never mistaken for a permanent one. Barbarians
+// are the only live source today (see turn-manager.ts); 'pirate' is future-proofed
+// in the event type but the current pirate-faction system (pirate-system.ts) has no
+// city-HP-damage mechanic to route through it.
+bus.on('city:sacked', ({ cityId, source, goldLost }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (!gameState.civilizations[city.owner]?.isHuman) return;
+  const raiders = source === 'barbarian' ? 'Barbarian raiders' : 'Pirates';
+  appendToCivLog(
+    city.owner,
+    `${raiders} have sacked ${city.name}! The city survives at 1 HP, but ${goldLost} gold was looted.`,
+    'warning',
+  );
+});
+
 bus.on('beast:awakened', ({ beastId, position }) => {
   const def = BEAST_DEFINITIONS[beastId];
   for (const [civId, civ] of Object.entries(gameState.civilizations)) {

--- a/src/systems/barbarian-system.ts
+++ b/src/systems/barbarian-system.ts
@@ -21,6 +21,7 @@ import {
   wrappedHexDistance,
 } from './hex-utils';
 import { selectDefenderForAttack } from './combat-system';
+import { getCityGarrisonUnit } from './city-siege-system';
 import { applyQuestGameplayAction, type ChainTransition } from './quest-chain-system';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { recordHuntCampKillerIfApplicable } from './hunt-crisis-linkage';
@@ -496,7 +497,15 @@ export function processPurposefulBarbarians(state: GameState): PurposefulBarbari
         }
       }
       if (!withdrawing && plan.target.kind === 'city' && barbarianDistance(state, unit.position, destination) <= 1) {
-        cityAttackOrders.push({ attackerUnitId: unit.id, cityId: plan.target.id, damage: 10 });
+        const city = state.cities[plan.target.id];
+        const garrison = city ? getCityGarrisonUnit(state.units, city) : undefined;
+        if (garrison) {
+          if (canAttackByProfileOnMap(unit, garrison, state.map)) {
+            attackOrders.push({ attackerUnitId: unit.id, defenderUnitId: garrison.id });
+          }
+        } else {
+          cityAttackOrders.push({ attackerUnitId: unit.id, cityId: plan.target.id, damage: 10 });
+        }
         continue;
       }
       const step = chooseStepToward(state, unit, destination);

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -1,0 +1,165 @@
+import type { City, Civilization, GameState, HexCoord, Unit } from '@/core/types';
+import type { OpponentChallenge } from '@/core/types';
+import { OPPONENT_CHALLENGE_PROFILES } from '@/core/opponent-challenge';
+import { getCityDefenseBreakdown } from '@/systems/combat-system';
+import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
+import { isAtWar } from '@/systems/diplomacy-system';
+
+export interface CitySiegeInput {
+  city: City;
+  ownerCiv: Civilization;
+  rawDamage: number;
+  attackerDomain: 'land' | 'naval' | 'air';
+  hasGarrison: boolean;
+  era: number;
+  challenge: OpponentChallenge;
+}
+
+export type CitySiegeOutcome = 'blocked' | 'damaged' | 'sacked' | 'destroyed';
+
+export interface CitySiegeResult {
+  hpLost: number;
+  newHp: number;
+  outcome: CitySiegeOutcome;
+  goldLost: number;
+}
+
+const SACK_GOLD_LOSS_FRACTION = 0.15;
+
+// A garrisoned defender fully blocks city-HP damage — the barbarian/pirate equivalent
+// of beginMajorCityAssault's "city-defended" gate for player-vs-player capture. This
+// also means HP can only ever reach 0 on an undefended city, so no separate
+// "destroy only if ungarrisoned" check is needed below.
+export function resolveCitySiegeDamage(input: CitySiegeInput): CitySiegeResult {
+  const currentHp = input.city.hp ?? 100;
+
+  if (input.hasGarrison) {
+    return { hpLost: 0, newHp: currentHp, outcome: 'blocked', goldLost: 0 };
+  }
+
+  const breakdown = getCityDefenseBreakdown({
+    cityBuildings: input.city.buildings ?? [],
+    defenderCompletedTechs: input.ownerCiv.techState.completed ?? [],
+    attackerDomain: input.attackerDomain,
+  });
+  const mitigatedDamage = Math.round(input.rawDamage / breakdown.multiplier);
+  const newHp = Math.max(0, currentHp - mitigatedDamage);
+
+  if (newHp > 0) {
+    return { hpLost: currentHp - newHp, newHp, outcome: 'damaged', goldLost: 0 };
+  }
+
+  const destructionEra = OPPONENT_CHALLENGE_PROFILES[input.challenge].citySiegeDestructionEra;
+  if (input.era > destructionEra) {
+    return { hpLost: currentHp, newHp: 0, outcome: 'destroyed', goldLost: 0 };
+  }
+
+  const goldLost = Math.round(input.ownerCiv.gold * SACK_GOLD_LOSS_FRACTION);
+  return { hpLost: currentHp - 1, newHp: 1, outcome: 'sacked', goldLost };
+}
+
+// Immutable state transform for a resolveCitySiegeDamage result. 'blocked' never
+// reaches here from a real caller (no HP change to apply) but is a documented no-op
+// for callers that don't special-case it.
+export function applyCitySiegeOutcome(state: GameState, cityId: string, result: CitySiegeResult): GameState {
+  if (result.outcome === 'blocked') return state;
+
+  const city = state.cities[cityId];
+  if (!city) return state;
+
+  if (result.outcome === 'destroyed') {
+    const { [cityId]: _removed, ...remainingCities } = state.cities;
+    const ownerCiv = state.civilizations[city.owner];
+    return {
+      ...state,
+      cities: remainingCities,
+      civilizations: ownerCiv
+        ? {
+          ...state.civilizations,
+          [city.owner]: { ...ownerCiv, cities: ownerCiv.cities.filter(id => id !== cityId) },
+        }
+        : state.civilizations,
+    };
+  }
+
+  const ownerCiv = state.civilizations[city.owner];
+  return {
+    ...state,
+    cities: { ...state.cities, [cityId]: { ...city, hp: result.newHp } },
+    civilizations: ownerCiv && result.goldLost > 0
+      ? {
+        ...state.civilizations,
+        [city.owner]: { ...ownerCiv, gold: Math.max(0, ownerCiv.gold - result.goldLost) },
+      }
+      : state.civilizations,
+  };
+}
+
+// A city tile is "garrisoned" if any living unit owned by the city's owner occupies it.
+export function getCityGarrisonUnit(units: Record<string, Unit>, city: Pick<City, 'owner' | 'position'>): Unit | undefined {
+  const cityKey = hexKey(city.position);
+  return Object.values(units).find(unit => unit.owner === city.owner && hexKey(unit.position) === cityKey);
+}
+
+export function hasCityGarrison(units: Record<string, Unit>, city: Pick<City, 'owner' | 'position'>): boolean {
+  return getCityGarrisonUnit(units, city) !== undefined;
+}
+
+// Any unit hostile to the city's owner (barbarian, pirate, or a civ at war) within
+// `range` hexes blocks passive HP regeneration — mirrors HEAL_PASSIVE's "idle" gate
+// for units, applied to cities instead.
+export function hasHostileUnitNearCity(
+  units: Record<string, Unit>,
+  city: Pick<City, 'owner' | 'position'>,
+  isHostile: (unitOwner: string) => boolean,
+  range: number,
+  distanceFn: (a: HexCoord, b: HexCoord) => number,
+): boolean {
+  return Object.values(units).some(unit =>
+    unit.owner !== city.owner
+    && isHostile(unit.owner)
+    && distanceFn(unit.position, city.position) <= range);
+}
+
+const CITY_HP_REGEN_PER_TURN = 5;
+const CITY_HP_MAX = 100;
+const CITY_HP_REGEN_HOSTILE_RANGE = 1;
+
+// True when a city below max HP has no hostile unit within regen range — shared by
+// applyCityHpRegeneration (turn processing) and the city panel (UI status label) so
+// the two never drift apart on what counts as "under siege" vs "recovering".
+export function isCityHpRegenerating(state: GameState, city: City): boolean {
+  const hp = city.hp ?? CITY_HP_MAX;
+  if (hp >= CITY_HP_MAX || hp <= 0) return false;
+
+  const ownerCiv = state.civilizations[city.owner];
+  const distanceFn = state.map.wrapsHorizontally
+    ? (a: HexCoord, b: HexCoord) => wrappedHexDistance(a, b, state.map.width)
+    : hexDistance;
+  return !hasHostileUnitNearCity(
+    state.units,
+    city,
+    unitOwner => isAlwaysHostilePair(unitOwner, city.owner) || (ownerCiv ? isAtWar(ownerCiv.diplomacy, unitOwner) : false),
+    CITY_HP_REGEN_HOSTILE_RANGE,
+    distanceFn,
+  );
+}
+
+// +5 HP/turn (same rate as unit HEAL_PASSIVE) for any city below max HP, as long as
+// no hostile unit is within 1 hex. A city at 0 HP does not regenerate on its own —
+// it only reaches 0 via the 'sacked' outcome, which already floors it at 1.
+export function applyCityHpRegeneration(state: GameState): GameState {
+  let nextCities: GameState['cities'] | null = null;
+
+  for (const city of Object.values(state.cities)) {
+    const hp = city.hp ?? CITY_HP_MAX;
+    if (hp >= CITY_HP_MAX || hp <= 0) continue;
+    if (!isCityHpRegenerating(state, city)) continue;
+
+    if (!nextCities) nextCities = { ...state.cities };
+    nextCities[city.id] = { ...city, hp: Math.min(CITY_HP_MAX, hp + CITY_HP_REGEN_PER_TURN) };
+  }
+
+  return nextCities ? { ...state, cities: nextCities } : state;
+}

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -125,6 +125,7 @@ export interface CombatStrengthBreakdown {
   cityDefense?: CityDefenseBreakdown;
   attackerModifierParts?: ModifierPart[];
   defenderModifierParts?: ModifierPart[];
+  defenderDefendsPoorly?: boolean;
 }
 
 export function calculateCombatStrengths(
@@ -145,6 +146,16 @@ export function calculateCombatStrengths(
   let defenderStrength = defenderDefinition.strength
     * (defender.health / 100)
     * (1 + getVeterancyCombatModifier(defender));
+
+  // Bombard-kind units (catapult, cannon, artillery, grenadier, bomber, stealth_bomber)
+  // defend poorly — classic "siege is terrible on defense" convention. Keyed off
+  // attackProfile.kind rather than the 'siege' UnitClass because that class includes
+  // ballista (kind 'ranged', more agile — no penalty) and excludes bomber/stealth_bomber
+  // (which do need it, per the #537 counter-intercept fix).
+  if (defenderDefinition.attackProfile?.kind === 'bombard') {
+    defenderStrength *= 0.5;
+  }
+
   const defenderTile = map.tiles[hexKey(defender.position)];
   const terrainDefenseBonus = defenderTile ? getTerrainDefenseBonus(defenderTile.terrain) : 0;
 
@@ -200,6 +211,7 @@ export function calculateCombatStrengths(
     cityDefense,
     attackerModifierParts: context?.attackerModifiers?.parts,
     defenderModifierParts: context?.defenderModifiers?.parts,
+    defenderDefendsPoorly: defenderDefinition.attackProfile?.kind === 'bombard',
   };
 }
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -35,6 +35,7 @@ import {
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier } from '@/systems/crisis-system';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { isCityHpRegenerating } from '@/systems/city-siege-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { getCityTechYields } from '@/systems/tech-yield-system';
@@ -627,13 +628,17 @@ export function createCityPanel(
     : '';
 
   const cityHp = city.hp ?? 100;
-  const cityUnderSiege = cityHp < 100;
+  const cityDamaged = cityHp < 100;
+  const cityRegenerating = cityDamaged && isCityHpRegenerating(state, city);
   const siegeHpPct = Math.max(0, cityHp);
-  const siegeBarHtml = cityUnderSiege
+  const hpStatusLabel = cityRegenerating
+    ? `🩹 Recovering — ${cityHp}/100 HP (+5/turn)`
+    : `⚔️ Under siege — ${cityHp}/100 HP (no regen)`;
+  const siegeBarHtml = cityDamaged
     ? `<div style="margin-top:6px;">
-        <div style="font-size:12px;color:#f87171;font-weight:bold;">⚔️ Under siege — ${cityHp}/100 HP</div>
+        <div style="font-size:12px;color:${cityRegenerating ? '#4ade80' : '#f87171'};font-weight:bold;">${hpStatusLabel}</div>
         <div style="background:rgba(0,0,0,0.4);border-radius:4px;height:6px;margin-top:4px;width:120px;">
-          <div style="background:#ef4444;border-radius:4px;height:6px;width:${siegeHpPct}%;transition:width 0.3s;"></div>
+          <div style="background:${cityRegenerating ? '#4ade80' : '#ef4444'};border-radius:4px;height:6px;width:${siegeHpPct}%;transition:width 0.3s;"></div>
         </div>
       </div>`
     : '';

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -21,5 +21,8 @@ export function formatCombatPreviewDetails(
   for (const part of preview.cityDefense?.parts ?? []) {
     details.push(part.label);
   }
+  if (preview.defenderDefendsPoorly) {
+    details.push('Siege defends poorly (−50%)');
+  }
   return details.join(' | ');
 }

--- a/tests/core/opponent-challenge.test.ts
+++ b/tests/core/opponent-challenge.test.ts
@@ -126,6 +126,18 @@ describe('crisis profile knobs', () => {
   });
 });
 
+describe('city siege destruction era knob (#522)', () => {
+  it('carries spec values: easier difficulties tolerate destruction until a later era', () => {
+    expect(OPPONENT_CHALLENGE_PROFILES.explorer.citySiegeDestructionEra).toBe(3);
+    expect(OPPONENT_CHALLENGE_PROFILES.standard.citySiegeDestructionEra).toBe(2);
+    expect(OPPONENT_CHALLENGE_PROFILES.veteran.citySiegeDestructionEra).toBe(1);
+  });
+
+  it('getChallengeProfileForCiv resolves the per-civ destruction era threshold', () => {
+    expect(getChallengeProfileForCiv(stateWith('explorer', 'veteran'), 'c1').citySiegeDestructionEra).toBe(3);
+  });
+});
+
 describe('per-civ pending challenge', () => {
   it('setPendingChallengeForCiv stages a change without touching other civs', () => {
     const state = stateWith('standard', undefined);

--- a/tests/systems/barbarian-system.test.ts
+++ b/tests/systems/barbarian-system.test.ts
@@ -283,6 +283,45 @@ describe('processPurposefulBarbarians', () => {
       toCoord: { q: 6, r: 5 },
     });
   });
+
+  it('attacks an undefended city normally when adjacent (garrison regression)', () => {
+    const state = purposefulState();
+    // Camp stays at (5,5); raider starts far enough from it that a garrison at the
+    // city (far from the camp) can't be mistaken for a camp-defense threat.
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.cities.town = {
+      id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 30,
+    } as never;
+    state.civilizations.player.cities = ['town'];
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.cityAttackOrders).toHaveLength(1);
+    expect(result.cityAttackOrders[0]).toMatchObject({ attackerUnitId: 'raider', cityId: 'town' });
+    expect(result.attackOrders).toHaveLength(0);
+  });
+
+  it('attacks the garrison unit instead of damaging the city when one is present (#522)', () => {
+    const state = purposefulState();
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const garrison = createUnit('warrior', 'player', { q: 12, r: 5 }, state.idCounters);
+    garrison.id = 'garrison';
+    state.units = { raider, garrison };
+    state.cities.town = {
+      id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 30,
+    } as never;
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.units = ['garrison'];
+
+    const result = processPurposefulBarbarians(state);
+
+    expect(result.cityAttackOrders).toHaveLength(0);
+    expect(result.attackOrders).toHaveLength(1);
+    expect(result.attackOrders[0]).toMatchObject({ attackerUnitId: 'raider', defenderUnitId: 'garrison' });
+  });
 });
 
 describe('barbarian camp evolution', () => {

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { foundCity } from '@/systems/city-system';
+import { createUnit } from '@/systems/unit-system';
+import type { City, Civilization, GameState } from '@/core/types';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, isCityHpRegenerating, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function makeGameStateWithCity(): { state: GameState; cityId: string } {
+  const state = createNewGame(undefined, 'city-siege-test', 'small');
+  const city = { ...foundCity('player', { q: 2, r: 2 }, state.map, mkC()), id: 'town', hp: 100 };
+  state.cities = { town: city };
+  state.civilizations.player.cities = ['town'];
+  return { state, cityId: 'town' };
+}
+
+function makeCityAndCiv(overrides: Partial<City> = {}, civOverrides: Partial<Civilization> = {}) {
+  const { state, cityId } = makeGameStateWithCity();
+  const city: City = { ...state.cities[cityId], hp: 100, buildings: [], ...overrides };
+  const ownerCiv: Civilization = { ...state.civilizations.player, gold: 200, ...civOverrides };
+  return { city, ownerCiv };
+}
+
+describe('resolveCitySiegeDamage (#522)', () => {
+  it('fully blocks damage when the city has a garrison', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ hp: 40 });
+
+    const result = resolveCitySiegeDamage({
+      city, ownerCiv, rawDamage: 10, attackerDomain: 'land', hasGarrison: true, era: 1, challenge: 'standard',
+    });
+
+    expect(result.outcome).toBe('blocked');
+    expect(result.hpLost).toBe(0);
+    expect(result.newHp).toBe(40);
+  });
+
+  it('applies raw damage to an undefended city with no walls', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ hp: 50, buildings: [] });
+
+    const result = resolveCitySiegeDamage({
+      city, ownerCiv, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 1, challenge: 'standard',
+    });
+
+    expect(result.outcome).toBe('damaged');
+    expect(result.hpLost).toBe(10);
+    expect(result.newHp).toBe(40);
+  });
+
+  it('mitigates damage via the walls defense multiplier', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ hp: 50, buildings: ['walls'] });
+
+    const result = resolveCitySiegeDamage({
+      city, ownerCiv, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 1, challenge: 'standard',
+    });
+
+    // walls -> x1.25 multiplier -> 10 / 1.25 = 8 mitigated damage
+    expect(result.hpLost).toBe(8);
+    expect(result.newHp).toBe(42);
+  });
+
+  it('sacks (survives at 1 HP, loses gold) instead of destroying below the difficulty era threshold', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ hp: 5, buildings: [] }, { gold: 200 });
+
+    const result = resolveCitySiegeDamage({
+      city, ownerCiv, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 2, challenge: 'standard',
+    });
+
+    expect(result.outcome).toBe('sacked');
+    expect(result.newHp).toBe(1);
+    expect(result.goldLost).toBe(30);
+  });
+
+  it('destroys the city once era exceeds the difficulty threshold', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ hp: 5, buildings: [] });
+
+    const result = resolveCitySiegeDamage({
+      city, ownerCiv, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 3, challenge: 'standard',
+    });
+
+    expect(result.outcome).toBe('destroyed');
+    expect(result.newHp).toBe(0);
+    expect(result.goldLost).toBe(0);
+  });
+
+  it('uses a harsher destruction threshold on veteran than explorer (negative test: same era, different outcome)', () => {
+    const { city: cityA, ownerCiv: civA } = makeCityAndCiv({ hp: 5, buildings: [] });
+    const { city: cityB, ownerCiv: civB } = makeCityAndCiv({ hp: 5, buildings: [] });
+
+    const explorerResult = resolveCitySiegeDamage({
+      city: cityA, ownerCiv: civA, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 2, challenge: 'explorer',
+    });
+    const veteranResult = resolveCitySiegeDamage({
+      city: cityB, ownerCiv: civB, rawDamage: 10, attackerDomain: 'land', hasGarrison: false, era: 2, challenge: 'veteran',
+    });
+
+    expect(explorerResult.outcome).toBe('sacked');
+    expect(veteranResult.outcome).toBe('destroyed');
+  });
+});
+
+describe('applyCitySiegeOutcome (#522)', () => {
+  it('applies HP damage without touching the roster on a "damaged" outcome', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 50 };
+
+    const next = applyCitySiegeOutcome(state, cityId, {
+      hpLost: 10, newHp: 40, outcome: 'damaged', goldLost: 0,
+    });
+
+    expect(next.cities[cityId]!.hp).toBe(40);
+    expect(next.civilizations.player.cities).toContain(cityId);
+  });
+
+  it('floors HP at 1 and deducts gold on a "sacked" outcome, keeps the city', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 5 };
+    state.civilizations.player.gold = 100;
+
+    const next = applyCitySiegeOutcome(state, cityId, {
+      hpLost: 4, newHp: 1, outcome: 'sacked', goldLost: 15,
+    });
+
+    expect(next.cities[cityId]!.hp).toBe(1);
+    expect(next.civilizations.player.gold).toBe(85);
+    expect(next.civilizations.player.cities).toContain(cityId);
+  });
+
+  it('removes the city from state and the owner roster on a "destroyed" outcome', () => {
+    const { state, cityId } = makeGameStateWithCity();
+
+    const next = applyCitySiegeOutcome(state, cityId, {
+      hpLost: 5, newHp: 0, outcome: 'destroyed', goldLost: 0,
+    });
+
+    expect(next.cities[cityId]).toBeUndefined();
+    expect(next.civilizations.player.cities).not.toContain(cityId);
+  });
+
+  it('is a no-op on a "blocked" outcome', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    const before = state.cities[cityId]!.hp;
+
+    const next: GameState = applyCitySiegeOutcome(state, cityId, {
+      hpLost: 0, newHp: before ?? 100, outcome: 'blocked', goldLost: 0,
+    });
+
+    expect(next).toBe(state);
+  });
+});
+
+describe('applyCityHpRegeneration (#522)', () => {
+  it('regenerates 5 HP/turn when no hostile unit is adjacent', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 50 };
+
+    const next = applyCityHpRegeneration(state);
+
+    expect(next.cities[cityId]!.hp).toBe(55);
+  });
+
+  it('caps regeneration at 100 HP', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 98 };
+
+    const next = applyCityHpRegeneration(state);
+
+    expect(next.cities[cityId]!.hp).toBe(100);
+  });
+
+  it('does not regenerate while a hostile (barbarian) unit is adjacent', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 50 };
+    const raider = createUnit('warrior', 'barbarian', state.cities[cityId]!.position, state.idCounters);
+    state.units[raider.id] = raider;
+
+    const next = applyCityHpRegeneration(state);
+
+    expect(next.cities[cityId]!.hp).toBe(50);
+  });
+
+  it('does not regenerate a destroyed/0-HP city', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 0 };
+
+    const next = applyCityHpRegeneration(state);
+
+    expect(next.cities[cityId]!.hp).toBe(0);
+  });
+
+  it('is a no-op (same state reference) when every city is at full HP', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 100 };
+
+    const next = applyCityHpRegeneration(state);
+
+    expect(next).toBe(state);
+  });
+});
+
+describe('isCityHpRegenerating (#522)', () => {
+  it('is true for a below-max-HP city with no hostile unit nearby', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 50 };
+
+    expect(isCityHpRegenerating(state, state.cities[cityId]!)).toBe(true);
+  });
+
+  it('is false when a hostile unit is adjacent', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 50 };
+    const raider = createUnit('warrior', 'barbarian', state.cities[cityId]!.position, state.idCounters);
+    state.units[raider.id] = raider;
+
+    expect(isCityHpRegenerating(state, state.cities[cityId]!)).toBe(false);
+  });
+
+  it('is false at full HP (negative test)', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    state.cities[cityId] = { ...state.cities[cityId]!, hp: 100 };
+
+    expect(isCityHpRegenerating(state, state.cities[cityId]!)).toBe(false);
+  });
+});

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -257,3 +257,53 @@ describe('fortify defense bonus', () => {
     expect(r1.attackerDamage).toBe(r2.attackerDamage);
   });
 });
+
+describe('bombard-kind defense penalty (MR: counter-attack rule fix, #537)', () => {
+  let map: GameMap;
+
+  beforeAll(() => {
+    map = generateMap(30, 30, 'bombard-defense-test');
+  });
+
+  it('halves defenderStrength for a bombard-kind unit (catapult) on defense', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const catapult = createUnit('catapult', 'p2', { q: 11, r: 10 }, mkC());
+
+    const preview = calculateCombatStrengths(attacker, catapult, map);
+    const terrain = getTerrainDefenseBonus(map.tiles['11,10']?.terrain ?? 'plains');
+
+    // Catapult strength is 20; bombard penalty halves it before terrain is applied.
+    expect(preview.defenderStrength).toBeCloseTo(20 * 0.5 * (1 + terrain), 5);
+  });
+
+  it('does not penalize a siege-class unit that is not bombard-kind (ballista, kind ranged)', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const ballista = createUnit('ballista', 'p2', { q: 11, r: 10 }, mkC());
+
+    const preview = calculateCombatStrengths(attacker, ballista, map);
+    const terrain = getTerrainDefenseBonus(map.tiles['11,10']?.terrain ?? 'plains');
+
+    expect(preview.defenderStrength).toBeCloseTo(25 * (1 + terrain), 5);
+  });
+
+  it('catapult defending against adjacent melee takes more damage and deals less counter-damage than an unpenalized defender of equal strength', () => {
+    const attacker = createUnit('warrior', 'p1', { q: 10, r: 10 }, mkC());
+    const catapult = createUnit('catapult', 'p2', { q: 11, r: 10 }, mkC());
+
+    const result = resolveCombat(attacker, catapult, map, 7);
+
+    expect(result.defenderDamage).toBeGreaterThan(0);
+    expect(result.attackerDamage).toBeGreaterThan(0);
+  });
+
+  it('bomber intercepted by a jet fighter still lands a reduced counter-hit, not full strength', () => {
+    const fighter = createUnit('jet_fighter', 'p1', { q: 10, r: 10 }, mkC());
+    const bomber = createUnit('bomber', 'p2', { q: 11, r: 10 }, mkC());
+
+    const preview = calculateCombatStrengths(fighter, bomber, map);
+    const terrain = getTerrainDefenseBonus(map.tiles['11,10']?.terrain ?? 'plains');
+
+    // Bomber strength 48, halved by the bombard penalty before terrain.
+    expect(preview.defenderStrength).toBeCloseTo(48 * 0.5 * (1 + terrain), 5);
+  });
+});

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -2037,3 +2037,49 @@ describe('city-panel tech-yield breakdown', () => {
     expect(panel.textContent).not.toContain('From technology');
   });
 });
+
+describe('city-panel HP status (#522)', () => {
+  it('shows a recovering label with the regen rate when damaged and no hostile unit is nearby', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.cities[city.id] = { ...city, hp: 60 };
+
+    const panel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Recovering — 60/100 HP (+5/turn)');
+    expect(panel.textContent).not.toContain('Under siege');
+  });
+
+  it('shows an under-siege label with no regen when a hostile unit is adjacent', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.cities[city.id] = { ...city, hp: 60 };
+    const raider = createUnit('warrior', 'barbarian', city.position, state.idCounters);
+    state.units[raider.id] = raider;
+
+    const panel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('Under siege — 60/100 HP (no regen)');
+    expect(panel.textContent).not.toContain('Recovering');
+  });
+
+  it('omits the HP status line entirely at full HP (negative test)', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.cities[city.id] = { ...city, hp: 100 };
+
+    const panel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).not.toContain('Recovering');
+    expect(panel.textContent).not.toContain('Under siege');
+  });
+});

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -55,4 +55,28 @@ describe('formatCombatPreviewDetails', () => {
     expect(details).not.toContain('Star Fort');
     expect(details).not.toContain('Professional Army');
   });
+
+  it('shows the bombard defense penalty when the defender is a bombard-kind unit', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 10,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+      defenderDefendsPoorly: true,
+    });
+
+    expect(details).toContain('Siege defends poorly (−50%)');
+  });
+
+  it('omits the bombard defense penalty line for a normal defender (negative test)', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 10,
+      defenderStrength: 10,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+      defenderDefendsPoorly: false,
+    });
+
+    expect(details).not.toContain('defends poorly');
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the two logic-fix issues from the battle-mechanics arc (#546):

**#537 — counter-attack rule matrix.** Working through all four flagged findings against
the desired behavior showed the existing distance-based retaliation check was already
correct (melee-adjacent retaliation, ranged-vs-ranged duels, and outranged defenders all
already behave as intended). The real fix is a single new mechanism: bombard-kind units
(`catapult`, `cannon`, `artillery`, `grenadier`, `bomber`, `stealth_bomber`) now defend at
half strength (`defenderStrength *= 0.5`), so they both take more damage and deal less
counter-damage on defense — the classic "siege is terrible on defense" convention. This
fixes L4 (catapults defending at full strength) and L2 (bombers counter-intercepting
fighters at full strength) with one rule, keyed off `attackProfile.kind === 'bombard'`
rather than the ground-only `siege` UnitClass (which excludes bombers and includes the
more agile `ballista`).

**#522 — city siege damage bypasses garrison/walls.** New `src/systems/city-siege-system.ts`:
- A garrisoned defender **fully blocks** barbarian city-HP damage (matches
  `beginMajorCityAssault`'s existing "defended tile can't be captured" rule); the
  barbarian AI now attacks the garrison unit instead of chipping the city.
- Undefended damage is mitigated through the existing `getCityDefenseBreakdown`
  (walls/Star Fort/Fortification Engineering/etc.).
- At 0 HP, the outcome is **sack** (survives at 1 HP, one-time gold plunder) or
  **destroy**, gated by era vs. a new per-difficulty `citySiegeDestructionEra` knob
  (explorer: era 4+, standard: era 3+, veteran: era 2+) — mirrors the existing
  `crisisGraceMaxEra` pattern.
- Cities now regenerate +5 HP/turn (same rate as unit `HEAL_PASSIVE`) when no hostile
  unit is adjacent.
- City panel shows a `Recovering (+5/turn)` vs `Under siege (no regen)` status label;
  new `city:sacked` notification distinguishes a recoverable raid from destruction.

**Deviation from #522 as filed:** the issue's pirate-side citations
(`threat-pressure-system.ts`'s `processPirateFleets`/`PirateFleet`) are dead code —
`tests/systems/pirate-end-to-end.test.ts`'s completion gate confirms that fleet/siege
model was deliberately retired for the newer faction-based pirate system
(`pirate-system.ts`), which has no city-HP-damage mechanic at all today. This PR scopes
the fix to the barbarian path (the only live siege-damage source); whether pirates
should gain an equivalent mechanic is flagged as a separate design follow-up, not
decided here.

Full design writeup: `docs/superpowers/specs/2026-07-11-combat-retaliation-and-city-siege-design.md`.

## Test plan
- [x] `yarn build` (tsc + vite) — clean
- [x] `yarn test` — 5949 tests pass, 0 failures (includes the pirate completion-gate
      regression test, confirming no dead-code path was reintroduced)
- [x] New TDD coverage: `combat-system.test.ts` (bombard defense penalty, ballista
      control), `city-siege-system.test.ts` (garrison block, wall mitigation, sack vs
      destroy by era/difficulty, HP regen + hostile-adjacency gate), `barbarian-system.test.ts`
      (garrison redirect, undefended regression), `city-panel.test.ts` (HP status label),
      `combat-preview.test.ts` (siege-defends-poorly line), `opponent-challenge.test.ts`
      (new difficulty knob)
- [x] Inline multi-dimension review completed (balance, fun, ages 7–43, playstyles,
      difficulty modes, AI usage, UI/UX, architecture, extensibility, data, SFX, save
      compatibility, hot-seat correctness) before opening this PR — no blocking findings.
      Confirmed HP regen fires once per round (not per hot-seat player-turn) via
      `runCompletedRound`'s single-invocation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)