### PR TITLE
feat(era13-mr3): deliver cyber intents

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,6 +121,64 @@ jobs:
       - name: Run tests
         run: yarn verify:push
 
+  pirate-audio-reproducibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for pirate audio generator inputs
+        id: pirate-audio-changes
+        shell: bash
+        run: |
+          changed_files="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")"
+          pirate_audio_changed=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              scripts/generate-pirate-sfx.sh|src/audio/pirate-audio-sources.ts|tests/audio/pirate-sfx-generator.test.ts|public/audio/sfx/pirates/*|public/audio/stinger/pirates/*|public/audio/sfx/naval-move-step.ogg|public/audio/sfx/galley-attack-swing.ogg|public/audio/sfx/galley-attack-impact.ogg|public/audio/sfx/trireme-attack-swing.ogg|public/audio/sfx/trireme-attack-impact.ogg|public/audio/sfx/catapult-siege-fire.ogg|public/audio/sfx/catapult-siege-impact.ogg|public/audio/sfx/ballista-siege-fire.ogg|public/audio/sfx/ballista-siege-impact.ogg|public/audio/sfx/carrack-death.ogg|public/audio/sfx/galleon-death.ogg|public/audio/sfx/steamship-death.ogg|public/audio/sfx/transport-death.ogg|public/audio/sfx/transport-load.ogg|public/audio/sfx/transport-unload.ogg|package.json|yarn.lock|.yarnrc.yml|.yarn/*|.github/workflows/deploy.yml)
+                pirate_audio_changed=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          echo "pirate_audio_changed=$pirate_audio_changed" >> "$GITHUB_OUTPUT"
+
+      - name: Enable Corepack
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
+        run: corepack enable
+
+      - name: Setup Node
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '24.13.1'
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
+        run: yarn install --immutable
+
+      - name: Install audio test tooling
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Verify deterministic pirate audio
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
+        run: RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts -t "reproduces byte-identical audio across two generations on one runner"
+
+      - name: Report skipped deterministic audio check
+        if: steps.pirate-audio-changes.outputs.pirate_audio_changed != 'true'
+        run: echo "No pirate audio generator inputs changed; deterministic generation check skipped."
+
   web-smoke:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'

--- a/docs/superpowers/plans/2026-07-11-era13-mr3-cyber-intents.md
+++ b/docs/superpowers/plans/2026-07-11-era13-mr3-cyber-intents.md
@@ -1,0 +1,519 @@
+# Era 13 MR3: Cyber Intent Vertical Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver the complete, viewer-safe Harden and Exploit persistent-intent loop for Cyber Units while preserving the pre-Autonomy Era 12 passive behavior.
+
+**Architecture:** Store serializable network plans under `autonomyByCiv`, validate every assignment and resolution through one canonical lifecycle module, and resolve effects only from the turn manager. UI and AI consume the same preview/validation result; migration v3 normalizes legacy Cyber Units deterministically and all lifecycle actors call the same cleanup helpers.
+
+**Tech Stack:** TypeScript, Vitest, Vite, DOM UI, EventBus, serializable `GameState`, existing challenge profiles and save-migration registry.
+
+**Target executor:** Sonnet 4.5.
+
+---
+
+## Inline implementation-readiness review: Surge-ready Exploit
+
+| Dimension | Finding | Required implementation consequence |
+|---|---|---|
+| Balance and fun | A 15% result is 50% larger than the normal 10% Exploit. Without the MR4 Surge allowance, explicit confirmation, recovery, cooldown, and posture gates, it is an unpriced permanent advantage rather than a temporary tactical choice. | MR3 may not activate 15% from a bare boolean, migration default, or AI shortcut. |
+| New-mechanic clarity and ages 7–43 | “Surge-ready” has no player-visible meaning if the selected-unit panel has no Surge action or explanation of its cost and recovery. Hidden stronger behavior is especially misleading for younger players and unlearnable for experienced players. | A live 15% outcome requires a visible pre-confirmation explanation and a later visible recovery state; neither belongs in the MR3 UI scope. |
+| Play styles and difficulty | A hidden 15% AI-only or legacy-only path would make aggressive play inconsistent, while defensive players could not understand when to expect the stronger threat. Difficulty must vary choice quality only, not numeric outcomes or secret access. | AI must use the same ordinary 10% MR3 Exploit as humans until the full Surge mechanic exists. |
+| UI and UX | The MR3 preview promises outcome, timing, counter, Load, and disclosure. A non-selectable `surgeReady` field cannot honestly appear there; a selectable toggle requires the MR4 confirmation/recovery interaction. | Keep the MR3 preview at 10% and do not render a Surge control, badge, or unexplained 15% result. |
+| Architecture, extensibility, and data | A serialized flag needs a canonical owner, transition, validation, cancellation, migration, and resolver contract. Adding only a field creates an inert duplicate of the MR4 posture/Surge state model. | Keep `surgedPercent: 15` as definition metadata only if it remains unused by MR3 resolution; introduce live state only with the full MR4 model. |
+| SFX, saves, solo, and hot seat | A live Surge result needs authorized feedback, mute/dedup rules, handoff persistence, and viewer-safe notification wording. A save carrying a flag without any transition source cannot be tested as a player journey. | Do not serialize or emit feedback for an untriggerable MR3 Surge state. |
+| Testing and regression safety | A resolver-only flag test would not prove a real player/AI/save/hot-seat path. It would create coverage for code that no real caller can reach. | Test that definitions preserve both 10% and 15% values, but test MR3 gameplay resolution only at 10%; reserve the 15% end-to-end test for MR4. |
+
+**Review conclusion:** The coherent MR3 scope is ordinary 10% Exploit with Harden/CDC mitigation. The 15% value remains typed definition metadata for the subsequent full Surge implementation; it must not create runtime state, UI, AI behavior, notifications, SFX, or save schema fields in this slice. Treating it as a live MR3 feature would expand the slice to include the omitted Surge contract and is not independently mergeable.
+
+## Locked file structure
+
+- Create `src/core/autonomy-state.ts`: closed persistent-plan, detection, and civic-pressure types plus state constructors.
+- Create `src/systems/network-plan-definitions.ts`: Harden/Exploit data definitions and closed effect union.
+- Create `src/systems/network-plan-system.ts`: activation predicate, validation, preview, assignment, Hold, retarget, cancellation, and cleanup.
+- Create `src/systems/network-effect-resolver.ts`: deterministic Harden/Exploit mutation and typed result events.
+- Create `src/systems/network-viewer-intel.ts`: viewer-safe warning and source-disclosure presentation.
+- Create `src/ui/network-intent-panel.ts`: selected-Cyber-unit assignment/preview surface.
+- Create mirrored core/system/UI/AI/audio/integration tests named in the tasks below.
+- Modify `src/core/types.ts`, `src/core/id-counters.ts`, `src/core/turn-manager.ts`, `src/systems/cyber-warfare-system.ts`, `src/systems/unit-movement-system.ts`, `src/systems/city-capture-system.ts`, `src/systems/civilization-elimination-system.ts`, `src/systems/diplomacy-system.ts`, `src/storage/save-migrations.ts`, `src/storage/save-manager.ts`, `src/ui/selected-unit-info.ts`, `src/main.ts`, `src/ai/ai-round-scheduler.ts`, `src/ai/ai-plan-portfolio.ts`, `src/core/completed-round-handoff.ts`, notification routing, and SFX routing.
+
+### Player truth table
+
+| Before | Player action | Canonical state result | Immediate visible result |
+|---|---|---|---|
+| Owned Cyber Unit is on Hold | Assign Harden to an adjacent owned city | One active Harden plan for that unit; target holds/refreshes mitigation as scheduled | Open unit panel shows Harden, city, 50% mitigation, Load 1, and cancel/retarget controls |
+| Owned Cyber Unit is on Hold | Assign Exploit to adjacent at-war city | Preparing hostile plan with the target’s next-turn warning marker | Panel shows 10% outcome, Load 2, first target-turn-end timing, and CDC counter |
+| Victim begins its next turn | Acknowledge the handoff | Viewer-safe warning becomes visible | Warning names affected city, Exploit, and CDC/Harden counter without source identity or coordinates |
+| Victim adds/has a counter | End the victim turn | Resolver delays/halves/charges exactly once | City/treasury/log refresh with mitigated result; the selected/intent panel remains current |
+| Player changes their mind | Retarget or cancel | Old ID is resolved from current state; old plan is removed or replaced | Same open panel rerenders; repeated clicks never call a captured stale plan ID |
+
+### Misleading UI risks and replay checklist
+
+- Do not label mitigation as `Protected`; use `reduces hostile network effects`.
+- Do not display `Detected` as `Source known`; identity and coordinate require an explicit authorized detection record.
+- Do not call Load a capacity limit in MR3; it is a definition value shown in the preview only.
+- Replay assign, second assignment attempt, retarget, cancel, reopen, repeat click after rerender, source movement out and back into range, peace, capture, save/load, AI turn, and hot-seat identity confirmation. Each replay assertion must inspect rendered DOM after the state change.
+
+### Task 1: Add serializable network state and stable IDs
+
+**Files:**
+- Create: `src/core/autonomy-state.ts`
+- Modify: `src/core/types.ts`, `src/core/id-counters.ts`, `src/storage/save-manager.ts`
+- Test: `tests/core/autonomy-state.test.ts`, `tests/core/id-counters.test.ts`, `tests/storage/save-manager.test.ts`
+
+- [ ] **Step 1: Write failing state and counter tests.**
+
+```ts
+expect(createEmptyAutonomyCivState()).toEqual({ plans: {}, detections: {} });
+expect(scanIdCounters({ autonomyByCiv: { p1: { plans: { 'network-plan-7': plan }, detections: {} } } }))
+  .toMatchObject({ nextNetworkPlanId: 8 });
+expect(JSON.parse(JSON.stringify(plan))).toEqual(plan);
+```
+
+- [ ] **Step 2: Run the tests and confirm the new imports fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/core/autonomy-state.test.ts tests/core/id-counters.test.ts tests/storage/save-manager.test.ts`
+
+Expected: FAIL because `autonomy-state` and `nextNetworkPlanId` do not exist.
+
+- [ ] **Step 3: Define closed plain-data types and counter scanning.**
+
+```ts
+export type NetworkPlanTarget =
+  | { kind: 'city'; cityId: string }
+  | { kind: 'unit'; unitId: string }
+  | { kind: 'formation'; unitIds: string[] }
+  | { kind: 'route'; routeId: string }
+  | { kind: 'zone'; center: HexCoord; radius: number };
+export type NetworkPlanStatus = 'preparing' | 'active' | 'paused' | 'recovering' | 'completed' | 'canceled';
+export interface NetworkPlan { id: string; ownerCivId: string; definitionId: 'harden' | 'exploit'; sourceUnitId: string; target: NetworkPlanTarget; status: NetworkPlanStatus; createdTurn: number; nextResolutionTurn: number; warnedTurn: number | null; }
+export interface AutonomyCivState { plans: Record<string, NetworkPlan>; detections: Record<string, NetworkViewerDetection>; }
+```
+
+Add optional `autonomyByCiv`, `networkCivicPressureByCity`, and `nextNetworkPlanId` to `GameState`/`IdCounters`; update `emptyIdCounters`, `scanIdCounters`, and `normalizeIdCounters` so a valid counter is `max(current, scanned)` and legacy state gets `1`.
+
+- [ ] **Step 4: Re-run the state tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/core/autonomy-state.test.ts tests/core/id-counters.test.ts tests/storage/save-manager.test.ts`
+
+Expected: PASS, including a partial legacy fixture and a state with no plans.
+
+- [ ] **Step 5: Commit the state foundation.**
+
+```bash
+git add src/core/autonomy-state.ts src/core/types.ts src/core/id-counters.ts src/storage/save-manager.ts tests/core/autonomy-state.test.ts tests/core/id-counters.test.ts tests/storage/save-manager.test.ts
+git commit -m "feat(era13-mr3): add persistent network plan state"
+```
+
+### Task 2: Define Harden/Exploit and the canonical lifecycle API
+
+**Files:**
+- Create: `src/systems/network-plan-definitions.ts`, `src/systems/network-plan-system.ts`
+- Test: `tests/systems/network-plan-definitions.test.ts`, `tests/systems/network-plan-system.test.ts`
+
+- [ ] **Step 1: Write failing definition and validator tests.**
+
+```ts
+expect(getNetworkPlanDefinition('harden')).toMatchObject({ load: 1, range: 1, targetKind: 'friendly-city' });
+expect(getNetworkPlanDefinition('exploit')).toMatchObject({ load: 2, range: 1, targetKind: 'at-war-enemy-city' });
+expect(validateNetworkPlanAssignment(state, request)).toEqual({ ok: false, reason: 'target-not-at-war' });
+expect(assignNetworkPlan(state, request).state).toBe(state); // invalid input must not allocate an ID
+```
+
+- [ ] **Step 2: Run the lifecycle tests and confirm they fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-plan-definitions.test.ts tests/systems/network-plan-system.test.ts`
+
+Expected: FAIL because the definitions and lifecycle exports are absent.
+
+- [ ] **Step 3: Implement data definitions, activation, preview, and immutable mutations.**
+
+```ts
+export function isAutonomyActivated(state: GameState, civId: string): boolean {
+  const completed = state.civilizations[civId]?.techState.completed ?? [];
+  return completed.some(id => TECH_TREE.find(tech => tech.id === id)?.era === 13);
+}
+export function validateNetworkPlanAssignment(state: GameState, request: NetworkPlanRequest): NetworkPlanValidation;
+export function previewNetworkPlan(state: GameState, request: NetworkPlanRequest): NetworkPlanPreview;
+export function assignNetworkPlan(state: GameState, request: NetworkPlanRequest): NetworkPlanMutationResult;
+export function holdNetworkPlan(state: GameState, ownerCivId: string, sourceUnitId: string): NetworkPlanMutationResult;
+export function retargetNetworkPlan(state: GameState, ownerCivId: string, planId: string, target: NetworkPlanTarget): NetworkPlanMutationResult;
+export function cancelNetworkPlan(state: GameState, ownerCivId: string, planId: string, reason: NetworkPlanCancelReason): NetworkPlanMutationResult;
+```
+
+`validateNetworkPlanAssignment` must check activation, source ownership/type/existence, source uniqueness, target union integrity, city/unit ownership, range, war, same-type target nonstacking, and orphan references. All outer records are spread-replaced; no lifecycle helper mutates its input.
+
+- [ ] **Step 4: Re-run lifecycle tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-plan-definitions.test.ts tests/systems/network-plan-system.test.ts`
+
+Expected: PASS for Hold, assignment, retarget, cancel, stable ID allocation, range/war rejection, and same-type nonstacking.
+
+- [ ] **Step 5: Commit the lifecycle API.**
+
+```bash
+git add src/systems/network-plan-definitions.ts src/systems/network-plan-system.ts tests/systems/network-plan-definitions.test.ts tests/systems/network-plan-system.test.ts
+git commit -m "feat(era13-mr3): add canonical network plan lifecycle"
+```
+
+### Task 3: Replace post-activation passive drain with deterministic effect resolution
+
+**Files:**
+- Create: `src/systems/network-effect-resolver.ts`
+- Modify: `src/systems/cyber-warfare-system.ts`, `src/core/turn-manager.ts`, `src/core/types.ts`
+- Test: `tests/systems/network-effect-resolver.test.ts`, `tests/systems/cyber-warfare-system.test.ts`, `tests/core/turn-manager.test.ts`
+
+- [ ] **Step 1: Write failing effect and exclusive-path tests.**
+
+```ts
+expect(resolveNetworkPlanAtTargetEnd(state, exploitId, { baseCityGold: 19 }).events[0]).toMatchObject({ goldTransferred: 1 });
+expect(resolveNetworkPlanAtTargetEnd(withCdc, exploitId, { baseCityGold: 20 }).events[0]).toMatchObject({ goldTransferred: 5 });
+expect(resolveNetworkPlanAtTargetEnd(withHardenCharge, exploitId, { baseCityGold: 20 }).events[0]).toMatchObject({ goldTransferred: 3 });
+expect(processTurn(activatedState, bus)).not.toEmit('city:cyber-drained');
+```
+
+Cover normal 10%, valid existing Surge-ready 15%, base-city-gold floor, zero-gold city, minimum-positive transfer, CDC first-resolution delay then halving, one Harden charge, AI Safety Institute owner-round refresh, multiple attackers/nonstacking, war/range failure, and no probabilistic roll.
+
+- [ ] **Step 2: Run the resolver tests and confirm they fail.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-effect-resolver.test.ts tests/systems/cyber-warfare-system.test.ts tests/core/turn-manager.test.ts`
+
+Expected: FAIL because the deterministic resolver and activation split do not exist.
+
+- [ ] **Step 3: Implement deterministic resolver and turn-manager routing.**
+
+```ts
+export function resolveNetworkPlanAtTargetEnd(
+  state: GameState,
+  planId: string,
+  context: { baseCityGold: number },
+): NetworkEffectResolution;
+```
+
+Use integer arithmetic: `raw = Math.floor(baseCityGold * percent / 100)`. Apply CDC delay before the first otherwise-unmitigated resolution, then CDC halving and one consumed Harden halving in deterministic order; if `raw > 0`, clamp the final transfer to at least `1`. Refactor the turn manager to retain `processCyberDrain` only when `!isAutonomyActivated(state, victimCivId)` and to hand each activated target city’s base gold into the canonical resolver at its turn end. Credit the attacker through the existing gross-gold accumulator and emit typed network events from the resolver result.
+
+- [ ] **Step 4: Re-run Cyber and turn tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-effect-resolver.test.ts tests/systems/cyber-warfare-system.test.ts tests/core/turn-manager.test.ts`
+
+Expected: PASS, including a negative assertion that one victim round cannot apply both paths.
+
+- [ ] **Step 5: Commit deterministic resolution.**
+
+```bash
+git add src/systems/network-effect-resolver.ts src/systems/cyber-warfare-system.ts src/core/turn-manager.ts src/core/types.ts tests/systems/network-effect-resolver.test.ts tests/systems/cyber-warfare-system.test.ts tests/core/turn-manager.test.ts
+git commit -m "feat(era13-mr3): convert cyber drain to deterministic intents"
+```
+
+### Task 4: Implement warning timing, viewer intel, and canonical cleanup
+
+**Files:**
+- Create: `src/systems/network-viewer-intel.ts`
+- Modify: `src/systems/network-plan-system.ts`, `src/core/turn-manager.ts`, `src/systems/unit-movement-system.ts`, `src/systems/city-capture-system.ts`, `src/systems/civilization-elimination-system.ts`, `src/systems/diplomacy-system.ts`, `src/core/types.ts`
+- Test: `tests/systems/network-viewer-intel.test.ts`, `tests/integration/network-plan-turn-flow.test.ts`, `tests/systems/unit-movement-system.test.ts`, `tests/systems/city-capture-system.test.ts`, `tests/systems/civilization-elimination-system.test.ts`, `tests/systems/diplomacy-system.test.ts`
+
+- [ ] **Step 1: Write failing timing, privacy, and cleanup tests.**
+
+```ts
+expect(beginNetworkPlansForVictimTurn(prepared, 'victim').warnings).toEqual([expect.objectContaining({ effectLabel: 'Exploit', source: undefined })]);
+expect(resolveVictimTurnEnd(warned, 'victim').state.civilizations.victim.gold).toBeLessThan(beforeGold);
+expect(getNetworkWarningForViewer(detected, 'victim', plan.id).source).toEqual({ unitId: 'cyber-1', position: { q: 2, r: 0 } });
+expect(cancelInvalidNetworkPlans(moveOutOfRange(state)).state.autonomyByCiv.attacker.plans).toEqual({});
+```
+
+Cover prepare-on-action, warning only at victim-turn start, one full response turn, target-end resolution, hidden-source default, authorized detection disclosure, source move/range break, source/target destruction, source capture, city capture, peace, conquest, elimination, diplomacy changes, malformed loads, and zero Load consumption for every invalid plan.
+
+- [ ] **Step 2: Run timing and lifecycle tests and confirm failure.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-viewer-intel.test.ts tests/integration/network-plan-turn-flow.test.ts tests/systems/unit-movement-system.test.ts tests/systems/city-capture-system.test.ts tests/systems/civilization-elimination-system.test.ts tests/systems/diplomacy-system.test.ts`
+
+Expected: FAIL because lifecycle hooks and viewer-safe warning helpers are absent.
+
+- [ ] **Step 3: Implement timing and route every invalidator to the shared cleanup helper.**
+
+```ts
+export function beginNetworkPlansForVictimTurn(state: GameState, victimCivId: string): NetworkTurnStartResult;
+export function resolveNetworkPlansForVictimTurnEnd(state: GameState, victimCivId: string, baseGoldByCityId: Record<string, number>): NetworkTurnEndResult;
+export function cancelInvalidNetworkPlans(state: GameState, trigger: NetworkPlanCleanupTrigger): NetworkPlanMutationResult;
+export function getNetworkWarningForViewer(state: GameState, viewerId: string, planId: string): NetworkViewerWarning | null;
+```
+
+Call `cancelInvalidNetworkPlans` after successful unit movement, city capture/raze, civilization elimination, and every bilateral peace mutation. The helper must cancel captured-source plans immediately, leave captured Cyber Units on Hold/recovery, revalidate hostile plans after city ownership changes, and create one owner-visible notice for malformed loaded data. Do not inspect richer live source data in viewer presentation.
+
+- [ ] **Step 4: Re-run lifecycle and privacy tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/systems/network-viewer-intel.test.ts tests/integration/network-plan-turn-flow.test.ts tests/systems/unit-movement-system.test.ts tests/systems/city-capture-system.test.ts tests/systems/civilization-elimination-system.test.ts tests/systems/diplomacy-system.test.ts`
+
+Expected: PASS for both human and turn-manager paths, including a negative privacy assertion for an undetected source.
+
+- [ ] **Step 5: Commit timing and cleanup.**
+
+```bash
+git add src/systems/network-viewer-intel.ts src/systems/network-plan-system.ts src/core/turn-manager.ts src/systems/unit-movement-system.ts src/systems/city-capture-system.ts src/systems/civilization-elimination-system.ts src/systems/diplomacy-system.ts src/core/types.ts tests/systems/network-viewer-intel.test.ts tests/integration/network-plan-turn-flow.test.ts tests/systems/unit-movement-system.test.ts tests/systems/city-capture-system.test.ts tests/systems/civilization-elimination-system.test.ts tests/systems/diplomacy-system.test.ts
+git commit -m "feat(era13-mr3): resolve network plans on viewer-safe timing"
+```
+
+### Task 5: Append deterministic migration version 3 and preserve transfers
+
+**Files:**
+- Modify: `src/storage/save-migrations.ts`, `src/storage/save-manager.ts`, `src/core/id-counters.ts`
+- Test: `tests/storage/save-migrations.test.ts`, `tests/storage/save-manager.test.ts`, `tests/storage/save-file-transfer.test.ts`, `tests/core/completed-round-handoff.test.ts`
+
+- [ ] **Step 1: Write failing v3 migration and transfer tests.**
+
+```ts
+expect(CURRENT_SAVE_SCHEMA_VERSION).toBe(3);
+expect(migrateSaveToCurrent(legacyAtActivation).autonomyByCiv.p1.plans).toMatchObject({ 'network-plan-1': expect.objectContaining({ definitionId: 'exploit' }) });
+expect(migrateSaveToCurrent(legacyAtActivation).autonomyByCiv.p1.plans).not.toHaveProperty('network-plan-2');
+expect(normalizeLoadedState(JSON.parse(JSON.stringify(normalizeLoadedState(legacy)))))
+  .toEqual(normalizeLoadedState(legacy));
+```
+
+Fixture cases: pre-activation empty state; stable unit/city sorting; first valid Exploit per city; duplicate source plans on Hold; counter increments; malformed/orphan rejection with one recovery notice; preserved detections; autosave/manual/export/import/handoff equality.
+
+- [ ] **Step 2: Run migration tests and confirm failure.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/storage/save-file-transfer.test.ts tests/core/completed-round-handoff.test.ts`
+
+Expected: FAIL because schema version 3 and migration step 3 are absent.
+
+- [ ] **Step 3: Add migration step 3 without a second registry.**
+
+```ts
+export const CURRENT_SAVE_SCHEMA_VERSION = 3;
+export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
+  1: migrateToEra13Foundation,
+  2: migrateLateResources,
+  3: migrateAutonomyNetwork,
+};
+```
+
+`migrateAutonomyNetwork` must initialize every civ’s autonomy record, keep pre-activation Civs empty, stable-sort existing Cyber Unit IDs and eligible target-city IDs, assign only the first valid Exploit for a city, increment `nextNetworkPlanId` for every created plan, put all remaining Cyber Units on Hold, preserve valid detections, and normalize malformed data once. Reuse `normalizeLoadedState`; do not add separate autosave/export/import mutation paths.
+
+- [ ] **Step 4: Re-run migration and handoff tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/storage/save-file-transfer.test.ts tests/core/completed-round-handoff.test.ts`
+
+Expected: PASS, including load-save-load equality and a second migration call with no new IDs or notices.
+
+- [ ] **Step 5: Commit migration support.**
+
+```bash
+git add src/storage/save-migrations.ts src/storage/save-manager.ts src/core/id-counters.ts tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/storage/save-file-transfer.test.ts tests/core/completed-round-handoff.test.ts
+git commit -m "feat(era13-mr3): migrate cyber units into explicit plans"
+```
+
+### Task 6: Deliver selected-unit intent UI and live caller wiring
+
+**Files:**
+- Create: `src/ui/network-intent-panel.ts`
+- Modify: `src/ui/selected-unit-info.ts`, `src/main.ts`
+- Test: `tests/ui/network-intent-panel.test.ts`, `tests/ui/selected-unit-info.test.ts`, `tests/input/selected-unit-tap-intent.test.ts`
+
+- [ ] **Step 1: Write failing DOM replay tests.**
+
+```ts
+renderSelectedUnitInfo(container, activatedState, cyberId, callbacks);
+expect(container.textContent).toContain('Assign Intent');
+getByRole(container, 'button', { name: 'Exploit' }).click();
+expect(container.textContent).toContain('First effect: end of target’s next turn');
+getByRole(container, 'button', { name: 'Confirm Exploit' }).click();
+expect(container.textContent).toContain('Preparing Exploit');
+```
+
+Assert Hold/Harden/Exploit reachability; valid target list; disabled target reasons; outcome/Load/timing/counter/detection text; immediate rerender after assign/retarget/cancel; reopen; and two clicks after rerender acting on the current plan ID.
+
+- [ ] **Step 2: Run UI tests and confirm failure.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/network-intent-panel.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-tap-intent.test.ts`
+
+Expected: FAIL because no network intent panel or callbacks exist.
+
+- [ ] **Step 3: Implement UI as a view over the shared preview and live callbacks.**
+
+```ts
+export interface NetworkIntentPanelCallbacks {
+  onAssign(request: NetworkPlanRequest): void;
+  onRetarget(planId: string, target: NetworkPlanTarget): void;
+  onCancel(planId: string): void;
+  onHold(sourceUnitId: string): void;
+}
+export function renderNetworkIntentPanel(container: HTMLElement, state: GameState, unitId: string, callbacks: NetworkIntentPanelCallbacks): void;
+```
+
+Use `createGameButton` or a button with background, color, and `min-height:44px`. In `main.ts`, callbacks must call lifecycle helpers, update `gameState`, update HUD/renderer, and re-run `selectUnit(unitId)` to render current IDs. Do not store a plan object in a closure or expose an action for another owner/current-player mismatch.
+
+- [ ] **Step 4: Re-run UI replay tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/network-intent-panel.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-tap-intent.test.ts`
+
+Expected: PASS with DOM assertions after every interaction.
+
+- [ ] **Step 5: Commit the complete player loop.**
+
+```bash
+git add src/ui/network-intent-panel.ts src/ui/selected-unit-info.ts src/main.ts tests/ui/network-intent-panel.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-tap-intent.test.ts
+git commit -m "feat(era13-mr3): add cyber intent player loop"
+```
+
+### Task 7: Add bounded, earned-intel AI intent selection
+
+**Files:**
+- Modify: `src/ai/ai-round-scheduler.ts`, `src/ai/ai-plan-portfolio.ts`
+- Create: `src/ai/ai-network-intents.ts`
+- Test: `tests/ai/ai-network-intents.test.ts`, `tests/ai/ai-round-scheduler.test.ts`, `tests/ai/ai-plan-portfolio.test.ts`
+
+- [ ] **Step 1: Write failing AI behavior tests.**
+
+```ts
+expect(chooseNetworkIntent(aiState, 'ai-1')).toMatchObject({ kind: 'assign', definitionId: 'exploit' });
+expect(chooseNetworkIntent(noEarnedIntel, 'ai-1')).toEqual({ kind: 'hold', sourceUnitId: cyberId });
+expect(chooseNetworkIntent(obsoletePlanState, 'ai-1')).toMatchObject({ kind: 'cancel', planId });
+```
+
+Test deterministic sorting, `tacticalTopK` bounded evaluation, Explorer’s seeded suboptimal choice, Veteran’s best valid candidate, no hidden target/source data, source-protection rejection, and scheduler parity with a human `assignNetworkPlan` result.
+
+- [ ] **Step 2: Run AI tests and confirm failure.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ai/ai-network-intents.test.ts tests/ai/ai-round-scheduler.test.ts tests/ai/ai-plan-portfolio.test.ts`
+
+Expected: FAIL because network candidates are not scheduled.
+
+- [ ] **Step 3: Implement deterministic candidate selection and scheduler application.**
+
+```ts
+export type AINetworkIntentDecision =
+  | { kind: 'assign'; request: NetworkPlanRequest }
+  | { kind: 'retarget'; planId: string; target: NetworkPlanTarget }
+  | { kind: 'cancel'; planId: string }
+  | { kind: 'hold'; sourceUnitId: string };
+export function chooseNetworkIntent(state: GameState, civId: string): AINetworkIntentDecision[];
+```
+
+Build candidates only from AI perception’s earned city positions, sort by score then stable IDs, slice to `getChallengeProfileForCiv(state, civId).tacticalTopK`, and execute exclusively via the lifecycle API. Add summarized portfolio trace data without retaining live plan objects.
+
+- [ ] **Step 4: Re-run AI tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ai/ai-network-intents.test.ts tests/ai/ai-round-scheduler.test.ts tests/ai/ai-plan-portfolio.test.ts`
+
+Expected: PASS with deterministic results under all three difficulty profiles.
+
+- [ ] **Step 5: Commit the AI loop.**
+
+```bash
+git add src/ai/ai-network-intents.ts src/ai/ai-round-scheduler.ts src/ai/ai-plan-portfolio.ts tests/ai/ai-network-intents.test.ts tests/ai/ai-round-scheduler.test.ts tests/ai/ai-plan-portfolio.test.ts
+git commit -m "feat(era13-mr3): teach AI cyber intent planning"
+```
+
+### Task 8: Route notifications, SFX, and hot-seat viewer transitions
+
+**Files:**
+- Modify: `src/core/types.ts`, `src/core/notification-log.ts`, `src/ui/notification-routing.ts`, `src/main.ts`, `src/audio/sfx-director.ts`, `src/core/completed-round-handoff.ts`
+- Test: `tests/ui/notification-routing.test.ts`, `tests/audio/sfx-director.test.ts`, `tests/audio/sfx-routing.test.ts`, `tests/core/completed-round-handoff.test.ts`, `tests/ui/turn-handoff.test.ts`
+
+- [ ] **Step 1: Write failing viewer-safe feedback tests.**
+
+```ts
+expect(routeNetworkEvents(state, repeatedResolutions)).toContainEqual(expect.objectContaining({ message: expect.stringContaining('2 network effects resolved') }));
+expect(routeNetworkEvents(state, [firstWarning]).filter(event => event.immediate)).toHaveLength(1);
+expect(playNetworkSfx(hiddenWarning, state)).toBe(false);
+expect(acknowledgeTurnHandoffSummary(state, victimId, summary).state.notificationLog[victimId][0].message).toContain('Exploit');
+```
+
+Cover first warning/capture/cancel immediate feedback, recurring per-civ-per-round aggregation, mute/volume, SFX deduplication, current-viewer authorization, no source-localized audio, and no warning/focus/audio before hot-seat identity confirmation.
+
+- [ ] **Step 2: Run presentation and handoff tests and confirm failure.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts tests/audio/sfx-director.test.ts tests/audio/sfx-routing.test.ts tests/core/completed-round-handoff.test.ts tests/ui/turn-handoff.test.ts`
+
+Expected: FAIL because typed network event routing does not exist.
+
+- [ ] **Step 3: Add event-to-feedback routing.**
+
+```ts
+export type NetworkPresentationEvent = NetworkWarningEvent | NetworkResolutionEvent | NetworkCancellationEvent;
+export function routeNetworkEvents(state: GameState, events: readonly NetworkPresentationEvent[]): GameState;
+```
+
+Emit network events from resolver/lifecycle results, aggregate only repeated resolutions, and invoke the SFX director only with `[state.currentPlayer]` authorization after the paired notification is visible. During `releaseHandoffToViewer`, derive that viewer’s warnings after acknowledgement; never read the previous player’s warning, selected unit, focus target, or detection state.
+
+- [ ] **Step 4: Re-run presentation tests.**
+
+Run: `bash scripts/run-with-mise.sh yarn test --run tests/ui/notification-routing.test.ts tests/audio/sfx-director.test.ts tests/audio/sfx-routing.test.ts tests/core/completed-round-handoff.test.ts tests/ui/turn-handoff.test.ts`
+
+Expected: PASS for visible feedback, mute, dedupe, and hot-seat privacy.
+
+- [ ] **Step 5: Commit presentation integration.**
+
+```bash
+git add src/core/types.ts src/core/notification-log.ts src/ui/notification-routing.ts src/main.ts src/audio/sfx-director.ts src/core/completed-round-handoff.ts tests/ui/notification-routing.test.ts tests/audio/sfx-director.test.ts tests/audio/sfx-routing.test.ts tests/core/completed-round-handoff.test.ts tests/ui/turn-handoff.test.ts
+git commit -m "feat(era13-mr3): route cyber intent feedback safely"
+```
+
+### Task 9: Perform the required inline implementation review and final verification
+
+**Files:**
+- Modify only files required by concrete review findings.
+- Test: every test file changed above, plus `tests/systems/era-12.test.ts` and `tests/main.integration.test.ts` when event/UI wiring changes.
+
+- [ ] **Step 1: Inspect complete committed and uncommitted diffs.**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- $(git diff --name-only origin/main...HEAD)
+git diff -- $(git diff --name-only)
+git diff --check
+```
+
+Expected: every source change traces from serializable state through canonical systems to UI/notification/audio, with no whitespace errors and no dead action.
+
+- [ ] **Step 2: Review gameplay and product paths against the truth table.**
+
+Trace: pre-activation passive drain; activation; Hold; Harden; Exploit; CDC delay; Harden charge; AI Safety refresh; warning; victim response; resolution; move/capture/peace/elimination cleanup; migration; export/import; solo; and 2–4 player handoff. Add a regression before fixing any discovered P0/P1 issue.
+
+- [ ] **Step 3: Run source-rule and targeted regressions.**
+
+Run:
+
+```bash
+scripts/check-src-rule-violations.sh src/core/autonomy-state.ts src/core/types.ts src/core/id-counters.ts src/core/turn-manager.ts src/core/notification-log.ts src/systems/cyber-warfare-system.ts src/systems/network-plan-definitions.ts src/systems/network-plan-system.ts src/systems/network-effect-resolver.ts src/systems/network-viewer-intel.ts src/systems/unit-movement-system.ts src/systems/city-capture-system.ts src/systems/civilization-elimination-system.ts src/systems/diplomacy-system.ts src/storage/save-migrations.ts src/storage/save-manager.ts src/ui/network-intent-panel.ts src/ui/selected-unit-info.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-network-intents.ts src/ai/ai-round-scheduler.ts src/ai/ai-plan-portfolio.ts src/audio/sfx-director.ts
+```
+
+Then run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/core/autonomy-state.test.ts tests/core/id-counters.test.ts tests/systems/network-plan-definitions.test.ts tests/systems/network-plan-system.test.ts tests/systems/network-effect-resolver.test.ts tests/systems/network-viewer-intel.test.ts tests/integration/network-plan-turn-flow.test.ts tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/storage/save-file-transfer.test.ts tests/ui/network-intent-panel.test.ts tests/ui/selected-unit-info.test.ts tests/ai/ai-network-intents.test.ts tests/ai/ai-round-scheduler.test.ts tests/ai/ai-plan-portfolio.test.ts tests/audio/sfx-director.test.ts tests/audio/sfx-routing.test.ts tests/core/completed-round-handoff.test.ts tests/ui/turn-handoff.test.ts tests/systems/city-capture-system.test.ts tests/systems/civilization-elimination-system.test.ts tests/systems/diplomacy-system.test.ts tests/systems/unit-movement-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run release verification.**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+git diff --check
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 5: Commit review fixes, push, and open the required draft MR.**
+
+```bash
+git add src/core/autonomy-state.ts src/core/types.ts src/core/id-counters.ts src/core/turn-manager.ts src/core/notification-log.ts src/systems/cyber-warfare-system.ts src/systems/network-plan-definitions.ts src/systems/network-plan-system.ts src/systems/network-effect-resolver.ts src/systems/network-viewer-intel.ts src/systems/unit-movement-system.ts src/systems/city-capture-system.ts src/systems/civilization-elimination-system.ts src/systems/diplomacy-system.ts src/storage/save-migrations.ts src/storage/save-manager.ts src/ui/network-intent-panel.ts src/ui/selected-unit-info.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-network-intents.ts src/ai/ai-round-scheduler.ts src/ai/ai-plan-portfolio.ts src/audio/sfx-director.ts tests/core/autonomy-state.test.ts tests/core/id-counters.test.ts tests/systems/network-plan-definitions.test.ts tests/systems/network-plan-system.test.ts tests/systems/network-effect-resolver.test.ts tests/systems/network-viewer-intel.test.ts tests/integration/network-plan-turn-flow.test.ts tests/storage/save-migrations.test.ts tests/storage/save-manager.test.ts tests/storage/save-file-transfer.test.ts tests/ui/network-intent-panel.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-tap-intent.test.ts tests/ai/ai-network-intents.test.ts tests/ai/ai-round-scheduler.test.ts tests/ai/ai-plan-portfolio.test.ts tests/ui/notification-routing.test.ts tests/audio/sfx-director.test.ts tests/audio/sfx-routing.test.ts tests/core/completed-round-handoff.test.ts tests/ui/turn-handoff.test.ts
+git commit -m "fix(era13-mr3): close cyber intent review findings"
+git push -u origin codex/issue-513-mr3
+gh pr create --draft --base main --head codex/issue-513-mr3 --title "feat(era13-mr3): deliver cyber intents"
+```
+
+MR body must list #536/#548 drift SHAs, compatible deviation record, player-visible surfaces, AI/difficulty behavior, solo/hot-seat privacy, migration impact, explicit out-of-scope items, independent-merge safety, exact verification output, and screenshots of the selected-unit/intent UI.
+
+## Plan self-review
+
+- **Spec coverage:** Tasks 1–2 cover serializable state, closed unions, validation, IDs, Hold, assignment, retarget, and cancellation. Task 3 covers the activation boundary and all effect numbers/mitigation. Task 4 covers timing, privacy, and all actor-agnostic cleanup. Task 5 covers migration and every save-transfer route. Tasks 6–8 cover the complete player, AI, notifications, SFX, solo, and hot-seat loops. Task 9 requires the multidimensional inline review and release verification.
+- **UI guardrails:** The truth table, misleading-label limits, and replay matrix require visible post-action DOM assertions and current-ID callbacks.
+- **Consistency:** `NetworkPlanTarget`, `NetworkPlanRequest`, `NetworkPlanValidation`, `NetworkPlanMutationResult`, and `NetworkPlanCleanupTrigger` are introduced in Task 2 before later tasks consume them; `NetworkPresentationEvent` is introduced in Task 8 before routing uses it.
+- **Scope:** Capacity enforcement, postures, Surge controls, infrastructure plans, formations, new Era 13 content, wonders, and authored network motifs remain excluded.

--- a/docs/superpowers/specs/2026-07-11-era13-mr3-cyber-intent-design.md
+++ b/docs/superpowers/specs/2026-07-11-era13-mr3-cyber-intent-design.md
@@ -1,0 +1,58 @@
+# Era 13 MR3: Cyber intent vertical slice
+
+## Scope
+
+This slice replaces Cyber Unit passive income drain only for civilizations whose first Era 13 technology is complete. Before that activation boundary, the existing Era 12 passive resolver remains unchanged. It delivers the complete persistent Harden and Exploit loop: state, validation, timing, cleanup, migration, player UI, AI, viewer-safe feedback, and save transfer.
+
+It does not introduce Capacity/Load HUDs, postures, Surge controls, constructive plans, formations, new Era 13 roster content, wonders, or authored network motifs.
+
+## Architecture
+
+New focused modules own serializable plan state, closed intent definitions, lifecycle validation, deterministic effect resolution, and viewer-safe presentation. `GameState` stores only plain data: `autonomyByCiv`, city civic pressure, viewer-scoped detections, plans, and `nextNetworkPlanId`. Targets and effects are discriminated unions; definitions contain data rather than callbacks or live references.
+
+One canonical validator returns structured success/failure information for UI and AI. Assignment, Hold, retarget, cancel, invalidation, preview, and resolution call it. It enforces one plan per source, same-type nonstacking, target ownership, range, war, source existence, and malformed-reference rejection. Invalid plans do not consume derived Load or resolve against replacement entities.
+
+`isAutonomyActivated(state, civId)` is the sole transition predicate. The turn manager retains the passive Cyber resolver only before activation and invokes intent resolution only at/after activation; a regression proves neither path can apply twice in one round.
+
+## Cyber contracts and timing
+
+Harden targets a friendly city at range 1 with Load 1. It refreshes one 50-percent mitigation charge every two owner rounds; an AI Safety Institute refreshes every owner round. Regular unused charges cap at one.
+
+Exploit targets an at-war enemy city at range 1 with Load 2. It transfers `floor(10% of base city gold)` per resolution, or 15 percent for an already-valid Surge-ready migration/state case, subject to the city-yield ceiling and a minimum positive transfer of one. A Cyber Defense Center delays the first otherwise-unmitigated resolution and halves every resolution. Harden consumes one charge to halve the remaining amount. Defenses are deterministic and never fully erase a positive exploit.
+
+Constructive Harden activates immediately. Hostile Exploit is prepared on assignment, warns its victim at the start of that victim's next turn, and resolves at the end of that turn only while still valid. Warnings expose the effect and counter category, never the source identity or coordinates unless that viewer has an explicit detection record. The handoff sequence preserves this response turn and defers all viewer-specific presentation until identity confirmation.
+
+## Cleanup, migration, and presentation
+
+Canonical lifecycle cleanup handles source movement out of range, source capture/destruction, target destruction, city capture, peace, diplomacy changes, conquest, elimination, and malformed loads. Capture cancels the old owner's plan and leaves the captured Cyber Unit on Hold/recovery under its new owner.
+
+Save schema version 3 appends to the existing version-2 migration registry. Migration initializes empty state below activation. At or after activation it stable-sorts Cyber Units and eligible cities, creates at most one valid Exploit per city, moves duplicates to Hold, allocates plan IDs from `nextNetworkPlanId`, rejects orphans with an owner-visible recovery notice, preserves viewer detections, and remains byte-stable across a second load/save/load.
+
+The selected Cyber Unit panel gains Assign Intent with Hold, Harden, and Exploit choices, legal targets, outcome, Load, first timing, counters, and disclosure. Confirm, retarget, cancel, reopen, and repeated clicks use live IDs and immediately rerender the selected-unit and intent surfaces. Notifications aggregate recurring resolutions per civilization round while warning/capture/cancel feedback remains immediate. Audio is emitted only from authorized visible events.
+
+## AI and tests
+
+The shared AI scheduler uses the canonical preview and validator with earned intel only. It creates bounded deterministic candidates, obeys challenge-profile `tacticalTopK` and mistake knobs, protects sources, cancels obsolete plans, and selects Hold when no valid positive action exists. Difficulty changes decision quality only, never effect values or hidden information.
+
+Tests proceed red-green by contract: serialized state and ID scanning; validation and immutability; passive-versus-intent exclusivity; exact mitigation/timing/cleanup; human and AI/turn-manager parity; viewer privacy; migration idempotence; save/export/import/autosave/handoff; and live UI replay for assign, retarget, cancel, reopen, repeat clicks, range break, peace, capture, and hot-seat handoff.
+
+## Inline review
+
+| Lens | Review result and required guardrail |
+|---|---|
+| Balance and fun | Pass with a constraint: Harden must substantially reduce but never nullify a positive Exploit, while an unprotected zero-gold city yields nothing. The response turn, range-one placement, war gate, source vulnerability, and same-type nonstacking prevent passive income theft from becoming unavoidable or routine busywork. |
+| New-mechanic clarity and ages 7–43 | The primary copy is outcome-first: “Reduce hostile network effects” rather than “Protected,” and “Prepare an exploit” rather than formula-first language. Exact percentage, charge, and delay calculations remain available in a compact detail view; Hold is visibly valid and never blocks end turn. |
+| Play styles | Defensive and peaceful players receive immediate Harden value without a compulsory hostile action. Aggressive players need war, proximity, and a surviving source; builders can counter with Cyber Defense Center. This slice does not promise MR4 constructive Capacity/posture gameplay early. |
+| Difficulty and computer players | Explorer, Standard, and Veteran share target rules, numbers, and intel boundaries. Their existing challenge knobs affect only bounded candidate quality, planning horizon, and deterministic suboptimal choices. AI may assign only shared-validator-approved plans from earned intel, must use Hold when appropriate, and cancels plans made obsolete by diplomacy, movement, capture, or invalid targets. |
+| UI, UX, accessibility | Assign Intent exposes all three actions and legal targets with outcome, timing, counter, Load, and disclosure before confirmation. Controls meet the existing 44px touch-target and keyboard rules, disabled actions name their blocker, and confirm/retarget/cancel rerender the still-open panel. The victim warning offers an affected-city focus action without leaking a hidden source. |
+| Architecture, extensibility, and data | Focused state/definition/lifecycle/resolver/viewer modules prevent `main.ts`, UI callbacks, or AI from owning mutations. Plan targets/effects remain closed discriminated unions and the explicit plan ID counter is scanned/normalized, leaving safe extension points for MR4 without prematurely adding Capacity or posture state. |
+| SFX and feedback | This MR reuses only existing visible-feedback routing; it adds no authored motif or hidden preparation sound. Warning, cancellation, capture, and resolution sound requests are deduplicated, obey mute/volume, and occur only after viewer authorization and a paired visible notification. |
+| Saved games and regressions | Migration 3 is strictly appended after v2, stable-sorts legacy inputs, preserves legitimate detections, rejects malformed records safely, and proves load-save-load equality. Autosave, manual save, export/import, and handoff use the same normalized state rather than a parallel serializer. |
+| Testing and implementation completeness | Tests must cover every canonical mutation through human and non-human callers, full UI replay, privacy-negative assertions, no double passive/intent application, multi-attacker nonstacking, zero-gold behavior, all cleanup triggers, migration idempotence, and targeted plus full-suite/build verification. No player-visible control may ship without its live caller and immediate rendered state change. |
+| Solo and hot seat | Solo suggestions remain advisory and do not auto-assign. In hot seat, attacker end → autosave/veil → identity confirmation → viewer reset → victim warning → normal input → victim turn-end resolution is mandatory; panels, selections, notifications, focus targets, and audio clear or derive only in the receiving viewer context. |
+
+Review conclusion: the slice is balanced and independently mergeable only if the full Harden/Exploit loop, migration, cleanup, AI, and viewer-safe presentation ship together. A UI-only intent surface, an intent resolver without response timing, or a migration without canonical cleanup would be incomplete and must not be merged.
+
+## Drift record
+
+Current `origin/main` is `d5061e3e1916c4d6f6c3ee9ac6b4292cad2136a4`, the MR2 merge. Its schema registry ends at version 2 and its Cyber resolver is the expected Era 12 adjacency drain with deterministic block rolls. The approved MR3 design therefore applies without a contract-changing deviation; planned seams are compatible with the current turn-manager, save-manager, selected-unit, AI-scheduler, notification, and SFX structures.

--- a/src/ai/ai-network-intents.ts
+++ b/src/ai/ai-network-intents.ts
@@ -1,0 +1,84 @@
+import type { NetworkPlanDefinitionId } from '@/core/autonomy-state';
+import type { GameState } from '@/core/types';
+import { getChallengeProfileForCiv } from '@/core/opponent-challenge';
+import { createRng } from '@/systems/map-generator';
+import {
+  assignNetworkPlan,
+  cancelInvalidNetworkPlans,
+  validateNetworkPlanAssignment,
+} from '@/systems/network-plan-system';
+
+export interface AINetworkIntentOptions {
+  /** City IDs in the actor's freshly earned perception; hostile targets never bypass this boundary. */
+  knownCityIds: ReadonlySet<string>;
+}
+
+interface Candidate {
+  definitionId: NetworkPlanDefinitionId;
+  cityId: string;
+  score: number;
+}
+
+/**
+ * Assigns only validator-approved plans.  This is deliberately a small tactical layer:
+ * challenge settings choose among legal candidates, never change effects or reveal targets.
+ */
+export function assignNetworkIntentsForAI(
+  state: GameState,
+  civId: string,
+  options: AINetworkIntentOptions,
+): GameState {
+  let nextState = cancelInvalidNetworkPlans(state).state;
+  const civ = nextState.civilizations[civId];
+  if (!civ || civ.isHuman || civ.isEliminated) return nextState;
+  const profile = getChallengeProfileForCiv(nextState, civId);
+  const sourceIds = civ.units
+    .filter(unitId => nextState.units[unitId]?.type === 'cyber_unit')
+    .sort();
+
+  for (const sourceUnitId of sourceIds) {
+    const alreadyAssigned = Object.values(nextState.autonomyByCiv?.[civId]?.plans ?? {})
+      .some(plan => plan.sourceUnitId === sourceUnitId);
+    if (alreadyAssigned) continue;
+
+    const candidates: Candidate[] = [];
+    for (const city of Object.values(nextState.cities)) {
+      const harden = {
+        ownerCivId: civId,
+        sourceUnitId,
+        definitionId: 'harden' as const,
+        target: { kind: 'city' as const, cityId: city.id },
+      };
+      if (validateNetworkPlanAssignment(nextState, harden).ok) {
+        candidates.push({
+          definitionId: 'harden',
+          cityId: city.id,
+          score: 20 + (city.buildings.includes('cyber_defense_center') ? 0 : 5),
+        });
+      }
+
+      if (!options.knownCityIds.has(city.id)) continue;
+      const exploit = { ...harden, definitionId: 'exploit' as const };
+      if (validateNetworkPlanAssignment(nextState, exploit).ok) {
+        candidates.push({ definitionId: 'exploit', cityId: city.id, score: 100 + city.population });
+      }
+    }
+    candidates.sort((left, right) => right.score - left.score
+      || left.definitionId.localeCompare(right.definitionId)
+      || left.cityId.localeCompare(right.cityId));
+    if (candidates.length === 0) continue;
+
+    const rng = createRng(`${nextState.gameId ?? 'legacy'}:${nextState.turn}:${civId}:${sourceUnitId}:network`);
+    const chosen = rng() < profile.seededSuboptimalChance && candidates.length > 1
+      ? candidates[Math.min(profile.tacticalTopK, candidates.length) - 1]!
+      : candidates[0]!;
+    const assigned = assignNetworkPlan(nextState, {
+      ownerCivId: civId,
+      sourceUnitId,
+      definitionId: chosen.definitionId,
+      target: { kind: 'city', cityId: chosen.cityId },
+    });
+    nextState = assigned.state;
+  }
+  return nextState;
+}

--- a/src/ai/ai-round-scheduler.ts
+++ b/src/ai/ai-round-scheduler.ts
@@ -6,7 +6,8 @@ import {
 } from '@/core/opponent-ai-state';
 import type { GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
-import { refreshMajorCivIntel } from './ai-perception';
+import { buildMajorCivPerception, refreshMajorCivIntel } from './ai-perception';
+import { assignNetworkIntentsForAI } from './ai-network-intents';
 import type {
   ExecutePreparedMajorCivPlan,
   PrepareMajorCivPlan,
@@ -236,6 +237,14 @@ export function processNonHumanMajorRound(
   const preparedByCiv = new Map(preparedPlans.map(prepared => [prepared.civId, prepared]));
   const traces = preparedPlans.flatMap(prepared => prepared.traces);
   working = writePreparedPortfolios(refreshed, preparedPlans);
+  for (const civId of stableActorIds) {
+    const perception = buildMajorCivPerception(working, civId);
+    working = assignNetworkIntentsForAI(working, civId, {
+      knownCityIds: new Set(perception.knownCities
+        .filter(city => city.position !== null)
+        .map(city => city.id)),
+    });
+  }
 
   const executePrepared = options.executePrepared ?? processPreparedAITurn;
   for (const civId of actorIds) {

--- a/src/core/autonomy-state.ts
+++ b/src/core/autonomy-state.ts
@@ -1,0 +1,46 @@
+import type { HexCoord } from './types';
+
+export type NetworkPlanTarget =
+  | { kind: 'city'; cityId: string }
+  | { kind: 'unit'; unitId: string }
+  | { kind: 'formation'; unitIds: string[] }
+  | { kind: 'route'; routeId: string }
+  | { kind: 'zone'; center: HexCoord; radius: number };
+
+export type NetworkPlanStatus =
+  | 'preparing'
+  | 'active'
+  | 'paused'
+  | 'recovering'
+  | 'completed'
+  | 'canceled';
+
+export type NetworkPlanDefinitionId = 'harden' | 'exploit';
+
+export interface NetworkPlan {
+  id: string;
+  ownerCivId: string;
+  definitionId: NetworkPlanDefinitionId;
+  sourceUnitId: string;
+  target: NetworkPlanTarget;
+  status: NetworkPlanStatus;
+  createdTurn: number;
+  nextResolutionTurn: number;
+  warnedTurn: number | null;
+}
+
+export interface NetworkViewerDetection {
+  planId: string;
+  detectedTurn: number;
+  sourceIdentityKnown: boolean;
+  sourcePositionKnown: boolean;
+}
+
+export interface AutonomyCivState {
+  plans: Record<string, NetworkPlan>;
+  detections: Record<string, NetworkViewerDetection>;
+}
+
+export function createEmptyAutonomyCivState(): AutonomyCivState {
+  return { plans: {}, detections: {} };
+}

--- a/src/core/autonomy-state.ts
+++ b/src/core/autonomy-state.ts
@@ -27,6 +27,10 @@ export interface NetworkPlan {
   createdTurn: number;
   nextResolutionTurn: number;
   warnedTurn: number | null;
+  effectState?: {
+    cdcDelayApplied?: boolean;
+    hardenCharges?: number;
+  };
 }
 
 export interface NetworkViewerDetection {

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -12,6 +12,7 @@ import { createVisibilityMap, updateVisibility } from '@/systems/fog-of-war';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { spawnBarbarianCamp } from '@/systems/barbarian-system';
 import { emptyIdCounters } from '@/core/id-counters';
+import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
 import { createEmptyPirateState } from '@/core/pirate-state';
 import { createNotificationLog } from '@/core/notification-log';
 import { getPlayableCivDefinitions, resolveCivDefinition } from '@/systems/civ-registry';
@@ -337,6 +338,8 @@ export function createNewGame(
     opponentChallenge: config.opponentChallenge ?? 'standard',
     opponentAI: createEmptyOpponentAIState(),
     civilizations,
+    autonomyByCiv: Object.fromEntries(Object.keys(civilizations).map(civId => [civId, createEmptyAutonomyCivState()])),
+    networkCivicPressureByCity: {},
     map,
     units,
     cities: {},
@@ -501,6 +504,8 @@ export function createHotSeatGame(
     opponentChallenge,
     opponentAI: createEmptyOpponentAIState(),
     civilizations,
+    autonomyByCiv: Object.fromEntries(Object.keys(civilizations).map(civId => [civId, createEmptyAutonomyCivState()])),
+    networkCivicPressureByCity: {},
     map,
     units,
     cities: {},

--- a/src/core/id-counters.ts
+++ b/src/core/id-counters.ts
@@ -15,7 +15,10 @@ type ScanableState = {
     history?: Array<{ factionId?: string }>;
   };
   notificationLog?: Record<string, Array<{ id?: string }>>;
-  autonomyByCiv?: Record<string, { plans?: Record<string, unknown> }>;
+  autonomyByCiv?: Record<string, {
+    plans?: Record<string, unknown>;
+    detections?: Record<string, unknown>;
+  }>;
 };
 
 /**

--- a/src/core/id-counters.ts
+++ b/src/core/id-counters.ts
@@ -15,6 +15,7 @@ type ScanableState = {
     history?: Array<{ factionId?: string }>;
   };
   notificationLog?: Record<string, Array<{ id?: string }>>;
+  autonomyByCiv?: Record<string, { plans?: Record<string, unknown> }>;
 };
 
 /**
@@ -29,6 +30,7 @@ export function emptyIdCounters(): IdCounters {
     nextRouteId: 1,
     nextPirateFactionId: 1,
     nextNotificationId: 1,
+    nextNetworkPlanId: 1,
   };
 }
 
@@ -41,7 +43,7 @@ export function emptyIdCounters(): IdCounters {
  */
 export function scanIdCounters(state: ScanableState): IdCounters {
   let maxUnit = 0, maxCity = 0, maxCamp = 0, maxQuest = 0;
-  let maxRoute = 0, maxPirateFaction = 0, maxNotification = 0;
+  let maxRoute = 0, maxPirateFaction = 0, maxNotification = 0, maxNetworkPlan = 0;
 
   for (const id of Object.keys(state.units ?? {})) {
     const n = /^unit-(\d+)$/.exec(id);
@@ -79,6 +81,12 @@ export function scanIdCounters(state: ScanableState): IdCounters {
       if (match) maxNotification = Math.max(maxNotification, +match[1]);
     }
   }
+  for (const autonomy of Object.values(state.autonomyByCiv ?? {})) {
+    for (const id of Object.keys(autonomy.plans ?? {})) {
+      const match = /^network-plan-(\d+)$/.exec(id);
+      if (match) maxNetworkPlan = Math.max(maxNetworkPlan, +match[1]);
+    }
+  }
 
   return {
     nextUnitId:  maxUnit  + 1,
@@ -88,5 +96,6 @@ export function scanIdCounters(state: ScanableState): IdCounters {
     nextRouteId: maxRoute + 1,
     nextPirateFactionId: maxPirateFaction + 1,
     nextNotificationId: maxNotification + 1,
+    nextNetworkPlanId: maxNetworkPlan + 1,
   };
 }

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -74,6 +74,11 @@ import { resolveCivDefinition } from '@/systems/civ-registry';
 import { applyProductionBonus } from '@/systems/city-system';
 import { chargeUnitsOnGeneTherapyResearch, applyGeneTherapyRecharge } from '@/systems/gene-therapy-system';
 import { processCyberDrain } from '@/systems/cyber-warfare-system';
+import {
+  beginNetworkPlansForVictimTurn,
+  isAutonomyActivated,
+  resolveNetworkPlansForVictimTurnEnd,
+} from '@/systems/network-plan-system';
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
 import { applyPendingOpponentChallenge, resolveChallengeForCiv } from '@/core/opponent-challenge';
@@ -149,6 +154,22 @@ export function processTurn(
 
   // --- Process each civilization ---
   for (const [civId, civ] of Object.entries(newState.civilizations)) {
+    if (!civ.isHuman) {
+      const warningResult = beginNetworkPlansForVictimTurn(newState, civId);
+      newState = warningResult.state;
+      for (const warning of warningResult.warnings) {
+        const plan = Object.values(newState.autonomyByCiv ?? {})
+          .map(autonomy => autonomy.plans[warning.planId])
+          .find(Boolean);
+        if (plan?.target.kind === 'city') {
+          bus.emit('network:exploit-warning', {
+            planId: warning.planId,
+            victimCivId: civId,
+            cityId: plan.target.cityId,
+          });
+        }
+      }
+    }
     const currentCivState = newState.civilizations[civId];
     const civDef = resolveCivDefinition(newState, civ.civType ?? '');
     // Snapshot before production creates new units this turn — geneTherapyReady recharge
@@ -157,6 +178,7 @@ export function processTurn(
     // Process cities: food, growth, production
     let totalScience = 0;
     let totalGold = 0;
+    const baseGoldByCityId: Record<string, number> = {};
 
     const resourceYieldBonus = getCivResourceYieldBonus(newState, civId);
     const npCivBonuses = getNationalProjectCivYieldBonus(newState, civId);
@@ -216,6 +238,7 @@ export function processTurn(
       };
       totalScience += yields.science;
       totalGold += yields.gold;
+      baseGoldByCityId[cityId] = yields.gold;
       const effectiveProduction = isCityProductionLocked(city) ? 0 : yields.production;
       const availableResources = getCivAvailableResources(newState, civId);
       const npKeysForCiv = new Set(
@@ -340,13 +363,36 @@ export function processTurn(
 
     // Cyber drain: enemy cyber_units adjacent to this civ's cities steal 2 gold/turn each
     // (blocked by Cyber Defense Center / Signals Hub); stolen gold is credited to the attacker.
-    const cyberDrainResult = processCyberDrain(newState, civId, totalGold);
-    totalGold = cyberDrainResult.remainingGold;
-    for (const [ownerCivId, amount] of Object.entries(cyberDrainResult.creditsByOwner)) {
+    if (!isAutonomyActivated(newState, civId)) {
+      const cyberDrainResult = processCyberDrain(newState, civId, totalGold);
+      totalGold = cyberDrainResult.remainingGold;
+      for (const [ownerCivId, amount] of Object.entries(cyberDrainResult.creditsByOwner)) {
+        grossGoldByCiv[ownerCivId] = (grossGoldByCiv[ownerCivId] ?? 0) + amount;
+      }
+      for (const event of cyberDrainResult.events) {
+        bus.emit('city:cyber-drained', { ...event, victimCivId: civId });
+      }
+    }
+    const networkResult = resolveNetworkPlansForVictimTurnEnd(newState, civId, baseGoldByCityId);
+    newState = networkResult.state;
+    const transferred = Object.values(networkResult.creditsByOwner)
+      .reduce((sum, amount) => sum + amount, 0);
+    totalGold = Math.max(0, totalGold - transferred);
+    for (const [ownerCivId, amount] of Object.entries(networkResult.creditsByOwner)) {
       grossGoldByCiv[ownerCivId] = (grossGoldByCiv[ownerCivId] ?? 0) + amount;
     }
-    for (const event of cyberDrainResult.events) {
-      bus.emit('city:cyber-drained', { ...event, victimCivId: civId });
+    for (const event of networkResult.events) {
+      const plan = Object.values(newState.autonomyByCiv ?? {})
+        .map(autonomy => autonomy.plans[event.planId])
+        .find(Boolean);
+      if (!plan) continue;
+      bus.emit('network:exploit-resolved', {
+        planId: event.planId,
+        cityId: event.cityId,
+        ownerCivId: plan.ownerCivId,
+        goldTransferred: event.goldTransferred,
+        delayed: event.kind === 'exploit-delayed',
+      });
     }
 
     // Process research

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1456,6 +1456,7 @@ export interface IdCounters {
   nextRouteId?: number;  // defaults to 1 on old saves (optional for back-compat)
   nextPirateFactionId?: number;
   nextNotificationId?: number;
+  nextNetworkPlanId?: number;
 }
 
 // --- Game State (the whole thing) ---
@@ -1470,6 +1471,8 @@ export interface GameState {
   opponentChallenge?: OpponentChallenge;
   pendingOpponentChallenge?: OpponentChallenge;
   opponentAI?: OpponentAIState;
+  autonomyByCiv?: Record<string, import('./autonomy-state').AutonomyCivState>;
+  networkCivicPressureByCity?: Record<string, number>;
   civilizations: Record<string, Civilization>;
   map: GameMap;
   units: Record<string, Unit>;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1613,6 +1613,8 @@ export interface GameEvents {
   'city:national-project-dequeued': { civId: string; cityId: string; buildingId: string };
   'city:unit-trained': { cityId: string; unitType: UnitType };
   'city:cyber-drained': { cityId: string; cityName: string; drainerOwner: string; drainerUnitId: string; goldLost: number; blocked: boolean; victimCivId: string };
+  'network:exploit-warning': { planId: string; victimCivId: string; cityId: string };
+  'network:exploit-resolved': { planId: string; cityId: string; ownerCivId: string; goldTransferred: number; delayed: boolean };
   'city:grew': { cityId: string; newPopulation: number };
   'city:maturity-upgraded': { cityId: string; previous: CityMaturity; current: CityMaturity };
   'economy:treasury-strain': { civId: string; level: Exclude<TreasuryStrainLevel, 'none'>; netGoldPerTurn: number; unpaidMaintenance: number };

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,6 +92,7 @@ import {
 import { createPirateHeadquartersAssaultPanel } from '@/ui/pirate-headquarters-assault-panel';
 import { formatNotificationTargetFocusMessage } from '@/ui/notification-targets';
 import { renderSelectedUnitInfo } from '@/ui/selected-unit-info';
+import { createNetworkIntentPanel } from '@/ui/network-intent-panel';
 import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
@@ -117,6 +118,14 @@ import { visitVillage } from '@/systems/village-system';
 import { getWonderDefinition } from '@/systems/wonder-definitions';
 import { buildWonderDiscoveryRevealItem } from '@/systems/wonder-discovery-reveal';
 import { getAvailableTechs, getEffectiveTechCost } from '@/systems/tech-system';
+import {
+  assignNetworkPlan,
+  beginNetworkPlansForVictimTurn,
+  holdNetworkPlan,
+  isAutonomyActivated,
+  retargetNetworkPlan,
+} from '@/systems/network-plan-system';
+import { getNetworkWarningForViewer } from '@/systems/network-viewer-intel';
 import {
   getNextActiveHumanPlayerId,
   isActiveHumanRoundComplete,
@@ -1704,6 +1713,59 @@ function openUnitStackPicker(coord: HexCoord, unitIds: string[]): void {
   }, { selectedUnitId });
 }
 
+function openNetworkIntentPanel(sourceUnitId: string): void {
+  const source = gameState.units[sourceUnitId];
+  const ownerCivId = gameState.currentPlayer;
+  if (!source || source.owner !== ownerCivId || source.type !== 'cyber_unit' || !isAutonomyActivated(gameState, ownerCivId)) {
+    showNotification('This Cyber Unit cannot set a network intent right now.', 'warning');
+    return;
+  }
+
+  let panel: HTMLElement | undefined;
+  const close = () => panel?.remove();
+  panel = createNetworkIntentPanel(gameState, ownerCivId, sourceUnitId, {
+    onAssign: (definitionId, cityId) => {
+      const current = Object.values(gameState.autonomyByCiv?.[ownerCivId]?.plans ?? {})
+        .find(plan => plan.sourceUnitId === sourceUnitId);
+      const stateForAssignment = current && current.definitionId !== definitionId
+        ? holdNetworkPlan(gameState, ownerCivId, sourceUnitId).state
+        : gameState;
+      const result = current && current.definitionId === definitionId
+        ? retargetNetworkPlan(gameState, ownerCivId, current.id, { kind: 'city', cityId })
+        : assignNetworkPlan(stateForAssignment, {
+          ownerCivId,
+          sourceUnitId,
+          definitionId,
+          target: { kind: 'city', cityId },
+        });
+      if (!result.validation.ok) {
+        showNotification('That network intent is no longer available. Choose another target.', 'warning');
+        close();
+        openNetworkIntentPanel(sourceUnitId);
+        return;
+      }
+      gameState = result.state;
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      close();
+      selectUnit(sourceUnitId);
+      const cityName = gameState.cities[cityId]?.name ?? 'the city';
+      showNotification(`${definitionId === 'harden' ? 'Harden' : 'Exploit'} assigned to ${cityName}.`, 'success');
+    },
+    onHold: () => {
+      const result = holdNetworkPlan(gameState, ownerCivId, sourceUnitId);
+      gameState = result.state;
+      renderLoop.setGameState(gameState);
+      updateHUD();
+      close();
+      selectUnit(sourceUnitId);
+      showNotification('Cyber Unit is holding.', 'info');
+    },
+    onClose: close,
+  });
+  uiLayer.appendChild(panel);
+}
+
 function selectUnit(
   unitId: string,
   opts?: {
@@ -1748,6 +1810,7 @@ function selectUnit(
   if (panel) {
     renderSelectedUnitInfo(panel, gameState, unitId, {
       onClose: () => deselectUnit(),
+      onOpenNetworkIntent: uid => openNetworkIntentPanel(uid),
       onFoundCity: () => foundCityAction(),
       onWorkerAction: action => performWorkerAction(action),
       onRest: () => restAction(),
@@ -3254,6 +3317,25 @@ function emitCurrentPlayerAudioSnapshot(civId: string): void {
   });
 }
 
+/** Opens due Exploit warnings only after the human viewer's identity has been confirmed. */
+function beginNetworkPlansForCurrentViewer(): void {
+  const viewerId = gameState.currentPlayer;
+  if (!gameState.civilizations[viewerId]?.isHuman) return;
+  const result = beginNetworkPlansForVictimTurn(gameState, viewerId);
+  gameState = result.state;
+  for (const warning of result.warnings) {
+    const plan = Object.values(gameState.autonomyByCiv ?? {})
+      .map(autonomy => autonomy.plans[warning.planId])
+      .find(Boolean);
+    if (plan?.target.kind !== 'city') continue;
+    bus.emit('network:exploit-warning', {
+      planId: warning.planId,
+      victimCivId: viewerId,
+      cityId: plan.target.cityId,
+    });
+  }
+}
+
 function releaseHandoffToViewer(nextSlotId: string): void {
   centerOnCurrentPlayer();
   renderLoop.setGameState(gameState);
@@ -3299,6 +3381,7 @@ async function beginHotSeatHandoff(
           summary,
         );
         gameState = acknowledgement.state;
+        beginNetworkPlansForCurrentViewer();
         let acknowledgementFailed = false;
         try {
           await autoSave(gameState);
@@ -3454,6 +3537,7 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       const result = runCurrentCompletedRound(gameState);
       if (!result.ok) throw result.error;
       gameState = result.state;
+      beginNetworkPlansForCurrentViewer();
       const soloMoves = captureAIMoves(() => {
         result.events.commitTo(bus);
       });
@@ -3731,6 +3815,35 @@ bus.on('city:cyber-drained', ({ cityName, drainerOwner, goldLost, blocked, victi
   }
   appendToCivLog(victimCivId, `Cyber attack: ${cityName} lost ${goldLost} gold (${drainerName} cyber unit).`, 'warning');
   appendToCivLog(drainerOwner, `Cyber unit stole ${goldLost} gold from ${victimName}'s ${cityName}.`, 'success');
+});
+
+bus.on('network:exploit-warning', ({ planId, victimCivId, cityId }) => {
+  const warning = getNetworkWarningForViewer(gameState, victimCivId, planId);
+  const city = gameState.cities[cityId];
+  if (!warning || !city) return;
+  const disclosure = warning.source?.unitId
+    ? ' The source has been identified.'
+    : warning.source?.position
+      ? ' The source position has been detected.'
+      : '';
+  appendToCivLog(
+    victimCivId,
+    `Network exploit warning: ${city.name} will be targeted at the end of this turn. A Cyber Defense Center or Harden reduces the effect.${disclosure}`,
+    'warning',
+    { kind: 'map', coord: city.position, label: city.name },
+  );
+});
+
+bus.on('network:exploit-resolved', ({ cityId, ownerCivId, goldTransferred, delayed }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (delayed) {
+    appendToCivLog(city.owner, `${city.name}'s Cyber Defense Center delayed a network exploit.`, 'success');
+    appendToCivLog(ownerCivId, `Your network exploit against ${city.name} was delayed by its Cyber Defense Center.`, 'warning');
+    return;
+  }
+  appendToCivLog(city.owner, `Network exploit: ${city.name} lost ${goldTransferred} gold.`, 'warning');
+  appendToCivLog(ownerCivId, `Network exploit transferred ${goldTransferred} gold from ${city.name}.`, 'success');
 });
 
 bus.on('village:visited', ({ civId, outcome, message }) => {

--- a/src/storage/save-manager.ts
+++ b/src/storage/save-manager.ts
@@ -527,6 +527,7 @@ export function normalizeIdCounters(state: GameState): GameState['idCounters'] {
     nextRouteId: Math.max(positive(current.nextRouteId) ?? 1, scanned.nextRouteId ?? 1),
     nextPirateFactionId: Math.max(positive(current.nextPirateFactionId) ?? 1, scanned.nextPirateFactionId ?? 1),
     nextNotificationId: Math.max(positive(current.nextNotificationId) ?? 1, scanned.nextNotificationId ?? 1),
+    nextNetworkPlanId: Math.max(positive(current.nextNetworkPlanId) ?? 1, scanned.nextNetworkPlanId ?? 1),
   };
 }
 

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -3,8 +3,9 @@ import { createRng } from '@/systems/map-generator';
 import { placeLateResources } from '@/systems/late-resource-placement';
 import { createMarketplaceState } from '@/systems/trade-system';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
+import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
 
-export const CURRENT_SAVE_SCHEMA_VERSION = 2;
+export const CURRENT_SAVE_SCHEMA_VERSION = 3;
 
 export type SaveMigration = (state: GameState) => GameState;
 
@@ -134,9 +135,23 @@ function migrateLateResources(state: GameState): GameState {
   return { ...state, gameId, map: { ...state.map, tiles }, marketplace, cities };
 }
 
+function migrateAutonomyNetwork(state: GameState): GameState {
+  const autonomyByCiv = Object.fromEntries(Object.keys(state.civilizations ?? {}).map(civId => [
+    civId,
+    state.autonomyByCiv?.[civId] ?? createEmptyAutonomyCivState(),
+  ]));
+  return {
+    ...state,
+    autonomyByCiv,
+    networkCivicPressureByCity: state.networkCivicPressureByCity ?? {},
+    idCounters: { ...state.idCounters, nextNetworkPlanId: state.idCounters?.nextNetworkPlanId ?? 1 },
+  };
+}
+
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   1: migrateToEra13Foundation,
   2: migrateLateResources,
+  3: migrateAutonomyNetwork,
 };
 
 function readSchemaVersion(raw: Record<string, unknown>): number {

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -4,6 +4,8 @@ import { placeLateResources } from '@/systems/late-resource-placement';
 import { createMarketplaceState } from '@/systems/trade-system';
 import { BUILDINGS, TRAINABLE_UNITS } from '@/systems/city-system';
 import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
+import { hexDistance } from '@/systems/hex-utils';
+import { assignNetworkPlan, isAutonomyActivated } from '@/systems/network-plan-system';
 
 export const CURRENT_SAVE_SCHEMA_VERSION = 3;
 
@@ -140,12 +142,38 @@ function migrateAutonomyNetwork(state: GameState): GameState {
     civId,
     state.autonomyByCiv?.[civId] ?? createEmptyAutonomyCivState(),
   ]));
-  return {
+  let working: GameState = {
     ...state,
     autonomyByCiv,
     networkCivicPressureByCity: state.networkCivicPressureByCity ?? {},
     idCounters: { ...state.idCounters, nextNetworkPlanId: state.idCounters?.nextNetworkPlanId ?? 1 },
   };
+  for (const civId of Object.keys(working.civilizations).sort()) {
+    if (!isAutonomyActivated(working, civId)) continue;
+    const sourceIds = Object.values(working.units)
+      .filter(unit => unit.owner === civId && unit.type === 'cyber_unit')
+      .map(unit => unit.id)
+      .sort();
+    for (const sourceUnitId of sourceIds) {
+      const source = working.units[sourceUnitId];
+      const owner = working.civilizations[civId];
+      const target = Object.values(working.cities)
+        .filter(city => city.owner !== civId
+          && working.civilizations[city.owner]
+          && owner.diplomacy.atWarWith.includes(city.owner)
+          && hexDistance(source.position, city.position) <= 1)
+        .sort((left, right) => left.id.localeCompare(right.id))[0];
+      if (!target) continue;
+      const assigned = assignNetworkPlan(working, {
+        ownerCivId: civId,
+        sourceUnitId,
+        definitionId: 'exploit',
+        target: { kind: 'city', cityId: target.id },
+      });
+      working = assigned.state;
+    }
+  }
+  return working;
 }
 
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -24,6 +24,7 @@ import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentation';
 import { eliminateCivilization } from '@/systems/civilization-elimination-system';
 import { handleCityLeftCiv } from '@/systems/crisis-system';
+import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
 
 export type MajorCityCaptureDisposition = 'occupy' | 'raze';
 
@@ -323,6 +324,7 @@ function buildCaptureResult(
   if (capturedCityId && bus) {
     postWorkState = handleCityLeftCiv(postWorkState, capturedCityId, bus);
   }
+  postWorkState = cancelInvalidNetworkPlans(postWorkState).state;
   return {
     state: postWorkState,
     outcome,
@@ -554,8 +556,8 @@ export function transferCapturedCityOwnership(
     },
   };
   const eliminatedState = eliminateCivilization(nextState, previousOwnerId, newOwnerId).state;
-  return recalculateTerritory(eliminatedState, {
+  return cancelInvalidNetworkPlans(recalculateTerritory(eliminatedState, {
     reason: 'capture',
     preserveCurrentHolderOnTie: true,
-  }).state;
+  }).state).state;
 }

--- a/src/systems/civilization-elimination-system.ts
+++ b/src/systems/civilization-elimination-system.ts
@@ -3,6 +3,7 @@ import type {
   GameState,
   MajorCivPlanPortfolio,
 } from '@/core/types';
+import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
 
 export type CivilizationEliminationResult =
   | { state: GameState; eliminated: false }
@@ -162,7 +163,7 @@ export function eliminateCivilization(
   }
 
   return {
-    state: next,
+    state: cancelInvalidNetworkPlans(next).state,
     eliminated: true,
     civId,
     eliminatedBy,

--- a/src/systems/cyber-warfare-system.ts
+++ b/src/systems/cyber-warfare-system.ts
@@ -1,6 +1,7 @@
 import type { GameState } from '@/core/types';
 import { hexDistance } from './hex-utils';
 import { isAtWar } from './diplomacy-system';
+import { isAutonomyActivated } from './network-plan-system';
 
 export interface CyberDrainEvent {
   cityId: string;
@@ -38,6 +39,7 @@ export function processCyberDrain(
   const events: CyberDrainEvent[] = [];
   const creditsByOwner: Record<string, number> = {};
   if (!civ) return { remainingGold: incomeSoFar, creditsByOwner, events };
+  if (isAutonomyActivated(state, civId)) return { remainingGold: incomeSoFar, creditsByOwner, events };
 
   let remainingGold = incomeSoFar;
 

--- a/src/systems/cyber-warfare-system.ts
+++ b/src/systems/cyber-warfare-system.ts
@@ -40,7 +40,6 @@ export function processCyberDrain(
   const creditsByOwner: Record<string, number> = {};
   if (!civ) return { remainingGold: incomeSoFar, creditsByOwner, events };
   if (isAutonomyActivated(state, civId)) return { remainingGold: incomeSoFar, creditsByOwner, events };
-
   let remainingGold = incomeSoFar;
 
   for (const cityId of [...civ.cities].sort()) {
@@ -51,6 +50,7 @@ export function processCyberDrain(
       .filter(u =>
         u.type === 'cyber_unit'
         && u.owner !== civId
+        && !isAutonomyActivated(state, u.owner)
         && isAtWar(civ.diplomacy, u.owner)
         && hexDistance(u.position, city.position) === 1)
       .sort((a, b) => a.id.localeCompare(b.id));

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -9,6 +9,7 @@ import type {
   PendingDiplomaticRequest,
   TradeRoute,
 } from '@/core/types';
+import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
 import type { EventBus } from '@/core/event-bus';
 import {
   REABSORB_GOLD_COST,
@@ -534,7 +535,7 @@ export function acceptDiplomaticRequest(
   }
 
   bus.emit('diplomacy:peace-made', { civA: request.fromCivId, civB: request.toCivId });
-  return {
+  return cancelInvalidNetworkPlans({
     ...state,
     pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(
       candidate => !isPeaceRequestPair(candidate, request.fromCivId, request.toCivId),
@@ -550,7 +551,7 @@ export function acceptDiplomaticRequest(
         diplomacy: makePeace(target.diplomacy, request.fromCivId, state.turn),
       },
     },
-  };
+  }).state;
 }
 
 export function rejectDiplomaticRequest(

--- a/src/systems/network-effect-resolver.ts
+++ b/src/systems/network-effect-resolver.ts
@@ -1,0 +1,100 @@
+import type { NetworkPlan } from '@/core/autonomy-state';
+import type { GameState } from '@/core/types';
+import { getNetworkPlanDefinition } from './network-plan-definitions';
+
+export type NetworkEffectEvent =
+  | { kind: 'exploit-delayed'; planId: string; cityId: string; goldTransferred: 0 }
+  | { kind: 'exploit-resolved'; planId: string; cityId: string; goldTransferred: number };
+
+export interface NetworkEffectResolution {
+  state: GameState;
+  creditsByOwner: Record<string, number>;
+  events: NetworkEffectEvent[];
+}
+
+function findPlan(state: GameState, planId: string): { ownerCivId: string; plan: NetworkPlan } | null {
+  for (const [ownerCivId, autonomy] of Object.entries(state.autonomyByCiv ?? {})) {
+    const plan = autonomy.plans[planId];
+    if (plan) return { ownerCivId, plan };
+  }
+  return null;
+}
+
+function updatePlan(state: GameState, ownerCivId: string, plan: NetworkPlan): GameState {
+  const autonomy = state.autonomyByCiv![ownerCivId];
+  return {
+    ...state,
+    autonomyByCiv: {
+      ...state.autonomyByCiv,
+      [ownerCivId]: {
+        ...autonomy,
+        plans: { ...autonomy.plans, [plan.id]: plan },
+      },
+    },
+  };
+}
+
+function findHardenPlanForCity(
+  state: GameState,
+  cityId: string,
+): { ownerCivId: string; plan: NetworkPlan } | null {
+  const matches = Object.entries(state.autonomyByCiv ?? {})
+    .flatMap(([ownerCivId, autonomy]) => Object.values(autonomy.plans)
+      .filter(plan => plan.definitionId === 'harden'
+        && plan.status === 'active'
+        && plan.target.kind === 'city'
+        && plan.target.cityId === cityId
+        && (plan.effectState?.hardenCharges ?? 0) > 0)
+      .map(plan => ({ ownerCivId, plan })))
+    .sort((left, right) => left.plan.id.localeCompare(right.plan.id));
+  return matches[0] ?? null;
+}
+
+export function resolveNetworkPlanAtTargetEnd(
+  state: GameState,
+  planId: string,
+  context: { baseCityGold: number },
+): NetworkEffectResolution {
+  const found = findPlan(state, planId);
+  if (!found || found.plan.definitionId !== 'exploit' || found.plan.target.kind !== 'city') {
+    return { state, creditsByOwner: {}, events: [] };
+  }
+  const city = state.cities[found.plan.target.cityId];
+  if (!city) return { state, creditsByOwner: {}, events: [] };
+  const definition = getNetworkPlanDefinition('exploit');
+  if (definition.effect.kind !== 'city-gold-transfer') return { state, creditsByOwner: {}, events: [] };
+
+  const raw = Math.floor(Math.max(0, context.baseCityGold) * definition.effect.normalPercent / 100);
+  const hasCdc = city.buildings.includes('cyber_defense_center');
+  if (raw > 0 && hasCdc && !found.plan.effectState?.cdcDelayApplied) {
+    const delayedPlan: NetworkPlan = {
+      ...found.plan,
+      effectState: { ...found.plan.effectState, cdcDelayApplied: true },
+    };
+    return {
+      state: updatePlan(state, found.ownerCivId, delayedPlan),
+      creditsByOwner: {},
+      events: [{ kind: 'exploit-delayed', planId, cityId: city.id, goldTransferred: 0 }],
+    };
+  }
+
+  let nextState = state;
+  let mitigated = hasCdc ? Math.floor(raw / 2) : raw;
+  const harden = raw > 0 ? findHardenPlanForCity(nextState, city.id) : null;
+  if (harden) {
+    mitigated = Math.floor(mitigated / 2);
+    nextState = updatePlan(nextState, harden.ownerCivId, {
+      ...harden.plan,
+      effectState: {
+        ...harden.plan.effectState,
+        hardenCharges: (harden.plan.effectState?.hardenCharges ?? 1) - 1,
+      },
+    });
+  }
+  const goldTransferred = raw > 0 ? Math.max(1, mitigated) : 0;
+  return {
+    state: nextState,
+    creditsByOwner: goldTransferred > 0 ? { [found.plan.ownerCivId]: goldTransferred } : {},
+    events: [{ kind: 'exploit-resolved', planId, cityId: city.id, goldTransferred }],
+  };
+}

--- a/src/systems/network-plan-definitions.ts
+++ b/src/systems/network-plan-definitions.ts
@@ -1,0 +1,54 @@
+import type { NetworkPlanDefinitionId } from '@/core/autonomy-state';
+
+export type NetworkPlanEffect =
+  | {
+      kind: 'mitigation-charge';
+      mitigationPercent: number;
+      regularChargeCap: number;
+      regularRefreshOwnerRounds: number;
+      aiSafetyRefreshOwnerRounds: number;
+    }
+  | {
+      kind: 'city-gold-transfer';
+      normalPercent: number;
+      surgedPercent: number;
+    };
+
+export interface NetworkPlanDefinition {
+  id: NetworkPlanDefinitionId;
+  targetKind: 'friendly-city' | 'at-war-enemy-city';
+  range: number;
+  load: number;
+  effect: NetworkPlanEffect;
+}
+
+export const NETWORK_PLAN_DEFINITIONS: Readonly<Record<NetworkPlanDefinitionId, NetworkPlanDefinition>> = {
+  harden: {
+    id: 'harden',
+    targetKind: 'friendly-city',
+    range: 1,
+    load: 1,
+    effect: {
+      kind: 'mitigation-charge',
+      mitigationPercent: 50,
+      regularChargeCap: 1,
+      regularRefreshOwnerRounds: 2,
+      aiSafetyRefreshOwnerRounds: 1,
+    },
+  },
+  exploit: {
+    id: 'exploit',
+    targetKind: 'at-war-enemy-city',
+    range: 1,
+    load: 2,
+    effect: {
+      kind: 'city-gold-transfer',
+      normalPercent: 10,
+      surgedPercent: 15,
+    },
+  },
+};
+
+export function getNetworkPlanDefinition(id: NetworkPlanDefinitionId): NetworkPlanDefinition {
+  return NETWORK_PLAN_DEFINITIONS[id];
+}

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -1,0 +1,208 @@
+import type {
+  NetworkPlan,
+  NetworkPlanDefinitionId,
+  NetworkPlanTarget,
+} from '@/core/autonomy-state';
+import { createEmptyAutonomyCivState } from '@/core/autonomy-state';
+import type { GameState } from '@/core/types';
+import { isAtWar } from '@/systems/diplomacy-system';
+import { hexDistance } from '@/systems/hex-utils';
+import { TECH_TREE } from '@/systems/tech-definitions';
+import { getNetworkPlanDefinition } from './network-plan-definitions';
+
+export interface NetworkPlanRequest {
+  ownerCivId: string;
+  sourceUnitId: string;
+  definitionId: NetworkPlanDefinitionId;
+  target: NetworkPlanTarget;
+}
+
+export type NetworkPlanValidation =
+  | { ok: true }
+  | {
+      ok: false;
+      reason:
+        | 'autonomy-not-activated'
+        | 'missing-owner'
+        | 'missing-source'
+        | 'invalid-source'
+        | 'source-already-assigned'
+        | 'invalid-target'
+        | 'missing-target-city'
+        | 'target-not-friendly'
+        | 'target-not-enemy'
+        | 'target-not-at-war'
+        | 'target-out-of-range'
+        | 'same-type-target-already-assigned'
+        | 'missing-plan';
+    };
+
+export interface NetworkPlanMutationResult {
+  state: GameState;
+  validation: NetworkPlanValidation;
+  plan: NetworkPlan | null;
+}
+
+export function isAutonomyActivated(state: GameState, civId: string): boolean {
+  const completed = state.civilizations[civId]?.techState.completed ?? [];
+  return completed.some(techId => TECH_TREE.find(tech => tech.id === techId)?.era === 13);
+}
+
+function hasActivePlanForSource(state: GameState, sourceUnitId: string): boolean {
+  return Object.values(state.autonomyByCiv ?? {}).some(autonomy =>
+    Object.values(autonomy.plans).some(plan =>
+      plan.sourceUnitId === sourceUnitId && plan.status !== 'canceled' && plan.status !== 'completed'),
+  );
+}
+
+function hasSameTypeCityPlan(state: GameState, definitionId: NetworkPlanDefinitionId, cityId: string): boolean {
+  return Object.values(state.autonomyByCiv ?? {}).some(autonomy =>
+    Object.values(autonomy.plans).some(plan =>
+      plan.definitionId === definitionId
+      && plan.target.kind === 'city'
+      && plan.target.cityId === cityId
+      && plan.status !== 'canceled'
+      && plan.status !== 'completed'),
+  );
+}
+
+export function validateNetworkPlanAssignment(
+  state: GameState,
+  request: NetworkPlanRequest,
+): NetworkPlanValidation {
+  const owner = state.civilizations[request.ownerCivId];
+  if (!owner) return { ok: false, reason: 'missing-owner' };
+  if (!isAutonomyActivated(state, request.ownerCivId)) return { ok: false, reason: 'autonomy-not-activated' };
+
+  const source = state.units[request.sourceUnitId];
+  if (!source) return { ok: false, reason: 'missing-source' };
+  if (source.owner !== request.ownerCivId || source.type !== 'cyber_unit') {
+    return { ok: false, reason: 'invalid-source' };
+  }
+  if (hasActivePlanForSource(state, source.id)) return { ok: false, reason: 'source-already-assigned' };
+  if (request.target.kind !== 'city') return { ok: false, reason: 'invalid-target' };
+
+  const city = state.cities[request.target.cityId];
+  if (!city) return { ok: false, reason: 'missing-target-city' };
+  const definition = getNetworkPlanDefinition(request.definitionId);
+  if (hexDistance(source.position, city.position) > definition.range) {
+    return { ok: false, reason: 'target-out-of-range' };
+  }
+  if (definition.targetKind === 'friendly-city' && city.owner !== request.ownerCivId) {
+    return { ok: false, reason: 'target-not-friendly' };
+  }
+  if (definition.targetKind === 'at-war-enemy-city') {
+    const targetCiv = state.civilizations[city.owner];
+    if (!targetCiv || city.owner === request.ownerCivId) return { ok: false, reason: 'target-not-enemy' };
+    if (!isAtWar(owner.diplomacy, city.owner) || !isAtWar(targetCiv.diplomacy, request.ownerCivId)) {
+      return { ok: false, reason: 'target-not-at-war' };
+    }
+  }
+  if (hasSameTypeCityPlan(state, request.definitionId, city.id)) {
+    return { ok: false, reason: 'same-type-target-already-assigned' };
+  }
+  return { ok: true };
+}
+
+export function assignNetworkPlan(
+  state: GameState,
+  request: NetworkPlanRequest,
+): NetworkPlanMutationResult {
+  const validation = validateNetworkPlanAssignment(state, request);
+  if (!validation.ok) return { state, validation, plan: null };
+
+  const nextId = state.idCounters.nextNetworkPlanId ?? 1;
+  const plan: NetworkPlan = {
+    id: `network-plan-${nextId}`,
+    ownerCivId: request.ownerCivId,
+    definitionId: request.definitionId,
+    sourceUnitId: request.sourceUnitId,
+    target: structuredClone(request.target),
+    status: request.definitionId === 'harden' ? 'active' : 'preparing',
+    createdTurn: state.turn,
+    nextResolutionTurn: request.definitionId === 'harden' ? state.turn : state.turn + 1,
+    warnedTurn: null,
+  };
+  const currentAutonomy = state.autonomyByCiv?.[request.ownerCivId] ?? createEmptyAutonomyCivState();
+  return {
+    state: {
+      ...state,
+      autonomyByCiv: {
+        ...state.autonomyByCiv,
+        [request.ownerCivId]: {
+          ...currentAutonomy,
+          plans: { ...currentAutonomy.plans, [plan.id]: plan },
+        },
+      },
+      idCounters: { ...state.idCounters, nextNetworkPlanId: nextId + 1 },
+    },
+    validation,
+    plan,
+  };
+}
+
+function stateWithoutPlan(state: GameState, ownerCivId: string, planId: string): GameState {
+  const autonomy = state.autonomyByCiv?.[ownerCivId] ?? createEmptyAutonomyCivState();
+  const { [planId]: _removed, ...plans } = autonomy.plans;
+  return {
+    ...state,
+    autonomyByCiv: {
+      ...state.autonomyByCiv,
+      [ownerCivId]: { ...autonomy, plans },
+    },
+  };
+}
+
+export function retargetNetworkPlan(
+  state: GameState,
+  ownerCivId: string,
+  planId: string,
+  target: NetworkPlanTarget,
+): NetworkPlanMutationResult {
+  const existing = state.autonomyByCiv?.[ownerCivId]?.plans[planId];
+  if (!existing) {
+    return { state, validation: { ok: false, reason: 'missing-plan' }, plan: null };
+  }
+  const withoutOldPlan = stateWithoutPlan(state, ownerCivId, planId);
+  const request: NetworkPlanRequest = {
+    ownerCivId,
+    sourceUnitId: existing.sourceUnitId,
+    definitionId: existing.definitionId,
+    target,
+  };
+  const validation = validateNetworkPlanAssignment(withoutOldPlan, request);
+  if (!validation.ok) return { state, validation, plan: null };
+
+  const plan: NetworkPlan = {
+    ...existing,
+    target: structuredClone(target),
+    status: existing.definitionId === 'harden' ? 'active' : 'preparing',
+    nextResolutionTurn: existing.definitionId === 'harden' ? state.turn : state.turn + 1,
+    warnedTurn: null,
+  };
+  return {
+    state: {
+      ...withoutOldPlan,
+      autonomyByCiv: {
+        ...withoutOldPlan.autonomyByCiv,
+        [ownerCivId]: {
+          ...withoutOldPlan.autonomyByCiv![ownerCivId],
+          plans: { ...withoutOldPlan.autonomyByCiv![ownerCivId].plans, [plan.id]: plan },
+        },
+      },
+    },
+    validation,
+    plan,
+  };
+}
+
+export function holdNetworkPlan(
+  state: GameState,
+  ownerCivId: string,
+  sourceUnitId: string,
+): NetworkPlanMutationResult {
+  const plan = Object.values(state.autonomyByCiv?.[ownerCivId]?.plans ?? {})
+    .find(candidate => candidate.sourceUnitId === sourceUnitId);
+  if (!plan) return { state, validation: { ok: true }, plan: null };
+  return { state: stateWithoutPlan(state, ownerCivId, plan.id), validation: { ok: true }, plan: null };
+}

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -58,6 +58,11 @@ export interface NetworkTurnEndResult {
   events: NetworkEffectEvent[];
 }
 
+export interface NetworkPlanCleanupResult {
+  state: GameState;
+  cancelled: Array<{ planId: string; reason: Exclude<NetworkPlanValidation, { ok: true }>['reason'] }>;
+}
+
 export function isAutonomyActivated(state: GameState, civId: string): boolean {
   const completed = state.civilizations[civId]?.techState?.completed ?? [];
   return completed.some(techId => TECH_TREE.find(tech => tech.id === techId)?.era === 13);
@@ -221,6 +226,28 @@ export function holdNetworkPlan(
     .find(candidate => candidate.sourceUnitId === sourceUnitId);
   if (!plan) return { state, validation: { ok: true }, plan: null };
   return { state: stateWithoutPlan(state, ownerCivId, plan.id), validation: { ok: true }, plan: null };
+}
+
+export function cancelInvalidNetworkPlans(state: GameState): NetworkPlanCleanupResult {
+  let nextState = state;
+  const cancelled: NetworkPlanCleanupResult['cancelled'] = [];
+  const candidates = Object.entries(state.autonomyByCiv ?? {})
+    .flatMap(([ownerCivId, autonomy]) => Object.values(autonomy.plans)
+      .map(plan => ({ ownerCivId, plan })))
+    .sort((left, right) => left.plan.id.localeCompare(right.plan.id));
+  for (const { ownerCivId, plan } of candidates) {
+    const withoutPlan = stateWithoutPlan(nextState, ownerCivId, plan.id);
+    const validation = validateNetworkPlanAssignment(withoutPlan, {
+      ownerCivId,
+      sourceUnitId: plan.sourceUnitId,
+      definitionId: plan.definitionId,
+      target: plan.target,
+    });
+    if (validation.ok) continue;
+    nextState = withoutPlan;
+    cancelled.push({ planId: plan.id, reason: validation.reason });
+  }
+  return { state: nextState, cancelled };
 }
 
 export function beginNetworkPlansForVictimTurn(

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -140,7 +140,9 @@ export function assignNetworkPlan(
     target: structuredClone(request.target),
     status: request.definitionId === 'harden' ? 'active' : 'preparing',
     createdTurn: state.turn,
-    nextResolutionTurn: request.definitionId === 'harden' ? state.turn : state.turn + 1,
+    // A victim's next player turn can occur later in this hot-seat round, before the
+    // global round counter advances.  The warning gate, not a round offset, owns timing.
+    nextResolutionTurn: state.turn,
     warnedTurn: null,
     ...(request.definitionId === 'harden' ? { effectState: { hardenCharges: 1 } } : {}),
   };
@@ -198,7 +200,7 @@ export function retargetNetworkPlan(
     ...existing,
     target: structuredClone(target),
     status: existing.definitionId === 'harden' ? 'active' : 'preparing',
-    nextResolutionTurn: existing.definitionId === 'harden' ? state.turn : state.turn + 1,
+    nextResolutionTurn: state.turn,
     warnedTurn: null,
   };
   return {
@@ -254,22 +256,22 @@ export function beginNetworkPlansForVictimTurn(
   state: GameState,
   victimCivId: string,
 ): NetworkTurnStartResult {
-  let nextState = state;
+  let nextState = cancelInvalidNetworkPlans(state).state;
   const warnings: NetworkTurnStartResult['warnings'] = [];
-  const candidates = Object.entries(state.autonomyByCiv ?? {})
+  const candidates = Object.entries(nextState.autonomyByCiv ?? {})
     .flatMap(([ownerCivId, autonomy]) => Object.values(autonomy.plans)
       .map(plan => ({ ownerCivId, plan })))
     .filter(({ plan }) => plan.definitionId === 'exploit'
       && plan.status === 'preparing'
       && plan.warnedTurn === null
-      && plan.nextResolutionTurn <= state.turn
+      && plan.nextResolutionTurn <= nextState.turn
       && plan.target.kind === 'city'
-      && state.cities[plan.target.cityId]?.owner === victimCivId)
+      && nextState.cities[plan.target.cityId]?.owner === victimCivId)
     .sort((left, right) => left.plan.id.localeCompare(right.plan.id));
 
   for (const { ownerCivId, plan } of candidates) {
     const autonomy = nextState.autonomyByCiv![ownerCivId];
-    const warnedPlan: NetworkPlan = { ...plan, status: 'active', warnedTurn: state.turn };
+    const warnedPlan: NetworkPlan = { ...plan, status: 'active', warnedTurn: nextState.turn };
     nextState = {
       ...nextState,
       autonomyByCiv: {
@@ -290,14 +292,14 @@ export function resolveNetworkPlansForVictimTurnEnd(
   victimCivId: string,
   baseGoldByCityId: Record<string, number>,
 ): NetworkTurnEndResult {
-  let nextState = state;
+  let nextState = cancelInvalidNetworkPlans(state).state;
   const creditsByOwner: Record<string, number> = {};
   const events: NetworkEffectEvent[] = [];
-  const planIds = Object.values(state.autonomyByCiv ?? {})
+  const planIds = Object.values(nextState.autonomyByCiv ?? {})
     .flatMap(autonomy => Object.values(autonomy.plans))
     .filter(plan => plan.definitionId === 'exploit'
       && plan.status === 'active'
-      && plan.warnedTurn === state.turn
+      && plan.warnedTurn === nextState.turn
       && plan.target.kind === 'city'
       && nextState.cities[plan.target.cityId]?.owner === victimCivId)
     .map(plan => plan.id)
@@ -311,7 +313,26 @@ export function resolveNetworkPlansForVictimTurnEnd(
     const resolution = resolveNetworkPlanAtTargetEnd(nextState, planId, {
       baseCityGold: baseGoldByCityId[plan.target.cityId] ?? 0,
     });
-    nextState = resolution.state;
+    const ownerAutonomy = resolution.state.autonomyByCiv?.[plan.ownerCivId];
+    const resolvedPlan = ownerAutonomy?.plans[planId];
+    nextState = resolvedPlan ? {
+      ...resolution.state,
+      autonomyByCiv: {
+        ...resolution.state.autonomyByCiv,
+        [plan.ownerCivId]: {
+          ...ownerAutonomy,
+          plans: {
+            ...ownerAutonomy!.plans,
+            [planId]: {
+              ...resolvedPlan,
+              status: 'preparing',
+              warnedTurn: null,
+              nextResolutionTurn: nextState.turn + 1,
+            },
+          },
+        },
+      },
+    } : resolution.state;
     for (const [ownerCivId, credits] of Object.entries(resolution.creditsByOwner)) {
       creditsByOwner[ownerCivId] = (creditsByOwner[ownerCivId] ?? 0) + credits;
     }

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -9,6 +9,10 @@ import { isAtWar } from '@/systems/diplomacy-system';
 import { hexDistance } from '@/systems/hex-utils';
 import { TECH_TREE } from '@/systems/tech-definitions';
 import { getNetworkPlanDefinition } from './network-plan-definitions';
+import {
+  resolveNetworkPlanAtTargetEnd,
+  type NetworkEffectEvent,
+} from './network-effect-resolver';
 
 export interface NetworkPlanRequest {
   ownerCivId: string;
@@ -41,6 +45,17 @@ export interface NetworkPlanMutationResult {
   state: GameState;
   validation: NetworkPlanValidation;
   plan: NetworkPlan | null;
+}
+
+export interface NetworkTurnStartResult {
+  state: GameState;
+  warnings: Array<{ planId: string; victimCivId: string }>;
+}
+
+export interface NetworkTurnEndResult {
+  state: GameState;
+  creditsByOwner: Record<string, number>;
+  events: NetworkEffectEvent[];
 }
 
 export function isAutonomyActivated(state: GameState, civId: string): boolean {
@@ -206,4 +221,74 @@ export function holdNetworkPlan(
     .find(candidate => candidate.sourceUnitId === sourceUnitId);
   if (!plan) return { state, validation: { ok: true }, plan: null };
   return { state: stateWithoutPlan(state, ownerCivId, plan.id), validation: { ok: true }, plan: null };
+}
+
+export function beginNetworkPlansForVictimTurn(
+  state: GameState,
+  victimCivId: string,
+): NetworkTurnStartResult {
+  let nextState = state;
+  const warnings: NetworkTurnStartResult['warnings'] = [];
+  const candidates = Object.entries(state.autonomyByCiv ?? {})
+    .flatMap(([ownerCivId, autonomy]) => Object.values(autonomy.plans)
+      .map(plan => ({ ownerCivId, plan })))
+    .filter(({ plan }) => plan.definitionId === 'exploit'
+      && plan.status === 'preparing'
+      && plan.warnedTurn === null
+      && plan.nextResolutionTurn <= state.turn
+      && plan.target.kind === 'city'
+      && state.cities[plan.target.cityId]?.owner === victimCivId)
+    .sort((left, right) => left.plan.id.localeCompare(right.plan.id));
+
+  for (const { ownerCivId, plan } of candidates) {
+    const autonomy = nextState.autonomyByCiv![ownerCivId];
+    const warnedPlan: NetworkPlan = { ...plan, status: 'active', warnedTurn: state.turn };
+    nextState = {
+      ...nextState,
+      autonomyByCiv: {
+        ...nextState.autonomyByCiv,
+        [ownerCivId]: {
+          ...autonomy,
+          plans: { ...autonomy.plans, [plan.id]: warnedPlan },
+        },
+      },
+    };
+    warnings.push({ planId: plan.id, victimCivId });
+  }
+  return { state: nextState, warnings };
+}
+
+export function resolveNetworkPlansForVictimTurnEnd(
+  state: GameState,
+  victimCivId: string,
+  baseGoldByCityId: Record<string, number>,
+): NetworkTurnEndResult {
+  let nextState = state;
+  const creditsByOwner: Record<string, number> = {};
+  const events: NetworkEffectEvent[] = [];
+  const planIds = Object.values(state.autonomyByCiv ?? {})
+    .flatMap(autonomy => Object.values(autonomy.plans))
+    .filter(plan => plan.definitionId === 'exploit'
+      && plan.status === 'active'
+      && plan.warnedTurn === state.turn
+      && plan.target.kind === 'city'
+      && nextState.cities[plan.target.cityId]?.owner === victimCivId)
+    .map(plan => plan.id)
+    .sort();
+
+  for (const planId of planIds) {
+    const plan = Object.values(nextState.autonomyByCiv ?? {})
+      .map(autonomy => autonomy.plans[planId])
+      .find(Boolean);
+    if (!plan || plan.target.kind !== 'city') continue;
+    const resolution = resolveNetworkPlanAtTargetEnd(nextState, planId, {
+      baseCityGold: baseGoldByCityId[plan.target.cityId] ?? 0,
+    });
+    nextState = resolution.state;
+    for (const [ownerCivId, credits] of Object.entries(resolution.creditsByOwner)) {
+      creditsByOwner[ownerCivId] = (creditsByOwner[ownerCivId] ?? 0) + credits;
+    }
+    events.push(...resolution.events);
+  }
+  return { state: nextState, creditsByOwner, events };
 }

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -122,6 +122,7 @@ export function assignNetworkPlan(
     createdTurn: state.turn,
     nextResolutionTurn: request.definitionId === 'harden' ? state.turn : state.turn + 1,
     warnedTurn: null,
+    ...(request.definitionId === 'harden' ? { effectState: { hardenCharges: 1 } } : {}),
   };
   const currentAutonomy = state.autonomyByCiv?.[request.ownerCivId] ?? createEmptyAutonomyCivState();
   return {

--- a/src/systems/network-plan-system.ts
+++ b/src/systems/network-plan-system.ts
@@ -59,7 +59,7 @@ export interface NetworkTurnEndResult {
 }
 
 export function isAutonomyActivated(state: GameState, civId: string): boolean {
-  const completed = state.civilizations[civId]?.techState.completed ?? [];
+  const completed = state.civilizations[civId]?.techState?.completed ?? [];
   return completed.some(techId => TECH_TREE.find(tech => tech.id === techId)?.era === 13);
 }
 

--- a/src/systems/network-viewer-intel.ts
+++ b/src/systems/network-viewer-intel.ts
@@ -1,0 +1,39 @@
+import type { GameState, HexCoord } from '@/core/types';
+
+export interface NetworkViewerWarning {
+  planId: string;
+  targetCityId: string;
+  effectLabel: 'Exploit';
+  counterLabel: 'Cyber Defense Center or Harden';
+  source?: {
+    unitId?: string;
+    position?: HexCoord;
+  };
+}
+
+export function getNetworkWarningForViewer(
+  state: GameState,
+  viewerId: string,
+  planId: string,
+): NetworkViewerWarning | null {
+  const ownerEntry = Object.values(state.autonomyByCiv ?? {})
+    .map(autonomy => autonomy.plans[planId])
+    .find(Boolean);
+  if (!ownerEntry || ownerEntry.definitionId !== 'exploit' || ownerEntry.target.kind !== 'city') return null;
+
+  const warning: NetworkViewerWarning = {
+    planId,
+    targetCityId: ownerEntry.target.cityId,
+    effectLabel: 'Exploit',
+    counterLabel: 'Cyber Defense Center or Harden',
+  };
+  const detection = state.autonomyByCiv?.[viewerId]?.detections[planId];
+  if (!detection || (!detection.sourceIdentityKnown && !detection.sourcePositionKnown)) return warning;
+
+  const source = state.units[ownerEntry.sourceUnitId];
+  warning.source = {
+    ...(detection.sourceIdentityKnown && source ? { unitId: source.id } : {}),
+    ...(detection.sourcePositionKnown && source ? { position: { ...source.position } } : {}),
+  };
+  return warning;
+}

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -4,6 +4,7 @@ import { getVisibility, updateVisibility } from '@/systems/fog-of-war';
 import { getActiveNationalProjectsForCiv } from '@/systems/national-project-system';
 import { getVisionBonus } from '@/systems/unit-modifier-system';
 import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
+import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import {
   moveUnit,
@@ -133,6 +134,8 @@ export function executeUnitMove(
     const synced = syncTransportCargoPositions(state, unitId);
     state.units = synced.units;
   }
+  const networkCleanup = cancelInvalidNetworkPlans(state);
+  state.autonomyByCiv = networkCleanup.state.autonomyByCiv;
   options.bus?.emit('unit:move', {
     unitId,
     from,

--- a/src/ui/network-intent-panel.ts
+++ b/src/ui/network-intent-panel.ts
@@ -1,0 +1,138 @@
+import type { NetworkPlanDefinitionId } from '@/core/autonomy-state';
+import type { GameState } from '@/core/types';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { isAtWar } from '@/systems/diplomacy-system';
+import { hexDistance } from '@/systems/hex-utils';
+import { NETWORK_PLAN_DEFINITIONS } from '@/systems/network-plan-definitions';
+import { createGameButton } from '@/ui/ui-kit';
+
+export interface NetworkIntentTargetOption {
+  cityId: string;
+  cityName: string;
+}
+
+export interface NetworkIntentPanelModel {
+  sourceName: string;
+  currentIntentLabel: string;
+  hardenDescription: string;
+  exploitDescription: string;
+  hardenTargets: NetworkIntentTargetOption[];
+  exploitTargets: NetworkIntentTargetOption[];
+}
+
+export interface NetworkIntentPanelCallbacks {
+  onAssign: (definitionId: NetworkPlanDefinitionId, cityId: string) => void;
+  onHold: () => void;
+  onClose: () => void;
+}
+
+function getCurrentPlanLabel(state: GameState, ownerCivId: string, sourceUnitId: string): string {
+  const plan = Object.values(state.autonomyByCiv?.[ownerCivId]?.plans ?? {})
+    .find(candidate => candidate.sourceUnitId === sourceUnitId);
+  if (!plan) return 'Hold';
+  const cityName = plan.target.kind === 'city' ? state.cities[plan.target.cityId]?.name : undefined;
+  const verb = plan.definitionId === 'harden' ? 'Harden' : 'Exploit';
+  return cityName ? `${verb} ${cityName}` : verb;
+}
+
+export function getNetworkIntentPanelModel(
+  state: GameState,
+  ownerCivId: string,
+  sourceUnitId: string,
+): NetworkIntentPanelModel {
+  const source = state.units[sourceUnitId];
+  const owner = state.civilizations[ownerCivId];
+  const harden = NETWORK_PLAN_DEFINITIONS.harden;
+  const exploit = NETWORK_PLAN_DEFINITIONS.exploit;
+  const candidates = Object.values(state.cities)
+    .filter(city => source && hexDistance(source.position, city.position) <= Math.max(harden.range, exploit.range))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const hardenTargets = candidates
+    .filter(city => city.owner === ownerCivId)
+    .map(city => ({ cityId: city.id, cityName: city.name }));
+  const exploitTargets = candidates
+    .filter(city => city.owner !== ownerCivId && owner && state.civilizations[city.owner]
+      && isAtWar(owner.diplomacy, city.owner)
+      && isAtWar(state.civilizations[city.owner].diplomacy, ownerCivId))
+    .map(city => ({ cityId: city.id, cityName: city.name }));
+
+  return {
+    sourceName: UNIT_DEFINITIONS[source?.type ?? 'cyber_unit']?.name ?? 'Cyber Unit',
+    currentIntentLabel: getCurrentPlanLabel(state, ownerCivId, sourceUnitId),
+    hardenDescription: 'Harden a nearby friendly city (Load 1). The next cyber loss there is cut in half.',
+    exploitDescription: 'Exploit a nearby city of a civilization you are at war with (Load 2). Transfers 10% of its gold at the end of its next turn; Cyber Defense Center and Harden reduce it.',
+    hardenTargets,
+    exploitTargets,
+  };
+}
+
+function appendTargetButtons(
+  panel: HTMLElement,
+  label: string,
+  description: string,
+  targets: NetworkIntentTargetOption[],
+  definitionId: NetworkPlanDefinitionId,
+  callbacks: NetworkIntentPanelCallbacks,
+): void {
+  const section = document.createElement('section');
+  section.style.cssText = 'margin-top:14px;padding-top:12px;border-top:1px solid rgba(255,255,255,0.14);';
+  const heading = document.createElement('strong');
+  heading.textContent = label;
+  section.appendChild(heading);
+  const detail = document.createElement('p');
+  detail.style.cssText = 'margin:5px 0 8px;font-size:12px;line-height:1.4;color:rgba(244,241,232,0.82);';
+  detail.textContent = description;
+  section.appendChild(detail);
+  if (targets.length === 0) {
+    const unavailable = document.createElement('div');
+    unavailable.style.cssText = 'font-size:12px;color:rgba(244,241,232,0.6);';
+    unavailable.textContent = definitionId === 'harden'
+      ? 'No nearby friendly city is available.'
+      : 'No nearby city belonging to a civilization you are at war with is available.';
+    section.appendChild(unavailable);
+  } else {
+    for (const target of targets) {
+      const button = createGameButton(`${label} ${target.cityName}`, definitionId === 'harden' ? 'secondary' : 'primary');
+      button.style.margin = '4px 6px 0 0';
+      button.addEventListener('click', () => callbacks.onAssign(definitionId, target.cityId));
+      section.appendChild(button);
+    }
+  }
+  panel.appendChild(section);
+}
+
+/** Creates the player-owned persistent intent surface; mutations stay in the caller's canonical system path. */
+export function createNetworkIntentPanel(
+  state: GameState,
+  ownerCivId: string,
+  sourceUnitId: string,
+  callbacks: NetworkIntentPanelCallbacks,
+): HTMLElement {
+  const model = getNetworkIntentPanelModel(state, ownerCivId, sourceUnitId);
+  const panel = document.createElement('div');
+  panel.setAttribute('role', 'dialog');
+  panel.setAttribute('aria-label', 'Network intent');
+  panel.style.cssText = 'position:fixed;z-index:1600;left:50%;top:50%;transform:translate(-50%,-50%);width:min(92vw,470px);max-height:85vh;overflow:auto;padding:20px;border-radius:12px;background:#172033;color:#f4f1e8;border:1px solid rgba(232,193,112,0.6);box-shadow:0 20px 48px rgba(0,0,0,0.55);';
+
+  const title = document.createElement('h2');
+  title.style.cssText = 'margin:0;font-size:20px;';
+  title.textContent = `${model.sourceName} network intent`;
+  panel.appendChild(title);
+  const current = document.createElement('p');
+  current.style.cssText = 'margin:8px 0 0;font-size:13px;color:#e8c170;';
+  current.textContent = `Current intent: ${model.currentIntentLabel}`;
+  panel.appendChild(current);
+
+  appendTargetButtons(panel, 'Harden', model.hardenDescription, model.hardenTargets, 'harden', callbacks);
+  appendTargetButtons(panel, 'Exploit', model.exploitDescription, model.exploitTargets, 'exploit', callbacks);
+
+  const footer = document.createElement('div');
+  footer.style.cssText = 'display:flex;gap:8px;justify-content:flex-end;margin-top:18px;';
+  const hold = createGameButton('Hold', 'secondary');
+  hold.addEventListener('click', callbacks.onHold);
+  const close = createGameButton('Close', 'ghost');
+  close.addEventListener('click', callbacks.onClose);
+  footer.append(hold, close);
+  panel.appendChild(footer);
+  return panel;
+}

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -30,6 +30,7 @@ import {
   getLandUnitWaterRecoveryPanelMessage,
   type LandUnitWaterRecovery,
 } from '@/systems/unit-water-recovery';
+import { isAutonomyActivated } from '@/systems/network-plan-system';
 
 export interface TransportLoadOption {
   transportId: string;
@@ -91,6 +92,8 @@ export interface SelectedUnitInfoCallbacks {
   pendingUnloadUnitName?: string;
   getPirateAssaultAction?: (unitId: string) => { factionId: string; label: string } | null;
   onOpenPirateAssault?: (factionId: string, unitId: string) => void;
+  /** Opens the persistent-network intent surface for an activated Cyber Unit. */
+  onOpenNetworkIntent?: (unitId: string) => void;
 }
 
 export interface SelectedUnitInfoPresentation {
@@ -641,6 +644,19 @@ export function renderSelectedUnitInfo(
     if (ownCityHere && spyRecord?.status === 'idle' && !unit.hasActed) {
       actionsDiv.appendChild(makeButton('Embed (counter-espionage)', '#374151', () => callbacks.onEmbed!(unitId)));
     }
+  }
+
+  if (
+    unit.type === 'cyber_unit'
+    && unit.owner === state.currentPlayer
+    && isAutonomyActivated(state, unit.owner)
+    && callbacks.onOpenNetworkIntent
+  ) {
+    actionsDiv.appendChild(makeButton(
+      'Set Network Intent',
+      '#2563eb',
+      () => callbacks.onOpenNetworkIntent!(unitId),
+    ));
   }
 
   if (callbacks.onUpgradeUnit && !unit.hasActed) {

--- a/tests/ai/ai-network-intents.test.ts
+++ b/tests/ai/ai-network-intents.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, Unit } from '@/core/types';
+import { assignNetworkIntentsForAI } from '@/ai/ai-network-intents';
+
+function city(id: string, owner: string, q: number): City {
+  return {
+    id, name: id, owner, position: { q, r: 0 }, population: 2, food: 0, foodNeeded: 10,
+    buildings: [], productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'village', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+  };
+}
+
+function cyber(): Unit {
+  return { id: 'ai-cyber', type: 'cyber_unit', owner: 'ai-1', position: { q: 1, r: 0 }, movementPointsLeft: 3, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false };
+}
+
+describe('AI network intents', () => {
+  it('assigns a legal Exploit only when the target city is earned intel, otherwise leaves the Cyber Unit on Hold', () => {
+    const state = createNewGame(undefined, 'ai-network-intent', 'small');
+    state.units = { 'ai-cyber': cyber() };
+    state.cities = { target: city('target', 'player', 2) };
+    state.civilizations['ai-1'] = {
+      ...state.civilizations['ai-1'], units: ['ai-cyber'], cities: [],
+      techState: { ...state.civilizations['ai-1'].techState, completed: ['quantum-computing'] },
+      diplomacy: { ...state.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+      knownCivilizations: ['player'],
+    };
+    state.civilizations.player = {
+      ...state.civilizations.player,
+      cities: ['target'],
+      diplomacy: { ...state.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+    };
+
+    const unknown = assignNetworkIntentsForAI(state, 'ai-1', { knownCityIds: new Set() });
+    expect(unknown.autonomyByCiv!['ai-1'].plans).toEqual({});
+
+    const known = assignNetworkIntentsForAI(state, 'ai-1', { knownCityIds: new Set(['target']) });
+    expect(Object.values(known.autonomyByCiv!['ai-1'].plans)).toEqual([
+      expect.objectContaining({ definitionId: 'exploit', target: { kind: 'city', cityId: 'target' } }),
+    ]);
+  });
+});

--- a/tests/audio/pirate-sfx-generator.test.ts
+++ b/tests/audio/pirate-sfx-generator.test.ts
@@ -27,6 +27,18 @@ function generatedHashes(root: string): Record<string, string> {
   ));
 }
 
+function createGeneratorSandbox(): string {
+  const root = mkdtempSync(join(tmpdir(), 'conquestoria-pirate-sfx-'));
+  const script = join(root, 'scripts/generate-pirate-sfx.sh');
+  cpSync(join(PROJECT_ROOT, 'scripts/generate-pirate-sfx.sh'), script, { recursive: true });
+  for (const sourcePath of PIRATE_AUDIO_SOURCES.flatMap(source => source.sourceAssetFiles ?? [])) {
+    const localPath = join(root, 'public', sourcePath);
+    mkdirSync(dirname(localPath), { recursive: true });
+    cpSync(join(PROJECT_ROOT, 'public', sourcePath), localPath);
+  }
+  return root;
+}
+
 describe('pirate SFX generator', () => {
   it('records open-license provenance for every generated pirate cue', () => {
     const coveredFiles = new Set(PIRATE_AUDIO_SOURCES.flatMap(source => source.localFiles));
@@ -41,26 +53,30 @@ describe('pirate SFX generator', () => {
     expect(PIRATE_AUDIO_SOURCES.every(source => source.derivativeNotes.length > 0)).toBe(true);
   });
 
-  it('reproduces byte-identical audio on one runner and keeps checked-in outputs complete', () => {
-    const root = mkdtempSync(join(tmpdir(), 'conquestoria-pirate-sfx-'));
+  it('regenerates the checked-in pirate audio byte-for-byte', () => {
+    const root = createGeneratorSandbox();
     const script = join(root, 'scripts/generate-pirate-sfx.sh');
-    cpSync(join(PROJECT_ROOT, 'scripts/generate-pirate-sfx.sh'), script, { recursive: true });
-    for (const sourcePath of PIRATE_AUDIO_SOURCES.flatMap(source => source.sourceAssetFiles ?? [])) {
-      const localPath = join(root, 'public', sourcePath);
-      mkdirSync(dirname(localPath), { recursive: true });
-      cpSync(join(PROJECT_ROOT, 'public', sourcePath), localPath);
-    }
-
-    execFileSync('bash', [script], { stdio: 'pipe' });
-    const first = generatedHashes(root);
     execFileSync('bash', [script], { stdio: 'pipe' });
 
-    expect(generatedHashes(root)).toEqual(first);
-    expect(Object.keys(first)).toEqual(Object.keys(generatedHashes(PROJECT_ROOT)));
-    for (const outputPath of Object.keys(first)) {
+    const generated = generatedHashes(root);
+    expect(generated).toEqual(generatedHashes(PROJECT_ROOT));
+    expect(Object.keys(generated).sort()).toEqual(PIRATE_AUDIO_FILES.map(file => `public/${file}`).sort());
+    for (const outputPath of Object.keys(generated)) {
       expect(readFileSync(join(PROJECT_ROOT, outputPath)).subarray(0, 4).toString('ascii')).toBe('OggS');
     }
-    expect(Object.keys(first)).toHaveLength(35);
-  // CI can take longer than a developer laptop to encode the complete cue set twice.
-  }, 60_000);
+  }, 45_000);
+
+  it.skipIf(process.env.RUN_PIRATE_SFX_DETERMINISM !== '1')(
+    'reproduces byte-identical audio across two generations on one runner',
+    () => {
+      const root = createGeneratorSandbox();
+      const script = join(root, 'scripts/generate-pirate-sfx.sh');
+      execFileSync('bash', [script], { stdio: 'pipe' });
+      const first = generatedHashes(root);
+      execFileSync('bash', [script], { stdio: 'pipe' });
+
+      expect(generatedHashes(root)).toEqual(first);
+    },
+    90_000,
+  );
 });

--- a/tests/audio/pirate-sfx-generator.test.ts
+++ b/tests/audio/pirate-sfx-generator.test.ts
@@ -61,5 +61,6 @@ describe('pirate SFX generator', () => {
       expect(readFileSync(join(PROJECT_ROOT, outputPath)).subarray(0, 4).toString('ascii')).toBe('OggS');
     }
     expect(Object.keys(first)).toHaveLength(35);
-  }, 20_000);
+  // CI can take longer than a developer laptop to encode the complete cue set twice.
+  }, 60_000);
 });

--- a/tests/audio/pirate-sfx-generator.test.ts
+++ b/tests/audio/pirate-sfx-generator.test.ts
@@ -53,15 +53,16 @@ describe('pirate SFX generator', () => {
     expect(PIRATE_AUDIO_SOURCES.every(source => source.derivativeNotes.length > 0)).toBe(true);
   });
 
-  it('regenerates the checked-in pirate audio byte-for-byte', () => {
+  it('generates and ships exactly the declared pirate Ogg cues', () => {
     const root = createGeneratorSandbox();
     const script = join(root, 'scripts/generate-pirate-sfx.sh');
     execFileSync('bash', [script], { stdio: 'pipe' });
 
     const generated = generatedHashes(root);
-    expect(generated).toEqual(generatedHashes(PROJECT_ROOT));
     expect(Object.keys(generated).sort()).toEqual(PIRATE_AUDIO_FILES.map(file => `public/${file}`).sort());
-    for (const outputPath of Object.keys(generated)) {
+    const checkedIn = generatedHashes(PROJECT_ROOT);
+    expect(Object.keys(checkedIn).sort()).toEqual(Object.keys(generated).sort());
+    for (const outputPath of Object.keys(checkedIn)) {
       expect(readFileSync(join(PROJECT_ROOT, outputPath)).subarray(0, 4).toString('ascii')).toBe('OggS');
     }
   }, 45_000);

--- a/tests/core/autonomy-state.test.ts
+++ b/tests/core/autonomy-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyAutonomyCivState,
+  type NetworkPlan,
+} from '@/core/autonomy-state';
+import { createNewGame } from '@/core/game-state';
+
+describe('autonomy network state', () => {
+  it('creates an independent empty serializable state for a civilization', () => {
+    const first = createEmptyAutonomyCivState();
+    const second = createEmptyAutonomyCivState();
+
+    first.plans['network-plan-1'] = {
+      id: 'network-plan-1',
+      ownerCivId: 'player',
+      definitionId: 'exploit',
+      sourceUnitId: 'unit-1',
+      target: { kind: 'city', cityId: 'city-2' },
+      status: 'preparing',
+      createdTurn: 12,
+      nextResolutionTurn: 13,
+      warnedTurn: null,
+    };
+
+    expect(second).toEqual({ plans: {}, detections: {} });
+    expect(JSON.parse(JSON.stringify(first))).toEqual(first);
+  });
+
+  it('keeps closed target data rather than a live target reference', () => {
+    const plan: NetworkPlan = {
+      id: 'network-plan-8',
+      ownerCivId: 'ai-1',
+      definitionId: 'harden',
+      sourceUnitId: 'unit-4',
+      target: { kind: 'city', cityId: 'city-3' },
+      status: 'active',
+      createdTurn: 9,
+      nextResolutionTurn: 10,
+      warnedTurn: null,
+    };
+
+    expect(plan.target).toEqual({ kind: 'city', cityId: 'city-3' });
+    expect(Object.keys(plan.target)).toEqual(['kind', 'cityId']);
+  });
+
+  it('initializes independent empty autonomy records for every new civilization', () => {
+    const state = createNewGame('rome', 'autonomy-state-new-game', 'small');
+
+    expect(state.autonomyByCiv).toEqual(Object.fromEntries(
+      Object.keys(state.civilizations).map(civId => [civId, { plans: {}, detections: {} }]),
+    ));
+    expect(state.networkCivicPressureByCity).toEqual({});
+  });
+});

--- a/tests/core/migrate-id-counters.test.ts
+++ b/tests/core/migrate-id-counters.test.ts
@@ -12,6 +12,7 @@ describe('emptyIdCounters', () => {
       nextRouteId: 1,
       nextPirateFactionId: 1,
       nextNotificationId: 1,
+      nextNetworkPlanId: 1,
     });
   });
 
@@ -113,6 +114,22 @@ describe('scanIdCounters', () => {
 
     expect(counters.nextPirateFactionId).toBe(8);
     expect(counters.nextNotificationId).toBe(13);
+  });
+
+  it('scans persistent network plan IDs', () => {
+    const counters = scanIdCounters({
+      autonomyByCiv: {
+        player: {
+          plans: {
+            'network-plan-3': {} as never,
+            'network-plan-11': {} as never,
+          },
+          detections: {},
+        },
+      },
+    });
+
+    expect(counters.nextNetworkPlanId).toBe(12);
   });
 
   it('migrateLegacySave pattern: injects idCounters into a save that lacks it', () => {

--- a/tests/hooks/verification-config.test.sh
+++ b/tests/hooks/verification-config.test.sh
@@ -21,3 +21,19 @@ printf '%s' "$test_job" | grep -Fq 'run: yarn verify:push' || {
   echo "GitHub test job does not use the canonical verifier"
   exit 1
 }
+
+pirate_audio_job="$(
+  sed -n '/^  pirate-audio-reproducibility:/,/^  web-smoke:/p' "$ROOT/.github/workflows/deploy.yml"
+)"
+printf '%s' "$pirate_audio_job" | grep -Fq 'timeout-minutes: 10' || {
+  echo "Pirate audio reproducibility job has no bounded timeout"
+  exit 1
+}
+printf '%s' "$pirate_audio_job" | grep -Fq 'id: pirate-audio-changes' || {
+  echo "Pirate audio reproducibility job has no scoped input check"
+  exit 1
+}
+printf '%s' "$pirate_audio_job" | grep -Fq "RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts" || {
+  echo "Pirate audio reproducibility job does not run the scoped determinism test"
+  exit 1
+}

--- a/tests/integration/network-plan-turn-flow.test.ts
+++ b/tests/integration/network-plan-turn-flow.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+import { processTurn } from '@/core/turn-manager';
 import type { City, Unit } from '@/core/types';
 import {
   assignNetworkPlan,
@@ -40,7 +42,6 @@ function makePreparedExploit() {
 describe('network plan turn flow', () => {
   it('warns at victim-turn start and resolves only after that full response turn', () => {
     const prepared = makePreparedExploit();
-    prepared.turn = 2;
 
     const warned = beginNetworkPlansForVictimTurn(prepared, 'ai-1');
     const resolved = resolveNetworkPlansForVictimTurnEnd(
@@ -50,7 +51,7 @@ describe('network plan turn flow', () => {
     );
 
     expect(warned.warnings).toEqual([{ planId: 'network-plan-1', victimCivId: 'ai-1' }]);
-    expect(warned.state.autonomyByCiv!.player.plans['network-plan-1'].warnedTurn).toBe(2);
+    expect(warned.state.autonomyByCiv!.player.plans['network-plan-1'].warnedTurn).toBe(1);
     expect(resolved.creditsByOwner).toEqual({ player: 2 });
   });
 
@@ -62,5 +63,23 @@ describe('network plan turn flow', () => {
 
     expect(resolved.creditsByOwner).toEqual({});
     expect(resolved.events).toEqual([]);
+  });
+
+  it('routes activated victims through intent warning and resolution instead of the legacy passive drain', () => {
+    const prepared = makePreparedExploit();
+    prepared.turn = 2;
+    const bus = new EventBus();
+    const warned = vi.fn();
+    const resolved = vi.fn();
+    const passiveDrain = vi.fn();
+    bus.on('network:exploit-warning', warned);
+    bus.on('network:exploit-resolved', resolved);
+    bus.on('city:cyber-drained', passiveDrain);
+
+    processTurn(prepared, bus);
+
+    expect(warned).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'city-ai', victimCivId: 'ai-1' }));
+    expect(resolved).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'city-ai', ownerCivId: 'player' }));
+    expect(passiveDrain).not.toHaveBeenCalled();
   });
 });

--- a/tests/integration/network-plan-turn-flow.test.ts
+++ b/tests/integration/network-plan-turn-flow.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, Unit } from '@/core/types';
+import {
+  assignNetworkPlan,
+  beginNetworkPlansForVictimTurn,
+  resolveNetworkPlansForVictimTurnEnd,
+} from '@/systems/network-plan-system';
+
+function makePreparedExploit() {
+  const state = createNewGame('rome', 'network-plan-turn-flow', 'small');
+  const city: City = {
+    id: 'city-ai', name: 'Target', owner: 'ai-1', position: { q: 0, r: 0 }, population: 1,
+    food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'village', unrestLevel: 0,
+    unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+  };
+  const cyber: Unit = {
+    id: 'unit-cyber', type: 'cyber_unit', owner: 'player', position: { q: 1, r: 0 },
+    movementPointsLeft: 3, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+  };
+  state.cities = { [city.id]: city };
+  state.units = { [cyber.id]: cyber };
+  state.civilizations.player = {
+    ...state.civilizations.player,
+    units: [cyber.id],
+    techState: { ...state.civilizations.player.techState, completed: ['quantum-computing'] },
+    diplomacy: { ...state.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+  };
+  state.civilizations['ai-1'] = {
+    ...state.civilizations['ai-1'],
+    cities: [city.id],
+    diplomacy: { ...state.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+  };
+  return assignNetworkPlan(state, {
+    ownerCivId: 'player', sourceUnitId: cyber.id, definitionId: 'exploit', target: { kind: 'city', cityId: city.id },
+  }).state;
+}
+
+describe('network plan turn flow', () => {
+  it('warns at victim-turn start and resolves only after that full response turn', () => {
+    const prepared = makePreparedExploit();
+    prepared.turn = 2;
+
+    const warned = beginNetworkPlansForVictimTurn(prepared, 'ai-1');
+    const resolved = resolveNetworkPlansForVictimTurnEnd(
+      warned.state,
+      'ai-1',
+      { 'city-ai': 20 },
+    );
+
+    expect(warned.warnings).toEqual([{ planId: 'network-plan-1', victimCivId: 'ai-1' }]);
+    expect(warned.state.autonomyByCiv!.player.plans['network-plan-1'].warnedTurn).toBe(2);
+    expect(resolved.creditsByOwner).toEqual({ player: 2 });
+  });
+
+  it('does not resolve an un-warned prepared Exploit at victim-turn end', () => {
+    const prepared = makePreparedExploit();
+    prepared.turn = 2;
+
+    const resolved = resolveNetworkPlansForVictimTurnEnd(prepared, 'ai-1', { 'city-ai': 20 });
+
+    expect(resolved.creditsByOwner).toEqual({});
+    expect(resolved.events).toEqual([]);
+  });
+});

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
+import type { City, Unit } from '@/core/types';
 import {
   CURRENT_SAVE_SCHEMA_VERSION,
   migrateSaveToCurrent,
@@ -142,5 +143,41 @@ describe('save migrations', () => {
     ));
     expect(migrated.idCounters.nextNetworkPlanId).toBe(1);
     expect(loadedAgain).toEqual(migrated);
+  });
+
+  it('migrates activated legacy Cyber Units in stable order with one Exploit per city', () => {
+    const legacySave = createNewGame('rome', 'autonomy-activated-migration', 'small');
+    legacySave.saveSchemaVersion = 2;
+    const city: City = {
+      id: 'city-ai', name: 'Target', owner: 'ai-1', position: { q: 0, r: 0 }, population: 1,
+      food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+      ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'village', unrestLevel: 0,
+      unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+    };
+    const cyber = (id: string): Unit => ({
+      id, type: 'cyber_unit', owner: 'player', position: { q: 1, r: 0 }, movementPointsLeft: 3,
+      health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+    });
+    legacySave.cities = { [city.id]: city };
+    legacySave.units = { 'unit-9': cyber('unit-9'), 'unit-2': cyber('unit-2') };
+    legacySave.civilizations.player = {
+      ...legacySave.civilizations.player,
+      units: ['unit-9', 'unit-2'],
+      techState: { ...legacySave.civilizations.player.techState, completed: ['quantum-computing'] },
+      diplomacy: { ...legacySave.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+    };
+    legacySave.civilizations['ai-1'] = {
+      ...legacySave.civilizations['ai-1'],
+      cities: [city.id],
+      diplomacy: { ...legacySave.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+    };
+    delete legacySave.autonomyByCiv;
+
+    const migrated = migrateSaveToCurrent(legacySave);
+
+    expect(migrated.autonomyByCiv!.player.plans).toEqual({
+      'network-plan-1': expect.objectContaining({ sourceUnitId: 'unit-2', definitionId: 'exploit', target: { kind: 'city', cityId: 'city-ai' } }),
+    });
+    expect(migrated.idCounters.nextNetworkPlanId).toBe(2);
   });
 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -106,7 +106,7 @@ describe('save migrations', () => {
     const loadedAgain = migrateSaveToCurrent(migrated);
     const resources = new Set(Object.values(migrated.map.tiles).map(tile => tile.resource));
 
-    expect(migrated.saveSchemaVersion).toBe(2);
+    expect(migrated.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
     for (const resource of ['coal', 'oil', 'aluminum', 'uranium', 'rare-earth-elements', 'battery-minerals']) {
       expect(resources).toContain(resource);
       expect(migrated.marketplace!.prices[resource]).toBeGreaterThan(0);
@@ -123,5 +123,24 @@ describe('save migrations', () => {
 
     const migrated = migrateSaveToCurrent(legacySave);
     expect(migrated.cities[city.id].legacyResourceGrace).toEqual(['oil_refinery']);
+  });
+
+  it('migrates a schema-v2 pre-Autonomy save to empty network state once', () => {
+    const legacySave = createNewGame('rome', 'autonomy-pre-activation', 'small');
+    legacySave.saveSchemaVersion = 2;
+    delete legacySave.autonomyByCiv;
+    delete legacySave.networkCivicPressureByCity;
+    delete legacySave.idCounters.nextNetworkPlanId;
+
+    const migrated = migrateSaveToCurrent(legacySave);
+    const loadedAgain = migrateSaveToCurrent(migrated);
+
+    expect(migrated.saveSchemaVersion).toBe(3);
+    expect(migrated.networkCivicPressureByCity).toEqual({});
+    expect(migrated.autonomyByCiv).toEqual(Object.fromEntries(
+      Object.keys(migrated.civilizations).map(civId => [civId, { plans: {}, detections: {} }]),
+    ));
+    expect(migrated.idCounters.nextNetworkPlanId).toBe(1);
+    expect(loadedAgain).toEqual(migrated);
   });
 });

--- a/tests/systems/cyber-warfare-system.test.ts
+++ b/tests/systems/cyber-warfare-system.test.ts
@@ -108,6 +108,16 @@ describe('processCyberDrain', () => {
     expect(result.events).toEqual([]);
   });
 
+  it('does not apply the Era 12 passive drain after the victim activates Autonomy', () => {
+    const state = makeState({
+      cities: [makeCity({ id: 'city-p1', owner: 'p1', position: { q: 1, r: 0 } })],
+      units: [makeCyberUnit({ id: 'cu1', owner: 'p2', position: { q: 2, r: 0 } })],
+    });
+    state.civilizations.p1.techState = { completed: ['quantum-computing'] } as any;
+
+    expect(processCyberDrain(state, 'p1', 10)).toEqual({ remainingGold: 10, creditsByOwner: {}, events: [] });
+  });
+
   it('drains 4 total gold when two adjacent enemy cyber units threaten the same city', () => {
     const state = makeState({
       turn: 1,

--- a/tests/systems/id-counters.test.ts
+++ b/tests/systems/id-counters.test.ts
@@ -204,6 +204,7 @@ describe('emptyIdCounters', () => {
       nextRouteId: 1,
       nextPirateFactionId: 1,
       nextNotificationId: 1,
+      nextNetworkPlanId: 1,
     });
   });
 

--- a/tests/systems/network-effect-resolver.test.ts
+++ b/tests/systems/network-effect-resolver.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, GameState, Unit } from '@/core/types';
+import { assignNetworkPlan } from '@/systems/network-plan-system';
+import { resolveNetworkPlanAtTargetEnd } from '@/systems/network-effect-resolver';
+
+function makeCity(id: string, owner: string, q: number, buildings: string[] = []): City {
+  return {
+    id, name: id, owner, position: { q, r: 0 }, population: 1, food: 0, foodNeeded: 10,
+    buildings, productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'village', unrestLevel: 0, unrestTurns: 0,
+    spyUnrestBonus: 0, idleProduction: null,
+  };
+}
+
+function makeCyberUnit(id: string, owner: string, q: number): Unit {
+  return {
+    id, type: 'cyber_unit', owner, position: { q, r: 0 }, movementPointsLeft: 3,
+    health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+  };
+}
+
+function makeExploitState(targetBuildings: string[] = []): GameState {
+  const state = createNewGame('rome', 'network-effect-resolver', 'small');
+  const target = makeCity('city-ai', 'ai-1', 0, targetBuildings);
+  const source = makeCyberUnit('unit-cyber', 'player', 1);
+  state.cities = { [target.id]: target };
+  state.units = { [source.id]: source };
+  state.civilizations.player = {
+    ...state.civilizations.player,
+    units: [source.id],
+    techState: { ...state.civilizations.player.techState, completed: ['quantum-computing'] },
+    diplomacy: { ...state.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+  };
+  state.civilizations['ai-1'] = {
+    ...state.civilizations['ai-1'],
+    cities: [target.id],
+    diplomacy: { ...state.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+  };
+  const assigned = assignNetworkPlan(state, {
+    ownerCivId: 'player', sourceUnitId: source.id, definitionId: 'exploit', target: { kind: 'city', cityId: target.id },
+  });
+  return assigned.state;
+}
+
+describe('network effect resolver', () => {
+  it('transfers floor of the normal 10 percent base city gold', () => {
+    const result = resolveNetworkPlanAtTargetEnd(makeExploitState(), 'network-plan-1', { baseCityGold: 19 });
+
+    expect(result.events).toEqual([expect.objectContaining({ kind: 'exploit-resolved', goldTransferred: 1 })]);
+    expect(result.creditsByOwner).toEqual({ player: 1 });
+  });
+
+  it('does not transfer gold from a zero-gold city', () => {
+    const result = resolveNetworkPlanAtTargetEnd(makeExploitState(), 'network-plan-1', { baseCityGold: 0 });
+
+    expect(result.events).toEqual([expect.objectContaining({ kind: 'exploit-resolved', goldTransferred: 0 })]);
+    expect(result.creditsByOwner).toEqual({});
+  });
+
+  it('delays the first CDC-protected resolution then halves the next one', () => {
+    const delayed = resolveNetworkPlanAtTargetEnd(
+      makeExploitState(['cyber_defense_center']),
+      'network-plan-1',
+      { baseCityGold: 20 },
+    );
+    const resolved = resolveNetworkPlanAtTargetEnd(delayed.state, 'network-plan-1', { baseCityGold: 20 });
+
+    expect(delayed.events).toEqual([expect.objectContaining({ kind: 'exploit-delayed', goldTransferred: 0 })]);
+    expect(resolved.events).toEqual([expect.objectContaining({ kind: 'exploit-resolved', goldTransferred: 1 })]);
+  });
+
+  it('consumes one Harden charge to halve the remaining Exploit amount', () => {
+    const state = makeExploitState();
+    const hardener = makeCyberUnit('unit-hardener', 'ai-1', 1);
+    state.units[hardener.id] = hardener;
+    state.civilizations['ai-1'] = {
+      ...state.civilizations['ai-1'],
+      units: [hardener.id],
+      techState: { ...state.civilizations['ai-1'].techState, completed: ['quantum-computing'] },
+    };
+    const hardened = assignNetworkPlan(state, {
+      ownerCivId: 'ai-1', sourceUnitId: hardener.id, definitionId: 'harden', target: { kind: 'city', cityId: 'city-ai' },
+    });
+
+    const result = resolveNetworkPlanAtTargetEnd(hardened.state, 'network-plan-1', { baseCityGold: 20 });
+
+    expect(result.events).toEqual([expect.objectContaining({ kind: 'exploit-resolved', goldTransferred: 1 })]);
+    expect(result.state.autonomyByCiv!['ai-1'].plans['network-plan-2'].effectState?.hardenCharges).toBe(0);
+  });
+});

--- a/tests/systems/network-plan-definitions.test.ts
+++ b/tests/systems/network-plan-definitions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getNetworkPlanDefinition,
+  NETWORK_PLAN_DEFINITIONS,
+} from '@/systems/network-plan-definitions';
+
+describe('network plan definitions', () => {
+  it('defines Harden as a friendly adjacent mitigation plan', () => {
+    expect(getNetworkPlanDefinition('harden')).toEqual({
+      id: 'harden',
+      targetKind: 'friendly-city',
+      range: 1,
+      load: 1,
+      effect: {
+        kind: 'mitigation-charge',
+        mitigationPercent: 50,
+        regularChargeCap: 1,
+        regularRefreshOwnerRounds: 2,
+        aiSafetyRefreshOwnerRounds: 1,
+      },
+    });
+  });
+
+  it('defines Exploit as an adjacent at-war city plan with future Surge metadata only', () => {
+    expect(getNetworkPlanDefinition('exploit')).toEqual({
+      id: 'exploit',
+      targetKind: 'at-war-enemy-city',
+      range: 1,
+      load: 2,
+      effect: {
+        kind: 'city-gold-transfer',
+        normalPercent: 10,
+        surgedPercent: 15,
+      },
+    });
+    expect(Object.keys(NETWORK_PLAN_DEFINITIONS).sort()).toEqual(['exploit', 'harden']);
+  });
+});

--- a/tests/systems/network-plan-system.test.ts
+++ b/tests/systems/network-plan-system.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, GameState, Unit } from '@/core/types';
+import {
+  assignNetworkPlan,
+  holdNetworkPlan,
+  isAutonomyActivated,
+  retargetNetworkPlan,
+  validateNetworkPlanAssignment,
+} from '@/systems/network-plan-system';
+
+function makeCity(id: string, owner: string, q: number): City {
+  return {
+    id,
+    name: id,
+    owner,
+    position: { q, r: 0 },
+    population: 1,
+    food: 0,
+    foodNeeded: 10,
+    buildings: [],
+    productionQueue: [],
+    productionProgress: 0,
+    ownedTiles: [],
+    workedTiles: [],
+    focus: 'balanced',
+    maturity: 'village',
+    unrestLevel: 0,
+    unrestTurns: 0,
+    spyUnrestBonus: 0,
+    idleProduction: null,
+  };
+}
+
+function makeCyberUnit(id: string, owner: string, q: number): Unit {
+  return {
+    id,
+    type: 'cyber_unit',
+    owner,
+    position: { q, r: 0 },
+    movementPointsLeft: 3,
+    health: 100,
+    experience: 0,
+    hasMoved: false,
+    hasActed: false,
+    isResting: false,
+  };
+}
+
+function makeState(): GameState {
+  const state = createNewGame('rome', 'network-plan-system', 'small');
+  const playerCity = makeCity('city-player', 'player', 0);
+  const enemyCity = makeCity('city-ai', 'ai-1', 2);
+  const cyberUnit = makeCyberUnit('unit-cyber', 'player', 1);
+  state.cities = { [playerCity.id]: playerCity, [enemyCity.id]: enemyCity };
+  state.units = { [cyberUnit.id]: cyberUnit };
+  state.civilizations.player = {
+    ...state.civilizations.player,
+    cities: [playerCity.id],
+    units: [cyberUnit.id],
+    techState: { ...state.civilizations.player.techState, completed: ['quantum-computing'] },
+    diplomacy: { ...state.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+  };
+  state.civilizations['ai-1'] = {
+    ...state.civilizations['ai-1'],
+    cities: [enemyCity.id],
+    units: [],
+    diplomacy: { ...state.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+  };
+  state.idCounters.nextNetworkPlanId = 1;
+  return state;
+}
+
+describe('network plan lifecycle', () => {
+  it('activates only after a civilization completes its first Era 13 technology', () => {
+    const state = makeState();
+    expect(isAutonomyActivated(state, 'player')).toBe(true);
+
+    state.civilizations.player.techState.completed = ['cloud-computing'];
+    expect(isAutonomyActivated(state, 'player')).toBe(false);
+  });
+
+  it('assigns Harden immutably with a stable plan ID', () => {
+    const state = makeState();
+    const result = assignNetworkPlan(state, {
+      ownerCivId: 'player',
+      sourceUnitId: 'unit-cyber',
+      definitionId: 'harden',
+      target: { kind: 'city', cityId: 'city-player' },
+    });
+
+    expect(result.validation).toEqual({ ok: true });
+    expect(result.plan).toMatchObject({
+      id: 'network-plan-1',
+      definitionId: 'harden',
+      status: 'active',
+      sourceUnitId: 'unit-cyber',
+    });
+    expect(result.state.autonomyByCiv!.player.plans['network-plan-1']).toEqual(result.plan);
+    expect(result.state.idCounters.nextNetworkPlanId).toBe(2);
+    expect(state.autonomyByCiv!.player.plans).toEqual({});
+    expect(state.idCounters.nextNetworkPlanId).toBe(1);
+  });
+
+  it('rejects Exploit without bilateral war and leaves state untouched', () => {
+    const state = makeState();
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+    const request = {
+      ownerCivId: 'player',
+      sourceUnitId: 'unit-cyber',
+      definitionId: 'exploit' as const,
+      target: { kind: 'city' as const, cityId: 'city-ai' },
+    };
+
+    expect(validateNetworkPlanAssignment(state, request)).toEqual({ ok: false, reason: 'target-not-at-war' });
+    expect(assignNetworkPlan(state, request)).toMatchObject({ state, validation: { ok: false, reason: 'target-not-at-war' }, plan: null });
+  });
+
+  it('retargets an active Harden plan without allocating another ID', () => {
+    const state = makeState();
+    const secondCity = makeCity('city-player-2', 'player', 2);
+    state.cities[secondCity.id] = secondCity;
+    state.civilizations.player.cities.push(secondCity.id);
+    const assigned = assignNetworkPlan(state, {
+      ownerCivId: 'player',
+      sourceUnitId: 'unit-cyber',
+      definitionId: 'harden',
+      target: { kind: 'city', cityId: 'city-player' },
+    });
+
+    const retargeted = retargetNetworkPlan(assigned.state, 'player', 'network-plan-1', {
+      kind: 'city', cityId: 'city-player-2',
+    });
+
+    expect(retargeted.validation).toEqual({ ok: true });
+    expect(retargeted.plan).toMatchObject({ id: 'network-plan-1', target: { kind: 'city', cityId: 'city-player-2' } });
+    expect(retargeted.state.idCounters.nextNetworkPlanId).toBe(2);
+  });
+
+  it('puts a Cyber Unit on Hold by removing its current plan', () => {
+    const assigned = assignNetworkPlan(makeState(), {
+      ownerCivId: 'player',
+      sourceUnitId: 'unit-cyber',
+      definitionId: 'harden',
+      target: { kind: 'city', cityId: 'city-player' },
+    });
+
+    const held = holdNetworkPlan(assigned.state, 'player', 'unit-cyber');
+
+    expect(held.validation).toEqual({ ok: true });
+    expect(held.plan).toBeNull();
+    expect(held.state.autonomyByCiv!.player.plans).toEqual({});
+    expect(held.state.idCounters.nextNetworkPlanId).toBe(2);
+  });
+});

--- a/tests/systems/network-plan-system.test.ts
+++ b/tests/systems/network-plan-system.test.ts
@@ -5,6 +5,7 @@ import {
   assignNetworkPlan,
   holdNetworkPlan,
   isAutonomyActivated,
+  cancelInvalidNetworkPlans,
   retargetNetworkPlan,
   validateNetworkPlanAssignment,
 } from '@/systems/network-plan-system';
@@ -152,5 +153,20 @@ describe('network plan lifecycle', () => {
     expect(held.plan).toBeNull();
     expect(held.state.autonomyByCiv!.player.plans).toEqual({});
     expect(held.state.idCounters.nextNetworkPlanId).toBe(2);
+  });
+
+  it('cancels an Exploit immediately when its source leaves range', () => {
+    const assigned = assignNetworkPlan(makeState(), {
+      ownerCivId: 'player',
+      sourceUnitId: 'unit-cyber',
+      definitionId: 'exploit',
+      target: { kind: 'city', cityId: 'city-ai' },
+    });
+    assigned.state.units['unit-cyber'] = { ...assigned.state.units['unit-cyber'], position: { q: 5, r: 0 } };
+
+    const cleaned = cancelInvalidNetworkPlans(assigned.state);
+
+    expect(cleaned.state.autonomyByCiv!.player.plans).toEqual({});
+    expect(cleaned.cancelled).toEqual([{ planId: 'network-plan-1', reason: 'target-out-of-range' }]);
   });
 });

--- a/tests/systems/network-viewer-intel.test.ts
+++ b/tests/systems/network-viewer-intel.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, Unit } from '@/core/types';
+import { assignNetworkPlan } from '@/systems/network-plan-system';
+import { getNetworkWarningForViewer } from '@/systems/network-viewer-intel';
+
+function makeState() {
+  const state = createNewGame('rome', 'network-viewer-intel', 'small');
+  const city: City = {
+    id: 'city-ai', name: 'Target', owner: 'ai-1', position: { q: 0, r: 0 }, population: 1,
+    food: 0, foodNeeded: 10, buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'village', unrestLevel: 0,
+    unrestTurns: 0, spyUnrestBonus: 0, idleProduction: null,
+  };
+  const cyber: Unit = {
+    id: 'unit-cyber', type: 'cyber_unit', owner: 'player', position: { q: 1, r: 0 },
+    movementPointsLeft: 3, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+  };
+  state.cities = { [city.id]: city };
+  state.units = { [cyber.id]: cyber };
+  state.civilizations.player = {
+    ...state.civilizations.player,
+    units: [cyber.id],
+    techState: { ...state.civilizations.player.techState, completed: ['quantum-computing'] },
+    diplomacy: { ...state.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+  };
+  state.civilizations['ai-1'] = {
+    ...state.civilizations['ai-1'],
+    cities: [city.id],
+    diplomacy: { ...state.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+  };
+  return assignNetworkPlan(state, {
+    ownerCivId: 'player', sourceUnitId: cyber.id, definitionId: 'exploit', target: { kind: 'city', cityId: city.id },
+  }).state;
+}
+
+describe('network viewer intel', () => {
+  it('shows an Exploit victim the effect and counter without leaking its source', () => {
+    const warning = getNetworkWarningForViewer(makeState(), 'ai-1', 'network-plan-1');
+
+    expect(warning).toEqual({
+      planId: 'network-plan-1',
+      targetCityId: 'city-ai',
+      effectLabel: 'Exploit',
+      counterLabel: 'Cyber Defense Center or Harden',
+    });
+  });
+
+  it('discloses source identity and coordinates only from the viewer detection record', () => {
+    const state = makeState();
+    state.autonomyByCiv!['ai-1'].detections['network-plan-1'] = {
+      planId: 'network-plan-1', detectedTurn: state.turn, sourceIdentityKnown: true, sourcePositionKnown: true,
+    };
+
+    expect(getNetworkWarningForViewer(state, 'ai-1', 'network-plan-1')).toMatchObject({
+      source: { unitId: 'unit-cyber', position: { q: 1, r: 0 } },
+    });
+  });
+});

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -138,6 +138,44 @@ describe('unit-movement-system', () => {
     expect(moves).toHaveLength(1);
   });
 
+  it('cancels a Cyber Exploit when live movement breaks its range', () => {
+    const cyber = createUnit('cyber_unit', 'player', { q: 1, r: 0 }, mkC());
+    cyber.id = 'unit-cyber';
+    const state = movementState(cyber, [tile({ q: 0, r: 0 }), tile({ q: 1, r: 0 }), tile({ q: 2, r: 0 })], {
+      completedTechs: ['quantum-computing'],
+    });
+    const target = foundCity('ai-1', { q: 0, r: 0 }, state.map, state.idCounters);
+    target.id = 'city-ai';
+    state.cities[target.id] = target;
+    state.civilizations['ai-1'] = {
+      ...state.civilizations.player,
+      id: 'ai-1',
+      name: 'ai-1',
+      isHuman: false,
+      cities: [target.id],
+      units: [],
+      diplomacy: createDiplomacyState(['player', 'ai-1'], 'ai-1'),
+    };
+    state.civilizations.player.diplomacy = createDiplomacyState(['player', 'ai-1'], 'player');
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.autonomyByCiv = {
+      player: {
+        plans: {
+          'network-plan-1': {
+            id: 'network-plan-1', ownerCivId: 'player', definitionId: 'exploit', sourceUnitId: cyber.id,
+            target: { kind: 'city', cityId: target.id }, status: 'preparing', createdTurn: 1, nextResolutionTurn: 2, warnedTurn: null,
+          },
+        },
+        detections: {},
+      },
+      'ai-1': { plans: {}, detections: {} },
+    };
+
+    expect(executeUnitMove(state, cyber.id, { q: 2, r: 0 }, { actor: 'player', civId: 'player' })).toMatchObject({ ok: true });
+    expect(state.autonomyByCiv.player.plans).toEqual({});
+  });
+
   it('does not let world actors bypass occupancy', () => {
     const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
     mover.id = 'world-mover';

--- a/tests/ui/network-intent-panel.test.ts
+++ b/tests/ui/network-intent-panel.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import type { City, GameState, Unit } from '@/core/types';
+import { getNetworkIntentPanelModel } from '@/ui/network-intent-panel';
+
+function city(id: string, owner: string, q: number): City {
+  return {
+    id, name: id, owner, position: { q, r: 0 }, population: 1, food: 0, foodNeeded: 10,
+    buildings: [], productionQueue: [], productionProgress: 0, ownedTiles: [], workedTiles: [],
+    focus: 'balanced', maturity: 'village', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    idleProduction: null,
+  };
+}
+
+function cyber(): Unit {
+  return {
+    id: 'cyber', type: 'cyber_unit', owner: 'player', position: { q: 1, r: 0 },
+    movementPointsLeft: 3, health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+  };
+}
+
+function state(): GameState {
+  const game = createNewGame(undefined, 'network-intent-panel', 'small');
+  game.units = { cyber: cyber() };
+  game.cities = {
+    friendly: city('friendly', 'player', 0),
+    enemy: city('enemy', 'ai-1', 2),
+    distant: city('distant', 'ai-1', 5),
+  };
+  game.civilizations.player = {
+    ...game.civilizations.player,
+    units: ['cyber'], cities: ['friendly'],
+    techState: { ...game.civilizations.player.techState, completed: ['quantum-computing'] },
+    diplomacy: { ...game.civilizations.player.diplomacy, atWarWith: ['ai-1'] },
+  };
+  game.civilizations['ai-1'] = {
+    ...game.civilizations['ai-1'], cities: ['enemy', 'distant'],
+    diplomacy: { ...game.civilizations['ai-1'].diplomacy, atWarWith: ['player'] },
+  };
+  return game;
+}
+
+describe('network intent panel model', () => {
+  it('keeps both persistent choices understandable and filters city targets to legal range and war state', () => {
+    const model = getNetworkIntentPanelModel(state(), 'player', 'cyber');
+
+    expect(model).toMatchObject({ sourceName: 'Cyber Unit', currentIntentLabel: 'Hold' });
+    expect(model.hardenTargets).toEqual([{ cityId: 'friendly', cityName: 'friendly' }]);
+    expect(model.exploitTargets).toEqual([{ cityId: 'enemy', cityName: 'enemy' }]);
+    expect(model.hardenDescription).toContain('half');
+    expect(model.exploitDescription).toContain('10%');
+  });
+});

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -1525,3 +1525,36 @@ describe('renderSelectedUnitInfo — pirate enclave assault', () => {
     expect(opened).toBe(true);
   });
 });
+
+describe('renderSelectedUnitInfo — Cyber Unit intent launcher', () => {
+  beforeEach(installMockDocument);
+  afterEach(restoreMockDocument);
+
+  it('shows the intent launcher only to an activated owning player and invokes it with the current unit', () => {
+    const state = createNewGame(undefined, 'cyber-intent-launcher', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      cyber: {
+        ...createUnit('cyber_unit', 'player', { q: 1, r: 1 }, {
+          nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+        }),
+        id: 'cyber',
+      },
+    };
+    state.civilizations.player.units = ['cyber'];
+    state.civilizations.player.techState.completed = ['quantum-computing'];
+    const onOpenNetworkIntent = vi.fn();
+    const container = new MockElement('div');
+
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'cyber', { onOpenNetworkIntent });
+
+    const launcher = findButtons(container).find(button => button.textContent === 'Set Network Intent');
+    expect(launcher).toBeDefined();
+    launcher?.click();
+    expect(onOpenNetworkIntent).toHaveBeenCalledWith('cyber');
+
+    state.civilizations.player.techState.completed = [];
+    renderSelectedUnitInfo(container as unknown as HTMLElement, state, 'cyber', { onOpenNetworkIntent });
+    expect(collectAllText(container)).not.toContain('Set Network Intent');
+  });
+});


### PR DESCRIPTION
## Summary
- Deliver persistent Harden and Exploit Cyber Unit intents with deterministic effect resolution, migration, lifecycle cleanup, and viewer-safe warnings.
- Wire selected-unit UI, solo and hot-seat response timing, AI intent selection, notifications, and existing feedback routing.
- Preserve Era 12 passive drain before Autonomy and prevent double application after activation.

## Verification
- `bash scripts/run-with-mise.sh yarn test --reporter=dot`
- `bash scripts/run-with-mise.sh yarn build`
- `git diff --check origin/main...HEAD`

## Inline review
Reviewed balance/fun, player clarity for ages 7–43, play styles, difficulties, AI, UI/UX, architecture/data extensibility, feedback, saves, testing, solo and hot-seat behavior. Fixed the P0 hot-seat response-timing issue before this MR.