### PR TITLE
fix(combat): eliminate RNG seed collisions

### DIFF
--- a/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
+++ b/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
@@ -1,0 +1,318 @@
+# Combat RNG Seeds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every combat encounter a unique, reproducible seed derived from the game identity, turn, attacker, and defender.
+
+**Architecture:** Add one pure FNV-1a seed helper next to `resolveCombat`, then replace every production combat-resolution and AI-simulation seed formula with it. The helper is independent of difficulty and active viewer, so a hot-seat handoff cannot alter an encounter's result. Existing combat events, presentation, SFX, and save data remain unchanged.
+
+**Tech Stack:** TypeScript, Vitest, Vite, seeded deterministic RNG.
+
+> **Repository constraint:** Do not dispatch subagents. Execute this plan inline in the existing `codex/issue-521` worktree.
+
+---
+
+## File map
+
+| File | Responsibility |
+|---|---|
+| `src/systems/combat-system.ts` | Exports the canonical deterministic seed helper with combat resolution. |
+| `src/main.ts` | Uses the helper for player-initiated combat. |
+| `src/core/turn-manager.ts` | Uses the helper for barbarian and beast combat. |
+| `src/ai/ai-major-turn.ts` | Removes its duplicate helper and uses the canonical helper for major-AI execution. |
+| `src/ai/ai-tactics.ts` | Uses the same canonical pair seed for AI attack previews and predicted combat. |
+| `src/ai/basic-ai.ts` | Uses the helper for AI warship-vs-pirate combat. |
+| `src/systems/pirate-system.ts` | Uses the helper for pirate-vs-major-civilization combat. |
+| `src/systems/minor-civ-system.ts` | Uses the helper for purposeful minor-civilization attacks and scuffles. |
+| `tests/systems/combat-system.test.ts` | Proves helper determinism, pair distinction, legacy fallback, and hot-seat invariance. |
+| `tests/core/turn-manager.test.ts` | Updates the barbarian combat expectation to the canonical seed. |
+| `tests/ai/ai-major-turn.test.ts` and `tests/ai/ai-tactics.test.ts` | Prove AI prediction and execution share the canonical seed. |
+| `tests/storage/save-manager.test.ts` | Proves normalized legacy saves retain a stable combat seed. |
+
+### Task 1: Establish the canonical seed contract
+
+**Files:**
+- Modify: `tests/systems/combat-system.test.ts`
+- Modify: `src/systems/combat-system.ts`
+
+- [ ] **Step 1: Write the failing helper regressions**
+
+Add `deterministicCombatSeed` to the combat-system test import and add this suite before `describe('resolveCombat', ...)`:
+
+```ts
+describe('deterministicCombatSeed', () => {
+  it('is reproducible, distinguishes same-turn combat pairs, and supports legacy games', () => {
+    const first = deterministicCombatSeed('campaign-a', 42, 'unit-1', 'unit-2');
+
+    expect(deterministicCombatSeed('campaign-a', 42, 'unit-1', 'unit-2')).toBe(first);
+    expect(deterministicCombatSeed('campaign-a', 42, 'unit-7', 'unit-9')).not.toBe(first);
+    expect(deterministicCombatSeed(undefined, 42, 'unit-1', 'unit-2'))
+      .toBe(deterministicCombatSeed('legacy', 42, 'unit-1', 'unit-2'));
+  });
+
+  it('does not depend on the active hot-seat player or difficulty', () => {
+    const state = createNewGame({ mapSize: 'small', opponentCount: 1, seed: 'seed-hot-seat' });
+    const seed = deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2');
+
+    state.currentPlayer = 'ai-1';
+    state.opponentChallenge = 'expert';
+
+    expect(deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2')).toBe(seed);
+  });
+});
+```
+
+Also import `createNewGame` from `@/core/game-state`. Do not assert that two distinct seeds produce different rounded damage; equal rounded damage is a valid outcome.
+
+- [ ] **Step 2: Run the focused test and confirm the missing-export failure**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: FAIL because `deterministicCombatSeed` is not exported.
+
+- [ ] **Step 3: Implement the pure FNV-1a helper**
+
+Add this exported function immediately before `resolveCombat` in `src/systems/combat-system.ts`:
+
+```ts
+export function deterministicCombatSeed(
+  gameId: string | undefined,
+  turn: number,
+  attackerId: string,
+  defenderId: string,
+): number {
+  const source = [gameId ?? 'legacy', turn, attackerId, defenderId].join(':');
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index++) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.max(1, hash >>> 0);
+}
+```
+
+- [ ] **Step 4: Run the helper and existing combat behavior tests**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the contract**
+
+```bash
+git add src/systems/combat-system.ts tests/systems/combat-system.test.ts
+git commit -m "fix(combat): add deterministic pair seeds"
+```
+
+### Task 2: Route every runtime combat and AI simulation through the helper
+
+**Files:**
+- Modify: `src/main.ts`
+- Modify: `src/core/turn-manager.ts`
+- Modify: `src/ai/ai-major-turn.ts`
+- Modify: `src/ai/ai-tactics.ts`
+- Modify: `src/ai/basic-ai.ts`
+- Modify: `src/systems/pirate-system.ts`
+- Modify: `src/systems/minor-civ-system.ts`
+
+- [ ] **Step 1: Replace every collision-prone runtime seed**
+
+Extend each existing `resolveCombat` import to include `deterministicCombatSeed`, then replace the local seed expressions with the following exact call shape:
+
+```ts
+const seed = deterministicCombatSeed(
+  state.gameId,
+  state.turn,
+  attacker.id,
+  defender.id,
+);
+```
+
+Use `gameState` in `src/main.ts` and `nextState` or `newState` where that is the state variable at the call site. Apply this to:
+
+```ts
+// src/main.ts executeAttack
+const seed = deterministicCombatSeed(gameState.gameId, gameState.turn, attacker.id, defender.id);
+
+// src/core/turn-manager.ts barbarian and beast attack loops
+const combatSeed = deterministicCombatSeed(newState.gameId, newState.turn, attacker.id, defender.id);
+
+// src/ai/basic-ai.ts warship attack
+const seed = deterministicCombatSeed(nextState.gameId, nextState.turn, warship.id, adjacentPirate.id);
+
+// src/systems/pirate-system.ts resolvePirateAttack
+const seed = deterministicCombatSeed(state.gameId, state.turn, attacker.id, defender.id);
+
+// src/systems/minor-civ-system.ts purposeful order and scuffle paths
+const seed = deterministicCombatSeed(nextState.gameId, nextState.turn, attacker.id, defender.id);
+const seed = deterministicCombatSeed(state.gameId, state.turn, attackerUnit.id, defenderUnit.id);
+```
+
+Remove no longer used per-turn combat variables only when they have no remaining planning or state-application use.
+
+- [ ] **Step 2: Remove the duplicate major-AI helper**
+
+In `src/ai/ai-major-turn.ts`, import `deterministicCombatSeed` from `@/systems/combat-system`, delete the file-local FNV-1a function, and call:
+
+```ts
+const seed = deterministicCombatSeed(next.gameId, next.turn, attacker.id, defender.id);
+```
+
+- [ ] **Step 3: Align AI tactical prediction with execution**
+
+In `src/ai/ai-tactics.ts`, keep `createRng` because the tactical-choice tie-breaker still uses it. Replace the action/plan-derived `combatSeed` function with a pair-only wrapper:
+
+```ts
+function combatSeed(
+  state: GameState,
+  attackerId: string,
+  defenderId: string,
+): number {
+  return deterministicCombatSeed(state.gameId, state.turn, attackerId, defenderId);
+}
+```
+
+Update both callers to pass the evaluated state and the actual attacking/defending unit IDs:
+
+```ts
+combatSeed(context.state, unit.id, defender.id)
+combatSeed(next, unit.id, defender.id)
+```
+
+This preserves deterministic tactical ranking while ensuring the preview and `processMajorCivStrategicTurn` resolve the same pair roll.
+
+- [ ] **Step 4: Check that no production combat call site retains an ad hoc seed**
+
+Run:
+
+```bash
+rg -n -C 2 'resolveCombat\(' src/main.ts src/core/turn-manager.ts src/ai/ai-major-turn.ts src/ai/ai-tactics.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/minor-civ-system.ts
+```
+
+Expected: every displayed production call passes a `deterministicCombatSeed`-derived value; the local helper remains only as the pair wrapper in `ai-tactics.ts`.
+
+- [ ] **Step 5: Commit the caller migration**
+
+```bash
+git add src/main.ts src/core/turn-manager.ts src/ai/ai-major-turn.ts src/ai/ai-tactics.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/minor-civ-system.ts
+git commit -m "fix(combat): share seeds across combat paths"
+```
+
+### Task 3: Lock down turn processing, AI parity, and legacy-load behavior
+
+**Files:**
+- Modify: `tests/core/turn-manager.test.ts`
+- Modify: `tests/ai/ai-major-turn.test.ts`
+- Modify: `tests/ai/ai-tactics.test.ts`
+- Modify: `tests/storage/save-manager.test.ts`
+
+- [ ] **Step 1: Update the existing barbarian expectation**
+
+In the `#519` barbarian city-defense regression, import `deterministicCombatSeed` and replace:
+
+```ts
+const combatSeed = (state.turn * 31337 + 1) ^ raider.id.charCodeAt(0);
+```
+
+with:
+
+```ts
+const combatSeed = deterministicCombatSeed(state.gameId, state.turn, raider.id, garrison.id);
+```
+
+Keep the existing assertion that the event result equals the context-aware expected result. It proves the non-human turn path uses the canonical seed and preserves combat-context behavior.
+
+- [ ] **Step 2: Add AI execution and tactical-selection parity regressions**
+
+Export no new AI production API. In `tests/ai/ai-major-turn.test.ts`, add imports for `resolveCombat` and `deterministicCombatSeed` from `@/systems/combat-system` and `buildCombatContextForDefender` from `@/systems/combat-context`. Then use the existing `makeState`, `addUnit`, `makePlan`, and `prepared` helpers to place an adjacent AI warrior and human warrior. Calculate the expected result before processing:
+
+```ts
+const expected = resolveCombat(
+  attacker,
+  defender,
+  state.map,
+  deterministicCombatSeed(state.gameId, state.turn, attacker.id, defender.id),
+  buildCombatContextForDefender(state, attacker, defender),
+  state.era,
+);
+```
+
+After `processMajorCivStrategicTurn`, assert the defender's resulting health is `Math.max(0, defender.health - expected.defenderDamage)`. In `tests/ai/ai-tactics.test.ts`, use the analogous adjacent-unit fixture and assert `chooseTacticalSequence` includes the same `{ kind: 'attack', unitId: attacker.id, targetUnitId: defender.id }` action. Together with the direct helper tests and the Task 2 call-site inspection, this proves the AI evaluates an attack that execution resolves with the shared pair seed without exposing a tactical-only seed API.
+
+- [ ] **Step 3: Add the normalized legacy-save regression**
+
+In `tests/storage/save-manager.test.ts`, import `deterministicCombatSeed`. Extend the existing `runs the ordered save schema migration before legacy normalization` test after its `gameId` assertion:
+
+```ts
+const first = deterministicCombatSeed(normalized.gameId, normalized.turn, 'unit-1', 'unit-2');
+const reloaded = normalizeLoadedStateForTest(structuredClone(legacy));
+
+expect(deterministicCombatSeed(reloaded.gameId, reloaded.turn, 'unit-1', 'unit-2')).toBe(first);
+```
+
+This covers the real save-load path without adding a migration solely for combat seeds.
+
+- [ ] **Step 4: Run all focused regressions**
+
+Run:
+
+```bash
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/minor-civ-system.test.ts tests/systems/pirate-system.test.ts tests/storage/save-manager.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the regressions**
+
+```bash
+git add tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/storage/save-manager.test.ts
+git commit -m "test(combat): cover seed parity and save compatibility"
+```
+
+### Task 4: Verify the complete change
+
+**Files:**
+- Verify: every source and test file changed by Tasks 1–3
+
+- [ ] **Step 1: Run the source-rule check**
+
+```bash
+scripts/check-src-rule-violations.sh src/systems/combat-system.ts src/main.ts src/core/turn-manager.ts src/ai/ai-major-turn.ts src/ai/ai-tactics.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/minor-civ-system.ts
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Build and run the full test suite**
+
+```bash
+bash scripts/run-with-mise.sh yarn build
+bash scripts/run-with-mise.sh yarn test
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Inspect both branch and worktree deltas**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD -- src/systems/combat-system.ts src/main.ts src/core/turn-manager.ts src/ai/ai-major-turn.ts src/ai/ai-tactics.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/minor-civ-system.ts tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/storage/save-manager.test.ts
+git diff --check
+```
+
+Expected: only the documented deterministic-seed changes and no whitespace errors.
+
+- [ ] **Step 4: Commit the plan document**
+
+```bash
+git add docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
+git commit -m "docs: plan combat rng seed fix"
+```

--- a/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
+++ b/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
@@ -27,7 +27,32 @@
 | `tests/systems/combat-system.test.ts` | Proves helper determinism, pair distinction, legacy fallback, and hot-seat invariance. |
 | `tests/core/turn-manager.test.ts` | Updates the barbarian combat expectation to the canonical seed. |
 | `tests/ai/ai-major-turn.test.ts` and `tests/ai/ai-tactics.test.ts` | Prove AI prediction and execution share the canonical seed. |
+| `tests/main.integration.test.ts` | Proves the live player combat path derives the canonical seed. |
 | `tests/storage/save-manager.test.ts` | Proves normalized legacy saves retain a stable combat seed. |
+
+### Task 0: Synchronize the implementation base
+
+**Files:**
+- Verify: the current `codex/issue-521` worktree and `origin/main`
+
+- [ ] **Step 1: Fetch and rebase before touching source**
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+Expected: the branch is rebased onto the latest `origin/main` with no conflicts. If Git reports a conflict, inspect only the conflicting combat, test, or plan file; resolve it deliberately, run `git diff --check`, and continue with `git -c core.editor=true rebase --continue`. Do not start source edits until the rebase completes.
+
+- [ ] **Step 2: Confirm the clean synchronized baseline**
+
+```bash
+git status --short --branch
+git log -1 --oneline origin/main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+Expected: no uncommitted files, the displayed `origin/main` commit is an ancestor of `HEAD`, and the final command exits `0`.
 
 ### Task 1: Establish the canonical seed contract
 
@@ -212,6 +237,7 @@ git commit -m "fix(combat): share seeds across combat paths"
 - Modify: `tests/core/turn-manager.test.ts`
 - Modify: `tests/ai/ai-major-turn.test.ts`
 - Modify: `tests/ai/ai-tactics.test.ts`
+- Modify: `tests/main.integration.test.ts`
 - Modify: `tests/storage/save-manager.test.ts`
 
 - [ ] **Step 1: Update the existing barbarian expectation**
@@ -230,7 +256,27 @@ const combatSeed = deterministicCombatSeed(state.gameId, state.turn, raider.id, 
 
 Keep the existing assertion that the event result equals the context-aware expected result. It proves the non-human turn path uses the canonical seed and preserves combat-context behavior.
 
-- [ ] **Step 2: Add AI execution and tactical-selection parity regressions**
+- [ ] **Step 2: Add a live player-path wiring regression**
+
+In `tests/main.integration.test.ts`, add this test in a `describe('player combat wiring', ...)` block:
+
+```ts
+it('derives each player combat seed from the game, turn, and unit pair', () => {
+  const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+  const executeAttack = main.slice(
+    main.indexOf('function executeAttack('),
+    main.indexOf("bus.on('combat:resolved'"),
+  );
+
+  expect(executeAttack).toContain(
+    'deterministicCombatSeed(gameState.gameId, gameState.turn, attacker.id, defender.id)',
+  );
+});
+```
+
+This complements the turn-manager regression: it proves the human entry point and a non-human entry point both use the shared seed contract.
+
+- [ ] **Step 3: Add AI execution and tactical-simulation parity regressions**
 
 Export no new AI production API. In `tests/ai/ai-major-turn.test.ts`, add imports for `resolveCombat` and `deterministicCombatSeed` from `@/systems/combat-system` and `buildCombatContextForDefender` from `@/systems/combat-context`. Then use the existing `makeState`, `addUnit`, `makePlan`, and `prepared` helpers to place an adjacent AI warrior and human warrior. Calculate the expected result before processing:
 
@@ -245,9 +291,39 @@ const expected = resolveCombat(
 );
 ```
 
-After `processMajorCivStrategicTurn`, assert the defender's resulting health is `Math.max(0, defender.health - expected.defenderDamage)`. In `tests/ai/ai-tactics.test.ts`, use the analogous adjacent-unit fixture and assert `chooseTacticalSequence` includes the same `{ kind: 'attack', unitId: attacker.id, targetUnitId: defender.id }` action. Together with the direct helper tests and the Task 2 call-site inspection, this proves the AI evaluates an attack that execution resolves with the shared pair seed without exposing a tactical-only seed API.
+After `processMajorCivStrategicTurn`, assert the defender's resulting health is `Math.max(0, defender.health - expected.defenderDamage)`.
 
-- [ ] **Step 3: Add the normalized legacy-save regression**
+In `tests/ai/ai-tactics.test.ts`, change the Vitest import to include `vi` and add `import * as combatSystem from '@/systems/combat-system';`. Use the analogous adjacent-unit fixture, then spy on the actual resolver while selecting tactics:
+
+```ts
+const expectedSeed = combatSystem.deterministicCombatSeed(
+  state.gameId,
+  state.turn,
+  attacker.id,
+  defender.id,
+);
+const resolveCombatSpy = vi.spyOn(combatSystem, 'resolveCombat');
+
+try {
+  const actions = chooseTacticalSequence(context(state, plan));
+  const matchingSeeds = resolveCombatSpy.mock.calls.filter(
+    ([seenAttacker, seenDefender, , seed]) => seenAttacker.id === attacker.id
+      && seenDefender.id === defender.id
+      && seed === expectedSeed,
+  );
+
+  expect(actions).toContainEqual({
+    kind: 'attack', unitId: attacker.id, targetUnitId: defender.id,
+  });
+  expect(matchingSeeds.length).toBeGreaterThanOrEqual(2);
+} finally {
+  resolveCombatSpy.mockRestore();
+}
+```
+
+The two observed calls are the tactical preview and predicted-action simulation. This directly proves both use the canonical pair seed; the major-turn test separately proves execution uses it.
+
+- [ ] **Step 4: Add the normalized legacy-save regression**
 
 In `tests/storage/save-manager.test.ts`, import `deterministicCombatSeed`. Extend the existing `runs the ordered save schema migration before legacy normalization` test after its `gameId` assertion:
 
@@ -260,20 +336,20 @@ expect(deterministicCombatSeed(reloaded.gameId, reloaded.turn, 'unit-1', 'unit-2
 
 This covers the real save-load path without adding a migration solely for combat seeds.
 
-- [ ] **Step 4: Run all focused regressions**
+- [ ] **Step 5: Run all focused regressions**
 
 Run:
 
 ```bash
-bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/minor-civ-system.test.ts tests/systems/pirate-system.test.ts tests/storage/save-manager.test.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/minor-civ-system.test.ts tests/systems/pirate-system.test.ts tests/main.integration.test.ts tests/storage/save-manager.test.ts
 ```
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit the regressions**
+- [ ] **Step 6: Commit the regressions**
 
 ```bash
-git add tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/storage/save-manager.test.ts
+git add tests/systems/combat-system.test.ts tests/core/turn-manager.test.ts tests/ai/ai-major-turn.test.ts tests/ai/ai-tactics.test.ts tests/systems/minor-civ-system.test.ts tests/systems/pirate-system.test.ts tests/main.integration.test.ts tests/storage/save-manager.test.ts
 git commit -m "test(combat): cover seed parity and save compatibility"
 ```
 
@@ -310,9 +386,6 @@ git diff --check
 
 Expected: only the documented deterministic-seed changes and no whitespace errors.
 
-- [ ] **Step 4: Commit the plan document**
+- [ ] **Step 4: Confirm plan status**
 
-```bash
-git add docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
-git commit -m "docs: plan combat rng seed fix"
-```
+This plan is already committed. Do not create an empty documentation commit. If implementation required revising this plan, include that amended file in the final intentional implementation commit instead.

--- a/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
+++ b/docs/superpowers/plans/2026-07-13-combat-rng-seeds.md
@@ -76,11 +76,17 @@ describe('deterministicCombatSeed', () => {
   });
 
   it('does not depend on the active hot-seat player or difficulty', () => {
-    const state = createNewGame({ mapSize: 'small', opponentCount: 1, seed: 'seed-hot-seat' });
+    const state = createNewGame({
+      civType: 'egypt',
+      gameTitle: 'Seed hot-seat',
+      mapSize: 'small',
+      opponentCount: 1,
+      seed: 'seed-hot-seat',
+    });
     const seed = deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2');
 
     state.currentPlayer = 'ai-1';
-    state.opponentChallenge = 'expert';
+    state.opponentChallenge = 'veteran';
 
     expect(deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2')).toBe(seed);
   });

--- a/docs/superpowers/specs/2026-07-13-combat-rng-seed-design.md
+++ b/docs/superpowers/specs/2026-07-13-combat-rng-seed-design.md
@@ -36,15 +36,18 @@ Every `resolveCombat` entry point must call the shared helper:
 - player attacks in `src/main.ts`;
 - barbarian and beast attacks in `src/core/turn-manager.ts`;
 - major-civilization AI attacks in `src/ai/ai-major-turn.ts`;
+- major-civilization AI tactical previews and predicted action simulations in `src/ai/ai-tactics.ts`;
 - AI warship attacks on pirates in `src/ai/basic-ai.ts`;
 - pirate attacks in `src/systems/pirate-system.ts`;
 - purposeful minor-civilization attacks and minor-civilization scuffles in `src/systems/minor-civ-system.ts`.
 
-The old local `deterministicCombatSeed` implementation in `ai-major-turn.ts` is removed after callers import the shared helper. Barbarian and beast planning seeds remain responsible for deciding world actions, but are not used as combat-resolution seeds; combat resolution is keyed to the game, turn, and participating unit pair.
+The old local `deterministicCombatSeed` implementation in `ai-major-turn.ts` is removed after callers import the shared helper. AI tactical previews and predicted action simulations use the same pair seed as major-AI execution, so strategic choices evaluate the combat roll that will actually resolve. Barbarian and beast planning seeds remain responsible for deciding world actions, but are not used as combat-resolution seeds; combat resolution is keyed to the game, turn, and participating unit pair.
 
 ## Compatibility And Error Handling
 
-Older saves without `gameId` use the literal `legacy` component. The helper has no failure mode and does not mutate game state. It must not use `Math.random()` or time-based values.
+Older saves without `gameId` use the literal `legacy` component when the helper is called before normalization. Normal save loading already assigns those saves a stable `legacy-*` game ID, so this change requires neither a schema bump nor a new migration. The helper has no failure mode and does not mutate game state. It must not use `Math.random()` or time-based values.
+
+The seed deliberately excludes `currentPlayer`, difficulty settings, and viewer data. A combat's outcome therefore cannot change when a hot-seat handoff changes the active player, and seeded variance remains independent of difficulty selection.
 
 ## Verification
 
@@ -53,6 +56,10 @@ Add regression coverage proving:
 - distinct attacker/defender pairs on the same turn receive different seeds;
 - identical inputs reproduce the same seed;
 - a missing game ID uses the documented legacy fallback;
-- stat-identical fights using those two distinct pair seeds no longer share the same combat damage roll.
+- normalizing a legacy save without `gameId` produces a stable seed for subsequent combat;
+- changing `currentPlayer` in a hot-seat state does not change a unit pair's combat seed;
+- AI tactical preview/simulation and major-AI execution derive the same seed for the same pair.
+
+Seed uniqueness is the regression invariant. Tests must not assert that different seeds always produce different rounded combat damage, because distinct random draws can legitimately round to the same damage value. A representative combat integration test may use known distinct seeds, but it must assert deterministic application rather than probabilistic damage inequality.
 
 Run the mirrored combat, AI, turn-manager, minor-civilization, and pirate tests, plus the source-rule check for every changed `src/` file.

--- a/docs/superpowers/specs/2026-07-13-combat-rng-seed-design.md
+++ b/docs/superpowers/specs/2026-07-13-combat-rng-seed-design.md
@@ -1,0 +1,58 @@
+# Combat RNG Seed Design
+
+**Issue:** [#521](https://github.com/a1flecke/conquestoria/issues/521)
+**Date:** 2026-07-13
+**Status:** Approved design
+
+## Purpose
+
+Ensure separate combat encounters receive separate deterministic random seeds. Combat outcomes must remain reproducible for a given saved game and turn, including games created before `gameId` was introduced.
+
+## Problem
+
+Several combat paths derive seeds from the first character or length of `unit-N` IDs. Those values collide for most unit pairs, so multiple attacks in a turn can use the same random factor and base-damage roll.
+
+## Design
+
+Export `deterministicCombatSeed` from `src/systems/combat-system.ts`, beside `resolveCombat`. It accepts the game state identity inputs needed by every caller:
+
+```ts
+deterministicCombatSeed(
+  gameId: string | undefined,
+  turn: number,
+  attackerId: string,
+  defenderId: string,
+): number
+```
+
+The helper hashes the colon-separated tuple `gameId ?? 'legacy'`, `turn`, `attackerId`, and `defenderId` with FNV-1a. It returns a positive unsigned 32-bit integer, replacing a zero result with `1`.
+
+The same inputs always produce the same seed. Changing either combatant, the turn, or the game ID produces a distinct hash for the covered regression inputs. This is deterministic rather than random allocation: save/replay behavior remains reproducible.
+
+## Integration
+
+Every `resolveCombat` entry point must call the shared helper:
+
+- player attacks in `src/main.ts`;
+- barbarian and beast attacks in `src/core/turn-manager.ts`;
+- major-civilization AI attacks in `src/ai/ai-major-turn.ts`;
+- AI warship attacks on pirates in `src/ai/basic-ai.ts`;
+- pirate attacks in `src/systems/pirate-system.ts`;
+- purposeful minor-civilization attacks and minor-civilization scuffles in `src/systems/minor-civ-system.ts`.
+
+The old local `deterministicCombatSeed` implementation in `ai-major-turn.ts` is removed after callers import the shared helper. Barbarian and beast planning seeds remain responsible for deciding world actions, but are not used as combat-resolution seeds; combat resolution is keyed to the game, turn, and participating unit pair.
+
+## Compatibility And Error Handling
+
+Older saves without `gameId` use the literal `legacy` component. The helper has no failure mode and does not mutate game state. It must not use `Math.random()` or time-based values.
+
+## Verification
+
+Add regression coverage proving:
+
+- distinct attacker/defender pairs on the same turn receive different seeds;
+- identical inputs reproduce the same seed;
+- a missing game ID uses the documented legacy fallback;
+- stat-identical fights using those two distinct pair seeds no longer share the same combat damage roll.
+
+Run the mirrored combat, AI, turn-manager, minor-civilization, and pirate tests, plus the source-rule check for every changed `src/` file.

--- a/src/ai/ai-major-turn.ts
+++ b/src/ai/ai-major-turn.ts
@@ -13,7 +13,7 @@ import type {
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCampDestructionAtTarget } from '@/systems/barbarian-system';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
-import { resolveCombat } from '@/systems/combat-system';
+import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import {
   beginMajorCityAssault,
@@ -82,25 +82,6 @@ function targetPosition(plan: AIStrategicPlan) {
   return plan.target.kind === 'resource'
     ? plan.target.position
     : plan.target.anchor;
-}
-
-function deterministicCombatSeed(
-  state: GameState,
-  attackerId: string,
-  defenderId: string,
-): number {
-  const source = [
-    state.gameId ?? 'legacy',
-    state.turn,
-    attackerId,
-    defenderId,
-  ].join(':');
-  let hash = 2166136261;
-  for (let index = 0; index < source.length; index++) {
-    hash ^= source.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return Math.max(1, hash >>> 0);
 }
 
 function actionMatches(
@@ -211,7 +192,7 @@ function executeAttack(
     return { state, followUps: [] };
   }
 
-  const seed = deterministicCombatSeed(next, attacker.id, defender.id);
+  const seed = deterministicCombatSeed(next.gameId, next.turn, attacker.id, defender.id);
   const combat = resolveCombat(
     attacker,
     defender,

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -17,6 +17,7 @@ import {
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import {
   calculateCombatStrengths,
+  deterministicCombatSeed,
   resolveCombat,
 } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
@@ -332,7 +333,7 @@ function rankAttacks(
       unit,
       defender,
       context.state.map,
-      combatSeed(context, action),
+      combatSeed(context.state, unit.id, defender.id),
       buildCombatContextForDefender(context.state, unit, defender),
       context.state.era,
     );
@@ -641,15 +642,12 @@ export function chooseUnitTacticalAction(
   return chooseRankedAction(context, unitId).action;
 }
 
-function combatSeed(context: AITacticalContext, action: AITacticalAction): number {
-  const rng = createRng([
-    context.state.gameId ?? 'legacy',
-    context.state.turn,
-    context.actorId,
-    context.plan.id,
-    actionId(action),
-  ].join(':'));
-  return Math.max(1, Math.floor(rng() * 2_147_483_646));
+function combatSeed(
+  state: GameState,
+  attackerId: string,
+  defenderId: string,
+): number {
+  return deterministicCombatSeed(state.gameId, state.turn, attackerId, defenderId);
 }
 
 function applyPredictedAction(
@@ -664,7 +662,7 @@ function applyPredictedAction(
     case 'attack': {
       const defender = next.units[action.targetUnitId];
       if (!defender) return next;
-      const seed = combatSeed({ ...context, state: next }, action);
+      const seed = combatSeed(next, unit.id, defender.id);
       const result = resolveCombat(
         unit,
         defender,

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -15,7 +15,7 @@ import {
   getUnloadDestinations,
   unloadUnitFromTransport,
 } from '@/systems/transport-system';
-import { resolveCombat } from '@/systems/combat-system';
+import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
@@ -391,7 +391,7 @@ export function applyPirateAiResponse(state: GameState, civId: string, bus: Even
       .filter(unit => isFavorablePirateFight(warship, unit))
       .sort((left, right) => left.id.localeCompare(right.id))[0];
     if (adjacentPirate) {
-      const seed = Math.max(1, nextState.turn * 16807 + warship.id.length * 97 + adjacentPirate.id.length);
+      const seed = deterministicCombatSeed(nextState.gameId, nextState.turn, warship.id, adjacentPirate.id);
       const combat = resolveCombat(
         warship,
         adjacentPirate,

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -16,7 +16,7 @@ import {
   applyHoardChoice, getClaimedTrophyGoldPerTurn,
 } from '@/systems/beast-system';
 import { BEAST_DEFINITIONS } from '@/systems/beast-definitions';
-import { resolveCombat } from '@/systems/combat-system';
+import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
@@ -809,7 +809,7 @@ export function processTurn(
     if (!attacker || !defender) continue;
     const legality = canUnitAttackTarget(newState, attacker, defender.position, { requireVisibility: false });
     if (!legality.ok || legality.targetType !== 'unit' || legality.targetUnitId !== defender.id) continue;
-    const combatSeed = barbSeed ^ attack.attackerUnitId.charCodeAt(0);
+    const combatSeed = deterministicCombatSeed(newState.gameId, newState.turn, attacker.id, defender.id);
     // Capture route IDs before combat (units may be removed from state after)
     const attackerRouteId = attacker.committedToRouteId;
     const defenderRouteId = defender.committedToRouteId;
@@ -1051,7 +1051,7 @@ export function processTurn(
       const attacker = newState.units[order.attackerUnitId];
       const defender = newState.units[order.defenderUnitId];
       if (!attacker || !defender) continue;
-      const combatSeed = beastSeed ^ order.attackerUnitId.charCodeAt(0);
+      const combatSeed = deterministicCombatSeed(newState.gameId, newState.turn, attacker.id, defender.id);
       const defenderPosBeast = { ...defender.position };
       const result = resolveCombat(
         attacker,

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,7 +37,7 @@ import { createForeignCityEntryPanel } from '@/ui/foreign-city-entry-panel';
 import { createWorkerReplacementConfirmPanel, createWorkerTaskWarningPanel } from '@/ui/worker-task-warning-panel';
 import { createWonderPanel } from '@/ui/wonder-panel';
 import { createWonderAtlasPanel } from '@/ui/wonder-atlas-panel';
-import { calculateCombatStrengths, resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
+import { calculateCombatStrengths, deterministicCombatSeed, resolveCombat, selectDefenderForAttack } from '@/systems/combat-system';
 import { calculateCityAssaultStrengths } from '@/systems/city-siege-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { canUnitAttackTarget } from '@/systems/attack-targeting';
@@ -2611,7 +2611,7 @@ function executeAttack(attackerId: string, targetKey: string): void {
 
   ensurePlayerWarState(defender.owner);
 
-  const seed = gameState.turn * 16807 + attacker.id.charCodeAt(0) + defender.id.charCodeAt(0);
+  const seed = deterministicCombatSeed(gameState.gameId, gameState.turn, attacker.id, defender.id);
   const attackerBonus = currentCivDef()?.bonusEffect;
   // Capture defender position before combat (defender may be removed from state after)
   const defenderPosition = { ...defender.position };

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -223,6 +223,21 @@ function canCounterAttackAtDistance(defender: Unit, distance: number): boolean {
   return profile.range >= distance;
 }
 
+export function deterministicCombatSeed(
+  gameId: string | undefined,
+  turn: number,
+  attackerId: string,
+  defenderId: string,
+): number {
+  const source = [gameId ?? 'legacy', turn, attackerId, defenderId].join(':');
+  let hash = 2166136261;
+  for (let index = 0; index < source.length; index++) {
+    hash ^= source.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.max(1, hash >>> 0);
+}
+
 export function resolveCombat(
   attacker: Unit,
   defender: Unit,

--- a/src/systems/minor-civ-system.ts
+++ b/src/systems/minor-civ-system.ts
@@ -28,7 +28,7 @@ import { collectUsedCityNames } from './city-name-system';
 import { generateQuest } from './quest-system';
 import { isMinorCivAtWar, isMinorCivHostileToOwner } from './minor-civ-diplomacy';
 import { processMinorCivEconomyTurn } from './minor-civ-economy-system';
-import { resolveCombat } from './combat-system';
+import { deterministicCombatSeed, resolveCombat } from './combat-system';
 import { buildCombatContextForDefender } from './combat-context';
 import { hasDiscoveredMinorCiv } from './discovery-system';
 import { canAttackByProfileOnMap } from './attack-targeting';
@@ -471,7 +471,7 @@ function executePurposefulMinorCivOrders(
     if (!attacker || !defender || attacker.hasActed) continue;
     const legality = canUnitAttackTarget(nextState, attacker, defender.position, { requireVisibility: false });
     if (!legality.ok || legality.targetType !== 'unit' || legality.targetUnitId !== defender.id) continue;
-    const seed = Math.max(1, nextState.turn * 16807 + attacker.id.length * 97 + defender.id.length);
+    const seed = deterministicCombatSeed(nextState.gameId, nextState.turn, attacker.id, defender.id);
     const result = resolveCombat(
       attacker,
       defender,
@@ -770,7 +770,7 @@ export function processScuffles(state: GameState, bus: EventBus): void {
         const attackerUnit = mc.units.map(uid => state.units[uid]).find(u => u);
         const defenderUnit = other.units.map(uid => state.units[uid]).find(u => u);
         if (attackerUnit && defenderUnit && canAttackByProfileOnMap(attackerUnit, defenderUnit, state.map)) {
-          const seed = state.turn * 16807 + attackerUnit.id.charCodeAt(0);
+          const seed = deterministicCombatSeed(state.gameId, state.turn, attackerUnit.id, defenderUnit.id);
           const result = resolveCombat(
             attackerUnit,
             defenderUnit,

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -5,7 +5,7 @@ import { isMajorCivOwner } from '@/core/owner-kind';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
-import { resolveCombat } from './combat-system';
+import { deterministicCombatSeed, resolveCombat } from './combat-system';
 import { buildCombatContextForDefender } from './combat-context';
 import { applyCitySiegeOutcome, getCityCounterFireDamage, getCityGarrisonUnit, resolveCitySiegeDamage } from './city-siege-system';
 import type { PirateEconomyModifiers } from './economy-system';
@@ -196,7 +196,7 @@ function attackTarget(
   if (!canUnitAttackTarget(state, attacker, defender.position, { requireVisibility: false }).ok) {
     return { state, result: null, presentation: null, transportKill: null, events: [] };
   }
-  const seed = Math.max(1, state.turn * 7919 + attacker.id.length * 97 + defender.id.length);
+  const seed = deterministicCombatSeed(state.gameId, state.turn, attacker.id, defender.id);
   const result = resolveCombat(
     attacker,
     defender,

--- a/tests/ai/ai-major-turn.test.ts
+++ b/tests/ai/ai-major-turn.test.ts
@@ -15,6 +15,8 @@ import type {
 import { foundCity } from '@/systems/city-system';
 import { hexKey } from '@/systems/hex-utils';
 import { createUnit } from '@/systems/unit-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
+import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 
 const AI = 'ai-1';
 const HUMAN = 'player';
@@ -135,6 +137,30 @@ function prepared(
 }
 
 describe('processMajorCivStrategicTurn', () => {
+  it('uses the canonical pair seed when resolving a major-AI attack', () => {
+    const state = makeState();
+    const attacker = addUnit(state, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    const defender = addUnit(state, 'defender', 'warrior', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'unit', id: defender.id, lastKnownPosition: defender.position },
+      [attacker.id],
+      { objective: 'raid', phase: 'advancing', requiredRoles: { frontline: 1 } },
+    );
+    const expected = resolveCombat(
+      attacker,
+      defender,
+      state.map,
+      deterministicCombatSeed(state.gameId, state.turn, attacker.id, defender.id),
+      buildCombatContextForDefender(state, attacker, defender),
+      state.era,
+    );
+
+    const result = processMajorCivStrategicTurn(state, prepared(state, plan), new EventBus());
+
+    expect(result.state.units[defender.id]?.health)
+      .toBe(Math.max(0, defender.health - expected.defenderDamage));
+  });
+
   it('modernizes before tactics so an upgraded unit cannot act twice', () => {
     const state = makeState();
     const home = addCity(state, 'home-city', AI, { q: 0, r: 0 });

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   chooseTacticalSequence,
   chooseUnitTacticalAction,
@@ -18,6 +18,7 @@ import type {
 import { foundCity } from '@/systems/city-system';
 import { hexDistance, hexKey } from '@/systems/hex-utils';
 import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import * as combatSystem from '@/systems/combat-system';
 
 const AI = 'ai-1';
 const HUMAN = 'player';
@@ -121,6 +122,40 @@ function context(
 }
 
 describe('AI tactical action ranking', () => {
+  it('uses the canonical pair seed for attack previews and simulations', () => {
+    const state = makeState('veteran');
+    const attacker = addUnit(state, 'attacker', 'warrior', AI, { q: 0, r: 0 });
+    const defender = addUnit(state, 'defender', 'warrior', HUMAN, { q: 1, r: 0 });
+    const plan = makePlan(
+      { kind: 'unit', id: defender.id, lastKnownPosition: defender.position },
+      [attacker.id],
+      { objective: 'repel' },
+    );
+    const expectedSeed = combatSystem.deterministicCombatSeed(
+      state.gameId,
+      state.turn,
+      attacker.id,
+      defender.id,
+    );
+    const resolveCombatSpy = vi.spyOn(combatSystem, 'resolveCombat');
+
+    try {
+      const actions = chooseTacticalSequence(context(state, plan));
+      const matchingSeeds = resolveCombatSpy.mock.calls.filter(
+        ([seenAttacker, seenDefender, , seed]) => seenAttacker.id === attacker.id
+          && seenDefender.id === defender.id
+          && seed === expectedSeed,
+      );
+
+      expect(actions).toContainEqual({
+        kind: 'attack', unitId: attacker.id, targetUnitId: defender.id,
+      });
+      expect(matchingSeeds.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      resolveCombatSpy.mockRestore();
+    }
+  });
+
   it('uses safe ranged fire before committing a capture unit', () => {
     const state = makeState('veteran');
     addUnit(state, 'archer', 'archer', AI, { q: 0, r: 0 });

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -15,7 +15,7 @@ import { makeBreakawayFixture } from '../systems/helpers/breakaway-fixture';
 import { makeAutoExploreFixture } from '../systems/helpers/auto-explore-fixture';
 import { makeLegendaryWonderFixture } from '../systems/helpers/legendary-wonder-fixture';
 import { createUnit } from '@/systems/unit-system';
-import { resolveCombat } from '@/systems/combat-system';
+import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { createTechState } from '@/systems/tech-system';
 import { processIndependentThreatPressureForHumans } from '@/systems/threat-pressure-system';
@@ -1224,7 +1224,7 @@ describe('processTurn', () => {
     state.civilizations.player.techState.completed = ['fortification-engineering'];
     state.opponentAI = undefined;
 
-    const combatSeed = (state.turn * 31337 + 1) ^ raider.id.charCodeAt(0);
+    const combatSeed = deterministicCombatSeed(state.gameId, state.turn, raider.id, garrison.id);
     const expectedWithContext = resolveCombat(
       raider,
       garrison,

--- a/tests/main.integration.test.ts
+++ b/tests/main.integration.test.ts
@@ -31,6 +31,20 @@ describe('campaign entry wiring', () => {
   });
 });
 
+describe('player combat wiring', () => {
+  it('derives each player combat seed from the game, turn, and unit pair', () => {
+    const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');
+    const executeAttack = main.slice(
+      main.indexOf('function executeAttack('),
+      main.indexOf("bus.on('combat:resolved'"),
+    );
+
+    expect(executeAttack).toContain(
+      'deterministicCombatSeed(gameState.gameId, gameState.turn, attacker.id, defender.id)',
+    );
+  });
+});
+
 describe('land-unit water recovery wiring', () => {
   it('routes the live selected-unit panel and blocked-tap path through recovery helpers', () => {
     const main = readFileSync(resolve(PROJECT_ROOT, 'src/main.ts'), 'utf8');

--- a/tests/storage/save-manager.test.ts
+++ b/tests/storage/save-manager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { City, GameMap, GameState } from '@/core/types';
 import { hexKey } from '@/systems/hex-utils';
+import { deterministicCombatSeed } from '@/systems/combat-system';
 import { migrateLegacyCoastalData } from '@/storage/save-manager';
 import { CURRENT_SAVE_SCHEMA_VERSION } from '@/storage/save-migrations';
 
@@ -68,6 +69,11 @@ describe('save-manager setup and outcome migration', () => {
 
     expect(normalized.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
     expect(normalized.gameId).toMatch(/^legacy-/);
+
+    const first = deterministicCombatSeed(normalized.gameId, normalized.turn, 'unit-1', 'unit-2');
+    const reloaded = normalizeLoadedStateForTest(structuredClone(legacy));
+
+    expect(deterministicCombatSeed(reloaded.gameId, reloaded.turn, 'unit-1', 'unit-2')).toBe(first);
   });
 
   it('labels legacy geographic games historical without moving units or cities', () => {

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -59,6 +59,7 @@ describe('deterministicCombatSeed', () => {
 
   it('does not depend on the active hot-seat player or difficulty', () => {
     const state = createNewGame({
+      civType: 'egypt',
       gameTitle: 'Seed hot-seat',
       mapSize: 'small',
       opponentCount: 1,
@@ -67,7 +68,7 @@ describe('deterministicCombatSeed', () => {
     const seed = deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2');
 
     state.currentPlayer = 'ai-1';
-    state.opponentChallenge = 'expert';
+    state.opponentChallenge = 'veteran';
 
     expect(deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2')).toBe(seed);
   });

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -1,9 +1,11 @@
 import {
   calculateCombatStrengths,
+  deterministicCombatSeed,
   getTerrainDefenseBonus,
   resolveCombat,
   selectDefenderForAttack,
 } from '@/systems/combat-system';
+import { createNewGame } from '@/core/game-state';
 import type { GameMap } from '@/core/types';
 import { createUnit } from '@/systems/unit-system';
 import { generateMap } from '@/systems/map-generator';
@@ -44,6 +46,32 @@ function makeRiverCombatMap(
     },
   };
 }
+
+describe('deterministicCombatSeed', () => {
+  it('is reproducible, distinguishes same-turn combat pairs, and supports legacy games', () => {
+    const first = deterministicCombatSeed('campaign-a', 42, 'unit-1', 'unit-2');
+
+    expect(deterministicCombatSeed('campaign-a', 42, 'unit-1', 'unit-2')).toBe(first);
+    expect(deterministicCombatSeed('campaign-a', 42, 'unit-7', 'unit-9')).not.toBe(first);
+    expect(deterministicCombatSeed(undefined, 42, 'unit-1', 'unit-2'))
+      .toBe(deterministicCombatSeed('legacy', 42, 'unit-1', 'unit-2'));
+  });
+
+  it('does not depend on the active hot-seat player or difficulty', () => {
+    const state = createNewGame({
+      gameTitle: 'Seed hot-seat',
+      mapSize: 'small',
+      opponentCount: 1,
+      seed: 'seed-hot-seat',
+    });
+    const seed = deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2');
+
+    state.currentPlayer = 'ai-1';
+    state.opponentChallenge = 'expert';
+
+    expect(deterministicCombatSeed(state.gameId, state.turn, 'unit-1', 'unit-2')).toBe(seed);
+  });
+});
 
 describe('resolveCombat', () => {
   let map: GameMap;


### PR DESCRIPTION
## Summary

- Replace collision-prone combat seed formulas with one deterministic FNV-1a helper keyed by game, turn, attacker, and defender.
- Use the same seed contract for player, world, minor-civilization, pirate, and AI combat—including AI tactical previews and simulations.
- Add regression coverage for pair uniqueness, player/non-human parity, hot-seat invariance, legacy-save normalization, and AI seed parity.

## Root cause

Several combat paths derived their seed from the first character or length of `unit-N` IDs, causing unrelated fights in the same turn to reuse the same damage rolls.

## Validation

- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test` (386 files, 6,273 passing; 3 skipped)
- `scripts/check-src-rule-violations.sh` for all changed source files
