### PR TITLE
test(ci): isolate pirate audio generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,11 +113,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Install audio test tooling
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ffmpeg
-
       - name: Run tests
         run: yarn verify:push
 
@@ -171,9 +166,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y ffmpeg
 
-      - name: Verify deterministic pirate audio
+      - name: Verify pirate audio generation and determinism
         if: steps.pirate-audio-changes.outputs.pirate_audio_changed == 'true'
-        run: RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts -t "reproduces byte-identical audio across two generations on one runner"
+        run: RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts
 
       - name: Report skipped deterministic audio check
         if: steps.pirate-audio-changes.outputs.pirate_audio_changed != 'true'

--- a/tests/audio/pirate-sfx-generator.test.ts
+++ b/tests/audio/pirate-sfx-generator.test.ts
@@ -53,19 +53,13 @@ describe('pirate SFX generator', () => {
     expect(PIRATE_AUDIO_SOURCES.every(source => source.derivativeNotes.length > 0)).toBe(true);
   });
 
-  it('generates and ships exactly the declared pirate Ogg cues', () => {
-    const root = createGeneratorSandbox();
-    const script = join(root, 'scripts/generate-pirate-sfx.sh');
-    execFileSync('bash', [script], { stdio: 'pipe' });
-
-    const generated = generatedHashes(root);
-    expect(Object.keys(generated).sort()).toEqual(PIRATE_AUDIO_FILES.map(file => `public/${file}`).sort());
+  it('ships exactly the declared pirate Ogg cues', () => {
     const checkedIn = generatedHashes(PROJECT_ROOT);
-    expect(Object.keys(checkedIn).sort()).toEqual(Object.keys(generated).sort());
+    expect(Object.keys(checkedIn).sort()).toEqual(PIRATE_AUDIO_FILES.map(file => `public/${file}`).sort());
     for (const outputPath of Object.keys(checkedIn)) {
       expect(readFileSync(join(PROJECT_ROOT, outputPath)).subarray(0, 4).toString('ascii')).toBe('OggS');
     }
-  }, 45_000);
+  });
 
   it.skipIf(process.env.RUN_PIRATE_SFX_DETERMINISM !== '1')(
     'reproduces byte-identical audio across two generations on one runner',
@@ -74,6 +68,10 @@ describe('pirate SFX generator', () => {
       const script = join(root, 'scripts/generate-pirate-sfx.sh');
       execFileSync('bash', [script], { stdio: 'pipe' });
       const first = generatedHashes(root);
+      expect(Object.keys(first).sort()).toEqual(PIRATE_AUDIO_FILES.map(file => `public/${file}`).sort());
+      for (const outputPath of Object.keys(first)) {
+        expect(readFileSync(join(root, outputPath)).subarray(0, 4).toString('ascii')).toBe('OggS');
+      }
       execFileSync('bash', [script], { stdio: 'pipe' });
 
       expect(generatedHashes(root)).toEqual(first);

--- a/tests/hooks/verification-config.test.sh
+++ b/tests/hooks/verification-config.test.sh
@@ -11,7 +11,7 @@ grep -Fq '"verify:push": "sh scripts/verify-before-push.sh --no-mise"' "$ROOT/pa
 }
 
 test_job="$(
-  sed -n '/^  test:/,/^  web-smoke:/p' "$ROOT/.github/workflows/deploy.yml"
+  sed -n '/^  test:/,/^  pirate-audio-reproducibility:/p' "$ROOT/.github/workflows/deploy.yml"
 )"
 printf '%s' "$test_job" | grep -Fq 'timeout-minutes: 15' || {
   echo "GitHub test job has no 15-minute timeout"
@@ -21,6 +21,10 @@ printf '%s' "$test_job" | grep -Fq 'run: yarn verify:push' || {
   echo "GitHub test job does not use the canonical verifier"
   exit 1
 }
+if printf '%s' "$test_job" | grep -Fq 'Install audio test tooling'; then
+  echo "GitHub test job runs pirate audio tooling in the parallel suite"
+  exit 1
+fi
 
 pirate_audio_job="$(
   sed -n '/^  pirate-audio-reproducibility:/,/^  web-smoke:/p' "$ROOT/.github/workflows/deploy.yml"
@@ -33,7 +37,11 @@ printf '%s' "$pirate_audio_job" | grep -Fq 'id: pirate-audio-changes' || {
   echo "Pirate audio reproducibility job has no scoped input check"
   exit 1
 }
-printf '%s' "$pirate_audio_job" | grep -Fq "RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts" || {
-  echo "Pirate audio reproducibility job does not run the scoped determinism test"
+printf '%s' "$pirate_audio_job" | grep -Fq "run: RUN_PIRATE_SFX_DETERMINISM=1 yarn vitest run tests/audio/pirate-sfx-generator.test.ts" || {
+  echo "Pirate audio reproducibility job does not run the scoped generator test"
   exit 1
 }
+if printf '%s' "$pirate_audio_job" | grep -Fq -- ' -t '; then
+  echo "Pirate audio reproducibility job skips catalog or format coverage"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- keep the normal Vitest suite free of FFmpeg generation work
- run pirate-audio generation and same-run determinism only in its scoped CI job
- lock the lane separation with the verification-config hook test

## Root cause
The pirate generator launches many FFmpeg/FFprobe processes. Running it inside the default parallel suite made UI tests load-sensitive; the heavy generator belongs in a dedicated integration lane.

## Verification
- bash scripts/run-with-mise.sh yarn test
- bash scripts/run-with-mise.sh yarn build
- focused pirate generator tests with and without RUN_PIRATE_SFX_DETERMINISM=1