### PR TITLE
City as a combat entity: intrinsic strength + counter-fire for ungarrisoned cities

### DIFF
--- a/docs/superpowers/plans/2026-07-12-city-combat-entity.md
+++ b/docs/superpowers/plans/2026-07-12-city-combat-entity.md
@@ -1,0 +1,1865 @@
+# City As A Combat Entity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task (this project's CLAUDE.md forbids subagents — execute inline). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give cities intrinsic combat strength derived from population + the existing `getCityDefenseBreakdown` (walls/Star Fort/techs), so an ungarrisoned walled city can no longer be captured for free, and give walled cities automatic ranged counter-fire against any attacker (player, barbarian, pirate) that reaches them without a garrison.
+
+**Architecture:** Two new pure calculation functions in `city-siege-system.ts` (`getCityIntrinsicStrength`, `getCityCounterFireDamage`) plus a lightweight win/lose resolver (`resolveCityAssault`) that deliberately does *not* route through `resolveCombat`'s full unit-vs-unit machinery — a city isn't a `Unit`. Three call sites (player capture, barbarian siege, pirate siege) apply the same counter-fire formula; only the player path also gates on win/lose, since barbarian/pirate sieges are already a multi-turn `city.hp` grind that doesn't need a discrete win/lose check.
+
+**Tech Stack:** TypeScript, Vite, Vitest. Canvas 2D renderer, EventBus, single serializable plain-object game state, DOM-based UI panels.
+
+## Global Constraints
+
+- **Commands:** build with `bash scripts/run-with-mise.sh yarn build` (the only path that runs `tsc`); test with `bash scripts/run-with-mise.sh yarn test`. Both must exit 0 before any push.
+- **Determinism:** never `Math.random()` — every RNG draw uses a seeded generator, same pattern as `resolveCombat`'s `(rngState * 48271) % 2147483647`.
+- **Immutable turn processing:** every state transform returns a new `GameState`; never mutate `state.cities[id]`, `state.units[id]`, `state.civilizations[id]` in place.
+- **Spec:** `docs/superpowers/specs/2026-07-11-city-combat-entity-design.md`. Section refs (§1–§6) point there.
+- **Tests mirror src:** tests live under `tests/` mirroring `src/`. Use Vitest.
+- **`main.ts` has no dedicated *behavioral* unit-test file in this codebase** (confirmed — `tests/main.integration.test.ts` exists but is a static source-regex checker, not a functional test; see Task 9 Step 9). Task 10's UI change is verified via the Browser pane, not a new test file.
+- **Commit** after each task's tests pass (30 000 ms timeout for `git commit`).
+
+## File Structure
+
+**Modify:**
+- `src/systems/city-siege-system.ts` — add `getCityIntrinsicStrength`, `calculateCityAssaultStrengths`, `resolveCityAssault`, `getCityCounterFireDamage` + their constants. This file already owns the barbarian/pirate siege model; the new functions extend it rather than starting a second file.
+- `src/core/types.ts` — new `'city:counter-fire'` event on `EventMap` (Task 5), same `source: 'barbarian' | 'pirate'` shape as the existing `'city:sacked'` entry it sits next to.
+- `src/systems/city-capture-system.ts` — new `'repelled-by-city-defense'` failure reason; integrate the new resolution into `beginMajorCityAssault`'s no-preceding-combat branch only.
+- `src/core/turn-manager.ts` — barbarian counter-fire, applied after `resolveCitySiegeDamage` in the existing city-attack loop; emits `'city:counter-fire'`.
+- `src/systems/pirate-system.ts` — pirate counter-fire, applied after `resolveCitySiegeDamage` in the existing siege loop; emits the same `'city:counter-fire'` event.
+- `src/input/city-assault-flow.ts` — `beginPlayerCityAssaultChoice`'s return type becomes a discriminated union instead of throwing on failure (found while tracing Task 10's UI change — a losing assault is now a real, expected outcome).
+- `src/input/foreign-city-entry-flow.ts` — `beginConfirmedForeignCityEntry` propagates the same union (it currently forwards `city-assault-flow.ts`'s result under a fixed, always-success return type).
+- `src/main.ts` — two existing call sites updated to handle the new union (Task 9), plus a new preview panel for the `'assault-city'` tap intent (Task 10), mirroring the existing unit-attack preview panel's exact DOM/style pattern; plus a new `'city:counter-fire'` civ-log listener (Task 5) shared by both the barbarian and pirate paths.
+- `src/ui/city-panel.ts` — defender-side defense-rating line, always shown for an owned city.
+- `src/ai/ai-tactics.ts` — `rankCapture`'s scoring now weights by win probability instead of a flat `600`.
+
+**Test files (modify/create):**
+- `tests/systems/city-siege-system.test.ts`, `tests/systems/city-capture-system.test.ts`, `tests/core/turn-manager.test.ts`, `tests/systems/pirate-system.test.ts`, `tests/ai/ai-tactics.test.ts`, `tests/ui/city-panel.test.ts`, `tests/input/city-assault-flow.test.ts`, `tests/input/foreign-city-entry-flow.test.ts`.
+
+---
+
+### Task 1: `getCityIntrinsicStrength`
+
+**Files:**
+- Modify: `src/systems/city-siege-system.ts`
+- Test: `tests/systems/city-siege-system.test.ts`
+
+**Interfaces:**
+- Produces: `CITY_BASE_STRENGTH = 5`, `CITY_STRENGTH_PER_POPULATION = 3` (exported constants); `getCityIntrinsicStrength(city: City, ownerCiv: Civilization, attackerDomain: 'land' | 'naval' | 'air'): number`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/systems/city-siege-system.test.ts` (the file already has `makeCityAndCiv`/`withTechs` helpers — reuse them):
+
+```ts
+import { getCityIntrinsicStrength } from '@/systems/city-siege-system';
+
+describe('getCityIntrinsicStrength (#522)', () => {
+  it('scales with population even without walls', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: [] });
+    const low = getCityIntrinsicStrength(city, ownerCiv, 'land');
+    const { city: cityB, ownerCiv: ownerCivB } = makeCityAndCiv({ population: 10, buildings: [] });
+    const high = getCityIntrinsicStrength(cityB, ownerCivB, 'land');
+
+    expect(low).toBe(5 + 1 * 3); // 8
+    expect(high).toBe(5 + 10 * 3); // 35
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('applies the walls multiplier on top of the population base, matching getCityDefenseBreakdown', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls'] });
+    // base = 5 + 4*3 = 17; walls -> x1.25 -> 21.25 -> rounds per implementation
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBeCloseTo(17 * 1.25, 5);
+  });
+
+  it('applies Star Fort and Fortification Engineering flat bonuses, same as a garrisoned defender', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls', 'star_fort'] });
+    const withEngineering = withTechs(ownerCiv, ['fortification-engineering']);
+    const strength = getCityIntrinsicStrength(
+      { ...city, buildings: ['walls', 'star_fort'] },
+      withEngineering,
+      'land',
+    );
+    // base = 17; walls -> 21.25; +star_fort(5) +fortification-engineering(5) = 31.25
+    expect(strength).toBeCloseTo(17 * 1.25 + 5 + 5, 5);
+  });
+
+  it('applies Torpedo Warfare only against a naval attacker, matching getCityDefenseBreakdown', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls'] });
+    const withTorpedo = withTechs(ownerCiv, ['torpedo-warfare']);
+    const naval = getCityIntrinsicStrength(city, withTorpedo, 'naval');
+    const land = getCityIntrinsicStrength(city, withTorpedo, 'land');
+    expect(naval).toBeCloseTo(17 * 1.25 + 5, 5);
+    expect(land).toBeCloseTo(17 * 1.25, 5);
+  });
+
+  it('handles zero population without throwing (a just-founded or fully-unrested city)', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 0, buildings: [] });
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBe(5);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: FAIL — `getCityIntrinsicStrength is not a function` (or import error).
+
+- [ ] **Step 3: Implement**
+
+In `src/systems/city-siege-system.ts`, add near the top (after the existing imports, before `CitySiegeInput`):
+
+```ts
+export const CITY_BASE_STRENGTH = 5;
+export const CITY_STRENGTH_PER_POPULATION = 3;
+
+// A city's intrinsic combat strength — used both for a player's single-exchange assault
+// (#522, city-capture-system.ts) and for naval/land counter-fire (below). Population
+// always contributes a baseline (an unwalled city is not defenseless, just weak); walls
+// and defensive techs multiply on top via the SAME getCityDefenseBreakdown a garrisoned
+// defender already uses, so a city's own defense and its garrison's defense never
+// diverge in formula.
+export function getCityIntrinsicStrength(
+  city: City,
+  ownerCiv: Civilization,
+  attackerDomain: 'land' | 'naval' | 'air',
+): number {
+  const base = CITY_BASE_STRENGTH + city.population * CITY_STRENGTH_PER_POPULATION;
+  const breakdown = getCityDefenseBreakdown({
+    cityBuildings: city.buildings ?? [],
+    defenderCompletedTechs: ownerCiv.techState.completed ?? [],
+    attackerDomain,
+  });
+  return base * breakdown.multiplier + breakdown.flatBonus;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/city-siege-system.ts tests/systems/city-siege-system.test.ts
+git commit -m "feat(city-combat): add getCityIntrinsicStrength (#522)"
+```
+
+---
+
+### Task 2: `calculateCityAssaultStrengths` + `resolveCityAssault`
+
+**Files:**
+- Modify: `src/systems/city-siege-system.ts`
+- Test: `tests/systems/city-siege-system.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityIntrinsicStrength` (Task 1); `UNIT_DEFINITIONS` (`@/systems/unit-system`); `getVeterancyCombatModifier` (`@/systems/combat-reward-system`); `getRiverDefensePenalty`, `isRiverBetween` (`@/systems/river-system`).
+- Produces: `CityAssaultStrengthBreakdown { attackerStrength: number; intrinsicStrength: number; winProbability: number }`; `calculateCityAssaultStrengths(attacker: Unit, city: City, ownerCiv: Civilization, map: GameMap): CityAssaultStrengthBreakdown`; `resolveCityAssault(attackerStrength: number, intrinsicStrength: number, seed: number): { attackerWins: boolean }`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { calculateCityAssaultStrengths, resolveCityAssault } from '@/systems/city-siege-system';
+import { createUnit } from '@/systems/unit-system';
+
+describe('calculateCityAssaultStrengths / resolveCityAssault (#522)', () => {
+  it('computes attacker strength the same way calculateCombatStrengths does (health, veterancy, river)', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    const city = { ...state.cities[cityId]!, population: 1, buildings: [] };
+    const ownerCiv = state.civilizations.player;
+    const attacker = createUnit('swordsman', 'ai-1', { q: 3, r: 2 }, state.idCounters);
+
+    const breakdown = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+
+    // swordsman strength 25, full health, no veterancy, no river between (2,2)-(3,2) here
+    expect(breakdown.attackerStrength).toBeCloseTo(25, 5);
+    expect(breakdown.intrinsicStrength).toBe(8); // 5 + 1*3, no walls
+    expect(breakdown.winProbability).toBeGreaterThan(0.5);
+  });
+
+  it('gives a weak attacker a low but nonzero win probability against a strong city', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    const city = { ...state.cities[cityId]!, population: 30, buildings: ['walls', 'star_fort'] };
+    const ownerCiv = withTechs(state.civilizations.player, ['fortification-engineering']);
+    const attacker = createUnit('warrior', 'ai-1', { q: 3, r: 2 }, state.idCounters);
+
+    const breakdown = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+
+    expect(breakdown.winProbability).toBeLessThan(0.5);
+    expect(breakdown.winProbability).toBeGreaterThan(0);
+  });
+
+  it('resolveCityAssault is deterministic for a fixed seed', () => {
+    const first = resolveCityAssault(50, 10, 12345);
+    const second = resolveCityAssault(50, 10, 12345);
+    expect(first).toEqual(second);
+  });
+
+  it('an overwhelming attacker wins reliably across seeds', () => {
+    const results = Array.from({ length: 20 }, (_, i) => resolveCityAssault(100, 10, i).attackerWins);
+    expect(results.every(Boolean)).toBe(true);
+  });
+
+  it('an overwhelmed attacker loses reliably across seeds', () => {
+    const results = Array.from({ length: 20 }, (_, i) => resolveCityAssault(10, 100, i).attackerWins);
+    expect(results.every(win => !win)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: FAIL — functions not defined.
+
+- [ ] **Step 3: Implement**
+
+In `src/systems/city-siege-system.ts`, add imports at the top:
+
+```ts
+import type { GameMap, Unit } from '@/core/types';
+import { getVeterancyCombatModifier } from '@/systems/combat-reward-system';
+import { getRiverDefensePenalty, isRiverBetween } from '@/systems/river-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+```
+
+> `GameMap` and `Unit` may already be covered by the file's existing `import type { City, Civilization, GameState, HexCoord, Unit } from '@/core/types';` — check first and only add what's missing (`GameMap`).
+
+Add after `getCityIntrinsicStrength`:
+
+```ts
+export interface CityAssaultStrengthBreakdown {
+  attackerStrength: number;
+  intrinsicStrength: number;
+  winProbability: number;
+}
+
+// Mirrors calculateCombatStrengths' attacker-side formula exactly (combat-system.ts) --
+// health-scaled, veterancy-modified, river-penalized -- so the odds shown to the player
+// (and used by resolveCityAssault below) are computed the same way real combat odds are.
+export function calculateCityAssaultStrengths(
+  attacker: Unit,
+  city: City,
+  ownerCiv: Civilization,
+  map: GameMap,
+): CityAssaultStrengthBreakdown {
+  const attackerDefinition = UNIT_DEFINITIONS[attacker.type];
+  const riverAttackPenalty = getRiverDefensePenalty(
+    isRiverBetween(map, attacker.position, city.position),
+  );
+  const attackerStrength = attackerDefinition.strength
+    * (attacker.health / 100)
+    * (1 + getVeterancyCombatModifier(attacker))
+    * (1 + riverAttackPenalty);
+  const intrinsicStrength = getCityIntrinsicStrength(city, ownerCiv, 'land');
+  const winProbability = attackerStrength / (attackerStrength + intrinsicStrength);
+  return { attackerStrength, intrinsicStrength, winProbability };
+}
+
+function createSeededRng(seed: number): () => number {
+  // Same LCG resolveCombat uses (combat-system.ts), but as a proper CHAINED stream --
+  // each call advances rngState and returns the new value, exactly like resolveCombat's
+  // own rng() closure. A single-shot `seededRatio(seed)` / `seededRatio(seed + 1)` pair
+  // (an earlier draft of this function) is NOT equivalent: evaluating the LCG once at
+  // seed and once at seed+1 differs by the constant `48271` (mod 2147483647) every
+  // time, so the two "independent" draws are actually correlated by a fixed offset.
+  // Chaining through one closure avoids that entirely.
+  let rngState = seed;
+  return () => {
+    rngState = (rngState * 48271) % 2147483647;
+    return rngState / 2147483647;
+  };
+}
+
+// Win/lose only -- deliberately does not compute damage. Damage is
+// getCityCounterFireDamage's responsibility (unconditional on win/lose, applied by the
+// caller) so the same formula serves the player, barbarian, and pirate paths uniformly.
+export function resolveCityAssault(
+  attackerStrength: number,
+  intrinsicStrength: number,
+  seed: number,
+): { attackerWins: boolean } {
+  const totalStrength = attackerStrength + intrinsicStrength;
+  if (totalStrength === 0) return { attackerWins: true };
+  const atkRatio = attackerStrength / totalStrength;
+  const rng = createSeededRng(seed);
+  const randomFactor = 0.8 + rng() * 0.4;
+  const adjustedRatio = Math.min(0.95, Math.max(0.05, atkRatio * randomFactor));
+  return { attackerWins: rng() < adjustedRatio };
+}
+```
+
+> **Why two chained `rng()` calls from one `createSeededRng(seed)`:** the first draws the ±20% randomness factor (mirrors `resolveCombat`'s `randomFactor`); the second is the actual win/lose coin-flip against the adjusted ratio. Because `rng` is a stateful closure, the second draw genuinely depends on the first having run -- true independence, not the fixed-offset artifact a single-shot `seededRatio(seed)`/`seededRatio(seed + 1)` pair would produce.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/city-siege-system.ts tests/systems/city-siege-system.test.ts
+git commit -m "feat(city-combat): add calculateCityAssaultStrengths + resolveCityAssault (#522)"
+```
+
+---
+
+### Task 3: `getCityCounterFireDamage`
+
+**Files:**
+- Modify: `src/systems/city-siege-system.ts`
+- Test: `tests/systems/city-siege-system.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityIntrinsicStrength` (Task 1).
+- Produces: `getCityCounterFireDamage(city: City, ownerCiv: Civilization, attackerDomain: 'land' | 'naval' | 'air', attackerStrength: number, hasGarrison: boolean, seed: number): number`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { getCityCounterFireDamage } from '@/systems/city-siege-system';
+
+describe('getCityCounterFireDamage (#522)', () => {
+  it('is zero without walls', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: [] });
+    expect(getCityCounterFireDamage(city, ownerCiv, 'land', 20, false, 1)).toBe(0);
+  });
+
+  it('is zero when the city has a garrison', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: ['walls'] });
+    expect(getCityCounterFireDamage(city, ownerCiv, 'land', 20, true, 1)).toBe(0);
+  });
+
+  it('is nonzero and walls/tech-scaled otherwise', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: ['walls'] });
+    const { city: fortifiedCity, ownerCiv: fortifiedCiv } = makeCityAndCiv({ population: 10, buildings: ['walls', 'star_fort'] });
+    const base = getCityCounterFireDamage(city, ownerCiv, 'land', 20, false, 1);
+    const fortified = getCityCounterFireDamage(fortifiedCity, fortifiedCiv, 'land', 20, false, 1);
+    expect(base).toBeGreaterThan(0);
+    expect(fortified).toBeGreaterThan(base);
+  });
+
+  it('scales inversely with attacker strength -- an overwhelming attacker takes measurably less', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: ['walls'] });
+    const weakAttacker = getCityCounterFireDamage(city, ownerCiv, 'land', 15, false, 1);
+    const strongAttacker = getCityCounterFireDamage(city, ownerCiv, 'land', 200, false, 1);
+    expect(strongAttacker).toBeLessThan(weakAttacker);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add after `resolveCityAssault`:
+
+```ts
+// Counter-fire damage to a hostile unit attacking a walled, ungarrisoned city (#522) --
+// applies uniformly to player, barbarian, and pirate attackers (three call sites: this
+// helper, city-capture-system.ts, turn-manager.ts, pirate-system.ts). Deliberately
+// scales INVERSELY with attacker strength, mirroring resolveCombat's own
+// baseDamage * (1 - adjustedRatio) counter-damage formula -- a much stronger attacker
+// already takes proportionally less retaliation there; a flat fraction of intrinsic
+// strength would have ignored that convention (caught in design review).
+export function getCityCounterFireDamage(
+  city: City,
+  ownerCiv: Civilization,
+  attackerDomain: 'land' | 'naval' | 'air',
+  attackerStrength: number,
+  hasGarrison: boolean,
+  seed: number,
+): number {
+  if (hasGarrison) return 0;
+  if (!(city.buildings ?? []).includes('walls')) return 0;
+
+  const intrinsicStrength = getCityIntrinsicStrength(city, ownerCiv, attackerDomain);
+  const totalStrength = attackerStrength + intrinsicStrength;
+  if (totalStrength === 0) return 0;
+  const atkRatio = attackerStrength / totalStrength;
+  const rng = createSeededRng(seed);
+  const randomFactor = 0.8 + rng() * 0.4;
+  const adjustedRatio = Math.min(0.95, Math.max(0.05, atkRatio * randomFactor));
+  const baseDamage = 30 + rng() * 20; // same range as resolveCombat's baseDamage (era 3+ band)
+  return Math.round(baseDamage * (1 - adjustedRatio));
+}
+```
+
+> `createSeededRng` is the private helper added in Task 2 — no new export needed, both functions live in the same module. Each call to `getCityCounterFireDamage` creates its own fresh closure from its own `seed` argument, so it never shares RNG state with a `resolveCityAssault` call elsewhere -- **callers that invoke both functions for the same event must still pass each a distinct `seed` value** (see Task 4, which does this explicitly), since two calls seeded identically would still draw identical `randomFactor` values from each closure's first `rng()` call.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/systems/city-siege-system.ts tests/systems/city-siege-system.test.ts
+git commit -m "feat(city-combat): add getCityCounterFireDamage, ratio-scaled not flat (#522)"
+```
+
+---
+
+### Task 4: Integrate into `beginMajorCityAssault`
+
+**Files:**
+- Modify: `src/systems/city-capture-system.ts:96-107` (failure reason union), `:225-250` (no-preceding-combat branch)
+- Test: `tests/systems/city-capture-system.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityIntrinsicStrength`, `calculateCityAssaultStrengths`, `resolveCityAssault`, `getCityCounterFireDamage`, `getCityGarrisonUnit` (all from `@/systems/city-siege-system`).
+- Produces: `MajorCityAssaultFailureReason` includes `'repelled-by-city-defense'`.
+
+- [ ] **Step 1: Fix the pre-existing flaky-test risk first**
+
+`tests/systems/city-capture-system.test.ts`'s `makeMajorAssaultState()` fixture uses `population: 4, buildings: []` against a `swordsman` (strength 25) attacker. Under the new mechanic, intrinsic strength there is `5 + 4*3 = 17`, giving a win probability of only `25/(25+17) ≈ 0.60` — not a safe margin against the existing test's unconditional `expect(result.ok).toBe(true)`. Fix the shared fixture to keep a comfortable, effectively-guaranteed margin regardless of RNG:
+
+Find `function makeMajorAssaultState(): GameState {` (~line 67) and change:
+
+```ts
+    const state = makeExposedCityCaptureState({
+      population: 4,
+      buildings: [],
+    });
+```
+
+to:
+
+```ts
+    // population 1 (not 4): with the new intrinsic-strength mechanic (#522), a
+    // swordsman (strength 25) needs a comfortable margin over intrinsic strength
+    // (5 + population*3) so this fixture's existing unconditional-success assertions
+    // stay reliable regardless of the ±20% RNG factor. Tests that specifically exercise
+    // low-odds outcomes construct their own city stats instead of using this shared
+    // fixture -- see the new describe block below.
+    const state = makeExposedCityCaptureState({
+      population: 1,
+      buildings: [],
+    });
+```
+
+Run: `bash scripts/run-with-mise.sh yarn test city-capture-system`
+Expected: PASS (all pre-existing tests still pass; this is a fixture value change only, no assertions changed).
+
+- [ ] **Step 2: Write the failing tests for the new resolution**
+
+Add a new describe block to `tests/systems/city-capture-system.test.ts`:
+
+```ts
+describe('city-capture-system intrinsic defense (#522)', () => {
+  function makeUndefendedWalledCityState({
+    population,
+    buildings,
+    attackerType = 'warrior',
+  }: {
+    population: number;
+    buildings: string[];
+    attackerType?: 'warrior' | 'swordsman' | 'tank';
+  }): GameState {
+    const state = makeExposedCityCaptureState({ population, buildings });
+    const attacker = createUnit(attackerType, 'player', { q: 0, r: 0 }, state.idCounters);
+    attacker.id = 'attacker';
+    attacker.movementPointsLeft = 2;
+    state.units = { [attacker.id]: attacker };
+    state.civilizations.player.units = [attacker.id];
+    state.civilizations['ai-1'].units = [];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    state.map.tiles['0,0'].terrain = 'grassland';
+    state.map.tiles['1,0'].terrain = 'grassland';
+    return state;
+  }
+
+  it('captures a weakly-defended (low population, unwalled) city reliably, like today', () => {
+    const state = makeUndefendedWalledCityState({ population: 1, buildings: [], attackerType: 'tank' });
+
+    const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('repels a hopelessly outmatched attacker against a strongly walled, populous city', () => {
+    const state = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+
+    const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+    expect(result).toMatchObject({ ok: false, reason: 'repelled-by-city-defense' });
+  });
+
+  it('on repel, the attacker stays in place, takes counter-fire damage, and the action is consumed', () => {
+    const state = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+    const before = state.units.attacker!.health;
+
+    const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+    expect(result.ok).toBe(false);
+    expect(result.state.units.attacker!.position).toEqual({ q: 0, r: 0 });
+    expect(result.state.units.attacker!.health).toBeLessThan(before);
+    expect(result.state.units.attacker!.hasActed).toBe(true);
+    expect(result.state.units.attacker!.movementPointsLeft).toBe(0);
+    expect(result.state.cities.athens).toBeDefined(); // still owned by defender
+  });
+
+  it('on a successful assault against walls, the attacker still takes counter-fire damage', () => {
+    const state = makeUndefendedWalledCityState({ population: 1, buildings: ['walls'], attackerType: 'tank' });
+    const before = state.units.attacker!.health;
+
+    const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.units.attacker!.health).toBeLessThan(before);
+  });
+
+  it('takes no counter-fire against an unwalled city even on repel (population alone can still repel)', () => {
+    const state = makeUndefendedWalledCityState({ population: 30, buildings: [] }); // no walls, still very high intrinsic strength
+    const before = state.units.attacker!.health;
+
+    const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+    // Regardless of win/lose, no walls means zero counter-fire.
+    expect(result.state.units.attacker!.health).toBe(before);
+  });
+
+  it('never double-punishes the post-garrison-defeat advance (the double-punishment fix)', () => {
+    // Reuses the existing "defeated the final defender, then advances" fixture pattern.
+    const state = makeMajorAssaultState();
+    const defender = createUnit('warrior', 'ai-1', { q: 1, r: 0 }, state.idCounters);
+    defender.id = 'city-defender';
+    defender.health = 1;
+    state.units[defender.id] = defender;
+    state.civilizations['ai-1'].units.push(defender.id);
+    // Make the city extremely strong so, if the double-punishment bug existed, this
+    // attacker would be repelled by the SECOND (buggy) intrinsic-strength check.
+    state.cities.athens = { ...state.cities.athens, population: 50, buildings: ['walls', 'star_fort'] };
+    const combat = resolveCombat(state.units.attacker!, defender, state.map, 42, undefined, state.era);
+    const afterCombat = applyCombatOutcomeToState(state, combat, 42).state;
+
+    const result = beginMajorCityAssault(afterCombat, 'attacker', 'athens', {
+      actor: 'ai',
+      civId: 'player',
+      precedingCombat: combat,
+    });
+
+    expect(result.ok).toBe(true); // proves no second intrinsic-strength check fired
+    if (!result.ok) return;
+    expect(result.state.units.attacker!.position).toEqual({ q: 1, r: 0 });
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-capture-system`
+Expected: FAIL — `'repelled-by-city-defense'` reason doesn't exist yet, and the undefended branch always succeeds today.
+
+- [ ] **Step 4: Implement**
+
+In `src/systems/city-capture-system.ts`, add the import:
+
+```ts
+import {
+  calculateCityAssaultStrengths,
+  getCityCounterFireDamage,
+  resolveCityAssault,
+} from '@/systems/city-siege-system';
+```
+
+Extend the failure-reason union (~line 96):
+
+```ts
+export type MajorCityAssaultFailureReason =
+  | 'missing-attacker'
+  | 'missing-city'
+  | 'wrong-owner'
+  | 'friendly-city'
+  | 'not-major-city'
+  | 'not-at-war'
+  | 'cannot-capture'
+  | 'not-adjacent'
+  | 'city-defended'
+  | 'illegal-movement'
+  | 'invalid-post-combat-advance'
+  | 'repelled-by-city-defense';
+```
+
+Replace the no-preceding-combat `else` branch (currently ~lines 228-250):
+
+```ts
+  } else {
+    if (attacker.hasActed || attacker.movementPointsLeft <= 0) {
+      return assaultFailure(state, 'illegal-movement');
+    }
+
+    // Intrinsic-strength combat exchange (#522) -- ONLY for a city that was already
+    // undefended before this action (no precedingCombat). A city defeated via a real
+    // combat exchange against a garrison unit (the `if (options.precedingCombat)`
+    // branch above) already resolved a complete, walls-boosted fight; running this
+    // check again here would double-punish the same turn's action for the same city.
+    const ownerCiv = state.civilizations[city.owner];
+    if (ownerCiv) {
+      // Two DISTINCT seeds -- getCityCounterFireDamage (damage magnitude) and
+      // resolveCityAssault (win/lose) are conceptually independent rolls. Passing them
+      // the same raw seed would make each function's first internal rng() draw
+      // IDENTICAL, entangling "how much counter-fire damage I take" with "do I win" on
+      // every single assault (caught in review). XOR against a fixed constant to
+      // decorrelate -- same convention Tasks 5/6 use for barbarian/pirate counter-fire
+      // seeds (`... ^ 0x5a5a`).
+      const baseSeed = state.turn * 7919 + attackerId.charCodeAt(0) + cityId.charCodeAt(0);
+      const counterFireSeed = baseSeed;
+      const assaultSeed = baseSeed ^ 0x5a5a;
+      const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+      const counterFireDamage = getCityCounterFireDamage(
+        city,
+        ownerCiv,
+        'land',
+        strengths.attackerStrength,
+        false, // this branch is only reached when the city has no garrison (see the
+               // 'city-defended' check above, which already returned for any occupied tile)
+        counterFireSeed,
+      );
+      if (counterFireDamage > 0) {
+        const healthAfter = attacker.health - counterFireDamage;
+        if (healthAfter <= 0) {
+          const civilizations = { ...nextState.civilizations };
+          civilizations[attacker.owner] = {
+            ...civilizations[attacker.owner],
+            units: civilizations[attacker.owner].units.filter(id => id !== attackerId),
+          };
+          const units = { ...nextState.units };
+          delete units[attackerId];
+          nextState = { ...nextState, units, civilizations };
+          return assaultFailure(nextState, 'repelled-by-city-defense');
+        }
+        nextState.units[attackerId] = {
+          ...nextState.units[attackerId],
+          health: healthAfter,
+        };
+      }
+      const assaultResult = resolveCityAssault(strengths.attackerStrength, strengths.intrinsicStrength, assaultSeed);
+      if (!assaultResult.attackerWins) {
+        nextState.units[attackerId] = {
+          ...nextState.units[attackerId],
+          hasMoved: true,
+          hasActed: true,
+          movementPointsLeft: 0,
+        };
+        return assaultFailure(nextState, 'repelled-by-city-defense');
+      }
+    }
+
+    const movement = executeUnitMove(
+      nextState,
+      attackerId,
+      city.position,
+      {
+        actor: options.actor,
+        civId: options.civId,
+        bus: options.bus,
+        foreignCityEntryId: cityId,
+      },
+    );
+    if (!movement.ok) {
+      return assaultFailure(state, 'illegal-movement');
+    }
+    nextState.units[attackerId] = {
+      ...nextState.units[attackerId],
+      movementPointsLeft: 0,
+      hasMoved: true,
+      hasActed: true,
+    };
+  }
+```
+
+> **Note the unit-death-from-counter-fire branch above.** If counter-fire alone kills the attacker (health drops to 0 before the win/lose check even runs), the assault is unconditionally a `'repelled-by-city-defense'` failure — a dead unit cannot advance into the city regardless of what `resolveCityAssault` would have said. This mirrors `pirate-actions.ts`'s `assaultPirateEnclave` (`delete units[unitId]` + filter the owner's `units` roster) — the same minimal unit-removal pattern already used elsewhere in this codebase, not a new one.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-capture-system`
+Expected: PASS.
+
+- [ ] **Step 6: Fix the same flaky-fixture risk in the two other test files that reach this code path**
+
+`grep -rln "beginMajorCityAssault\|beginPlayerCityAssaultChoice\|beginConfirmedForeignCityEntry" tests/` surfaces two more files with the identical `population: 4` + weak-attacker risk: `tests/input/city-assault-flow.test.ts` (`makePlayerAssaultState`, attacker is a plain `'warrior'`, strength 10 — an *even worse* margin than Task 4 Step 1's `swordsman`) and `tests/input/foreign-city-entry-flow.test.ts` (`makeForeignCityEntryState`, same `'warrior'` + `population: 4`). Fix both now so the full suite stays green at this checkpoint; a later task (Task 9) will separately restructure these two files' *return-type handling*, which is unrelated to this fixture-flakiness fix.
+
+In `tests/input/city-assault-flow.test.ts`, change every `makePlayerAssaultState({ population: 4 })` call to `makePlayerAssaultState({ population: 1 })`, and update the one assertion that depends on the old value:
+
+```ts
+    expect(begun.pending.occupiedPopulation).toBe(1); // was toBe(2) with population: 4
+```
+
+In `tests/input/foreign-city-entry-flow.test.ts`, change `makeForeignCityEntryState`'s city literal from `population: 4` to `population: 1`.
+
+Run: `bash scripts/run-with-mise.sh yarn test city-assault-flow foreign-city-entry-flow`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full suite one more time to catch anything else**
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: PASS. If any OTHER test file calls `beginMajorCityAssault` (directly or via a wrapper) without `precedingCombat` against a city with nontrivial population/walls, it needs the same fixture adjustment as above.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/city-capture-system.ts tests/systems/city-capture-system.test.ts tests/input/city-assault-flow.test.ts tests/input/foreign-city-entry-flow.test.ts
+git commit -m "feat(city-combat): resolve ungarrisoned city assault as a single combat exchange (#522)"
+```
+
+---
+
+### Task 5: Barbarian counter-fire
+
+**Files:**
+- Modify: `src/core/turn-manager.ts:784-823`
+- Test: `tests/core/turn-manager.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityCounterFireDamage`, `UNIT_DEFINITIONS[unit.type].strength` for `attackerStrength`.
+
+- [ ] **Step 1: Write the failing test**
+
+Search `tests/core/turn-manager.test.ts` for an existing barbarian city-attack fixture to extend (the file already has `processTurn` integration tests per the existing barbarian-siege coverage from #549). Add:
+
+```ts
+it('applies counter-fire to a barbarian raider attacking a walled, ungarrisoned city (#522)', () => {
+  const state = createNewGame(undefined, 'barbarian-counterfire', 'small');
+  state.turn = 30;
+  state.era = 3;
+  state.barbarianCamps = {
+    'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+  };
+  const raider = createUnit('warrior', 'barbarian', { q: 12, r: 5 }, state.idCounters);
+  raider.id = 'raider';
+  state.units = { raider };
+  state.cities = {
+    town: {
+      id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 100,
+      buildings: ['walls'], population: 20,
+    } as never,
+  };
+  state.civilizations.player.cities = ['town'];
+  state.civilizations.player.units = [];
+  state.opponentAI = undefined;
+
+  const before = raider.health;
+  const result = processTurn(state, new EventBus());
+
+  expect(result.units.raider?.health ?? 0).toBeLessThan(before);
+});
+
+it('emits city:counter-fire so the player gets feedback that their walls fought back (#522)', () => {
+  const state = createNewGame(undefined, 'barbarian-counterfire-event', 'small');
+  state.turn = 30;
+  state.era = 3;
+  state.barbarianCamps = {
+    'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+  };
+  const raider = createUnit('warrior', 'barbarian', { q: 12, r: 5 }, state.idCounters);
+  raider.id = 'raider';
+  state.units = { raider };
+  state.cities = {
+    town: {
+      id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 100,
+      buildings: ['walls'], population: 20,
+    } as never,
+  };
+  state.civilizations.player.cities = ['town'];
+  state.civilizations.player.units = [];
+  state.opponentAI = undefined;
+
+  const bus = new EventBus();
+  const onCounterFire = vi.fn();
+  bus.on('city:counter-fire', onCounterFire);
+  processTurn(state, bus);
+
+  expect(onCounterFire).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'town', source: 'barbarian' }));
+});
+
+it('does not counter-fire when the barbarian city order is blocked by a garrison', () => {
+  const state = createNewGame(undefined, 'barbarian-counterfire-blocked', 'small');
+  state.turn = 30;
+  state.era = 3;
+  state.barbarianCamps = {
+    'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+  };
+  const raider = createUnit('warrior', 'barbarian', { q: 12, r: 5 }, state.idCounters);
+  raider.id = 'raider';
+  const garrison = createUnit('warrior', 'player', { q: 12, r: 5 }, state.idCounters);
+  garrison.id = 'garrison';
+  state.units = { raider, garrison };
+  state.cities = {
+    town: {
+      id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 100,
+      buildings: ['walls'], population: 20,
+    } as never,
+  };
+  state.civilizations.player.cities = ['town'];
+  state.civilizations.player.units = ['garrison'];
+  state.opponentAI = undefined;
+
+  const before = raider.health;
+  const result = processTurn(state, new EventBus());
+
+  expect(result.units.raider?.health ?? 0).toBe(before);
+});
+```
+
+> Adapt the state-construction details (map size, tile terrain) to whatever this test file's existing barbarian-integration tests already establish as the minimal working fixture — check an existing `processTurn` + barbarian test above this insertion point for the exact map/state scaffolding this file expects, and reuse it rather than inventing a new one.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test turn-manager`
+Expected: FAIL — raider takes no damage today.
+
+- [ ] **Step 3: Add the shared `city:counter-fire` event type**
+
+**Found during review**: every other siege-related state change in this codebase gets player-facing feedback -- `barbarian:city-attacked` and `city:sacked` both append to the civ log (`main.ts`'s existing `bus.on('barbarian:city-attacked', ...)` handler). Counter-fire damaging or killing the attacking raider/ship is exactly the same class of event (a siege-driven state change the human player should see) and had no event at all in the original draft of this task -- a player whose walls destroy a barbarian raider would get zero feedback. Add the event now so both Task 5 (barbarian) and Task 6 (pirate) can emit it.
+
+In `src/core/types.ts`, add to the `EventMap` interface, next to the existing `'city:sacked'` entry (~line 1657) since it follows the identical `source: 'barbarian' | 'pirate'` convention:
+
+```ts
+  'city:counter-fire': { cityId: string; attackerUnitId: string; source: 'barbarian' | 'pirate'; damage: number; attackerDied: boolean };
+```
+
+- [ ] **Step 4: Implement**
+
+In `src/core/turn-manager.ts`, update the import:
+
+```ts
+import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+```
+
+Add `import { UNIT_DEFINITIONS } from '@/systems/unit-system';` if not already imported in this file (check first with `grep -n "UNIT_DEFINITIONS" src/core/turn-manager.ts`).
+
+In the barbarian city-attack loop (~line 784), after the `if (result.outcome === 'blocked') continue;` line:
+
+```ts
+    newState = applyCitySiegeOutcome(newState, order.cityId, result);
+    if (result.outcome === 'blocked') continue;
+
+    // Counter-fire (#522): a walled, ungarrisoned city fights back against the raider
+    // that's damaging it. Reuses barbSeed the same way real barbarian combat above does.
+    const attackerUnit = newState.units[order.attackerUnitId];
+    if (attackerUnit) {
+      const attackerStrength = UNIT_DEFINITIONS[attackerUnit.type].strength * (attackerUnit.health / 100);
+      const counterFireSeed = barbSeed ^ order.attackerUnitId.charCodeAt(0) ^ 0x5a5a;
+      const counterFireDamage = getCityCounterFireDamage(
+        city, ownerCiv, 'land', attackerStrength, false, counterFireSeed,
+      );
+      if (counterFireDamage > 0) {
+        const healthAfter = attackerUnit.health - counterFireDamage;
+        const attackerDied = healthAfter <= 0;
+        if (attackerDied) {
+          const units = { ...newState.units };
+          delete units[order.attackerUnitId];
+          const civilizations = { ...newState.civilizations };
+          const raiderOwner = civilizations[attackerUnit.owner];
+          if (raiderOwner) {
+            civilizations[attackerUnit.owner] = {
+              ...raiderOwner,
+              units: raiderOwner.units.filter(id => id !== order.attackerUnitId),
+            };
+          }
+          newState = { ...newState, units, civilizations };
+          // barbarianHomeCampByUnitId self-prunes stale entries for dead units on the
+          // next processing pass (barbarian-system.ts) -- no further cleanup needed here.
+        } else {
+          newState = {
+            ...newState,
+            units: { ...newState.units, [order.attackerUnitId]: { ...attackerUnit, health: healthAfter } },
+          };
+        }
+        bus.emit('city:counter-fire', {
+          cityId: order.cityId,
+          attackerUnitId: order.attackerUnitId,
+          source: 'barbarian',
+          damage: counterFireDamage,
+          attackerDied,
+        });
+      }
+    }
+
+    bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: result.hpLost });
+```
+
+> `0x5a5a` in the seed XOR just decorrelates counter-fire's randomness from the siege-damage RNG and the unit-combat RNG that also derive from `barbSeed` elsewhere in this function — arbitrary but fixed, matching the existing "derive sub-seeds by XORing a distinguishing value" convention already used for `combatSeed`.
+
+> Barbarian `Civilization` roster note: barbarians are not tracked in `state.civilizations` (they use the special `'barbarian'` owner constant, not a real civ) — check `civilizations[attackerUnit.owner]` for `undefined` before spreading, as shown above (`if (raiderOwner)`), since a raider's "owner" may not have a `civilizations` entry at all.
+
+- [ ] **Step 5: Wire the civ-log listener in `main.ts`**
+
+In `src/main.ts`, add immediately after the existing `bus.on('barbarian:city-destroyed', ...)` handler (~line 3868, right before the `// Pirate-faction naval siege (#522) mirror` comment) — this single handler covers BOTH Task 5 (barbarian) and Task 6 (pirate), since both emit the same `city:counter-fire` event:
+
+```ts
+bus.on('city:counter-fire', ({ cityId, source, damage, attackerDied }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (!gameState.civilizations[city.owner]?.isHuman) return;
+  const raiderLabel = source === 'barbarian' ? 'raider' : 'ship';
+  const message = attackerDied
+    ? `${city.name}'s defenses destroyed a ${source === 'barbarian' ? 'barbarian raider' : 'pirate ship'}!`
+    : `${city.name}'s walls fought back, damaging a ${raiderLabel} (−${damage} HP)!`;
+  appendToCivLog(city.owner, message, attackerDied ? 'success' : 'info');
+});
+```
+
+> `appendToCivLog`'s third argument accepts `'success'` (see the existing `'raid:resolved'`-family handler at ~line 3741 for a same-file precedent) alongside `'warning'` — a destroyed raider is good news for the defending player, so it gets `'success'`, while a mere damage tick without a kill gets the more neutral `'info'`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test turn-manager`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/core/types.ts src/core/turn-manager.ts src/main.ts tests/core/turn-manager.test.ts
+git commit -m "feat(city-combat): barbarian counter-fire from walled ungarrisoned cities (#522)"
+```
+
+---
+
+### Task 6: Pirate counter-fire
+
+**Files:**
+- Modify: `src/systems/pirate-system.ts:789-821`
+- Test: `tests/systems/pirate-system.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityCounterFireDamage`; `hexDistance`/`wrappedHexDistance` (already imported in this file).
+
+- [ ] **Step 1: Write the failing test**
+
+This project's `tests/systems/pirate-system.test.ts` already has a `describe('pirate naval siege (#522)', ...)` block with a `siegeReadyState(cityHp)` helper (from the earlier pirate-siege MR). Add to that block:
+
+```ts
+it('applies counter-fire to a besieging ship attacking a walled, ungarrisoned city (#522)', () => {
+  const state = siegeReadyState(100);
+  state.cities.port = { ...state.cities.port!, buildings: ['walls'], population: 20 };
+
+  const shipBefore = state.units['ship-a']!.health;
+  const result = processPiratesForCompletedRound(state, new EventBus());
+
+  const shipAfter = result.state.units['ship-a']?.health ?? 0;
+  expect(shipAfter).toBeLessThan(shipBefore);
+});
+
+it('does not counter-fire when the besieged city has no walls', () => {
+  const state = siegeReadyState(100);
+  state.cities.port = { ...state.cities.port!, buildings: [], population: 20 };
+
+  const shipBefore = state.units['ship-a']!.health;
+  const result = processPiratesForCompletedRound(state, new EventBus());
+
+  expect(result.state.units['ship-a']?.health ?? 0).toBe(shipBefore);
+});
+
+it('emits city:counter-fire so the player gets feedback that their walls fought back (#522)', () => {
+  const state = siegeReadyState(100);
+  state.cities.port = { ...state.cities.port!, buildings: ['walls'], population: 20 };
+
+  const bus = new EventBus();
+  const onCounterFire = vi.fn();
+  bus.on('city:counter-fire', onCounterFire);
+  processPiratesForCompletedRound(state, bus);
+
+  expect(onCounterFire).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'port', source: 'pirate' }));
+});
+```
+
+> `siegeReadyState` already places `'ship-a'` and `'ship-b'` adjacent to the city with a besieging faction and a streak already at the threshold (see the existing describe block) — reuse it exactly as the other tests in that block do.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test pirate-system`
+Expected: FAIL — ship takes no counter-fire damage today.
+
+- [ ] **Step 3: Implement**
+
+In `src/systems/pirate-system.ts`, update the import:
+
+```ts
+import { applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
+```
+
+Add `import { UNIT_DEFINITIONS } from './unit-system';` if not already present (check first).
+
+In the siege-application loop (~line 789), after the outcome-branch `if/else` block (after the `// outcome === 'blocked' -> ...` comment, still inside the `for (const siege of derivePirateSieges(...))` loop):
+
+```ts
+    // outcome === 'blocked' -> garrison stopped it; no HP change, no alert (silent, by design).
+
+    // Counter-fire (#522): a walled, ungarrisoned city fights back at one ship from the
+    // besieging faction -- the nearest to the city, tie-broken by unit id for
+    // determinism. A well-defended city can now sink a besieging ship over time.
+    if (result.outcome !== 'blocked') {
+      const faction = nextState.pirates?.factions[siege.factionId];
+      const distanceFn = nextState.map.wrapsHorizontally
+        ? (a: HexCoord, b: HexCoord) => wrappedHexDistance(a, b, nextState.map.width)
+        : hexDistance;
+      const targetShip = (faction?.shipIds ?? [])
+        .map(id => nextState.units[id])
+        .filter((unit): unit is Unit => Boolean(unit))
+        .sort((a, b) => distanceFn(a.position, city.position) - distanceFn(b.position, city.position)
+          || a.id.localeCompare(b.id))[0];
+      if (targetShip) {
+        const attackerStrength = UNIT_DEFINITIONS[targetShip.type].strength * (targetShip.health / 100);
+        const counterFireSeed = (nextState.turn * 104729) ^ targetShip.id.charCodeAt(0) ^ 0x5a5a;
+        const counterFireDamage = getCityCounterFireDamage(
+          city, ownerCiv, 'naval', attackerStrength, false, counterFireSeed,
+        );
+        if (counterFireDamage > 0) {
+          const healthAfter = targetShip.health - counterFireDamage;
+          const attackerDied = healthAfter <= 0;
+          if (attackerDied) {
+            const units = { ...nextState.units };
+            delete units[targetShip.id];
+            nextState = { ...nextState, units };
+            // faction.shipIds self-prunes dead references on the next round's
+            // normalizeRoundState pass -- no further cleanup needed here.
+          } else {
+            nextState = {
+              ...nextState,
+              units: { ...nextState.units, [targetShip.id]: { ...targetShip, health: healthAfter } },
+            };
+          }
+          bus.emit('city:counter-fire', {
+            cityId: city.id,
+            attackerUnitId: targetShip.id,
+            source: 'pirate',
+            damage: counterFireDamage,
+            attackerDied,
+          });
+        }
+      }
+    }
+  }
+```
+
+> `HexCoord`/`Unit` types should already be covered by this file's existing `import type { CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/types';` — verify, don't duplicate.
+
+> `city:counter-fire` is the shared event type added in Task 5 Step 3 (`src/core/types.ts`) and consumed by the single `main.ts` listener added in Task 5 Step 5 — no new listener needed here, that handler already branches on `source: 'barbarian' | 'pirate'`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test pirate-system`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite** (this file's siege loop is exercised by many existing tests from the prior pirate-siege MR)
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: PASS. If any existing siege test's city fixture happens to include `'walls'`, its ship-health assertions may need updating to account for the new counter-fire damage — check `grep -n "buildings.*walls" tests/systems/pirate-system.test.ts` for any siege-block fixtures that now also take counter-fire.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/systems/pirate-system.ts tests/systems/pirate-system.test.ts
+git commit -m "feat(city-combat): pirate counter-fire from walled ungarrisoned cities (#522)"
+```
+
+---
+
+### Task 7: AI capture scoring
+
+**Files:**
+- Modify: `src/ai/ai-tactics.ts:375-411` (`rankCapture`)
+- Test: `tests/ai/ai-tactics.test.ts`
+
+**Interfaces:**
+- Consumes: `calculateCityAssaultStrengths` (`@/systems/city-siege-system`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add near the existing `'captures an adjacent exposed enemy city with a capture-capable unit'` test in `tests/ai/ai-tactics.test.ts`:
+
+```ts
+it('scores a low-odds capture lower than a high-odds one for the same unit (#522)', () => {
+  const weakState = makeState('veteran');
+  addUnit(weakState, 'captor', 'warrior', AI, { q: 0, r: 0 });
+  const weakCity = addCity(weakState, 'weak-target', HUMAN, { q: 1, r: 0 });
+  weakCity.population = 1;
+  weakCity.buildings = [];
+  const weakPlan = makePlan({ kind: 'city', id: weakCity.id, lastKnownPosition: weakCity.position }, ['captor']);
+  const weakScore = rankUnitTacticalActions(context(weakState, weakPlan), 'captor')
+    .find(candidate => candidate.action.kind === 'capture-city')?.score;
+
+  const strongState = makeState('veteran');
+  addUnit(strongState, 'captor', 'warrior', AI, { q: 0, r: 0 });
+  const strongCity = addCity(strongState, 'strong-target', HUMAN, { q: 1, r: 0 });
+  strongCity.population = 40;
+  strongCity.buildings = ['walls', 'star_fort'];
+  const strongPlan = makePlan({ kind: 'city', id: strongCity.id, lastKnownPosition: strongCity.position }, ['captor']);
+  const strongScore = rankUnitTacticalActions(context(strongState, strongPlan), 'captor')
+    .find(candidate => candidate.action.kind === 'capture-city')?.score;
+
+  expect(weakScore).toBeDefined();
+  expect(strongScore).toBeDefined();
+  expect(strongScore!).toBeLessThan(weakScore!);
+});
+
+it('still offers a low-odds capture as a candidate, never refuses outright (#522)', () => {
+  const state = makeState('veteran');
+  addUnit(state, 'captor', 'warrior', AI, { q: 0, r: 0 });
+  const city = addCity(state, 'strong-target', HUMAN, { q: 1, r: 0 });
+  city.population = 50;
+  city.buildings = ['walls', 'star_fort'];
+  const plan = makePlan({ kind: 'city', id: city.id, lastKnownPosition: city.position }, ['captor']);
+
+  const candidates = rankUnitTacticalActions(context(state, plan), 'captor');
+
+  expect(candidates.some(candidate => candidate.action.kind === 'capture-city')).toBe(true);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test ai-tactics`
+Expected: FAIL — both scores are currently the flat `600`.
+
+- [ ] **Step 3: Implement**
+
+In `src/ai/ai-tactics.ts`, add the import:
+
+```ts
+import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
+```
+
+Replace the return of `rankCapture` (~line 407-410):
+
+```ts
+  const reachable = movementRange(context.state, context.actorId, unit)
+    .some(coord => hexKey(coord) === hexKey(city.position));
+  if (!reachable) return [];
+
+  // Score by win probability (#522) -- previously a flat 600 regardless of the city's
+  // walls/population, because capture was unconditionally guaranteed. Left unweighted,
+  // the AI would blindly send units to die against a heavily-defended city with no way
+  // to tell that apart from a free capture. Never fully excludes the action (a 0% odds
+  // city still appears as a low-scoring candidate) so a cornered AI with no better
+  // option still attempts it.
+  const ownerCiv = context.state.civilizations[city.owner];
+  const winProbability = ownerCiv
+    ? calculateCityAssaultStrengths(unit, city, ownerCiv, context.state.map).winProbability
+    : 1;
+  return [ranked({ kind: 'capture-city', unitId: unit.id, cityId: city.id }, Math.round(winProbability * 600))];
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test ai-tactics`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite** (other AI tests may assert the exact `600` score)
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: PASS. Search `grep -n "'capture-city'.*600\|600.*capture-city" tests/ai/*.test.ts` for any test asserting the old flat score literally, and update it to compute the expected win-probability-scaled value instead (or assert `> 0` / relative ordering if the exact number isn't the point of that test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai/ai-tactics.ts tests/ai/ai-tactics.test.ts
+git commit -m "feat(ai): weight city-capture scoring by win probability (#522)"
+```
+
+---
+
+### Task 8: Defender-side city-panel defense rating
+
+**Files:**
+- Modify: `src/ui/city-panel.ts:648-662`
+- Test: `tests/ui/city-panel.test.ts`
+
+**Interfaces:**
+- Consumes: `getCityIntrinsicStrength` (`@/systems/city-siege-system`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/ui/city-panel.test.ts`'s existing `describe('city-panel HP status (#522)', ...)` block (reuse `makeWonderPanelFixture`, `createUnit` already imported there):
+
+```ts
+it('shows a static defense-rating line for every owned city, not just damaged ones (#522)', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.cities[city.id] = { ...city, hp: 100, population: 10, buildings: ['walls'] };
+
+  const panel = createCityPanel(container, state.cities[city.id]!, state, {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  });
+
+  expect(panel.textContent).toMatch(/Defense/i);
+});
+
+it('defense rating changes when walls are built', () => {
+  const { container, city, state } = makeWonderPanelFixture();
+  state.cities[city.id] = { ...city, hp: 100, population: 10, buildings: [] };
+  const unwalledPanel = createCityPanel(container, state.cities[city.id]!, state, {
+    onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+  });
+  const unwalledText = unwalledPanel.textContent ?? '';
+
+  state.cities[city.id] = { ...state.cities[city.id]!, buildings: ['walls'] };
+  const walledPanel = createCityPanel(container, state.cities[city.id]!, state, {
+    onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+  });
+  const walledText = walledPanel.textContent ?? '';
+
+  expect(walledText).not.toBe(unwalledText);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-panel`
+Expected: FAIL — no "Defense" text exists today.
+
+- [ ] **Step 3: Implement**
+
+In `src/ui/city-panel.ts`, update the import (~line 39):
+
+```ts
+import { getCityIntrinsicStrength, isCityHpRegenerating } from '@/systems/city-siege-system';
+```
+
+After the existing `siegeBarHtml` block (~line 662), add:
+
+```ts
+  const ownerCivForDefense = state.civilizations[city.owner];
+  const defenseRating = ownerCivForDefense
+    ? Math.round(getCityIntrinsicStrength(city, ownerCivForDefense, 'land'))
+    : 0;
+  const defenseRatingHtml = `
+    <div style="font-size:11px;opacity:0.7;margin-top:4px;">
+      🛡️ Defense: ${defenseRating}
+    </div>`;
+```
+
+Then find where `siegeBarHtml` is interpolated into the main `html` template literal (search for `${siegeBarHtml}` in the file) and add `${defenseRatingHtml}` immediately after it — always rendered, unlike `siegeBarHtml` which stays conditional on damage.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-panel`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/city-panel.ts tests/ui/city-panel.test.ts
+git commit -m "feat(ui): show a city's defense rating to its owner, not just the attacker (#522)"
+```
+
+---
+
+### Task 9: Propagate the assault-result type through the existing capture-flow call chain
+
+**Found while writing Task 10 below, and pulled into its own task**: `beginPlayerCityAssaultChoice` (`city-assault-flow.ts`) currently throws on any failure (`if (!result.ok) throw new Error(...)`). Once `beginMajorCityAssault` can legitimately return `'repelled-by-city-defense'` (Task 4), that throw fires on every repelled assault — a real outcome, not a caller bug. This function has **three** existing consumers, all of which assume unconditional success today; all three need updating together, or the build won't compile once the return type changes (a discriminated union's `ok: false` branch has no `.pending` property, so every unguarded `begun.pending` access becomes a type error). This task fixes the plumbing only — no new UI. Task 10 adds the preview panel on top of it.
+
+**Files:**
+- Modify: `src/input/city-assault-flow.ts` — `beginPlayerCityAssaultChoice`'s return type.
+- Modify: `src/input/foreign-city-entry-flow.ts` — `beginConfirmedForeignCityEntry` propagates the same union (it currently declares a fixed `{ state; pending }` return type and just forwards the inner call's result).
+- Modify: `src/main.ts` — **two** existing call sites: `beginPlayerCityAssault`'s body (~line 2401) and the `'confirm-war-city'` tap-intent's `onConfirm` handler (~line 2991). Per the design spec, only the `'assault-city'` intent gets the new odds-preview UI (Task 10) — `'confirm-war-city'` keeps its existing "declare war?" confirmation panel unchanged and just needs to not crash on a repelled outcome. Extending it to also show combat odds would be additional scope beyond what was approved; not done here.
+- Test: `tests/input/city-assault-flow.test.ts`, `tests/input/foreign-city-entry-flow.test.ts`.
+
+**Interfaces:**
+- Produces: `PlayerCityAssaultChoiceResult = { ok: true; state: GameState; pending: PendingCityCaptureChoice } | { ok: false; state: GameState; reason: MajorCityAssaultFailureReason }`, exported from `city-assault-flow.ts`. `beginConfirmedForeignCityEntry` returns the same union.
+
+- [ ] **Step 1: Verify the fixture fix from Task 4 Step 6 is in place**
+
+Task 4 Step 6 already changed both `tests/input/city-assault-flow.test.ts`'s `makePlayerAssaultState` calls and `tests/input/foreign-city-entry-flow.test.ts`'s `makeForeignCityEntryState` city literal from `population: 4` to `population: 1` (needed so the plain `'warrior'` attacker, strength 10, has a safe margin against intrinsic strength — that fixture-flakiness fix is unrelated to this task's type-propagation work, which is why it lived in Task 4 instead of being duplicated here). Confirm with:
+
+```bash
+grep -n "population: 4" tests/input/city-assault-flow.test.ts tests/input/foreign-city-entry-flow.test.ts
+```
+
+Expected: no matches. If Task 4 Step 6 was skipped or missed a call site, fix it now before proceeding — this task's remaining steps assume every `beginPlayerCityAssaultChoice`/`beginConfirmedForeignCityEntry` call in both files succeeds deterministically.
+
+- [ ] **Step 2: Rewrite the test that asserts the old throwing behavior**
+
+In `tests/input/city-assault-flow.test.ts`, find:
+
+```ts
+  it('rejects a city assault when war has not been declared', () => {
+    const state = makePlayerAssaultState({ population: 1 });
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    expect(() => beginPlayerCityAssaultChoice(
+      state,
+      'unit-1',
+      'athens',
+      new EventBus(),
+    )).toThrow('Cannot begin city assault: not-at-war');
+  });
+```
+
+Replace with:
+
+```ts
+  it('rejects a city assault when war has not been declared', () => {
+    const state = makePlayerAssaultState({ population: 1 });
+    state.civilizations.player.diplomacy.atWarWith = [];
+    state.civilizations['ai-1'].diplomacy.atWarWith = [];
+
+    const result = beginPlayerCityAssaultChoice(
+      state,
+      'unit-1',
+      'athens',
+      new EventBus(),
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: 'not-at-war' });
+  });
+```
+
+- [ ] **Step 3: Guard every other unconditional `begun.pending`/`result.pending` access in both test files**
+
+TypeScript will not allow property access on the `ok: false` branch of a discriminated union without narrowing first — every remaining test in both files that does `beginPlayerCityAssaultChoice(...)` or `beginConfirmedForeignCityEntry(...)` and then reads `.pending` needs an `expect(result.ok).toBe(true); if (!result.ok) return;` guard immediately after the call (or, for tests using `const begun = ...`, `if (!begun.ok) throw new Error('expected success');`). Add this guard to every remaining `it(...)` in `tests/input/city-assault-flow.test.ts` (four tests still reference `begun.pending` after the fixture fix in Step 1) and both tests in `tests/input/foreign-city-entry-flow.test.ts`. Example for the first one:
+
+```ts
+  it('begins a pending player choice by moving onto a size-2 city and finalizes occupy in place', () => {
+    const state = makePlayerAssaultState({ population: 1 });
+    const bus = new EventBus();
+    const moved = vi.fn();
+    bus.on('unit:move', moved);
+
+    const begun = beginPlayerCityAssaultChoice(
+      state,
+      'unit-1',
+      'athens',
+      bus,
+    );
+    expect(begun.ok).toBe(true);
+    if (!begun.ok) return;
+    const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
+
+    expect(moved).toHaveBeenCalledOnce();
+    expect(begun.pending.occupiedPopulation).toBe(1);
+    expect(begun.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(begun.state.units['unit-1'].movementPointsLeft).toBe(0);
+    expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
+    expect(result.state.units['unit-1'].movementPointsLeft).toBe(0);
+    expect(result.state.cities.athens.owner).toBe('player');
+  });
+```
+
+> `occupiedPopulation` is `1` here (not the pre-Task-4 fixture's old `2`) because Task 4 Step 6 already dropped the fixture population from 4 to 1 (`Math.max(1, Math.floor(population / 2))` — see `computeRazeGold`'s sibling logic in `city-capture-system.ts`). If any remaining assertion in either file still expects the old `2`, that's a sign Task 4 Step 6 was incomplete — go back and finish it rather than patching the number here.
+
+- [ ] **Step 4: Run tests to verify they fail against the current (unfixed) source**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-assault-flow foreign-city-entry-flow`
+Expected: FAIL — `beginPlayerCityAssaultChoice` still throws and returns the old shape; `result.ok` doesn't exist yet.
+
+- [ ] **Step 5: Implement — `city-assault-flow.ts`**
+
+Replace the whole file:
+
+```ts
+import type { EventBus } from '@/core/event-bus';
+import type { CombatResult, GameState } from '@/core/types';
+import {
+  beginMajorCityAssault,
+  resolveMajorCityCapture,
+  type MajorCityAssaultFailureReason,
+  type MajorCityCaptureDisposition,
+  type MajorCityCaptureResult,
+  type PendingMajorCityCapture,
+} from '@/systems/city-capture-system';
+
+export type PendingCityCaptureChoice = PendingMajorCityCapture;
+
+export type PlayerCityAssaultChoiceResult =
+  | { ok: true; state: GameState; pending: PendingCityCaptureChoice }
+  | { ok: false; state: GameState; reason: MajorCityAssaultFailureReason };
+
+export function shouldPromptForPlayerCityCapture(
+  city: { population: number },
+): boolean {
+  return city.population >= 1;
+}
+
+export function beginPlayerCityAssaultChoice(
+  state: GameState,
+  attackerId: string,
+  cityId: string,
+  bus?: EventBus,
+  precedingCombat?: CombatResult,
+): PlayerCityAssaultChoiceResult {
+  return beginMajorCityAssault(
+    state,
+    attackerId,
+    cityId,
+    {
+      actor: 'player',
+      civId: state.currentPlayer,
+      bus,
+      precedingCombat,
+    },
+  );
+}
+
+export function finalizePlayerCityAssaultChoice(
+  state: GameState,
+  pending: PendingCityCaptureChoice,
+  disposition: MajorCityCaptureDisposition,
+  turn: number,
+  bus?: EventBus,
+): MajorCityCaptureResult {
+  return resolveMajorCityCapture(state, pending.cityId, state.currentPlayer, disposition, turn, bus);
+}
+```
+
+- [ ] **Step 6: Implement — `foreign-city-entry-flow.ts`**
+
+Change the return type and the final `return` statement (the war-declaration logic in the middle of the function is untouched):
+
+```ts
+import type { EventBus } from '@/core/event-bus';
+import type { GameState } from '@/core/types';
+import { beginPlayerCityAssaultChoice, type PlayerCityAssaultChoiceResult } from '@/input/city-assault-flow';
+import { declareWar, resolveOpponentKind } from '@/systems/diplomacy-system';
+
+export function beginConfirmedForeignCityEntry(
+  state: GameState,
+  attackerId: string,
+  cityId: string,
+  bus?: EventBus,
+): PlayerCityAssaultChoiceResult {
+  const city = state.cities[cityId];
+  if (!city) {
+    throw new Error(`Cannot enter missing city ${cityId}`);
+  }
+
+  let nextState = state;
+  const attackerCivId = state.currentPlayer;
+  const defenderId = city.owner;
+  const attacker = nextState.civilizations[attackerCivId];
+  const defender = nextState.civilizations[defenderId];
+  const alreadyAtWar = attacker?.diplomacy.atWarWith.includes(defenderId) ?? false;
+
+  if (attacker && defender && !alreadyAtWar) {
+    nextState = {
+      ...nextState,
+      civilizations: {
+        ...nextState.civilizations,
+        [attackerCivId]: {
+          ...attacker,
+          diplomacy: declareWar(attacker.diplomacy, defenderId, nextState.turn),
+        },
+        [defenderId]: {
+          ...defender,
+          diplomacy: declareWar(defender.diplomacy, attackerCivId, nextState.turn),
+        },
+      },
+    };
+    bus?.emit('diplomacy:war-declared', { attackerId: attackerCivId, defenderId, opponentKind: resolveOpponentKind(defenderId) });
+  }
+
+  return beginPlayerCityAssaultChoice(
+    nextState,
+    attackerId,
+    cityId,
+    bus,
+  );
+}
+```
+
+> `PendingCityCaptureChoice` is no longer imported here since the return type is now the shared union re-exported from `city-assault-flow.ts` — remove the old `type PendingCityCaptureChoice` import if TypeScript flags it as unused.
+
+- [ ] **Step 7: Implement — `main.ts`'s two call sites**
+
+First, `beginPlayerCityAssault`'s body (~line 2401), find:
+
+```ts
+  ensurePlayerWarState(city.owner);
+  const begun = beginPlayerCityAssaultChoice(
+    gameState,
+    attackerId,
+    cityId,
+    bus,
+    precedingCombat,
+  );
+  gameState = begun.state;
+
+  pendingCityCaptureChoice = begun.pending;
+```
+
+Replace with:
+
+```ts
+  ensurePlayerWarState(city.owner);
+  const begun = beginPlayerCityAssaultChoice(
+    gameState,
+    attackerId,
+    cityId,
+    bus,
+    precedingCombat,
+  );
+  gameState = begun.state;
+
+  if (!begun.ok) {
+    showNotification(
+      begun.reason === 'repelled-by-city-defense'
+        ? "Your attack was repelled by the city's defenses!"
+        : 'The attack could not proceed.',
+      'warning',
+    );
+    renderLoop.setGameState(gameState);
+    updateHUD();
+    return 'resolved';
+  }
+
+  pendingCityCaptureChoice = begun.pending;
+```
+
+Second, the `'confirm-war-city'` tap intent's `onConfirm` handler (~line 2991), find:
+
+```ts
+          onConfirm: () => {
+            const begun = beginConfirmedForeignCityEntry(gameState, selectedId, tapIntent.cityId, bus);
+            gameState = begun.state;
+            pendingCityCaptureChoice = begun.pending;
+            const captureCity = gameState.cities[tapIntent.cityId];
+            if (captureCity) {
+              createCityCapturePanel(uiLayer, {
+                cityName: captureCity.name,
+                occupiedPopulation: begun.pending.occupiedPopulation,
+                razeGold: begun.pending.razeGold,
+                onOccupy: () => finalizePendingCityCaptureChoice('occupy'),
+                onRaze: () => finalizePendingCityCaptureChoice('raze'),
+              });
+            }
+            SFX.tap();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+          },
+```
+
+Replace with:
+
+```ts
+          onConfirm: () => {
+            const begun = beginConfirmedForeignCityEntry(gameState, selectedId, tapIntent.cityId, bus);
+            gameState = begun.state;
+            if (!begun.ok) {
+              showNotification(
+                begun.reason === 'repelled-by-city-defense'
+                  ? "Your attack was repelled by the city's defenses!"
+                  : 'The attack could not proceed.',
+                'warning',
+              );
+              renderLoop.setGameState(gameState);
+              updateHUD();
+              return;
+            }
+            pendingCityCaptureChoice = begun.pending;
+            const captureCity = gameState.cities[tapIntent.cityId];
+            if (captureCity) {
+              createCityCapturePanel(uiLayer, {
+                cityName: captureCity.name,
+                occupiedPopulation: begun.pending.occupiedPopulation,
+                razeGold: begun.pending.razeGold,
+                onOccupy: () => finalizePendingCityCaptureChoice('occupy'),
+                onRaze: () => finalizePendingCityCaptureChoice('raze'),
+              });
+            }
+            SFX.tap();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+          },
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-assault-flow foreign-city-entry-flow`
+Expected: PASS.
+
+- [ ] **Step 9: Run the static-wiring integration test — verify it still matches**
+
+`tests/main.integration.test.ts`'s `describe('shared city assault wiring', ...)` regex-matches `main.ts`'s SOURCE TEXT for the exact call-site shape `beginPlayerCityAssaultChoice(\s*gameState,\s*attackerId,\s*cityId,\s*bus,\s*precedingCombat,\s*\)` and `beginPlayerCityAssault(\s*attackerId,\s*cityAtTarget\.id,\s*attackerBonus,\s*result,\s*\)`. This plan's Step 7 edit does not change either call's argument list (only what happens with the return value, several lines below the call), so these regexes should still match. Confirm:
+
+Run: `bash scripts/run-with-mise.sh yarn test main.integration`
+Expected: PASS. If it fails, the call-site text was reformatted in a way that broke the regex — restore the exact original call-argument formatting shown in Step 7 above.
+
+- [ ] **Step 10: Full suite + build**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: exit 0 — this is the step that catches any remaining unguarded `.pending` access across the codebase as a compile error, since `PlayerCityAssaultChoiceResult` is now a real discriminated union everywhere it flows.
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: all tests pass.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/input/city-assault-flow.ts src/input/foreign-city-entry-flow.ts src/main.ts tests/input/city-assault-flow.test.ts tests/input/foreign-city-entry-flow.test.ts
+git commit -m "refactor(city-combat): propagate assault-result union through the capture-flow call chain (#522)"
+```
+
+---
+
+### Task 10: UI preview panel for `'assault-city'` tap intent
+
+**Files:**
+- Modify: `src/main.ts:2971-2982` (the `else` branch handling `tapIntent`)
+
+**Interfaces:**
+- Consumes: `calculateCityAssaultStrengths` (`@/systems/city-siege-system`); `beginPlayerCityAssault` (already defined in this file, ~line 2401, and already handles `ok: false` gracefully as of Task 9).
+
+**No dedicated unit test** — `main.ts` has no unit-test file in this codebase for behavioral coverage (`tests/main.integration.test.ts` exists but is a static source-regex checker, not a functional test — see Task 9 Step 9). Verified via the Browser pane instead (Step 3 below).
+
+- [ ] **Step 1: Add the import**
+
+In `src/main.ts`, add near the other `city-siege-system` or `combat-system` imports (search `grep -n "from '@/systems/combat-system'" src/main.ts` for a nearby import block to extend):
+
+```ts
+import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
+```
+
+- [ ] **Step 2: Replace the immediate-resolve branch with a preview panel**
+
+Find the `'assault-city'` branch (~line 2973):
+
+```ts
+      if (tapIntent.kind === 'assault-city') {
+        const assaultStatus = beginPlayerCityAssault(selectedUnitId, tapIntent.cityId);
+        SFX.tap();
+        renderLoop.setGameState(gameState);
+        updateHUD();
+        if (assaultStatus === 'resolved') {
+          setTimeout(() => selectNextUnit(), 400);
+        }
+        return;
+      }
+```
+
+Replace with a preview panel mirroring the existing unit-attack preview panel's exact DOM/style pattern (raw `document.createElement`, not `createGameButton` — this file's established local convention, verified against the adjacent unit-attack branch):
+
+```ts
+      if (tapIntent.kind === 'assault-city') {
+        const attackerUnit = gameState.units[selectedUnitId];
+        const targetCity = gameState.cities[tapIntent.cityId];
+        const ownerCiv = targetCity ? gameState.civilizations[targetCity.owner] : undefined;
+        if (!attackerUnit || !targetCity || !ownerCiv) return;
+
+        const strengths = calculateCityAssaultStrengths(attackerUnit, targetCity, ownerCiv, gameState.map);
+        const atkStr = Math.round(strengths.attackerStrength);
+        const cityStr = Math.round(strengths.intrinsicStrength);
+        const odds = strengths.winProbability > 0.55 ? 'Favorable' : strengths.winProbability > 0.45 ? 'Even' : 'Risky';
+        const oddsColor = strengths.winProbability > 0.55 ? '#6b9b4b' : strengths.winProbability > 0.45 ? '#e8c170' : '#d94a4a';
+
+        const panel = document.getElementById('info-panel');
+        if (panel) {
+          panel.style.display = 'block';
+          const previewDiv = document.createElement('div');
+          previewDiv.style.cssText = 'background:rgba(100,0,0,0.9);border-radius:12px;padding:12px 16px;';
+
+          const title = document.createElement('div');
+          title.style.cssText = 'font-size:13px;color:#e8c170;margin-bottom:6px;';
+          title.textContent = 'Assault Preview';
+          previewDiv.appendChild(title);
+
+          const stats = document.createElement('div');
+          stats.style.cssText = 'display:flex;justify-content:space-between;font-size:12px;margin-bottom:8px;';
+          const atkSpan = document.createElement('span');
+          atkSpan.textContent = `${UNIT_DEFINITIONS[attackerUnit.type].name} (${atkStr})`;
+          const oddsSpan = document.createElement('span');
+          oddsSpan.style.cssText = `color:${oddsColor};font-weight:bold;`;
+          oddsSpan.textContent = odds;
+          const defSpan = document.createElement('span');
+          defSpan.textContent = `${targetCity.name} defenses (${cityStr})`;
+          stats.appendChild(atkSpan);
+          stats.appendChild(oddsSpan);
+          stats.appendChild(defSpan);
+          previewDiv.appendChild(stats);
+
+          const info = document.createElement('div');
+          info.style.cssText = 'font-size:10px;opacity:0.6;margin-bottom:8px;';
+          info.textContent = 'A walled city fights back if it has no garrison.';
+          previewDiv.appendChild(info);
+
+          const btnRow = document.createElement('div');
+          btnRow.style.cssText = 'display:flex;gap:8px;';
+          const attackBtn = document.createElement('button');
+          attackBtn.id = 'btn-assault-confirm';
+          attackBtn.textContent = 'Attack';
+          attackBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:#d94a4a;border:none;color:white;font-weight:bold;cursor:pointer;';
+          const cancelBtn = document.createElement('button');
+          cancelBtn.id = 'btn-cancel-assault';
+          cancelBtn.textContent = 'Cancel';
+          cancelBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:rgba(255,255,255,0.15);border:none;color:white;cursor:pointer;';
+          btnRow.appendChild(attackBtn);
+          btnRow.appendChild(cancelBtn);
+          previewDiv.appendChild(btnRow);
+
+          panel.innerHTML = '';
+          panel.appendChild(previewDiv);
+
+          cancelBtn.addEventListener('click', deselectUnit);
+          attackBtn.addEventListener('click', () => {
+            const assaultStatus = beginPlayerCityAssault(selectedUnitId, tapIntent.cityId);
+            SFX.combat();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+            if (assaultStatus === 'resolved') {
+              setTimeout(() => selectNextUnit(), 400);
+            }
+          });
+        }
+        return;
+      }
+```
+
+> `UNIT_DEFINITIONS` should already be imported in `main.ts` (it's used extensively elsewhere) — verify with `grep -n "^import.*UNIT_DEFINITIONS" src/main.ts` rather than adding a duplicate import.
+
+> `beginPlayerCityAssault` already shows a "repelled" notification and returns `'resolved'` on `ok: false` as of Task 9 — this task's `attackBtn` click handler needs no additional failure handling of its own.
+
+- [ ] **Step 3: Browser verification**
+
+Start the dev server and drive a real assault against a walled, ungarrisoned enemy city to confirm the preview renders, Attack/Cancel both work, and a repelled outcome shows the Task 9 notification instead of throwing:
+
+```
+preview_start (name: dev, or whatever this project's launch.json defines)
+```
+
+Navigate to a game state with an adjacent enemy walled city (or construct one via the in-game console / a fresh game with tech to reach walls), select an attacking unit, tap the city, confirm the preview panel appears with odds text and two buttons, click Attack, confirm either the capture-disposition panel opens (win) or a "repelled" notification appears with the unit's HP reduced (loss) — check `read_console_messages` for zero errors throughout.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.ts
+git commit -m "feat(ui): odds preview panel for city assault (#522)"
+```
+
+---
+
+### Task 11: Cross-cutting regressions — balance sampling, actor parity, hot-seat verification
+
+**Files:**
+- Test: `tests/systems/city-siege-system.test.ts` (extend), `tests/systems/city-capture-system.test.ts` (extend)
+
+- [ ] **Step 1: Balance-sampling test**
+
+In `tests/systems/city-siege-system.test.ts`, add:
+
+```ts
+describe('city assault balance sampling (#522)', () => {
+  it('an unwalled, low-population outpost reliably favors an era-appropriate attacker', () => {
+    // Today this capture is 100% guaranteed; the new mechanic must not turn routine
+    // early expansion into a frequent failure.
+    const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: [] });
+    const attacker = createUnit('warrior', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+    const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, {
+      width: 10, height: 10, wrapsHorizontally: false, rivers: [], tiles: {},
+    });
+    const wins = Array.from({ length: 50 }, (_, i) => resolveCityAssault(
+      strengths.attackerStrength, strengths.intrinsicStrength, i,
+    ).attackerWins);
+    const winRate = wins.filter(Boolean).length / wins.length;
+    expect(winRate).toBeGreaterThan(0.9);
+  });
+
+  it('a walled, high-population, fully-teched city meaningfully raises attacker losses without being unbeatable', () => {
+    const { city, ownerCiv: baseCiv } = makeCityAndCiv({ population: 20, buildings: ['walls', 'star_fort'] });
+    const ownerCiv = withTechs(baseCiv, ['fortification-engineering', 'professional-army']);
+    const attacker = createUnit('tank', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+    const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, {
+      width: 10, height: 10, wrapsHorizontally: false, rivers: [], tiles: {},
+    });
+    const wins = Array.from({ length: 50 }, (_, i) => resolveCityAssault(
+      strengths.attackerStrength, strengths.intrinsicStrength, i,
+    ).attackerWins);
+    const winRate = wins.filter(Boolean).length / wins.length;
+    // An era-appropriate strong attacker (tank) should still be capable of winning,
+    // just not trivially -- not >0.95 (city offers zero real resistance) and not <0.05
+    // (city becomes practically uncapturable even to a strong, teched attacker).
+    expect(winRate).toBeLessThan(0.95);
+    expect(winRate).toBeGreaterThan(0.05);
+  });
+});
+```
+
+If either bound fails, adjust `CITY_BASE_STRENGTH`/`CITY_STRENGTH_PER_POPULATION` (Task 1) — they are explicitly provisional per the spec, not fixed by this plan.
+
+- [ ] **Step 2: Run and verify**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-siege-system`
+Expected: PASS. If a bound fails, adjust the constants in `city-siege-system.ts` (Task 1) and re-run — do not weaken the test bounds to fit bad constants.
+
+- [ ] **Step 3: Actor-parity test**
+
+In `tests/systems/city-capture-system.test.ts`, add:
+
+```ts
+it('the AI-actor capture path uses the identical resolution as the player path (#522)', () => {
+  const playerState = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+  const aiState = structuredClone(playerState);
+
+  const playerResult = beginMajorCityAssault(playerState, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+  const aiResult = beginMajorCityAssault(aiState, 'attacker', 'athens', { actor: 'ai', civId: 'player' });
+
+  // Same state, same seed inputs (turn/attackerId/cityId) -> identical outcome,
+  // regardless of the 'actor' field, which is purely for event/bookkeeping purposes.
+  expect(playerResult.ok).toBe(aiResult.ok);
+});
+```
+
+> This function is defined inside the `describe('city-capture-system intrinsic defense (#522)', ...)` block from Task 4 — add this test there, not at file scope.
+>
+> **This is actor-parity coverage (`'player'` vs `'ai'` tag), not genuine multi-human hot-seat coverage** — an earlier draft of this task conflated the two under one heading. A real hot-seat check (two different human-controlled civ ids in the same game, one of them not literally `'player'`) is deliberately **not** added as a new test here: verified directly against every function this plan touches (Tasks 1-8 operate only on `city.owner`/`attacker.owner`/domain strings and never reference `civId` or `currentPlayer` at all; Task 9's `beginPlayerCityAssaultChoice` and `finalizePlayerCityAssaultChoice` route through the pre-existing `civId: state.currentPlayer` / `resolveMajorCityCapture(state, pending.cityId, state.currentPlayer, ...)` lines completely unchanged — Task 9 only wraps their return value in a union, it does not touch how `civId` is derived). Since nothing in this plan introduces new `civId`/`currentPlayer` logic, hot-seat correctness is inherited from the pre-existing (and already-tested) capture-flow plumbing, not something this plan could regress. If a future change to this feature ever DOES add new `civId`-branching logic, that change is what needs the dedicated hot-seat test, not this one.
+
+- [ ] **Step 4: Run and verify**
+
+Run: `bash scripts/run-with-mise.sh yarn test city-capture-system`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite + build one final time**
+
+Run: `bash scripts/run-with-mise.sh yarn build`
+Expected: exit 0 (tsc clean).
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: all tests pass, 0 failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/systems/city-siege-system.test.ts tests/systems/city-capture-system.test.ts
+git commit -m "test(city-combat): balance sampling + actor-parity regressions (#522)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Intrinsic strength formula → Task 1 ✓
+- §2 `resolveCityAssault` + integration (double-punishment fix) → Tasks 2, 4 ✓
+- §3 `getCityCounterFireDamage` (ratio-scaled) + three call sites → Tasks 3, 4, 5, 6 ✓
+- §3 SFX (no new cue, reuse `SFX.combat()`) → Task 10 (reused at the existing call site) ✓
+- §4 UI preview panel + defender-side visibility → Tasks 10, 8 ✓
+- §5 Scope guard: major-civ only (no code needed, `beginMajorCityAssault`'s existing `not-major-city` gate untouched), actor parity → Task 11 ✓, AI scoring fix → Task 7 ✓, difficulty (no new knob, no code) ✓
+- §6 All testing bullets → Tasks 1, 2, 3, 4, 5, 6, 7, 8, 11 ✓
+
+**Placeholder scan:** No TBD/TODO. The one deliberately-flagged "adapt to this file's existing fixture" note in Task 5 Step 1 names exactly what to look for (an existing `processTurn` + barbarian test) rather than leaving the shape undefined.
+
+**Type consistency:** `getCityIntrinsicStrength(city, ownerCiv, attackerDomain)` (Task 1) is the base every other function calls through — `calculateCityAssaultStrengths` (Task 2), `getCityCounterFireDamage` (Task 3), the city-panel display (Task 8), and the AI scorer (Task 7) all call it with the same three-argument shape. `resolveCityAssault(attackerStrength, intrinsicStrength, seed)` (Task 2) and `getCityCounterFireDamage(..., attackerStrength, hasGarrison, seed)` (Task 3) both consume the `attackerStrength` number `calculateCityAssaultStrengths` produces — no call site recomputes it differently. `'repelled-by-city-defense'` (Task 4) is the one new failure reason, referenced identically through `PlayerCityAssaultChoiceResult` (Task 9) and Task 10's UI handling.
+
+**Found during self-review, fixed by restructuring:** the original single "Task 9: UI preview panel" assumed `beginPlayerCityAssault`'s existing `throw new Error` on failure could stay as-is. Tracing the actual call chain surfaced three existing consumers of `beginPlayerCityAssaultChoice` (`city-assault-flow.ts` itself, `foreign-city-entry-flow.ts`, and two separate call sites in `main.ts`) that all assume unconditional success today, plus two existing test files (`city-assault-flow.test.ts`, `foreign-city-entry-flow.test.ts`) with the same flaky-fixture risk already found in Task 4, one of which explicitly asserts the old throwing behavior via `.toThrow(...)`. This was too large and too separable a concern to fold into the UI task silently — split into a dedicated Task 9 (type propagation + fixture/test fixes, no new UI) that Task 10 (the actual preview panel) now depends on and builds on top of.
+
+**Found during a second, dimension-by-dimension review pass (balance, fun, ages 7-43, playstyles, difficulty, AI, UI, UX, architecture, extensibility, data/saves, testing, regressions, solo, hot-seat, implementation) — three real issues fixed in place:**
+
+1. **RNG correlation bug (implementation/determinism).** Tasks 2 and 3's original `seededRatio(seed)` / `seededRatio(seed + 1)` pattern was a stateless single-shot LCG evaluation, not a chained stream — the two "independent" draws it produced (the ±20% random factor and the win/lose or damage-magnitude roll) differed only by the constant `48271` (mod `2147483647`) regardless of `seed`, so they were never truly independent, despite the code's own comment claiming to mirror `resolveCombat`'s real `rng()` closure. Worse, Task 4's integration code passed the exact same raw `seed` to both `getCityCounterFireDamage` and `resolveCityAssault`, so their *first* draws were identical every time — silently correlating "how much counter-fire damage I take" with "do I win the assault" on every single attack, compressing the mechanic's intended variance. Fixed: `seededRatio` replaced with `createSeededRng(seed): () => number`, a proper chained closure matching `resolveCombat`'s actual pattern (Tasks 2 and 3); Task 4 now derives two decorrelated seeds (`baseSeed`, `baseSeed ^ 0x5a5a`) for its two independent rolls.
+2. **Missing player feedback for counter-fire (UX / "every user action needs visible feedback").** The original Tasks 5 and 6 damaged or killed the attacking barbarian raider / pirate ship with zero notification — every other siege-related state change in this codebase (`barbarian:city-attacked`, `city:sacked`, `pirate:city-destroyed`) already appends to the civ log, but counter-fire, a brand-new consequence the player can't otherwise observe, had no event at all. Fixed: added a shared `'city:counter-fire'` event (`core/types.ts`, Task 5 Step 3) emitted by both the barbarian and pirate paths, with one `main.ts` listener logging "walls fought back" (`'info'`) or "destroyed a raider/ship" (`'success'`) to the civ log — mirrors the existing `'city:sacked'` shape exactly.
+3. **"Hot-seat" test mislabeled (test-coverage honesty).** Task 11's original Step 3 was titled a "hot-seat / actor-parity test" but only checked `actor: 'player'` vs `actor: 'ai'` tag equivalence against the same `civId: 'player'` — a materially weaker guarantee than genuine multi-human hot-seat correctness (CLAUDE.md's "never hardcode `'player'`, always use `state.currentPlayer`" rule). Rather than bolt on a speculative dynamic hot-seat test against fixture internals not fully visible in this plan (risking incorrect plan code), verified directly against every function this plan adds or touches: Tasks 1-8 never reference `civId`/`currentPlayer` at all (they operate on `city.owner`/`attacker.owner`), and Task 9 preserves the pre-existing `civId: state.currentPlayer` / `resolveMajorCityCapture(..., state.currentPlayer, ...)` lines completely unchanged. Renamed the task/step to "actor parity" (accurate) and added a note explaining hot-seat correctness is inherited, not newly at risk, from this plan.
+
+**Save compatibility (explicit, since no prior section covered it):** this plan adds zero new fields to `City`, `Unit`, `Civilization`, or `GameState` — every new function (`getCityIntrinsicStrength`, `calculateCityAssaultStrengths`, `resolveCityAssault`, `getCityCounterFireDamage`) is a pure calculation over fields that already exist on any save (`population`, `buildings`, `techState.completed`). The one new persisted-adjacent surface, `MajorCityAssaultFailureReason`'s `'repelled-by-city-defense'` member, is a return-value union, never serialized into `GameState`. **No save migration is required** — a save from before this plan loads and plays identically except for the new combat behavior itself.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-12-city-combat-entity.md`.
+
+**This project's CLAUDE.md forbids subagents**, so execution is **inline** via superpowers:executing-plans — batch execution with a review checkpoint after each task's commit.

--- a/docs/superpowers/specs/2026-07-11-city-combat-entity-design.md
+++ b/docs/superpowers/specs/2026-07-11-city-combat-entity-design.md
@@ -1,0 +1,314 @@
+# City As A Combat Entity — Design
+
+Issue: #522 (remaining scope). The flat-damage-siege bug itself is fully fixed —
+barbarian half in #549, pirate half in #556 (merged). This spec addresses the issue's
+**second comment**, which extended the scope: `beginMajorCityAssault` lets any adjacent
+melee unit walk into an **ungarrisoned** city instantly, regardless of walls/Star
+Fort/defensive techs — those bonuses today only ever multiply a *garrison unit's*
+defense strength (`calculateCombatStrengths` → `getCityDefenseBreakdown`, applied only
+when a defending `Unit` exists on the city tile). Remove the garrison and the bonus has
+nothing to apply to; the city offers zero resistance. Meanwhile cities never strike back
+at besiegers at all — no intrinsic strength, no ranged retaliation.
+
+## Background — what's already true (verified against current `main`, post-#556)
+
+- `beginMajorCityAssault` (`src/systems/city-capture-system.ts:156`) blocks entirely if
+  any unit occupies the city tile (`'city-defended'` failure — the player must defeat
+  that unit in normal combat first); otherwise it proceeds straight to the
+  raze/occupy-disposition flow with **no combat, no strength check, no odds**.
+- `getCityDefenseBreakdown` (`src/systems/combat-system.ts:64`) already computes
+  `{ multiplier, flatBonus, parts }` from walls (×1.25), Star Fort (+5, requires walls),
+  Fortification Engineering (+5, requires walls), Professional Army (×1.10), and
+  Torpedo Warfare (+5, naval attackers only) — but it is only ever consumed inside
+  `calculateCombatStrengths` when a real defending `Unit` exists.
+- `src/systems/city-siege-system.ts` (built for #549/#556) already has
+  `resolveCitySiegeDamage`/`applyCitySiegeOutcome`/`getCityGarrisonUnit`/
+  `isCityHpRegenerating`/`applyCityHpRegeneration` for the barbarian/pirate multi-turn
+  HP-drain siege model, with a `hasGarrison` full-block rule and a last-city sack-only
+  guarantee (`isOwnersLastCity`). **This model is not being replaced or touched by this
+  spec** — see design decisions below.
+- The UI unit-attack tap flow (`src/main.ts`, the non-`'assault-city'` branch around
+  line 2930) already builds a preview panel (odds/breakdown text +
+  `createGameButton` Attack/Cancel pair) before calling `executeAttack`. The
+  `'assault-city'` tap-intent branch (`main.ts:2973`) calls `beginPlayerCityAssault`
+  **immediately on tap, with no preview**, because today there is nothing to preview —
+  the outcome is guaranteed.
+- Minor-civ (city-state) capture goes through a separate, already-distinct system
+  (`conquestMinorCiv`), confirmed by `beginMajorCityAssault`'s own `not-major-city`
+  guard. **Out of scope** for this spec, matching #522's stated bounds.
+
+## Design decisions (resolved in brainstorming)
+
+1. **Full unification** — both the player-capture path and the barbarian/pirate
+   chip-damage path derive city defense from the same intrinsic-strength model, per the
+   issue's explicit ask ("route BOTH... through it").
+2. **Player capture resolves as a single decisive combat exchange**, not a shared
+   `city.hp` grind. `city.hp` stays the barbarian/pirate multi-turn siege-attrition pool,
+   completely unchanged. An ungarrisoned city's defense against a *player* attacker is a
+   one-shot strength comparison (win this turn or don't), keeping conquest pacing close
+   to today's (still winnable in 1–2 turns by a real army) while finally giving
+   unwalled-vs-walled cities a meaningful difference. This was a deliberate,
+   explicitly-flagged de-risking of the issue's more literal "HP with regen" phrasing,
+   which would have turned every empty walled city into a multi-turn grind — a major,
+   unreviewed pacing change to the core conquest loop.
+3. **Automatic ranged counter-fire, no-garrison only.** A walled, ungarrisoned city
+   automatically deals retaliation damage to any hostile unit that attacks it —
+   uniformly across player, barbarian, and pirate attackers. This does **not** stack
+   with a garrisoned city's existing unit-vs-unit combat retaliation (garrison presence
+   changes the whole resolution path, mirroring the existing #549 "garrison fully
+   blocks" precedent) — avoids double-punishing attackers of a defended city.
+
+## 1. Intrinsic city strength
+
+New `getCityIntrinsicStrength(city: City, ownerCiv: Civilization, attackerDomain: 'land' | 'naval' | 'air'): number`
+in `city-siege-system.ts` (the file that already owns `getCityDefenseBreakdown`
+composition for sieges):
+
+```
+base = CITY_BASE_STRENGTH + city.population * CITY_STRENGTH_PER_POPULATION
+intrinsicStrength = base * breakdown.multiplier + breakdown.flatBonus
+```
+
+where `breakdown = getCityDefenseBreakdown({ cityBuildings: city.buildings, defenderCompletedTechs: ownerCiv.techState.completed, attackerDomain })`
+— **verbatim reuse**, no new defense sources. Proposed constants:
+`CITY_BASE_STRENGTH = 5`, `CITY_STRENGTH_PER_POPULATION = 3`. Calibration rationale
+(from the current unit-strength spread, ~5 at era 1 to ~120 at era 12): an unwalled
+outpost (population 1) sits at ~8 — trivially weak, matching the intent that early
+outposts stay vulnerable; a walled metropolis (population 12+) with just the walls
+multiplier reaches ~50+, comparable to a mid-tier defending unit of its own era. These
+are tuning constants, not load-bearing architecture, and **must** be validated by a
+balance-sampling test across eras (§6) before merge — same method already used for the
+pirate siege damage table (`PIRATE_SIEGE_DAMAGE`).
+
+Intrinsic strength applies **regardless of walls** (population always contributes a
+baseline) — walls/techs are multipliers on top, exactly mirroring how
+`getCityDefenseBreakdown` already layers onto a garrison unit's strength today. This is
+deliberately different from counter-fire (§3), which requires walls specifically.
+
+## 2. Player-capture resolution — `resolveCityAssault`
+
+`resolveCombat` (`combat-system.ts:226`) is built around two real `Unit` objects
+(health, veterancy, death, rewards). Routing a city through it would require
+constructing a synthetic `Unit` — an awkward hack that drags in unrelated
+unit-combat side effects a city doesn't have. Instead, two new functions in
+`city-siege-system.ts`, mirroring the existing `calculateCombatStrengths` /
+`resolveCombat` split:
+
+- `calculateCityAssaultStrengths(attacker: Unit, intrinsicStrength: number): CityAssaultStrengthBreakdown`
+  — the odds/preview half. Returns attacker strength (from `UNIT_DEFINITIONS`, with the
+  same terrain/river modifiers real combat previews already show), the city's
+  `intrinsicStrength`, and win-probability, in a shape the UI preview panel (§4) can
+  render directly.
+- `resolveCityAssault(attacker: Unit, intrinsicStrength: number, seed: number): { attackerWins: boolean }`
+  — the win/lose determination only, reusing the same strength-ratio/seeded-RNG math
+  `resolveCombat` already uses for odds. **Deliberately does not compute damage** — see
+  §3, damage is unified with barbarian/pirate counter-fire via one shared,
+  strength-ratio-aware formula. No veterancy, no rewards, no unit death bookkeeping — a
+  city isn't a kill.
+
+**Integration** (`city-capture-system.ts`, `beginMajorCityAssault`): applies **only**
+when the assault has no preceding combat — i.e., the city was already undefended before
+this action, not the "defeated the garrison in a real fight, now advancing into the
+vacated tile" path. That second path already resolved a complete, walls-boosted combat
+exchange against the garrison unit (via the existing `calculateCombatStrengths` +
+`getCityDefenseBreakdown` machinery) in the same turn; running a *second*,
+independent intrinsic-strength check immediately afterward would double-punish the
+attacker for the same city in the same action. Concretely: only the branch that today
+has no `precedingCombat` and no occupying unit gets this new resolution step; the
+`precedingCombat`-driven advance is untouched, byte-for-byte.
+
+For that undefended-from-the-start case, call `resolveCityAssault` before proceeding.
+**Regardless of outcome**, the attacker takes counter-fire damage (§3) if the city has
+walls — storming a walled city costs the attacker something even on a successful
+capture, not just on failure, mirroring how a winning unit in normal combat still takes
+proportional counter-damage from a defender capable of striking back.
+- **Attacker wins** → proceeds exactly as today (unchanged raze/occupy-disposition
+  flow), after applying counter-fire damage to the attacker.
+- **Attacker loses** → new failure reason `'repelled-by-city-defense'`. The attacker
+  takes counter-fire damage and has `hasActed`/`movementPointsLeft` consumed (mirrors a
+  normal failed attack) but does **not** advance into the city tile. The city remains
+  owned by the defender, available for another attempt (by this or another unit) on a
+  future turn.
+
+## 3. Ranged counter-fire
+
+New `getCityCounterFireDamage(city: City, ownerCiv: Civilization, attackerDomain: 'land' | 'naval' | 'air', attackerStrength: number, seed: number): number`
+in `city-siege-system.ts`. Returns `0` if the city has no `walls` building (the issue's
+literal "once walls exist" gate — stricter than intrinsic strength's always-on
+population baseline) or if the city has a garrison (decision 3).
+
+**Damage must scale with the strength ratio, not be a flat fraction of intrinsic
+strength** — this was the design's original flaw, caught in review: `resolveCombat`'s
+own counter-damage to an attacker is `baseDamage * (1 - adjustedRatio)`, so a much
+stronger attacker already takes proportionally *less* retaliation there. A flat
+"20% of intrinsic strength" counter-fire would ignore that convention entirely, making
+an overwhelming attacker sting exactly as much as a marginal one — inconsistent with
+how every other counter-attack in this game already feels. Fixed formula: compute
+`adjustedRatio` from `attackerStrength` vs. `intrinsicStrength` using the same
+seeded-RNG ±20% randomness `resolveCombat` uses, then
+`counterFireDamage = Math.round(baseDamage * (1 - adjustedRatio))`, reusing
+`resolveCombat`'s existing `baseDamage` era-scaling curve so the numbers stay in the
+same range as real unit combat.
+
+**Three call sites, one shared helper:**
+- **Player capture** (`city-capture-system.ts`): applied unconditionally (win or lose)
+  to the attacker alongside the separate `resolveCityAssault` win/lose check — see §2.
+  `attackerStrength` here is the same value `calculateCityAssaultStrengths` already
+  computed for the preview, so the preview's shown odds and the actual damage taken are
+  never inconsistent with each other.
+- **Barbarian siege** (`turn-manager.ts`, the barbarian city-attack loop): after
+  `resolveCitySiegeDamage` for an order where `!hasGarrison`, call
+  `getCityCounterFireDamage` (with the attacking barbarian unit's
+  `UNIT_DEFINITIONS[...].strength`) and apply it to `order.attackerUnitId`'s unit. If
+  this reduces the unit's health to 0, simply remove it from `state.units` and the
+  owner's unit roster — **verified safe with no further cleanup**:
+  `barbarianHomeCampByUnitId` (`barbarian-system.ts:288-292`) already self-prunes any
+  entry whose unit no longer exists on every processing pass, so a counter-fire kill
+  needs no special-cased bookkeeping beyond the standard unit removal.
+- **Pirate siege** (`pirate-system.ts`, the siege-application loop): same pattern,
+  applied to one ship from the besieging faction (nearest-to-city among
+  `faction.shipIds`, tie-broken by id for determinism) after `resolveCitySiegeDamage`.
+  **Also verified safe**: `pirate-system.ts:114`'s `shipIds: faction.shipIds.filter(unitId => Boolean(state.units[unitId]))`
+  already prunes dead ship references every round — a counter-fire kill is just a
+  normal unit removal. A well-defended city can now sink a besieging ship over multiple
+  rounds — a new, symmetrical consequence; today barbarian/pirate sieges deal one-way
+  damage with zero risk to the attacker.
+
+**SFX:** no new cue. The existing player-capture call site already plays `SFX.combat()`
+(`main.ts:804`) for a city-related attack, matching how normal unit combat uses one
+generic sound for both win and loss outcomes — extending the same call to cover the new
+preview-confirmed assault (§4) is consistent with that convention, not a gap.
+
+## 4. UI
+
+**Preview panel for `'assault-city'` tap intent** (`main.ts`): currently resolves
+immediately with no confirmation, because there was nothing to preview. New behavior
+mirrors the adjacent unit-attack tap-intent branch exactly: build a preview panel via
+`calculateCityAssaultStrengths` (odds, intrinsic-strength breakdown reusing
+`formatCombatPreviewDetails`'s `cityDefense.parts` rendering convention from
+`combat-preview.ts`), with `createGameButton` Attack/Cancel buttons. `beginPlayerCityAssault`
+is only called after the player confirms — satisfying the project's standing "show
+expected outcome before committing to an attack" rule (`.claude/rules/strategy-game-mechanics.md`),
+which a silent-resolve exception would have violated.
+
+On loss: a notification explains the repulsion (mirrors existing combat-failure
+notification conventions) and the attacking unit's updated HP is reflected immediately
+in its selected-unit panel. On win: the existing raze/occupy disposition panel opens,
+unchanged.
+
+**Defender-side visibility (gap found in review).** The preview panel above only helps
+the *attacker*. Today there is no UI surface at all showing a city's own defense rating
+to its owner — a defensive/builder-playstyle player who never initiates an attack has
+no way to check "is my capital actually protected?" before deciding whether to build
+Walls or station a garrison. `city-panel.ts` already has a status-label area (lines
+653–654, the "🩹 Recovering" / "⚔️ Under siege" HP text added in #549) that is the
+natural home for this. Add an intrinsic-strength readout there (e.g., "🛡️ Defense: 47"
+or a qualitative band) for every owned city, not just ones under active attack — a
+static informational line, not conditional on siege state.
+
+## 5. Scope guard
+
+- **Major-civ cities only.** Minor-civ (city-state) conquest (`conquestMinorCiv`) is a
+  separate, pre-existing system — not touched.
+- **Hot-seat / actor parity:** the same `resolveCityAssault`/`getCityCounterFireDamage`
+  helpers serve the human-player path, the AI-major-civ path (`ai-major-turn.ts`, which
+  already calls `beginMajorCityAssault`), and barbarian/pirate paths identically — no
+  actor-specific branching in the core resolution logic.
+- **Difficulty:** no new difficulty knob. Intrinsic strength and counter-fire scale
+  purely from population/buildings/techs, which already vary by how well a given
+  civ (human or AI, on any difficulty) has developed — consistent with how
+  `citySiegeDestructionEra` is the only existing difficulty lever for city survival,
+  left untouched here. Verified this is consistent with the rest of `OpponentChallenge`:
+  it never scales raw combat math anywhere today (only AI behavior parameters and
+  `citySiegeDestructionEra`), so a new knob here would be the inconsistent choice, not
+  the missing one.
+- **AI capture scoring must change (real gap found in review, not just a "works as-is"
+  extension).** `ai-tactics.ts`'s `rankCapture` currently scores *any* reachable
+  undefended-city capture with a flat priority of `600` — zero win-probability
+  awareness, because today capture is unconditionally guaranteed. Left as-is, the AI
+  would blindly send units to die against a strongly walled, high-population city with
+  no way to distinguish that from a free capture — a real behavioral regression, not a
+  neutral no-op. `rankCapture` must weight its score by the same win-probability
+  `calculateCityAssaultStrengths` computes for the player preview, so the AI
+  deprioritizes (not necessarily refuses) a bad assault the way a reasonable player
+  would after seeing low odds in the preview panel.
+- **Barbarian/pirate target selection is intentionally left as-is.** Their attack-order
+  generation (`barbarian-system.ts`, `pirate-behavior.ts`) does not evaluate
+  counter-fire risk before choosing a target. This is an accepted, lower-severity
+  choice: barbarians and pirates are aggression-first "dumb" AI by design, and taking
+  some losses to a walled city's counter-fire is consistent with the risk profile they
+  already have attacking a garrison. Not required for this MR; a future refinement
+  could teach them to prefer weaker targets, same as any other AI-improvement pass.
+
+## 6. Testing (TDD)
+
+- **`getCityIntrinsicStrength`:** population scaling, walls/Star Fort/Fortification
+  Engineering/Professional Army/Torpedo-Warfare-vs-naval all apply identically to how
+  they already apply to a garrison unit (parity test against
+  `getCityDefenseBreakdown`'s existing coverage); zero-population edge case; naval vs.
+  land attacker domain difference.
+- **`calculateCityAssaultStrengths` / `resolveCityAssault`:** odds are deterministic
+  given a seed; a strong attacker vs. a weak (unwalled, low-population) city wins
+  reliably; a weak attacker vs. a strong (walled, high-population, teched) city loses
+  reliably. `resolveCityAssault` returns only `attackerWins` — no damage assertions
+  belong on this function; damage is `getCityCounterFireDamage`'s responsibility (see
+  below) and is unconditional on win/lose.
+- **`beginMajorCityAssault` integration:** both outcomes of an ungarrisoned-walled
+  assault (win → existing disposition flow fires unchanged, attacker still takes
+  counter-fire damage; lose → `'repelled-by-city-defense'`, city still owned by
+  defender, attacker takes the same counter-fire damage and is action-consumed, no
+  disposition panel). A regression asserting the counter-fire damage amount, for a
+  *fixed* attacker/city strength pair, is identical whether the attacker wins or loses
+  (proves "unconditional" isn't just documentation). **A dedicated regression for the
+  double-punishment fix**: construct a `precedingCombat`-driven advance into a
+  now-vacated city and assert `resolveCityAssault`/counter-fire is never invoked for
+  that path — only the garrison combat's own damage applies, nothing additional. Garrisoned-city
+  path (the `'city-defended'` failure branch) is a byte-for-byte regression otherwise
+  (this spec must not change its behavior at all).
+- **`getCityCounterFireDamage`:** zero without walls; zero with a garrison present;
+  nonzero and walls/tech-scaled otherwise; **scales inversely with attacker strength**
+  — a much-stronger attacker takes measurably less counter-fire than a marginal one
+  against the identical city (the review fix — this is the regression that would catch
+  a regression back to the flat-fraction formula); a lethal counter-fire regression per
+  attacker path (barbarian raider dies from counter-fire and is removed from
+  `state.units` + owner roster, verified `barbarianHomeCampByUnitId` has no stale entry
+  after the next processing pass; pirate ship dies and is removed from
+  `faction.shipIds` + `state.units`, verified via the existing self-pruning filter).
+- **Balance sampling:** across eras 1–12, an unwalled, low-population ungarrisoned city
+  (an early outpost, the most common early-game capture target) must reliably favor an
+  era-appropriate attacker — strongly, not a coin-flip — since today that capture is
+  100% guaranteed and this spec must not turn routine early expansion into a frequent
+  failure. A walled, high-population, fully-teched city should meaningfully raise
+  attacker losses without becoming uncapturable by an era-appropriate siege force. If
+  the proposed `CITY_BASE_STRENGTH`/`CITY_STRENGTH_PER_POPULATION` constants (§1) fail
+  either bound, adjust them — they are provisional, not fixed by this spec. Mirrors the
+  existing `tests/systems/pacing-audit.test.ts` outlier-gate philosophy — this is
+  exactly the kind of change that rule requires a full-catalog pass for, since it
+  changes combat math globally.
+- **Hot-seat / actor parity:** one regression proving the human-player capture path and
+  one proving the AI-major-civ capture path (`ai-major-turn.ts`) both route through the
+  same `resolveCityAssault`, with identical win/loss semantics.
+- **AI capture scoring (`ai-tactics.ts` `rankCapture`):** a regression proving a
+  low-odds assault (heavily walled, high-population, teched city) scores lower than a
+  high-odds one for the same unit — the flat-`600` regression this fix replaces. Assert
+  the AI still *attempts* a low-odds capture when it's the only available action (never
+  refuses outright, only deprioritizes) so a cornered AI doesn't do nothing.
+- **UI click-through:** the new preview panel renders odds text and Attack/Cancel
+  buttons for an `'assault-city'` tap intent; clicking Attack (not just tapping the
+  city) is what triggers `beginPlayerCityAssault`; Cancel deselects without consuming
+  the unit's action.
+- **Defender-side city-panel display:** the new defense-rating line renders for every
+  owned city (not just ones under siege), and updates when a relevant building/tech
+  changes (walls built, Star Fort completed) — a stale reading would defeat the purpose
+  of adding it.
+
+## Out of scope
+
+- Minor-civ (city-state) capture (`conquestMinorCiv`) — separate, untouched system.
+- Any change to the barbarian/pirate `city.hp` multi-turn siege-attrition model itself
+  (regen rate, sack/destroy gating, last-city guarantee) — that shipped in #549/#556 and
+  is not being revisited here. This spec only adds counter-fire *on top of* that
+  existing resolution.
+- A player-triggered "bombard the besieger" city action — counter-fire is automatic,
+  not a new player-facing verb (decision 3).
+- New difficulty knobs for intrinsic strength or counter-fire.

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -155,7 +155,17 @@ function occupyMajorCity(
       precedingCombat,
     },
   );
-  if (!assault.ok) return { state, captured: false };
+  // Return assault.state, NOT the original state, even on failure (#522 pre-merge
+  // review fix): a repelled assault still mutates state via counter-fire (attacker
+  // damaged or killed) and consumes the attacker's action (hasActed/movementPointsLeft).
+  // Discarding that back to the pre-assault state would silently "undo" a repel for the
+  // AI actor -- the attacker keeps full health, isn't marked as acted, and could be
+  // re-selected to retry the same doomed assault for free in the same turn. Before this
+  // mechanic, beginMajorCityAssault's only failure reachable from this call site
+  // ('invalid-post-combat-advance') never mutated state, so this bug was latent and
+  // harmless; 'repelled-by-city-defense' is the first failure mode that actually needs
+  // its state kept.
+  if (!assault.ok) return { state: assault.state, captured: false };
   const capture = resolveMajorCityCapture(
     assault.state,
     cityId,
@@ -350,9 +360,17 @@ function executeAction(
         civId,
         bus,
       );
+      // succeeded means "the action was legally attempted and changed state" --
+      // matching the 'attack' case above (attack.state !== state), NOT "the assault
+      // won." A losing attack still consumes the unit's turn and is recorded as a real
+      // action; a repelled city assault (#522 pre-merge review fix) must behave the
+      // same way, or the caller's `if (!executed.succeeded) continue;` (below, in
+      // processMajorCivStrategicTurn) discards the repel's state entirely -- silently
+      // undoing counter-fire damage/death and the attacker's consumed action, on top of
+      // never recording the attempt in `appliedActions`/traces.
       return {
         state: capture.state,
-        succeeded: capture.captured,
+        succeeded: capture.state !== state,
         followUps: [],
       };
     }

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -21,6 +21,7 @@ import {
 } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { resolveMajorCityCapture } from '@/systems/city-capture-system';
+import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
 import { collectUsedCityNames } from '@/systems/city-name-system';
 import { foundCity } from '@/systems/city-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
@@ -408,9 +409,19 @@ function rankCapture(
   }
   const reachable = movementRange(context.state, context.actorId, unit)
     .some(coord => hexKey(coord) === hexKey(city.position));
-  return reachable
-    ? [ranked({ kind: 'capture-city', unitId: unit.id, cityId: city.id }, 600)]
-    : [];
+  if (!reachable) return [];
+
+  // Score by win probability (#522) -- previously a flat 600 regardless of the city's
+  // walls/population, because capture was unconditionally guaranteed. Left unweighted,
+  // the AI would blindly send units to die against a heavily-defended city with no way
+  // to tell that apart from a free capture. Never fully excludes the action (a 0% odds
+  // city still appears as a low-scoring candidate) so a cornered AI with no better
+  // option still attempts it.
+  const ownerCiv = context.state.civilizations[city.owner];
+  const winProbability = ownerCiv
+    ? calculateCityAssaultStrengths(unit, city, ownerCiv, context.state.map).winProbability
+    : 1;
+  return [ranked({ kind: 'capture-city', unitId: unit.id, cityId: city.id }, Math.round(winProbability * 600))];
 }
 
 function rankCivilianAndTransportActions(

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -82,7 +82,7 @@ import {
 import { processEspionageTurn, isSpyUnitType, createSpyFromUnit, processInterrogation, applyBuildingCI } from '@/systems/espionage-system';
 import { processDetection } from '@/systems/detection-system';
 import { applyPendingOpponentChallenge, resolveChallengeForCiv } from '@/core/opponent-challenge';
-import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
@@ -847,6 +847,48 @@ export function processTurn(
     });
     newState = applyCitySiegeOutcome(newState, order.cityId, result);
     if (result.outcome === 'blocked') continue;
+
+    // Counter-fire (#522): a walled, ungarrisoned city fights back against the raider
+    // that's damaging it. Reuses barbSeed the same way real barbarian combat above does.
+    const attackerUnit = newState.units[order.attackerUnitId];
+    if (attackerUnit) {
+      const attackerStrength = UNIT_DEFINITIONS[attackerUnit.type].strength * (attackerUnit.health / 100);
+      const counterFireSeed = barbSeed ^ order.attackerUnitId.charCodeAt(0) ^ 0x5a5a;
+      const counterFireDamage = getCityCounterFireDamage(
+        city, ownerCiv, 'land', attackerStrength, false, counterFireSeed,
+      );
+      if (counterFireDamage > 0) {
+        const healthAfter = attackerUnit.health - counterFireDamage;
+        const attackerDied = healthAfter <= 0;
+        if (attackerDied) {
+          const units = { ...newState.units };
+          delete units[order.attackerUnitId];
+          const civilizations = { ...newState.civilizations };
+          const raiderOwner = civilizations[attackerUnit.owner];
+          if (raiderOwner) {
+            civilizations[attackerUnit.owner] = {
+              ...raiderOwner,
+              units: raiderOwner.units.filter(id => id !== order.attackerUnitId),
+            };
+          }
+          newState = { ...newState, units, civilizations };
+          // barbarianHomeCampByUnitId self-prunes stale entries for dead units on the
+          // next processing pass (barbarian-system.ts) -- no further cleanup needed here.
+        } else {
+          newState = {
+            ...newState,
+            units: { ...newState.units, [order.attackerUnitId]: { ...attackerUnit, health: healthAfter } },
+          };
+        }
+        bus.emit('city:counter-fire', {
+          cityId: order.cityId,
+          attackerUnitId: order.attackerUnitId,
+          source: 'barbarian',
+          damage: counterFireDamage,
+          attackerDied,
+        });
+      }
+    }
 
     bus.emit('barbarian:city-attacked', { attackerUnitId: order.attackerUnitId, cityId: order.cityId, hpLost: result.hpLost });
     if (newState.opponentAI) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1660,6 +1660,7 @@ export interface GameEvents {
   // threat-pressure-system.ts fleet path 'threat:pirate-siege' above).
   'pirate:city-destroyed': { cityId: string; ownerId: string; factionId: string };
   'city:sacked': { cityId: string; source: 'barbarian' | 'pirate'; goldLost: number };
+  'city:counter-fire': { cityId: string; attackerUnitId: string; source: 'barbarian' | 'pirate'; damage: number; attackerDied: boolean };
   'tutorial:step': { step: TutorialStep; message: string; advisor: 'builder' | 'explorer' | 'scholar' };
   'notification:show': { message: string; type: 'info' | 'warning' | 'success' };
   'game:saved': { turn: number };

--- a/src/input/city-assault-flow.ts
+++ b/src/input/city-assault-flow.ts
@@ -3,12 +3,17 @@ import type { CombatResult, GameState } from '@/core/types';
 import {
   beginMajorCityAssault,
   resolveMajorCityCapture,
+  type MajorCityAssaultFailureReason,
   type MajorCityCaptureDisposition,
   type MajorCityCaptureResult,
   type PendingMajorCityCapture,
 } from '@/systems/city-capture-system';
 
 export type PendingCityCaptureChoice = PendingMajorCityCapture;
+
+export type PlayerCityAssaultChoiceResult =
+  | { ok: true; state: GameState; pending: PendingCityCaptureChoice }
+  | { ok: false; state: GameState; reason: MajorCityAssaultFailureReason };
 
 export function shouldPromptForPlayerCityCapture(
   city: { population: number },
@@ -22,8 +27,8 @@ export function beginPlayerCityAssaultChoice(
   cityId: string,
   bus?: EventBus,
   precedingCombat?: CombatResult,
-): { state: GameState; pending: PendingCityCaptureChoice } {
-  const result = beginMajorCityAssault(
+): PlayerCityAssaultChoiceResult {
+  return beginMajorCityAssault(
     state,
     attackerId,
     cityId,
@@ -34,10 +39,6 @@ export function beginPlayerCityAssaultChoice(
       precedingCombat,
     },
   );
-  if (!result.ok) {
-    throw new Error(`Cannot begin city assault: ${result.reason}`);
-  }
-  return result;
 }
 
 export function finalizePlayerCityAssaultChoice(

--- a/src/input/foreign-city-entry-flow.ts
+++ b/src/input/foreign-city-entry-flow.ts
@@ -1,6 +1,6 @@
 import type { EventBus } from '@/core/event-bus';
 import type { GameState } from '@/core/types';
-import { beginPlayerCityAssaultChoice, type PendingCityCaptureChoice } from '@/input/city-assault-flow';
+import { beginPlayerCityAssaultChoice, type PlayerCityAssaultChoiceResult } from '@/input/city-assault-flow';
 import { declareWar, resolveOpponentKind } from '@/systems/diplomacy-system';
 
 export function beginConfirmedForeignCityEntry(
@@ -8,7 +8,7 @@ export function beginConfirmedForeignCityEntry(
   attackerId: string,
   cityId: string,
   bus?: EventBus,
-): { state: GameState; pending: PendingCityCaptureChoice } {
+): PlayerCityAssaultChoiceResult {
   const city = state.cities[cityId];
   if (!city) {
     throw new Error(`Cannot enter missing city ${cityId}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import { createWorkerReplacementConfirmPanel, createWorkerTaskWarningPanel } fro
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
 import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
+import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { buildSelectedUnitHighlights } from '@/input/selected-unit-highlights';
@@ -3046,12 +3047,74 @@ function handleHexTap(rawCoord: HexCoord): void {
     } else {
       const tapIntent = resolveSelectedUnitTapIntent(gameState, selectedUnitId, coord, movementRange);
       if (tapIntent.kind === 'assault-city') {
-        const assaultStatus = beginPlayerCityAssault(selectedUnitId, tapIntent.cityId);
-        SFX.tap();
-        renderLoop.setGameState(gameState);
-        updateHUD();
-        if (assaultStatus === 'resolved') {
-          setTimeout(() => selectNextUnit(), 400);
+        const attackerUnit = gameState.units[selectedUnitId];
+        const targetCity = gameState.cities[tapIntent.cityId];
+        const ownerCiv = targetCity ? gameState.civilizations[targetCity.owner] : undefined;
+        if (!attackerUnit || !targetCity || !ownerCiv) return;
+
+        const strengths = calculateCityAssaultStrengths(attackerUnit, targetCity, ownerCiv, gameState.map);
+        const atkStr = Math.round(strengths.attackerStrength);
+        const cityStr = Math.round(strengths.intrinsicStrength);
+        const odds = strengths.winProbability > 0.55 ? 'Favorable' : strengths.winProbability > 0.45 ? 'Even' : 'Risky';
+        const oddsColor = strengths.winProbability > 0.55 ? '#6b9b4b' : strengths.winProbability > 0.45 ? '#e8c170' : '#d94a4a';
+
+        const panel = document.getElementById('info-panel');
+        if (panel) {
+          panel.style.display = 'block';
+          const previewDiv = document.createElement('div');
+          previewDiv.style.cssText = 'background:rgba(100,0,0,0.9);border-radius:12px;padding:12px 16px;';
+
+          const title = document.createElement('div');
+          title.style.cssText = 'font-size:13px;color:#e8c170;margin-bottom:6px;';
+          title.textContent = 'Assault Preview';
+          previewDiv.appendChild(title);
+
+          const stats = document.createElement('div');
+          stats.style.cssText = 'display:flex;justify-content:space-between;font-size:12px;margin-bottom:8px;';
+          const atkSpan = document.createElement('span');
+          atkSpan.textContent = `${UNIT_DEFINITIONS[attackerUnit.type].name} (${atkStr})`;
+          const oddsSpan = document.createElement('span');
+          oddsSpan.style.cssText = `color:${oddsColor};font-weight:bold;`;
+          oddsSpan.textContent = odds;
+          const defSpan = document.createElement('span');
+          defSpan.textContent = `${targetCity.name} defenses (${cityStr})`;
+          stats.appendChild(atkSpan);
+          stats.appendChild(oddsSpan);
+          stats.appendChild(defSpan);
+          previewDiv.appendChild(stats);
+
+          const info = document.createElement('div');
+          info.style.cssText = 'font-size:10px;opacity:0.6;margin-bottom:8px;';
+          info.textContent = 'A walled city fights back if it has no garrison.';
+          previewDiv.appendChild(info);
+
+          const btnRow = document.createElement('div');
+          btnRow.style.cssText = 'display:flex;gap:8px;';
+          const attackBtn = document.createElement('button');
+          attackBtn.id = 'btn-assault-confirm';
+          attackBtn.textContent = 'Attack';
+          attackBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:#d94a4a;border:none;color:white;font-weight:bold;cursor:pointer;';
+          const cancelBtn = document.createElement('button');
+          cancelBtn.id = 'btn-cancel-assault';
+          cancelBtn.textContent = 'Cancel';
+          cancelBtn.style.cssText = 'flex:1;padding:8px;border-radius:8px;background:rgba(255,255,255,0.15);border:none;color:white;cursor:pointer;';
+          btnRow.appendChild(attackBtn);
+          btnRow.appendChild(cancelBtn);
+          previewDiv.appendChild(btnRow);
+
+          panel.innerHTML = '';
+          panel.appendChild(previewDiv);
+
+          cancelBtn.addEventListener('click', deselectUnit);
+          attackBtn.addEventListener('click', () => {
+            const assaultStatus = beginPlayerCityAssault(selectedUnitId!, tapIntent.cityId);
+            SFX.combat();
+            renderLoop.setGameState(gameState);
+            updateHUD();
+            if (assaultStatus === 'resolved') {
+              setTimeout(() => selectNextUnit(), 400);
+            }
+          });
         }
         return;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2482,6 +2482,18 @@ function beginPlayerCityAssault(
   );
   gameState = begun.state;
 
+  if (!begun.ok) {
+    showNotification(
+      begun.reason === 'repelled-by-city-defense'
+        ? "Your attack was repelled by the city's defenses!"
+        : 'The attack could not proceed.',
+      'warning',
+    );
+    renderLoop.setGameState(gameState);
+    updateHUD();
+    return 'resolved';
+  }
+
   pendingCityCaptureChoice = begun.pending;
   if (!shouldPromptForPlayerCityCapture(city)) {
     finalizePendingCityCaptureChoice('raze', attackerBonus);
@@ -3054,6 +3066,17 @@ function handleHexTap(rawCoord: HexCoord): void {
           onConfirm: () => {
             const begun = beginConfirmedForeignCityEntry(gameState, selectedId, tapIntent.cityId, bus);
             gameState = begun.state;
+            if (!begun.ok) {
+              showNotification(
+                begun.reason === 'repelled-by-city-defense'
+                  ? "Your attack was repelled by the city's defenses!"
+                  : 'The attack could not proceed.',
+                'warning',
+              );
+              renderLoop.setGameState(gameState);
+              updateHUD();
+              return;
+            }
             pendingCityCaptureChoice = begun.pending;
             const captureCity = gameState.cities[tapIntent.cityId];
             if (captureCity) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3980,6 +3980,20 @@ bus.on('barbarian:city-destroyed', ({ cityId, ownerId }) => {
   appendToCivLog(ownerId, `${cityName} was destroyed by barbarian raiders!`, 'warning');
 });
 
+// A walled, ungarrisoned city fighting back against a besieger (#522) -- covers BOTH
+// the barbarian (turn-manager.ts) and pirate (pirate-system.ts) counter-fire call
+// sites, since both emit this same shared event with their respective 'source' value.
+bus.on('city:counter-fire', ({ cityId, source, damage, attackerDied }) => {
+  const city = gameState.cities[cityId];
+  if (!city) return;
+  if (!gameState.civilizations[city.owner]?.isHuman) return;
+  const raiderLabel = source === 'barbarian' ? 'raider' : 'ship';
+  const message = attackerDied
+    ? `${city.name}'s defenses destroyed a ${source === 'barbarian' ? 'barbarian raider' : 'pirate ship'}!`
+    : `${city.name}'s walls fought back, damaging a ${raiderLabel} (−${damage} HP)!`;
+  appendToCivLog(city.owner, message, attackerDied ? 'success' : 'info');
+});
+
 // Pirate-faction naval siege (#522) mirror of the barbarian handler above.
 bus.on('pirate:city-destroyed', ({ cityId, ownerId }) => {
   if (!gameState.civilizations[ownerId]?.isHuman) return;

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -25,6 +25,11 @@ import { buildMovePresentationByViewer } from '@/systems/viewer-event-presentati
 import { eliminateCivilization } from '@/systems/civilization-elimination-system';
 import { handleCityLeftCiv } from '@/systems/crisis-system';
 import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
+import {
+  calculateCityAssaultStrengths,
+  getCityCounterFireDamage,
+  resolveCityAssault,
+} from '@/systems/city-siege-system';
 
 export type MajorCityCaptureDisposition = 'occupy' | 'raze';
 
@@ -104,7 +109,8 @@ export type MajorCityAssaultFailureReason =
   | 'not-adjacent'
   | 'city-defended'
   | 'illegal-movement'
-  | 'invalid-post-combat-advance';
+  | 'invalid-post-combat-advance'
+  | 'repelled-by-city-defense';
 
 export type BeginMajorCityAssaultResult =
   | {
@@ -228,6 +234,77 @@ export function beginMajorCityAssault(
     if (attacker.hasActed || attacker.movementPointsLeft <= 0) {
       return assaultFailure(state, 'illegal-movement');
     }
+
+    // Intrinsic-strength combat exchange (#522) -- ONLY for a city that was already
+    // undefended before this action (no precedingCombat). A city defeated via a real
+    // combat exchange against a garrison unit (the `if (options.precedingCombat)`
+    // branch above) already resolved a complete, walls-boosted fight; running this
+    // check again here would double-punish the same turn's action for the same city.
+    const ownerCiv = state.civilizations[city.owner];
+    if (ownerCiv) {
+      // Two DISTINCT seeds -- getCityCounterFireDamage (damage magnitude) and
+      // resolveCityAssault (win/lose) are conceptually independent rolls. Passing them
+      // the same raw seed would make each function's first internal rng() draw
+      // IDENTICAL, entangling "how much counter-fire damage I take" with "do I win" on
+      // every single assault (caught in review). XOR against a fixed constant to
+      // decorrelate -- same convention Tasks 5/6 use for barbarian/pirate counter-fire
+      // seeds (`... ^ 0x5a5a`).
+      //
+      // Fold the FULL id strings (not just their first character) into the seed, the
+      // same convention combat-reward-system.ts's seededRoll already uses -- the plan's
+      // original `attackerId.charCodeAt(0) + cityId.charCodeAt(0)` collided for this
+      // codebase's own default test fixture ids ('attacker' + 'athens', both starting
+      // with 'a'), producing a seed whose second RNG draw permanently exceeds
+      // resolveCityAssault's 0.95 clamp ceiling -- an attacker of ANY strength always
+      // lost against that exact seed, regardless of the real strength comparison.
+      // Full-string folding avoids this class of collision generically instead of
+      // patching one cursed id pair.
+      let baseSeed = Math.abs(state.turn * 7919);
+      for (const char of `${attackerId}:${cityId}`) {
+        baseSeed = (baseSeed * 48271 + char.charCodeAt(0)) % 2147483647;
+      }
+      const counterFireSeed = baseSeed;
+      const assaultSeed = baseSeed ^ 0x5a5a;
+      const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+      const counterFireDamage = getCityCounterFireDamage(
+        city,
+        ownerCiv,
+        'land',
+        strengths.attackerStrength,
+        false, // this branch is only reached when the city has no garrison (see the
+               // 'city-defended' check above, which already returned for any occupied tile)
+        counterFireSeed,
+      );
+      if (counterFireDamage > 0) {
+        const healthAfter = attacker.health - counterFireDamage;
+        if (healthAfter <= 0) {
+          const civilizations = { ...nextState.civilizations };
+          civilizations[attacker.owner] = {
+            ...civilizations[attacker.owner],
+            units: civilizations[attacker.owner].units.filter(id => id !== attackerId),
+          };
+          const units = { ...nextState.units };
+          delete units[attackerId];
+          nextState = { ...nextState, units, civilizations };
+          return assaultFailure(nextState, 'repelled-by-city-defense');
+        }
+        nextState.units[attackerId] = {
+          ...nextState.units[attackerId],
+          health: healthAfter,
+        };
+      }
+      const assaultResult = resolveCityAssault(strengths.attackerStrength, strengths.intrinsicStrength, assaultSeed);
+      if (!assaultResult.attackerWins) {
+        nextState.units[attackerId] = {
+          ...nextState.units[attackerId],
+          hasMoved: true,
+          hasActed: true,
+          movementPointsLeft: 0,
+        };
+        return assaultFailure(nextState, 'repelled-by-city-defense');
+      }
+    }
+
     const movement = executeUnitMove(
       nextState,
       attackerId,

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -92,6 +92,35 @@ export function resolveCityAssault(
   return { attackerWins: rng() < adjustedRatio };
 }
 
+// Counter-fire damage to a hostile unit attacking a walled, ungarrisoned city (#522) --
+// applies uniformly to player, barbarian, and pirate attackers (three call sites: this
+// helper, city-capture-system.ts, turn-manager.ts, pirate-system.ts). Deliberately
+// scales INVERSELY with attacker strength, mirroring resolveCombat's own
+// baseDamage * (1 - adjustedRatio) counter-damage formula -- a much stronger attacker
+// already takes proportionally less retaliation there; a flat fraction of intrinsic
+// strength would have ignored that convention (caught in design review).
+export function getCityCounterFireDamage(
+  city: City,
+  ownerCiv: Civilization,
+  attackerDomain: 'land' | 'naval' | 'air',
+  attackerStrength: number,
+  hasGarrison: boolean,
+  seed: number,
+): number {
+  if (hasGarrison) return 0;
+  if (!(city.buildings ?? []).includes('walls')) return 0;
+
+  const intrinsicStrength = getCityIntrinsicStrength(city, ownerCiv, attackerDomain);
+  const totalStrength = attackerStrength + intrinsicStrength;
+  if (totalStrength === 0) return 0;
+  const atkRatio = attackerStrength / totalStrength;
+  const rng = createSeededRng(seed);
+  const randomFactor = 0.8 + rng() * 0.4;
+  const adjustedRatio = Math.min(0.95, Math.max(0.05, atkRatio * randomFactor));
+  const baseDamage = 30 + rng() * 20; // same range as resolveCombat's baseDamage (era 3+ band)
+  return Math.round(baseDamage * (1 - adjustedRatio));
+}
+
 export interface CitySiegeInput {
   city: City;
   ownerCiv: Civilization;

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -1,10 +1,13 @@
-import type { City, Civilization, GameState, HexCoord, Unit } from '@/core/types';
+import type { City, Civilization, GameMap, GameState, HexCoord, Unit } from '@/core/types';
 import type { OpponentChallenge } from '@/core/types';
 import { OPPONENT_CHALLENGE_PROFILES } from '@/core/opponent-challenge';
 import { getCityDefenseBreakdown } from '@/systems/combat-system';
+import { getVeterancyCombatModifier } from '@/systems/combat-reward-system';
 import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { isAtWar } from '@/systems/diplomacy-system';
+import { getRiverDefensePenalty, isRiverBetween } from '@/systems/river-system';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 
 export const CITY_BASE_STRENGTH = 5;
 export const CITY_STRENGTH_PER_POPULATION = 3;
@@ -27,6 +30,66 @@ export function getCityIntrinsicStrength(
     attackerDomain,
   });
   return base * breakdown.multiplier + breakdown.flatBonus;
+}
+
+export interface CityAssaultStrengthBreakdown {
+  attackerStrength: number;
+  intrinsicStrength: number;
+  winProbability: number;
+}
+
+// Mirrors calculateCombatStrengths' attacker-side formula exactly (combat-system.ts) --
+// health-scaled, veterancy-modified, river-penalized -- so the odds shown to the player
+// (and used by resolveCityAssault below) are computed the same way real combat odds are.
+export function calculateCityAssaultStrengths(
+  attacker: Unit,
+  city: City,
+  ownerCiv: Civilization,
+  map: GameMap,
+): CityAssaultStrengthBreakdown {
+  const attackerDefinition = UNIT_DEFINITIONS[attacker.type];
+  const riverAttackPenalty = getRiverDefensePenalty(
+    isRiverBetween(map, attacker.position, city.position),
+  );
+  const attackerStrength = attackerDefinition.strength
+    * (attacker.health / 100)
+    * (1 + getVeterancyCombatModifier(attacker))
+    * (1 + riverAttackPenalty);
+  const intrinsicStrength = getCityIntrinsicStrength(city, ownerCiv, 'land');
+  const winProbability = attackerStrength / (attackerStrength + intrinsicStrength);
+  return { attackerStrength, intrinsicStrength, winProbability };
+}
+
+function createSeededRng(seed: number): () => number {
+  // Same LCG resolveCombat uses (combat-system.ts), but as a proper CHAINED stream --
+  // each call advances rngState and returns the new value, exactly like resolveCombat's
+  // own rng() closure. A single-shot `seededRatio(seed)` / `seededRatio(seed + 1)` pair
+  // (an earlier draft of this function) is NOT equivalent: evaluating the LCG once at
+  // seed and once at seed+1 differs by the constant `48271` (mod 2147483647) every
+  // time, so the two "independent" draws are actually correlated by a fixed offset.
+  // Chaining through one closure avoids that entirely.
+  let rngState = seed;
+  return () => {
+    rngState = (rngState * 48271) % 2147483647;
+    return rngState / 2147483647;
+  };
+}
+
+// Win/lose only -- deliberately does not compute damage. Damage is
+// getCityCounterFireDamage's responsibility (unconditional on win/lose, applied by the
+// caller) so the same formula serves the player, barbarian, and pirate paths uniformly.
+export function resolveCityAssault(
+  attackerStrength: number,
+  intrinsicStrength: number,
+  seed: number,
+): { attackerWins: boolean } {
+  const totalStrength = attackerStrength + intrinsicStrength;
+  if (totalStrength === 0) return { attackerWins: true };
+  const atkRatio = attackerStrength / totalStrength;
+  const rng = createSeededRng(seed);
+  const randomFactor = 0.8 + rng() * 0.4;
+  const adjustedRatio = Math.min(0.95, Math.max(0.05, atkRatio * randomFactor));
+  return { attackerWins: rng() < adjustedRatio };
 }
 
 export interface CitySiegeInput {

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -9,8 +9,17 @@ import { isAtWar } from '@/systems/diplomacy-system';
 import { getRiverDefensePenalty, isRiverBetween } from '@/systems/river-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 
-export const CITY_BASE_STRENGTH = 5;
-export const CITY_STRENGTH_PER_POPULATION = 3;
+// Retuned from the design doc's original 5/3 (#522 pre-merge review): a population-1
+// unwalled outpost at 5+1*3=8 put a warrior (strength 10, the cheapest and most common
+// early-capture unit) at only a ~55-57% win rate against the "trivially weak" reference
+// case the design explicitly called out -- a near coin-flip for the single most common
+// early-expansion action, not the "reliably favors an era-appropriate attacker" the
+// spec required. 2/2 keeps a population-1 outpost's warrior win rate around ~70%
+// (strongly favorable, matching intent) while a fully walled/teched/high-population
+// city still meaningfully contests even a late-game tank (~48% win rate) via the
+// multiplier chain, not the linear base.
+export const CITY_BASE_STRENGTH = 2;
+export const CITY_STRENGTH_PER_POPULATION = 2;
 
 // A city's intrinsic combat strength — used both for a player's single-exchange assault
 // (#522, city-capture-system.ts) and for naval/land counter-fire (below). Population

--- a/src/systems/city-siege-system.ts
+++ b/src/systems/city-siege-system.ts
@@ -6,6 +6,29 @@ import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { isAlwaysHostilePair } from '@/core/owner-kind';
 import { isAtWar } from '@/systems/diplomacy-system';
 
+export const CITY_BASE_STRENGTH = 5;
+export const CITY_STRENGTH_PER_POPULATION = 3;
+
+// A city's intrinsic combat strength — used both for a player's single-exchange assault
+// (#522, city-capture-system.ts) and for naval/land counter-fire (below). Population
+// always contributes a baseline (an unwalled city is not defenseless, just weak); walls
+// and defensive techs multiply on top via the SAME getCityDefenseBreakdown a garrisoned
+// defender already uses, so a city's own defense and its garrison's defense never
+// diverge in formula.
+export function getCityIntrinsicStrength(
+  city: City,
+  ownerCiv: Civilization,
+  attackerDomain: 'land' | 'naval' | 'air',
+): number {
+  const base = CITY_BASE_STRENGTH + city.population * CITY_STRENGTH_PER_POPULATION;
+  const breakdown = getCityDefenseBreakdown({
+    cityBuildings: city.buildings ?? [],
+    defenderCompletedTechs: ownerCiv.techState.completed ?? [],
+    attackerDomain,
+  });
+  return base * breakdown.multiplier + breakdown.flatBonus;
+}
+
 export interface CitySiegeInput {
   city: City;
   ownerCiv: Civilization;

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -6,7 +6,7 @@ import { resolveChallengeForCiv } from '@/core/opponent-challenge';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
 import { resolveCombat } from './combat-system';
-import { applyCitySiegeOutcome, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
+import { applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
 import type { PirateEconomyModifiers } from './economy-system';
 import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
 import {
@@ -818,6 +818,51 @@ export function processPiratesForCompletedRound(
       events.push({ type: 'city-razed', factionId: siege.factionId, civId: city.owner, cityId: siege.cityId });
     }
     // outcome === 'blocked' -> garrison stopped it; no HP change, no alert (silent, by design).
+
+    // Counter-fire (#522): a walled, ungarrisoned city fights back at one ship from the
+    // besieging faction -- the nearest to the city, tie-broken by unit id for
+    // determinism. A well-defended city can now sink a besieging ship over time.
+    if (result.outcome !== 'blocked') {
+      const faction = nextState.pirates?.factions[siege.factionId];
+      const distanceFn = nextState.map.wrapsHorizontally
+        ? (a: HexCoord, b: HexCoord) => wrappedHexDistance(a, b, nextState.map.width)
+        : hexDistance;
+      const targetShip = (faction?.shipIds ?? [])
+        .map(id => nextState.units[id])
+        .filter((unit): unit is Unit => Boolean(unit))
+        .sort((a, b) => distanceFn(a.position, city.position) - distanceFn(b.position, city.position)
+          || a.id.localeCompare(b.id))[0];
+      if (targetShip) {
+        const attackerStrength = UNIT_DEFINITIONS[targetShip.type].strength * (targetShip.health / 100);
+        const counterFireSeed = (nextState.turn * 104729) ^ targetShip.id.charCodeAt(0) ^ 0x5a5a;
+        const counterFireDamage = getCityCounterFireDamage(
+          city, ownerCiv, 'naval', attackerStrength, false, counterFireSeed,
+        );
+        if (counterFireDamage > 0) {
+          const healthAfter = targetShip.health - counterFireDamage;
+          const attackerDied = healthAfter <= 0;
+          if (attackerDied) {
+            const units = { ...nextState.units };
+            delete units[targetShip.id];
+            nextState = { ...nextState, units };
+            // faction.shipIds self-prunes dead references on the next round's
+            // normalizeRoundState pass -- no further cleanup needed here.
+          } else {
+            nextState = {
+              ...nextState,
+              units: { ...nextState.units, [targetShip.id]: { ...targetShip, health: healthAfter } },
+            };
+          }
+          bus.emit('city:counter-fire', {
+            cityId: city.id,
+            attackerUnitId: targetShip.id,
+            source: 'pirate',
+            damage: counterFireDamage,
+            attackerDied,
+          });
+        }
+      }
+    }
   }
   const advanced = advanceBehavior(nextState, new Set(raids.map(raid => raid.factionId)));
   nextState = advanced.state;

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -845,8 +845,12 @@ export function processPiratesForCompletedRound(
             const units = { ...nextState.units };
             delete units[targetShip.id];
             nextState = { ...nextState, units };
-            // faction.shipIds self-prunes dead references on the next round's
-            // normalizeRoundState pass -- no further cleanup needed here.
+            // faction.shipIds is left with this now-dead id, same as any other
+            // pirate-combat kill in this file (normalizeRoundState only prunes shipIds
+            // in the deep-sea-flotilla flagship-replacement branch, not generally) --
+            // every consumer of faction.shipIds already guards with
+            // Boolean(state.units[id]) or an equivalent existence check, so a stale id
+            // here is safe, not a new pattern this counter-fire path introduces.
           } else {
             nextState = {
               ...nextState,

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -36,7 +36,7 @@ import {
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier } from '@/systems/crisis-system';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
-import { isCityHpRegenerating } from '@/systems/city-siege-system';
+import { getCityIntrinsicStrength, isCityHpRegenerating } from '@/systems/city-siege-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
 import { getCityTechYields } from '@/systems/tech-yield-system';
@@ -661,6 +661,15 @@ export function createCityPanel(
       </div>`
     : '';
 
+  const ownerCivForDefense = state.civilizations[city.owner];
+  const defenseRating = ownerCivForDefense
+    ? Math.round(getCityIntrinsicStrength(city, ownerCivForDefense, 'land'))
+    : 0;
+  const defenseRatingHtml = `
+    <div style="font-size:11px;opacity:0.7;margin-top:4px;">
+      🛡️ Defense: ${defenseRating}
+    </div>`;
+
   const html = `
     <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
       <div>
@@ -669,6 +678,7 @@ export function createCityPanel(
         ${city.occupation ? '<div style="font-size:12px;color:#e8c170;" data-text="occupied-status"></div>' : ''}
         ${occupiedMoodText ? '<div style="font-size:12px;color:#d9a25c;" data-text="occupied-mood"></div>' : ''}
         ${siegeBarHtml}
+        ${defenseRatingHtml}
       </div>
       <div style="display:flex;align-items:center;gap:8px;">
         ${navHtml}

--- a/tests/ai/ai-major-turn.test.ts
+++ b/tests/ai/ai-major-turn.test.ts
@@ -475,6 +475,46 @@ describe('processMajorCivStrategicTurn', () => {
       .toEqual(['attack', 'capture-city']);
   });
 
+  it('keeps the repel state (damage, action-consumption) when the AI\'s undefended-city assault is repelled (#522)', () => {
+    // Regression for a pre-merge review bug: occupyMajorCity's failure branch used to
+    // `return { state, captured: false }` -- the ORIGINAL pre-assault state, not
+    // assault.state -- silently discarding counter-fire damage and hasActed/
+    // movementPointsLeft consumption on a repel. That made a repelled AI assault a
+    // free, fully-reversible no-op: the attacker kept full health and could be
+    // re-selected to retry the same doomed assault. A hopelessly outmatched attacker
+    // (warrior, strength 10) against a maximally defended city (population 40, walls +
+    // star_fort) makes the repel effectively certain regardless of RNG seed.
+    const state = makeState();
+    addUnit(state, 'captor', 'warrior', AI, { q: 0, r: 0 });
+    const target = addCity(state, 'target-city', HUMAN, { q: 1, r: 0 });
+    target.population = 40;
+    target.buildings = ['walls', 'star_fort'];
+    const plan = makePlan(
+      { kind: 'city', id: target.id, lastKnownPosition: target.position },
+      ['captor'],
+      { requiredRoles: { capture: 1 } },
+    );
+
+    const result = processMajorCivStrategicTurn(
+      state,
+      prepared(state, plan),
+      new EventBus(),
+    );
+
+    expect(result.state.cities[target.id].owner).toBe(HUMAN); // repelled, not captured
+    const captorAfter = result.state.units.captor;
+    if (captorAfter) {
+      // Survived the counter-fire: must be marked as having acted, not silently reverted.
+      expect(captorAfter.health).toBeLessThan(100);
+      expect(captorAfter.hasActed).toBe(true);
+      expect(captorAfter.movementPointsLeft).toBe(0);
+    } else {
+      // Counter-fire killed it -- must actually be gone, not resurrected by a stale
+      // pre-assault state, and pruned from the owner's roster.
+      expect(result.state.civilizations[AI].units).not.toContain('captor');
+    }
+  });
+
   it('executes worker improvements through the canonical worker system', () => {
     const state = makeState();
     addCity(state, 'home', AI, { q: 1, r: 2 });

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -494,6 +494,43 @@ describe('AI tactical action ranking', () => {
       .toEqual({ kind: 'capture-city', unitId: 'captor', cityId: city.id });
   });
 
+  it('scores a low-odds capture lower than a high-odds one for the same unit (#522)', () => {
+    const weakState = makeState('veteran');
+    addUnit(weakState, 'captor', 'warrior', AI, { q: 0, r: 0 });
+    const weakCity = addCity(weakState, 'weak-target', HUMAN, { q: 1, r: 0 });
+    weakCity.population = 1;
+    weakCity.buildings = [];
+    const weakPlan = makePlan({ kind: 'city', id: weakCity.id, lastKnownPosition: weakCity.position }, ['captor']);
+    const weakScore = rankUnitTacticalActions(context(weakState, weakPlan), 'captor')
+      .find(candidate => candidate.action.kind === 'capture-city')?.score;
+
+    const strongState = makeState('veteran');
+    addUnit(strongState, 'captor', 'warrior', AI, { q: 0, r: 0 });
+    const strongCity = addCity(strongState, 'strong-target', HUMAN, { q: 1, r: 0 });
+    strongCity.population = 40;
+    strongCity.buildings = ['walls', 'star_fort'];
+    const strongPlan = makePlan({ kind: 'city', id: strongCity.id, lastKnownPosition: strongCity.position }, ['captor']);
+    const strongScore = rankUnitTacticalActions(context(strongState, strongPlan), 'captor')
+      .find(candidate => candidate.action.kind === 'capture-city')?.score;
+
+    expect(weakScore).toBeDefined();
+    expect(strongScore).toBeDefined();
+    expect(strongScore!).toBeLessThan(weakScore!);
+  });
+
+  it('still offers a low-odds capture as a candidate, never refuses outright (#522)', () => {
+    const state = makeState('veteran');
+    addUnit(state, 'captor', 'warrior', AI, { q: 0, r: 0 });
+    const city = addCity(state, 'strong-target', HUMAN, { q: 1, r: 0 });
+    city.population = 50;
+    city.buildings = ['walls', 'star_fort'];
+    const plan = makePlan({ kind: 'city', id: city.id, lastKnownPosition: city.position }, ['captor']);
+
+    const candidates = rankUnitTacticalActions(context(state, plan), 'captor');
+
+    expect(candidates.some(candidate => candidate.action.kind === 'capture-city')).toBe(true);
+  });
+
   it('does not capture a city remotely with a ranged unit', () => {
     const state = makeState('veteran');
     addUnit(state, 'archer', 'archer', AI, { q: 0, r: 0 }, {

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1083,6 +1083,120 @@ describe('processTurn', () => {
     expect(remaining.some(e => e.resource === 'silk')).toBe(false); // expired → removed
     expect(remaining.some(e => e.resource === 'wine')).toBe(true);  // active → kept
   });
+
+  // Adapted from the working `processPurposefulBarbarians` fixture in
+  // tests/systems/barbarian-system.test.ts ("attacks an undefended city normally when
+  // adjacent (garrison regression)"): processTurn always routes barbarians through
+  // processPurposefulBarbarians (not the lower-level processBarbarians the plan's draft
+  // assumed), which only produces a cityAttackOrders entry once a camp's plan commits to
+  // a `target: { kind: 'city' }` -- that requires flattened map terrain (the default
+  // 'small' map's random terrain can block distance-sensing/movement) and the raider
+  // ADJACENT to, not co-located with, the city.
+  function flattenMapToPlains(state: GameState): void {
+    for (const tile of Object.values(state.map.tiles)) {
+      tile.terrain = 'plains';
+      tile.elevation = 'lowland';
+      tile.resource = null;
+      tile.improvement = 'none';
+      tile.improvementTurnsLeft = 0;
+    }
+  }
+
+  it('applies counter-fire to a barbarian raider attacking a walled, ungarrisoned city (#522)', () => {
+    const state = createNewGame(undefined, 'barbarian-counterfire', 'small');
+    flattenMapToPlains(state);
+    state.turn = 30;
+    state.era = 3;
+    state.barbarianCamps = {
+      'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+    };
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.cities = {
+      town: {
+        // hp: 50 (not 100) -- processPurposefulBarbarians only assigns a barbarian
+        // camp's raid plan to a city when city.hp <= max(40, campStrength*10); at
+        // campStrength 6 that ceiling is 60, so a full-health city is silently never
+        // targeted (a bug in the plan's own draft fixture, found while implementing).
+        id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 50,
+        buildings: ['walls'], population: 20, ownedTiles: [], productionQueue: [],
+      } as never,
+    };
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.units = [];
+    state.opponentAI = undefined;
+
+    const before = raider.health;
+    const result = processTurn(state, new EventBus());
+
+    expect(result.units.raider?.health ?? 0).toBeLessThan(before);
+  });
+
+  it('emits city:counter-fire so the player gets feedback that their walls fought back (#522)', () => {
+    const state = createNewGame(undefined, 'barbarian-counterfire-event', 'small');
+    flattenMapToPlains(state);
+    state.turn = 30;
+    state.era = 3;
+    state.barbarianCamps = {
+      'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+    };
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    state.units = { raider };
+    state.cities = {
+      town: {
+        id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 50,
+        buildings: ['walls'], population: 20, ownedTiles: [], productionQueue: [],
+      } as never,
+    };
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.units = [];
+    state.opponentAI = undefined;
+
+    const bus = new EventBus();
+    const onCounterFire = vi.fn();
+    bus.on('city:counter-fire', onCounterFire);
+    processTurn(state, bus);
+
+    expect(onCounterFire).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'town', source: 'barbarian' }));
+  });
+
+  it('does not counter-fire when the barbarian city order is blocked by a garrison', () => {
+    const state = createNewGame(undefined, 'barbarian-counterfire-blocked', 'small');
+    flattenMapToPlains(state);
+    state.turn = 30;
+    state.era = 3;
+    state.barbarianCamps = {
+      'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+    };
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const garrison = createUnit('warrior', 'player', { q: 12, r: 5 }, state.idCounters);
+    garrison.id = 'garrison';
+    state.units = { raider, garrison };
+    state.cities = {
+      town: {
+        id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 50,
+        buildings: ['walls'], population: 20, ownedTiles: [], productionQueue: [],
+      } as never,
+    };
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.units = ['garrison'];
+    state.opponentAI = undefined;
+
+    // Health alone can't isolate city counter-fire here: a garrisoned city routes the
+    // barbarian into normal unit-vs-unit combat against the garrison (attackOrders, not
+    // cityAttackOrders), and the garrison's own counter-damage legitimately changes the
+    // raider's health too. Assert the counter-fire EVENT specifically instead -- the
+    // thing this test is actually about (getCityCounterFireDamage's hasGarrison gate).
+    const bus = new EventBus();
+    const onCounterFire = vi.fn();
+    bus.on('city:counter-fire', onCounterFire);
+    processTurn(state, bus);
+
+    expect(onCounterFire).not.toHaveBeenCalled();
+  });
 });
 
 describe('opponent round finalization', () => {

--- a/tests/input/city-assault-flow.test.ts
+++ b/tests/input/city-assault-flow.test.ts
@@ -48,7 +48,7 @@ function makePlayerAssaultState({ population }: { population: number }): GameSta
 
 describe('city-assault-flow', () => {
   it('begins a pending player choice by moving onto a size-2 city and finalizes occupy in place', () => {
-    const state = makePlayerAssaultState({ population: 4 });
+    const state = makePlayerAssaultState({ population: 1 });
     const bus = new EventBus();
     const moved = vi.fn();
     bus.on('unit:move', moved);
@@ -62,7 +62,7 @@ describe('city-assault-flow', () => {
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
 
     expect(moved).toHaveBeenCalledOnce();
-    expect(begun.pending.occupiedPopulation).toBe(2);
+    expect(begun.pending.occupiedPopulation).toBe(1); // was toBe(2) with population: 4
     expect(begun.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
     expect(begun.state.units['unit-1'].movementPointsLeft).toBe(0);
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
@@ -71,7 +71,7 @@ describe('city-assault-flow', () => {
   });
 
   it('rejects a city assault when war has not been declared', () => {
-    const state = makePlayerAssaultState({ population: 4 });
+    const state = makePlayerAssaultState({ population: 1 });
     state.civilizations.player.diplomacy.atWarWith = [];
     state.civilizations['ai-1'].diplomacy.atWarWith = [];
 
@@ -84,7 +84,7 @@ describe('city-assault-flow', () => {
   });
 
   it('begins a pending player choice by moving onto a size-2 city and finalizes raze in place', () => {
-    const state = makePlayerAssaultState({ population: 4 });
+    const state = makePlayerAssaultState({ population: 1 });
 
     const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'raze', begun.state.turn);
@@ -111,7 +111,7 @@ describe('city-assault-flow', () => {
   });
 
   it('preserves territory flip events when finalizing an occupied city', () => {
-    const state = makePlayerAssaultState({ population: 4 });
+    const state = makePlayerAssaultState({ population: 1 });
     const farmCoord = { q: 1, r: 0 };
     state.map.tiles[hexKey(farmCoord)] = {
       ...state.map.tiles[hexKey(farmCoord)],

--- a/tests/input/city-assault-flow.test.ts
+++ b/tests/input/city-assault-flow.test.ts
@@ -59,6 +59,8 @@ describe('city-assault-flow', () => {
       'athens',
       bus,
     );
+    expect(begun.ok).toBe(true);
+    if (!begun.ok) return;
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
 
     expect(moved).toHaveBeenCalledOnce();
@@ -75,18 +77,22 @@ describe('city-assault-flow', () => {
     state.civilizations.player.diplomacy.atWarWith = [];
     state.civilizations['ai-1'].diplomacy.atWarWith = [];
 
-    expect(() => beginPlayerCityAssaultChoice(
+    const result = beginPlayerCityAssaultChoice(
       state,
       'unit-1',
       'athens',
       new EventBus(),
-    )).toThrow('Cannot begin city assault: not-at-war');
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: 'not-at-war' });
   });
 
   it('begins a pending player choice by moving onto a size-2 city and finalizes raze in place', () => {
     const state = makePlayerAssaultState({ population: 1 });
 
     const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    expect(begun.ok).toBe(true);
+    if (!begun.ok) return;
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'raze', begun.state.turn);
 
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });
@@ -100,6 +106,8 @@ describe('city-assault-flow', () => {
     expect(shouldPromptForPlayerCityCapture(state.cities.athens)).toBe(true);
 
     const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    expect(begun.ok).toBe(true);
+    if (!begun.ok) return;
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
 
     expect(begun.pending.occupiedPopulation).toBe(1);
@@ -122,6 +130,8 @@ describe('city-assault-flow', () => {
     };
 
     const begun = beginPlayerCityAssaultChoice(state, 'unit-1', 'athens');
+    expect(begun.ok).toBe(true);
+    if (!begun.ok) return;
     const result = finalizePlayerCityAssaultChoice(begun.state, begun.pending, 'occupy', begun.state.turn);
 
     expect(result.territoryEvents).toEqual(expect.arrayContaining([

--- a/tests/input/foreign-city-entry-flow.test.ts
+++ b/tests/input/foreign-city-entry-flow.test.ts
@@ -26,7 +26,7 @@ function makeForeignCityEntryState(): GameState {
     name: 'Athens',
     owner: 'ai-1',
     position: { q: 1, r: 0 },
-    population: 4,
+    population: 1,
     ownedTiles: [{ q: 1, r: 0 }],
   };
   state.civilizations['ai-1'].cities = ['athens'];

--- a/tests/input/foreign-city-entry-flow.test.ts
+++ b/tests/input/foreign-city-entry-flow.test.ts
@@ -46,6 +46,8 @@ describe('foreign-city-entry-flow', () => {
 
     const result = beginConfirmedForeignCityEntry(state, 'unit-1', 'athens', bus);
 
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
     expect(result.state.civilizations.player.diplomacy.atWarWith).toContain('ai-1');
     expect(result.state.civilizations['ai-1'].diplomacy.atWarWith).toContain('player');
     expect(result.state.units['unit-1'].position).toEqual({ q: 1, r: 0 });

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -65,8 +65,14 @@ describe('city-capture-system', () => {
   }
 
   function makeMajorAssaultState(): GameState {
+    // population 1 (not 4): with the new intrinsic-strength mechanic (#522), a
+    // swordsman (strength 25) needs a comfortable margin over intrinsic strength
+    // (5 + population*3) so this fixture's existing unconditional-success assertions
+    // stay reliable regardless of the ±20% RNG factor. Tests that specifically exercise
+    // low-odds outcomes construct their own city stats instead of using this shared
+    // fixture -- see the new describe block below.
     const state = makeExposedCityCaptureState({
-      population: 4,
+      population: 1,
       buildings: [],
     });
     const attacker = createUnit(
@@ -542,5 +548,106 @@ describe('city-capture-system', () => {
     const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
 
     expect(result.state.civilizations['ai-1'].isEliminated).toBeFalsy();
+  });
+
+  describe('city-capture-system intrinsic defense (#522)', () => {
+    function makeUndefendedWalledCityState({
+      population,
+      buildings,
+      attackerType = 'warrior',
+    }: {
+      population: number;
+      buildings: string[];
+      attackerType?: 'warrior' | 'swordsman' | 'tank';
+    }): GameState {
+      const state = makeExposedCityCaptureState({ population, buildings });
+      const attacker = createUnit(attackerType, 'player', { q: 0, r: 0 }, state.idCounters);
+      attacker.id = 'attacker';
+      attacker.movementPointsLeft = 2;
+      state.units = { [attacker.id]: attacker };
+      state.civilizations.player.units = [attacker.id];
+      state.civilizations['ai-1'].units = [];
+      state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+      state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+      state.map.tiles['0,0'].terrain = 'grassland';
+      state.map.tiles['1,0'].terrain = 'grassland';
+      return state;
+    }
+
+    it('captures a weakly-defended (low population, unwalled) city reliably, like today', () => {
+      const state = makeUndefendedWalledCityState({ population: 1, buildings: [], attackerType: 'tank' });
+
+      const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it('repels a hopelessly outmatched attacker against a strongly walled, populous city', () => {
+      const state = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+
+      const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+      expect(result).toMatchObject({ ok: false, reason: 'repelled-by-city-defense' });
+    });
+
+    it('on repel, the attacker stays in place, takes counter-fire damage, and the action is consumed', () => {
+      const state = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+      const before = state.units.attacker!.health;
+
+      const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+      expect(result.ok).toBe(false);
+      expect(result.state.units.attacker!.position).toEqual({ q: 0, r: 0 });
+      expect(result.state.units.attacker!.health).toBeLessThan(before);
+      expect(result.state.units.attacker!.hasActed).toBe(true);
+      expect(result.state.units.attacker!.movementPointsLeft).toBe(0);
+      expect(result.state.cities.athens).toBeDefined(); // still owned by defender
+    });
+
+    it('on a successful assault against walls, the attacker still takes counter-fire damage', () => {
+      const state = makeUndefendedWalledCityState({ population: 1, buildings: ['walls'], attackerType: 'tank' });
+      const before = state.units.attacker!.health;
+
+      const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.state.units.attacker!.health).toBeLessThan(before);
+    });
+
+    it('takes no counter-fire against an unwalled city even on repel (population alone can still repel)', () => {
+      const state = makeUndefendedWalledCityState({ population: 30, buildings: [] }); // no walls, still very high intrinsic strength
+      const before = state.units.attacker!.health;
+
+      const result = beginMajorCityAssault(state, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+
+      // Regardless of win/lose, no walls means zero counter-fire.
+      expect(result.state.units.attacker!.health).toBe(before);
+    });
+
+    it('never double-punishes the post-garrison-defeat advance (the double-punishment fix)', () => {
+      // Reuses the existing "defeated the final defender, then advances" fixture pattern.
+      const state = makeMajorAssaultState();
+      const defender = createUnit('warrior', 'ai-1', { q: 1, r: 0 }, state.idCounters);
+      defender.id = 'city-defender';
+      defender.health = 1;
+      state.units[defender.id] = defender;
+      state.civilizations['ai-1'].units.push(defender.id);
+      // Make the city extremely strong so, if the double-punishment bug existed, this
+      // attacker would be repelled by the SECOND (buggy) intrinsic-strength check.
+      state.cities.athens = { ...state.cities.athens, population: 50, buildings: ['walls', 'star_fort'] };
+      const combat = resolveCombat(state.units.attacker!, defender, state.map, 42, undefined, state.era);
+      const afterCombat = applyCombatOutcomeToState(state, combat, 42).state;
+
+      const result = beginMajorCityAssault(afterCombat, 'attacker', 'athens', {
+        actor: 'ai',
+        civId: 'player',
+        precedingCombat: combat,
+      });
+
+      expect(result.ok).toBe(true); // proves no second intrinsic-strength check fired
+      if (!result.ok) return;
+      expect(result.state.units.attacker!.position).toEqual({ q: 1, r: 0 });
+    });
   });
 });

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -649,5 +649,17 @@ describe('city-capture-system', () => {
       if (!result.ok) return;
       expect(result.state.units.attacker!.position).toEqual({ q: 1, r: 0 });
     });
+
+    it('the AI-actor capture path uses the identical resolution as the player path (#522)', () => {
+      const playerState = makeUndefendedWalledCityState({ population: 30, buildings: ['walls', 'star_fort'] });
+      const aiState = structuredClone(playerState);
+
+      const playerResult = beginMajorCityAssault(playerState, 'attacker', 'athens', { actor: 'player', civId: 'player' });
+      const aiResult = beginMajorCityAssault(aiState, 'attacker', 'athens', { actor: 'ai', civId: 'player' });
+
+      // Same state, same seed inputs (turn/attackerId/cityId) -> identical outcome,
+      // regardless of the 'actor' field, which is purely for event/bookkeeping purposes.
+      expect(playerResult.ok).toBe(aiResult.ok);
+    });
   });
 });

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -67,10 +67,11 @@ describe('city-capture-system', () => {
   function makeMajorAssaultState(): GameState {
     // population 1 (not 4): with the new intrinsic-strength mechanic (#522), a
     // swordsman (strength 25) needs a comfortable margin over intrinsic strength
-    // (5 + population*3) so this fixture's existing unconditional-success assertions
-    // stay reliable regardless of the ±20% RNG factor. Tests that specifically exercise
-    // low-odds outcomes construct their own city stats instead of using this shared
-    // fixture -- see the new describe block below.
+    // (CITY_BASE_STRENGTH + population*CITY_STRENGTH_PER_POPULATION, city-siege-system.ts)
+    // so this fixture's existing unconditional-success assertions stay reliable
+    // regardless of the ±20% RNG factor. Tests that specifically exercise low-odds
+    // outcomes construct their own city stats instead of using this shared fixture --
+    // see the new describe block below.
     const state = makeExposedCityCaptureState({
       population: 1,
       buildings: [],

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -3,7 +3,7 @@ import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { createUnit } from '@/systems/unit-system';
 import type { City, Civilization, GameState } from '@/core/types';
-import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityIntrinsicStrength, isCityHpRegenerating, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, calculateCityAssaultStrengths, getCityIntrinsicStrength, isCityHpRegenerating, resolveCityAssault, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -353,5 +353,56 @@ describe('getCityIntrinsicStrength (#522)', () => {
   it('handles zero population without throwing (a just-founded or fully-unrested city)', () => {
     const { city, ownerCiv } = makeCityAndCiv({ population: 0, buildings: [] });
     expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBe(5);
+  });
+});
+
+describe('calculateCityAssaultStrengths / resolveCityAssault (#522)', () => {
+  it('computes attacker strength the same way calculateCombatStrengths does (health, veterancy, river)', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    const city = { ...state.cities[cityId]!, population: 1, buildings: [] };
+    const ownerCiv = state.civilizations.player;
+    const attacker = createUnit('swordsman', 'ai-1', { q: 3, r: 2 }, state.idCounters);
+
+    const breakdown = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+
+    // swordsman strength 25, full health, no veterancy, no river between (2,2)-(3,2) here
+    expect(breakdown.attackerStrength).toBeCloseTo(25, 5);
+    expect(breakdown.intrinsicStrength).toBe(8); // 5 + 1*3, no walls
+    expect(breakdown.winProbability).toBeGreaterThan(0.5);
+  });
+
+  it('gives a weak attacker a low but nonzero win probability against a strong city', () => {
+    const { state, cityId } = makeGameStateWithCity();
+    const city = { ...state.cities[cityId]!, population: 30, buildings: ['walls', 'star_fort'] };
+    const ownerCiv = withTechs(state.civilizations.player, ['fortification-engineering']);
+    const attacker = createUnit('warrior', 'ai-1', { q: 3, r: 2 }, state.idCounters);
+
+    const breakdown = calculateCityAssaultStrengths(attacker, city, ownerCiv, state.map);
+
+    expect(breakdown.winProbability).toBeLessThan(0.5);
+    expect(breakdown.winProbability).toBeGreaterThan(0);
+  });
+
+  it('resolveCityAssault is deterministic for a fixed seed', () => {
+    const first = resolveCityAssault(50, 10, 12345);
+    const second = resolveCityAssault(50, 10, 12345);
+    expect(first).toEqual(second);
+  });
+
+  it('an overwhelming attacker wins reliably across seeds', () => {
+    // Rate-based, not `.every(...)`: the ±20% randomFactor is clamped to
+    // [0.05, 0.95] before the RNG draw, so even a 10:1 strength ratio caps out at a
+    // 95% per-trial win chance -- `.every()` across 20 seeds would fail ~1 run in 3
+    // by construction, regardless of implementation correctness. Mirrors the rate-based
+    // philosophy Task 11's balance-sampling tests already use for the same reason.
+    const results = Array.from({ length: 20 }, (_, i) => resolveCityAssault(100, 10, i).attackerWins);
+    const winRate = results.filter(Boolean).length / results.length;
+    expect(winRate).toBeGreaterThan(0.75);
+  });
+
+  it('an overwhelmed attacker loses reliably across seeds', () => {
+    const results = Array.from({ length: 20 }, (_, i) => resolveCityAssault(10, 100, i).attackerWins);
+    const winRate = results.filter(Boolean).length / results.length;
+    expect(winRate).toBeLessThan(0.25);
   });
 });

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -318,15 +318,15 @@ describe('getCityIntrinsicStrength (#522)', () => {
     const { city: cityB, ownerCiv: ownerCivB } = makeCityAndCiv({ population: 10, buildings: [] });
     const high = getCityIntrinsicStrength(cityB, ownerCivB, 'land');
 
-    expect(low).toBe(5 + 1 * 3); // 8
-    expect(high).toBe(5 + 10 * 3); // 35
+    expect(low).toBe(2 + 1 * 2); // 4
+    expect(high).toBe(2 + 10 * 2); // 22
     expect(high).toBeGreaterThan(low);
   });
 
   it('applies the walls multiplier on top of the population base, matching getCityDefenseBreakdown', () => {
     const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls'] });
-    // base = 5 + 4*3 = 17; walls -> x1.25 -> 21.25 -> rounds per implementation
-    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBeCloseTo(17 * 1.25, 5);
+    // base = 2 + 4*2 = 10; walls -> x1.25 -> 12.5 -> rounds per implementation
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBeCloseTo(10 * 1.25, 5);
   });
 
   it('applies Star Fort and Fortification Engineering flat bonuses, same as a garrisoned defender', () => {
@@ -337,8 +337,8 @@ describe('getCityIntrinsicStrength (#522)', () => {
       withEngineering,
       'land',
     );
-    // base = 17; walls -> 21.25; +star_fort(5) +fortification-engineering(5) = 31.25
-    expect(strength).toBeCloseTo(17 * 1.25 + 5 + 5, 5);
+    // base = 10; walls -> 12.5; +star_fort(5) +fortification-engineering(5) = 22.5
+    expect(strength).toBeCloseTo(10 * 1.25 + 5 + 5, 5);
   });
 
   it('applies Torpedo Warfare only against a naval attacker, matching getCityDefenseBreakdown', () => {
@@ -346,13 +346,13 @@ describe('getCityIntrinsicStrength (#522)', () => {
     const withTorpedo = withTechs(ownerCiv, ['torpedo-warfare']);
     const naval = getCityIntrinsicStrength(city, withTorpedo, 'naval');
     const land = getCityIntrinsicStrength(city, withTorpedo, 'land');
-    expect(naval).toBeCloseTo(17 * 1.25 + 5, 5);
-    expect(land).toBeCloseTo(17 * 1.25, 5);
+    expect(naval).toBeCloseTo(10 * 1.25 + 5, 5);
+    expect(land).toBeCloseTo(10 * 1.25, 5);
   });
 
   it('handles zero population without throwing (a just-founded or fully-unrested city)', () => {
     const { city, ownerCiv } = makeCityAndCiv({ population: 0, buildings: [] });
-    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBe(5);
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBe(2);
   });
 });
 
@@ -367,7 +367,7 @@ describe('calculateCityAssaultStrengths / resolveCityAssault (#522)', () => {
 
     // swordsman strength 25, full health, no veterancy, no river between (2,2)-(3,2) here
     expect(breakdown.attackerStrength).toBeCloseTo(25, 5);
-    expect(breakdown.intrinsicStrength).toBe(8); // 5 + 1*3, no walls
+    expect(breakdown.intrinsicStrength).toBe(4); // 2 + 1*2, no walls
     expect(breakdown.winProbability).toBeGreaterThan(0.5);
   });
 
@@ -459,11 +459,20 @@ describe('city assault balance sampling (#522)', () => {
     // early expansion into a frequent failure. NOTE: >0.9 (the plan's original bound)
     // is unreachable here -- the RNG model's asymptotic ceiling (~92%, only approached
     // with a near-infinitely strong attacker per the randomFactor/clamp math) means no
-    // realistic era-1 unit can hit >90% against even the weakest possible city. 0.65 is
-    // the bound that actually reflects "not a frequent failure" for a real early unit
-    // (swordsman, strength 25) against a population-1 unwalled outpost (intrinsic 8).
+    // realistic era-1 unit can hit >90% against even the weakest possible city.
+    //
+    // Uses 'warrior' (strength 10, cost 8) -- the cheapest and most common unit
+    // available for early-expansion capture, not a stronger/pricier alternative -- since
+    // that's the actual "era-appropriate attacker" a player reaches for against a
+    // population-1 outpost. This caught a real balance bug pre-merge: with the design
+    // doc's original CITY_BASE_STRENGTH=5/CITY_STRENGTH_PER_POPULATION=3, a warrior's
+    // win rate against this exact scenario was only ~55-57% -- a near coin-flip for the
+    // single most common early-game action, not "reliably favors" as the spec required.
+    // Retuned to 2/2 (see city-siege-system.ts) to fix this; 0.6 leaves margin below the
+    // ~0.66-0.74 range observed across seed offsets while still proving it's well above
+    // a 50/50 coin-flip.
     const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: [] });
-    const attacker = createUnit('swordsman', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+    const attacker = createUnit('warrior', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
     const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, {
       width: 10, height: 10, wrapsHorizontally: false, rivers: [], tiles: {},
     });
@@ -471,7 +480,7 @@ describe('city assault balance sampling (#522)', () => {
       strengths.attackerStrength, strengths.intrinsicStrength, sampleSeed(i),
     ).attackerWins);
     const winRate = wins.filter(Boolean).length / wins.length;
-    expect(winRate).toBeGreaterThan(0.65);
+    expect(winRate).toBeGreaterThan(0.6);
   });
 
   it('a walled, high-population, fully-teched city meaningfully raises attacker losses without being unbeatable', () => {

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -3,7 +3,7 @@ import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { createUnit } from '@/systems/unit-system';
 import type { City, Civilization, GameState } from '@/core/types';
-import { applyCityHpRegeneration, applyCitySiegeOutcome, isCityHpRegenerating, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, getCityIntrinsicStrength, isCityHpRegenerating, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -308,5 +308,50 @@ describe('isCityHpRegenerating (#522)', () => {
     state.cities[cityId] = { ...state.cities[cityId]!, hp: 100 };
 
     expect(isCityHpRegenerating(state, state.cities[cityId]!)).toBe(false);
+  });
+});
+
+describe('getCityIntrinsicStrength (#522)', () => {
+  it('scales with population even without walls', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: [] });
+    const low = getCityIntrinsicStrength(city, ownerCiv, 'land');
+    const { city: cityB, ownerCiv: ownerCivB } = makeCityAndCiv({ population: 10, buildings: [] });
+    const high = getCityIntrinsicStrength(cityB, ownerCivB, 'land');
+
+    expect(low).toBe(5 + 1 * 3); // 8
+    expect(high).toBe(5 + 10 * 3); // 35
+    expect(high).toBeGreaterThan(low);
+  });
+
+  it('applies the walls multiplier on top of the population base, matching getCityDefenseBreakdown', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls'] });
+    // base = 5 + 4*3 = 17; walls -> x1.25 -> 21.25 -> rounds per implementation
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBeCloseTo(17 * 1.25, 5);
+  });
+
+  it('applies Star Fort and Fortification Engineering flat bonuses, same as a garrisoned defender', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls', 'star_fort'] });
+    const withEngineering = withTechs(ownerCiv, ['fortification-engineering']);
+    const strength = getCityIntrinsicStrength(
+      { ...city, buildings: ['walls', 'star_fort'] },
+      withEngineering,
+      'land',
+    );
+    // base = 17; walls -> 21.25; +star_fort(5) +fortification-engineering(5) = 31.25
+    expect(strength).toBeCloseTo(17 * 1.25 + 5 + 5, 5);
+  });
+
+  it('applies Torpedo Warfare only against a naval attacker, matching getCityDefenseBreakdown', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 4, buildings: ['walls'] });
+    const withTorpedo = withTechs(ownerCiv, ['torpedo-warfare']);
+    const naval = getCityIntrinsicStrength(city, withTorpedo, 'naval');
+    const land = getCityIntrinsicStrength(city, withTorpedo, 'land');
+    expect(naval).toBeCloseTo(17 * 1.25 + 5, 5);
+    expect(land).toBeCloseTo(17 * 1.25, 5);
+  });
+
+  it('handles zero population without throwing (a just-founded or fully-unrested city)', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 0, buildings: [] });
+    expect(getCityIntrinsicStrength(city, ownerCiv, 'land')).toBe(5);
   });
 });

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -3,7 +3,7 @@ import { createNewGame } from '@/core/game-state';
 import { foundCity } from '@/systems/city-system';
 import { createUnit } from '@/systems/unit-system';
 import type { City, Civilization, GameState } from '@/core/types';
-import { applyCityHpRegeneration, applyCitySiegeOutcome, calculateCityAssaultStrengths, getCityIntrinsicStrength, isCityHpRegenerating, resolveCityAssault, resolveCitySiegeDamage } from '@/systems/city-siege-system';
+import { applyCityHpRegeneration, applyCitySiegeOutcome, calculateCityAssaultStrengths, getCityCounterFireDamage, getCityIntrinsicStrength, isCityHpRegenerating, resolveCityAssault, resolveCitySiegeDamage } from '@/systems/city-siege-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -404,5 +404,40 @@ describe('calculateCityAssaultStrengths / resolveCityAssault (#522)', () => {
     const results = Array.from({ length: 20 }, (_, i) => resolveCityAssault(10, 100, i).attackerWins);
     const winRate = results.filter(Boolean).length / results.length;
     expect(winRate).toBeLessThan(0.25);
+  });
+});
+
+describe('getCityCounterFireDamage (#522)', () => {
+  it('is zero without walls', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: [] });
+    expect(getCityCounterFireDamage(city, ownerCiv, 'land', 20, false, 1)).toBe(0);
+  });
+
+  it('is zero when the city has a garrison', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: ['walls'] });
+    expect(getCityCounterFireDamage(city, ownerCiv, 'land', 20, true, 1)).toBe(0);
+  });
+
+  it('is nonzero and walls/tech-scaled otherwise', () => {
+    // population: 1 (not 10, as the plan's draft used) -- at population 10 the base vs.
+    // fortified damage figures both round to the identical integer at seed 1 (23.75 vs
+    // 24.33, a real but sub-1-HP difference the plan's own rounding step erases), making
+    // `toBeGreaterThan` fail regardless of implementation correctness. Population 1
+    // widens star_fort's flat +5 bonus relative to the smaller population-scaled base,
+    // producing a clean, non-colliding separation (15 vs 17) while testing the exact
+    // same thing: fortification increases counter-fire damage.
+    const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: ['walls'] });
+    const { city: fortifiedCity, ownerCiv: fortifiedCiv } = makeCityAndCiv({ population: 1, buildings: ['walls', 'star_fort'] });
+    const base = getCityCounterFireDamage(city, ownerCiv, 'land', 20, false, 1);
+    const fortified = getCityCounterFireDamage(fortifiedCity, fortifiedCiv, 'land', 20, false, 1);
+    expect(base).toBeGreaterThan(0);
+    expect(fortified).toBeGreaterThan(base);
+  });
+
+  it('scales inversely with attacker strength -- an overwhelming attacker takes measurably less', () => {
+    const { city, ownerCiv } = makeCityAndCiv({ population: 10, buildings: ['walls'] });
+    const weakAttacker = getCityCounterFireDamage(city, ownerCiv, 'land', 15, false, 1);
+    const strongAttacker = getCityCounterFireDamage(city, ownerCiv, 'land', 200, false, 1);
+    expect(strongAttacker).toBeLessThan(weakAttacker);
   });
 });

--- a/tests/systems/city-siege-system.test.ts
+++ b/tests/systems/city-siege-system.test.ts
@@ -441,3 +441,54 @@ describe('getCityCounterFireDamage (#522)', () => {
     expect(strongAttacker).toBeLessThan(weakAttacker);
   });
 });
+
+describe('city assault balance sampling (#522)', () => {
+  // Seeds spread by a large odd multiplier, not raw consecutive integers 0..49: the
+  // resolveCityAssault LCG's FIRST draw from a small seed s is (s*48271) mod M, which
+  // for s in 0..49 is a tiny fraction of the modulus -- randomFactor barely moves off
+  // 0.8 for the entire sample, capping the achievable win rate at ~76% for ANY attacker
+  // strength (verified empirically: even an attacker 1000x the city's strength only
+  // reaches ~90% with consecutive seeds, vs. the RNG model's true asymptotic ceiling of
+  // ~92% with well-spread seeds). This is a small-seed correlation artifact of the LCG,
+  // not a signal about the combat model -- spreading seeds avoids it without touching
+  // production code (which never seeds with tiny sequential integers in practice).
+  const sampleSeed = (i: number) => i * 104729 + 17;
+
+  it('an unwalled, low-population outpost favors an era-appropriate attacker far more often than not', () => {
+    // Today this capture is 100% guaranteed; the new mechanic must not turn routine
+    // early expansion into a frequent failure. NOTE: >0.9 (the plan's original bound)
+    // is unreachable here -- the RNG model's asymptotic ceiling (~92%, only approached
+    // with a near-infinitely strong attacker per the randomFactor/clamp math) means no
+    // realistic era-1 unit can hit >90% against even the weakest possible city. 0.65 is
+    // the bound that actually reflects "not a frequent failure" for a real early unit
+    // (swordsman, strength 25) against a population-1 unwalled outpost (intrinsic 8).
+    const { city, ownerCiv } = makeCityAndCiv({ population: 1, buildings: [] });
+    const attacker = createUnit('swordsman', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+    const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, {
+      width: 10, height: 10, wrapsHorizontally: false, rivers: [], tiles: {},
+    });
+    const wins = Array.from({ length: 50 }, (_, i) => resolveCityAssault(
+      strengths.attackerStrength, strengths.intrinsicStrength, sampleSeed(i),
+    ).attackerWins);
+    const winRate = wins.filter(Boolean).length / wins.length;
+    expect(winRate).toBeGreaterThan(0.65);
+  });
+
+  it('a walled, high-population, fully-teched city meaningfully raises attacker losses without being unbeatable', () => {
+    const { city, ownerCiv: baseCiv } = makeCityAndCiv({ population: 20, buildings: ['walls', 'star_fort'] });
+    const ownerCiv = withTechs(baseCiv, ['fortification-engineering', 'professional-army']);
+    const attacker = createUnit('tank', 'ai-1', { q: 3, r: 2 }, { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+    const strengths = calculateCityAssaultStrengths(attacker, city, ownerCiv, {
+      width: 10, height: 10, wrapsHorizontally: false, rivers: [], tiles: {},
+    });
+    const wins = Array.from({ length: 50 }, (_, i) => resolveCityAssault(
+      strengths.attackerStrength, strengths.intrinsicStrength, sampleSeed(i),
+    ).attackerWins);
+    const winRate = wins.filter(Boolean).length / wins.length;
+    // An era-appropriate strong attacker (tank) should still be capable of winning,
+    // just not trivially -- not >0.95 (city offers zero real resistance) and not <0.05
+    // (city becomes practically uncapturable even to a strong, teched attacker).
+    expect(winRate).toBeLessThan(0.95);
+    expect(winRate).toBeGreaterThan(0.05);
+  });
+});

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
 import { createEmptyPirateState, type PirateFactionState } from '@/core/pirate-state';
@@ -576,5 +576,38 @@ describe('pirate naval siege (#522)', () => {
     expect(result.state.cities.port).toBeDefined();
     expect(result.state.cities.port!.hp).toBe(1);
     expect(result.economyModifiers).toBeDefined();
+  });
+
+  it('applies counter-fire to a besieging ship attacking a walled, ungarrisoned city (#522)', () => {
+    const state = siegeReadyState(100);
+    state.cities.port = { ...state.cities.port!, buildings: ['walls'], population: 20 };
+
+    const shipBefore = state.units['ship-a']!.health;
+    const result = processPiratesForCompletedRound(state, new EventBus());
+
+    const shipAfter = result.state.units['ship-a']?.health ?? 0;
+    expect(shipAfter).toBeLessThan(shipBefore);
+  });
+
+  it('does not counter-fire when the besieged city has no walls', () => {
+    const state = siegeReadyState(100);
+    state.cities.port = { ...state.cities.port!, buildings: [], population: 20 };
+
+    const shipBefore = state.units['ship-a']!.health;
+    const result = processPiratesForCompletedRound(state, new EventBus());
+
+    expect(result.state.units['ship-a']?.health ?? 0).toBe(shipBefore);
+  });
+
+  it('emits city:counter-fire so the player gets feedback that their walls fought back (#522)', () => {
+    const state = siegeReadyState(100);
+    state.cities.port = { ...state.cities.port!, buildings: ['walls'], population: 20 };
+
+    const bus = new EventBus();
+    const onCounterFire = vi.fn();
+    bus.on('city:counter-fire', onCounterFire);
+    processPiratesForCompletedRound(state, bus);
+
+    expect(onCounterFire).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'port', source: 'pirate' }));
   });
 });

--- a/tests/ui/city-panel.test.ts
+++ b/tests/ui/city-panel.test.ts
@@ -2082,4 +2082,34 @@ describe('city-panel HP status (#522)', () => {
     expect(panel.textContent).not.toContain('Recovering');
     expect(panel.textContent).not.toContain('Under siege');
   });
+
+  it('shows a static defense-rating line for every owned city, not just damaged ones (#522)', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.cities[city.id] = { ...city, hp: 100, population: 10, buildings: ['walls'] };
+
+    const panel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toMatch(/Defense/i);
+  });
+
+  it('defense rating changes when walls are built', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.cities[city.id] = { ...city, hp: 100, population: 10, buildings: [] };
+    const unwalledPanel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    const unwalledText = unwalledPanel.textContent ?? '';
+
+    state.cities[city.id] = { ...state.cities[city.id]!, buildings: ['walls'] };
+    const walledPanel = createCityPanel(container, state.cities[city.id]!, state, {
+      onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {},
+    });
+    const walledText = walledPanel.textContent ?? '';
+
+    expect(walledText).not.toBe(unwalledText);
+  });
 });


### PR DESCRIPTION
## Summary

Implements the full plan for #560 (part of the battle-mechanics arc, #546): cities now have intrinsic combat strength derived from population + existing walls/tech defense bonuses, so an ungarrisoned walled city can no longer be captured for free. Walled cities also deal automatic ranged counter-fire against any attacker (player, barbarian, or pirate) that reaches them without a garrison.

- `getCityIntrinsicStrength` — population baseline + the same `getCityDefenseBreakdown` a garrisoned defender already uses (walls, Star Fort, Fortification Engineering, Professional Army, Torpedo Warfare)
- `calculateCityAssaultStrengths` / `resolveCityAssault` — odds preview + single-exchange win/lose resolution for the player-capture path (`city.hp` sieges stay a separate, untouched multi-turn model)
- `getCityCounterFireDamage` — ratio-scaled (not flat) retaliation damage, applied uniformly across player, barbarian, and pirate attackers
- AI capture scoring (`rankCapture`) now weights by win probability instead of a flat score
- Defender-side city-panel defense-rating display, and a new odds-preview panel for the player's assault tap intent
- Full TDD coverage: balance sampling, actor parity, hot-seat safety (no `civId`/`currentPlayer` branching added), and a no-double-punishment regression for the "defeated garrison, then advances" path

## Review fixes (found in a full pre-merge multi-dimensional pass across balance, AI, hot-seat, and architecture)

- **Balance bug**: the design doc's original constants (base 5, +3/pop) made the cheapest, most common early-capture unit (warrior) only ~55-57% likely to beat a population-1 "trivially weak" outpost — a near coin-flip for the single most common early-game action. Retuned to base 2, +2/pop (warrior ~70% vs. the same outpost; a fully walled/teched high-population city still meaningfully contests a late-game tank at ~48%).
- **AI state-discard bug** (two layers, `ai-major-turn.ts`): a repelled AI city assault was silently reversible — `occupyMajorCity`'s failure branch returned the pre-assault state (discarding counter-fire damage/death and action-consumption), and `executeAction`'s `capture-city` case used an outcome-based `succeeded` flag instead of the attempt-based one `'attack'` already uses, so the outer turn loop discarded the state a second time and never recorded the attempt.
- **RNG seed collision**: the plan's `attackerId.charCodeAt(0) + cityId.charCodeAt(0)` seed derivation collided for this codebase's own default test fixture ids (`'attacker'` + `'athens'`), producing a seed that always lost regardless of attacker strength. Fixed to fold full id strings, matching `combat-reward-system.ts`'s existing convention.
- Several plan-authored tests used statistically-unreachable bounds (`.every()` across `0..49` consecutive small-integer seeds, which triggers a known LCG small-seed correlation artifact) — fixed to rate-based thresholds with well-spread seeds.

## Test plan

- [x] `yarn build` (tsc + vite) — clean
- [x] `yarn test` — 6076 passed, 3 skipped, 0 failed
- [x] Balance-sampling regressions for both a weak unwalled outpost and a maximally-defended city
- [x] Actor-parity regression (player vs. AI route through identical resolution)
- [x] AI regression proving a repelled assault keeps its counter-fire damage/action-consumption and is recorded in the turn's action log

No new persisted fields — a save from before this change loads and plays identically except for the new combat behavior itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)