### PR TITLE
feat(pressure): MR1 — actor-agnostic pipeline behind dark flags (#526)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-world-pressure-symmetry.md
+++ b/docs/superpowers/plans/2026-07-11-world-pressure-symmetry.md
@@ -1,0 +1,642 @@
+# World-Pressure Symmetry Implementation Plan
+
+> **For agentic workers:** Execute ONE MR per fresh session using superpowers:executing-plans (inline). **NEVER dispatch subagents — this repo's CLAUDE.md Agent Policy forbids them.** Steps use checkbox (`- [ ]`) syntax for tracking. Each MR section below maps 1:1 to a GitHub issue; work only your MR's tasks.
+
+**Goal:** AI civilizations experience the same crises and pirate pressure humans do — fairly scheduled, competently answered per difficulty, visible to the player, and eventually interactable — per `docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md` (issue #526).
+
+**Architecture:** Generalize the existing human-only crisis/threat pipeline in place (no parallel orchestrator). New severity resolver avoids the challenge-inversion trap; a deterministic `ai-crisis-response` policy module answers crises using the same helpers the human UI calls; interactions are a typed data table. Three staged feature flags keep unfinished stages dark.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D + DOM UI (existing app stack). No new dependencies.
+
+## Global Constraints
+
+- Run every command through `bash scripts/run-with-mise.sh yarn <cmd>` — never `eval "$(mise activate bash)"`.
+- Before any `git push`/`gh pr create`: `bash scripts/run-with-mise.sh yarn build` AND `yarn test` must both exit 0. `yarn test` does NOT type-check; only `yarn build` runs tsc.
+- Bash timeouts: `git commit` 30 000 ms; `git push`/`gh pr create` 120 000 ms.
+- All work in a git worktree; never commit to main. `mise trust <worktree>/mise.toml` before first push.
+- NEVER `Math.random()` — seeded RNG only (LCG or `createRng`).
+- Immutable turn processing: return new `GameState` via spread-copy; never mutate `state.cities[id] = ...` in systems.
+- Diplomacy is bilateral: every relationship change applies to BOTH civs' `diplomacy.relationships`.
+- Events are notifications: the state mutation must happen in the same block that emits the event.
+- UI: `textContent`/`createTextNode` for dynamic text (never `innerHTML`); every button via `createGameButton()` from `src/ui/ui-kit.ts`; min-height 44px.
+- Never hardcode `'player'`; use `state.currentPlayer` / per-viewer parameters.
+- Tests live in `tests/` mirroring `src/` structure.
+- PR titles reflect the subset shipped; PR bodies never say "closes #NNN" for a *future* MR's issue.
+- Flavor text register: family game (ages 7+) — adventure-story tone, no grim prose.
+- Any MR that changes yields/economy must re-run `tests/systems/pacing-audit.test.ts`.
+
+## Verified codebase facts (read once, trust throughout)
+
+| Fact | Where |
+|---|---|
+| Crisis scheduler (human-gated) | `processCrisisSchedulerForHumans` + `maybeStartCrisis`, `src/systems/crisis-system.ts:41-101` |
+| Severity lookups to replace | `flavor.severityByChallenge[resolveChallengeForCiv(state, civId)]` at `crisis-system.ts:130, 156, 256, 278, 325, 338, 508` |
+| Threat pressure human gates | `src/systems/threat-pressure-system.ts:81, 173, 233, 257, 355 (computeThreatScore), 803 (processThreatPressure)`. **Turn-loop entry:** `processIndependentThreatPressureForHumans` (`threat-pressure-system.ts:251`), called at `turn-manager.ts:965` — this wrapper owns the per-civ loop; `processThreatPressure` (`:796`) is per-civ. |
+| Pressure ledger | `OpponentAIState.pressureByHuman: Record<string, HumanPressureLedger>` (`src/core/types.ts:1282`); normalizer reads it in `src/core/opponent-ai-state.ts:~304` |
+| Challenge profiles | `OPPONENT_CHALLENGE_PROFILES`, `resolveChallengeForCiv`, `getChallengeProfileForCiv` in `src/core/opponent-challenge.ts` |
+| Quarantine/remedy helpers (human UI calls these) | `applyQuarantine(state, crisisId, cityId)`, `applyRemedy(state, crisisId, cityId)`, `crisis-system.ts:592-640`; cost = `getCityAppeaseCost(city)` from `faction-system.ts` |
+| Worker restoration | `canRestoreLand(tile, ownerId?, options)` `src/systems/improvement-system.ts:223`; action `'restore_land'` applied in `worker-action-system.ts:227` |
+| AI plan portfolio | `AIPlanCandidate`, `AIPortfolioContext`, `refreshMajorCivPortfolio` in `src/ai/ai-plan-portfolio.ts` |
+| Relationship helper | `modifyRelationship(diplomacyState, civId, delta)` `src/systems/diplomacy-system.ts:60` (clamps ±100; caller must apply to both civs) |
+| Spy missions | `SpyMissionType` union `src/core/types.ts:715`; staged lists + `case` dispatch in `src/systems/espionage-system.ts:353, 441, 749` |
+| Turn/game test fixture pattern | `tests/core/turn-manager-crisis.test.ts` — `createNewGame(undefined, seed, 'small')`, `foundCity`, `processTurn(state, new EventBus())` |
+| `GameSettings` (optional-field precedent: `beastsMode?`) | `src/core/types.ts:1511` |
+| Pirate fleet processing | `processPirateFleets`, `createPirateFleetNear` in `threat-pressure-system.ts` |
+| Notification routing pattern | `src/ui/notification-routing.ts` (`routeFactionTransition` etc. — event → message + target) |
+| Devastated-tile tint (fog-aware) | `src/renderer/hex-renderer.ts:446` |
+
+---
+
+## MR 0 — Prerequisite bug fixes (existing issues; 2 sessions suggested)
+
+These are fully specified in their issues; no new plan detail needed here. Complete in this order:
+
+1. **#521** (combat seed collisions) + **#519** (world-actor combat paths pass `buildCombatContextForDefender`) — one MR. Both touch the same call sites: `src/core/turn-manager.ts:754/759, 940/942`, `src/systems/pirate-system.ts:192-193`, `src/systems/minor-civ-system.ts:478-479, 770-771`, `src/ai/basic-ai.ts:389-390`, `src/main.ts:2457`. Export `deterministicCombatSeed` from `src/ai/ai-major-turn.ts:87` into `src/systems/combat-system.ts` and reuse.
+2. **#522** (city-siege redesign: defense-mitigated damage, settled zero-HP consequence, HP regen) — one MR. Blocks MR 2 (AI cities get sieged).
+3. **#520** (wrap-aware `mapDistance`/`mapNeighbors`/`mapHexesInRange` helpers in `hex-utils.ts` + migrate the spawn/AI call sites listed in the issue + its round-2 comment) — one MR. Blocks MR 3 (hunt spawns near AI cities).
+
+Acceptance: all three issues' repro tests pass; `yarn build` + `yarn test` green.
+
+---
+
+## MR 1 — Pipeline generalization behind dark flags (zero behavior change)
+
+**Issue theme:** rename/reshape only; with flags at defaults, every existing test passes unchanged. This MR is the parity seam the whole arc rests on.
+
+### Task 1.1: World-pressure flags + resolver
+
+**Files:**
+- Modify: `src/core/types.ts:1511` (GameSettings — add 3 optional fields)
+- Create: `src/systems/world-pressure-flags.ts`
+- Test: `tests/systems/world-pressure-flags.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export type AiPressureFlag = 'off' | 'pirates' | 'full';
+export type AiCrisisInteractionsFlag = 'off' | 'benign' | 'full';
+export interface WorldPressureFlags {
+  aiPressure: AiPressureFlag;
+  aiPressureVisibility: boolean;
+  aiCrisisInteractions: AiCrisisInteractionsFlag;
+}
+export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags;
+```
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/systems/world-pressure-flags.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
+import type { GameSettings } from '@/core/types';
+
+describe('resolveWorldPressureFlags', () => {
+  it('defaults everything off for legacy saves (undefined settings fields)', () => {
+    expect(resolveWorldPressureFlags({} as GameSettings)).toEqual({
+      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+    });
+    expect(resolveWorldPressureFlags(undefined)).toEqual({
+      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+    });
+  });
+  it('passes explicit values through', () => {
+    const settings = { aiPressure: 'pirates', aiPressureVisibility: true, aiCrisisInteractions: 'benign' } as GameSettings;
+    expect(resolveWorldPressureFlags(settings)).toEqual({
+      aiPressure: 'pirates', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run** `bash scripts/run-with-mise.sh yarn vitest run tests/systems/world-pressure-flags.test.ts` — Expected: FAIL (module not found).
+
+- [ ] **Step 3: Implement**
+
+In `types.ts` GameSettings (after `aiContestsBeasts?`):
+```ts
+  // World-pressure symmetry flags (#526). Optional: legacy saves resolve via
+  // resolveWorldPressureFlags defaults — never read these fields directly.
+  aiPressure?: 'off' | 'pirates' | 'full';
+  aiPressureVisibility?: boolean;
+  aiCrisisInteractions?: 'off' | 'benign' | 'full';
+```
+
+```ts
+// src/systems/world-pressure-flags.ts
+import type { GameSettings } from '@/core/types';
+
+export type AiPressureFlag = 'off' | 'pirates' | 'full';
+export type AiCrisisInteractionsFlag = 'off' | 'benign' | 'full';
+
+export interface WorldPressureFlags {
+  aiPressure: AiPressureFlag;
+  aiPressureVisibility: boolean;
+  aiCrisisInteractions: AiCrisisInteractionsFlag;
+}
+
+// Stage defaults: flipped by the final MR of each stage (MR 2/3 → aiPressure,
+// MR 5 → visibility, MR 6/7 → interactions). Until then, dark.
+export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags {
+  return {
+    aiPressure: settings?.aiPressure ?? 'off',
+    aiPressureVisibility: settings?.aiPressureVisibility ?? false,
+    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'off',
+  };
+}
+```
+
+- [ ] **Step 4: Run** same command — Expected: PASS.
+- [ ] **Step 5: Commit** `git add -A && git commit -m "feat(pressure): world-pressure flags + resolver (dark, #526 MR1)"`
+
+### Task 1.2: Severity resolver (`resolvePressureSeverityForCiv`)
+
+**Files:**
+- Modify: `src/core/opponent-challenge.ts`
+- Test: `tests/core/opponent-challenge.test.ts` (append)
+
+**Interfaces (Produces):**
+```ts
+export function resolvePressureSeverityForCiv(
+  state: Pick<GameState, 'opponentChallenge' | 'civilizations'>,
+  civId: string,
+): OpponentChallenge;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('resolvePressureSeverityForCiv', () => {
+  it('returns the personal challenge for humans', () => {
+    const state = { opponentChallenge: 'veteran', civilizations: {
+      h1: { isHuman: true, challenge: 'explorer' },
+    } } as any;
+    expect(resolvePressureSeverityForCiv(state, 'h1')).toBe('explorer');
+  });
+  it('returns standard for AI even at veteran opponentChallenge (inversion trap)', () => {
+    const state = { opponentChallenge: 'veteran', civilizations: {
+      'ai-1': { isHuman: false },
+    } } as any;
+    expect(resolvePressureSeverityForCiv(state, 'ai-1')).toBe('standard');
+    // Contrast: resolveChallengeForCiv would return 'veteran' here — that is
+    // the inversion trap this function exists to avoid. See spec §severity.
+  });
+});
+```
+
+- [ ] **Step 2: Run** `bash scripts/run-with-mise.sh yarn vitest run tests/core/opponent-challenge.test.ts` — Expected: FAIL.
+
+- [ ] **Step 3: Implement** (in `opponent-challenge.ts`, beside `resolveChallengeForCiv`):
+
+```ts
+// Severity for world pressure (crises, pirate fleets). Humans: personal challenge.
+// AI: ALWAYS 'standard' — never resolveChallengeForCiv, whose game-wide
+// opponentChallenge would invert difficulty (veteran would make AI suffer MORE,
+// making the game easier). Spec: docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md
+export function resolvePressureSeverityForCiv(
+  state: Pick<GameState, 'opponentChallenge' | 'civilizations'>,
+  civId: string,
+): OpponentChallenge {
+  const civ = state.civilizations[civId];
+  if (civ?.isHuman) return resolveChallengeForCiv(state, civId);
+  return 'standard';
+}
+```
+
+- [ ] **Step 4: Run** — PASS. **Step 5: Commit.**
+
+### Task 1.3: Swap every severity lookup in crisis/threat systems
+
+**Files:**
+- Modify: `src/systems/crisis-system.ts` (lines 130, 156, 256, 278, 325, 338, 508 — every `resolveChallengeForCiv` used for `severityByChallenge`/`devastationTurnsByChallenge`/outcome decisions about the TARGET civ)
+- Modify: `src/ui/city-panel.ts` (grep `resolveChallengeForCiv` — the crisis severity display must use the same resolver so shown % matches applied %)
+- Test: existing crisis tests are the parity net; add one new test
+
+**Do NOT swap:** `getChallengeProfileForCiv` calls used for scheduling knobs of *humans* (`maybeStartCrisis` line 52) — those stay personal. AI scheduling knobs arrive in MR 3.
+
+- [ ] **Step 1: Failing test** (append to `tests/systems/crisis-system.test.ts`):
+
+```ts
+it('resolves AI crisis severity as standard even when opponentChallenge is veteran', () => {
+  const flavor = getCrisisFlavor('plague')!;
+  const std = 1 - flavor.severityByChallenge.standard.yieldPenalty;
+  const vet = 1 - flavor.severityByChallenge.veteran.yieldPenalty;
+  expect(std).not.toBe(vet); // guard: the test is meaningful
+  // Minimal literal state — getCrisisYieldMultiplier only reads activeCrises,
+  // cities (for membership), civilizations, opponentChallenge.
+  const state = {
+    opponentChallenge: 'veteran',
+    civilizations: { 'ai-1': { id: 'ai-1', isHuman: false } },
+    cities: { 'ai-city': { id: 'ai-city' } },
+    activeCrises: {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: 'plague', archetype: 'outbreak', targetCivId: 'ai-1',
+        cityIds: ['ai-city'], tileKeys: [], startedTurn: 1, stage: 'active', turnsInStage: 1,
+      },
+    },
+  } as unknown as GameState;
+  expect(getCrisisYieldMultiplier(state, 'ai-city')).toBeCloseTo(std);
+});
+```
+
+- [ ] **Step 2: Run** crisis tests — Expected: new test FAILS (veteran multiplier applied).
+- [ ] **Step 3: Implement** — mechanical: `import { resolvePressureSeverityForCiv } from '@/core/opponent-challenge'` and replace at the listed lines. `grep -n "resolveChallengeForCiv" src/systems/crisis-system.ts` afterward must return zero severity-context hits.
+- [ ] **Step 4: Run FULL suite** `bash scripts/run-with-mise.sh yarn test` — every pre-existing test must still pass (humans resolve identically through both functions, so this is behavior-neutral for them).
+- [ ] **Step 5: Commit.**
+
+### Task 1.4: `pressureByHuman` → `pressureByCiv` rename + load migration
+
+**Files:**
+- Modify: `src/core/types.ts:1267-1282` (rename `HumanPressureLedger` → `CivPressureLedger`; field `pressureByHuman` → `pressureByCiv`)
+- Modify: `src/core/opponent-ai-state.ts` (empty-state + normalizer: read `source.pressureByCiv ?? source.pressureByHuman`)
+- Modify: all compile-error sites (`grep -rln "pressureByHuman" src/ tests/`) — mechanical rename
+- Test: `tests/core/opponent-ai-state.test.ts` (append)
+
+- [ ] **Step 1: Failing test**
+
+```ts
+it('migrates legacy pressureByHuman key on normalize', () => {
+  // normalizeOpponentAIState is `(state: GameState) => GameState` (opponent-ai-state.ts:249).
+  const opponentAI = { ...createEmptyOpponentAIState() } as any;
+  delete opponentAI.pressureByCiv;
+  opponentAI.pressureByHuman = { h1: { activeIndependentThreatIds: ['t1'], recoveryUntilTurn: 5, lastResolvedThreatTurn: 3, lastWarningTurnByKey: {}, lastStrategicAudioTurn: null } };
+  const state = { opponentAI, civilizations: {} } as unknown as GameState;
+  const normalized = normalizeOpponentAIState(state);
+  expect(normalized.opponentAI!.pressureByCiv.h1.activeIndependentThreatIds).toEqual(['t1']);
+});
+```
+
+- [ ] **Step 2: Run** — FAIL. **Step 3: Implement** rename + `?? source.pressureByHuman` fallback in the normalizer (one line at the existing read site, `opponent-ai-state.ts:~304`). **Step 4:** `yarn build` (catches every missed rename site) then `yarn test`. **Step 5: Commit.**
+
+### Task 1.5: Eligibility helper + scheduler rename (flag-off parity)
+
+**Files:**
+- Create: `src/systems/world-pressure-eligibility.ts`
+- Modify: `src/systems/crisis-system.ts:41-47` (rename `processCrisisSchedulerForHumans` → `processCrisisScheduler`, iterate eligible civs)
+- Modify: `src/core/turn-manager.ts:965-966` (rename BOTH calls: `processIndependentThreatPressureForHumans` → `processIndependentThreatPressure`, `processCrisisSchedulerForHumans` → `processCrisisScheduler`)
+- Modify: `src/systems/threat-pressure-system.ts:251` (rename `processIndependentThreatPressureForHumans` → `processIndependentThreatPressure`; its internal human filter switches to `isPiratePressureEligible`)
+- Modify: `src/systems/threat-pressure-system.ts:81, 173, 233, 257, 355, 803` (replace `isHuman` checks with the helpers; `computeThreatScore` + `processThreatPressure` use pirate eligibility)
+- Test: `tests/systems/world-pressure-eligibility.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export function isCrisisPressureEligible(state: GameState, civId: string): boolean; // human || flags.aiPressure === 'full'
+export function isPiratePressureEligible(state: GameState, civId: string): boolean; // human || flags.aiPressure !== 'off'
+export function getCrisisEligibleCivIds(state: GameState): string[]; // sorted, non-eliminated, has ≥1 city
+```
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+describe('world-pressure eligibility', () => {
+  const base = (aiPressure?: string) => ({
+    settings: aiPressure ? { aiPressure } : {},
+    civilizations: {
+      h1: { id: 'h1', isHuman: true, isEliminated: false, cities: ['c1'] },
+      'ai-1': { id: 'ai-1', isHuman: false, isEliminated: false, cities: ['c2'] },
+    },
+  } as any);
+  it('flags off: humans only (parity with today)', () => {
+    expect(getCrisisEligibleCivIds(base())).toEqual(['h1']);
+    expect(isPiratePressureEligible(base(), 'ai-1')).toBe(false);
+  });
+  it('pirates flag: pirate pressure includes AI, crisis does not', () => {
+    expect(isPiratePressureEligible(base('pirates'), 'ai-1')).toBe(true);
+    expect(isCrisisPressureEligible(base('pirates'), 'ai-1')).toBe(false);
+  });
+  it('full flag: both include AI', () => {
+    expect(getCrisisEligibleCivIds(base('full'))).toEqual(['ai-1', 'h1']);
+  });
+});
+```
+
+- [ ] **Step 2: Run** — FAIL. **Step 3: Implement** the module; then in `crisis-system.ts` replace the human filter with `getCrisisEligibleCivIds(state)` (keep `.sort()` determinism); in `threat-pressure-system.ts` replace each `civ.isHuman` gate with the pirate helper (lines 81/173/233/257/355/803 — check each: gates guarding *human-only UI/audio warnings* at :233 keep `isHuman`, gates guarding *pressure computation* switch; read the surrounding function to classify, and note the classification in the PR body).
+- [ ] **Step 4: FULL suite** — all pre-existing crisis/threat tests pass unchanged (flags default off ⇒ identical behavior). **Step 5: Commit, open PR** titled `feat(pressure): MR1 — actor-agnostic pipeline behind dark flags (#526)`.
+
+---
+
+## MR 2 — Pirates vs AI + navy dispatch
+
+### Task 2.1: Competence knobs on OpponentChallengeProfile
+
+**Files:**
+- Modify: `src/core/opponent-challenge.ts` (interface + all three profiles)
+- Test: `tests/core/opponent-challenge.test.ts` (append)
+
+Add to `OpponentChallengeProfile`:
+```ts
+  crisisResponseDelayTurns: number;   // crisis age before the AI acts
+  crisisRemedyGoldMultiplier: number; // treasury needed as multiple of remedy cost
+  crisisDispatchWeight: number;       // multiplier on dispatch objective score
+```
+Values — explorer: `4 / 3.0 / 0.5`; standard: `2 / 2.0 / 1.0`; veteran: `0 / 1.2 / 1.5`.
+
+- [ ] Test asserting the three values per profile → FAIL → implement → PASS → commit.
+
+### Task 2.2: AI pirate spawn eligibility (flag `'pirates'`)
+
+**Files:**
+- Modify: `src/systems/threat-pressure-system.ts` (spawn scheduling paths now pass AI civs when `isPiratePressureEligible`)
+- Test: `tests/systems/threat-pressure-system.test.ts` (append)
+
+- [ ] **Step 1: Failing test** — build a state (reuse this file's existing fixtures) with one AI civ owning a coastal city on a tagged landmass, `settings.aiPressure = 'pirates'`; run the spawn-phase entry (`processThreatPressure(state, 'ai-1', bus)`); assert a pirate fleet targeting the AI city exists in `state.pirateFleets`. Negative twin: same state with flags absent ⇒ no fleet.
+- [ ] **Steps 2-4:** FAIL → implement. Two known change sites: (a) `processIndependentThreatPressure`'s civ loop (`threat-pressure-system.ts:251-260`) iterates `isPiratePressureEligible` civs instead of humans; (b) inside `processThreatPressure` / `computeThreatScore`, any remaining human-specific reads (e.g. per-human warning bookkeeping in the `pressureByCiv` ledger) must tolerate AI civ ids — the ledger is already keyed by civId after Task 1.4. Warning/audio emission paths (`lastWarningTurnByKey`, `lastStrategicAudioTurn`) stay HUMAN-ONLY: guard them with `civ.isHuman` explicitly — AI civs don't get UI warnings.
+- [ ] **Step 5:** Confirm existing pirate siege/plunder tests still pass (mechanics are owner-generic; only scheduling changed). Commit.
+
+### Task 2.3: `ai-crisis-response.ts` — dispatch candidates (pirate fleets)
+
+**Files:**
+- Create: `src/ai/ai-crisis-response.ts`
+- Modify: `src/ai/ai-prepared-turn.ts` (merge dispatch candidates into the portfolio context's candidate list — find the `AIPlanCandidate[]` assembly via `grep -n "AIPlanCandidate" src/ai/ai-prepared-turn.ts src/ai/ai-plan-portfolio.ts`)
+- Test: `tests/ai/ai-crisis-response.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export interface CrisisDispatchCandidate {
+  kind: 'pirate-fleet' | 'hunt-foe';
+  sourceId: string;        // fleetId or crisisId — used for expiry checks
+  targetUnitId: string;    // the pirate ship / hunt foe unit
+  score: number;           // base score × profile.crisisDispatchWeight
+}
+export function getCrisisDispatchCandidates(state: GameState, civId: string): CrisisDispatchCandidate[];
+```
+
+- [ ] **Step 1: Failing tests** — (a) AI civ with a pirate fleet sieging its coastal city ⇒ one candidate with `kind: 'pirate-fleet'`, `targetUnitId` = the fleet's `unitId`, score scaled by `crisisDispatchWeight` (assert veteran > explorer for same state); (b) fleet's unit dead or fleet absent ⇒ zero candidates (expiry); (c) fleet targeting a DIFFERENT civ ⇒ zero candidates.
+- [ ] **Step 3: Implement** — pure function over `state.pirateFleets` filtered to `fleet.targetCivId === civId && state.units[fleet.unitId]`. Base score 100 (comparable to existing defend-city candidates — verify magnitude against `ai-objective-scoring.ts` and note the comparison in a comment).
+- [ ] **Step 4-5:** PASS; wire the merge in `ai-prepared-turn.ts` (append candidates before `refreshMajorCivPortfolio` is called), guarded by `isPiratePressureEligible(state, civId)`; add one integration assertion in `tests/ai/ai-prepared-turn.test.ts` that a sieged AI's portfolio contains a plan targeting the pirate unit. Commit; PR `feat(pressure): MR2 — pirate fleets pressure AI civs + navy dispatch (#526)`. Flip default `aiPressure` resolver fallback to `'pirates'` in this MR's final commit (update Task 1.1's two default-assert tests accordingly). **Intended consequence, note in PR body:** flipping the resolver default turns AI-targeted pirates on for existing saves too (their settings lack the field) — that is the rollout mechanism, and it strictly softens the human's relative position.
+
+---
+
+## MR 3 — Crises vs AI: scheduling, response policy, world cap, fairness
+
+### Task 3.1: AI crisis scheduling + world cap
+
+**Files:**
+- Modify: `src/systems/crisis-system.ts` (`processCrisisScheduler` + `maybeStartCrisis`)
+- Test: `tests/systems/crisis-system.test.ts` (append)
+
+Rules to implement (spec §Architecture seam 2):
+- AI civs use `OPPONENT_CHALLENGE_PROFILES.standard` for grace/cooldown/pressure-floor knobs (humans keep `getChallengeProfileForCiv`). In `maybeStartCrisis`, resolve the profile as: `civ.isHuman ? getChallengeProfileForCiv(state, civId) : OPPONENT_CHALLENGE_PROFILES.standard`.
+- `maxIndependentCrisesPerHuman` continues to cap humans per-human. AI civs are instead capped globally: `const AI_CRISIS_WORLD_CAP = { small: 2, medium: 3, large: 4 } as const;` — count `Object.values(state.activeCrises ?? {}).filter(c => !state.civilizations[c.targetCivId]?.isHuman)` and skip AI civs when at cap.
+- Keep the eligible-civ iteration order sorted for determinism.
+
+- [ ] **Step 1: Failing tests** — (a) with `aiPressure: 'full'` and AI preconditions met, an AI civ receives an `ActiveCrisis`; (b) at cap (seed `activeCrises` with N AI crises for the map size), no new AI crisis starts but a human still can; (c) with `aiPressure: 'pirates'`, no AI crisis starts.
+- [ ] **Steps 2-5:** FAIL → implement → full suite → commit.
+
+### Task 3.2: Response policy — quarantine + remedy
+
+**Files:**
+- Modify: `src/ai/ai-crisis-response.ts`
+- Modify: `src/core/turn-manager.ts:134` (the `processCrisisTurn` call is at line 134, near the top of `processTurn`; insert `newState = applyCrisisResponses(newState);` immediately after it — AI civ turns run later via the AI round scheduler, so responses recorded here shape the same round's plans)
+- Test: `tests/ai/ai-crisis-response.test.ts` (append)
+
+**Interfaces (Produces):**
+```ts
+export type CrisisResponseAction =
+  | { kind: 'quarantine'; crisisId: string; cityId: string }
+  | { kind: 'fund-remedy'; crisisId: string; cityId: string };
+export function getCrisisResponseActions(state: GameState, civId: string): CrisisResponseAction[];
+export function applyCrisisResponses(state: GameState): GameState; // loops AI civs, applies via applyQuarantine/applyRemedy
+```
+
+Policy (deterministic, spec §AI response competence — profile from `OPPONENT_CHALLENGE_PROFILES[resolveOpponentChallenge(state)]`):
+- Quarantine an infected, un-quarantined city when `crisis age ≥ crisisResponseDelayTurns` OR `crisis.cityIds.length ≥ 2 + (challenge === 'veteran' ? 0 : 1)`. Crisis age = `state.turn - crisis.startedTurn`. One quarantine per crisis per turn, lowest-population infected city first (sorted, deterministic).
+- Fund remedy for the most-populous infected city without a pending remedy when `civ.gold ≥ getCityAppeaseCost(city) × crisisRemedyGoldMultiplier`. One per civ per turn.
+- Humans are never processed (`civ.isHuman` skip) — their crisis choices are theirs.
+
+- [ ] **Step 1: Failing tests** — per challenge level: exact turn the first quarantine appears (explorer: crisis age 4; veteran: age 0), remedy funded iff treasury threshold met (assert gold actually deducted via `applyRemedy`'s existing behavior), humans untouched, determinism (two runs on structuredClone'd state produce identical actions).
+- [ ] **Steps 2-5:** implement → wire `newState = applyCrisisResponses(newState)` in turn-manager (guarded by `resolveWorldPressureFlags(newState.settings).aiPressure === 'full'`) → full suite → commit.
+
+### Task 3.3: Fairness smoke test (the 50–120% band)
+
+**Files:**
+- Create: `tests/systems/world-pressure-fairness.test.ts`
+
+- [ ] **Step 1: Write the test** (this is a new permanent regression, not scaffolding):
+
+```ts
+// Pattern from tests/core/turn-manager-crisis.test.ts: createNewGame + processTurn loop.
+// Counts crisis:started events per civ over 150 turns at standard/full flags.
+import { describe, it, expect } from 'vitest';
+import { processTurn } from '@/core/turn-manager';
+import { createNewGame } from '@/core/game-state';
+import { EventBus } from '@/core/event-bus';
+
+it('AI civs experience crises within 50-120% of the human rate over 150 turns', () => {
+  let state = createNewGame(undefined, 'fairness-seed-1', 'small');
+  state = { ...state, settings: { ...state.settings, aiPressure: 'full' } };
+  const counts: Record<string, number> = {};
+  const bus = new EventBus();
+  bus.on('crisis:started', ({ civId }) => { counts[civId] = (counts[civId] ?? 0) + 1; });
+  for (let i = 0; i < 150; i++) state = processTurn(state, bus);
+  const humanId = state.currentPlayer;
+  const humanCount = counts[humanId] ?? 0;
+  const aiCivs = Object.values(state.civilizations).filter(c => !c.isHuman && !c.isEliminated);
+  expect(humanCount).toBeGreaterThan(0); // the run must actually produce pressure
+  for (const ai of aiCivs) {
+    const aiCount = counts[ai.id] ?? 0;
+    expect(aiCount).toBeGreaterThanOrEqual(Math.floor(humanCount * 0.5));
+    expect(aiCount).toBeLessThanOrEqual(Math.ceil(humanCount * 1.2));
+  }
+}, 120_000); // 150 full turns is slow; generous timeout, still one test
+```
+
+- [ ] **Step 2: Run.** If the band fails, this is a TUNING task, not a test-editing task: adjust `AI_CRISIS_WORLD_CAP` and/or AI scheduling knobs until the band holds across seeds `fairness-seed-1..3` (parameterize with `it.each`). Only widen the band with a written justification in the PR body.
+- [ ] **Step 3: Commit; PR** `feat(pressure): MR3 — AI civs experience crises (#526)`. Flip `aiPressure` default to `'full'` in the final commit (update flag-default tests).
+
+---
+
+## MR 4 — AI catastrophe restoration
+
+**Files:**
+- Modify: `src/ai/ai-crisis-response.ts` (new action kind)
+- Modify: `src/ai/ai-prepared-turn.ts` (worker tasking — locate the existing worker-assignment block via `grep -n "workerTask" src/ai/ai-prepared-turn.ts` and the role assignment in `src/ai/ai-unit-assignment.ts`)
+- Test: `tests/ai/ai-crisis-response.test.ts` (append)
+
+**Interfaces (Produces):** add to the union — `{ kind: 'restore'; crisisId: string; tileKey: string; workerUnitId: string }`.
+
+Policy: for each of the civ's catastrophe crises in `recovery` stage with `age ≥ crisisResponseDelayTurns`, pair idle owned workers (no `workerTask`, not committed) with the nearest tile in `crisis.tileKeys` where `canRestoreLand(tile, civId, { currentTurn: state.turn })` — assignment applies the same `workerTask` shape the human `restore_land` flow sets (read `worker-action-system.ts:200-250` for the exact fields; reuse its helper if one is exported, otherwise extract one — do not duplicate the mutation inline).
+
+- [ ] **Step 1: Failing tests** — (a) veteran: idle AI worker adjacent to a devastated owned tile gets a `restore` action on the first recovery turn; (b) explorer: no action until crisis age 4; (c) the end-to-end payoff: run enough turns for restoration to complete inside `CATASTROPHE_RECOVERY_WINDOW_TURNS` and assert the AI civ's city gained `resilienceBonusUntilTurn` (veteran) vs. missed it (explorer) — both asserted, the delay knob must have teeth.
+- [ ] **Steps 2-5:** implement → full suite → commit → PR `feat(pressure): MR4 — AI workers restore catastrophe devastation (#526)`.
+
+---
+
+## MR 5 — Visibility layer
+
+### Task 5.1: Viewer-safe presentation helper
+
+**Files:**
+- Create: `src/systems/world-pressure-presentation.ts`
+- Test: `tests/systems/world-pressure-presentation.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export interface WorldPressureCityBadge { cityId: string; coord: HexCoord; archetype: CrisisArchetype }
+export interface WorldPressureStatusLine { civId: string; text: string } // "Suffering: Red Tide outbreak — 3 cities, 4 turns"
+export interface WorldPressurePresentation {
+  cityBadges: WorldPressureCityBadge[];      // known civs' crisis cities on VISIBLE tiles only
+  statusLinesByCivId: Record<string, WorldPressureStatusLine>; // known civs only
+}
+export function getWorldPressurePresentationForViewer(state: GameState, viewerCivId: string): WorldPressurePresentation;
+```
+
+- [ ] **Step 1: Failing tests** — the spec's three negatives plus positives:
+  (a) viewer has NOT met the target civ ⇒ no status line, no badges, even with full visibility of the tile;
+  (b) met civ, crisis city tile NOT visible to viewer (`getVisibility` from `fog-of-war.ts`) ⇒ status line yes, badge no;
+  (c) met civ + visible tile ⇒ badge with correct archetype;
+  (d) hot-seat: viewer B with different `knownCivilizations` gets an independent result;
+  (e) `aiPressureVisibility: false` ⇒ empty result regardless.
+- [ ] **Steps 2-5:** implement (gate on `resolveWorldPressureFlags`; met = `viewer.knownCivilizations.includes(targetCivId)`; humans' own crises excluded — their existing UI covers them) → PASS → commit.
+
+### Task 5.2: Notifications (batched, start/resolve only)
+
+**Files:**
+- Modify: `src/ui/notification-routing.ts` (two new routers, following `routeFactionTransition`'s shape)
+- Modify: `src/main.ts` (subscribe the routers to `crisis:started` / `crisis:resolved` — grep the existing `crisis:` subscriptions and extend beside them)
+- Test: `tests/ui/notification-routing.test.ts` (append)
+
+Rules: route only when the crisis's `targetCivId` is an AI civ (human crises already notify their owner), only to viewers who know that civ, message register per spec tone ("Plague reported in Carthage" / "Carthage has contained its plague"). No routing for spread/siege ticks — assert a spread event produces zero notifications (anti-spam negative).
+
+- [ ] TDD cycle as above; commit.
+
+### Task 5.3: Map badge + diplomacy status line
+
+**Files:**
+- Modify: `src/renderer/city-render-passes.ts` (badge draw for `presentation.cityBadges` — reuse the human crisis badge glyph; find it via `grep -rn "crisis" src/renderer/city-render-passes.ts src/renderer/city-renderer.ts`)
+- Modify: `src/renderer/render-loop.ts` (compute presentation in `setGameState` — NOT per frame; it scans cities/crises and the result only changes when state changes; cache it on the render-loop instance and pass down)
+- Modify: `src/ui/diplomacy-panel.ts` (status line under each known civ, from `statusLinesByCivId`; `textContent` only)
+- Test: `tests/ui/diplomacy-panel.test.ts` (append: line renders for known crisis civ; absent for unknown/no-crisis; re-renders after state change per panel-rerender rule)
+
+- [ ] TDD cycle; commit; PR `feat(pressure): MR5 — AI crises visible: notifications, badges, diplomacy status (#526)`. Flip `aiPressureVisibility` default to `true` in the final commit.
+
+---
+
+## MR 6 — Benign interactions: hunt-their-foe + send aid
+
+### Task 6.1: Interaction definition table + resolver
+
+**Files:**
+- Create: `src/systems/crisis-interaction-system.ts`
+- Test: `tests/systems/crisis-interaction-system.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export interface CrisisInteractionDefinition {
+  id: 'hunt_their_foe' | 'send_aid' | 'exploit_weakness' | 'sabotage_relief';
+  techRequired: string | null;           // null = always available once visibility ships
+  kind: 'overt' | 'covert';
+  targetReputationDelta: number;         // applied actor<->target bilaterally
+  witnessReputationDelta: number;        // applied actor<->each witness bilaterally
+  oncePerCrisisPerActor: boolean;
+}
+export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[]; // data table — new hooks are rows, not branches
+export function getWitnessCivIds(state: GameState, actorId: string, targetId: string): string[]; // met BOTH actor and target; excludes actor/target
+export function applyInteractionReputation(state: GameState, actorId: string, targetId: string, def: CrisisInteractionDefinition): GameState; // bilateral modifyRelationship for target + witnesses
+```
+
+Initial rows (MR 6 ships the first two; MR 7 appends the rest):
+```ts
+{ id: 'hunt_their_foe', techRequired: null,          kind: 'overt', targetReputationDelta: +15, witnessReputationDelta: +4, oncePerCrisisPerActor: true },
+{ id: 'send_aid',       techRequired: 'medicine',    kind: 'overt', targetReputationDelta: +15, witnessReputationDelta: +4, oncePerCrisisPerActor: true },
+```
+(Delta magnitudes are the plan's starting values — tune in MR 8 against existing diplomacy scales; `recordMilitaryAttack` uses −20-order deltas, so ±15/±4 sit plausibly below war-grade events.)
+
+- [ ] **Step 1: Failing tests** — witness set excludes actor/target and requires mutual contact (three-civ fixture); `applyInteractionReputation` moves BOTH sides of every pair (bilateral assertion); deltas clamp via `modifyRelationship`.
+- [ ] **Steps 2-5:** implement → commit.
+
+### Task 6.2: Hunt-their-foe reward wiring
+
+**Files:**
+- Modify: `src/systems/crisis-system.ts` (`tickHuntCrisis` — the `killerCivId` resolution block at `:519-534` already knows the killer; when killer ≠ target civ AND killer is a major civ, apply `hunt_their_foe` reputation + emit `crisis:foe-hunted-by-ally` event with `{ crisisId, killerCivId, targetCivId, foeName }`)
+- Modify: `src/core/types.ts` (GameEvents entry for the new event)
+- Modify: `src/ui/notification-routing.ts` (route it: "Rome slew the beast menacing Carthage!" to viewers knowing either civ)
+- Test: `tests/systems/crisis-system.test.ts` (append)
+
+- [ ] **Step 1: Failing tests** — third-civ kill ⇒ both relationship sides move by +15, witnesses by +4, event emitted once; self-kill (target civ kills own foe) ⇒ no reputation, no event; AI killer of an AI target ⇒ same deltas (no humanity special-casing).
+- [ ] **Steps 2-5:** implement → commit.
+
+### Task 6.3: Send aid — action + UI
+
+**Files:**
+- Modify: `src/systems/crisis-interaction-system.ts` (add `applySendAid`)
+- Modify: `src/core/types.ts` (`ActiveCrisis.aidedByCivIds?: string[]`; GameEvents `'crisis:aid-sent'`)
+- Modify: `src/ui/diplomacy-panel.ts` (Send Aid button on the crisis status line)
+- Test: system + panel tests
+
+**Interfaces (Produces):**
+```ts
+export function canSendAid(state: GameState, actorCivId: string, crisisId: string):
+  { ok: true; goldCost: number } | { ok: false; reason: 'no-tech' | 'already-aided' | 'not-enough-gold' | 'unknown-civ' | 'flag-off' | 'no-crisis' };
+export function applySendAid(state: GameState, actorCivId: string, crisisId: string, bus: EventBus): GameState;
+```
+
+Behavior: outbreak — actor pays `getCityAppeaseCost(most-populous infected city)`. **Do NOT call `applyRemedy`** — it deducts the TARGET civ's gold (`crisis-system.ts:636`). Instead `applySendAid` deducts the ACTOR's gold and writes the same completion record shape directly: `remedyCompletionByCity: { ...(crisis.remedyCompletionByCity ?? {}), [cityId]: state.turn + 2 }` (mirror `applyRemedy`'s record exactly so the tick's remedy-completion block works unchanged). Catastrophe — actor pays the same formula against the target city; the target civ receives that gold as relief (add to its treasury). Tech gates per definition row: `medicine` (outbreak) / `trade-routes` (catastrophe) — encode as a second row or a per-archetype techRequired map `{ outbreak: 'medicine', catastrophe: 'trade-routes' }` on the `send_aid` row (pick the map; one row per hook stays the invariant). Append actor to `aidedByCivIds`; apply reputation; emit event; button UX per spec: label shows cost + effect + memory line, built with `createGameButton`, disabled state carries the `reason` as help text.
+
+- [ ] **Step 1: Failing tests** — happy path (gold moves from actor only; remedy scheduled; reputation bilateral; event once); each `reason` negative including `already-aided` (once-per-crisis); **human-target test**: human A aids human B's crisis, both relationships move, witnesses notified (hot-seat requirement).
+- [ ] **Steps 2-5:** implement → panel test (click-through: button click calls `applySendAid`, panel re-renders) → commit.
+
+### Task 6.4: Tech honesty text
+
+**Files:**
+- Modify: `src/systems/tech-definitions-eras1-4.ts` (`medicine`, `trade-routes` — append unlocks strings: `'Send medical aid to a plague-struck civilization you have met'` / `'Send relief gold to a disaster-struck civilization you have met'`)
+- Test: the positive tests from 6.3 ARE the honesty proof; add the strings in the same commit (content-description-honesty rule).
+
+- [ ] Implement + full suite + commit; PR `feat(pressure): MR6 — hunt-their-foe and send-aid interactions (#526)`. Flip `aiCrisisInteractions` default to `'benign'`.
+
+---
+
+## MR 7 — Full interactions: exploit weakness + sabotage relief
+
+### Task 7.1: Exploit weakness — intel + opportunistic war
+
+**Files:**
+- Modify: `src/systems/crisis-interaction-system.ts` (append the `exploit_weakness` row: `techRequired: 'diplomatic-networks'`, `kind: 'overt'`, deltas `-15 / -8`, `oncePerCrisisPerActor: false`)
+- Modify: `src/systems/world-pressure-presentation.ts` (with `diplomatic-networks` completed, status lines include severity + infected-city list — extend `WorldPressureStatusLine` with `detail?: string`)
+- Modify: `src/main.ts` war-declaration path + `src/systems/diplomacy-system.ts` `declareWar` (grep both; the shared helper is the mutation point per actor-complete rule): when the declared-upon civ has an active crisis, apply `exploit_weakness` reputation (declarer ↔ target and witnesses) and emit `'diplomacy:opportunistic-war'`
+- Test: system tests + one AI-path parity test (AI declaring war on a crisis-struck civ takes the same reputation hit — actor-complete)
+
+- [ ] **Failing tests:** war on crisis-struck civ ⇒ deltas + event; war on healthy civ ⇒ no extra deltas; intel detail present only with the tech; AI-declarer parity.
+- [ ] Implement → commit. **Accepted design note:** AI civs also eat the opportunistic-war penalty when they happen to declare on a crisis-struck civ — symmetric fairness, no special-casing. Teaching AI war-scoring to *avoid* opportunistic timing is explicitly out of scope (would be an AI-initiated-interaction feature).
+
+### Task 7.2: Sabotage relief — spy mission
+
+**Files:**
+- Modify: `src/core/types.ts` (`SpyMissionType` + `'sabotage_relief'`; `ActiveCrisis.sabotage?: { byCivId: string; untilTurn: number; discovered: boolean }`; GameEvents `'espionage:sabotage-relief-discovered'`)
+- Modify: `src/systems/espionage-system.ts` (add to the stage list gated by `covert-operations` — read the stage arrays at `:353` and the tech mapping near `:441`; add a `case 'sabotage_relief'` to the resolution dispatch at `:749` following the adjacent cases' shape)
+- Modify: `src/systems/crisis-system.ts` (`tickOutbreakCrisis`: while `sabotage.untilTurn > state.turn`, remedy completions are paused — skip the remedy-completion block for affected cities; spread continues)
+- Modify: `src/ui/espionage-panel.ts` (mission appears in the existing mission list — it inherits the panel's catalog rendering; verify, don't rebuild)
+- Test: espionage + crisis system tests
+
+Mechanics: mission success sets `crisis.sabotage = { byCivId, untilTurn: state.turn + 4, discovered: false }` (4 turns — MR 8 tunes). One active sabotage per crisis (`ok: false, reason: 'already-sabotaged'`). Detection uses the mission's existing detection roll (same as `sabotage_production`'s — copy its detection parameters); on detection set `discovered: true` and apply `sabotage_relief` reputation (deltas `-25 / -8`) + emit the discovery event; notification: "{Actor}'s spies were caught sabotaging {Target}'s relief!" to all witnesses (hot-seat drama requirement — human witnesses see it).
+
+- [ ] **Failing tests:** remedy paused during sabotage window then resumes; one-active-per-crisis negative; undiscovered ⇒ zero reputation change; discovered ⇒ bilateral deltas to target AND witnesses + notification routed; family-tone string asserted verbatim.
+- [ ] Implement → commit.
+
+### Task 7.3: Tech honesty text (era 5-7)
+
+- Modify `src/systems/tech-definitions-eras5-7.ts`: `diplomatic-networks` += `'Reveal detailed crisis intelligence on civilizations you have met'`; `covert-operations` += `'Spy mission: sabotage a rival's crisis relief'`. Same-commit rule; positive tests from 7.1/7.2 are the proof.
+- [ ] Full suite → commit → PR `feat(pressure): MR7 — exploit weakness + sabotage relief (#526)`. Flip `aiCrisisInteractions` default to `'full'`.
+
+---
+
+## MR 8 — Balance pass
+
+**Files:**
+- Modify: tuning constants only (`AI_CRISIS_WORLD_CAP`, competence knobs, reputation deltas, sabotage duration)
+- Test: existing suites are the harness
+
+- [ ] Run the fairness suite across seeds `fairness-seed-1..3` (`it.each`); tune until the 50–120% band holds on all three. Runtime note: 3 × 150 full turns is the suite's slowest test — keep the per-case timeout at 120 000 ms and mark the describe `sequential`; if wall time exceeds ~5 min, drop to 100 turns and re-derive the band before weakening it.
+- [ ] Run `tests/systems/pacing-audit.test.ts` + `tests/systems/pacing-reference-economy.test.ts`; if reference-economy snapshots shift, include updated numbers + one-line justification in the PR (game-balance rule).
+- [ ] Play-check hot seat (2 humans, small map, 60 turns via `yarn dev`) for notification volume; if the log exceeds ~3 world-pressure entries per turn, batch or coalesce further.
+- [ ] Update `docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md` "Open items" with the final tuned values.
+- [ ] PR `feat(pressure): MR8 — fairness + pacing balance pass (#526)`. Optional handoff note to the audio arc for bespoke stingers.
+
+---
+
+## Self-review checklist (run before finalizing any MR's PR)
+
+1. Spec section implemented by this MR is fully covered (re-read it).
+2. No new `resolveChallengeForCiv` call in a severity context (grep).
+3. No `Math.random`, no state mutation in place, bilateral diplomacy everywhere (grep `modifyRelationship` call sites — must come in pairs or via `applyInteractionReputation`).
+4. Flags: every new behavior is unreachable at the previous stage's defaults.
+5. `yarn build` && `yarn test` green before push.

--- a/docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md
+++ b/docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md
@@ -1,0 +1,213 @@
+# World-Pressure Symmetry — Design
+
+**Issue:** #526
+**Date:** 2026-07-11
+**Status:** Approved design, awaiting implementation plan
+**Predecessor specs:** `2026-06-15-threat-pressure-system-design.md` (scoped AI pressure out as a non-goal), `2026-07-09-crisis-events-and-revolutions-design.md` (listed "AI civs suffering crises" as a future extension — this is that extension)
+
+## Problem
+
+World-pressure systems split into two groups today, and the split is invisible to the player:
+
+- **Human-only (hard-gated):** crises (`processCrisisSchedulerForHumans`, `src/systems/crisis-system.ts`) and pirate fleets / threat pressure (`processThreatPressure` early-returns on `!civ.isHuman`, `src/systems/threat-pressure-system.ts`; the ledger is named `pressureByHuman`).
+- **Symmetric already:** barbarians, beasts, faction unrest, minor-civ hostility.
+
+Consequences: a hidden difficulty tax on the human (compounding #523's world-era racing), a rigged-feeling world (plagues only ever strike the player), and a missing gameplay surface (rival crises can't be aided, exploited, or hunted).
+
+## Goals (staged, in one implementation plan)
+
+1. **Fairness** — AI civs take comparable pressure so the human isn't structurally behind.
+2. **Living world** — AI crises are visible stories: notifications, map indicators, diplomacy-panel status.
+3. **Gameplay surface** — tech-gated interactions with any crisis-struck civ (AI *or* human), with reputation consequences observed by witnesses.
+
+Delivery constraint: many small, self-contained, never-broken MRs. Dark (flag-disabled) code is acceptable between stages.
+
+### Play-style coverage (all four hooks are load-bearing — do not cut one "for scope")
+
+| Style | Hook that serves it |
+|---|---|
+| Peaceful builder / diplomat | Send aid |
+| Warmonger | Exploit weakness (informed, reputation-priced aggression) |
+| Explorer / quester | Hunt their foe |
+| Espionage player | Sabotage relief |
+
+## Non-goals
+
+- Minor civs experiencing crises or pirate fleets (excluded; revisit only if a concrete need appears).
+- Changing what barbarians/beasts/unrest do — they are already symmetric; this spec documents that so it isn't "fixed" twice.
+- Changing per-human personal challenge semantics in any way.
+- AI-initiated aid/exploit/sabotage (future extension; AI participates in hunt-their-foe implicitly — see Interactions).
+- New audio assets (see SFX).
+
+## Decisions (settled during brainstorm)
+
+| Question | Decision |
+|---|---|
+| Architecture | **Generalize in place** — the existing scheduler/pressure pipeline becomes actor-agnostic. No parallel AI orchestrator, no abstracted shadow crises. |
+| AI severity | **Fixed `'standard'`** severity columns, always, regardless of any challenge setting. |
+| AI competence | **Scales with the game-wide `opponentChallenge`** (veteran AI responds fast and pays for remedies; explorer AI dithers). Hot-seat-safe: one shared knob, personal challenges untouched. |
+| Crisis depth | **Same machinery** — real `ActiveCrisis` objects, real spread/devastation/hunt entities. |
+| Interactions | All four hooks, tech-gated, targetable at **any known crisis-struck civ, human or AI**, with witness-visible reputation effects. |
+
+### The severity inversion trap (do not reuse `resolveChallengeForCiv` for AI severity)
+
+`resolveChallengeForCiv` returns the game-wide `opponentChallenge` for AI civs. The `severityByChallenge` tables are written human-facing: veteran = harsher on *you*. Feeding `opponentChallenge` into severity for AI civs would mean picking veteran makes AI civs suffer **more**, making the game **easier** — inverted. Severity for AI must come from a separate resolver that always returns `'standard'`.
+
+### Intended veteran asymmetry (do not "fix")
+
+At `opponentChallenge: 'veteran'`, AI civs respond to crises immediately and fund remedies readily — crises barely dent them — while a veteran human still takes full personal pressure. The fairness gain is smallest exactly on the hardest setting. This is intentional: veteran means "the world does not help you." A future reviewer noticing this asymmetry should find this paragraph, not file a bug.
+
+## Architecture
+
+### New/changed seams
+
+1. **`resolvePressureSeverityForCiv(state, civId): OpponentChallenge`** (in `src/core/opponent-challenge.ts`)
+   Humans → personal challenge via existing resolution; AI → literal `'standard'`. Every severity lookup in crisis/threat systems switches from `resolveChallengeForCiv` to this. `resolveChallengeForCiv` remains for AI-competence lookups.
+
+2. **`processCrisisScheduler(state, bus)`** (renames `processCrisisSchedulerForHumans`, `src/systems/crisis-system.ts`)
+   Iterates all non-eliminated major civs with ≥ 1 city. **AI civs pass through the same preconditions humans do** — grace era/turns, per-civ cooldown, and the `CRISIS_PRESSURE_FLOOR` check against the generalized threat score (seam 3) — using the standard profile's values. On top of that, a **world-level AI crisis cap**: at most 2 (small map) / 3 (medium) / 4 (large) AI-targeted crises active globally. Human crises never count against the AI cap and vice versa.
+
+3. **`processThreatPressure` / `computeThreatScore`** (`src/systems/threat-pressure-system.ts`)
+   Drop `isHuman` early-returns. `pressureByHuman` generalizes to `pressureByCiv`; the save loader migrates the old key on read (old saves keep working).
+
+4. **`src/ai/ai-crisis-response.ts`** (new)
+   Pure deterministic policy — `(state, civId, profile) → CrisisResponseAction[]`. No RNG. Actions: `{ kind: 'quarantine', crisisId, cityId }`, `{ kind: 'fund-remedy', crisisId, cityId }`, `{ kind: 'dispatch', targetKind: 'hunt-foe' | 'pirate-fleet', targetId }`. Quarantine/remedy call the same `applyQuarantine`/`applyRemedy` helpers the human UI calls (AI pays real gold via `getCityAppeaseCost`). Dispatch injects a target into the existing AI plan portfolio (`src/ai/ai-plan-portfolio.ts`) — no parallel unit-mover. **Dispatch objectives carry the crisis/fleet id and are invalidated when it resolves or the foe dies**, using the portfolio's existing plan-expiry path, so AI navies never chase resolved threats.
+
+   **Turn-order placement:** invoked from `turn-manager.ts` after `processCrisisTurn` and before AI planning each round, so this turn's responses feed this turn's plans.
+
+5. **`getWorldPressurePresentationForViewer(state, viewerCivId)`** (new, `src/systems/` presentation module)
+   The single viewer-safe read path for all AI-pressure UI (see Visibility).
+
+6. **`CRISIS_INTERACTION_DEFINITIONS`** (new typed data table, stage 5/6)
+   One row per hook: `{ id, techRequired, kind: 'overt' | 'covert', targetReputationDelta, witnessReputationDelta, oncePerCrisisPerActor }`. The resolver consumes rows generically — adding a future hook is a row, not a branch (same pattern as `NP_PRODUCTION_DISCOUNTS` in `city-system.ts`, per `.claude/rules/game-balance.md`).
+
+7. **Feature flags** (on `GameState.settings`): `aiPressure: 'off' | 'pirates' | 'full'`, `aiPressureVisibility: boolean`, `aiCrisisInteractions: 'off' | 'benign' | 'full'` (`'benign'` = hunt-their-foe + aid only). Read exclusively through a `resolveWorldPressureFlags(settings)` helper that supplies defaults, so legacy saves without the fields resolve to the current defaults with no migration. Each MR merges with its surfaces dark until the stage completes; the stage's final MR flips the default.
+
+### Per-system behavior
+
+- **Pirate fleets (first system):** spawn scheduling extends to AI coastal cities via the same landmass threat scoring. Siege/plunder mechanics are already owner-generic. Cooldown keys (`civId:landmassId`) already generalize. AI response: navy-intercept objective through the plan portfolio (a partial adjacent-pirate attack already exists in `src/ai/basic-ai.ts` and remains as the close-range fallback).
+- **Crises — all three archetypes:** outbreaks spread among the AI civ's own cities; catastrophes devastate its tiles; hunts spawn real foes near its cities (`findHuntSpawnHex` is already owner-agnostic). The tick pipeline (`processCrisisTurn`, `tickCrisisByArchetype`) is untouched apart from severity resolution.
+- **Unchanged (already symmetric):** barbarians, beasts, faction unrest, minor-civ hostility/coalitions.
+
+### Prerequisites (MR 0)
+
+Extending pressure onto known-buggy mechanics multiplies the damage. Before stage 1:
+
+- **#519** — world-actor combat paths must pass `CombatContext` (walls/techs defend).
+- **#521** — combat seed collisions fixed (shared `deterministicCombatSeed`).
+- **#522** — city-siege flat damage / permanent destruction / no-HP-regen redesign (AI cities will now be sieged too; the zero-HP consequence must be settled first).
+- **#520** — wrap-aware distance helpers, at minimum for hunt spawn rings and pirate retargeting.
+
+## AI response competence
+
+Three new fields on `OpponentChallengeProfile` (`src/core/opponent-challenge.ts`), sitting beside the existing tactical knobs:
+
+| Field | explorer | standard | veteran |
+|---|---|---|---|
+| `crisisResponseDelayTurns` — crisis age before the AI acts | 4 | 2 | 0 |
+| `crisisRemedyGoldMultiplier` — treasury required as a multiple of remedy cost | 3.0 | 2.0 | 1.2 |
+| `crisisDispatchWeight` — numeric multiplier on the dispatch objective's plan-portfolio score | 0.5 | 1.0 | 1.5 |
+
+Policy rules (deterministic):
+
+- **Quarantine** when `crisis age ≥ crisisResponseDelayTurns` OR `infected cities ≥ 2 + (veteran ? 0 : 1)`.
+- **Fund remedy** for one infected city per turn when `civ.gold ≥ getCityAppeaseCost(city) × crisisRemedyGoldMultiplier`, most-populous city first.
+- **Dispatch** against a hunt foe or sieging fleet whenever one menaces the civ, scored with `crisisDispatchWeight`.
+
+Severity is identical at all three levels; only response speed and willingness differ. On explorer this visibly softens rivals; on veteran crises barely dent them (see Intended veteran asymmetry).
+
+### Fairness target (makes goal 1 measurable)
+
+Over a scripted 150-turn standard-challenge reference game, each surviving AI civ's crisis count must land within **50–120% of the human's** crisis count, and AI civs must show measurable yield/population loss from crises. The stage-3 fairness smoke test asserts this band; the stage-7 balance pass tunes the world cap and scheduler knobs against it. Without a numeric band, "fairness" regresses silently.
+
+### AI catastrophe restoration (committed, stage 3)
+
+Humans respond to catastrophes with the `restore_land` worker action (`src/systems/worker-action-system.ts:227`), clearing `devastatedUntilTurn` early; clearing every tile inside the recovery window earns the resilience bonus (`tickCatastropheCrisis`). No AI code path uses `restore_land` today — AI worker tasking lives in `src/ai/ai-prepared-turn.ts`.
+
+The AI gets the same verb: during a catastrophe's recovery stage, AI worker assignment prioritizes `restore_land` on its own devastated tiles above normal improvement tasks, using the existing eligibility helper (`isRestoreLandEligible`-style check in `src/systems/improvement-system.ts:230`) — no parallel restoration path. Competence scales the same way as the other responses: restoration tasking begins after `crisisResponseDelayTurns` (veteran: immediately, explorer: 4 turns), which naturally decides whether the AI makes the resilience-bonus window. The resilience bonus itself is evaluated by the existing crisis tick with zero owner-awareness — an AI that restores in time earns it exactly like a human.
+
+## Visibility (stage 2)
+
+All AI-pressure UI reads exclusively from `getWorldPressurePresentationForViewer(state, viewerCivId)`:
+
+- **Met-civ gate:** events for a civ appear only if that civ is in the viewer's `knownCivilizations`. Notification-log entries (turn-stamped, queued, never toast-only): "Plague reported in Carthage", "Corsairs raiding Aztec waters", "Carthage has contained its plague."
+- **Notification discipline (anti-spam):** notify on crisis **start** and **resolution** only — never per spread step, per siege tick, or per AI response. All world-pressure notifications for a turn are batched into at most one log group per civ per turn. With 7 AI civs this is the difference between a living world and an unreadable log.
+- **Tile-visibility gate:** map indicators render only on tiles the viewer's fog state allows. Real entities (pirate ships, hunt foes, devastation tints) already obey fog; the new surface is a crisis badge on known AI cities, reusing the human crisis badge in an "intel" style.
+- **Diplomacy panel:** a known civ with an active crisis shows a status line ("Suffering: Red Tide outbreak — 3 cities, 4 turns"). This is the anchor surface for stage-3 interaction buttons, so it ships in the visibility MR and the buttons attach later (no dead buttons in between, per `.claude/rules/incremental-mr-completion.md`).
+- **Hot seat:** strictly per-viewer. Each human's intel is independent.
+- **Required negative tests:** unmet civ ⇒ no notification/no panel line; unseen tile ⇒ no badge; hot-seat human B sees nothing human A hasn't earned.
+
+## Interactions (stage 3)
+
+**Targets:** any *known* civ with an active crisis — **AI or human**. In hot seat this is deliberate and is the payoff of hot-seat-first design: Dad can fund the remedy for his daughter's plague (relationship boost both ways), and a sibling *can* sabotage yours — with the same discovery risk and reputation fallout as against an AI. No special-casing by target's humanity anywhere in the resolver.
+
+Witness set for all reputation effects: civs that have met **both** actor and target — including human civs. **Human witnesses receive a notification when a covert act against anyone is discovered** ("Rome's spies were caught sabotaging Carthage's relief!"), and when overt acts occur (aid sent, opportunistic war declared). Relationship changes go through the existing bilateral diplomacy helpers (both sides updated, dedup preserved).
+
+| Hook | Tech gate | Effect | Limits | Reputation |
+|---|---|---|---|---|
+| **Hunt their foe** | none (available once visibility ships; hunts already resolve for any killer) | Slaying a known civ's hunt foe grants the existing kill rewards plus a relationship boost with the target | inherent (one foe per hunt) | Target: large +. Witnesses: small +. |
+| **Send aid** | `medicine` (era 4) for outbreak remedy funding; `trade-routes` (era 4) for catastrophe relief gold | Pay the target's remedy/relief cost from your treasury; their recovery accelerates (remedy timer starts immediately / recovery multiplier eases) | **once per crisis per actor** — prevents farming alliances by serially funding plagues | Target: large +. Witnesses: small +. |
+| **Exploit weakness** | `diplomatic-networks` (era 5–7, espionage track) | Full crisis intel on known civs (severity, turns active, infected-city list); declaring war on a crisis-struck civ is marked *opportunistic* | — | Target: large − on opportunistic war. Witnesses: medium −. |
+| **Sabotage relief** | `covert-operations` (era 5–7, espionage track) | Spy mission: extend a rival's outbreak / block their remedy for N turns | **one active sabotage per crisis** (across all actors); costs a spy mission slot like existing missions | Covert. On discovery (existing espionage detection roll): target huge −, witnesses medium −. Undiscovered: no penalty. |
+
+- Overt acts (aid, foe-hunt, opportunistic war) apply reputation immediately.
+- Covert acts reuse the espionage system's existing detection mechanics — no new stealth subsystem.
+- AI civs already participate in *hunt-their-foe* implicitly — hunts resolve for whoever kills the foe, and the reward/reputation wiring applies to AI killers too. Aid, exploit, and sabotage are **human-initiated only** in this arc; AI-initiated versions are a future extension (keeps stage 3 bounded).
+- Content-honesty rule applies: the tech `unlocks` strings for `medicine`, `trade-routes`, `diplomatic-networks`, and `covert-operations` gain new effect text **in the same MR that implements the effect**, with a positive test each (`.claude/rules/content-description-honesty.md`).
+
+### Tone (ages 7–43)
+
+This is a family game (players from ~7 up). All crisis and interaction flavor text stays in the adventure-story register: "spoil their relief supplies", "the plague lifts", "bandits menace their roads" — no graphic disease or suffering prose. Sabotage is framed as mischief-with-consequences, not cruelty. Existing crisis flavor text already follows this register; new interaction strings must match it.
+
+## UI/UX requirements
+
+- Every interaction button is built with `createGameButton()` (44px touch targets, `.claude/rules/ui-panels.md`) and shows **cost, effect, and risk inline at the point of choice** — e.g. Send Aid: "Pay 45 gold — Carthage's plague is cured in 2 turns. Carthage and onlookers will remember this." A 7-year-old should understand the trade from the button alone.
+- Interaction buttons live on the diplomacy panel's crisis status line (the stage-4 anchor surface); sabotage additionally appears in the espionage panel's mission list alongside existing missions.
+- Panels that mutate crisis state re-render immediately (panel-rerender rule).
+- Mobile-first: the city crisis badge and status lines must be legible at phone sizes; no new hover-only affordances.
+
+## Data & save compatibility
+
+- **`pressureByHuman` → `pressureByCiv`:** loader migrates the key on read; shape unchanged; no save-version bump.
+- **New optional fields** (all optional ⇒ legacy saves load unchanged, matching the `hasRoad?` precedent in `HexTile`):
+  - `ActiveCrisis.aidedByCivIds?: string[]` (enforces once-per-crisis aid, powers "X sent aid" history)
+  - `ActiveCrisis.sabotage?: { byCivId: string; untilTurn: number; discovered: boolean }` (one active sabotage per crisis)
+  - `GameState.settings.aiPressure? / aiPressureVisibility? / aiCrisisInteractions?` (resolved through `resolveWorldPressureFlags` with defaults)
+- **Mid-flight saves:** active human crises and fleets are untouched by every stage; AI crises simply begin scheduling on the first post-load turn where preconditions pass.
+
+## SFX
+
+No new audio assets. World-pressure notifications reuse the existing notification stinger; AI-city sieges and hunt combat reuse existing combat/crisis SFX (they run through the same combat and crisis event paths). Bespoke stingers (aid fanfare, sabotage-discovered sting) are deferred to the audio-curation arc as optional polish — listed in the plan, not silently dropped.
+
+## MR staging
+
+Each MR is self-contained, green, and player-unbroken; flags keep incomplete stages dark.
+
+| Stage | MRs | Flag |
+|---|---|---|
+| 0 | Bug fixes #519, #521, #522, #520 (1–3 MRs as sized during planning) | — |
+| 1 | Scheduler + threat-pressure generalization, `resolvePressureSeverityForCiv`, `pressureByCiv` migration, parity regressions (zero behavior change, flag off) | `aiPressure: 'off'` |
+| 2 | Pirates vs AI + navy dispatch policy | `aiPressure: 'pirates'` |
+| 3 | Crises vs AI + full response policy + world cap + fairness smoke test; second MR: AI catastrophe restoration (worker `restore_land` dispatch) | `aiPressure: 'full'` |
+| 4 | Visibility: presentation helper, notifications (batched), map badge, diplomacy status line | `aiPressureVisibility: true` |
+| 5 | Hunt-their-foe rewards + send-aid (+ interaction definition table) | `aiCrisisInteractions: 'benign'` |
+| 6 | Exploit weakness + sabotage relief + witness reputation | `aiCrisisInteractions: 'full'` |
+| 7 | Balance pass: pacing-audit re-run, fairness-band tuning, optional bespoke SFX handoff | — |
+
+## Testing
+
+- **Parity regressions (stage 1):** human crisis/pirate behavior is byte-identical before/after the refactor with flags off — the seam that lets every later MR merge safely.
+- **Policy determinism:** unit tests per challenge level asserting exact response turns and gold thresholds; no RNG in the policy module.
+- **Privacy negatives:** the three visibility negative tests above, per viewer.
+- **Hot-seat isolation:** two humans, different `knownCivilizations`, independent intel; plus a human-target interaction test (aid from human A to human B updates both relationships and notifies witnesses).
+- **Fairness smoke test:** the 150-turn reference game asserting the 50–120% crisis-count band and measurable AI yield/pop loss (guards against the policy accidentally neutralizing all pressure).
+- **Interaction limits:** once-per-crisis aid and one-active-sabotage negative tests; dispatch-objective expiry when the crisis resolves.
+- **AI restoration:** at veteran, an AI civ's workers restore devastated tiles within the recovery window and earn the resilience bonus; at explorer, the delay makes them miss it (both asserted — the delay knob must have teeth).
+- **Pacing gate:** `tests/systems/pacing-audit.test.ts` full-catalog run in stage 7, and at any stage that touches yields (`.claude/rules/game-balance.md` requirement).
+- **Reputation:** bilateral-update assertions for every interaction (both civs' relationship records move; witness set computed from mutual contact; human witnesses notified).
+
+## Open items deferred to the implementation plan
+
+- Exact relationship delta values (large/medium/small here are tuned in stage 5/6 MRs against existing diplomacy scales).
+- Sabotage mission's N-turn extension value and its detection-chance source (reuse nearest existing espionage mission's numbers).
+- Whether stage 2's AI navy dispatch needs a new unit-role or reuses the existing warship role (decide in-plan after reading `ai-unit-roles.ts`).

--- a/src/core/opponent-ai-state.ts
+++ b/src/core/opponent-ai-state.ts
@@ -1,6 +1,7 @@
 import type {
   AIStrategicPlan,
   AITarget,
+  CivPressureLedger,
   GameState,
   MajorCivPlanPortfolio,
   OpponentAIState,
@@ -227,7 +228,7 @@ export function createEmptyOpponentAIState(): OpponentAIState {
     barbarianCamps: {},
     barbarianHomeCampByUnitId: {},
     minorCivs: {},
-    pressureByHuman: {},
+    pressureByCiv: {},
     lastPlannedRound: null,
     lastProcessedRound: null,
     lastFinalizedRound: null,
@@ -301,8 +302,10 @@ export function normalizeOpponentAIState(state: GameState): GameState {
     .map(civ => civ.id)
     .sort();
   for (const humanId of livingHumanIds) {
-    const ledger = source.pressureByHuman?.[humanId];
-    opponentAI.pressureByHuman[humanId] = {
+    const ledger = source.pressureByCiv?.[humanId]
+      // Legacy save migration: pre-#526 saves used the `pressureByHuman` key name.
+      ?? (source as unknown as { pressureByHuman?: Record<string, CivPressureLedger> }).pressureByHuman?.[humanId];
+    opponentAI.pressureByCiv[humanId] = {
       activeIndependentThreatIds: Array.isArray(ledger?.activeIndependentThreatIds)
         ? [...new Set(ledger.activeIndependentThreatIds
             .filter(id => isIndependentThreatId(id)))]

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -92,6 +92,19 @@ export function resolveChallengeForCiv(
   return resolveOpponentChallenge(state);
 }
 
+// Severity for world pressure (crises, pirate fleets). Humans: personal challenge.
+// AI: ALWAYS 'standard' — never resolveChallengeForCiv, whose game-wide
+// opponentChallenge would invert difficulty (veteran would make AI suffer MORE,
+// making the game easier). Spec: docs/superpowers/specs/2026-07-11-world-pressure-symmetry-design.md
+export function resolvePressureSeverityForCiv(
+  state: Pick<GameState, 'opponentChallenge' | 'civilizations'>,
+  civId: string,
+): OpponentChallenge {
+  const civ = state.civilizations[civId];
+  if (civ?.isHuman) return resolveChallengeForCiv(state, civId);
+  return 'standard';
+}
+
 export function getChallengeProfileForCiv(
   state: Pick<GameState, 'opponentChallenge' | 'civilizations'>,
   civId: string,

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -22,7 +22,7 @@ import { canUnitAttackTarget } from '@/systems/attack-targeting';
 import { applyCombatOutcomeToState } from '@/systems/combat-reward-system';
 import {
   PIRATE_OWNER,
-  processIndependentThreatPressureForHumans,
+  processIndependentThreatPressure,
   recordCombatForCiv,
 } from '@/systems/threat-pressure-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
@@ -89,7 +89,7 @@ import { normalizeOpponentAIState } from '@/core/opponent-ai-state';
 import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } from '@/systems/faction-system';
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
-import { processCrisisTurn, processCrisisSchedulerForHumans, getCrisisYieldMultiplier } from '@/systems/crisis-system';
+import { processCrisisTurn, processCrisisScheduler, getCrisisYieldMultiplier } from '@/systems/crisis-system';
 import {
   applyTerritoryFrontierProgressWithEvents,
   buildTerritoryTileFlippedEvents,
@@ -1083,8 +1083,8 @@ export function processTurn(
   }
 
   // --- Threat pressure (spawn phase: land resurgence + pirate spawn) ---
-  newState = processIndependentThreatPressureForHumans(newState, bus);
-  newState = processCrisisSchedulerForHumans(newState, bus);
+  newState = processIndependentThreatPressure(newState, bus);
+  newState = processCrisisScheduler(newState, bus);
 
   // --- Process espionage ---
   newState = processEspionageTurn(newState, bus);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1558,6 +1558,11 @@ export interface GameSettings {
   tutorialEnabled: boolean;
   beastsMode?: BeastsMode;    // default 'wild' for new games; undefined on legacy saves
   aiContestsBeasts?: boolean; // default false: AI ignores beasts, players keep the glory
+  // World-pressure symmetry flags (#526). Optional: legacy saves resolve via
+  // resolveWorldPressureFlags defaults — never read these fields directly.
+  aiPressure?: 'off' | 'pirates' | 'full';
+  aiPressureVisibility?: boolean;
+  aiCrisisInteractions?: 'off' | 'benign' | 'full';
   advisorsEnabled: Record<AdvisorType, boolean>;
   councilTalkLevel: CouncilTalkLevel;
   customCivilizations?: CustomCivDefinition[];

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1294,7 +1294,7 @@ export interface MajorCivPlanPortfolio {
   lastExecutedTurn: number;
 }
 
-export interface HumanPressureLedger {
+export interface CivPressureLedger {
   activeIndependentThreatIds: string[];
   recoveryUntilTurn: number;
   lastResolvedThreatTurn: number | null;
@@ -1309,7 +1309,7 @@ export interface OpponentAIState {
   barbarianCamps: Record<string, AIStrategicPlan>;
   barbarianHomeCampByUnitId: Record<string, string>;
   minorCivs: Record<string, AIStrategicPlan>;
-  pressureByHuman: Record<string, HumanPressureLedger>;
+  pressureByCiv: Record<string, CivPressureLedger>;
   lastPlannedRound: number | null;
   lastProcessedRound: number | null;
   lastFinalizedRound: number | null;

--- a/src/systems/civilization-elimination-system.ts
+++ b/src/systems/civilization-elimination-system.ts
@@ -145,7 +145,7 @@ export function eliminateCivilization(
 
   if (next.opponentAI) {
     delete next.opponentAI.majorCivs[civId];
-    delete next.opponentAI.pressureByHuman[civId];
+    delete next.opponentAI.pressureByCiv[civId];
     for (const [otherId, portfolio] of Object.entries(next.opponentAI.majorCivs)) {
       next.opponentAI.majorCivs[otherId] = scrubPortfolio(portfolio, removedUnits);
     }

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -2,6 +2,7 @@ import type { ActiveCrisis, BeastLair, City, CrisisOutcome, GameState, HexCoord 
 import type { EventBus } from '@/core/event-bus';
 import { getChallengeProfileForCiv, resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { computeThreatScore, deriveActiveIndependentThreatIds, createPirateFleetNear, pickBanditName } from './threat-pressure-system';
+import { getCrisisEligibleCivIds } from './world-pressure-eligibility';
 import { CRISIS_FLAVORS, getCrisisFlavor, type CrisisFlavor } from './crisis-flavor-definitions';
 import { seededLcg, weightedPick } from './seeded-lcg';
 import { hexKey, mapDistance, mapHexesInRange } from './hex-utils';
@@ -38,11 +39,9 @@ export function countActiveCrisesForCiv(state: GameState, civId: string): number
   return scheduled + countUnrestGroups(state, civId);
 }
 
-export function processCrisisSchedulerForHumans(state: GameState, bus: EventBus): GameState {
+export function processCrisisScheduler(state: GameState, bus: EventBus): GameState {
   let next = state;
-  const humanIds = Object.values(state.civilizations)
-    .filter(c => c.isHuman && !c.isEliminated).map(c => c.id).sort();
-  for (const civId of humanIds) next = maybeStartCrisis(next, civId, bus);
+  for (const civId of getCrisisEligibleCivIds(state)) next = maybeStartCrisis(next, civId, bus);
   return next;
 }
 

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -56,7 +56,7 @@ function maybeStartCrisis(state: GameState, civId: string, bus: EventBus): GameS
       state.turn - civ.lastCrisisOnsetTurn < profile.crisisCooldownTurns) return state;
   if (countActiveCrisesForCiv(state, civId) >= profile.maxIndependentCrisesPerHuman) return state;
   if (deriveActiveIndependentThreatIds(state, civId).length > 0) return state;
-  const ledger = state.opponentAI?.pressureByHuman?.[civId];
+  const ledger = state.opponentAI?.pressureByCiv?.[civId];
   if (ledger?.lastResolvedThreatTurn !== undefined && ledger.lastResolvedThreatTurn !== null &&
       state.turn - ledger.lastResolvedThreatTurn < EXTERNAL_THREAT_RECENCY_TURNS) return state;
 

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -1,6 +1,6 @@
 import type { ActiveCrisis, BeastLair, City, CrisisOutcome, GameState, HexCoord } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
-import { getChallengeProfileForCiv, resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { getChallengeProfileForCiv, resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { computeThreatScore, deriveActiveIndependentThreatIds, createPirateFleetNear, pickBanditName } from './threat-pressure-system';
 import { CRISIS_FLAVORS, getCrisisFlavor, type CrisisFlavor } from './crisis-flavor-definitions';
 import { seededLcg, weightedPick } from './seeded-lcg';
@@ -127,7 +127,7 @@ export function getCrisisYieldMultiplier(state: GameState, cityId: string): numb
     if (!crisis.cityIds.includes(cityId)) continue;
     const flavor = getCrisisFlavor(crisis.flavorId);
     if (!flavor) continue;
-    const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
+    const severity = flavor.severityByChallenge[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
     if (crisis.archetype === 'outbreak') {
       multiplier *= getOutbreakSeverityMultiplier(severity, crisis.quarantinedCityIds?.includes(cityId) ?? false);
     } else if (crisis.archetype === 'catastrophe' && crisis.stage === 'recovery') {
@@ -153,7 +153,7 @@ function tickOutbreakCrisis(
 
   let working: ActiveCrisis = { ...crisis, turnsInStage: crisis.turnsInStage + 1 };
   let nextState = state;
-  const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
+  const severity = flavor.severityByChallenge[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
 
   // Remedy completion
   if (working.remedyCompletionByCity) {
@@ -253,7 +253,7 @@ function applyCatastropheShock(
   const epicenter = epicenterCandidates[Math.floor(rng() * epicenterCandidates.length)];
   const epicenterKey = hexKey(epicenter);
 
-  const devastationTurns = params.devastationTurnsByChallenge[resolveChallengeForCiv(state, owner)];
+  const devastationTurns = params.devastationTurnsByChallenge[resolvePressureSeverityForCiv(state, owner)];
   const devastatedUntilTurn = state.turn + devastationTurns;
   const affectedKeys = mapHexesInRange(state.map, epicenter, params.blastRadius)
     .map(hexKey)
@@ -275,7 +275,7 @@ function applyCatastropheShock(
     return { crisis: null, state };
   }
 
-  const isVeteran = resolveChallengeForCiv(state, owner) === 'veteran';
+  const isVeteran = resolvePressureSeverityForCiv(state, owner) === 'veteran';
   const destroysImprovement = params.destroysEpicenterImprovement && isVeteran && state.era >= 3;
 
   const tiles = { ...state.map.tiles };
@@ -322,7 +322,7 @@ function tickCatastropheCrisis(
   // completed within the recovery window, earns the resilience bonus.
   const allActivelyRestored = tiles.every(t => t.devastatedUntilTurn === undefined);
   const withinWindow = nextState.turn <= working.startedTurn + CATASTROPHE_RECOVERY_WINDOW_TURNS;
-  const challenge = resolveChallengeForCiv(nextState, working.targetCivId);
+  const challenge = resolvePressureSeverityForCiv(nextState, working.targetCivId);
 
   if (allActivelyRestored && withinWindow) {
     const cities = { ...nextState.cities };
@@ -505,7 +505,7 @@ function tickHuntCrisis(
   }
 
   if (huntEntityExists(nextState, working, flavor)) {
-    const challenge = resolveChallengeForCiv(nextState, working.targetCivId);
+    const challenge = resolvePressureSeverityForCiv(nextState, working.targetCivId);
     if (challenge === 'veteran' && working.stage === 'menacing' && working.turnsInStage >= HUNT_ESCALATION_TURNS) {
       working = { ...working, stage: 'assaulting' };
       bus.emit('crisis:escalated', {

--- a/src/systems/strategic-warning-system.ts
+++ b/src/systems/strategic-warning-system.ts
@@ -3,7 +3,7 @@ import type {
   GameEvents,
   GameState,
   HexCoord,
-  HumanPressureLedger,
+  CivPressureLedger,
   ResourceType,
 } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
@@ -18,7 +18,7 @@ import {
 
 type StrategicWarning = GameEvents['ai:strategic-warning'];
 
-function emptyLedger(): HumanPressureLedger {
+function emptyLedger(): CivPressureLedger {
   return {
     activeIndependentThreatIds: [],
     recoveryUntilTurn: 0,
@@ -321,8 +321,8 @@ function deriveRecoveryWarning(
   after: GameState,
   viewerId: string,
 ): StrategicWarning[] {
-  const previous = before.opponentAI?.pressureByHuman[viewerId];
-  const current = after.opponentAI?.pressureByHuman[viewerId];
+  const previous = before.opponentAI?.pressureByCiv[viewerId];
+  const current = after.opponentAI?.pressureByCiv[viewerId];
   if (
     !previous
     || !current
@@ -346,7 +346,7 @@ export function deriveStrategicWarningTransitions(
 ): StrategicWarning[] {
   const viewer = finalState.civilizations[viewerId];
   if (!viewer?.isHuman || viewer.isEliminated) return [];
-  const ledger = finalState.opponentAI?.pressureByHuman[viewerId] ?? emptyLedger();
+  const ledger = finalState.opponentAI?.pressureByCiv[viewerId] ?? emptyLedger();
   const warnings = [
     ...deriveMajorWarnings(beforeRound as GameState, finalState, viewerId),
     ...derivePirateWarnings(beforeRound as GameState, finalState, viewerId),
@@ -386,8 +386,8 @@ export function applyStrategicWarningTransitions(
       viewerId,
     );
     if (viewerWarnings.length === 0) continue;
-    const ledger = opponentAI.pressureByHuman[viewerId] ?? emptyLedger();
-    opponentAI.pressureByHuman[viewerId] = {
+    const ledger = opponentAI.pressureByCiv[viewerId] ?? emptyLedger();
+    opponentAI.pressureByCiv[viewerId] = {
       ...ledger,
       lastWarningTurnByKey: {
         ...ledger.lastWarningTurnByKey,

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -6,7 +6,7 @@ import type {
   GameState,
   GameMap,
   HexCoord,
-  HumanPressureLedger,
+  CivPressureLedger,
 } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { createEmptyOpponentAIState } from '@/core/opponent-ai-state';
@@ -38,7 +38,7 @@ export interface IndependentThreatSpawnPolicy {
   canStart(state: GameState, candidate: IndependentThreatSpawnCandidate): boolean;
 }
 
-function emptyPressureLedger(): HumanPressureLedger {
+function emptyPressureLedger(): CivPressureLedger {
   return {
     activeIndependentThreatIds: [],
     recoveryUntilTurn: 0,
@@ -186,7 +186,7 @@ export function deriveActiveIndependentThreatIds(
     }
   }
   for (
-    const threatId of state.opponentAI?.pressureByHuman[humanId]
+    const threatId of state.opponentAI?.pressureByCiv[humanId]
       ?.activeIndependentThreatIds ?? []
   ) {
     if (isIndependentThreatLive(state, threatId)) active.add(threatId);
@@ -200,7 +200,7 @@ export function canStartIndependentThreat(
   threatId: string,
 ): IndependentThreatDecision {
   const profile = getChallengeProfileForCiv(state, humanId);
-  const ledger = state.opponentAI?.pressureByHuman[humanId] ?? emptyPressureLedger();
+  const ledger = state.opponentAI?.pressureByCiv[humanId] ?? emptyPressureLedger();
   const activeCount = ledger.activeIndependentThreatIds.length;
   const base = { activeCount, cap: profile.maxIndependentCrisesPerHuman };
   if (ledger.activeIndependentThreatIds.includes(threatId)) {
@@ -224,15 +224,15 @@ export function reserveIndependentThreatForHumans(
   humanIds: string[],
 ): GameState {
   if (!state.opponentAI) return state;
-  const pressureByHuman = { ...state.opponentAI.pressureByHuman };
+  const pressureByCiv = { ...state.opponentAI.pressureByCiv };
   let changed = false;
   for (const humanId of [...new Set(humanIds)].sort()) {
     const civ = state.civilizations[humanId];
     if (!civ?.isHuman || civ.isEliminated) continue;
-    const ledger = pressureByHuman[humanId] ?? emptyPressureLedger();
+    const ledger = pressureByCiv[humanId] ?? emptyPressureLedger();
     if (ledger.activeIndependentThreatIds.includes(threatId)) continue;
     changed = true;
-    pressureByHuman[humanId] = {
+    pressureByCiv[humanId] = {
       ...ledger,
       activeIndependentThreatIds: [
         ...ledger.activeIndependentThreatIds,
@@ -242,7 +242,7 @@ export function reserveIndependentThreatForHumans(
   }
   return changed ? {
     ...state,
-    opponentAI: { ...state.opponentAI, pressureByHuman },
+    opponentAI: { ...state.opponentAI, pressureByCiv },
   } : state;
 }
 
@@ -255,18 +255,18 @@ export function processIndependentThreatPressureForHumans(
     .filter(civ => civ.isHuman && !civ.isEliminated)
     .map(civ => civ.id)
     .sort();
-  initialOpponentAI.pressureByHuman = Object.fromEntries(humanIds.map(humanId => [
+  initialOpponentAI.pressureByCiv = Object.fromEntries(humanIds.map(humanId => [
     humanId,
-    initialOpponentAI.pressureByHuman[humanId] ?? emptyPressureLedger(),
+    initialOpponentAI.pressureByCiv[humanId] ?? emptyPressureLedger(),
   ]));
-  const pressureByHuman: Record<string, HumanPressureLedger> = {};
+  const pressureByCiv: Record<string, CivPressureLedger> = {};
   for (const humanId of humanIds) {
     const profile = getChallengeProfileForCiv(state, humanId);
-    const previous = initialOpponentAI.pressureByHuman[humanId] ?? emptyPressureLedger();
+    const previous = initialOpponentAI.pressureByCiv[humanId] ?? emptyPressureLedger();
     const activeIndependentThreatIds = deriveActiveIndependentThreatIds(state, humanId);
     const resolved = previous.activeIndependentThreatIds
       .filter(threatId => !activeIndependentThreatIds.includes(threatId));
-    pressureByHuman[humanId] = {
+    pressureByCiv[humanId] = {
       ...previous,
       activeIndependentThreatIds,
       ...(resolved.length > 0 ? {
@@ -275,7 +275,7 @@ export function processIndependentThreatPressureForHumans(
       } : {}),
     };
   }
-  initialOpponentAI.pressureByHuman = pressureByHuman;
+  initialOpponentAI.pressureByCiv = pressureByCiv;
   let nextState: GameState = { ...state, opponentAI: initialOpponentAI };
   const spawnPolicy: IndependentThreatSpawnPolicy = {
     canStart: (candidateState, candidate) =>

--- a/src/systems/threat-pressure-system.ts
+++ b/src/systems/threat-pressure-system.ts
@@ -15,6 +15,7 @@ import { BEAST_DEFINITIONS } from './beast-definitions';
 import { hexKey, mapDistance, mapNeighbors } from './hex-utils';
 import { createUnit } from './unit-system';
 import { seededLcg } from './seeded-lcg';
+import { isPiratePressureEligible } from './world-pressure-eligibility';
 
 export const PIRATE_OWNER = 'pirate';
 
@@ -76,7 +77,7 @@ export function deriveHumansMateriallyAffectedByPosition(
   radius: number,
 ): string[] {
   return Object.values(state.civilizations)
-    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .filter(civ => !civ.isEliminated && isPiratePressureEligible(state, civ.id))
     .filter(civ =>
       humanAssetPositions(state, civ.id)
         .some(asset => threatDistance(state, position, asset) <= radius))
@@ -167,8 +168,8 @@ export function deriveActiveIndependentThreatIds(
   state: GameState,
   humanId: string,
 ): string[] {
-  const human = state.civilizations[humanId];
-  if (!human?.isHuman || human.isEliminated) return [];
+  const civ = state.civilizations[humanId];
+  if (!civ || civ.isEliminated || !isPiratePressureEligible(state, humanId)) return [];
   const active = new Set<string>();
   for (const campId of Object.keys(state.barbarianCamps).sort()) {
     if (barbarianMateriallyAffectsHuman(state, campId, humanId)) {
@@ -228,7 +229,7 @@ export function reserveIndependentThreatForHumans(
   let changed = false;
   for (const humanId of [...new Set(humanIds)].sort()) {
     const civ = state.civilizations[humanId];
-    if (!civ?.isHuman || civ.isEliminated) continue;
+    if (!civ || civ.isEliminated || !isPiratePressureEligible(state, humanId)) continue;
     const ledger = pressureByCiv[humanId] ?? emptyPressureLedger();
     if (ledger.activeIndependentThreatIds.includes(threatId)) continue;
     changed = true;
@@ -246,13 +247,13 @@ export function reserveIndependentThreatForHumans(
   } : state;
 }
 
-export function processIndependentThreatPressureForHumans(
+export function processIndependentThreatPressure(
   state: GameState,
   bus: EventBus,
 ): GameState {
   const initialOpponentAI = structuredClone(state.opponentAI ?? createEmptyOpponentAIState());
   const humanIds = Object.values(state.civilizations)
-    .filter(civ => civ.isHuman && !civ.isEliminated)
+    .filter(civ => !civ.isEliminated && isPiratePressureEligible(state, civ.id))
     .map(civ => civ.id)
     .sort();
   initialOpponentAI.pressureByCiv = Object.fromEntries(humanIds.map(humanId => [
@@ -350,7 +351,7 @@ export function nearestLandmassId(position: HexCoord, map: GameMap): string | nu
 
 export function computeThreatScore(state: GameState, civId: string, landmassId: string): number {
   const civ = state.civilizations[civId];
-  if (!civ || !civ.isHuman) return 0;
+  if (!civ || !isPiratePressureEligible(state, civId)) return 0;
 
   // Only evaluate landmasses where civ has at least one city
   const hasCityOnLandmass = civ.cities.some(cityId => {
@@ -798,7 +799,7 @@ export function processThreatPressure(
   options: { includeLegacyPirates?: boolean } = {},
 ): GameState {
   const civ = state.civilizations[civId];
-  if (!civ || !civ.isHuman) return state;
+  if (!civ || !isPiratePressureEligible(state, civId)) return state;
 
   // Collect unique landmass IDs where civ has cities
   const landmassIds = new Set<string>();

--- a/src/systems/world-pressure-eligibility.ts
+++ b/src/systems/world-pressure-eligibility.ts
@@ -1,0 +1,23 @@
+import type { GameState } from '@/core/types';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+
+export function isCrisisPressureEligible(state: Pick<GameState, 'settings' | 'civilizations'>, civId: string): boolean {
+  const civ = state.civilizations[civId];
+  if (!civ) return false;
+  if (civ.isHuman) return true;
+  return resolveWorldPressureFlags(state.settings).aiPressure === 'full';
+}
+
+export function isPiratePressureEligible(state: Pick<GameState, 'settings' | 'civilizations'>, civId: string): boolean {
+  const civ = state.civilizations[civId];
+  if (!civ) return false;
+  if (civ.isHuman) return true;
+  return resolveWorldPressureFlags(state.settings).aiPressure !== 'off';
+}
+
+export function getCrisisEligibleCivIds(state: Pick<GameState, 'settings' | 'civilizations'>): string[] {
+  return Object.values(state.civilizations)
+    .filter(civ => !civ.isEliminated && civ.cities.length > 0 && isCrisisPressureEligible(state, civ.id))
+    .map(civ => civ.id)
+    .sort();
+}

--- a/src/systems/world-pressure-eligibility.ts
+++ b/src/systems/world-pressure-eligibility.ts
@@ -3,21 +3,21 @@ import { resolveWorldPressureFlags } from './world-pressure-flags';
 
 export function isCrisisPressureEligible(state: Pick<GameState, 'settings' | 'civilizations'>, civId: string): boolean {
   const civ = state.civilizations[civId];
-  if (!civ) return false;
+  if (!civ || civ.isEliminated) return false;
   if (civ.isHuman) return true;
   return resolveWorldPressureFlags(state.settings).aiPressure === 'full';
 }
 
 export function isPiratePressureEligible(state: Pick<GameState, 'settings' | 'civilizations'>, civId: string): boolean {
   const civ = state.civilizations[civId];
-  if (!civ) return false;
+  if (!civ || civ.isEliminated) return false;
   if (civ.isHuman) return true;
   return resolveWorldPressureFlags(state.settings).aiPressure !== 'off';
 }
 
 export function getCrisisEligibleCivIds(state: Pick<GameState, 'settings' | 'civilizations'>): string[] {
   return Object.values(state.civilizations)
-    .filter(civ => !civ.isEliminated && civ.cities.length > 0 && isCrisisPressureEligible(state, civ.id))
+    .filter(civ => civ.cities.length > 0 && isCrisisPressureEligible(state, civ.id))
     .map(civ => civ.id)
     .sort();
 }

--- a/src/systems/world-pressure-flags.ts
+++ b/src/systems/world-pressure-flags.ts
@@ -1,0 +1,20 @@
+import type { GameSettings } from '@/core/types';
+
+export type AiPressureFlag = 'off' | 'pirates' | 'full';
+export type AiCrisisInteractionsFlag = 'off' | 'benign' | 'full';
+
+export interface WorldPressureFlags {
+  aiPressure: AiPressureFlag;
+  aiPressureVisibility: boolean;
+  aiCrisisInteractions: AiCrisisInteractionsFlag;
+}
+
+// Stage defaults: flipped by the final MR of each stage (MR 2/3 → aiPressure,
+// MR 5 → visibility, MR 6/7 → interactions). Until then, dark.
+export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags {
+  return {
+    aiPressure: settings?.aiPressure ?? 'off',
+    aiPressureVisibility: settings?.aiPressureVisibility ?? false,
+    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'off',
+  };
+}

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -40,7 +40,7 @@ import {
 } from '@/systems/faction-system';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier } from '@/systems/crisis-system';
-import { resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { getCityIntrinsicStrength, isCityHpRegenerating } from '@/systems/city-siege-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
 import { calculateProjectedCityYields } from '@/systems/city-work-system';
@@ -316,7 +316,7 @@ export function createCityPanel(
     const flavor = getCrisisFlavor(crisis.flavorId);
     if (!flavor) return null;
     const civ = state.civilizations[crisis.targetCivId];
-    const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
+    const severity = flavor.severityByChallenge[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
     const isQuarantined = crisis.quarantinedCityIds?.includes(city.id) ?? false;
     const remedyCompletionTurn = crisis.remedyCompletionByCity?.[city.id];
     const remedyPending = remedyCompletionTurn !== undefined;
@@ -347,7 +347,7 @@ export function createCityPanel(
   const catastropheChips = catastropheCrises.map(crisis => {
     const flavor = getCrisisFlavor(crisis.flavorId);
     if (!flavor) return null;
-    const severity = flavor.severityByChallenge[resolveChallengeForCiv(state, crisis.targetCivId)];
+    const severity = flavor.severityByChallenge[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
     const recoveryPenaltyPct = Math.round((1 - getCatastropheRecoveryMultiplier(severity)) * 100);
     return { crisis, flavor, recoveryPenaltyPct };
   }).filter((c): c is NonNullable<typeof c> => c !== null);

--- a/src/ui/turn-handoff.ts
+++ b/src/ui/turn-handoff.ts
@@ -40,7 +40,7 @@ export function acknowledgeTurnHandoffSummary(
   const opponentAI = structuredClone(
     state.opponentAI ?? createEmptyOpponentAIState(),
   );
-  const ledger = opponentAI.pressureByHuman[viewerId] ?? {
+  const ledger = opponentAI.pressureByCiv[viewerId] ?? {
     activeIndependentThreatIds: [],
     recoveryUntilTurn: 0,
     lastResolvedThreatTurn: null,
@@ -50,7 +50,7 @@ export function acknowledgeTurnHandoffSummary(
   const playStrategicWarningAudio = hasStrategicWarning
     && ledger.lastStrategicAudioTurn !== summary.turn;
   if (hasStrategicWarning) {
-    opponentAI.pressureByHuman[viewerId] = {
+    opponentAI.pressureByCiv[viewerId] = {
       ...ledger,
       lastStrategicAudioTurn: summary.turn,
     };

--- a/tests/core/opponent-ai-state.test.ts
+++ b/tests/core/opponent-ai-state.test.ts
@@ -65,7 +65,7 @@ describe('opponent AI state normalization', () => {
       barbarianCamps: {},
       barbarianHomeCampByUnitId: {},
       minorCivs: {},
-      pressureByHuman: {},
+      pressureByCiv: {},
       lastPlannedRound: null,
       lastProcessedRound: null,
       lastFinalizedRound: null,
@@ -269,7 +269,7 @@ describe('opponent AI state normalization', () => {
       strength: 5,
       spawnCooldown: 1,
     };
-    state.opponentAI!.pressureByHuman = {
+    state.opponentAI!.pressureByCiv = {
       player: {
         activeIndependentThreatIds: [
           'barbarian:missing',
@@ -296,8 +296,8 @@ describe('opponent AI state normalization', () => {
 
     const normalized = normalizeOpponentAIState(state);
 
-    expect(Object.keys(normalized.opponentAI!.pressureByHuman)).toEqual(['player', 'player-2']);
-    expect(normalized.opponentAI!.pressureByHuman.player).toEqual({
+    expect(Object.keys(normalized.opponentAI!.pressureByCiv)).toEqual(['player', 'player-2']);
+    expect(normalized.opponentAI!.pressureByCiv.player).toEqual({
       activeIndependentThreatIds: [
         'barbarian:live',
         'barbarian:missing',
@@ -309,8 +309,30 @@ describe('opponent AI state normalization', () => {
       lastWarningTurnByKey: { valid: 3 },
       lastStrategicAudioTurn: null,
     });
-    expect(normalized.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+    expect(normalized.opponentAI!.pressureByCiv['player-2'].activeIndependentThreatIds)
       .toEqual([]);
     expect(state).toEqual(snapshot);
+  });
+
+  it('migrates legacy pressureByHuman key on normalize', () => {
+    // Deviation from the plan's literal fixture (civilizations: {}): the
+    // ledger loop is gated on living-human civ ids (unchanged in this MR —
+    // that gating is Task 1.5's eligibility-helper job, not this task's key
+    // rename), so a ledger entry for an id with no matching civ can never
+    // surface regardless of the legacy-key fallback. Use a real living human
+    // so the test actually exercises the `pressureByCiv ?? pressureByHuman`
+    // fallback under the gating that exists today. Also uses a valid
+    // `barbarian:`-prefixed threat id (the plan's literal 't1' fails
+    // isIndependentThreatId's format check and would be filtered regardless
+    // of the key migration).
+    const opponentAI = { ...createEmptyOpponentAIState() } as any;
+    delete opponentAI.pressureByCiv;
+    opponentAI.pressureByHuman = { h1: { activeIndependentThreatIds: ['barbarian:t1'], recoveryUntilTurn: 5, lastResolvedThreatTurn: 3, lastWarningTurnByKey: {}, lastStrategicAudioTurn: null } };
+    const state = {
+      opponentAI,
+      civilizations: { h1: { id: 'h1', isHuman: true, isEliminated: false } },
+    } as unknown as GameState;
+    const normalized = normalizeOpponentAIState(state);
+    expect(normalized.opponentAI!.pressureByCiv.h1.activeIndependentThreatIds).toEqual(['barbarian:t1']);
   });
 });

--- a/tests/core/opponent-challenge.test.ts
+++ b/tests/core/opponent-challenge.test.ts
@@ -9,6 +9,7 @@ import {
   OPPONENT_CHALLENGE_PROFILES,
   resolveChallengeForCiv,
   resolveOpponentChallenge,
+  resolvePressureSeverityForCiv,
   setPendingChallengeForCiv,
   setPendingOpponentChallenge,
 } from '@/core/opponent-challenge';
@@ -108,6 +109,23 @@ describe('per-civ challenge resolution', () => {
   });
   it('ignores invalid values', () => {
     expect(resolveChallengeForCiv(stateWith('bogus', undefined), 'c1')).toBe('standard');
+  });
+});
+
+describe('resolvePressureSeverityForCiv', () => {
+  it('returns the personal challenge for humans', () => {
+    const state = { opponentChallenge: 'veteran', civilizations: {
+      h1: { isHuman: true, challenge: 'explorer' },
+    } } as any;
+    expect(resolvePressureSeverityForCiv(state, 'h1')).toBe('explorer');
+  });
+  it('returns standard for AI even at veteran opponentChallenge (inversion trap)', () => {
+    const state = { opponentChallenge: 'veteran', civilizations: {
+      'ai-1': { isHuman: false },
+    } } as any;
+    expect(resolvePressureSeverityForCiv(state, 'ai-1')).toBe('standard');
+    // Contrast: resolveChallengeForCiv would return 'veteran' here — that is
+    // the inversion trap this function exists to avoid. See spec §severity.
   });
 });
 

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -120,7 +120,7 @@ describe('processTurn', () => {
     const result = processTurn(structuredClone(state), new EventBus());
 
     expect(Object.values(result.barbarianCamps).some(camp => camp.resurgent)).toBe(true);
-    expect(result.opponentAI!.pressureByHuman['ai-1'].activeIndependentThreatIds)
+    expect(result.opponentAI!.pressureByCiv['ai-1'].activeIndependentThreatIds)
       .toEqual(expect.arrayContaining([expect.stringMatching(/^barbarian:camp-/)]));
   });
 

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -18,7 +18,7 @@ import { createUnit } from '@/systems/unit-system';
 import { deterministicCombatSeed, resolveCombat } from '@/systems/combat-system';
 import { buildCombatContextForDefender } from '@/systems/combat-context';
 import { createTechState } from '@/systems/tech-system';
-import { processIndependentThreatPressureForHumans } from '@/systems/threat-pressure-system';
+import { processIndependentThreatPressure } from '@/systems/threat-pressure-system';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
@@ -112,7 +112,7 @@ describe('processTurn', () => {
         regionKeys.map(regionKey => [regionKey, civ.id === 'ai-1' ? 0 : state.turn]),
       );
     }
-    expect(Object.values(processIndependentThreatPressureForHumans(
+    expect(Object.values(processIndependentThreatPressure(
       structuredClone(state),
       new EventBus(),
     ).barbarianCamps).some(camp => camp.resurgent)).toBe(true);

--- a/tests/simulation/ai-playability-fixture.ts
+++ b/tests/simulation/ai-playability-fixture.ts
@@ -507,7 +507,7 @@ function simulate(
       }
     }
     for (const humanId of humanIds) {
-      const ledger = state.opponentAI?.pressureByHuman[humanId];
+      const ledger = state.opponentAI?.pressureByCiv[humanId];
       if (!ledger) throw new Error(`${options.seed}: missing pressure ledger for ${humanId}`);
       const activeCount = ledger.activeIndependentThreatIds.length;
       metrics.maxIndependentThreatsByHuman[humanId] = Math.max(
@@ -520,12 +520,12 @@ function simulate(
       }
     }
     for (const threatId of new Set(humanIds.flatMap(
-      humanId => state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds,
+      humanId => state.opponentAI!.pressureByCiv[humanId]!.activeIndependentThreatIds,
     ))) {
       const materiallyAffected = humanIds.filter(humanId =>
-        state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds.includes(threatId));
+        state.opponentAI!.pressureByCiv[humanId]!.activeIndependentThreatIds.includes(threatId));
       if (materiallyAffected.length > 1 && materiallyAffected.some(humanId =>
-        !state.opponentAI!.pressureByHuman[humanId]!.activeIndependentThreatIds.includes(threatId))) {
+        !state.opponentAI!.pressureByCiv[humanId]!.activeIndependentThreatIds.includes(threatId))) {
         throw new Error(`${options.seed}: shared threat ${threatId} has inconsistent ledgers`);
       }
     }

--- a/tests/systems/crisis-system.test.ts
+++ b/tests/systems/crisis-system.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
-import { processCrisisSchedulerForHumans, countActiveCrisesForCiv, countUnrestGroups } from '@/systems/crisis-system';
+import { processCrisisSchedulerForHumans, countActiveCrisesForCiv, countUnrestGroups, getCrisisYieldMultiplier } from '@/systems/crisis-system';
+import { getCrisisFlavor } from '@/systems/crisis-flavor-definitions';
 import { makeCrisisFixture } from './helpers/crisis-fixture';
+import type { GameState } from '@/core/types';
 
 describe('crisis scheduler', () => {
   it('fires a crisis for an idle human past grace', () => {
@@ -85,5 +87,28 @@ describe('crisis scheduler', () => {
     bus.on('crisis:started', e => events.push(e));
     processCrisisSchedulerForHumans(makeCrisisFixture({ era: 3, turn: 40 }).state, bus);
     expect(events).toHaveLength(1);
+  });
+});
+
+describe('AI crisis severity uses standard, not opponentChallenge (#526 MR1)', () => {
+  it('resolves AI crisis severity as standard even when opponentChallenge is veteran', () => {
+    const flavor = getCrisisFlavor('plague')!;
+    const std = 1 - flavor.severityByChallenge.standard.yieldPenalty;
+    const vet = 1 - flavor.severityByChallenge.veteran.yieldPenalty;
+    expect(std).not.toBe(vet); // guard: the test is meaningful
+    // Minimal literal state — getCrisisYieldMultiplier only reads activeCrises,
+    // cities (for membership), civilizations, opponentChallenge.
+    const state = {
+      opponentChallenge: 'veteran',
+      civilizations: { 'ai-1': { id: 'ai-1', isHuman: false } },
+      cities: { 'ai-city': { id: 'ai-city' } },
+      activeCrises: {
+        'crisis-1': {
+          id: 'crisis-1', flavorId: 'plague', archetype: 'outbreak', targetCivId: 'ai-1',
+          cityIds: ['ai-city'], tileKeys: [], startedTurn: 1, stage: 'active', turnsInStage: 1,
+        },
+      },
+    } as unknown as GameState;
+    expect(getCrisisYieldMultiplier(state, 'ai-city')).toBeCloseTo(std);
   });
 });

--- a/tests/systems/crisis-system.test.ts
+++ b/tests/systems/crisis-system.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { EventBus } from '@/core/event-bus';
-import { processCrisisSchedulerForHumans, countActiveCrisesForCiv, countUnrestGroups, getCrisisYieldMultiplier } from '@/systems/crisis-system';
+import { processCrisisScheduler, countActiveCrisesForCiv, countUnrestGroups, getCrisisYieldMultiplier } from '@/systems/crisis-system';
 import { getCrisisFlavor } from '@/systems/crisis-flavor-definitions';
 import { makeCrisisFixture } from './helpers/crisis-fixture';
 import type { GameState } from '@/core/types';
@@ -8,7 +8,7 @@ import type { GameState } from '@/core/types';
 describe('crisis scheduler', () => {
   it('fires a crisis for an idle human past grace', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40, challenge: 'standard' });
-    const next = processCrisisSchedulerForHumans(state, new EventBus());
+    const next = processCrisisScheduler(state, new EventBus());
     const crises = Object.values(next.activeCrises ?? {});
     expect(crises).toHaveLength(1);
     // This fixture's city (population 5, grassland, no forest/mountain/coast/jungle
@@ -26,20 +26,20 @@ describe('crisis scheduler', () => {
   it('respects era grace: no crisis in era 1 for anyone, era 2 for explorer', () => {
     for (const [challenge, era] of [['veteran', 1], ['explorer', 2]] as const) {
       const { state } = makeCrisisFixture({ era, turn: 99, challenge });
-      expect(Object.keys(processCrisisSchedulerForHumans(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
+      expect(Object.keys(processCrisisScheduler(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
     }
   });
 
   it('respects turn grace floors (30/20/10)', () => {
     for (const [challenge, turn] of [['explorer', 29], ['standard', 19], ['veteran', 9]] as const) {
       const { state } = makeCrisisFixture({ era: 5, turn, challenge });
-      expect(Object.keys(processCrisisSchedulerForHumans(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
+      expect(Object.keys(processCrisisScheduler(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
     }
   });
 
   it('respects cooldown', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40, challenge: 'standard', lastCrisisOnsetTurn: 35 });
-    expect(Object.keys(processCrisisSchedulerForHumans(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
+    expect(Object.keys(processCrisisScheduler(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
   });
 
   it('is blocked at cap, counting unrest groups', () => {
@@ -50,7 +50,7 @@ describe('crisis scheduler', () => {
     });
     expect(countUnrestGroups(state, 'p1')).toBe(1);
     expect(countActiveCrisesForCiv(state, 'p1')).toBe(2);
-    const next = processCrisisSchedulerForHumans(state, new EventBus());
+    const next = processCrisisScheduler(state, new EventBus());
     expect(Object.keys(next.activeCrises ?? {})).toHaveLength(1); // unchanged
   });
 
@@ -71,21 +71,21 @@ describe('crisis scheduler', () => {
 
   it('is deterministic: same state → same crisis id and target', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40 });
-    const a = processCrisisSchedulerForHumans(state, new EventBus());
-    const b = processCrisisSchedulerForHumans(state, new EventBus());
+    const a = processCrisisScheduler(state, new EventBus());
+    const b = processCrisisScheduler(state, new EventBus());
     expect(a.activeCrises).toEqual(b.activeCrises);
   });
 
   it('skips players with an active external threat', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40, activeExternalThreat: true });
-    expect(Object.keys(processCrisisSchedulerForHumans(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
+    expect(Object.keys(processCrisisScheduler(state, new EventBus()).activeCrises ?? {})).toHaveLength(0);
   });
 
   it('emits crisis:started with what-to-do copy routed later', () => {
     const bus = new EventBus();
     const events: unknown[] = [];
     bus.on('crisis:started', e => events.push(e));
-    processCrisisSchedulerForHumans(makeCrisisFixture({ era: 3, turn: 40 }).state, bus);
+    processCrisisScheduler(makeCrisisFixture({ era: 3, turn: 40 }).state, bus);
     expect(events).toHaveLength(1);
   });
 });

--- a/tests/systems/helpers/crisis-fixture.ts
+++ b/tests/systems/helpers/crisis-fixture.ts
@@ -192,7 +192,7 @@ export function makeCrisisFixture({
     activeCrises: Object.keys(activeCrises).length > 0 ? activeCrises : undefined,
     opponentAI: activeExternalThreat ? {
       ...createEmptyOpponentAIState(),
-      pressureByHuman: {
+      pressureByCiv: {
         [civId]: {
           activeIndependentThreatIds: ['barbarian:camp-x'],
           recoveryUntilTurn: 0,

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -72,7 +72,7 @@ describe('completed-round pirate coordinator', () => {
       strength: 5,
       spawnCooldown: 2,
     };
-    state.opponentAI.pressureByHuman.player = {
+    state.opponentAI.pressureByCiv.player = {
       activeIndependentThreatIds: ['barbarian:existing-pressure'],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,

--- a/tests/systems/strategic-warning-system.test.ts
+++ b/tests/systems/strategic-warning-system.test.ts
@@ -46,7 +46,7 @@ function fixture(): { before: GameState; after: GameState; aiId: string; aiUnitI
     seed: 'strategic-warning',
   });
   before.opponentAI = createEmptyOpponentAIState();
-  before.opponentAI.pressureByHuman.player = {
+  before.opponentAI.pressureByCiv.player = {
     activeIndependentThreatIds: [],
     recoveryUntilTurn: 0,
     lastResolvedThreatTurn: null,
@@ -394,9 +394,9 @@ describe('strategic warning transition derivation', () => {
 
   it('emits recovery only from an explicit pressure-ledger resolution', () => {
     const { before, after } = fixture();
-    before.opponentAI!.pressureByHuman.player.activeIndependentThreatIds = ['barbarian:camp-1'];
-    after.opponentAI!.pressureByHuman.player = {
-      ...after.opponentAI!.pressureByHuman.player,
+    before.opponentAI!.pressureByCiv.player.activeIndependentThreatIds = ['barbarian:camp-1'];
+    after.opponentAI!.pressureByCiv.player = {
+      ...after.opponentAI!.pressureByCiv.player,
       activeIndependentThreatIds: [],
       lastResolvedThreatTurn: after.turn,
       recoveryUntilTurn: after.turn + 2,
@@ -423,7 +423,7 @@ describe('strategic warning transition derivation', () => {
 
     expect(warnings).toHaveLength(1);
     expect(warnings.filter((warning: any) => warning.playAudio)).toHaveLength(1);
-    expect(Object.keys(applied.opponentAI!.pressureByHuman.player.lastWarningTurnByKey))
+    expect(Object.keys(applied.opponentAI!.pressureByCiv.player.lastWarningTurnByKey))
       .toHaveLength(1);
     expect(after).toEqual(snapshot);
     expect(deriveStrategicWarningTransitions(before, applied, 'player')).toEqual([]);

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -9,7 +9,7 @@ import {
   empireShare,
   nearestLandmassId,
   recordCombatForCiv,
-  processIndependentThreatPressureForHumans,
+  processIndependentThreatPressure,
   processLandResurgence,
   processThreatPressure,
   processPirateSpawn,
@@ -306,7 +306,7 @@ describe('independent threat pressure governor', () => {
     const state = makePressureState();
     state.civilizations['player-2'].isEliminated = true;
 
-    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+    const result = processIndependentThreatPressure(state, new EventBus());
 
     expect(Object.keys(result.opponentAI!.pressureByCiv))
       .toEqual(['player-1', 'player-3']);
@@ -352,7 +352,7 @@ describe('independent threat pressure governor', () => {
       exposureResolvedRaidKeys: [],
     };
 
-    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+    const result = processIndependentThreatPressure(state, new EventBus());
 
     expect(result.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-7']);
@@ -383,7 +383,7 @@ describe('independent threat pressure governor', () => {
       return state;
     };
 
-    const allowed = processIndependentThreatPressureForHumans(makeEligible(), new EventBus());
+    const allowed = processIndependentThreatPressure(makeEligible(), new EventBus());
     const [sharedId] = allowed.opponentAI!.pressureByCiv['player-1']
       .activeIndependentThreatIds;
     expect(sharedId).toMatch(/^barbarian:camp-/);
@@ -403,7 +403,7 @@ describe('independent threat pressure governor', () => {
     const bus = new EventBus();
     bus.on('threat:barbarian-resurgence', event => blockedEvents.push(event));
 
-    const result = processIndependentThreatPressureForHumans(blocked, bus);
+    const result = processIndependentThreatPressure(blocked, bus);
 
     expect(result.barbarianCamps).toEqual({});
     expect(result.idCounters.nextCampId).toBe(blocked.idCounters.nextCampId);
@@ -433,7 +433,7 @@ describe('independent threat pressure governor', () => {
     expect(canStartIndependentThreat(state, 'player-1', 'barbarian:new'))
       .toMatchObject({ allowed: false, reason: 'recovery' });
 
-    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+    const result = processIndependentThreatPressure(state, new EventBus());
     expect(result.pirates!.factions['pirate-1']).toEqual(state.pirates!.factions['pirate-1']);
     expect(result.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-1', 'pirate:pirate-2']);
@@ -455,13 +455,13 @@ describe('independent threat pressure governor', () => {
     };
     state.pirates!.factions['pirate-1'].intent = null;
 
-    const retargeted = processIndependentThreatPressureForHumans(state, new EventBus());
+    const retargeted = processIndependentThreatPressure(state, new EventBus());
     expect(retargeted.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-1']);
     expect(retargeted.opponentAI!.pressureByCiv['player-1'].recoveryUntilTurn).toBe(0);
 
     delete state.pirates!.factions['pirate-1'];
-    const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
+    const resolved = processIndependentThreatPressure(state, new EventBus());
     expect(resolved.opponentAI!.pressureByCiv['player-1']).toEqual({
       activeIndependentThreatIds: [],
       recoveryUntilTurn: state.turn + rounds,
@@ -470,7 +470,7 @@ describe('independent threat pressure governor', () => {
       lastStrategicAudioTurn: 3,
     });
 
-    const repeated = processIndependentThreatPressureForHumans(resolved, new EventBus());
+    const repeated = processIndependentThreatPressure(resolved, new EventBus());
     expect(repeated.opponentAI!.pressureByCiv['player-1']).toEqual(
       resolved.opponentAI!.pressureByCiv['player-1'],
     );
@@ -505,13 +505,13 @@ describe('independent threat pressure governor', () => {
       lastWarningTurnByKey: {},
       lastStrategicAudioTurn: null,
     };
-    const stillActive = processIndependentThreatPressureForHumans(state, new EventBus());
+    const stillActive = processIndependentThreatPressure(state, new EventBus());
     expect(stillActive.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['barbarian:camp-1', 'beast:lair-giant_boar']);
 
     delete state.barbarianCamps['camp-1'];
     state.beasts.lairs['lair-giant_boar'].status = 'slain';
-    const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
+    const resolved = processIndependentThreatPressure(state, new EventBus());
 
     expect(resolved.opponentAI!.pressureByCiv['player-1']).toMatchObject({
       activeIndependentThreatIds: [],
@@ -548,7 +548,7 @@ describe('independent threat pressure governor', () => {
       lastStrategicAudioTurn: null,
     };
 
-    const result = processIndependentThreatPressureForHumans(state, new EventBus());
+    const result = processIndependentThreatPressure(state, new EventBus());
 
     expect(result.barbarianCamps).toEqual({});
     expect(result.opponentAI!.pressureByCiv['player-1']).toMatchObject({

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -308,9 +308,9 @@ describe('independent threat pressure governor', () => {
 
     const result = processIndependentThreatPressureForHumans(state, new EventBus());
 
-    expect(Object.keys(result.opponentAI!.pressureByHuman))
+    expect(Object.keys(result.opponentAI!.pressureByCiv))
       .toEqual(['player-1', 'player-3']);
-    expect(state.opponentAI!.pressureByHuman).toEqual({});
+    expect(state.opponentAI!.pressureByCiv).toEqual({});
   });
 
   it.each([
@@ -319,7 +319,7 @@ describe('independent threat pressure governor', () => {
     ['veteran', 3],
   ] as const)('%s caps new independent threats at %i per human', (challenge, cap) => {
     const state = makePressureState(challenge);
-    state.opponentAI!.pressureByHuman['player-1'] = {
+    state.opponentAI!.pressureByCiv['player-1'] = {
       activeIndependentThreatIds: Array.from({ length: cap }, (_, index) => `barbarian:camp-${index}`),
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -354,9 +354,9 @@ describe('independent threat pressure governor', () => {
 
     const result = processIndependentThreatPressureForHumans(state, new EventBus());
 
-    expect(result.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+    expect(result.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-7']);
-    expect(result.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+    expect(result.opponentAI!.pressureByCiv['player-2'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-7']);
     expect(canStartIndependentThreat(result, 'player-3', 'barbarian:new'))
       .toMatchObject({ allowed: true, activeCount: 0 });
@@ -384,15 +384,15 @@ describe('independent threat pressure governor', () => {
     };
 
     const allowed = processIndependentThreatPressureForHumans(makeEligible(), new EventBus());
-    const [sharedId] = allowed.opponentAI!.pressureByHuman['player-1']
+    const [sharedId] = allowed.opponentAI!.pressureByCiv['player-1']
       .activeIndependentThreatIds;
     expect(sharedId).toMatch(/^barbarian:camp-/);
-    expect(allowed.opponentAI!.pressureByHuman['player-2'].activeIndependentThreatIds)
+    expect(allowed.opponentAI!.pressureByCiv['player-2'].activeIndependentThreatIds)
       .toContain(sharedId);
 
     const blocked = makeEligible();
     addPirateThreat(blocked, 'pirate-1', 'player-2');
-    blocked.opponentAI!.pressureByHuman['player-2'] = {
+    blocked.opponentAI!.pressureByCiv['player-2'] = {
       activeIndependentThreatIds: ['pirate:pirate-1'],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -416,7 +416,7 @@ describe('independent threat pressure governor', () => {
     addPirateThreat(state, 'pirate-1', 'player-1');
     addPirateThreat(state, 'pirate-2', 'player-1');
     state.opponentAI!.migrationGraceRoundsRemaining = 1;
-    state.opponentAI!.pressureByHuman['player-1'] = {
+    state.opponentAI!.pressureByCiv['player-1'] = {
       activeIndependentThreatIds: ['pirate:pirate-1', 'pirate:pirate-2'],
       recoveryUntilTurn: state.turn + 3,
       lastResolvedThreatTurn: state.turn - 1,
@@ -435,7 +435,7 @@ describe('independent threat pressure governor', () => {
 
     const result = processIndependentThreatPressureForHumans(state, new EventBus());
     expect(result.pirates!.factions['pirate-1']).toEqual(state.pirates!.factions['pirate-1']);
-    expect(result.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+    expect(result.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-1', 'pirate:pirate-2']);
   });
 
@@ -446,7 +446,7 @@ describe('independent threat pressure governor', () => {
   ] as const)('%s begins %i rounds of recovery only after explicit destruction', (challenge, rounds) => {
     const state = makePressureState(challenge);
     addPirateThreat(state, 'pirate-1', 'player-1');
-    state.opponentAI!.pressureByHuman['player-1'] = {
+    state.opponentAI!.pressureByCiv['player-1'] = {
       activeIndependentThreatIds: ['pirate:pirate-1'],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -456,13 +456,13 @@ describe('independent threat pressure governor', () => {
     state.pirates!.factions['pirate-1'].intent = null;
 
     const retargeted = processIndependentThreatPressureForHumans(state, new EventBus());
-    expect(retargeted.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+    expect(retargeted.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['pirate:pirate-1']);
-    expect(retargeted.opponentAI!.pressureByHuman['player-1'].recoveryUntilTurn).toBe(0);
+    expect(retargeted.opponentAI!.pressureByCiv['player-1'].recoveryUntilTurn).toBe(0);
 
     delete state.pirates!.factions['pirate-1'];
     const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
-    expect(resolved.opponentAI!.pressureByHuman['player-1']).toEqual({
+    expect(resolved.opponentAI!.pressureByCiv['player-1']).toEqual({
       activeIndependentThreatIds: [],
       recoveryUntilTurn: state.turn + rounds,
       lastResolvedThreatTurn: state.turn,
@@ -471,8 +471,8 @@ describe('independent threat pressure governor', () => {
     });
 
     const repeated = processIndependentThreatPressureForHumans(resolved, new EventBus());
-    expect(repeated.opponentAI!.pressureByHuman['player-1']).toEqual(
-      resolved.opponentAI!.pressureByHuman['player-1'],
+    expect(repeated.opponentAI!.pressureByCiv['player-1']).toEqual(
+      resolved.opponentAI!.pressureByCiv['player-1'],
     );
   });
 
@@ -498,7 +498,7 @@ describe('independent threat pressure governor', () => {
       },
       sightingsByCiv: {},
     };
-    state.opponentAI!.pressureByHuman['player-1'] = {
+    state.opponentAI!.pressureByCiv['player-1'] = {
       activeIndependentThreatIds: ['barbarian:camp-1', 'beast:lair-giant_boar'],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -506,14 +506,14 @@ describe('independent threat pressure governor', () => {
       lastStrategicAudioTurn: null,
     };
     const stillActive = processIndependentThreatPressureForHumans(state, new EventBus());
-    expect(stillActive.opponentAI!.pressureByHuman['player-1'].activeIndependentThreatIds)
+    expect(stillActive.opponentAI!.pressureByCiv['player-1'].activeIndependentThreatIds)
       .toEqual(['barbarian:camp-1', 'beast:lair-giant_boar']);
 
     delete state.barbarianCamps['camp-1'];
     state.beasts.lairs['lair-giant_boar'].status = 'slain';
     const resolved = processIndependentThreatPressureForHumans(state, new EventBus());
 
-    expect(resolved.opponentAI!.pressureByHuman['player-1']).toMatchObject({
+    expect(resolved.opponentAI!.pressureByCiv['player-1']).toMatchObject({
       activeIndependentThreatIds: [],
       lastResolvedThreatTurn: state.turn,
       recoveryUntilTurn: state.turn + 2,
@@ -540,7 +540,7 @@ describe('independent threat pressure governor', () => {
         regionKey: 'continent-0',
       },
     ]));
-    state.opponentAI!.pressureByHuman['player-1'] = {
+    state.opponentAI!.pressureByCiv['player-1'] = {
       activeIndependentThreatIds: ['barbarian:destroyed'],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -551,7 +551,7 @@ describe('independent threat pressure governor', () => {
     const result = processIndependentThreatPressureForHumans(state, new EventBus());
 
     expect(result.barbarianCamps).toEqual({});
-    expect(result.opponentAI!.pressureByHuman['player-1']).toMatchObject({
+    expect(result.opponentAI!.pressureByCiv['player-1']).toMatchObject({
       activeIndependentThreatIds: [],
       recoveryUntilTurn: state.turn + 2,
       lastResolvedThreatTurn: state.turn,

--- a/tests/systems/world-pressure-eligibility.test.ts
+++ b/tests/systems/world-pressure-eligibility.test.ts
@@ -24,4 +24,18 @@ describe('world-pressure eligibility', () => {
   it('full flag: both include AI', () => {
     expect(getCrisisEligibleCivIds(base('full'))).toEqual(['ai-1', 'h1']);
   });
+
+  it('excludes eliminated civs directly, not just via getCrisisEligibleCivIds', () => {
+    const state = {
+      settings: { aiPressure: 'full' },
+      civilizations: {
+        h1: { id: 'h1', isHuman: true, isEliminated: true, cities: [] },
+        'ai-1': { id: 'ai-1', isHuman: false, isEliminated: true, cities: [] },
+      },
+    } as any;
+    expect(isCrisisPressureEligible(state, 'h1')).toBe(false);
+    expect(isCrisisPressureEligible(state, 'ai-1')).toBe(false);
+    expect(isPiratePressureEligible(state, 'h1')).toBe(false);
+    expect(isPiratePressureEligible(state, 'ai-1')).toBe(false);
+  });
 });

--- a/tests/systems/world-pressure-eligibility.test.ts
+++ b/tests/systems/world-pressure-eligibility.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isCrisisPressureEligible,
+  isPiratePressureEligible,
+  getCrisisEligibleCivIds,
+} from '@/systems/world-pressure-eligibility';
+
+describe('world-pressure eligibility', () => {
+  const base = (aiPressure?: string) => ({
+    settings: aiPressure ? { aiPressure } : {},
+    civilizations: {
+      h1: { id: 'h1', isHuman: true, isEliminated: false, cities: ['c1'] },
+      'ai-1': { id: 'ai-1', isHuman: false, isEliminated: false, cities: ['c2'] },
+    },
+  } as any);
+  it('flags off: humans only (parity with today)', () => {
+    expect(getCrisisEligibleCivIds(base())).toEqual(['h1']);
+    expect(isPiratePressureEligible(base(), 'ai-1')).toBe(false);
+  });
+  it('pirates flag: pirate pressure includes AI, crisis does not', () => {
+    expect(isPiratePressureEligible(base('pirates'), 'ai-1')).toBe(true);
+    expect(isCrisisPressureEligible(base('pirates'), 'ai-1')).toBe(false);
+  });
+  it('full flag: both include AI', () => {
+    expect(getCrisisEligibleCivIds(base('full'))).toEqual(['ai-1', 'h1']);
+  });
+});

--- a/tests/systems/world-pressure-flags.test.ts
+++ b/tests/systems/world-pressure-flags.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
+import type { GameSettings } from '@/core/types';
+
+describe('resolveWorldPressureFlags', () => {
+  it('defaults everything off for legacy saves (undefined settings fields)', () => {
+    expect(resolveWorldPressureFlags({} as GameSettings)).toEqual({
+      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+    });
+    expect(resolveWorldPressureFlags(undefined)).toEqual({
+      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+    });
+  });
+  it('passes explicit values through', () => {
+    const settings = { aiPressure: 'pirates', aiPressureVisibility: true, aiCrisisInteractions: 'benign' } as GameSettings;
+    expect(resolveWorldPressureFlags(settings)).toEqual({
+      aiPressure: 'pirates', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
+    });
+  });
+});

--- a/tests/ui/turn-handoff.test.ts
+++ b/tests/ui/turn-handoff.test.ts
@@ -49,7 +49,7 @@ describe('turn handoff', () => {
   it('acknowledges multiple warning rows with one post-handoff cue and does not replay after reload', () => {
     const { state } = makeFixture();
     state.opponentAI = createEmptyOpponentAIState();
-    state.opponentAI.pressureByHuman['player-2'] = {
+    state.opponentAI.pressureByCiv['player-2'] = {
       activeIndependentThreatIds: [],
       recoveryUntilTurn: 0,
       lastResolvedThreatTurn: null,
@@ -73,7 +73,7 @@ describe('turn handoff', () => {
 
     expect(first.playStrategicWarningAudio).toBe(true);
     expect(first.state.pendingEvents?.['player-2']).toEqual([]);
-    expect(first.state.opponentAI!.pressureByHuman['player-2'].lastStrategicAudioTurn)
+    expect(first.state.opponentAI!.pressureByCiv['player-2'].lastStrategicAudioTurn)
       .toBe(summary.turn);
     expect(reloadedSummary.events).toEqual([]);
     expect(replay.playStrategicWarningAudio).toBe(false);


### PR DESCRIPTION
## Summary

Executes MR 1 (Tasks 1.1–1.5) of the world-pressure symmetry plan: renames/reshapes the human-only crisis/threat pipeline to be actor-agnostic, entirely behind new dark feature flags. **Zero behavior change** with flags at their defaults — this is the parity seam the rest of the arc (#528–#534) builds on.

- **Task 1.1** — `WorldPressureFlags` + `resolveWorldPressureFlags`, plus 3 new optional `GameSettings` fields (`aiPressure`, `aiPressureVisibility`, `aiCrisisInteractions`), all defaulting off/false for legacy saves.
- **Task 1.2** — `resolvePressureSeverityForCiv`: humans resolve their personal challenge; AI always resolves `'standard'` severity, never the game-wide `opponentChallenge` (avoids the "veteran inverts AI difficulty" trap).
- **Task 1.3** — every severity lookup in `crisis-system.ts` and `city-panel.ts`'s crisis display now routes through `resolvePressureSeverityForCiv` instead of `resolveChallengeForCiv`. `grep -n "resolveChallengeForCiv" src/systems/crisis-system.ts` returns no hits (acceptance criterion met).
- **Task 1.4** — `HumanPressureLedger`/`pressureByHuman` renamed to `CivPressureLedger`/`pressureByCiv` everywhere, with a legacy-key fallback in `normalizeOpponentAIState` so old saves still load.
- **Task 1.5** — new `world-pressure-eligibility.ts` (`isCrisisPressureEligible`, `isPiratePressureEligible`, `getCrisisEligibleCivIds`); `processCrisisSchedulerForHumans` → `processCrisisScheduler`, `processIndependentThreatPressureForHumans` → `processIndependentThreatPressure`.

## Deviations from the plan (noted per spec-fidelity.md)

- **Task 1.4's literal test fixture** (`civilizations: {}`) can't pass without also changing the ledger loop's civ-eligibility gate — which is Task 1.5's job, not 1.4's. Adjusted the fixture to a realistic living-human civ so the test exercises the legacy-key fallback under the gating that exists today. Also swapped the plan's literal `'t1'` threat id for `'barbarian:t1'` — the un-prefixed form fails `isIndependentThreatId`'s format check regardless of the key migration.
- **Task 1.5's `isHuman` gate classification**: the plan's step 3 flags one line as a "human-only UI/audio warning" gate to leave alone. `threat-pressure-system.ts` has no UI/audio-warning logic at all (that lives in `strategic-warning-system.ts`, outside this task's file list) — so all six `isHuman` gates in this file (`deriveHumansMateriallyAffectedByPosition`, `deriveActiveIndependentThreatIds`, `reserveIndependentThreatForHumans`, `processIndependentThreatPressure`'s humanIds derivation, `computeThreatScore`, `processThreatPressure`) were classified as pressure-computation and swapped to `isPiratePressureEligible`.

## Test plan

- [x] `bash scripts/run-with-mise.sh yarn build` — clean
- [x] `bash scripts/run-with-mise.sh yarn test` — 6282 passed, 3 skipped, 0 failed (full pre-existing suite passes unchanged — the parity proof)
- [x] New tests: `world-pressure-flags.test.ts`, `world-pressure-eligibility.test.ts`, appended cases in `opponent-challenge.test.ts`, `crisis-system.test.ts`, `opponent-ai-state.test.ts`

Depends on: MR 0 bug fixes #519, #521, #522, #520 (all merged). Part of the world-pressure symmetry arc, index #535.