### PR TITLE
fix(audio): recover suspended desktop audio after campaign load

### DIFF
--- a/src/audio/audio-system.ts
+++ b/src/audio/audio-system.ts
@@ -84,6 +84,7 @@ export class AudioSystem {
     this.pirateAudioDirector.start(bus);
     routeSfxComponents(this.mixer, this.loader, () => this.isPresentationSuppressed());
     this.armIosResume();
+    this.resumeAndDisarmGestureOnSuccess();
 
     void this.preloadForEra(state.era, this.currentCivType);
     void this.preloadSfx();
@@ -512,28 +513,41 @@ export class AudioSystem {
     );
   }
 
-  private async tryResume(): Promise<void> {
-    if (this.ctx.state === 'suspended') {
+  private async tryResume(): Promise<boolean> {
+    if (this.ctx.state === 'running') return true;
+    if (this.ctx.state !== 'suspended') return false;
+    try {
       await this.ctx.resume();
+    } catch {
+      return false;
     }
+    return (this.ctx.state as AudioContextState) === 'running';
+  }
+
+  private resumeAndDisarmGestureOnSuccess(): void {
+    void this.tryResume().then(resumed => {
+      if (resumed) this.disarmGestureResume();
+    });
+  }
+
+  private disarmGestureResume(): void {
+    if (!this.gestureResumeHandler || typeof document === 'undefined') return;
+    document.removeEventListener('pointerdown', this.gestureResumeHandler);
+    this.gestureResumeHandler = null;
   }
 
   private armIosResume(): void {
     if (typeof document === 'undefined') return;
 
     // Existing visibilitychange handler covers iOS background/foreground resume.
-    const visHandler = () => void this.tryResume();
+    const visHandler = () => this.resumeAndDisarmGestureOnSuccess();
     this.iosResumeListeners.push(visHandler);
     document.addEventListener('visibilitychange', visHandler);
 
     // Gesture resume: AudioContext created before the first user interaction is
-    // suspended by the browser. A single pointerdown unlocks it; remove the
-    // listener immediately after so it does not fire on every tap.
-    this.gestureResumeHandler = () => {
-      void this.tryResume();
-      document.removeEventListener('pointerdown', this.gestureResumeHandler!);
-      this.gestureResumeHandler = null;
-    };
+    // suspended by the browser. Keep retrying on pointerdown until an awaited
+    // resume attempt confirms that the context is running.
+    this.gestureResumeHandler = () => this.resumeAndDisarmGestureOnSuccess();
     document.addEventListener('pointerdown', this.gestureResumeHandler);
   }
 
@@ -543,10 +557,7 @@ export class AudioSystem {
       document.removeEventListener('visibilitychange', handler);
     }
     this.iosResumeListeners = [];
-    if (this.gestureResumeHandler) {
-      document.removeEventListener('pointerdown', this.gestureResumeHandler);
-      this.gestureResumeHandler = null;
-    }
+    this.disarmGestureResume();
   }
 
   private preloadSfx(): Promise<void> {

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -454,6 +454,22 @@ describe('AudioSystem integration', () => {
     expect(doc.listenerCount('pointerdown')).toBe(0);
   });
 
+  it('keeps gesture recovery armed when resume resolves without entering the running state', async () => {
+    const doc = makeMockDocument();
+    vi.stubGlobal('document', doc);
+    ctx.resume.mockImplementationOnce(() => Promise.resolve());
+
+    system.start(makeState({ era: 3 }), busHelper.bus);
+    await flushPromises();
+    expect(ctx.state).toBe('suspended');
+    expect(doc.listenerCount('pointerdown')).toBe(1);
+
+    doc.dispatch('pointerdown');
+    await flushPromises();
+    expect(ctx.state).toBe('running');
+    expect(doc.listenerCount('pointerdown')).toBe(0);
+  });
+
   it('does not duplicate recovery hooks when hot-seat audio rebinds after a failed resume', async () => {
     const doc = makeMockDocument();
     vi.stubGlobal('document', doc);

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -187,6 +187,9 @@ describe('AudioSystem integration', () => {
   ) => {
     const state = makeState({ turn: 9, ...(overrides as Partial<GameState>) });
     ctx.state = contextState;
+    if (contextState === 'suspended') {
+      ctx.resume.mockRejectedValueOnce(new Error('not activated'));
+    }
     system.start(state, busHelper.bus, () => state, () => !presentationAllowed);
     await flushPromises();
     ctx.clearTranscript();

--- a/tests/audio/audio-system.integration.test.ts
+++ b/tests/audio/audio-system.integration.test.ts
@@ -40,6 +40,24 @@ function makeEventBus() {
   return { bus: bus as unknown as EventBus, listeners, emit: bus.emit };
 }
 
+function makeMockDocument() {
+  const listeners = new Map<string, Set<() => void>>();
+  return {
+    addEventListener: vi.fn((event: string, listener: () => void) => {
+      const handlers = listeners.get(event) ?? new Set<() => void>();
+      handlers.add(listener);
+      listeners.set(event, handlers);
+    }),
+    removeEventListener: vi.fn((event: string, listener: () => void) => {
+      listeners.get(event)?.delete(listener);
+    }),
+    dispatch(event: string): void {
+      for (const listener of listeners.get(event) ?? []) listener();
+    },
+    listenerCount: (event: string) => listeners.get(event)?.size ?? 0,
+  };
+}
+
 describe('AudioSystem integration', () => {
   let ctx: MockAudioContext;
   let system: AudioSystem;
@@ -415,6 +433,48 @@ describe('AudioSystem integration', () => {
     expect(registered).toContain('pointerdown');
 
     vi.unstubAllGlobals();
+  });
+
+  it('keeps the solo-load gesture recovery armed after resume rejects, then disarms after a later successful gesture', async () => {
+    const doc = makeMockDocument();
+    vi.stubGlobal('document', doc);
+    ctx.resume.mockRejectedValueOnce(new Error('not activated'));
+
+    system.start(makeState({ era: 3 }), busHelper.bus);
+    await flushPromises();
+    expect(ctx.state).toBe('suspended');
+    expect(doc.listenerCount('pointerdown')).toBe(1);
+
+    doc.dispatch('pointerdown');
+    await flushPromises();
+    expect(ctx.state).toBe('running');
+    expect(doc.listenerCount('pointerdown')).toBe(0);
+  });
+
+  it('does not duplicate recovery hooks when hot-seat audio rebinds after a failed resume', async () => {
+    const doc = makeMockDocument();
+    vi.stubGlobal('document', doc);
+    ctx.resume.mockRejectedValueOnce(new Error('not activated'));
+
+    system.start(makeState({ era: 2, currentPlayer: 'rome' }), busHelper.bus);
+    await flushPromises();
+    system.start(makeState({ era: 2, currentPlayer: 'egypt' }), busHelper.bus);
+
+    expect(doc.listenerCount('pointerdown')).toBe(1);
+    expect(doc.listenerCount('visibilitychange')).toBe(1);
+  });
+
+  it('removes audio recovery hooks when disposed after a failed resume', async () => {
+    const doc = makeMockDocument();
+    vi.stubGlobal('document', doc);
+    ctx.resume.mockRejectedValueOnce(new Error('not activated'));
+
+    system.start(makeState(), busHelper.bus);
+    await flushPromises();
+    system.dispose();
+
+    expect(doc.listenerCount('pointerdown')).toBe(0);
+    expect(doc.listenerCount('visibilitychange')).toBe(0);
   });
 
   it('plays natural wonder discovery through the public audio system method', async () => {


### PR DESCRIPTION
## Summary

- make shared `AudioContext` recovery report whether the context actually reached the running state
- keep pointer recovery armed after rejected or incomplete resume attempts and disarm it only after confirmed success
- preserve exactly one visibility and pointer recovery hook across hot-seat campaign rebinds
- clean up both recovery hooks on disposal
- add focused solo-load, incomplete-resume, hot-seat deduplication, and disposal regressions

## Root cause

The `AudioContext` is created during application bootstrap, while campaign audio starts only after asynchronous save loading. In the macOS Tauri/WKWebView flow, the load click's activation can end before the existing pointer recovery listener is attached. The old listener also removed itself immediately after its first resume attempt, even if that attempt rejected or left the context suspended, permanently silencing the campaign.

## Inline review

- **Gameplay balance, fun, mechanics, ages 7–43, play styles, difficulty, and AI:** no gameplay rules, pacing, difficulty behavior, or computer-player decisions change. The fix restores existing audio feedback consistently for every player profile.
- **UI and UX:** no controls or flows change. Existing mute and volume settings remain authoritative; recovery is automatic and does not add platform-specific UI.
- **Architecture and extensibility:** recovery remains in the shared `AudioSystem` with one resume-and-cleanup path used by startup, visibility, and pointer recovery. No Tauri-specific branch was introduced.
- **Data and saved games:** no `GameState`, save schema, migrations, or persisted-setting semantics change. Existing saves remain compatible.
- **Music, SFX, voice, and stingers:** mixer routing and assets are unchanged. The lifecycle fix restores all existing channels together.
- **Solo and hot-seat:** regression coverage proves failed-then-successful solo recovery, incomplete recovery retry, listener deduplication across hot-seat rebinds, and cleanup after failure.
- **Implementation and regressions:** the complete `origin/main...HEAD` diff contains only `AudioSystem` lifecycle code and its mirrored integration tests.

## Verification

- `bash scripts/run-with-mise.sh yarn test --run tests/audio/audio-system.integration.test.ts` — 40 passed
- `scripts/check-src-rule-violations.sh src/audio/audio-system.ts` — passed
- `bash scripts/run-with-mise.sh yarn test` — 383 files passed; 6,108 tests passed; 3 skipped
- `bash scripts/run-with-mise.sh yarn build` — passed; generated assets retain `/conquestoria/` paths
- `bash scripts/run-with-mise.sh yarn build:tauri` — passed; generated assets use relative `./assets/` paths
- committed and uncommitted diffs reviewed; working tree clean

Closes #550
