### PR TITLE
fix(combat): apply defense context to world actors

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -16,6 +16,7 @@ import {
   unloadUnitFromTransport,
 } from '@/systems/transport-system';
 import { resolveCombat } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
 import { getAvailableTechs, startResearch } from '@/systems/tech-system';
@@ -391,7 +392,14 @@ export function applyPirateAiResponse(state: GameState, civId: string, bus: Even
       .sort((left, right) => left.id.localeCompare(right.id))[0];
     if (adjacentPirate) {
       const seed = Math.max(1, nextState.turn * 16807 + warship.id.length * 97 + adjacentPirate.id.length);
-      const combat = resolveCombat(warship, adjacentPirate, nextState.map, seed, undefined, nextState.era);
+      const combat = resolveCombat(
+        warship,
+        adjacentPirate,
+        nextState.map,
+        seed,
+        buildCombatContextForDefender(nextState, warship, adjacentPirate),
+        nextState.era,
+      );
       const combatPresentation = buildCombatPresentation(nextState, combat, warship, adjacentPirate);
       const applied = applyCombatOutcomeToState(nextState, combat, seed);
       nextState = applied.state;

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -17,6 +17,7 @@ import {
 } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
 import { resolveCombat } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import {
@@ -813,7 +814,14 @@ export function processTurn(
     const attackerRouteId = attacker.committedToRouteId;
     const defenderRouteId = defender.committedToRouteId;
     const defenderPosBarbarian = { ...defender.position };
-    const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
+    const result = resolveCombat(
+      attacker,
+      defender,
+      newState.map,
+      combatSeed,
+      buildCombatContextForDefender(newState, attacker, defender),
+      newState.era,
+    );
     const combatPresentation = buildCombatPresentation(newState, result, attacker, defender);
     const applied = applyCombatOutcomeToState(newState, result, combatSeed);
     newState = applied.state;
@@ -1045,7 +1053,14 @@ export function processTurn(
       if (!attacker || !defender) continue;
       const combatSeed = beastSeed ^ order.attackerUnitId.charCodeAt(0);
       const defenderPosBeast = { ...defender.position };
-      const result = resolveCombat(attacker, defender, newState.map, combatSeed, undefined, newState.era);
+      const result = resolveCombat(
+        attacker,
+        defender,
+        newState.map,
+        combatSeed,
+        buildCombatContextForDefender(newState, attacker, defender),
+        newState.era,
+      );
       const combatPresentation = buildCombatPresentation(newState, result, attacker, defender);
       const applied = applyCombatOutcomeToState(newState, result, combatSeed);
       newState = applied.state;

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -30,6 +30,7 @@ import { generateQuest } from './quest-system';
 import { isMinorCivAtWar, isMinorCivHostileToOwner } from './minor-civ-diplomacy';
 import { processMinorCivEconomyTurn } from './minor-civ-economy-system';
 import { resolveCombat } from './combat-system';
+import { buildCombatContextForDefender } from './combat-context';
 import { hasDiscoveredMinorCiv } from './discovery-system';
 import { canAttackByProfileOnMap } from './attack-targeting';
 import {
@@ -476,7 +477,14 @@ function executePurposefulMinorCivOrders(
     const legality = canUnitAttackTarget(nextState, attacker, defender.position, { requireVisibility: false });
     if (!legality.ok || legality.targetType !== 'unit' || legality.targetUnitId !== defender.id) continue;
     const seed = Math.max(1, nextState.turn * 16807 + attacker.id.length * 97 + defender.id.length);
-    const result = resolveCombat(attacker, defender, nextState.map, seed, undefined, nextState.era);
+    const result = resolveCombat(
+      attacker,
+      defender,
+      nextState.map,
+      seed,
+      buildCombatContextForDefender(nextState, attacker, defender),
+      nextState.era,
+    );
     const presentation = buildCombatPresentation(nextState, result, attacker, defender);
     const attackerRouteId = attacker.committedToRouteId;
     const defenderRouteId = defender.committedToRouteId;
@@ -768,7 +776,14 @@ export function processScuffles(state: GameState, bus: EventBus): void {
         const defenderUnit = other.units.map(uid => state.units[uid]).find(u => u);
         if (attackerUnit && defenderUnit && canAttackByProfileOnMap(attackerUnit, defenderUnit, state.map)) {
           const seed = state.turn * 16807 + attackerUnit.id.charCodeAt(0);
-          const result = resolveCombat(attackerUnit, defenderUnit, state.map, seed, undefined, state.era);
+          const result = resolveCombat(
+            attackerUnit,
+            defenderUnit,
+            state.map,
+            seed,
+            buildCombatContextForDefender(state, attackerUnit, defenderUnit),
+            state.era,
+          );
           attackerUnit.health = Math.max(1, attackerUnit.health - result.attackerDamage);
           defenderUnit.health = Math.max(1, defenderUnit.health - result.defenderDamage);
           bus.emit('minor-civ:scuffle', {

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -6,6 +6,7 @@ import { resolveChallengeForCiv } from '@/core/opponent-challenge';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
 import { resolveCombat } from './combat-system';
+import { buildCombatContextForDefender } from './combat-context';
 import { applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
 import type { PirateEconomyModifiers } from './economy-system';
 import { getWrappedHexNeighbors, hexDistance, hexKey, hexNeighbors, wrappedHexDistance } from './hex-utils';
@@ -196,7 +197,14 @@ function attackTarget(
     return { state, result: null, presentation: null, transportKill: null, events: [] };
   }
   const seed = Math.max(1, state.turn * 7919 + attacker.id.length * 97 + defender.id.length);
-  const result = resolveCombat(attacker, defender, state.map, seed, undefined, state.era);
+  const result = resolveCombat(
+    attacker,
+    defender,
+    state.map,
+    seed,
+    buildCombatContextForDefender(state, attacker, defender),
+    state.era,
+  );
   const applied = applyCombatOutcomeToState(state, result, seed);
   let appliedState = applied.state;
   if (bus && applied.attackerDefeated && attacker.committedToRouteId) {

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -15,6 +15,8 @@ import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 import { createUnit } from '@/systems/unit-system';
+import { resolveCombat } from '@/systems/combat-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { createTechState } from '@/systems/tech-system';
 import { processIndependentThreatPressureForHumans } from '@/systems/threat-pressure-system';
 
@@ -1196,6 +1198,51 @@ describe('processTurn', () => {
     processTurn(state, bus);
 
     expect(onCounterFire).not.toHaveBeenCalled();
+  });
+
+  it('applies the same city-defense context to a barbarian attack as the player attack path (#519)', () => {
+    const state = createNewGame(undefined, 'barbarian-combat-context', 'small');
+    flattenMapToPlains(state);
+    state.turn = 30;
+    state.era = 3;
+    state.barbarianCamps = {
+      'camp-a': { id: 'camp-a', position: { q: 5, r: 5 }, strength: 6, spawnCooldown: 4 },
+    };
+    const raider = createUnit('warrior', 'barbarian', { q: 11, r: 5 }, state.idCounters);
+    raider.id = 'raider';
+    const garrison = createUnit('warrior', 'player', { q: 12, r: 5 }, state.idCounters);
+    garrison.id = 'garrison';
+    state.units = { raider, garrison };
+    state.cities = {
+      town: {
+        id: 'town', owner: 'player', position: { q: 12, r: 5 }, hp: 50,
+        buildings: ['walls', 'star_fort'], population: 20, ownedTiles: [], productionQueue: [],
+      } as never,
+    };
+    state.civilizations.player.cities = ['town'];
+    state.civilizations.player.units = ['garrison'];
+    state.civilizations.player.techState.completed = ['fortification-engineering'];
+    state.opponentAI = undefined;
+
+    const combatSeed = (state.turn * 31337 + 1) ^ raider.id.charCodeAt(0);
+    const expectedWithContext = resolveCombat(
+      raider,
+      garrison,
+      state.map,
+      combatSeed,
+      buildCombatContextForDefender(state, raider, garrison),
+      state.era,
+    );
+    const expectedWithoutContext = resolveCombat(raider, garrison, state.map, combatSeed, undefined, state.era);
+    expect(expectedWithContext).not.toEqual(expectedWithoutContext);
+
+    const bus = new EventBus();
+    const combatResults: ReturnType<typeof resolveCombat>[] = [];
+    bus.on('combat:resolved', event => combatResults.push(event.result));
+
+    processTurn(state, bus);
+
+    expect(combatResults).toContainEqual(expectedWithContext);
   });
 });
 

--- a/tests/systems/city-defense.test.ts
+++ b/tests/systems/city-defense.test.ts
@@ -152,7 +152,7 @@ describe('calculateCombatStrengths with defenderCity', () => {
   });
 });
 
-describe('buildCombatContextForDefender parity (human vs AI paths)', () => {
+describe('buildCombatContextForDefender parity (human vs world-actor paths)', () => {
   function makeState(): GameState {
     const cityMap: GameMap = {
       width: 4,
@@ -190,20 +190,34 @@ describe('buildCombatContextForDefender parity (human vs AI paths)', () => {
     } as unknown as GameState;
   }
 
-  it('produces an identical CityDefenseBreakdown regardless of call site', () => {
+  it('gives a walled garrison the same defense against human and world attacks', () => {
     const state = makeState();
-    const attacker = Object.values(state.units).find(u => u.owner === 'p1')!;
+    const humanAttacker = Object.values(state.units).find(u => u.owner === 'p1')!;
     const defender = Object.values(state.units).find(u => u.owner === 'p2')!;
+    const worldAttacker = createUnit(
+      'warrior',
+      'barbarian',
+      { q: 1, r: 0 },
+      { ...mkC(), nextUnitId: 100 },
+    );
+    state.units[worldAttacker.id] = worldAttacker;
 
-    const contextA = buildCombatContextForDefender(state, attacker, defender);
-    const contextB = buildCombatContextForDefender(state, attacker, defender);
+    const humanContext = buildCombatContextForDefender(state, humanAttacker, defender);
+    const worldContext = buildCombatContextForDefender(state, worldAttacker, defender);
+    const humanStrengths = calculateCombatStrengths(humanAttacker, defender, state.map, humanContext);
+    const worldStrengths = calculateCombatStrengths(worldAttacker, defender, state.map, worldContext);
+    const uncontextualizedWorldStrengths = calculateCombatStrengths(worldAttacker, defender, state.map);
 
-    expect(contextA.defenderCity).toEqual(contextB.defenderCity);
-    expect(contextA.defenderCity?.cityBuildings).toEqual(['walls', 'star_fort']);
-    expect(contextA.defenderCity?.defenderCompletedTechs).toEqual([
+    expect(worldContext.defenderCity).toEqual(humanContext.defenderCity);
+    expect(worldContext.defenderCity?.cityBuildings).toEqual(['walls', 'star_fort']);
+    expect(worldContext.defenderCity?.defenderCompletedTechs).toEqual([
       'fortification-engineering',
       'professional-army',
     ]);
+    expect(worldStrengths.defenderStrength).toBeCloseTo(humanStrengths.defenderStrength);
+    expect(worldStrengths.defenderStrength).toBeGreaterThan(
+      uncontextualizedWorldStrengths.defenderStrength,
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Route barbarian, beast, pirate, minor-civ, and AI pirate-response combat through the shared defender-context builder.
- Restore walls, defensive techs, civ bonuses, anti-air, and unit modifiers for world-actor combat.
- Add an end-to-end barbarian-versus-walled-garrison regression.

## Root cause

Several non-player combat paths passed `undefined` to `resolveCombat`, bypassing the combat context already used by player and major-civ AI attacks.

## Player impact

Defensive investments now protect units against the world actors players encounter most often, and live outcomes match combat-preview expectations.

## Validation

- `bash scripts/run-with-mise.sh yarn test --run tests/core/turn-manager.test.ts tests/systems/pirate-system.test.ts tests/systems/minor-civ-system.test.ts tests/ai/basic-ai.test.ts tests/systems/city-defense.test.ts`
- `bash scripts/run-with-mise.sh yarn test`
- `scripts/check-src-rule-violations.sh src/core/turn-manager.ts src/systems/pirate-system.ts src/systems/minor-civ-system.ts src/ai/basic-ai.ts`
- `bash scripts/run-with-mise.sh yarn build`

Closes #519.
