### PR TITLE
MR2+MR3: notification delivery contract + diplomacy consent/war visibility

### DIFF
--- a/.claude/rules/ui-panels.md
+++ b/.claude/rules/ui-panels.md
@@ -35,6 +35,10 @@ paths:
 - Notifications must queue — never overwrite one notification with another
 - Maintain a persistent notification log (last 50 entries) accessible via a log button
 - Log entries must include the turn number for context
+- Game-consequence notifications MUST go through `notification-delivery`'s
+  `deliver(civId, …)` with an explicit recipient — never `showNotification`,
+  which is reserved for immediate feedback to the acting player's own input.
+  Emit-time `currentPlayer` attribution is the #551 leak bug class.
 
 ## Tech Panel
 - Must list ALL tech tracks from the `TechTrack` type union — never hardcode a subset

--- a/docs/superpowers/plans/2026-07-11-bug-arc-mr2-notification-delivery-contract.md
+++ b/docs/superpowers/plans/2026-07-11-bug-arc-mr2-notification-delivery-contract.md
@@ -1,0 +1,526 @@
+# MR2 — Notification Delivery Contract (#551) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task inline (this repo forbids subagents — see CLAUDE.md Agent Policy). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every game-consequence notification is delivered to an explicit recipient civ, never leaks to the wrong hot-seat player, and is stamped with the turn it happened — one delivery contract instead of three ad-hoc mechanisms.
+
+**Architecture:** A new `src/ui/notification-delivery.ts` module becomes the single sink. It writes the per-civ log always, toasts only when the recipient is the active unsuppressed viewer, and queues to `state.pendingEvents` (hot seat only) otherwise — the existing turn-handoff summary drains that queue. `showNotification` survives solely for immediate feedback to the acting player's own action.
+
+**Tech Stack:** TypeScript, vitest, existing EventBus/GameEventBuffer plumbing.
+
+## Global Constraints
+
+- All commands via `bash scripts/run-with-mise.sh yarn <cmd>`.
+- `yarn build` + `yarn test` green before push. Tests mirror `src/` under `tests/`.
+- NEVER hardcode `'player'`; recipients are explicit civ ids.
+- Notifications must queue, never overwrite; log keeps last 50 per player with turn numbers (existing `src/core/notification-log.ts` behavior — do not change caps).
+- `textContent` only for dynamic strings.
+
+## Background for the implementer (zero-context)
+
+Current mechanisms (all in `src/main.ts` unless noted):
+
+1. `showNotification(message, type, target?)` (line ~638): toasts immediately
+   AND appends to **whoever `gameState.currentPlayer` is at call time**. ~125
+   call sites; most are legitimate direct feedback ("Unit fortified.") — those
+   stay. A handful of `bus.on` listeners use it for game consequences — those
+   are the leak and must migrate (Task 3 lists every one).
+2. `appendToCivLog(civId, message, type, target?)` (line ~656): appends to the
+   correct civ's log; toasts only if `civId === currentPlayer` **at emit
+   time**. Used by the routers in `src/ui/notification-routing.ts`.
+3. `state.pendingEvents` (`src/core/hotseat-events.ts`): per-civ queue drained
+   ONLY by the hot-seat handoff summary (`src/ui/turn-handoff.ts:61` →
+   `clearEventsForPlayer`). Fed today by `queueFirstContactPendingEvents`
+   (main.ts:3797, unconditional — leaks stale queue growth into solo saves),
+   `queueStrategicWarningPendingEvent` (main.ts:3979, hot-seat gated), and
+   `appendFactionNotice` (main.ts:3985).
+
+Event timing: world simulation runs inside `runCompletedRound`
+(`src/core/completed-round-orchestrator.ts`) which **buffers** events
+(`src/core/game-event-buffer.ts`); the buffer is committed to the live bus
+AFTER the post-round state (turn already incremented, `currentPlayer` possibly
+advanced) is adopted. Commit sites:
+- Solo: `src/main.ts:3458` (`result.events.commitTo(bus)` inside `endTurn`).
+- Hot seat: `src/core/completed-round-handoff.ts:60` (inside
+  `runCompletedRoundSimulation`, invoked from `src/main.ts:3397`).
+
+Why the bugs happen: listeners run at commit time, so `currentPlayer`-based
+attribution and `gameState.turn` stamping are both wrong for events that
+happened during the completed round. In hot seat, a consequence for player A
+can toast on player B's screen (leak) or surface only at A's next summary
+(late). In solo, `pendingEvents` never drains at all.
+
+The delivery contract this MR installs:
+
+| Recipient state | Behavior |
+|---|---|
+| Recipient is AI (`!civ.isHuman`) | log only |
+| Recipient === `currentPlayer`, presentation not suppressed | log + toast now |
+| Otherwise, `state.hotSeat` set | log + queue to `pendingEvents[recipient]` (shown in that player's next handoff summary) |
+| Otherwise (solo) | log + toast (solo's single human is always the viewer) |
+
+Turn stamping: both commit sites wrap the commit in
+`withHappenedTurn(preRoundTurn, …)` so entries carry the turn the round
+belonged to, not the incremented turn.
+
+---
+
+### Task 1: The delivery module
+
+**Files:**
+- Create: `src/ui/notification-delivery.ts`
+- Test: `tests/ui/notification-delivery.test.ts`
+
+**Interfaces:**
+- Consumes: `appendNotification`, `NotificationEntry` from `@/core/notification-log`; `collectEvent` from `@/core/hotseat-events`.
+- Produces:
+
+```ts
+export interface NotificationDeliveryDeps {
+  getState: () => GameState;
+  toast: (message: string, type: NotificationEntry['type'], target?: NotificationEntry['target']) => void;
+  isSuppressed: () => boolean;
+}
+export interface NotificationDelivery {
+  deliver: NotificationSink; // (civId, message, type, target?) => void
+  withHappenedTurn<T>(turn: number, fn: () => T): T;
+}
+export function createNotificationDelivery(deps: NotificationDeliveryDeps): NotificationDelivery;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// tests/ui/notification-delivery.test.ts
+import { describe, it, expect, vi } from 'vitest';
+import { createNotificationDelivery } from '@/ui/notification-delivery';
+import type { GameState } from '@/core/types';
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 6,
+    currentPlayer: 'p1',
+    idCounters: {},
+    civilizations: {
+      p1: { isHuman: true } as any,
+      p2: { isHuman: true } as any,
+      ai1: { isHuman: false } as any,
+    },
+    notificationLog: {},
+    pendingEvents: {},
+    ...overrides,
+  } as unknown as GameState;
+}
+
+function make(state: GameState, suppressed = false) {
+  const toast = vi.fn();
+  const delivery = createNotificationDelivery({
+    getState: () => state,
+    toast,
+    isSuppressed: () => suppressed,
+  });
+  return { delivery, toast };
+}
+
+describe('notification delivery contract', () => {
+  it('toasts and logs for the active unsuppressed viewer', () => {
+    const state = makeState();
+    const { delivery, toast } = make(state);
+    delivery.deliver('p1', 'War!', 'warning');
+    expect(toast).toHaveBeenCalledWith('War!', 'warning', undefined);
+    expect(state.notificationLog!['p1']).toHaveLength(1);
+    expect(state.notificationLog!['p1'][0].turn).toBe(6);
+  });
+
+  it('hot seat: queues (no toast) for a non-current human — the leak regression', () => {
+    const state = makeState({ hotSeat: { players: [] } as any });
+    const { delivery, toast } = make(state); // currentPlayer is p1
+    delivery.deliver('p2', 'Secret consequence', 'warning');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.notificationLog!['p2']).toHaveLength(1);
+    expect(state.pendingEvents!['p2']).toHaveLength(1);
+    expect(state.pendingEvents!['p2'][0].message).toBe('Secret consequence');
+  });
+
+  it('hot seat: queues for the current player while presentation is suppressed', () => {
+    const state = makeState({ hotSeat: { players: [] } as any });
+    const { delivery, toast } = make(state, true);
+    delivery.deliver('p1', 'Mid-handoff event', 'info');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['p1']).toHaveLength(1);
+  });
+
+  it('solo: toasts even for consequence events (single human is always the viewer)', () => {
+    const state = makeState(); // no hotSeat
+    const { delivery, toast } = make(state);
+    delivery.deliver('p1', 'You met the Aztecs.', 'info');
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(state.pendingEvents!['p1'] ?? []).toHaveLength(0); // never queue in solo
+  });
+
+  it('AI recipients get log-only', () => {
+    const state = makeState();
+    const { delivery, toast } = make(state);
+    delivery.deliver('ai1', 'AI thing', 'info');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['ai1'] ?? []).toHaveLength(0);
+    expect(state.notificationLog!['ai1']).toHaveLength(1);
+  });
+
+  it('withHappenedTurn stamps the round the event belonged to', () => {
+    const state = makeState(); // state.turn === 6
+    const { delivery } = make(state);
+    delivery.withHappenedTurn(5, () => {
+      delivery.deliver('p1', 'Happened last round', 'info');
+    });
+    expect(state.notificationLog!['p1'][0].turn).toBe(5);
+    delivery.deliver('p1', 'Happens now', 'info');
+    expect(state.notificationLog!['p1'][1].turn).toBe(6); // context reset
+  });
+
+  it('withHappenedTurn resets context even when fn throws', () => {
+    const state = makeState();
+    const { delivery } = make(state);
+    expect(() => delivery.withHappenedTurn(5, () => { throw new Error('boom'); })).toThrow('boom');
+    delivery.deliver('p1', 'after throw', 'info');
+    expect(state.notificationLog!['p1'][0].turn).toBe(6);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn vitest run tests/ui/notification-delivery.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/ui/notification-delivery.ts
+import type { GameState } from '@/core/types';
+import { appendNotification, type NotificationEntry } from '@/core/notification-log';
+import { collectEvent } from '@/core/hotseat-events';
+import type { NotificationSink } from '@/ui/notification-routing';
+
+export interface NotificationDeliveryDeps {
+  getState: () => GameState;
+  toast: (message: string, type: NotificationEntry['type'], target?: NotificationEntry['target']) => void;
+  isSuppressed: () => boolean;
+}
+
+export interface NotificationDelivery {
+  deliver: NotificationSink;
+  withHappenedTurn<T>(turn: number, fn: () => T): T;
+}
+
+// The single delivery contract for game-consequence notifications (#551):
+// log always; toast only when the recipient is the active, unsuppressed
+// viewer; queue to pendingEvents (hot seat only) otherwise, where the
+// turn-handoff summary already drains it. Solo never queues — its single
+// human is always the viewer, so deferred delivery would mean "never".
+export function createNotificationDelivery(deps: NotificationDeliveryDeps): NotificationDelivery {
+  let happenedTurn: number | null = null;
+
+  const deliver: NotificationSink = (civId, message, type, target) => {
+    const state = deps.getState();
+    const turn = happenedTurn ?? state.turn;
+    appendNotification(state, civId, { message, type, turn, target });
+
+    const civ = state.civilizations[civId];
+    if (!civ?.isHuman) return;
+
+    const isActiveViewer = civId === state.currentPlayer && !deps.isSuppressed();
+    if (isActiveViewer || !state.hotSeat) {
+      deps.toast(message, type, target);
+      return;
+    }
+    state.pendingEvents ??= {};
+    collectEvent(state.pendingEvents, civId, {
+      type: 'info',
+      message,
+      turn,
+      ...(target ? { target } : {}),
+    });
+  };
+
+  return {
+    deliver,
+    withHappenedTurn<T>(turn: number, fn: () => T): T {
+      happenedTurn = turn;
+      try {
+        return fn();
+      } finally {
+        happenedTurn = null;
+      }
+    },
+  };
+}
+```
+
+Note: check the `GameEvent` type in `src/core/types.ts` for the exact allowed
+`type` values and whether it carries `target` — `queueStrategicWarningPendingEvent`
+in `src/ui/notification-routing.ts:285` already spreads a `target`, so follow
+whatever shape that compiles against. If `GameEvent.type` is a closed union
+without `'info'`, add `'info'` to the union (it is display-only).
+
+One subtlety: the solo branch calls `deps.toast` directly; the wired-up toast
+(Task 2) is `enqueueToast`, which itself drops toasts while the presentation
+gate is suppressed. That is correct — in solo the gate is only suppressed
+during victory/entry overlays, and the log copy is already written.
+
+- [ ] **Step 4: Run tests to verify pass, commit**
+
+```bash
+bash scripts/run-with-mise.sh yarn vitest run tests/ui/notification-delivery.test.ts
+git add src/ui/notification-delivery.ts tests/ui/notification-delivery.test.ts
+git commit -m "feat(notifications): single per-civ delivery contract (#551)"
+```
+
+### Task 2: Wire the module in and stamp round turns
+
+**Files:**
+- Modify: `src/main.ts` (~line 656 `appendToCivLog`; solo commit ~line 3452–3458; hot-seat commit call site ~line 3397)
+- Modify: `src/core/completed-round-handoff.ts` (no change needed if wrapping at the main.ts call site — see step 2)
+- Test: covered by Task 1 unit tests + Task 4 regression; this task is wiring.
+
+**Interfaces:**
+- Consumes: `createNotificationDelivery` from Task 1.
+- Produces: module-level `notificationDelivery` in main.ts; `appendToCivLog` becomes an alias so all existing router call sites keep working unchanged.
+
+- [ ] **Step 1: Instantiate and alias**
+
+In `src/main.ts`, replace the `appendToCivLog` const (line ~656) with:
+
+```ts
+const notificationDelivery = createNotificationDelivery({
+  getState: () => gameState,
+  toast: enqueueToast,
+  isSuppressed: () => roundPresentationGate.isSuppressed(),
+});
+// All routers keep using this name; it now enforces the delivery contract.
+const appendToCivLog: NotificationSink = notificationDelivery.deliver;
+```
+
+Import `createNotificationDelivery` from `@/ui/notification-delivery`.
+
+- [ ] **Step 2: Stamp the solo commit**
+
+In `endTurn`'s solo branch (main.ts ~3452), capture the pre-round turn and wrap
+the commit:
+
+```ts
+      const roundTurn = gameState.turn;
+      const result = runCurrentCompletedRound(gameState);
+      if (!result.ok) throw result.error;
+      gameState = result.state;
+      const soloMoves = captureAIMoves(() => {
+        notificationDelivery.withHappenedTurn(roundTurn, () => {
+          result.events.commitTo(bus);
+        });
+      });
+```
+
+- [ ] **Step 3: Stamp the hot-seat commit**
+
+The hot-seat commit happens inside `transaction.runCompletedRoundSimulation()`
+(main.ts:3397, implemented in `src/core/completed-round-handoff.ts:60`). The
+commit is synchronous within that call, so wrap where the transaction is
+created: find where `createCompletedRoundHandoff`'s options are built in
+main.ts (grep `runCompletedRound:` near line 3390) and capture
+`const roundTurn = <initial state>.turn` from the same `initialState` passed
+in, then wrap `eventTarget`: pass a proxy EventBus whose `emit` defers to
+`bus` inside `withHappenedTurn`, OR simpler and preferred — wrap the await:
+
+```ts
+    const roundTurn = gameState.turn; // before simulation adopts the new state
+    const outcome = await notificationDelivery.withHappenedTurn(
+      roundTurn,
+      () => transaction.runCompletedRoundSimulation(),
+    );
+```
+
+`withHappenedTurn` is synchronous; `runCompletedRoundSimulation` is async but
+its event commit (`commitTo`) executes synchronously before its first
+persistence await — verify by reading `src/core/completed-round-handoff.ts:46-63`
+(commit at line 60 precedes `persistCompletedRoundHandoff`). Since the
+happened-turn context only matters during the synchronous commit, wrapping the
+call works, but the context will have reset by the time the promise resolves —
+that is fine. Add this comment at the wrap site so a future refactor that
+makes the commit async knows to re-plumb:
+
+```ts
+    // withHappenedTurn only needs to cover the synchronous commitTo() inside
+    // runCompletedRoundSimulation (completed-round-handoff.ts). If that commit
+    // ever moves after an await, thread the turn through the options instead.
+```
+
+- [ ] **Step 4: Build, run full suite, commit**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+git add src/main.ts
+git commit -m "feat(notifications): wire delivery contract + round-turn stamping (#551)"
+```
+
+Expect some existing tests around notification routing to still pass — they
+inject their own sink. If a test constructed `appendToCivLog` behavior
+directly, update it to build a `createNotificationDelivery` instance.
+
+### Task 3: Migrate consequence listeners off showNotification
+
+**Files:**
+- Modify: `src/main.ts` — exactly these listeners:
+  - `bus.on('diplomacy:peace-requested', …)` (~3800): use `routePeaceRequested(gameState, fromCivId, toCivId, appendToCivLog)` — recipient `toCivId`, not currentPlayer.
+  - `bus.on('beast:slain', …)` (~3944): the reward toast targets `slayerCivId` via `appendToCivLog(slayerCivId, toast, 'success')`. The hoard-choice UI beneath it must stay gated on `slayerCivId === gameState.currentPlayer` (check the surrounding code; `maybeShowPendingHoardChoice` already re-checks on handoff).
+  - `bus.on('era:advanced', …)` (~3990): the era toast is a GLOBAL announcement misattributed to `currentPlayer` today. Replace with a loop delivering to every human civ, message `\`The world has entered Era ${era}!\``; keep `routeEraAdvanced`'s era-2 unrest primer per human civ (its `factionSink` already takes a civId — call it per human). Update `routeEraAdvanced`'s signature in `src/ui/notification-routing.ts` from `(era, civId, civName, toastSink, factionSink)` to `(era, humanCivIds: string[], sink: NotificationSink)` and let it deliver both lines itself; update its unit tests in `tests/ui/notification-routing.test.ts` accordingly.
+  - `bus.on('economy:treasury-strain', …)` (~4043): replace direct `showNotification(...)` with the existing `routeEconomyTreasuryStrain(gameState, event, appendToCivLog)` (it already targets `event.civId`).
+  - `bus.on('unit:journey-blocked', …)` (~4100): recipient is `gameState.units[unitId]?.owner`; fall back to skipping (log nothing) if the unit is gone — do NOT fall back to currentPlayer.
+  - `bus.on('trade:route-ended', …)` (~4162): recipient is the from-city owner: `gameState.cities[fromCityId]?.owner`; deliver additionally to the to-city owner when different and human.
+  - `bus.on('advisor:message', …)` (~3813): leave on `showNotification` — advisor checks run against the active viewer by construction; add the comment `// viewer-scoped by design: advisors run for the active player only`.
+- Modify: `src/ui/notification-routing.ts` (routeEraAdvanced signature change).
+- Modify: remove `queueFirstContactPendingEvents` call (main.ts:3797) and `queueStrategicWarningPendingEvent` call (main.ts:3977-3980) — the delivery contract now queues automatically for non-current recipients, so these are double-queues. Delete both helper functions from `src/ui/notification-routing.ts` and their tests (they exist solely for this plumbing; confirm no other callers with `grep -rn "queueFirstContactPendingEvents\|queueStrategicWarningPendingEvent" src tests`).
+- Test: update `tests/ui/notification-routing.test.ts` for the changed/deleted functions.
+
+- [ ] **Step 1: For each listener above, write/adjust a focused test first** — e.g. for peace-requested:
+
+```ts
+  it('routes a peace request to the recipient civ only', () => {
+    const sink = vi.fn();
+    routePeaceRequested(state, 'aggressor', 'victim', sink);
+    expect(sink).toHaveBeenCalledTimes(1);
+    expect(sink.mock.calls[0][0]).toBe('victim');
+  });
+```
+
+(`routePeaceRequested` already behaves this way — the bug is the listener not
+using it. The listener-level fix is verified by Task 4's integration
+regression; the unit tests here pin the router contracts.)
+
+- [ ] **Step 2: Apply the listener edits listed above, run the full suite**
+
+Run: `bash scripts/run-with-mise.sh yarn test`
+Expected: any test asserting the old routeEraAdvanced signature or the two
+deleted queue helpers fails until updated; update them to the new contracts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "fix(notifications): consequence listeners deliver to explicit recipients (#551)"
+```
+
+### Task 4: Hot-seat leak + solo staleness regressions
+
+**Files:**
+- Test: `tests/ui/notification-delivery-regressions.test.ts` (new)
+- Modify: `src/main.ts` `migrateLegacySave` (~line 4278): solo saves clear stale `pendingEvents`.
+
+- [ ] **Step 1: Write the regression tests**
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { createNotificationDelivery } from '@/ui/notification-delivery';
+// build a two-human hot-seat state fixture; reuse the state factory from
+// tests/ui/notification-delivery.test.ts by extracting it to
+// tests/ui/helpers/notification-state.ts (do that move in this step).
+
+describe('#551 regressions', () => {
+  it('a consequence for the previous player never toasts on the next player\'s screen', () => {
+    const state = makeState({ hotSeat: { players: [] } as any, currentPlayer: 'p2' });
+    const { delivery, toast } = make(state);
+    // Simulate round-commit: war declared against p1 while p2 is the viewer.
+    delivery.withHappenedTurn(9, () => {
+      delivery.deliver('p1', 'The Aztecs declared war on you!', 'warning');
+    });
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['p1'][0]).toMatchObject({ message: expect.stringContaining('declared war'), turn: 9 });
+    expect(state.notificationLog!['p1'][0].turn).toBe(9);
+  });
+
+  it('solo never accumulates pendingEvents', () => {
+    const state = makeState(); // solo
+    const { delivery } = make(state);
+    delivery.deliver('p1', 'You met the Mayans.', 'info');
+    delivery.deliver('p1', 'Barbarians spotted!', 'warning');
+    expect(Object.values(state.pendingEvents ?? {}).flat()).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Solo save hygiene in migrateLegacySave**
+
+Pre-MR2 solo saves can contain never-drained `pendingEvents` (from the
+previously unconditional first-contact queueing). In `migrateLegacySave`:
+
+```ts
+  // MR2 (#551): pendingEvents is hot-seat-only; solo saves from before the
+  // delivery contract may carry stale queued events that would never drain.
+  if (!gameState.hotSeat && gameState.pendingEvents
+      && Object.values(gameState.pendingEvents).some(list => list.length > 0)) {
+    gameState.pendingEvents = {};
+  }
+```
+
+Add a save-compat test: construct a solo state with non-empty `pendingEvents`,
+run the migration path (if `migrateLegacySave` is not exported, extract this
+block into an exported `clearStaleSoloPendingEvents(state)` in
+`src/core/hotseat-events.ts` and call it from `migrateLegacySave` — prefer the
+extraction; main.ts functions are untestable), assert it is emptied and that a
+hot-seat state keeps its queue.
+
+- [ ] **Step 3: Run full suite + build, commit**
+
+```bash
+bash scripts/run-with-mise.sh yarn test && bash scripts/run-with-mise.sh yarn build
+git add -A
+git commit -m "test(notifications): hot-seat leak + solo staleness regressions (#551)"
+```
+
+### Task 5: Rule-book update + manual verification
+
+- [ ] Append to `.claude/rules/ui-panels.md` Notifications section:
+
+```markdown
+- Game-consequence notifications MUST go through `notification-delivery`'s
+  `deliver(civId, …)` with an explicit recipient — never `showNotification`,
+  which is reserved for immediate feedback to the acting player's own input.
+  Emit-time `currentPlayer` attribution is the #551 leak bug class.
+```
+
+- [ ] Manual hot-seat verification (dev server): 2-human game; have an AI do
+  something visible to player 1 (e.g. borders shift); end player 1's turn;
+  confirm player 2's screen shows nothing about it; confirm player 1's next
+  turn summary lists it with the correct turn number; confirm the log panel
+  entry matches.
+- [ ] Manual solo verification: end turn; confirm consequence toasts appear at
+  the start of your next turn stamped with the round they happened, and the
+  notification log shows the same turn number.
+- [ ] Commit any fixes; final commit:
+
+```bash
+git add -A && git commit -m "docs(rules): notification delivery contract (#551)"
+```
+
+---
+
+## Inline Dimension Review
+
+- **Gameplay balance:** No mechanics change; information timing becomes *correct*, which in hot seat is itself a fairness fix (no more intel about the other player's round).
+- **Fun:** Wrong-player and missing notifications are trust-killers; the handoff summary becoming the reliable "what happened while you were away" beat is a core hot-seat pleasure.
+- **New mechanics:** None; a delivery contract, not a feature.
+- **Ages 7–43:** Younger players especially can't diagnose "the game told my sister my secret" — correctness here is invisible-but-essential. Message text unchanged.
+- **Play styles:** Aggressive players get war/combat consequences on time; builders get border/trade notices on time. No style favored.
+- **Difficulty modes:** Challenge-independent; strategic-warning delivery (a challenge-linked feature) now rides the same contract, removing its bespoke queue.
+- **AI usage:** AI recipients are log-only (cheap, inspectable); AI behavior unchanged. AI-generated events now attribute correctly to their human victims.
+- **UI:** No new surfaces; turn-handoff summary and notification log panel unchanged in appearance, corrected in content.
+- **UX:** Fixes both reported symptoms (late in solo, leaking in hot seat) with one rule a player can predict: "my news arrives on my turn, stamped when it happened."
+- **Architecture:** Replaces three ad-hoc paths with one injectable, pure-dependency module; `appendToCivLog` aliasing means ~40 router call sites need zero edits. `withHappenedTurn` documents its sync-commit assumption at the wrap site.
+- **Extensibility:** MR3's treaty proposals and any future consequence event get correct delivery for free by using the sink; the rule-book entry prevents regression by future agents.
+- **Data:** No schema change. `pendingEvents` semantics narrow to hot-seat-only; stale solo queues cleaned by migration.
+- **SFX:** None added; existing notification SFX fire from toast display, so suppressed/deferred events correctly stay silent until shown.
+- **Saved games:** Solo saves with stale `pendingEvents` are cleaned in `migrateLegacySave` (tested); hot-seat saves keep queues intact.
+- **Testing:** Contract matrix (6 unit cases), throw-safety, two named regressions, router recipient pinning, save-compat test, plus manual hot-seat and solo checklists.
+- **Solo regressions:** "Never queue in solo" is a tested invariant; turn stamping verified; existing solo toast behavior preserved for action feedback.
+- **Hot-seat regressions:** The leak test is the headline regression; suppressed-window delivery for the current player is covered; handoff summary drain path untouched (existing tests in tests/ui/turn-handoff.test.ts still apply).
+- **Implementation correctness:** The only behavioral edits are in enumerated listeners; the alias keeps every router call site identical, so the diff is reviewable line-by-line against the listener list in Task 3.

--- a/docs/superpowers/plans/2026-07-11-bug-arc-mr3-diplomacy-consent-war-visibility.md
+++ b/docs/superpowers/plans/2026-07-11-bug-arc-mr3-diplomacy-consent-war-visibility.md
@@ -1,0 +1,335 @@
+# MR3 — Diplomacy Consent + War Visibility (#554) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task inline (this repo forbids subagents — see CLAUDE.md Agent Policy). Steps use checkbox (`- [ ]`) syntax for tracking. **Depends on MR2 (notification delivery contract) being merged.**
+
+**Goal:** An AI can never sign a treaty with a human without the human clicking Accept, and a human who is at war can always see with whom, since when, and why.
+
+**Architecture:** Extend the existing pending-peace-request machinery (`PendingDiplomaticRequest`, accept/reject handlers, diplomacy-panel buttons) to carry treaty proposals. The AI's treaty branch in `basic-ai.ts` enqueues a proposal when the target is human instead of signing instantly. War visibility is derived from the `war_declared` records `declareWar` already writes into `diplomacy.events`.
+
+**Tech Stack:** TypeScript, vitest.
+
+## Global Constraints
+
+- All commands via `bash scripts/run-with-mise.sh yarn <cmd>`; green build+test before push.
+- Diplomacy operations MUST update BOTH sides (bilateral state updates).
+- NEVER hardcode `'player'` — humans are `civ.isHuman`; the viewer is `state.currentPlayer`.
+- `declareWar` must deduplicate `atWarWith` (existing behavior — do not regress).
+- Game-consequence notifications go through the MR2 delivery sink (`appendToCivLog`) with explicit recipients — never `showNotification`.
+- New buttons via `createGameButton()` unless extending the diplomacy panel's existing `data-action` HTML-string pattern — match the file's existing idiom, keep dynamic civ names out of HTML strings (use the panel's existing escaping approach; verify with a quote-containing civ name in tests).
+
+## Background for the implementer (zero-context)
+
+- **The bug:** `src/ai/basic-ai.ts` (~line 917, the `case 'non_aggression_pact': case 'trade_agreement': case 'open_borders': case 'alliance':` block) calls `proposeTreaty(...)` on both civs and emits `diplomacy:treaty-accepted` immediately. `proposeTreaty` (`src/systems/diplomacy-system.ts:170`) pushes a signed `Treaty` despite its name. Humans get pacts they never agreed to.
+- **The template:** peace requests already do consent correctly: `enqueuePeaceRequest` (`diplomacy-system.ts:486`) appends a `PendingDiplomaticRequest` (`src/core/types.ts:698`, currently `type: 'peace'` only) and emits `diplomacy:peace-requested`; the diplomacy panel (`src/ui/diplomacy-panel.ts:250-251, 407, 415`) renders Accept/Reject buttons wired to `acceptDiplomaticRequest` / `rejectDiplomaticRequest` via main.ts handlers (~line 921-934).
+- **War records:** `declareWar` (`diplomacy-system.ts`) already pushes `{ type: 'war_declared', turn, otherCiv }` into `diplomacy.events`, and `routeWarDeclared` (`src/ui/notification-routing.ts:192`) derives a relationship-based reason string. The data for "since when / why" exists; no schema addition needed.
+- **Naming honesty:** part of this MR is renaming `proposeTreaty` → `signTreaty` so the next agent cannot repeat the mistake.
+
+Player→AI proposals: today the human's own treaty actions also auto-sign (via
+`applyDiplomaticAction` → `proposeTreaty` both sides). That stays as-is in this
+MR (AI evaluation of incoming proposals is out of scope, noted in the arc
+spec); only AI→human gains consent.
+
+---
+
+### Task 1: Rename `proposeTreaty` → `signTreaty`
+
+**Files:**
+- Modify: `src/systems/diplomacy-system.ts:170`, `src/ai/basic-ai.ts` (import + 2 call sites ~921/926), `src/systems/diplomacy-system.ts` internal call sites (~400/408), any test referencing the name (`grep -rn "proposeTreaty" src tests`).
+
+- [ ] **Step 1:** Global rename (mechanical): `proposeTreaty` → `signTreaty`. Add doc comment:
+
+```ts
+// Signs the treaty into THIS side's diplomacy state immediately — no consent
+// step. Callers targeting a human must go through enqueueTreatyProposal
+// instead (#554). Both sides must be signed for a complete treaty.
+export function signTreaty(
+```
+
+- [ ] **Step 2:** Run: `bash scripts/run-with-mise.sh yarn build && bash scripts/run-with-mise.sh yarn test` → both green (pure rename).
+- [ ] **Step 3:** Commit: `git commit -am "refactor(diplomacy): rename proposeTreaty to signTreaty for honesty (#554)"`
+
+### Task 2: Treaty proposals in the pending-request pipeline
+
+**Files:**
+- Modify: `src/core/types.ts:698` (`PendingDiplomaticRequest`)
+- Modify: `src/systems/diplomacy-system.ts` (`enqueueTreatyProposal`, extend `acceptDiplomaticRequest` / `rejectDiplomaticRequest`, add `getPendingTreatyProposalsFor`)
+- Test: `tests/systems/diplomacy-system.test.ts` (extend)
+
+**Interfaces:**
+- Produces:
+
+```ts
+// types.ts
+export interface PendingDiplomaticRequest {
+  id: string;
+  type: 'peace' | 'treaty';
+  treatyType?: TreatyType;        // set when type === 'treaty'
+  turnsRemaining?: number;         // treaty duration to sign with (mirrors AI decision: 10 for NAP, -1 otherwise)
+  fromCivId: string;
+  toCivId: string;
+  turnIssued: number;
+}
+
+// diplomacy-system.ts
+export function enqueueTreatyProposal(
+  state: GameState, fromCivId: string, toCivId: string,
+  treatyType: TreatyType, turnsRemaining: number, bus?: EventBus,
+): GameState;
+export function getPendingTreatyProposalsFor(state: GameState, civId: string): PendingDiplomaticRequest[];
+```
+
+- Consumes: `signTreaty` (Task 1). Accepting a `'treaty'` request signs **both** sides and emits `diplomacy:treaty-accepted`; rejecting removes the request with **no relationship penalty** (family-friendly: declining is not an insult) and emits nothing new.
+
+- [ ] **Step 1: Write the failing tests** (extend `tests/systems/diplomacy-system.test.ts`; reuse its existing state fixture helpers — read the file's top first and follow its fixture idiom):
+
+```ts
+describe('treaty proposals (#554)', () => {
+  it('enqueues a proposal without touching either civ\'s treaties', () => {
+    const next = enqueueTreatyProposal(state, 'ai1', 'human1', 'non_aggression_pact', 10, bus);
+    expect(next.pendingDiplomacyRequests).toHaveLength(1);
+    expect(next.pendingDiplomacyRequests![0]).toMatchObject({
+      type: 'treaty', treatyType: 'non_aggression_pact', fromCivId: 'ai1', toCivId: 'human1', turnsRemaining: 10,
+    });
+    expect(next.civilizations['human1'].diplomacy.treaties).toHaveLength(0);
+    expect(next.civilizations['ai1'].diplomacy.treaties).toHaveLength(0);
+  });
+
+  it('dedupes: same pair+type proposal is not enqueued twice', () => {
+    let next = enqueueTreatyProposal(state, 'ai1', 'human1', 'open_borders', -1);
+    next = enqueueTreatyProposal(next, 'ai1', 'human1', 'open_borders', -1);
+    expect(next.pendingDiplomacyRequests).toHaveLength(1);
+  });
+
+  it('accept signs both sides and clears the request', () => {
+    let next = enqueueTreatyProposal(state, 'ai1', 'human1', 'trade_agreement', -1, bus);
+    const requestId = next.pendingDiplomacyRequests![0].id;
+    next = acceptDiplomaticRequest(next, 'human1', requestId, bus);
+    expect(next.civilizations['human1'].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+    expect(next.civilizations['ai1'].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+    expect(next.pendingDiplomacyRequests).toHaveLength(0);
+  });
+
+  it('only the recipient can accept', () => {
+    let next = enqueueTreatyProposal(state, 'ai1', 'human1', 'alliance', -1);
+    const requestId = next.pendingDiplomacyRequests![0].id;
+    const after = acceptDiplomaticRequest(next, 'ai1', requestId, bus); // proposer cannot self-accept
+    expect(after.civilizations['human1'].diplomacy.treaties).toHaveLength(0);
+  });
+
+  it('reject clears the request with no relationship penalty', () => {
+    let next = enqueueTreatyProposal(state, 'ai1', 'human1', 'alliance', -1);
+    const before = next.civilizations['human1'].diplomacy.relationships['ai1'] ?? 0;
+    const requestId = next.pendingDiplomacyRequests![0].id;
+    next = rejectDiplomaticRequest(next, 'human1', requestId);
+    expect(next.pendingDiplomacyRequests).toHaveLength(0);
+    expect(next.civilizations['human1'].diplomacy.relationships['ai1'] ?? 0).toBe(before);
+  });
+
+  it('proposals expire after 10 turns (pruned by the turn processor)', () => {
+    let next = enqueueTreatyProposal(state, 'ai1', 'human1', 'open_borders', -1);
+    next = { ...next, turn: next.turn + 11 };
+    next = pruneExpiredDiplomaticRequests(next);
+    expect(next.pendingDiplomacyRequests).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failures** (functions missing / union rejects `'treaty'`).
+
+- [ ] **Step 3: Implement**
+
+`enqueueTreatyProposal` mirrors `enqueuePeaceRequest` (id via a
+`buildPendingTreatyProposalId(from,to,type,turn)` sibling helper; dedupe on
+same from+to+treatyType). Extend `acceptDiplomaticRequest`: locate the request
+by id; require `request.toCivId === actingCivId`; branch on `request.type`:
+`'peace'` keeps existing behavior; `'treaty'` does:
+
+```ts
+    const turns = request.turnsRemaining ?? -1;
+    let next = { ...state, pendingDiplomacyRequests: remaining };
+    next.civilizations[request.fromCivId].diplomacy = signTreaty(
+      next.civilizations[request.fromCivId].diplomacy,
+      request.fromCivId, request.toCivId, request.treatyType!, turns, next.turn,
+    );
+    next.civilizations[request.toCivId].diplomacy = signTreaty(
+      next.civilizations[request.toCivId].diplomacy,
+      request.toCivId, request.fromCivId, request.treatyType!, turns, next.turn,
+    );
+    bus.emit('diplomacy:treaty-accepted', { civA: request.fromCivId, civB: request.toCivId, treaty: request.treatyType! });
+    return next;
+```
+
+Follow the file's existing immutability idiom exactly (spread civilizations
+map as the existing accept branch does — read it first). Add
+`pruneExpiredDiplomaticRequests(state)` (10-turn TTL on `turnIssued`, applies
+to both peace and treaty requests) and call it from the world turn processor —
+find where per-turn diplomacy upkeep runs in `src/core/turn-manager.ts` (grep
+`processRelationshipDrift`) and call it adjacent. Also emit
+`diplomacy:treaty-proposed { fromCivId, toCivId, treatyType }` from
+`enqueueTreatyProposal`; add it to `GameEvents` in types.ts.
+
+- [ ] **Step 4: Run tests → PASS; commit** `feat(diplomacy): pending treaty proposals with accept/decline (#554)`
+
+### Task 3: AI enqueues instead of signing when the target is human
+
+**Files:**
+- Modify: `src/ai/basic-ai.ts` treaty branch (~line 917)
+- Test: `tests/ai/basic-ai.test.ts` (extend — grep for existing `#435` treaty-guard tests and sit next to them)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+  it('never writes a treaty into a human civ\'s state without consent (#554)', () => {
+    // Arrange a state where the AI decision path will choose a treaty with the
+    // human: reuse the existing treaty-decision fixture in this file (the #435
+    // tests build one); mark the target civ isHuman: true.
+    const result = runAiRoundHelper(stateWithFriendlyHumanNeighbor);
+    const human = result.civilizations['human1'];
+    expect(human.diplomacy.treaties).toHaveLength(0);
+    expect(result.pendingDiplomacyRequests?.some(r =>
+      r.type === 'treaty' && r.toCivId === 'human1')).toBe(true);
+  });
+
+  it('still signs AI↔AI treaties instantly', () => {
+    const result = runAiRoundHelper(stateWithTwoFriendlyAIs);
+    expect(result.civilizations['ai2'].diplomacy.treaties.length).toBeGreaterThan(0);
+  });
+```
+
+(Adapt fixture/helper names to what `tests/ai/basic-ai.test.ts` actually
+exports — read it before writing; the assertions are the contract.)
+
+- [ ] **Step 2: Implement** — in the treaty `case` block of basic-ai.ts:
+
+```ts
+        case 'non_aggression_pact':
+        case 'trade_agreement':
+        case 'open_borders':
+        case 'alliance': {
+          const duration = decision.action === 'non_aggression_pact' ? 10 : -1;
+          // #554: humans must consent — enqueue a proposal instead of signing.
+          if (newState.civilizations[decision.targetCiv]?.isHuman) {
+            newState = enqueueTreatyProposal(
+              newState, civId, decision.targetCiv, decision.action, duration, bus,
+            );
+            break;
+          }
+          // AI↔AI: sign both sides immediately (existing behavior).
+          … (existing signTreaty x2 + treaty-accepted emit, unchanged)
+          break;
+        }
+```
+
+- [ ] **Step 3: Run suite; commit** `fix(ai): AI treaty offers to humans require consent (#554)`
+
+### Task 4: Diplomacy panel — proposals + "at war since" rows
+
+**Files:**
+- Modify: `src/ui/diplomacy-panel.ts`
+- Modify: `src/main.ts` (proposal accept/decline handlers next to `handleAcceptPeaceRequest` ~line 921; treaty-proposed notification listener)
+- Modify: `src/ui/notification-routing.ts` (extract + export `describeWarReason(relationship: number): string` from `routeWarDeclared`'s inline mapping; add `routeTreatyProposed`)
+- Test: `tests/ui/diplomacy-panel.test.ts` (extend, following its existing render-and-click test idiom)
+
+**Player truth table (required by plans README):**
+
+| Before | Action | Immediate visible result |
+|---|---|---|
+| Civ row shows "Proposes: Non-Aggression Pact — Accept / Decline" | Click Accept | Row rerenders showing the active treaty pill; proposal buttons gone; toast "Non-aggression pact with X signed." |
+| Same | Click Decline | Proposal row gone; no relationship change shown; toast "Proposal declined." |
+| Civ row for a civ you're at war with | (none — passive) | Row always shows "⚔ At war since turn N — <reason>" |
+| Proposal exists, player ignores it 10 turns | (expiry) | Proposal row gone next time panel opens |
+
+- [ ] **Step 1: Failing UI tests**
+
+```ts
+  it('renders an incoming treaty proposal with accept/decline and fires callbacks', () => {
+    // state: pending treaty proposal ai1 → currentPlayer
+    const onAccept = vi.fn(); const onDecline = vi.fn();
+    openDiplomacyPanel(container, state, { …existingCallbacks, onAcceptTreatyProposal: onAccept, onDeclineTreatyProposal: onDecline });
+    const accept = container.querySelector('[data-action="accept-treaty-proposal"]') as HTMLButtonElement;
+    expect(accept).toBeTruthy();
+    expect(container.textContent).toContain('Non-Aggression Pact');
+    accept.click();
+    expect(onAccept).toHaveBeenCalledWith(expect.stringContaining('treaty'));
+  });
+
+  it('shows war status with start turn and reason for a civ at war with the viewer', () => {
+    // state: viewer at war with ai1; ai1's war_declared event at turn 4; relationship -60
+    openDiplomacyPanel(container, state, callbacks);
+    expect(container.textContent).toContain('At war since turn 4');
+    expect(container.textContent).toContain('deep hostility');
+  });
+
+  it('never shows proposal buttons to the proposer or third parties', () => {
+    // state: proposal ai1 → human2; viewer is human1
+    openDiplomacyPanel(container, state, callbacks);
+    expect(container.querySelector('[data-action="accept-treaty-proposal"]')).toBeNull();
+  });
+```
+
+- [ ] **Step 2: Implement panel changes**
+
+- Proposals: in the per-civ row builder (where `getPendingPeaceRequestForPair`
+  is consulted, line ~97), also call `getPendingTreatyProposalsFor(state,
+  state.currentPlayer)` filtered to this civ as `fromCivId`, and render one
+  proposal line per entry using the panel's existing button-HTML idiom with
+  `data-action="accept-treaty-proposal"` / `"decline-treaty-proposal"` and
+  `data-request-id`. Treaty display names: add a `TREATY_LABELS: Record<TreatyType, string>`
+  map (`non_aggression_pact: 'Non-Aggression Pact'`, etc.) — grep first for an
+  existing label map to reuse (`grep -rn "Non-Aggression" src/ui`).
+- War row: for each civ where `viewerDiplomacy.atWarWith.includes(civId)`,
+  find the latest `war_declared` event for that civ in
+  `viewer.diplomacy.events` and render
+  `⚔ At war since turn ${event.turn} — ${describeWarReason(relationship)}`;
+  if no event exists (legacy save), render `⚔ At war` only (test this case).
+- Wire click delegation for the two new `data-action` values next to the
+  existing accept/reject-peace delegation (lines ~407-415).
+- main.ts handlers mirror `handleAcceptPeaceRequest` — call
+  `acceptDiplomaticRequest`/`rejectDiplomaticRequest`, rerender, and toast via
+  `showNotification` (direct action feedback — allowed under the MR2 rule).
+- Notification: `bus.on('diplomacy:treaty-proposed', …)` in main.ts →
+  `routeTreatyProposed(gameState, event, appendToCivLog)` delivering to
+  `toCivId`: message `` `${fromName} proposes a ${label}. Review it in the Diplomacy panel.` ``
+  (info). MR2's contract handles hot-seat deferral automatically.
+
+- [ ] **Step 3: Run suite + build; commit** `feat(diplomacy): consent UI for AI treaty proposals + war attribution rows (#554)`
+
+### Task 5: Save compatibility + manual verification
+
+- [ ] Save-compat: old saves have `pendingDiplomacyRequests` entries without
+  the new optional fields, and possibly **already-signed unconsented treaties**.
+  Signed treaties stay (retroactively voiding them would surprise players
+  mid-campaign; the player can break them in the panel — verify a break-treaty
+  affordance exists via `breakTreaty`; if the panel lacks one for these treaty
+  types, add a "Break Treaty" button with confirm to the treaty pill row — no
+  silent destructive UI). Add a test loading a state shaped like an old save
+  (peace-only requests, no `treatyType`) through `pruneExpiredDiplomaticRequests`
+  and the panel render without throwing.
+- [ ] Manual: solo game, befriend an AI, wait for its proposal → panel shows
+  it; accept → pact pill appears; new game, decline → nothing signed. Hot
+  seat: proposal to player 2 while player 1 active → nothing on player 1's
+  screen; player 2's summary mentions it.
+- [ ] `bash scripts/run-with-mise.sh yarn test && bash scripts/run-with-mise.sh yarn build`; commit.
+
+---
+
+## Inline Dimension Review
+
+- **Gameplay balance:** Consent slightly slows AI-human pact formation (a proposal round-trip); AI↔AI dynamics unchanged. NAP duration (10) and trade gold (+2/turn, inside `signTreaty`) unchanged — no economy shift.
+- **Fun:** Receiving an offer you can accept or refuse is a real decision moment (and a good "the world sees me" beat); silently acquiring pacts was anti-fun confusion. Declining without penalty keeps it low-stakes for kids.
+- **New mechanics:** One: pending treaty proposals with 10-turn expiry. Deliberately modeled on the existing peace-request mechanic rather than a new subsystem.
+- **Ages 7–43:** Accept/Decline buttons with plain treaty names; no penalty for declining means a 7-year-old can't be punished for ignoring the panel; expiry keeps the queue from rotting for players who never open diplomacy.
+- **Play styles:** Warmongers can decline everything and lose nothing; diplomats get agency they lacked; turtlers see NAP offers as readable AI intent.
+- **Difficulty modes:** Proposal frequency follows existing personality-driven decision logic (unchanged); no challenge-profile coupling added — reasonable, since consent is correctness, not difficulty.
+- **AI usage:** AI proposes via the same decision path it used to sign; it does not (yet) evaluate incoming human proposals — human→AI stays instant-sign, explicitly noted as a follow-up. AI never self-accepts (tested).
+- **UI:** Extends the existing per-civ row idiom (peace buttons) — no new panel; war rows add always-visible attribution.
+- **UX:** Fixes both reported mysteries: pacts now arrive as reviewable offers; "somehow at war" becomes "at war since turn N — deteriorating relations." Notification points at the Diplomacy panel (self-explanatory path).
+- **Architecture:** Reuses `PendingDiplomaticRequest` pipeline (one union widening, no parallel queue); rename makes the dangerous helper honest; `describeWarReason` shared between router and panel (one source of truth).
+- **Extensibility:** `type: 'treaty'` + `treatyType` generalizes to future request kinds (vassalage offers already have a bespoke path — candidates for later migration onto this pipeline).
+- **Data:** Two optional fields on an existing optional-array element — old saves parse untouched; expiry pruning handles pre-existing stale requests.
+- **SFX:** None new; the treaty-accepted event already drives any existing stinger — verify `grep -rn "treaty-accepted" src/audio` and note in PR if silent (acceptable).
+- **Saved games:** Old unconsented treaties persist by decision (documented + break-treaty affordance); requests without new fields tolerated (tested).
+- **Testing:** System-level consent matrix (7 cases incl. expiry, self-accept, no-penalty decline), AI human/AI-AI split regression, panel render+click tests incl. third-party negative, legacy-save render test.
+- **Solo regressions:** Peace-request flow untouched (same functions, new branch); existing diplomacy tests re-run; proposals surface via MR2 solo toast path.
+- **Hot-seat regressions:** Proposal notification rides MR2 (no leak, tested there); panel reads viewer-scoped state only (`state.currentPlayer`); manual two-player check included.
+- **Implementation correctness:** Bilateral signing asserted in tests on both civs; dedupe prevents proposal spam from repeated AI rounds; recipient-only accept enforced in the system layer, not just hidden in UI.

--- a/docs/superpowers/specs/2026-07-11-playtest-bug-arc-design.md
+++ b/docs/superpowers/specs/2026-07-11-playtest-bug-arc-design.md
@@ -1,0 +1,74 @@
+# Playtest Bug Arc — Design & Prioritization (Issues #550–#555)
+
+Status: approved direction (2026-07-11). Root-cause analysis posted on each issue.
+This arc is planned by an analysis/planning agent; each MR is implemented by a
+separate agent from its plan doc in `docs/superpowers/plans/`.
+
+## Source Issues
+
+| Issue | Title | Root cause (confirmed in code) |
+|---|---|---|
+| #550 | Sound stopped working | One-shot AudioContext gesture unlock + dual settings sources (save-embedded vs persisted) |
+| #551 | Notification queue needs work | Three delivery mechanisms with emit-time `currentPlayer` attribution; `pendingEvents` never drained in solo |
+| #552 | Unrest needs work | `REVOLT_UNREST_TURNS = 5`; **no building grants happiness** while notifications claim they do; resource→happiness invisible |
+| #553 | Trade routes | Hidden discovery chain (tech→caravan→select→button); routes only visible in marketplace panel; single trade unit for all eras |
+| #554 | Somehow I am at war | `basic-ai.ts:920` signs treaties with humans instantly via misnamed `proposeTreaty`; war declarations invisible (see #551) |
+| #555 | Wonder productions blocked | Quest completion ≠ buildability; "Blocked" is a dead-end label; build requirements hidden during questing |
+
+## MR Sequence
+
+| MR | Plan doc | Issues | Depends on | Size |
+|---|---|---|---|---|
+| MR1 Audio resilience | `2026-07-11-bug-arc-mr1-audio-resilience.md` | #550 | — | S |
+| MR2 Notification delivery contract | `2026-07-11-bug-arc-mr2-notification-delivery-contract.md` | #551, half of #554 | — | M |
+| MR3 Diplomacy consent + war visibility | `2026-07-11-bug-arc-mr3-diplomacy-consent-war-visibility.md` | #554 | MR2 | M |
+| MR4 Unrest pacing + honest happiness | `2026-07-11-bug-arc-mr4-unrest-pacing-happiness.md` | #552 | — | M |
+| MR5 Wonder blocked-state actionability | `2026-07-11-bug-arc-mr5-wonder-blocked-actionability.md` | #555 | — | S |
+| MR6 Trade route discoverability | `2026-07-11-bug-arc-mr6-trade-route-discoverability.md` | #553 (UX tier) | — | S |
+| MR7 Era/domain trade units | `2026-07-11-bug-arc-mr7-era-trade-units.md` | #553 (content tier) | MR6 | L |
+
+## Prioritization Rationale
+
+1. **MR1 first**: smallest, fully independent, and "the game is silent" is the most
+   immediately felt regression for every player at every age. No design risk.
+2. **MR2 before MR3**: the unified per-civ delivery contract is a prerequisite —
+   MR3's treaty proposals and war notices must arrive via a channel that neither
+   leaks across hot-seat players nor arrives late in solo. Fixing #554's
+   visibility half without MR2 would rebuild the same broken plumbing.
+3. **MR3 next**: silently-signed treaties are the largest *trust* bug — the game
+   changes the player's diplomatic state without consent. Highest confusion-per-
+   incident in the playtest reports.
+4. **MR4**: unrest is the system the playtesters actively fight every session;
+   it also fixes a content-honesty violation (text promises happiness buildings
+   that do not exist).
+5. **MR5, MR6**: dead-end UX fixes, independent, small.
+6. **MR7 last**: pure content feature with the largest wiring surface (four new
+   trainable units). MR6's UX groundwork makes the new units discoverable on
+   arrival.
+
+## Cross-MR Contracts
+
+- **One notification sink** (MR2): after MR2 merges, no listener may call
+  `showNotification` for a game consequence; consequence events go through the
+  per-civ delivery helper with an explicit recipient. MR3–MR7 must follow this.
+- **Content honesty** (MR4, MR7): every new description string naming a mechanic
+  requires a positive test asserting the mechanic (`.claude/rules/content-description-honesty.md`).
+- **Trainable-unit wiring** (MR7): all six wirings per
+  `.claude/rules/end-to-end-wiring.md` for each new unit.
+- **Save compatibility** (all MRs): every new optional state field must tolerate
+  absence in loaded saves; `migrateLegacySave` (src/main.ts) is the established
+  seam for backfills. No MR may break loading a pre-arc save.
+- **Inline dimension review**: each plan ends with a review across: gameplay
+  balance, fun, new mechanics, ages 7–43, play styles, difficulty modes
+  (explorer/standard/veteran via `OpponentChallenge`), AI usage, UI, UX,
+  architecture, extensibility, data, SFX, saved-game migration, testing, solo
+  regressions, hot-seat regressions, implementation correctness.
+
+## Explicitly Out of Scope
+
+- Player→AI treaty proposals gaining AI evaluation (accept/reject scoring) —
+  today the player's own proposals also auto-sign; symmetric consent for AI
+  recipients is a follow-up (noted in MR3).
+- Air trade routes beyond a single late-era freighter unit (MR7 keeps air as a
+  capstone, not a subsystem).
+- Notification log UI redesign — MR2 fixes routing/timing only.

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -29,6 +29,7 @@ import { evaluateDiplomacy, evaluateMinorCivDiplomacy, evaluateVassalage, evalua
 import {
   declareWar,
   enqueuePeaceRequest,
+  enqueueTreatyProposal,
   signTreaty,
   modifyRelationship,
   offerVassalage,
@@ -917,19 +918,28 @@ function processAITurnInternal(
         case 'non_aggression_pact':
         case 'trade_agreement':
         case 'open_borders':
-        case 'alliance':
+        case 'alliance': {
+          const duration = decision.action === 'non_aggression_pact' ? 10 : -1;
+          // #554: humans must consent -- enqueue a proposal instead of signing.
+          if (newState.civilizations[decision.targetCiv]?.isHuman) {
+            newState = enqueueTreatyProposal(
+              newState, civId, decision.targetCiv, decision.action, duration, bus,
+            );
+            break;
+          }
+          // AI<->AI: sign both sides immediately (existing behavior).
           newState.civilizations[civId].diplomacy = signTreaty(
-            currentDiplomacy, civId, decision.targetCiv, decision.action,
-            decision.action === 'non_aggression_pact' ? 10 : -1, newState.turn,
+            currentDiplomacy, civId, decision.targetCiv, decision.action, duration, newState.turn,
           );
           if (newState.civilizations[decision.targetCiv]?.diplomacy) {
             newState.civilizations[decision.targetCiv].diplomacy = signTreaty(
               newState.civilizations[decision.targetCiv].diplomacy, decision.targetCiv, civId, decision.action,
-              decision.action === 'non_aggression_pact' ? 10 : -1, newState.turn,
+              duration, newState.turn,
             );
           }
           bus.emit('diplomacy:treaty-accepted', { civA: civId, civB: decision.targetCiv, treaty: decision.action });
           break;
+        }
       }
     }
 

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -29,7 +29,7 @@ import { evaluateDiplomacy, evaluateMinorCivDiplomacy, evaluateVassalage, evalua
 import {
   declareWar,
   enqueuePeaceRequest,
-  proposeTreaty,
+  signTreaty,
   modifyRelationship,
   offerVassalage,
   joinEmbargo,
@@ -918,12 +918,12 @@ function processAITurnInternal(
         case 'trade_agreement':
         case 'open_borders':
         case 'alliance':
-          newState.civilizations[civId].diplomacy = proposeTreaty(
+          newState.civilizations[civId].diplomacy = signTreaty(
             currentDiplomacy, civId, decision.targetCiv, decision.action,
             decision.action === 'non_aggression_pact' ? 10 : -1, newState.turn,
           );
           if (newState.civilizations[decision.targetCiv]?.diplomacy) {
-            newState.civilizations[decision.targetCiv].diplomacy = proposeTreaty(
+            newState.civilizations[decision.targetCiv].diplomacy = signTreaty(
               newState.civilizations[decision.targetCiv].diplomacy, decision.targetCiv, civId, decision.action,
               decision.action === 'non_aggression_pact' ? 10 : -1, newState.turn,
             );

--- a/src/core/hotseat-events.ts
+++ b/src/core/hotseat-events.ts
@@ -39,6 +39,19 @@ export function clearEventsForPlayer(
   };
 }
 
+// MR2 (#551): pendingEvents is hot-seat-only -- solo saves from before the
+// delivery contract may carry stale queued events (from the previously
+// unconditional first-contact/strategic-warning queueing) that would never
+// drain, since solo always toasts immediately instead of deferring. Mutates
+// state in place, matching migrateLegacySave's existing convention.
+export function clearStaleSoloPendingEvents(state: GameState): void {
+  if (state.hotSeat) return;
+  if (!state.pendingEvents) return;
+  if (Object.values(state.pendingEvents).some(list => list.length > 0)) {
+    state.pendingEvents = {};
+  }
+}
+
 export interface TurnSummary {
   turn: number;
   era: number;

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -64,6 +64,7 @@ import {
   checkLeagueDissolution,
   triggerLeagueDefense,
   getLeagueForCiv,
+  pruneExpiredDiplomaticRequests,
 } from '@/systems/diplomacy-system';
 import { processTradeRouteIncome, processFashionCycle, updatePrices, removeRouteForUnit, scrubStaleForeignRoutes, scrubEmbargoedRoutes } from '@/systems/trade-system';
 import { advanceRouteRunners } from '@/systems/unit-movement-system';
@@ -690,6 +691,11 @@ export function processTurn(
     newState.civilizations[civId].satelliteSurveillanceTargets =
       Object.keys(updatedTargets).length > 0 ? updatedTargets : undefined;
   }
+
+  // #554: expire stale peace requests / treaty proposals once per turn (not
+  // once per civ) -- a proposal the recipient never opens the diplomacy panel
+  // to act on should not persist forever.
+  newState = pruneExpiredDiplomaticRequests(newState);
 
   for (const city of Object.values(newState.cities)) {
     if ((city.productionDisabledTurns ?? 0) > 0) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -697,7 +697,9 @@ export interface DefensiveLeague {
 
 export interface PendingDiplomaticRequest {
   id: string;
-  type: 'peace';
+  type: 'peace' | 'treaty';
+  treatyType?: TreatyType;        // set when type === 'treaty'
+  turnsRemaining?: number;         // treaty duration to sign with (mirrors AI decision: 10 for NAP, -1 otherwise)
   fromCivId: string;
   toCivId: string;
   turnIssued: number;

--- a/src/main.ts
+++ b/src/main.ts
@@ -232,6 +232,7 @@ import {
   routeCrisisResolved,
   type NotificationSink,
 } from '@/ui/notification-routing';
+import { createNotificationDelivery } from '@/ui/notification-delivery';
 import { registerConquestoriaServiceWorker } from '@/platform/service-worker';
 import { initializeDesktopMenu } from '@/platform/desktop-menu';
 import { beginConfirmedForeignCityEntry } from '@/input/foreign-city-entry-flow';
@@ -661,15 +662,19 @@ function showNotification(
   }
 }
 
-// Appends to a specific civ's log. If that civ is the active player, also
-// surfaces a toast. Used by routers that fan out global/bilateral events.
-const appendToCivLog: NotificationSink = (civId, message, type, target) => {
-  if (!gameState) return;
-  appendNotification(gameState, civId, { message, type, turn: gameState.turn, target });
-  if (civId === gameState.currentPlayer) {
-    enqueueToast(message, type, target);
-  }
-};
+// The single delivery contract for game-consequence notifications (#551):
+// logs to the recipient civ always, toasts only when that civ is the active
+// unsuppressed viewer, and queues to pendingEvents (hot seat only) otherwise
+// -- the turn-handoff summary drains that queue. All existing router call
+// sites keep using this name unchanged; it now enforces the contract instead
+// of the old emit-time currentPlayer attribution that leaked across hot-seat
+// players and never drained in solo.
+const notificationDelivery = createNotificationDelivery({
+  getState: () => gameState,
+  toast: enqueueToast,
+  isSuppressed: () => roundPresentationGate.isSuppressed(),
+});
+const appendToCivLog: NotificationSink = notificationDelivery.deliver;
 
 function focusNotificationTarget(target: NotificationEntry['target']): void {
   if (!target) return;
@@ -3563,7 +3568,16 @@ async function beginHotSeatHandoff(
   };
 
   const simulate = async (): Promise<void> => {
-    const outcome = await transaction.runCompletedRoundSimulation();
+    // withHappenedTurn only needs to cover the synchronous commitTo() inside
+    // runCompletedRoundSimulation (completed-round-handoff.ts) -- it runs
+    // before that function's first await, so wrapping the whole (async) call
+    // still stamps every event committed this round with the pre-round turn
+    // (#551). If that commit ever moves after an await, thread the turn
+    // through the transaction options instead.
+    const outcome = await notificationDelivery.withHappenedTurn(
+      preSimulationState.turn,
+      () => transaction.runCompletedRoundSimulation(),
+    );
     if (outcome.status === 'simulation-failed') {
       controller.setError(
         'The round could not be completed. Your turn is unchanged and was not autosaved.',
@@ -3620,12 +3634,15 @@ async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<v
       );
     } else {
       // --- Solo Mode ---
+      const roundTurn = gameState.turn;
       const result = runCurrentCompletedRound(gameState);
       if (!result.ok) throw result.error;
       gameState = result.state;
       beginNetworkPlansForCurrentViewer();
       const soloMoves = captureAIMoves(() => {
-        result.events.commitTo(bus);
+        notificationDelivery.withHappenedTurn(roundTurn, () => {
+          result.events.commitTo(bus);
+        });
       });
 
       if (handleVictoryIfNeeded()) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,7 +137,7 @@ import {
   showTurnHandoff,
 } from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
-import { collectCouncilInterrupt } from '@/core/hotseat-events';
+import { collectCouncilInterrupt, clearStaleSoloPendingEvents } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
@@ -4555,6 +4555,7 @@ function migrateLegacySave(): void {
   if (!gameState.pendingEvents) {
     gameState.pendingEvents = {};
   }
+  clearStaleSoloPendingEvents(gameState);
   // Add wonder/village state if missing
   if (!gameState.tribalVillages) (gameState as any).tribalVillages = {};
   if (!gameState.discoveredWonders) (gameState as any).discoveredWonders = {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -137,7 +137,7 @@ import {
   showTurnHandoff,
 } from '@/ui/turn-handoff';
 import { showHotSeatSetup } from '@/ui/hotseat-setup';
-import { collectCouncilInterrupt, collectEvent } from '@/core/hotseat-events';
+import { collectCouncilInterrupt } from '@/core/hotseat-events';
 import { refreshKnownCivilizations, syncCivilizationContactsFromVisibility } from '@/systems/discovery-system';
 import { getMinorCivPresentationForPlayer } from '@/systems/minor-civ-presentation';
 import { getMinorCivNotification } from '@/ui/minor-civ-notifications';
@@ -210,21 +210,18 @@ import {
   type NotificationEntry,
 } from '@/core/notification-log';
 import {
-  formatEconomyTreasuryStrainMessage,
   routeBarbarianSpawned,
   routeCombatRewardEarned,
   routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
   routeEraAdvanced,
   routeFactionTransition,
-  queueFirstContactPendingEvents,
   routeFirstContact,
   routeLegendaryWonder,
   routePeaceMade,
   routePeaceRequested,
   routeTerritoryTileFlipped,
   routeWarDeclared,
-  queueStrategicWarningPendingEvent,
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
@@ -4009,22 +4006,26 @@ bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
 });
 
 bus.on('civilization:first-contact', ({ civA, civB }) => {
+  // #551: routeFirstContact's sink is the delivery contract, which already
+  // queues to pendingEvents for a non-active hot-seat recipient -- the old
+  // unconditional queueFirstContactPendingEvents call was a second, always-on
+  // queue that leaked stale growth into solo saves (which never drain it).
   routeFirstContact(gameState, civA, civB, appendToCivLog);
-  queueFirstContactPendingEvents(gameState, civA, civB);
 });
 
 bus.on('diplomacy:peace-requested', ({ fromCivId, toCivId }) => {
+  // #551: routePeaceRequested already delivers to toCivId via appendToCivLog
+  // (the delivery contract) -- the old extra showNotification here duplicated
+  // the message AND leaked it to whoever currentPlayer was at emit time
+  // instead of the actual recipient.
   routePeaceRequested(gameState, fromCivId, toCivId, appendToCivLog);
-  if (toCivId === gameState.currentPlayer) {
-    const fromName = gameState.civilizations[fromCivId]?.name ?? 'Unknown';
-    showNotification(`${fromName} requests peace.`, 'info');
-  }
 });
 
 bus.on('diplomacy:peace-made', ({ civA, civB }) => {
   routePeaceMade(gameState, civA, civB, appendToCivLog);
 });
 
+// viewer-scoped by design: advisors run for the active player only (#551).
 bus.on('advisor:message', ({ advisor, message, icon }) => {
   showNotification(`${icon} ${message}`, 'info');
 });
@@ -4169,10 +4170,12 @@ bus.on('beast:slain', ({ beastId, lairId, slayerCivId, goldAwarded }) => {
         rewardLines,
         onContinue: () => { if (!isApex) maybeShowPendingHoardChoice(); },
       });
-    } else {
-      const toast = isChoiceTier ? `🏆 ${def.name} slain! Choose your reward.` : `🏆 ${def.name} slain! +${goldAwarded} gold`;
-      showNotification(toast, 'success');
     }
+    // #551: the tier<3 case's toast used to be a separate showNotification
+    // call here, duplicating the delivery-contract message the appendToCivLog
+    // loop above already sent to slayerCivId. Removed; the loop's message
+    // ("Hoard claimed: +N gold" / "Choose your reward.") is the single
+    // delivery for this event now.
   }
 });
 
@@ -4204,23 +4207,25 @@ bus.on('beast:sighted', ({ beastId, civId }) => {
 registerMinorCivNotificationListeners(bus, () => gameState, { appendToCivLog });
 
 bus.on('ai:strategic-warning', event => {
+  // #551: appendToCivLog (the delivery contract) already queues to
+  // pendingEvents for a non-active hot-seat recipient -- the old
+  // queueStrategicWarningPendingEvent call was a second, always-on queue.
   routeStrategicWarning(event, appendToCivLog);
-  if (gameState.hotSeat) {
-    queueStrategicWarningPendingEvent(gameState, event);
-  }
 });
 
 function appendFactionNotice(civId: string, message: string, type: NotificationEntry['type']): void {
+  // #551: appendToCivLog (the delivery contract) already queues to
+  // pendingEvents for a non-active hot-seat recipient -- the old manual
+  // collectEvent call here was a second, always-on queue that duplicated the
+  // entry in that player's next turn-handoff summary.
   appendToCivLog(civId, message, type);
-  if (gameState.pendingEvents) {
-    collectEvent(gameState.pendingEvents, civId, { type: 'faction:critical', message, turn: gameState.turn });
-  }
 }
 
 bus.on('era:advanced', ({ era }) => {
-  const civId = gameState.currentPlayer;
-  const civName = gameState.civilizations[civId]?.name ?? 'Your civilization';
-  routeEraAdvanced(era, civId, civName, showNotification, appendFactionNotice);
+  const humanCivIds = Object.entries(gameState.civilizations)
+    .filter(([, civ]) => civ.isHuman)
+    .map(([civId]) => civId);
+  routeEraAdvanced(era, humanCivIds, appendToCivLog);
 });
 
 bus.on('faction:unrest-started', event => {
@@ -4268,10 +4273,10 @@ bus.on('crisis:resolved', event => {
 });
 
 bus.on('economy:treasury-strain', event => {
+  // #551: routeEconomyTreasuryStrain already delivers to event.civId via the
+  // delivery contract; the old extra showNotification duplicated the message
+  // and leaked it to whoever currentPlayer was at emit time.
   routeEconomyTreasuryStrain(gameState, event, appendToCivLog);
-  if (event.civId === gameState.currentPlayer) {
-    showNotification(formatEconomyTreasuryStrainMessage(gameState, event), 'warning');
-  }
 });
 
 bus.on('espionage:spy-detected-traveling', ({ detectingCivId, spyOwner, wasDisguised, position }) => {
@@ -4324,11 +4329,15 @@ bus.on('unit:obsolete', ({ civId, unitType }) => {
 });
 
 bus.on('unit:journey-blocked', ({ unitId, position }) => {
+  // #551: recipient is the unit's actual owner, not whoever currentPlayer
+  // happens to be at emit time -- the old showNotification call leaked this
+  // to the wrong hot-seat player. Skip entirely if the unit is gone rather
+  // than falling back to currentPlayer.
   const unit = gameState.units[unitId];
-  const type = unit ? UNIT_DEFINITIONS[unit.type]?.name ?? unit.type : 'Unit';
+  if (!unit) return;
+  const type = UNIT_DEFINITIONS[unit.type]?.name ?? unit.type;
   const msg = `Your ${type} was blocked and stopped at (${position.q}, ${position.r}).`;
-  showNotification(msg, 'warning');
-  appendToCivLog(unit?.owner ?? gameState.currentPlayer, msg, 'warning');
+  appendToCivLog(unit.owner, msg, 'warning');
 });
 
 bus.on('espionage:spy-expired', ({ civId, spyName, unitType }) => {
@@ -4361,6 +4370,10 @@ bus.on('trade:route-ended', ({ fromCityId, toCityId, reason }) => {
     'trips-exhausted': 'caravan retired after completing its service',
   };
   appendToCivLog(ownerCity.owner, `Trade route to ${toCity?.name ?? toCityId} ended: ${reasonText[reason] ?? reason}`, 'warning');
+  // Also tell the other end of the route, if it's a different human civ (#551).
+  if (toCity && toCity.owner !== ownerCity.owner && gameState.civilizations[toCity.owner]?.isHuman) {
+    appendToCivLog(toCity.owner, `Trade route from ${ownerCity.name} ended: ${reasonText[reason] ?? reason}`, 'warning');
+  }
 });
 
 // --- Initialization ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ import { canInspectUnitForViewer } from '@/systems/viewer-intel';
 import {
   acceptDiplomaticRequest,
   applyDiplomaticAction,
+  breakTreaty,
   declareWar,
   makePeace,
   modifyRelationship,
@@ -203,7 +204,7 @@ import {
 } from '@/systems/transport-system';
 import { getPendingUnload, getUnloadRange, setPendingUnload, clearPendingUnload } from '@/ui/transport-ui-state';
 import { getCapitalCity } from '@/systems/capital-system';
-import type { CombatResult, GameState, HexCoord, ImprovementType, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType } from '@/core/types';
+import type { CombatResult, GameState, HexCoord, ImprovementType, Unit, UnitType, DiplomaticAction, CivBonusEffect, WorkerActionType, TreatyType } from '@/core/types';
 import {
   appendNotification,
   getNotificationsForPlayer,
@@ -223,6 +224,7 @@ import {
   routeTerritoryTileFlipped,
   routeWarDeclared,
   routeTreatyProposed,
+  TREATY_LABELS,
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
@@ -963,6 +965,25 @@ function handleDeclineTreatyProposal(requestId: string): void {
   showNotification('Proposal declined.', 'info');
 }
 
+function handleBreakTreaty(civId: string, treatyType: TreatyType): void {
+  const actorId = gameState.currentPlayer;
+  const actor = gameState.civilizations[actorId];
+  const target = gameState.civilizations[civId];
+  if (!actor || !target) return;
+  gameState = {
+    ...gameState,
+    civilizations: {
+      ...gameState.civilizations,
+      [actorId]: { ...actor, diplomacy: breakTreaty(actor.diplomacy, civId, treatyType, gameState.turn) },
+      [civId]: { ...target, diplomacy: breakTreaty(target.diplomacy, actorId, treatyType, gameState.turn) },
+    },
+  };
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  showNotification(`${TREATY_LABELS[treatyType]} broken with ${target.name}.`, 'warning');
+}
+
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = gameState.cities[cityId]?.name ?? 'City-State';
   const movement = executeAnimatedUnitMove(unitId, () => executeUnitMove(gameState, unitId, target, {
@@ -1045,6 +1066,7 @@ function openDiplomacyPanel(): void {
     onRejectPeaceRequest: handleRejectPeaceRequest,
     onAcceptTreatyProposal: handleAcceptTreatyProposal,
     onDeclineTreatyProposal: handleDeclineTreatyProposal,
+    onBreakTreaty: handleBreakTreaty,
     onGiftGold: handleGiftGold,
     onSponsorFestival: handleSponsorFestival,
     onMinorCivReparations: handleMinorCivReparations,

--- a/src/main.ts
+++ b/src/main.ts
@@ -222,6 +222,7 @@ import {
   routePeaceRequested,
   routeTerritoryTileFlipped,
   routeWarDeclared,
+  routeTreatyProposed,
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
@@ -946,6 +947,22 @@ function handleRejectPeaceRequest(requestId: string): void {
   showNotification('Peace request rejected.', 'info');
 }
 
+function handleAcceptTreatyProposal(requestId: string): void {
+  gameState = acceptDiplomaticRequest(gameState, gameState.currentPlayer, requestId, bus);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  showNotification('Treaty signed.', 'success');
+}
+
+function handleDeclineTreatyProposal(requestId: string): void {
+  gameState = rejectDiplomaticRequest(gameState, gameState.currentPlayer, requestId);
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+  showNotification('Proposal declined.', 'info');
+}
+
 function executeMinorCivConquest(unitId: string, target: HexCoord, minorCivId: string, cityId: string): void {
   const cityName = gameState.cities[cityId]?.name ?? 'City-State';
   const movement = executeAnimatedUnitMove(unitId, () => executeUnitMove(gameState, unitId, target, {
@@ -1026,6 +1043,8 @@ function openDiplomacyPanel(): void {
     onAction: handleDiplomaticAction,
     onAcceptPeaceRequest: handleAcceptPeaceRequest,
     onRejectPeaceRequest: handleRejectPeaceRequest,
+    onAcceptTreatyProposal: handleAcceptTreatyProposal,
+    onDeclineTreatyProposal: handleDeclineTreatyProposal,
     onGiftGold: handleGiftGold,
     onSponsorFestival: handleSponsorFestival,
     onMinorCivReparations: handleMinorCivReparations,
@@ -4003,6 +4022,10 @@ bus.on('wonder:legendary-race-revealed', ({ observerId, civId, cityId, wonderId 
 
 bus.on('diplomacy:war-declared', ({ attackerId, defenderId }) => {
   routeWarDeclared(gameState, attackerId, defenderId, appendToCivLog);
+});
+
+bus.on('diplomacy:treaty-proposed', event => {
+  routeTreatyProposed(gameState, event, appendToCivLog);
 });
 
 bus.on('civilization:first-contact', ({ civA, civB }) => {

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -487,6 +487,80 @@ export function getPendingPeaceRequestForPair(
   return (state.pendingDiplomacyRequests ?? []).find(request => isPeaceRequestPair(request, civA, civB));
 }
 
+function buildPendingTreatyProposalId(
+  fromCivId: string,
+  toCivId: string,
+  treatyType: TreatyType,
+  turn: number,
+): string {
+  return `treaty:${fromCivId}:${toCivId}:${treatyType}:${turn}`;
+}
+
+function isSameTreatyProposal(
+  request: PendingDiplomaticRequest,
+  fromCivId: string,
+  toCivId: string,
+  treatyType: TreatyType,
+): boolean {
+  return request.type === 'treaty'
+    && request.fromCivId === fromCivId
+    && request.toCivId === toCivId
+    && request.treatyType === treatyType;
+}
+
+export function getPendingTreatyProposalsFor(
+  state: GameState,
+  civId: string,
+): PendingDiplomaticRequest[] {
+  return (state.pendingDiplomacyRequests ?? []).filter(
+    request => request.type === 'treaty' && request.toCivId === civId,
+  );
+}
+
+// Enqueues a treaty offer for the recipient to accept/decline (#554) -- unlike
+// signTreaty, this never touches either side's diplomacy.treaties until the
+// recipient acts. Deduped on the same fromCivId+toCivId+treatyType triple.
+export function enqueueTreatyProposal(
+  state: GameState,
+  fromCivId: string,
+  toCivId: string,
+  treatyType: TreatyType,
+  turnsRemaining: number,
+  bus?: EventBus,
+): GameState {
+  const requests = state.pendingDiplomacyRequests ?? [];
+  if (requests.some(request => isSameTreatyProposal(request, fromCivId, toCivId, treatyType))) {
+    return state;
+  }
+
+  bus?.emit('diplomacy:treaty-proposed', { fromCiv: fromCivId, toCiv: toCivId, treaty: treatyType });
+  return {
+    ...state,
+    pendingDiplomacyRequests: [
+      ...requests,
+      {
+        id: buildPendingTreatyProposalId(fromCivId, toCivId, treatyType, state.turn),
+        type: 'treaty',
+        treatyType,
+        turnsRemaining,
+        fromCivId,
+        toCivId,
+        turnIssued: state.turn,
+      },
+    ],
+  };
+}
+
+// 10-turn TTL on any pending peace request or treaty proposal (#554) -- a
+// proposal the recipient never opens the diplomacy panel to act on should not
+// rot forever. Call once per turn from the world turn processor.
+export function pruneExpiredDiplomaticRequests(state: GameState): GameState {
+  const requests = state.pendingDiplomacyRequests ?? [];
+  const kept = requests.filter(request => state.turn - request.turnIssued < 10);
+  if (kept.length === requests.length) return state;
+  return { ...state, pendingDiplomacyRequests: kept };
+}
+
 export function enqueuePeaceRequest(
   state: GameState,
   fromCivId: string,
@@ -524,7 +598,7 @@ export function acceptDiplomaticRequest(
   bus: EventBus,
 ): GameState {
   const request = (state.pendingDiplomacyRequests ?? []).find(candidate => candidate.id === requestId);
-  if (!request || request.type !== 'peace' || request.toCivId !== actingCivId) {
+  if (!request || request.toCivId !== actingCivId) {
     return state;
   }
 
@@ -535,6 +609,27 @@ export function acceptDiplomaticRequest(
       ...state,
       pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
     };
+  }
+
+  if (request.type === 'treaty') {
+    const turns = request.turnsRemaining ?? -1;
+    const next = {
+      ...state,
+      pendingDiplomacyRequests: (state.pendingDiplomacyRequests ?? []).filter(candidate => candidate.id !== requestId),
+      civilizations: {
+        ...state.civilizations,
+        [request.fromCivId]: {
+          ...actor,
+          diplomacy: signTreaty(actor.diplomacy, request.fromCivId, request.toCivId, request.treatyType!, turns, state.turn),
+        },
+        [request.toCivId]: {
+          ...target,
+          diplomacy: signTreaty(target.diplomacy, request.toCivId, request.fromCivId, request.treatyType!, turns, state.turn),
+        },
+      },
+    };
+    bus.emit('diplomacy:treaty-accepted', { civA: request.fromCivId, civB: request.toCivId, treaty: request.treatyType! });
+    return next;
   }
 
   bus.emit('diplomacy:peace-made', { civA: request.fromCivId, civB: request.toCivId });

--- a/src/systems/diplomacy-system.ts
+++ b/src/systems/diplomacy-system.ts
@@ -168,7 +168,10 @@ export function makePeace(
   return newState;
 }
 
-export function proposeTreaty(
+// Signs the treaty into THIS side's diplomacy state immediately — no consent
+// step. Callers targeting a human must go through enqueueTreatyProposal
+// instead (#554). Both sides must be signed for a complete treaty.
+export function signTreaty(
   state: DiplomacyState,
   selfId: string,
   otherCivId: string,
@@ -398,7 +401,7 @@ export function applyDiplomaticAction(
         (actorTreatyBonus?.type === 'allied_kingdoms' ? actorTreatyBonus.treatyRelationshipBonus : 0) +
         (targetTreatyBonus?.type === 'allied_kingdoms' ? targetTreatyBonus.treatyRelationshipBonus : 0);
       bus.emit('diplomacy:treaty-accepted', { civA: actorId, civB: targetCivId, treaty: action });
-      const actorTreatyState = proposeTreaty(
+      const actorTreatyState = signTreaty(
         actor.diplomacy,
         actorId,
         targetCivId,
@@ -406,7 +409,7 @@ export function applyDiplomaticAction(
         action === 'non_aggression_pact' ? 10 : -1,
         state.turn,
       );
-      const targetTreatyState = proposeTreaty(
+      const targetTreatyState = signTreaty(
         target.diplomacy,
         targetCivId,
         actorId,

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -163,6 +163,21 @@ export function createDiplomacyPanel(
         : '⚔ At war';
     }
 
+    // #554: don't offer the generic treaty action again while a proposal for
+    // that exact type already sits pending between the viewer and this civ
+    // (either direction) -- mirrors the existing request_peace suppression
+    // just below. Without this, the player could instant-sign their own copy
+    // via onAction while an unrelated incoming proposal of the same type is
+    // still awaiting a decision, leaving a stale, already-fulfilled proposal
+    // row behind.
+    const pendingTreatyTypes = new Set(
+      (state.pendingDiplomacyRequests ?? [])
+        .filter(request => request.type === 'treaty'
+          && ((request.fromCivId === state.currentPlayer && request.toCivId === civId)
+            || (request.fromCivId === civId && request.toCivId === state.currentPlayer)))
+        .map(request => request.treatyType),
+    );
+
     civRows.push({
       civId,
       civIdx,
@@ -176,6 +191,7 @@ export function createDiplomacyPanel(
       treaties,
       actions: rowActions
         .filter(action => !(action === 'request_peace' && peaceRequestState !== 'none'))
+        .filter(action => !pendingTreatyTypes.has(action as TreatyType))
         .map(action => ({ action, isHostile: action === 'declare_war' })),
       peaceRequestState,
       peaceRequestId: pendingPeaceRequest?.id ?? null,

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -5,7 +5,9 @@ import {
   isAtWar,
   getAvailableActions,
   getPendingPeaceRequestForPair,
+  getPendingTreatyProposalsFor,
 } from '@/systems/diplomacy-system';
+import { TREATY_LABELS, describeWarReason } from '@/ui/notification-routing';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { hasDiscoveredMinorCiv } from '@/systems/discovery-system';
@@ -29,6 +31,8 @@ export interface DiplomacyPanelCallbacks {
   onAction: (targetCivId: string, action: DiplomaticAction) => void;
   onAcceptPeaceRequest?: (requestId: string) => void;
   onRejectPeaceRequest?: (requestId: string) => void;
+  onAcceptTreatyProposal?: (requestId: string) => void;
+  onDeclineTreatyProposal?: (requestId: string) => void;
   onGiftGold?: (mcId: string) => void;
   onSponsorFestival?: (mcId: string) => void;
   onMinorCivReparations?: (mcId: string) => void;
@@ -50,6 +54,9 @@ interface CivRowData {
   actions: Array<{ action: DiplomaticAction; isHostile: boolean }>;
   peaceRequestState: 'none' | 'incoming' | 'outgoing';
   peaceRequestId: string | null;
+  incomingTreatyProposals: Array<{ id: string; label: string }>;
+  atWar: boolean;
+  warSinceText: string | null;
 }
 
 interface MinorCivRowData {
@@ -136,6 +143,25 @@ export function createDiplomacyPanel(
       .filter(t => t.civB === civId || t.civA === civId)
       .map(t => ({ label: t.type.replace(/_/g, ' '), turns: t.turnsRemaining }));
 
+    // #554: incoming treaty proposals FROM this civ TO the viewer only --
+    // never surface the viewer's own outgoing proposals or third-party ones.
+    const incomingTreatyProposals = getPendingTreatyProposalsFor(state, state.currentPlayer)
+      .filter(request => request.fromCivId === civId)
+      .map(request => ({ id: request.id, label: TREATY_LABELS[request.treatyType!] }));
+
+    // #554: "at war since turn N -- reason" derived from the same
+    // war_declared event + relationship-based reason the notification uses
+    // (describeWarReason), so the two surfaces never disagree.
+    let warSinceText: string | null = null;
+    if (atWar) {
+      const warEvent = [...playerDiplomacy.events]
+        .filter(e => e.type === 'war_declared' && e.otherCiv === civId)
+        .sort((a, b) => b.turn - a.turn)[0];
+      warSinceText = warEvent
+        ? `⚔ At war since turn ${warEvent.turn} — ${describeWarReason(relationship)}`
+        : '⚔ At war';
+    }
+
     civRows.push({
       civId,
       civIdx,
@@ -152,6 +178,9 @@ export function createDiplomacyPanel(
         .map(action => ({ action, isHostile: action === 'declare_war' })),
       peaceRequestState,
       peaceRequestId: pendingPeaceRequest?.id ?? null,
+      incomingTreatyProposals,
+      atWar,
+      warSinceText,
     });
     civIdx++;
   }
@@ -245,6 +274,20 @@ export function createDiplomacyPanel(
       treatiesHtml += '</div>';
     }
 
+    let treatyProposalsHtml = '';
+    row.incomingTreatyProposals.forEach((proposal, pIdx) => {
+      treatyProposalsHtml += `
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;background:rgba(232,193,112,0.12);border-radius:6px;padding:6px 8px;">
+          <span style="font-size:11px;flex:1;">Proposes: <strong data-text="treaty-proposal-label-${row.civIdx}-${pIdx}"></strong></span>
+          <button class="diplo-accept-treaty" data-request-id="${proposal.id}" data-action="accept-treaty-proposal" style="padding:5px 10px;background:rgba(74,155,74,0.3);border:1px solid #4a9b4a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Accept</button>
+          <button class="diplo-decline-treaty" data-request-id="${proposal.id}" data-action="decline-treaty-proposal" style="padding:5px 10px;background:rgba(217,148,74,0.25);border:1px solid #d9944a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Decline</button>
+        </div>`;
+    });
+
+    const warSinceHtml = row.warSinceText
+      ? `<div style="font-size:11px;color:#d94a4a;margin-bottom:8px;" data-text="war-since-${row.civIdx}"></div>`
+      : '';
+
     let actionsHtml = '<div style="display:flex;flex-wrap:wrap;gap:6px;">';
     if (row.peaceRequestState === 'incoming' && row.peaceRequestId) {
       actionsHtml += `<button class="diplo-accept-peace" data-request-id="${row.peaceRequestId}" data-action="accept-peace-request" style="padding:6px 12px;background:rgba(74,155,74,0.3);border:1px solid #4a9b4a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Accept Peace</button>`;
@@ -266,6 +309,8 @@ export function createDiplomacyPanel(
           <div>
             <div style="font-weight:bold;font-size:14px;" data-text="civ-name-${row.civIdx}"></div>
             <div style="font-size:11px;opacity:0.6;"><span data-text="civ-bonus-${row.civIdx}"></span> · <span data-text="civ-status-${row.civIdx}"></span></div>
+            ${warSinceHtml}
+            ${treatyProposalsHtml}
           </div>
         </div>
         <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;">
@@ -340,6 +385,12 @@ export function createDiplomacyPanel(
     row.actions.forEach((a, aIdx) => {
       setText(`action-label-${row.civIdx}-${aIdx}`, a.action.replace(/_/g, ' '));
     });
+    if (row.warSinceText) {
+      setText(`war-since-${row.civIdx}`, row.warSinceText);
+    }
+    row.incomingTreatyProposals.forEach((proposal, pIdx) => {
+      setText(`treaty-proposal-label-${row.civIdx}-${pIdx}`, proposal.label);
+    });
   }
 
   for (const row of minorCivRows) {
@@ -413,6 +464,22 @@ export function createDiplomacyPanel(
       const requestId = (btn as HTMLElement).dataset.requestId!;
       panel.remove();
       callbacks.onRejectPeaceRequest?.(requestId);
+    });
+  });
+
+  panel.querySelectorAll('.diplo-accept-treaty').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const requestId = (btn as HTMLElement).dataset.requestId!;
+      panel.remove();
+      callbacks.onAcceptTreatyProposal?.(requestId);
+    });
+  });
+
+  panel.querySelectorAll('.diplo-decline-treaty').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const requestId = (btn as HTMLElement).dataset.requestId!;
+      panel.remove();
+      callbacks.onDeclineTreatyProposal?.(requestId);
     });
   });
 

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -1,4 +1,4 @@
-import type { GameState, DiplomaticAction } from '@/core/types';
+import type { GameState, DiplomaticAction, TreatyType } from '@/core/types';
 import {
   canReabsorbBreakaway,
   getRelationship,
@@ -33,6 +33,7 @@ export interface DiplomacyPanelCallbacks {
   onRejectPeaceRequest?: (requestId: string) => void;
   onAcceptTreatyProposal?: (requestId: string) => void;
   onDeclineTreatyProposal?: (requestId: string) => void;
+  onBreakTreaty?: (civId: string, treatyType: TreatyType) => void;
   onGiftGold?: (mcId: string) => void;
   onSponsorFestival?: (mcId: string) => void;
   onMinorCivReparations?: (mcId: string) => void;
@@ -50,7 +51,7 @@ interface CivRowData {
   barWidth: number;
   barColor: string;
   statusText: string;
-  treaties: Array<{ label: string; turns: number }>;
+  treaties: Array<{ label: string; turns: number; type: TreatyType }>;
   actions: Array<{ action: DiplomaticAction; isHostile: boolean }>;
   peaceRequestState: 'none' | 'incoming' | 'outgoing';
   peaceRequestId: string | null;
@@ -141,7 +142,7 @@ export function createDiplomacyPanel(
 
     const treaties = playerDiplomacy.treaties
       .filter(t => t.civB === civId || t.civA === civId)
-      .map(t => ({ label: t.type.replace(/_/g, ' '), turns: t.turnsRemaining }));
+      .map(t => ({ label: t.type.replace(/_/g, ' '), turns: t.turnsRemaining, type: t.type }));
 
     // #554: incoming treaty proposals FROM this civ TO the viewer only --
     // never surface the viewer's own outgoing proposals or third-party ones.
@@ -264,12 +265,16 @@ export function createDiplomacyPanel(
   for (const row of civRows) {
     let treatiesHtml = '';
     if (row.treaties.length > 0) {
-      treatiesHtml = '<div style="margin-bottom:8px;">';
+      treatiesHtml = '<div style="margin-bottom:8px;display:flex;flex-wrap:wrap;gap:4px;">';
       row.treaties.forEach((t, tIdx) => {
         const turnsPlaceholder = t.turns > 0
           ? ` (<span data-text="treaty-turns-${row.civIdx}-${tIdx}"></span> turns)`
           : '';
-        treatiesHtml += `<span style="display:inline-block;background:rgba(232,193,112,0.2);border-radius:4px;padding:2px 8px;font-size:10px;margin-right:4px;"><span data-text="treaty-label-${row.civIdx}-${tIdx}"></span>${turnsPlaceholder}</span>`;
+        treatiesHtml += `
+          <span style="display:inline-flex;align-items:center;gap:4px;background:rgba(232,193,112,0.2);border-radius:4px;padding:2px 4px 2px 8px;font-size:10px;">
+            <span><span data-text="treaty-label-${row.civIdx}-${tIdx}"></span>${turnsPlaceholder}</span>
+            <button class="diplo-break-treaty" data-civ-id="${row.civId}" data-treaty-type="${t.type}" style="padding:2px 6px;background:rgba(217,74,74,0.25);border:1px solid #d94a4a;border-radius:4px;color:white;cursor:pointer;font-size:9px;">Break</button>
+          </span>`;
       });
       treatiesHtml += '</div>';
     }
@@ -480,6 +485,30 @@ export function createDiplomacyPanel(
       const requestId = (btn as HTMLElement).dataset.requestId!;
       panel.remove();
       callbacks.onDeclineTreatyProposal?.(requestId);
+    });
+  });
+
+  // Two-click in-panel confirm (no window.confirm on mobile, #554): the first
+  // click arms the button; a second click within 3s actually breaks it.
+  panel.querySelectorAll('.diplo-break-treaty').forEach(btn => {
+    const button = btn as HTMLButtonElement;
+    let armed = false;
+    let disarmTimer: ReturnType<typeof setTimeout> | null = null;
+    button.addEventListener('click', () => {
+      if (!armed) {
+        armed = true;
+        button.textContent = 'Confirm?';
+        disarmTimer = setTimeout(() => {
+          armed = false;
+          button.textContent = 'Break';
+        }, 3000);
+        return;
+      }
+      if (disarmTimer) clearTimeout(disarmTimer);
+      const civId = button.dataset.civId!;
+      const treatyType = button.dataset.treatyType! as TreatyType;
+      panel.remove();
+      callbacks.onBreakTreaty?.(civId, treatyType);
     });
   });
 

--- a/src/ui/notification-delivery.ts
+++ b/src/ui/notification-delivery.ts
@@ -1,0 +1,58 @@
+import type { GameState } from '@/core/types';
+import { appendNotification, type NotificationEntry } from '@/core/notification-log';
+import { collectEvent } from '@/core/hotseat-events';
+import type { NotificationSink } from '@/ui/notification-routing';
+
+export interface NotificationDeliveryDeps {
+  getState: () => GameState;
+  toast: (message: string, type: NotificationEntry['type'], target?: NotificationEntry['target']) => void;
+  isSuppressed: () => boolean;
+}
+
+export interface NotificationDelivery {
+  deliver: NotificationSink;
+  withHappenedTurn<T>(turn: number, fn: () => T): T;
+}
+
+// The single delivery contract for game-consequence notifications (#551):
+// log always; toast only when the recipient is the active, unsuppressed
+// viewer; queue to pendingEvents (hot seat only) otherwise, where the
+// turn-handoff summary already drains it. Solo never queues -- its single
+// human is always the viewer, so deferred delivery would mean "never".
+export function createNotificationDelivery(deps: NotificationDeliveryDeps): NotificationDelivery {
+  let happenedTurn: number | null = null;
+
+  const deliver: NotificationSink = (civId, message, type, target) => {
+    const state = deps.getState();
+    const turn = happenedTurn ?? state.turn;
+    appendNotification(state, civId, { message, type, turn, target });
+
+    const civ = state.civilizations[civId];
+    if (!civ?.isHuman) return;
+
+    const isActiveViewer = civId === state.currentPlayer && !deps.isSuppressed();
+    if (isActiveViewer || !state.hotSeat) {
+      deps.toast(message, type, target);
+      return;
+    }
+    state.pendingEvents ??= {};
+    collectEvent(state.pendingEvents, civId, {
+      type: 'info',
+      message,
+      turn,
+      ...(target ? { target } : {}),
+    });
+  };
+
+  return {
+    deliver,
+    withHappenedTurn<T>(turn: number, fn: () => T): T {
+      happenedTurn = turn;
+      try {
+        return fn();
+      } finally {
+        happenedTurn = null;
+      }
+    },
+  };
+}

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -1,4 +1,4 @@
-import type { CombatResult, CombatRewardNotification, GameEvents, GameState, ProductionDropReason } from '@/core/types';
+import type { CombatResult, CombatRewardNotification, GameEvents, GameState, ProductionDropReason, TreatyType } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -188,6 +188,36 @@ export function formatEconomyTreasuryStrainMessage(
 }
 
 // Writes to both parties' logs from their own perspective.
+// Shared between the war-declared notification and the diplomacy panel's
+// "at war since" row (#554) -- one source of truth for the relationship-based
+// reason string, so the two surfaces never drift.
+export function describeWarReason(relationship: number): string {
+  if (relationship <= -50) return 'deep hostility';
+  if (relationship <= -20) return 'deteriorating relations';
+  if (relationship < 0) return 'territorial disputes';
+  return 'rising tensions';
+}
+
+// Shared between the treaty-proposed notification and the diplomacy panel's
+// proposal buttons (#554) -- one source of truth for display names.
+export const TREATY_LABELS: Record<TreatyType, string> = {
+  non_aggression_pact: 'Non-Aggression Pact',
+  trade_agreement: 'Trade Agreement',
+  open_borders: 'Open Borders',
+  alliance: 'Alliance',
+  vassalage: 'Vassalage',
+};
+
+export function routeTreatyProposed(
+  state: GameState,
+  event: GameEvents['diplomacy:treaty-proposed'],
+  sink: NotificationSink,
+): void {
+  const fromName = state.civilizations[event.fromCiv]?.name ?? 'Unknown';
+  const label = TREATY_LABELS[event.treaty];
+  sink(event.toCiv, `${fromName} proposes a ${label}. Review it in the Diplomacy panel.`, 'info');
+}
+
 export function routeWarDeclared(
   state: GameState,
   attackerId: string,
@@ -197,10 +227,7 @@ export function routeWarDeclared(
   const attackerName = state.civilizations[attackerId]?.name ?? 'Unknown';
   const defenderName = state.civilizations[defenderId]?.name ?? 'Unknown';
   const rel = state.civilizations[defenderId]?.diplomacy?.relationships[attackerId] ?? 0;
-  let reason = 'rising tensions';
-  if (rel <= -50) reason = 'deep hostility';
-  else if (rel <= -20) reason = 'deteriorating relations';
-  else if (rel < 0) reason = 'territorial disputes';
+  const reason = describeWarReason(rel);
   sink(defenderId, `${attackerName} has declared war! (Reason: ${reason})`, 'warning');
   sink(attackerId, `War has been declared on ${defenderName}!`, 'warning');
 }

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -1,5 +1,4 @@
 import type { CombatResult, CombatRewardNotification, GameEvents, GameState, ProductionDropReason } from '@/core/types';
-import { collectEvent } from '@/core/hotseat-events';
 import { hexKey } from '@/systems/hex-utils';
 import { getImprovementDisplayName } from '@/systems/improvement-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
@@ -257,18 +256,6 @@ export function routeDroppedProductionItem(
   sink(city.owner, message, 'warning');
 }
 
-export function queueFirstContactPendingEvents(
-  state: GameState,
-  civA: string,
-  civB: string,
-): void {
-  state.pendingEvents ??= {};
-  const aName = state.civilizations[civA]?.name ?? civA;
-  const bName = state.civilizations[civB]?.name ?? civB;
-  collectEvent(state.pendingEvents, civA, { type: 'first-contact', message: `Encountered ${bName}.`, turn: state.turn });
-  collectEvent(state.pendingEvents, civB, { type: 'first-contact', message: `Encountered ${aName}.`, turn: state.turn });
-}
-
 export function routeStrategicWarning(
   event: GameEvents['ai:strategic-warning'],
   sink: NotificationSink,
@@ -280,20 +267,6 @@ export function routeStrategicWarning(
     presentation.type,
     presentation.target,
   );
-}
-
-export function queueStrategicWarningPendingEvent(
-  state: GameState,
-  event: GameEvents['ai:strategic-warning'],
-): void {
-  state.pendingEvents ??= {};
-  const presentation = presentStrategicWarning(event);
-  collectEvent(state.pendingEvents, event.viewerId, {
-    type: 'ai:strategic-warning',
-    message: presentation.message,
-    turn: state.turn,
-    ...(presentation.target ? { target: presentation.target } : {}),
-  });
 }
 
 // Routes to the defender's owner regardless of who is currently acting.
@@ -385,20 +358,23 @@ export function routeBarbarianSpawned(
   }
 }
 
+// Era advancement is a world event, not attributable to whoever currentPlayer
+// happens to be at emit time (#551) -- deliver to every human civ via the
+// delivery contract, which handles hot-seat queueing and solo toasting itself.
 export function routeEraAdvanced(
   era: number,
-  civId: string,
-  civName: string,
-  toastSink: (message: string, type: NotificationEntry['type']) => void,
-  factionSink: NotificationSink,
+  humanCivIds: string[],
+  sink: NotificationSink,
 ): void {
-  toastSink(`${civName} has entered Era ${era}!`, 'success');
-  if (era === 2) {
-    factionSink(
-      civId,
-      `Era 2 begins — cities can now experience unrest. High pressure (overcrowding, distance from capital, unhappiness) will trigger it. Garrison units, spend gold to appease, or build happiness improvements to keep order.`,
-      'info',
-    );
+  for (const civId of humanCivIds) {
+    sink(civId, `The world has entered Era ${era}!`, 'success');
+    if (era === 2) {
+      sink(
+        civId,
+        `Era 2 begins — cities can now experience unrest. High pressure (overcrowding, distance from capital, unhappiness) will trigger it. Garrison units, spend gold to appease, or build happiness improvements to keep order.`,
+        'info',
+      );
+    }
   }
 }
 

--- a/tests/ai/basic-ai-treaty-contact-guard.test.ts
+++ b/tests/ai/basic-ai-treaty-contact-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
 import { processAITurn } from '@/ai/basic-ai';
+import { evaluateDiplomacy } from '@/ai/ai-diplomacy';
 
 // Issue #435 defense-in-depth: even if the decision layer regresses and emits a
 // treaty or war decision for an unmet civ (the June 2026 mass-discovery bug),
@@ -38,5 +39,62 @@ describe('basic-ai treaty execution contact guard', () => {
     expect(result.civilizations.player.diplomacy.treaties).toEqual([]);
     expect(result.civilizations['ai-1'].diplomacy.atWarWith).toEqual([]);
     expect(result.civilizations.player.diplomacy.atWarWith).toEqual([]);
+  });
+});
+
+// #554: an AI offering a treaty to a human must not sign it instantly --
+// the human has to accept a pending proposal in the diplomacy panel first.
+describe('basic-ai treaty consent (#554)', () => {
+  it('never writes a treaty into a human civ\'s state without consent', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Treaty Consent',
+      seed: 'treaty-consent-human',
+    });
+    state.era = 3;
+    state.civilizations['ai-1'].knownCivilizations = ['player'];
+    state.civilizations.player.knownCivilizations = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.relationships.player = 60;
+    state.civilizations.player.diplomacy.relationships['ai-1'] = 60;
+    state.pendingDiplomacyRequests = [];
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.civilizations.player.diplomacy.treaties).toHaveLength(0);
+    expect(result.civilizations['ai-1'].diplomacy.treaties).toHaveLength(0);
+    expect(result.pendingDiplomacyRequests?.some(r =>
+      r.type === 'treaty' && r.fromCivId === 'ai-1' && r.toCivId === 'player')).toBe(true);
+  });
+
+  it('still signs AI<->AI treaties instantly', () => {
+    const state = createNewGame({
+      civType: 'egypt',
+      mapSize: 'medium',
+      opponentCount: 2,
+      gameTitle: 'Treaty Consent AI-AI',
+      seed: 'treaty-consent-ai-ai',
+    });
+    state.era = 3;
+    const civIds = Object.keys(state.civilizations);
+    const secondAiId = civIds.find(id => id !== 'ai-1' && id !== 'player')!;
+    state.civilizations['ai-1'].knownCivilizations = [secondAiId];
+    state.civilizations[secondAiId].knownCivilizations = ['ai-1'];
+    state.civilizations['ai-1'].diplomacy.relationships[secondAiId] = 60;
+    state.civilizations[secondAiId].diplomacy.relationships['ai-1'] = 60;
+    state.pendingDiplomacyRequests = [];
+
+    // Override this file's module-level mock (hardcoded to targetCiv: 'player')
+    // for this one call, so the decision targets the other AI instead.
+    vi.mocked(evaluateDiplomacy).mockReturnValueOnce([
+      { action: 'trade_agreement', targetCiv: secondAiId },
+    ]);
+
+    const result = processAITurn(state, 'ai-1', new EventBus());
+
+    expect(result.civilizations['ai-1'].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+    expect(result.civilizations[secondAiId].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+    expect(result.pendingDiplomacyRequests ?? []).toHaveLength(0);
   });
 });

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { NotificationEntry } from '@/core/notification-log';
 import { routeEraAdvanced, type NotificationSink } from '@/ui/notification-routing';
 
 const PROJECT_ROOT = resolve(__dirname, '..');
@@ -192,38 +191,39 @@ function makeSink() {
   return { sink, calls };
 }
 
-function makeToastSink() {
-  const calls: Array<{ message: string; type: NotificationEntry['type'] }> = [];
-  const sink = (message: string, type: NotificationEntry['type']) => calls.push({ message, type });
-  return { sink, calls };
-}
-
 describe('era:advanced notification', () => {
-  it('era 2 calls toastSink with Era 2 and factionSink once with Era 2 and unrest', () => {
-    const { sink: toastSink, calls: toastCalls } = makeToastSink();
-    const { sink: factionSink, calls: factionCalls } = makeSink();
+  it('era 2 delivers to every human civ, with an extra unrest-primer line per civ', () => {
+    const { sink, calls } = makeSink();
 
-    routeEraAdvanced(2, 'p1', 'Alice', toastSink, factionSink);
+    routeEraAdvanced(2, ['p1', 'p2'], sink);
 
-    expect(toastCalls).toHaveLength(1);
-    expect(toastCalls[0]!.message).toContain('Era 2');
-    expect(toastCalls[0]!.type).toBe('success');
-
-    expect(factionCalls).toHaveLength(1);
-    expect(factionCalls[0]!.civId).toBe('p1');
-    expect(factionCalls[0]!.message).toContain('Era 2');
-    expect(factionCalls[0]!.message).toContain('unrest');
-    expect(factionCalls[0]!.type).toBe('info');
+    // Each human civ gets both the era announcement and the era-2 unrest primer.
+    const p1Calls = calls.filter(c => c.civId === 'p1');
+    const p2Calls = calls.filter(c => c.civId === 'p2');
+    expect(p1Calls).toHaveLength(2);
+    expect(p2Calls).toHaveLength(2);
+    expect(p1Calls[0]!.message).toContain('Era 2');
+    expect(p1Calls[0]!.type).toBe('success');
+    expect(p1Calls[1]!.message).toContain('Era 2');
+    expect(p1Calls[1]!.message).toContain('unrest');
+    expect(p1Calls[1]!.type).toBe('info');
   });
 
-  it('era 3 calls toastSink with Era 3 but does NOT call factionSink', () => {
-    const { sink: toastSink, calls: toastCalls } = makeToastSink();
-    const { sink: factionSink, calls: factionCalls } = makeSink();
+  it('era 3 delivers only the announcement line to each human civ, no unrest primer', () => {
+    const { sink, calls } = makeSink();
 
-    routeEraAdvanced(3, 'p1', 'Alice', toastSink, factionSink);
+    routeEraAdvanced(3, ['p1'], sink);
 
-    expect(toastCalls).toHaveLength(1);
-    expect(toastCalls[0]!.message).toContain('Era 3');
-    expect(factionCalls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.civId).toBe('p1');
+    expect(calls[0]!.message).toContain('Era 3');
+  });
+
+  it('delivers to no one when there are no human civs', () => {
+    const { sink, calls } = makeSink();
+
+    routeEraAdvanced(2, [], sink);
+
+    expect(calls).toHaveLength(0);
   });
 });

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -9,7 +9,7 @@ import {
   modifyRelationship,
   declareWar,
   makePeace,
-  proposeTreaty,
+  signTreaty,
   breakTreaty,
   processRelationshipDrift,
   recordMilitaryAttack,
@@ -145,9 +145,9 @@ describe('diplomacy-system', () => {
   });
 
   describe('treaties', () => {
-    it('proposeTreaty adds a treaty', () => {
+    it('signTreaty adds a treaty', () => {
       let state = createDiplomacyState(civIds, 'player');
-      state = proposeTreaty(state, 'player', 'ai-egypt', 'non_aggression_pact', 10, 15);
+      state = signTreaty(state, 'player', 'ai-egypt', 'non_aggression_pact', 10, 15);
       expect(state.treaties).toHaveLength(1);
       expect(state.treaties[0].type).toBe('non_aggression_pact');
       expect(state.treaties[0].turnsRemaining).toBe(10);
@@ -157,13 +157,13 @@ describe('diplomacy-system', () => {
     it('trade_agreement adds gold per turn', () => {
       let state = createDiplomacyState(civIds, 'player');
       state = modifyRelationship(state, 'ai-egypt', 10);
-      state = proposeTreaty(state, 'player', 'ai-egypt', 'trade_agreement', -1, 20);
+      state = signTreaty(state, 'player', 'ai-egypt', 'trade_agreement', -1, 20);
       expect(state.treaties[0].goldPerTurn).toBe(2);
     });
 
     it('breakTreaty removes treaty and penalizes -30', () => {
       let state = createDiplomacyState(civIds, 'player');
-      state = proposeTreaty(state, 'player', 'ai-egypt', 'non_aggression_pact', 10, 15);
+      state = signTreaty(state, 'player', 'ai-egypt', 'non_aggression_pact', 10, 15);
       state = breakTreaty(state, 'ai-egypt', 'non_aggression_pact', 20);
       expect(state.treaties).toHaveLength(0);
       expect(getRelationship(state, 'ai-egypt')).toBe(-25); // +5 from propose, -30 from break

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -17,6 +17,8 @@ import {
   getAvailableActions,
   isAtWar,
   rejectDiplomaticRequest,
+  enqueueTreatyProposal,
+  pruneExpiredDiplomaticRequests,
 } from '@/systems/diplomacy-system';
 import { EventBus } from '@/core/event-bus';
 import { createNewGame } from '@/core/game-state';
@@ -414,6 +416,81 @@ describe('diplomacy-system', () => {
 
       expect(() => applyDiplomaticAction(state, 'outsider', breakawayId, 'reabsorb_breakaway', bus))
         .toThrow(/origin owner/i);
+    });
+  });
+
+  describe('treaty proposals (#554)', () => {
+    function makeTreatyState(): GameState {
+      const state = createNewGame(undefined, 'treaty-proposal-test', 'small');
+      state.civilizations.player.diplomacy.relationships['ai-1'] = 40;
+      state.civilizations['ai-1'].diplomacy.relationships.player = 40;
+      state.pendingDiplomacyRequests = [];
+      return state;
+    }
+
+    it('enqueues a proposal without touching either civ\'s treaties', () => {
+      const state = makeTreatyState();
+      const bus = new EventBus();
+      const next = enqueueTreatyProposal(state, 'ai-1', 'player', 'non_aggression_pact', 10, bus);
+      expect(next.pendingDiplomacyRequests).toHaveLength(1);
+      expect(next.pendingDiplomacyRequests![0]).toMatchObject({
+        type: 'treaty', treatyType: 'non_aggression_pact', fromCivId: 'ai-1', toCivId: 'player', turnsRemaining: 10,
+      });
+      expect(next.civilizations.player.diplomacy.treaties).toHaveLength(0);
+      expect(next.civilizations['ai-1'].diplomacy.treaties).toHaveLength(0);
+    });
+
+    it('dedupes: same pair+type proposal is not enqueued twice', () => {
+      const state = makeTreatyState();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'open_borders', -1);
+      next = enqueueTreatyProposal(next, 'ai-1', 'player', 'open_borders', -1);
+      expect(next.pendingDiplomacyRequests).toHaveLength(1);
+    });
+
+    it('accept signs both sides and clears the request', () => {
+      const state = makeTreatyState();
+      const bus = new EventBus();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'trade_agreement', -1, bus);
+      const requestId = next.pendingDiplomacyRequests![0].id;
+      next = acceptDiplomaticRequest(next, 'player', requestId, bus);
+      expect(next.civilizations.player.diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+      expect(next.civilizations['ai-1'].diplomacy.treaties.some(t => t.type === 'trade_agreement')).toBe(true);
+      expect(next.pendingDiplomacyRequests).toHaveLength(0);
+    });
+
+    it('only the recipient can accept', () => {
+      const state = makeTreatyState();
+      const bus = new EventBus();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'alliance', -1);
+      const requestId = next.pendingDiplomacyRequests![0].id;
+      const after = acceptDiplomaticRequest(next, 'ai-1', requestId, bus); // proposer cannot self-accept
+      expect(after.civilizations.player.diplomacy.treaties).toHaveLength(0);
+    });
+
+    it('reject clears the request with no relationship penalty', () => {
+      const state = makeTreatyState();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'alliance', -1);
+      const before = next.civilizations.player.diplomacy.relationships['ai-1'] ?? 0;
+      const requestId = next.pendingDiplomacyRequests![0].id;
+      next = rejectDiplomaticRequest(next, 'player', requestId);
+      expect(next.pendingDiplomacyRequests).toHaveLength(0);
+      expect(next.civilizations.player.diplomacy.relationships['ai-1'] ?? 0).toBe(before);
+    });
+
+    it('proposals expire after 10 turns (pruned by the turn processor)', () => {
+      const state = makeTreatyState();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'open_borders', -1);
+      next = { ...next, turn: next.turn + 11 };
+      next = pruneExpiredDiplomaticRequests(next);
+      expect(next.pendingDiplomacyRequests).toHaveLength(0);
+    });
+
+    it('does not prune a peace request or treaty proposal before its 10-turn TTL', () => {
+      const state = makeTreatyState();
+      let next = enqueueTreatyProposal(state, 'ai-1', 'player', 'open_borders', -1);
+      next = { ...next, turn: next.turn + 9 };
+      next = pruneExpiredDiplomaticRequests(next);
+      expect(next.pendingDiplomacyRequests).toHaveLength(1);
     });
   });
 });

--- a/tests/systems/diplomacy-system.test.ts
+++ b/tests/systems/diplomacy-system.test.ts
@@ -492,5 +492,17 @@ describe('diplomacy-system', () => {
       next = pruneExpiredDiplomaticRequests(next);
       expect(next.pendingDiplomacyRequests).toHaveLength(1);
     });
+
+    it('tolerates a legacy-shaped peace request (no treatyType/turnsRemaining) when pruning', () => {
+      const state = makeTreatyState();
+      // Shaped like a pre-#554 save: only the original peace-request fields.
+      state.pendingDiplomacyRequests = [
+        { id: 'peace:ai-1:player:1', type: 'peace', fromCivId: 'ai-1', toCivId: 'player', turnIssued: state.turn },
+      ];
+      const next = pruneExpiredDiplomaticRequests({ ...state, turn: state.turn + 5 });
+      expect(next.pendingDiplomacyRequests).toHaveLength(1);
+      const pruned = pruneExpiredDiplomaticRequests({ ...state, turn: state.turn + 11 });
+      expect(pruned.pendingDiplomacyRequests).toHaveLength(0);
+    });
   });
 });

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -536,6 +536,26 @@ describe('diplomacy-panel treaty proposals + war attribution (#554)', () => {
     expect(onAccept).toHaveBeenCalledWith(expect.stringContaining('treaty'));
   });
 
+  it('does not offer the generic treaty action while an identical proposal is already pending (#554)', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.diplomacy.relationships.outsider = 60;
+    state.civilizations.outsider.diplomacy.relationships.player = 60;
+    const next = enqueueTreatyProposal(state, 'outsider', 'player', 'non_aggression_pact', 10);
+
+    const panel = createDiplomacyPanel(container, next, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    // The proposal's own accept/decline buttons are present, but the generic
+    // "non aggression pact" action button for THIS civ (outsider) must not
+    // also be offered (a different row, e.g. the breakaway civ, may still
+    // legitimately offer its own non_aggression_pact action).
+    expect(panel.querySelector('[data-action="accept-treaty-proposal"]')).toBeTruthy();
+    expect(panel.querySelector('[data-civ-id="outsider"][data-action="non_aggression_pact"]')).toBeNull();
+  });
+
   it('shows war status with start turn and reason for a civ at war with the viewer', () => {
     const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
     state.civilizations.player.diplomacy.atWarWith = ['outsider'];

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -582,4 +582,47 @@ describe('diplomacy-panel treaty proposals + war attribution (#554)', () => {
 
     expect(panel.querySelector('[data-action="accept-treaty-proposal"]')).toBeNull();
   });
+
+  it('breaking an existing treaty requires two clicks (arm then confirm) -- no silent destructive UI', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.diplomacy.treaties = [
+      { type: 'non_aggression_pact', civA: 'player', civB: 'outsider', turnsRemaining: -1 },
+    ];
+    const onBreakTreaty = vi.fn();
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onBreakTreaty,
+      onClose: () => {},
+    });
+
+    const breakBtn = panel.querySelector('.diplo-break-treaty') as HTMLButtonElement;
+    expect(breakBtn).toBeTruthy();
+
+    breakBtn.click();
+    expect(onBreakTreaty).not.toHaveBeenCalled();
+    expect(breakBtn.textContent).toBe('Confirm?');
+
+    breakBtn.click();
+    expect(onBreakTreaty).toHaveBeenCalledWith('outsider', 'non_aggression_pact');
+  });
+
+  it('renders a legacy-shaped save (peace-only pending request, no treatyType) without throwing', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    // Shaped like a pre-#554 save: peace request with none of the new optional fields.
+    state.pendingDiplomacyRequests = [
+      { id: 'peace:outsider:player:1', type: 'peace', fromCivId: 'outsider', toCivId: 'player', turnIssued: 1 } as any,
+    ];
+    // Also a legacy war with no war_declared event recorded yet.
+    state.civilizations.player.diplomacy.events = [];
+
+    expect(() => createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onClose: () => {},
+    })).not.toThrow();
+  });
 });

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createDiplomacyPanel } from '@/ui/diplomacy-panel';
 import {
   acceptDiplomaticRequest,
   enqueuePeaceRequest,
+  enqueueTreatyProposal,
   rejectDiplomaticRequest,
 } from '@/systems/diplomacy-system';
 import { EventBus } from '@/core/event-bus';
@@ -507,5 +508,78 @@ describe('diplomacy-panel breakaway rows', () => {
     expect(panel.textContent).not.toContain('Reject Peace');
     expect(panel.textContent).not.toContain('Peace Requested');
     expect(panel.textContent).toContain('declare war');
+  });
+});
+
+describe('diplomacy-panel treaty proposals + war attribution (#554)', () => {
+  it('renders an incoming treaty proposal with accept/decline and fires callbacks', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    // A real proposal implies the civs have already made contact -- panel
+    // visibility (shouldListMajorCivForViewer) requires contact memory, which
+    // a bare pending proposal alone doesn't establish.
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    const next = enqueueTreatyProposal(state, 'outsider', 'player', 'non_aggression_pact', 10);
+    const onAccept = vi.fn();
+    const onDecline = vi.fn();
+
+    const panel = createDiplomacyPanel(container, next, {
+      onAction: () => {},
+      onAcceptTreatyProposal: onAccept,
+      onDeclineTreatyProposal: onDecline,
+      onClose: () => {},
+    });
+
+    const accept = panel.querySelector('[data-action="accept-treaty-proposal"]') as HTMLButtonElement;
+    expect(accept).toBeTruthy();
+    expect(panel.textContent).toContain('Non-Aggression Pact');
+    accept.click();
+    expect(onAccept).toHaveBeenCalledWith(expect.stringContaining('treaty'));
+  });
+
+  it('shows war status with start turn and reason for a civ at war with the viewer', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.relationships.outsider = -60;
+    state.civilizations.player.diplomacy.events = [
+      { type: 'war_declared', turn: 4, otherCiv: 'outsider', weight: 1 },
+    ];
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('At war since turn 4');
+    expect(panel.textContent).toContain('deep hostility');
+  });
+
+  it('renders a bare "At war" row when no war_declared event exists (legacy save)', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.diplomacy.atWarWith = ['outsider'];
+    state.civilizations.outsider.diplomacy.atWarWith = ['player'];
+    state.civilizations.player.diplomacy.events = [];
+
+    const panel = createDiplomacyPanel(container, state, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.textContent).toContain('At War');
+    expect(panel.textContent).not.toContain('At war since turn');
+  });
+
+  it('never shows proposal buttons to the proposer or third parties', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    // Proposal FROM player TO outsider -- player is the proposer, not the recipient.
+    const next = enqueueTreatyProposal(state, 'player', 'outsider', 'trade_agreement', -1);
+
+    const panel = createDiplomacyPanel(container, next, {
+      onAction: () => {},
+      onClose: () => {},
+    });
+
+    expect(panel.querySelector('[data-action="accept-treaty-proposal"]')).toBeNull();
   });
 });

--- a/tests/ui/helpers/notification-state.ts
+++ b/tests/ui/helpers/notification-state.ts
@@ -1,0 +1,29 @@
+import { vi } from 'vitest';
+import { createNotificationDelivery } from '@/ui/notification-delivery';
+import type { GameState } from '@/core/types';
+
+export function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 6,
+    currentPlayer: 'p1',
+    idCounters: {},
+    civilizations: {
+      p1: { isHuman: true } as any,
+      p2: { isHuman: true } as any,
+      ai1: { isHuman: false } as any,
+    },
+    notificationLog: {},
+    pendingEvents: {},
+    ...overrides,
+  } as unknown as GameState;
+}
+
+export function make(state: GameState, suppressed = false) {
+  const toast = vi.fn();
+  const delivery = createNotificationDelivery({
+    getState: () => state,
+    toast,
+    isSuppressed: () => suppressed,
+  });
+  return { delivery, toast };
+}

--- a/tests/ui/notification-delivery-regressions.test.ts
+++ b/tests/ui/notification-delivery-regressions.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { makeState, make } from './helpers/notification-state';
+import { clearStaleSoloPendingEvents } from '@/core/hotseat-events';
+
+describe('#551 regressions', () => {
+  it('a consequence for the previous player never toasts on the next player\'s screen', () => {
+    const state = makeState({ hotSeat: { players: [] } as any, currentPlayer: 'p2' });
+    const { delivery, toast } = make(state);
+    // Simulate round-commit: war declared against p1 while p2 is the viewer.
+    delivery.withHappenedTurn(9, () => {
+      delivery.deliver('p1', 'The Aztecs declared war on you!', 'warning');
+    });
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['p1'][0]).toMatchObject({ message: expect.stringContaining('declared war'), turn: 9 });
+    expect(state.notificationLog!['p1'][0].turn).toBe(9);
+  });
+
+  it('solo never accumulates pendingEvents', () => {
+    const state = makeState(); // solo
+    const { delivery } = make(state);
+    delivery.deliver('p1', 'You met the Mayans.', 'info');
+    delivery.deliver('p1', 'Barbarians spotted!', 'warning');
+    expect(Object.values(state.pendingEvents ?? {}).flat()).toHaveLength(0);
+  });
+});
+
+describe('clearStaleSoloPendingEvents (#551 save compat)', () => {
+  it('clears a solo save carrying stale queued events', () => {
+    const state = makeState({
+      pendingEvents: { p1: [{ type: 'first-contact', message: 'Encountered Bob', turn: 3 }] },
+    });
+    clearStaleSoloPendingEvents(state);
+    expect(state.pendingEvents).toEqual({});
+  });
+
+  it('leaves a hot-seat save\'s queue intact', () => {
+    const state = makeState({
+      hotSeat: { players: [] } as any,
+      pendingEvents: { p1: [{ type: 'first-contact', message: 'Encountered Bob', turn: 3 }] },
+    });
+    clearStaleSoloPendingEvents(state);
+    expect(state.pendingEvents!['p1']).toHaveLength(1);
+  });
+
+  it('is a no-op when pendingEvents is already empty', () => {
+    const state = makeState({ pendingEvents: {} });
+    clearStaleSoloPendingEvents(state);
+    expect(state.pendingEvents).toEqual({});
+  });
+});

--- a/tests/ui/notification-delivery.test.ts
+++ b/tests/ui/notification-delivery.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createNotificationDelivery } from '@/ui/notification-delivery';
+import type { GameState } from '@/core/types';
+
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 6,
+    currentPlayer: 'p1',
+    idCounters: {},
+    civilizations: {
+      p1: { isHuman: true } as any,
+      p2: { isHuman: true } as any,
+      ai1: { isHuman: false } as any,
+    },
+    notificationLog: {},
+    pendingEvents: {},
+    ...overrides,
+  } as unknown as GameState;
+}
+
+function make(state: GameState, suppressed = false) {
+  const toast = vi.fn();
+  const delivery = createNotificationDelivery({
+    getState: () => state,
+    toast,
+    isSuppressed: () => suppressed,
+  });
+  return { delivery, toast };
+}
+
+describe('notification delivery contract', () => {
+  it('toasts and logs for the active unsuppressed viewer', () => {
+    const state = makeState();
+    const { delivery, toast } = make(state);
+    delivery.deliver('p1', 'War!', 'warning');
+    expect(toast).toHaveBeenCalledWith('War!', 'warning', undefined);
+    expect(state.notificationLog!['p1']).toHaveLength(1);
+    expect(state.notificationLog!['p1'][0].turn).toBe(6);
+  });
+
+  it('hot seat: queues (no toast) for a non-current human — the leak regression', () => {
+    const state = makeState({ hotSeat: { players: [] } as any });
+    const { delivery, toast } = make(state); // currentPlayer is p1
+    delivery.deliver('p2', 'Secret consequence', 'warning');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.notificationLog!['p2']).toHaveLength(1);
+    expect(state.pendingEvents!['p2']).toHaveLength(1);
+    expect(state.pendingEvents!['p2'][0].message).toBe('Secret consequence');
+  });
+
+  it('hot seat: queues for the current player while presentation is suppressed', () => {
+    const state = makeState({ hotSeat: { players: [] } as any });
+    const { delivery, toast } = make(state, true);
+    delivery.deliver('p1', 'Mid-handoff event', 'info');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['p1']).toHaveLength(1);
+  });
+
+  it('solo: toasts even for consequence events (single human is always the viewer)', () => {
+    const state = makeState(); // no hotSeat
+    const { delivery, toast } = make(state);
+    delivery.deliver('p1', 'You met the Aztecs.', 'info');
+    expect(toast).toHaveBeenCalledTimes(1);
+    expect(state.pendingEvents!['p1'] ?? []).toHaveLength(0); // never queue in solo
+  });
+
+  it('AI recipients get log-only', () => {
+    const state = makeState();
+    const { delivery, toast } = make(state);
+    delivery.deliver('ai1', 'AI thing', 'info');
+    expect(toast).not.toHaveBeenCalled();
+    expect(state.pendingEvents!['ai1'] ?? []).toHaveLength(0);
+    expect(state.notificationLog!['ai1']).toHaveLength(1);
+  });
+
+  it('withHappenedTurn stamps the round the event belonged to', () => {
+    const state = makeState(); // state.turn === 6
+    const { delivery } = make(state);
+    delivery.withHappenedTurn(5, () => {
+      delivery.deliver('p1', 'Happened last round', 'info');
+    });
+    expect(state.notificationLog!['p1'][0].turn).toBe(5);
+    delivery.deliver('p1', 'Happens now', 'info');
+    expect(state.notificationLog!['p1'][1].turn).toBe(6); // context reset
+  });
+
+  it('withHappenedTurn resets context even when fn throws', () => {
+    const state = makeState();
+    const { delivery } = make(state);
+    expect(() => delivery.withHappenedTurn(5, () => { throw new Error('boom'); })).toThrow('boom');
+    delivery.deliver('p1', 'after throw', 'info');
+    expect(state.notificationLog!['p1'][0].turn).toBe(6);
+  });
+});

--- a/tests/ui/notification-delivery.test.ts
+++ b/tests/ui/notification-delivery.test.ts
@@ -1,32 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { createNotificationDelivery } from '@/ui/notification-delivery';
-import type { GameState } from '@/core/types';
-
-function makeState(overrides: Partial<GameState> = {}): GameState {
-  return {
-    turn: 6,
-    currentPlayer: 'p1',
-    idCounters: {},
-    civilizations: {
-      p1: { isHuman: true } as any,
-      p2: { isHuman: true } as any,
-      ai1: { isHuman: false } as any,
-    },
-    notificationLog: {},
-    pendingEvents: {},
-    ...overrides,
-  } as unknown as GameState;
-}
-
-function make(state: GameState, suppressed = false) {
-  const toast = vi.fn();
-  const delivery = createNotificationDelivery({
-    getState: () => state,
-    toast,
-    isSuppressed: () => suppressed,
-  });
-  return { delivery, toast };
-}
+import { describe, it, expect } from 'vitest';
+import { makeState, make } from './helpers/notification-state';
 
 describe('notification delivery contract', () => {
   it('toasts and logs for the active unsuppressed viewer', () => {

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -9,14 +9,12 @@ import {
   routeCombatResolved,
   routeDroppedProductionItem,
   routeEconomyTreasuryStrain,
-  queueFirstContactPendingEvents,
   routeLegendaryWonder,
   routeFactionTransition,
   routeFirstContact,
   routePeaceMade,
   routePeaceRequested,
   routeWarDeclared,
-  queueStrategicWarningPendingEvent,
   routeStrategicWarning,
   routeCrisisStarted,
   routeCrisisSpread,
@@ -77,31 +75,6 @@ describe('notification routing', () => {
       type: 'warning',
       target,
     }]);
-  });
-
-  it('persists the same safe strategic warning row for a hot-seat handoff', () => {
-    const state = makeState({ pendingEvents: {} } as Partial<GameState>);
-    const target = { kind: 'map' as const, coord: { q: 4, r: 2 }, label: 'Ravenna' };
-
-    queueStrategicWarningPendingEvent(state, {
-      viewerId: 'p2',
-      actorId: 'rome',
-      actorName: 'Roman',
-      warningKey: 'p2:rome:mobilizing:4,2',
-      kind: 'mobilizing',
-      evidence: 'visible',
-      targetLabel: 'Ravenna',
-      target,
-      playAudio: true,
-    });
-
-    expect(state.pendingEvents?.p2).toEqual([{
-      type: 'ai:strategic-warning',
-      message: 'A Roman force is gathering against Ravenna. Reinforce the city, disrupt the rally, or seek peace.',
-      turn: state.turn,
-      target,
-    }]);
-    expect(state.pendingEvents?.p1).toBeUndefined();
   });
 
   it('war-declared writes to both attacker and defender logs', () => {
@@ -249,19 +222,6 @@ describe('notification routing', () => {
     }, sink);
 
     expect(calls).toEqual([]);
-  });
-
-  it('first-contact queues hot-seat notable events for both players', () => {
-    const state = makeState({ pendingEvents: {} } as Partial<GameState>);
-
-    queueFirstContactPendingEvents(state, 'p1', 'p2');
-
-    expect(state.pendingEvents?.p1).toEqual([
-      expect.objectContaining({ type: 'first-contact', message: expect.stringMatching(/Encountered Bob/i), turn: state.turn }),
-    ]);
-    expect(state.pendingEvents?.p2).toEqual([
-      expect.objectContaining({ type: 'first-contact', message: expect.stringMatching(/Encountered Alice/i), turn: state.turn }),
-    ]);
   });
 
   it('combat-resolved writes to the defender owner log even when current player is a third civ', () => {


### PR DESCRIPTION
## Summary

Implements MR2 (notification delivery contract) and MR3 (diplomacy consent + war visibility) from the playtest bug arc (index #559), fixing both reported symptoms directly.

**MR2 — one delivery contract instead of three ad-hoc mechanisms:**
- New `src/ui/notification-delivery.ts`: logs to the recipient civ always, toasts only when that civ is the active unsuppressed viewer, queues to `pendingEvents` (hot-seat only) otherwise — drained by the existing turn-handoff summary.
- Both round-commit sites (solo `endTurn`, hot-seat `runCompletedRoundSimulation`) now stamp events with the turn the round belonged to, not the turn after.
- Migrated every consequence listener off `showNotification`'s emit-time `currentPlayer` attribution onto explicit per-recipient delivery — this was the actual leak (hot seat) and staleness (solo) bug.
- Removed three now-redundant manual `pendingEvents` queue calls that duplicated what the delivery contract already does automatically.

**MR3 — AI can no longer sign a treaty with a human without consent:**
- Renamed the misleadingly-named `proposeTreaty` → `signTreaty` (it signed instantly, no consent step).
- New pending treaty proposal pipeline (mirrors the existing peace-request mechanic): `enqueueTreatyProposal`, extended `acceptDiplomaticRequest`/`rejectDiplomaticRequest`, 10-turn expiry.
- AI's treaty decisions now enqueue a proposal instead of instant-signing when the target is human; AI↔AI treaties are unaffected.
- Diplomacy panel: incoming proposals get Accept/Decline buttons; every at-war civ row shows "At war since turn N — reason"; added a "Break Treaty" affordance (two-click in-panel confirm, no `window.confirm` per this repo's mobile-first convention) since pre-#554 saves may already carry unconsented treaties that stay signed by design.

## Review fixes (two full pre-merge passes across balance, AI, hot-seat, UI/UX, architecture, saves)

- **Suppressed the generic treaty action while an identical proposal is already pending** for a civ (mirrors the existing `request_peace` suppression) — without this, a player could trigger their own instant-sign path while an unrelated incoming proposal of the same type sat unresolved, leaving a stale, already-fulfilled proposal row behind.
- Verified the AI's "re-propose after decline" behavior mirrors the already-shipped peace-request system's identical behavior by design (not a new regression) — `enqueueTreatyProposal`'s dedupe happens before the notification emit, so a *pending* offer never spams, only a *declined-then-reconsidered* one can recur, same as peace requests today.
- Confirmed `civilization-elimination-system.ts`'s `pendingDiplomacyRequests` scrub is generic (by civ id, not request type) — treaty proposals get cleaned up correctly when a civ is eliminated, no code change needed.
- Confirmed no other exhaustive switch/consumer of `PendingDiplomaticRequest.type` needed updating for the new `'treaty'` variant.

## Test plan

- [x] `yarn build` (tsc + vite) — clean
- [x] `yarn test` — 6104 passed, 3 skipped, 0 failed
- [x] Delivery-contract matrix: active viewer, hot-seat non-current human, suppressed presentation, solo, AI recipients, turn stamping (+ throw-safety)
- [x] Named regressions: hot-seat leak (previous player's event never toasts on next player's screen), solo staleness (never accumulates `pendingEvents`)
- [x] Treaty consent matrix: enqueue, dedupe, bilateral accept, recipient-only accept, no-penalty decline, expiry
- [x] AI regression: never writes a treaty into a human's state without consent; still signs AI↔AI instantly
- [x] Diplomacy panel: proposal render + accept/decline click-through, war-attribution row (with and without a recorded event, for legacy saves), third-party/proposer visibility negative tests, break-treaty two-click confirm
- [x] Save compatibility: legacy peace-only pending requests and solo saves with stale `pendingEvents` handled without throwing

No schema-breaking changes — old saves load and play identically except for the corrected notification timing/routing and (by design) still-honored pre-#554 treaties, which the new Break Treaty button can now unwind if the player chooses.

Closes #551
Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)