### PR TITLE
feat(trade): city panel Trade Routes section + shared extraction (#553 MR4/4)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1271,6 +1271,8 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
     },
     onClose: () => {},
     onTip: (message) => { showNotification(message, 'info'); },
+    onSelectUnit: (unitId) => selectUnit(unitId),
+    onEstablishRoute: handleEstablishRoute,
     onPrevCity: () => {
       const cities = currentCiv().cities;
       if (cities.length <= 1) return;
@@ -1841,6 +1843,23 @@ function openNetworkIntentPanel(sourceUnitId: string): void {
   uiLayer.appendChild(panel);
 }
 
+// Trade Routes Overhaul (#553 MR4/4) — extracted so the City panel's Trade Routes
+// section and selected-unit-info's Establish Route button trigger the exact same code
+// path (per ui-panels.md's Extracted UI Flows rule), not two copies that could drift.
+function handleEstablishRoute(caravanId: string): void {
+  openEstablishRoutePanel(uiLayer, gameState, caravanId, (toCityId) => {
+    const resourceDiversity = getCivAvailableResources(gameState, gameState.currentPlayer).size;
+    const routeResult = establishQuestAwareRoute(gameState, caravanId, toCityId, resourceDiversity);
+    gameState = routeResult.state;
+    emitMinorCivQuestTransitions(bus, routeResult.questTransitions, gameState);
+    bus.emit('trade:route-created', { route: routeResult.route });
+    renderLoop.setGameState(gameState);
+    updateHUD();
+    selectUnit(caravanId);
+    showNotification('Trade route established!', 'success');
+  });
+}
+
 function selectUnit(
   unitId: string,
   opts?: {
@@ -2156,19 +2175,7 @@ function selectUnit(
         updateHUD();
         showNotification('Expedition planted a flag! Outpost completes in 2 turns.', 'success');
       },
-      onEstablishRoute: (caravanId) => {
-        openEstablishRoutePanel(uiLayer, gameState, caravanId, (toCityId) => {
-          const resourceDiversity = getCivAvailableResources(gameState, gameState.currentPlayer).size;
-          const routeResult = establishQuestAwareRoute(gameState, caravanId, toCityId, resourceDiversity);
-          gameState = routeResult.state;
-          emitMinorCivQuestTransitions(bus, routeResult.questTransitions, gameState);
-          bus.emit('trade:route-created', { route: routeResult.route });
-          renderLoop.setGameState(gameState);
-          updateHUD();
-          selectUnit(caravanId);
-          showNotification('Trade route established!', 'success');
-        });
-      },
+      onEstablishRoute: handleEstablishRoute,
       onReplaceImprovement: (action) => {
         if (!selectedUnitId) return;
         const unit = gameState.units[selectedUnitId];

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -9,7 +9,7 @@ import {
   getProductionIconForItem,
 } from '@/systems/city-system';
 import { getCivAvailableResources, getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
-import { RESOURCE_DEFINITIONS, getRouteCapacity } from '@/systems/trade-system';
+import { RESOURCE_DEFINITIONS, getRouteCapacity, resolveFromCity } from '@/systems/trade-system';
 import { getResourceEffectLabel } from '@/systems/resource-definitions';
 import { getResourceAdvantagesForItem, getResourceAdvantageMultiplier } from '@/systems/resource-advantages';
 import { SESSION_SHOWN_TIPS } from '@/ui/advisor-system';
@@ -456,11 +456,16 @@ export function createCityPanel(
   const tradeRouteCapacity = showTradeRoutes ? getRouteCapacity(state, city.id) : 0;
   const outgoingTradeRoutes = showTradeRoutes ? getOutgoingRoutesForCity(state, city.id) : [];
   const tradeRouteRemainingCapacity = Math.max(0, tradeRouteCapacity - outgoingTradeRoutes.length);
-  // Idle trade unit check is empire-wide (matches basic-ai.ts/ROLE_OVERRIDES' generic
-  // hasAITradeRole check), not city-scoped — a trade unit built anywhere can establish a
-  // route from any city with capacity.
+  // Idle trade unit check is scoped to units that would actually resolve to THIS city
+  // via resolveFromCity (nearest city with capacity) — not just any owned idle trade
+  // unit anywhere. Without this, an "Establish Route" button shown in city A's panel
+  // could silently consume city B's capacity slot instead (whichever city
+  // resolveFromCity picks as nearest to that unit), which is confusing: the panel's
+  // capacity/action affordances must stay locally coherent to the city actually open.
   const idleTradeUnits = showTradeRoutes
-    ? Object.values(state.units).filter(u => u.owner === city.owner && hasAITradeRole(u.type) && !u.committedToRouteId)
+    ? Object.values(state.units).filter(u =>
+        u.owner === city.owner && hasAITradeRole(u.type) && !u.committedToRouteId
+        && resolveFromCity(state, u)?.id === city.id)
     : [];
   // Derived from getTrainableUnitsForCity (the same city-aware eligibility helper used
   // for the Build tab above) filtered to trade-role units — naturally offers Naval

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -9,12 +9,14 @@ import {
   getProductionIconForItem,
 } from '@/systems/city-system';
 import { getCivAvailableResources, getCivHappinessFromResources } from '@/systems/resource-acquisition-system';
-import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
+import { RESOURCE_DEFINITIONS, getRouteCapacity } from '@/systems/trade-system';
 import { getResourceEffectLabel } from '@/systems/resource-definitions';
 import { getResourceAdvantagesForItem, getResourceAdvantageMultiplier } from '@/systems/resource-advantages';
 import { SESSION_SHOWN_TIPS } from '@/ui/advisor-system';
 import { hexDistance, wrappedHexDistance } from '@/systems/hex-utils';
 import { createGameButton } from './ui-kit';
+import { hasAITradeRole } from '@/ai/ai-unit-roles';
+import { buildCityRouteRows, getOutgoingRoutesForCity } from './trade-route-presentation';
 import {
   getActiveNationalProjectsForCiv,
   getNationalProjectMultiplier,
@@ -68,6 +70,11 @@ export interface CityPanelCallbacks {
   onPrevCity?: () => void;
   onNextCity?: () => void;
   onUpgradeUnit?: (unitId: string) => void;
+  /** Selects a unit (e.g. clicking a committed trade route row). */
+  onSelectUnit?: (unitId: string) => void;
+  /** Opens the destination-city picker for an idle trade unit — same path as
+   *  selected-unit-info.ts's Establish Route button. */
+  onEstablishRoute?: (caravanId: string) => void;
   onSetIdleProduction?: (cityId: string, mode: 'gold' | 'science' | null) => void;
   onRushBuyActiveProduction?: (cityId: string) => GameState | void;
   onAppeaseFaction?: (cityId: string) => GameState | void;
@@ -441,6 +448,27 @@ export function createCityPanel(
   const completedTechs = currentCiv.techState.completed;
   const availableUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, playerResources);
 
+  // Trade Routes Overhaul (#553 MR4/4) — City panel Trade Routes section. Gated behind
+  // the same 'trade-routes' tech marketplace-panel.ts already uses. Scoped to this
+  // city's own outgoing routes only (fromCityId === city.id) — never derives ownership
+  // from a second computation, per ui-panels.md's Cities[0] Is Never The Answer rule.
+  const showTradeRoutes = completedTechs.includes('trade-routes');
+  const tradeRouteCapacity = showTradeRoutes ? getRouteCapacity(state, city.id) : 0;
+  const outgoingTradeRoutes = showTradeRoutes ? getOutgoingRoutesForCity(state, city.id) : [];
+  const tradeRouteRemainingCapacity = Math.max(0, tradeRouteCapacity - outgoingTradeRoutes.length);
+  // Idle trade unit check is empire-wide (matches basic-ai.ts/ROLE_OVERRIDES' generic
+  // hasAITradeRole check), not city-scoped — a trade unit built anywhere can establish a
+  // route from any city with capacity.
+  const idleTradeUnits = showTradeRoutes
+    ? Object.values(state.units).filter(u => u.owner === city.owner && hasAITradeRole(u.type) && !u.committedToRouteId)
+    : [];
+  // Derived from getTrainableUnitsForCity (the same city-aware eligibility helper used
+  // for the Build tab above) filtered to trade-role units — naturally offers Naval
+  // Trader for coastal cities and stays generic as new trade lines are added.
+  const eligibleTradeUnitTypes = showTradeRoutes
+    ? availableUnits.filter(u => hasAITradeRole(u.type))
+    : [];
+
   // Locked items: tech met + resource NOT met (tech-missing items stay hidden entirely)
   const allTechUnlockedUnits = getTrainableUnitsForCity(city, completedTechs, state.map, currentCiv.civType, undefined);
   const lockedUnits = allTechUnlockedUnits.filter(u => !availableUnits.some(a => a.type === u.type));
@@ -715,6 +743,7 @@ export function createCityPanel(
       <span>Net treasury: ${economyStatus.netGoldPerTurn >= 0 ? '+' : ''}${economyStatus.netGoldPerTurn}/turn</span>
       ${economyStatus.strainLevel !== 'none' ? '<span style="color:#d9a25c;" data-text="economy-strain"></span>' : ''}
     </div>
+    ${showTradeRoutes ? '<div data-section="trade-routes" style="background:rgba(255,255,255,0.06);border-radius:8px;padding:10px 12px;margin-bottom:16px;"></div>' : ''}
     ${immunitySectionHtml}
     ${spreadWarningHtml}
     ${unrestSectionHtml}
@@ -918,6 +947,66 @@ export function createCityPanel(
   });
 
   container.appendChild(panel);
+
+  // Trade Routes Overhaul (#553 MR4/4) — populate the Trade Routes section placeholder.
+  // Built with real DOM nodes (textContent-safe) rather than an HTML string, sharing
+  // buildCityRouteRows with marketplace-panel.ts so the route rows never drift.
+  if (showTradeRoutes) {
+    const tradeSection = panel.querySelector<HTMLElement>('[data-section="trade-routes"]');
+    if (tradeSection) {
+      const heading = document.createElement('div');
+      heading.textContent = 'Trade Routes';
+      heading.style.cssText = 'font-size:13px;font-weight:bold;color:#e8c170;margin-bottom:6px;';
+      tradeSection.appendChild(heading);
+
+      const helpText = document.createElement('div');
+      helpText.textContent = 'Trade routes earn gold every turn. Train a trade unit, then use Establish Route to start one.';
+      helpText.style.cssText = 'font-size:11px;opacity:0.7;margin-bottom:8px;';
+      tradeSection.appendChild(helpText);
+
+      const routeRows = buildCityRouteRows(state, city.id, callbacks.onSelectUnit);
+      if (routeRows) {
+        tradeSection.appendChild(routeRows);
+      } else {
+        const empty = document.createElement('div');
+        empty.textContent = 'No active routes from this city.';
+        empty.style.cssText = 'font-size:12px;opacity:0.5;padding:4px 0;';
+        tradeSection.appendChild(empty);
+      }
+
+      const capacityLine = document.createElement('div');
+      capacityLine.textContent = `Route capacity: ${outgoingTradeRoutes.length}/${tradeRouteCapacity}`;
+      capacityLine.style.cssText = 'font-size:11px;opacity:0.7;margin-top:6px;';
+      tradeSection.appendChild(capacityLine);
+
+      if (tradeRouteRemainingCapacity > 0) {
+        if (idleTradeUnits.length > 0) {
+          for (const unit of idleTradeUnits) {
+            const row = document.createElement('div');
+            row.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-top:6px;gap:8px;';
+            const label = document.createElement('span');
+            label.style.cssText = 'font-size:12px;';
+            label.textContent = `${UNIT_DEFINITIONS[unit.type]?.name ?? unit.type} ready to establish a route`;
+            row.appendChild(label);
+            if (callbacks.onEstablishRoute) {
+              const btn = createGameButton('Establish Route', 'primary');
+              btn.style.fontSize = '11px';
+              btn.style.padding = '4px 10px';
+              btn.addEventListener('click', () => callbacks.onEstablishRoute!(unit.id));
+              row.appendChild(btn);
+            }
+            tradeSection.appendChild(row);
+          }
+        } else if (eligibleTradeUnitTypes.length > 0) {
+          const prompt = document.createElement('div');
+          const names = eligibleTradeUnitTypes.map(u => u.name).join(', ');
+          prompt.textContent = `Train ${names} to start a new route.`;
+          prompt.style.cssText = 'font-size:11px;color:#d9a25c;margin-top:6px;';
+          tradeSection.appendChild(prompt);
+        }
+      }
+    }
+  }
 
   // Declare ref early so rerenderPanel (below) can cancel the timer via closure.
   const frustrationRef: { timer: ReturnType<typeof setTimeout> | null } = { timer: null };

--- a/src/ui/marketplace-panel.ts
+++ b/src/ui/marketplace-panel.ts
@@ -1,9 +1,10 @@
 import type { GameState, ResourceType } from '@/core/types';
-import { RESOURCE_DEFINITIONS, getEffectiveGoldPerTurn, getRouteCapacity, getRouteTechGoldBonus } from '@/systems/trade-system';
+import { RESOURCE_DEFINITIONS } from '@/systems/trade-system';
 import { getCivAvailableResources, canBuyResourceAccess, getResourceAccessCost } from '@/systems/resource-acquisition-system';
 import { isAtWar } from '@/systems/diplomacy-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
 import { createGameButton } from './ui-kit';
+import { buildPlayerRouteListSection } from './trade-route-presentation';
 
 interface MarketplaceCallbacks {
   onClose: () => void;
@@ -177,7 +178,7 @@ export function createMarketplacePanel(
   // Build route list via DOM (XSS-safe, uses new TradeRoute shape)
   const routesSection = panel.querySelector('#mp-routes-section');
   if (routesSection) {
-    routesSection.appendChild(buildRouteListSection(state, state.currentPlayer, callbacks.onSelectUnit));
+    routesSection.appendChild(buildPlayerRouteListSection(state, state.currentPlayer, callbacks.onSelectUnit));
   }
 
   // Known Civs section (Diplomatic Marketplace — S9, trade-routes tech gated)
@@ -204,75 +205,6 @@ function renderSparkline(history: number[]): string {
     const idx = Math.floor(((v - min) / range) * (bars.length - 1));
     return bars[idx];
   }).join('');
-}
-
-function buildRouteListSection(state: GameState, currentPlayer: string, onSelectUnit?: (unitId: string) => void): HTMLElement {
-  const wrapper = document.createElement('div');
-
-  const heading = document.createElement('div');
-  heading.textContent = 'Active Trade Routes';
-  heading.style.cssText = 'font-size:14px;color:#e8c170;margin-bottom:8px;';
-  wrapper.appendChild(heading);
-
-  const playerRoutes = (state.marketplace?.tradeRoutes ?? []).filter(r => {
-    const city = state.cities[r.fromCityId];
-    return city?.owner === currentPlayer;
-  });
-
-  if (playerRoutes.length === 0) {
-    const empty = document.createElement('div');
-    empty.textContent = 'No active routes. Train a Caravan to establish one.';
-    empty.style.cssText = 'font-size:12px;opacity:0.5;text-align:center;padding:16px 0;';
-    wrapper.appendChild(empty);
-    return wrapper;
-  }
-
-  // Group by fromCityId
-  const groups = new Map<string, typeof playerRoutes>();
-  for (const route of playerRoutes) {
-    const arr = groups.get(route.fromCityId) ?? [];
-    arr.push(route);
-    groups.set(route.fromCityId, arr);
-  }
-
-  for (const [cityId, routes] of groups) {
-    const city = state.cities[cityId];
-    if (!city) continue;
-    const total = getRouteCapacity(state, cityId);
-    const used  = routes.length;
-
-    const cityHeader = document.createElement('div');
-    cityHeader.style.cssText = 'font-size:13px;color:#e8c170;margin:10px 0 4px;';
-    cityHeader.appendChild(document.createTextNode(`${city.name}  (${used}/${total} slots)`));
-    wrapper.appendChild(cityHeader);
-
-    for (const route of routes) {
-      const toCity = state.cities[route.toCityId];
-      const committedUnit = Object.values(state.units).find(u => u.committedToRouteId === route.id);
-      const tripsLeft = committedUnit?.tripsRemaining ?? '?';
-      const gold = getEffectiveGoldPerTurn(route, getRouteTechGoldBonus(state, route));
-
-      const row = document.createElement('div');
-      row.style.cssText = 'font-size:12px;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;justify-content:space-between;min-height:44px;align-items:center;';
-      if (committedUnit && onSelectUnit) {
-        row.style.cursor = 'pointer';
-        row.addEventListener('click', () => onSelectUnit(committedUnit.id));
-      }
-
-      const routeLabel = document.createElement('span');
-      routeLabel.appendChild(document.createTextNode(`${city.name} → ${toCity?.name ?? route.toCityId}`));
-      row.appendChild(routeLabel);
-
-      const routeDetail = document.createElement('span');
-      routeDetail.style.cssText = 'font-size:11px;color:#6b9b4b;';
-      routeDetail.appendChild(document.createTextNode(`+${gold.toFixed(1)} gold/turn · ${tripsLeft} trips`));
-      row.appendChild(routeDetail);
-
-      wrapper.appendChild(row);
-    }
-  }
-
-  return wrapper;
 }
 
 /**

--- a/src/ui/trade-route-presentation.ts
+++ b/src/ui/trade-route-presentation.ts
@@ -1,0 +1,124 @@
+import type { GameState, TradeRoute, City } from '@/core/types';
+import { getEffectiveGoldPerTurn, getRouteCapacity, getRouteTechGoldBonus } from '@/systems/trade-system';
+
+// Trade Routes Overhaul (#553 MR4/4) — shared route-list rendering, extracted from
+// marketplace-panel.ts's original inline buildRouteListSection so the Marketplace panel
+// and the City panel's new Trade Routes section render identically instead of drifting.
+
+function renderRouteRow(
+  state: GameState,
+  fromCity: City,
+  route: TradeRoute,
+  onSelectUnit?: (unitId: string) => void,
+): HTMLElement {
+  const toCity = state.cities[route.toCityId];
+  const committedUnit = Object.values(state.units).find(u => u.committedToRouteId === route.id);
+  const tripsLeft = committedUnit?.tripsRemaining ?? '?';
+  const gold = getEffectiveGoldPerTurn(route, getRouteTechGoldBonus(state, route));
+
+  const row = document.createElement('div');
+  row.style.cssText = 'font-size:12px;padding:6px 0;border-bottom:1px solid rgba(255,255,255,0.08);display:flex;justify-content:space-between;min-height:44px;align-items:center;';
+  if (committedUnit && onSelectUnit) {
+    row.style.cursor = 'pointer';
+    row.addEventListener('click', () => onSelectUnit(committedUnit.id));
+  }
+
+  const routeLabel = document.createElement('span');
+  routeLabel.appendChild(document.createTextNode(`${fromCity.name} → ${toCity?.name ?? route.toCityId}`));
+  row.appendChild(routeLabel);
+
+  const routeDetail = document.createElement('span');
+  routeDetail.style.cssText = 'font-size:11px;color:#6b9b4b;';
+  routeDetail.appendChild(document.createTextNode(`+${gold.toFixed(1)} gold/turn · ${tripsLeft} trips`));
+  row.appendChild(routeDetail);
+
+  return row;
+}
+
+/**
+ * Builds the "Active Trade Routes" section for the Marketplace panel: every route the
+ * player owns (as fromCityId), grouped by origin city, across the whole civilization.
+ */
+export function buildPlayerRouteListSection(
+  state: GameState,
+  currentPlayer: string,
+  onSelectUnit?: (unitId: string) => void,
+): HTMLElement {
+  const wrapper = document.createElement('div');
+
+  const heading = document.createElement('div');
+  heading.textContent = 'Active Trade Routes';
+  heading.style.cssText = 'font-size:14px;color:#e8c170;margin-bottom:8px;';
+  wrapper.appendChild(heading);
+
+  const playerRoutes = (state.marketplace?.tradeRoutes ?? []).filter(r => {
+    const city = state.cities[r.fromCityId];
+    return city?.owner === currentPlayer;
+  });
+
+  if (playerRoutes.length === 0) {
+    const empty = document.createElement('div');
+    empty.textContent = 'No active routes. Train a Caravan to establish one.';
+    empty.style.cssText = 'font-size:12px;opacity:0.5;text-align:center;padding:16px 0;';
+    wrapper.appendChild(empty);
+    return wrapper;
+  }
+
+  // Group by fromCityId
+  const groups = new Map<string, typeof playerRoutes>();
+  for (const route of playerRoutes) {
+    const arr = groups.get(route.fromCityId) ?? [];
+    arr.push(route);
+    groups.set(route.fromCityId, arr);
+  }
+
+  for (const [cityId, routes] of groups) {
+    const city = state.cities[cityId];
+    if (!city) continue;
+    const total = getRouteCapacity(state, cityId);
+    const used  = routes.length;
+
+    const cityHeader = document.createElement('div');
+    cityHeader.style.cssText = 'font-size:13px;color:#e8c170;margin:10px 0 4px;';
+    cityHeader.appendChild(document.createTextNode(`${city.name}  (${used}/${total} slots)`));
+    wrapper.appendChild(cityHeader);
+
+    for (const route of routes) {
+      wrapper.appendChild(renderRouteRow(state, city, route, onSelectUnit));
+    }
+  }
+
+  return wrapper;
+}
+
+/**
+ * Returns the routes originating from a single city (fromCityId === cityId only — a
+ * route where this city is the destination is not this city's outgoing route). Used by
+ * the City panel's Trade Routes section, scoped to whichever city is currently open.
+ */
+export function getOutgoingRoutesForCity(state: GameState, cityId: string): TradeRoute[] {
+  return (state.marketplace?.tradeRoutes ?? []).filter(r => r.fromCityId === cityId);
+}
+
+/**
+ * Builds the route rows for a single city (no grouping header — the caller already
+ * knows which city is open). Returns null when there are no outgoing routes so callers
+ * can render their own empty-state copy.
+ */
+export function buildCityRouteRows(
+  state: GameState,
+  cityId: string,
+  onSelectUnit?: (unitId: string) => void,
+): HTMLElement | null {
+  const city = state.cities[cityId];
+  if (!city) return null;
+
+  const routes = getOutgoingRoutesForCity(state, cityId);
+  if (routes.length === 0) return null;
+
+  const wrapper = document.createElement('div');
+  for (const route of routes) {
+    wrapper.appendChild(renderRouteRow(state, city, route, onSelectUnit));
+  }
+  return wrapper;
+}

--- a/tests/ui/city-panel-trade-routes.test.ts
+++ b/tests/ui/city-panel-trade-routes.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createCityPanel } from '@/ui/city-panel';
+import { makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
+import type { HexCoord } from '@/core/types';
+
+// Trade Routes Overhaul (#553 MR4/4) — City panel Trade Routes section.
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+function baseCallbacks() {
+  return {
+    onBuild: () => {},
+    onOpenWonderPanel: () => {},
+    onClose: () => {},
+  };
+}
+
+describe('city-panel Trade Routes section', () => {
+  it('is not rendered when trade-routes is not researched', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    // Fixture's default completedTechs (['philosophy', 'sacred-sites']) does not include trade-routes.
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    expect(panel.querySelector('[data-section="trade-routes"]')).toBeNull();
+  });
+
+  it('shows the always-visible help text once trade-routes is researched', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]');
+    expect(section).toBeTruthy();
+    expect(section!.textContent).toContain('Trade routes earn gold every turn.');
+  });
+
+  it('shows "No active routes from this city" and capacity 0/1 when the city has no outgoing routes', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.marketplace = { prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [] };
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).toContain('No active routes from this city.');
+    expect(section.textContent).toContain('Route capacity: 0/1');
+  });
+
+  it('prompts to train Caravan for a land-only (non-coastal) city with tech but no idle trade unit', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.marketplace = { prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [] };
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).toContain('Train Caravan to start a new route.');
+    expect(section.textContent).not.toContain('Naval Trader');
+  });
+
+  it('prompts to train Naval Trader (in addition to Caravan) for a coastal city once colonial-trade is researched', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes', 'colonial-trade');
+    state.marketplace = { prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [] };
+    // Make city's own tile coastal (city-river sits at 2,2 — neighbor 3,2 becomes ocean).
+    const oceanCoord: HexCoord = { q: 3, r: 2 };
+    state.map.tiles['3,2'] = {
+      coord: oceanCoord, terrain: 'ocean', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: null, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).toContain('Naval Trader');
+  });
+
+  it('renders active outgoing routes via the shared trade-route-presentation helper, and shows correct capacity usage', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.cities['city-rival'] = { ...state.cities['city-rival'], owner: 'player', name: 'Ostia' } as never;
+    (state.cities[city.id] as { name: string }).name = 'Rome';
+    state.marketplace = {
+      prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0,
+      tradeRoutes: [{ id: 'route-1', fromCityId: city.id, toCityId: 'city-rival', goldPerTrip: 10, turnsPerTrip: 1 }],
+    };
+    state.units['caravan1'] = {
+      id: 'caravan1', type: 'caravan', owner: 'player', position: { ...city.position },
+      health: 100, movementPointsLeft: 3, committedToRouteId: 'route-1', tripsRemaining: 5,
+    } as never;
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).toContain('Rome → Ostia');
+    expect(section.textContent).toContain('5 trips');
+    expect(section.textContent).toContain('Route capacity: 1/1');
+    expect(section.textContent).not.toContain('No active routes');
+  });
+
+  it('clicking a route row with a committed unit calls onSelectUnit with the unit id', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.cities['city-rival'] = { ...state.cities['city-rival'], owner: 'player', name: 'Ostia' } as never;
+    (state.cities[city.id] as { name: string }).name = 'Rome';
+    state.marketplace = {
+      prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0,
+      tradeRoutes: [{ id: 'route-1', fromCityId: city.id, toCityId: 'city-rival', goldPerTrip: 10, turnsPerTrip: 1 }],
+    };
+    state.units['caravan1'] = {
+      id: 'caravan1', type: 'caravan', owner: 'player', position: { ...city.position },
+      health: 100, movementPointsLeft: 3, committedToRouteId: 'route-1', tripsRemaining: 5,
+    } as never;
+    const onSelectUnit = vi.fn();
+
+    const panel = createCityPanel(container, city, state, { ...baseCallbacks(), onSelectUnit });
+
+    const label = Array.from(panel.querySelectorAll('span')).find(el => el.textContent === 'Rome → Ostia');
+    expect(label).toBeTruthy();
+    label!.parentElement!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onSelectUnit).toHaveBeenCalledWith('caravan1');
+  });
+
+  it('shows an idle trade unit with an Establish Route button, and clicking it calls the same onEstablishRoute callback path used by selected-unit-info', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.marketplace = { prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [] };
+    state.units['caravan1'] = {
+      id: 'caravan1', type: 'caravan', owner: 'player', position: { ...city.position },
+      health: 100, movementPointsLeft: 3,
+    } as never;
+    const onEstablishRoute = vi.fn();
+
+    const panel = createCityPanel(container, city, state, { ...baseCallbacks(), onEstablishRoute });
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).toContain('ready to establish a route');
+    const btn = Array.from(section.querySelectorAll('button')).find(b => b.textContent === 'Establish Route');
+    expect(btn).toBeTruthy();
+    btn!.click();
+    expect(onEstablishRoute).toHaveBeenCalledWith('caravan1');
+  });
+
+  it('#553 MR4/4 hot-seat regression — a route another civ receives (toCityId) does not show as that civ\'s own outgoing route', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    // Player A's city (city-river) sends a route to rival's city (city-rival).
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.civilizations.rival.techState.completed.push('trade-routes');
+    state.marketplace = {
+      prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0,
+      tradeRoutes: [{ id: 'route-1', fromCityId: city.id, toCityId: 'city-rival', goldPerTrip: 10, turnsPerTrip: 1 }],
+    };
+
+    // Player A's own panel: city-river is fromCityId — shows the route.
+    const panelA = createCityPanel(container, city, state, baseCallbacks());
+    const sectionA = panelA.querySelector('[data-section="trade-routes"]')!;
+    expect(sectionA.textContent).not.toContain('No active routes from this city.');
+
+    document.body.innerHTML = '';
+    const container2 = document.createElement('div');
+    document.body.appendChild(container2);
+
+    // Switch current player to rival and render rival's destination city panel — must
+    // NOT show the route as its own outgoing route (city-rival is toCityId, not
+    // fromCityId).
+    state.currentPlayer = 'rival';
+    const rivalCity = state.cities['city-rival'];
+    const panelB = createCityPanel(container2, rivalCity, state, baseCallbacks());
+    const sectionB = panelB.querySelector('[data-section="trade-routes"]')!;
+    expect(sectionB.textContent).toContain('No active routes from this city.');
+  });
+});

--- a/tests/ui/city-panel-trade-routes.test.ts
+++ b/tests/ui/city-panel-trade-routes.test.ts
@@ -146,6 +146,36 @@ describe('city-panel Trade Routes section', () => {
     expect(onEstablishRoute).toHaveBeenCalledWith('caravan1');
   });
 
+  it('does not offer an "Establish Route" button for an idle trade unit that resolves to a different (nearer) city — the panel must stay locally coherent, not empire-wide', () => {
+    const { container, city, state } = makeWonderPanelFixture();
+    state.civilizations.player.techState.completed.push('trade-routes');
+    state.marketplace = { prices: {}, priceHistory: {}, fashionable: null, fashionTurnsLeft: 0, tradeRoutes: [] };
+    // Second player-owned city, far from city-river, with its own capacity.
+    state.cities['city-far'] = {
+      ...structuredClone(city),
+      id: 'city-far',
+      name: 'Farhaven',
+      position: { q: 5, r: 5 },
+      buildings: [],
+    };
+    state.civilizations.player.cities.push('city-far');
+    // Idle unit sits exactly on city-far's tile — resolveFromCity resolves it to
+    // city-far (path length 1), not city-river (no connected path through the
+    // fixture's sparse tile map).
+    state.units['caravan1'] = {
+      id: 'caravan1', type: 'caravan', owner: 'player', position: { q: 5, r: 5 },
+      health: 100, movementPointsLeft: 3,
+    } as never;
+
+    const panel = createCityPanel(container, city, state, baseCallbacks());
+
+    const section = panel.querySelector('[data-section="trade-routes"]')!;
+    expect(section.textContent).not.toContain('ready to establish a route');
+    expect(Array.from(section.querySelectorAll('button')).find(b => b.textContent === 'Establish Route')).toBeUndefined();
+    // Falls back to the "train a new unit" prompt since no idle unit resolves here.
+    expect(section.textContent).toContain('Train Caravan to start a new route.');
+  });
+
   it('#553 MR4/4 hot-seat regression — a route another civ receives (toCityId) does not show as that civ\'s own outgoing route', () => {
     const { container, city, state } = makeWonderPanelFixture();
     // Player A's city (city-river) sends a route to rival's city (city-rival).

--- a/tests/ui/marketplace-panel.test.ts
+++ b/tests/ui/marketplace-panel.test.ts
@@ -629,4 +629,50 @@ describe('createMarketplacePanel', () => {
       expect(buyBtn.disabled).toBe(true);
     });
   });
+
+  // Trade Routes Overhaul (#553 MR4/4) — extraction regression: buildPlayerRouteListSection
+  // was extracted from an inline function into trade-route-presentation.ts so the City
+  // panel could reuse it. This proves the Marketplace panel still renders identically
+  // through the shared helper, not a frozen inline copy.
+  describe('route list (shared with city-panel via trade-route-presentation.ts)', () => {
+    function buildStateWithRoute(): GameState {
+      const state = buildState({
+        currentPlayer: 'p1',
+        civTechs: ['trade-routes'],
+        cities: {
+          city1: { id: 'city1', name: 'Rome', owner: 'p1', position: { q: 0, r: 0 }, ownedTiles: [], workedTiles: [], buildings: [] },
+          city2: { id: 'city2', name: 'Ostia', owner: 'p1', position: { q: 2, r: 0 }, ownedTiles: [], workedTiles: [], buildings: [] },
+        },
+      });
+      state.marketplace!.tradeRoutes = [
+        { id: 'route-1', fromCityId: 'city1', toCityId: 'city2', goldPerTrip: 10, turnsPerTrip: 1 },
+      ];
+      (state as unknown as { units: Record<string, unknown> }).units = {
+        caravan1: { id: 'caravan1', type: 'caravan', owner: 'p1', committedToRouteId: 'route-1', tripsRemaining: 5 },
+      };
+      (state.civilizations.p1 as unknown as { diplomacy: { relationships: Record<string, unknown> } }).diplomacy = { relationships: {} };
+      return state;
+    }
+
+    it('shows the "Active Trade Routes" heading and the route row for city1 → city2', () => {
+      const state = buildStateWithRoute();
+      createMarketplacePanel(container, state, { onClose: vi.fn() });
+      const panel = document.getElementById('marketplace-panel');
+      expect(panel?.textContent).toContain('Active Trade Routes');
+      expect(panel?.textContent).toContain('Rome → Ostia');
+      expect(panel?.textContent).toContain('5 trips');
+    });
+
+    it('clicking a route row with a committed unit calls onSelectUnit with the unit id', () => {
+      const state = buildStateWithRoute();
+      const onSelectUnit = vi.fn();
+      createMarketplacePanel(container, state, { onClose: vi.fn(), onSelectUnit });
+      const panel = document.getElementById('marketplace-panel')!;
+      const label = Array.from(panel.querySelectorAll('span')).find(el => el.textContent === 'Rome → Ostia');
+      expect(label).toBeTruthy();
+      const row = label!.parentElement!;
+      row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      expect(onSelectUnit).toHaveBeenCalledWith('caravan1');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #553

Final MR of the Trade Routes Overhaul (MR1 #566, MR2 #568, MR3 #569). Extracts `marketplace-panel.ts`'s route-list rendering into a shared `src/ui/trade-route-presentation.ts` module, and adds a Trade Routes section to the City panel so route management is discoverable from the city you're actually managing, not just the Marketplace panel.

- `buildPlayerRouteListSection` (all cities, grouped — used by Marketplace panel) and `buildCityRouteRows` (single city — used by the new City panel section) share one row-rendering helper, so the two panels can never drift.
- City panel section, gated on `civ.techState.completed.includes('trade-routes')` (same gate `marketplace-panel.ts` already uses):
  1. Always-visible plain-language help text.
  2. This city's active outgoing routes (`fromCityId === city.id` only — never a second ownership computation).
  3. Remaining route capacity (`getRouteCapacity` — no new logic).
  4. If capacity > 0: either an **Establish Route** button per idle trade unit, or — if the player has no idle trade unit — a prompt naming the next trainable trade unit for this city's domain situation, derived from `getTrainableUnitsForCity` (the same city-aware eligibility helper the Build tab already uses) filtered to trade-role units via `hasAITradeRole`. This naturally offers Naval Trader for coastal cities and stays generic — no hardcoded unit list, no per-unit-ID branches.
- The Establish Route button calls the **exact same callback** as `selected-unit-info.ts`'s existing button: extracted the inline handler into `main.ts`'s `handleEstablishRoute` and both call sites now reference that one function.
- Hot-seat regression: a route where this city is the *destination* (`toCityId`) does not show as this city's own outgoing route when viewed by the receiving civ — only `fromCityId` routes list.

AI/UI generalization is already complete as of MR1-3 (`ROLE_OVERRIDES` + `hasAITradeRole`) — there was no cleanup task left there, matching this MR's plan.

## Verification note

Reaching the exact live game state (trade-routes tech + coastal city + an idle trade unit) through the multi-screen New Game setup wizard would take many manual steps disproportionate to this change, so I did not complete a full live playthrough. Verified instead via **37 jsdom tests** across `tests/ui/marketplace-panel.test.ts` (extraction regression: route rows + click-to-select still work through the shared helper) and the new `tests/ui/city-panel-trade-routes.test.ts` (9 tests: help text, empty state, land-only vs. coastal "train X" prompts, active-route rendering, click-through row selection, click-through Establish Route button calling the same callback path, and the hot-seat destination-city regression) — these exercise real DOM interactions, not render-only assertions.

## Test plan

- [x] `yarn build` green
- [x] `yarn test` green — 386 test files / 6194 tests
- [x] `tests/ui/marketplace-panel.test.ts`: extraction regression (route list unchanged after delegating to the shared helper)
- [x] `tests/ui/city-panel-trade-routes.test.ts`: section gating, help text, capacity/empty state, land vs. coastal unit prompts, active-route rendering, click-through selection, click-through Establish Route, hot-seat destination-city isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)