### PR TITLE
feat(pressure): MR2 — pirate fleets pressure AI civs + navy dispatch (#526)

### DIFF
--- a/src/ai/ai-crisis-response.ts
+++ b/src/ai/ai-crisis-response.ts
@@ -1,6 +1,7 @@
 import type { GameState } from '@/core/types';
 import { getChallengeProfileForCiv } from '@/core/opponent-challenge';
 import { getPirateFleetLeader } from '@/systems/pirate-behavior';
+import { isVisible } from '@/systems/fog-of-war';
 
 export interface CrisisDispatchCandidate {
   kind: 'pirate-fleet' | 'hunt-foe';
@@ -14,6 +15,7 @@ export interface CrisisDispatchCandidate {
 const PIRATE_FLEET_DISPATCH_BASE_SCORE = 100;
 
 export function getCrisisDispatchCandidates(state: GameState, civId: string): CrisisDispatchCandidate[] {
+  const civ = state.civilizations[civId];
   const profile = getChallengeProfileForCiv(state, civId);
   const candidates: CrisisDispatchCandidate[] = [];
   for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
@@ -21,6 +23,11 @@ export function getCrisisDispatchCandidates(state: GameState, civId: string): Cr
     if (faction.intent?.targetCivId !== civId) continue;
     const leader = getPirateFleetLeader(state, factionId);
     if (!leader) continue;
+    // Fog-of-war legitimacy: a dispatch candidate is an "exact target" plan
+    // (ai-playability-fixture.ts's targetWasPerceived invariant) -- the civ
+    // must actually currently see the fleet leader's tile, not just know its
+    // faction is targeting them.
+    if (!civ?.visibility || !isVisible(civ.visibility, leader.position)) continue;
     candidates.push({
       kind: 'pirate-fleet',
       sourceId: factionId,

--- a/src/ai/ai-crisis-response.ts
+++ b/src/ai/ai-crisis-response.ts
@@ -1,0 +1,32 @@
+import type { GameState } from '@/core/types';
+import { getChallengeProfileForCiv } from '@/core/opponent-challenge';
+import { getPirateFleetLeader } from '@/systems/pirate-behavior';
+
+export interface CrisisDispatchCandidate {
+  kind: 'pirate-fleet' | 'hunt-foe';
+  sourceId: string;        // fleetId or crisisId — used for expiry checks
+  targetUnitId: string;    // the pirate ship / hunt foe unit
+  score: number;           // base score × profile.crisisDispatchWeight
+}
+
+// 100 matches the ceiling of AICityThreat.captureRisk (ai-plan-portfolio.ts), the
+// existing defend-city candidate magnitude this competes against for primaryPlan.
+const PIRATE_FLEET_DISPATCH_BASE_SCORE = 100;
+
+export function getCrisisDispatchCandidates(state: GameState, civId: string): CrisisDispatchCandidate[] {
+  const profile = getChallengeProfileForCiv(state, civId);
+  const candidates: CrisisDispatchCandidate[] = [];
+  for (const factionId of Object.keys(state.pirates?.factions ?? {}).sort()) {
+    const faction = state.pirates!.factions[factionId];
+    if (faction.intent?.targetCivId !== civId) continue;
+    const leader = getPirateFleetLeader(state, factionId);
+    if (!leader) continue;
+    candidates.push({
+      kind: 'pirate-fleet',
+      sourceId: factionId,
+      targetUnitId: leader.id,
+      score: PIRATE_FLEET_DISPATCH_BASE_SCORE * profile.crisisDispatchWeight,
+    });
+  }
+  return candidates;
+}

--- a/src/ai/ai-prepared-turn.ts
+++ b/src/ai/ai-prepared-turn.ts
@@ -43,6 +43,8 @@ import {
   OPPONENT_CHALLENGE_PROFILES,
   resolveOpponentChallenge,
 } from '@/core/opponent-challenge';
+import { getCrisisDispatchCandidates } from './ai-crisis-response';
+import { isPiratePressureEligible } from '@/systems/world-pressure-eligibility';
 
 export interface PreparedMajorCivPlan {
   civId: string;
@@ -303,6 +305,31 @@ function planCandidates(
   });
 }
 
+// Converts CrisisDispatchCandidate (pirate fleets, later hunt foes) into the
+// same AIPlanCandidate shape objectiveCandidates() produces, so they compete
+// for primaryPlan through the existing selectPrimaryPlan scoring in
+// ai-plan-portfolio.ts rather than a parallel decision path.
+function crisisDispatchPlanCandidates(state: GameState, civId: string): AIPlanCandidate[] {
+  if (!isPiratePressureEligible(state, civId)) return [];
+  return getCrisisDispatchCandidates(state, civId).flatMap(candidate => {
+    const unit = state.units[candidate.targetUnitId];
+    if (!unit) return [];
+    return [{
+      objective: 'repel',
+      target: { kind: 'unit', id: candidate.targetUnitId, lastKnownPosition: { ...unit.position } },
+      theaterId: `local:${unit.position.q},${unit.position.r}`,
+      score: candidate.score,
+      reasonCodes: ['urgent-defense'],
+      requiredRoles: { 'naval-combat': 1 },
+      commitment: 0.25,
+      targetValid: true,
+      reasonValid: true,
+      expectedLossRatio: 0,
+      progress: false,
+    }];
+  });
+}
+
 function cityThreats(
   state: Readonly<GameState>,
   civId: string,
@@ -384,7 +411,7 @@ export function prepareMajorCivStrategicPlan(
     turn: state.turn,
     actorEliminated: civ.isEliminated === true,
     portfolio: previous,
-    candidates: planCandidates(candidates, choice),
+    candidates: [...planCandidates(candidates, choice), ...crisisDispatchPlanCandidates(state, civId)],
     cityThreats: threats,
     modernization: {
       bestTrainableStrength,

--- a/src/core/opponent-challenge.ts
+++ b/src/core/opponent-challenge.ts
@@ -18,6 +18,12 @@ export interface OpponentChallengeProfile {
   // state.era exceeds this value for the city owner's resolved challenge; below it,
   // a city that hits 0 HP is sacked (survives at 1 HP) instead. See #522.
   citySiegeDestructionEra: number;
+  // AI competence knobs (#526/#528): how well an AI civ responds to world pressure
+  // (crises, pirate fleets) once it is pressure-eligible. Lower delay / higher gold
+  // multiplier / higher dispatch weight = tougher, more responsive AI.
+  crisisResponseDelayTurns: number;   // crisis age before the AI acts
+  crisisRemedyGoldMultiplier: number; // treasury needed as multiple of remedy cost
+  crisisDispatchWeight: number;       // multiplier on dispatch objective score
 }
 
 export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChallengeProfile> = {
@@ -36,6 +42,9 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMinTurns: 30,
     crisisSeverityMultiplier: 0.5,
     citySiegeDestructionEra: 3,
+    crisisResponseDelayTurns: 4,
+    crisisRemedyGoldMultiplier: 3.0,
+    crisisDispatchWeight: 0.5,
   },
   standard: {
     mobilizationRounds: 1,
@@ -52,6 +61,9 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMinTurns: 20,
     crisisSeverityMultiplier: 1.0,
     citySiegeDestructionEra: 2,
+    crisisResponseDelayTurns: 2,
+    crisisRemedyGoldMultiplier: 2.0,
+    crisisDispatchWeight: 1.0,
   },
   veteran: {
     mobilizationRounds: 0,
@@ -68,6 +80,9 @@ export const OPPONENT_CHALLENGE_PROFILES: Record<OpponentChallenge, OpponentChal
     crisisGraceMinTurns: 10,
     crisisSeverityMultiplier: 1.3,
     citySiegeDestructionEra: 1,
+    crisisResponseDelayTurns: 0,
+    crisisRemedyGoldMultiplier: 1.2,
+    crisisDispatchWeight: 1.5,
   },
 };
 

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -3,6 +3,7 @@ import type { CombatResult, GameState, HexCoord, Unit, UnitType } from '@/core/t
 import type { PirateFactionState } from '@/core/pirate-state';
 import { isMajorCivOwner } from '@/core/owner-kind';
 import { resolveChallengeForCiv } from '@/core/opponent-challenge';
+import { isPiratePressureEligible } from './world-pressure-eligibility';
 import { canUnitAttackTarget } from './attack-targeting';
 import { applyCombatOutcomeToState } from './combat-reward-system';
 import { deterministicCombatSeed, resolveCombat } from './combat-system';
@@ -429,7 +430,7 @@ function processPurposefulMovementAndCombat(
     if (!faction) continue;
     let intent = choosePersistentPirateIntent(nextState, factionId);
     const targetCivId = intent?.targetCivId;
-    if (targetCivId && nextState.civilizations[targetCivId]?.isHuman) {
+    if (targetCivId && isPiratePressureEligible(nextState, targetCivId)) {
       const leader = getPirateFleetLeader(nextState, factionId);
       const targetPosition = intent?.targetCityId
         ? nextState.cities[intent.targetCityId]?.position

--- a/src/systems/world-pressure-flags.ts
+++ b/src/systems/world-pressure-flags.ts
@@ -9,11 +9,13 @@ export interface WorldPressureFlags {
   aiCrisisInteractions: AiCrisisInteractionsFlag;
 }
 
-// Stage defaults: flipped by the final MR of each stage (MR 2/3 → aiPressure,
-// MR 5 → visibility, MR 6/7 → interactions). Until then, dark.
+// Stage defaults: flipped by the final MR of each stage. aiPressure flipped to
+// 'pirates' in #528 (MR2) -- this is the rollout mechanism: existing saves have
+// no aiPressure field, so they pick up the new default on load. MR 5 flips
+// visibility, MR 6/7 flip interactions. Until then, those two stay dark.
 export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags {
   return {
-    aiPressure: settings?.aiPressure ?? 'off',
+    aiPressure: settings?.aiPressure ?? 'pirates',
     aiPressureVisibility: settings?.aiPressureVisibility ?? false,
     aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'off',
   };

--- a/tests/ai/ai-crisis-response.test.ts
+++ b/tests/ai/ai-crisis-response.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { GameState } from '@/core/types';
+import { getCrisisDispatchCandidates } from '@/ai/ai-crisis-response';
+
+function faction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
+    maritimeStage: 3, notoriety: 5, shipIds: ['ship-1'],
+    headquarters: { kind: 'coastal-enclave', position: { q: 1, r: 1 }, integrity: 100, maxIntegrity: 100 },
+    tributeByCiv: {}, demandByCiv: {}, contract: null,
+    intent: { kind: 'blockade', targetCivId: 'ai-1', targetCityId: 'ai-city', plannedRound: 1 },
+    transitionGuards: { emittedEventKeys: [] },
+    ...overrides,
+  };
+}
+
+function baseState(challenge: string): GameState {
+  return {
+    opponentChallenge: challenge,
+    civilizations: { 'ai-1': { id: 'ai-1', isHuman: false, isEliminated: false } },
+    units: { 'ship-1': { id: 'ship-1', type: 'pirate_frigate', owner: 'pirate-1', position: { q: 2, r: 1 } } },
+    pirates: { factions: { 'pirate-1': faction() } },
+  } as unknown as GameState;
+}
+
+describe('getCrisisDispatchCandidates', () => {
+  it('produces one pirate-fleet candidate targeting the fleet leader unit', () => {
+    const candidates = getCrisisDispatchCandidates(baseState('standard'), 'ai-1');
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      kind: 'pirate-fleet',
+      sourceId: 'pirate-1',
+      targetUnitId: 'ship-1',
+    });
+  });
+
+  it('scales score by crisisDispatchWeight (veteran > explorer for the same state)', () => {
+    const veteranScore = getCrisisDispatchCandidates(baseState('veteran'), 'ai-1')[0]!.score;
+    const explorerScore = getCrisisDispatchCandidates(baseState('explorer'), 'ai-1')[0]!.score;
+    expect(veteranScore).toBeGreaterThan(explorerScore);
+  });
+
+  it('produces zero candidates when the fleet leader unit is dead', () => {
+    const state = baseState('standard');
+    delete (state.units as Record<string, unknown>)['ship-1'];
+    expect(getCrisisDispatchCandidates(state, 'ai-1')).toEqual([]);
+  });
+
+  it('produces zero candidates when the fleet has no live faction', () => {
+    const state = baseState('standard');
+    state.pirates = { factions: {} } as GameState['pirates'];
+    expect(getCrisisDispatchCandidates(state, 'ai-1')).toEqual([]);
+  });
+
+  it('produces zero candidates when the fleet targets a different civ', () => {
+    const state = baseState('standard');
+    (state.pirates!.factions['pirate-1'] as { intent: { targetCivId: string } }).intent.targetCivId = 'ai-2';
+    expect(getCrisisDispatchCandidates(state, 'ai-1')).toEqual([]);
+  });
+});

--- a/tests/ai/ai-crisis-response.test.ts
+++ b/tests/ai/ai-crisis-response.test.ts
@@ -17,7 +17,12 @@ function faction(overrides: Record<string, unknown> = {}) {
 function baseState(challenge: string): GameState {
   return {
     opponentChallenge: challenge,
-    civilizations: { 'ai-1': { id: 'ai-1', isHuman: false, isEliminated: false } },
+    civilizations: {
+      'ai-1': {
+        id: 'ai-1', isHuman: false, isEliminated: false,
+        visibility: { tiles: { '2,1': 'visible' } },
+      },
+    },
     units: { 'ship-1': { id: 'ship-1', type: 'pirate_frigate', owner: 'pirate-1', position: { q: 2, r: 1 } } },
     pirates: { factions: { 'pirate-1': faction() } },
   } as unknown as GameState;
@@ -55,6 +60,13 @@ describe('getCrisisDispatchCandidates', () => {
   it('produces zero candidates when the fleet targets a different civ', () => {
     const state = baseState('standard');
     (state.pirates!.factions['pirate-1'] as { intent: { targetCivId: string } }).intent.targetCivId = 'ai-2';
+    expect(getCrisisDispatchCandidates(state, 'ai-1')).toEqual([]);
+  });
+
+  it('produces zero candidates when the civ cannot currently see the fleet leader (no unearned exact targets)', () => {
+    const state = baseState('standard');
+    (state.civilizations['ai-1'] as { visibility: { tiles: Record<string, string> } })
+      .visibility.tiles = {};
     expect(getCrisisDispatchCandidates(state, 'ai-1')).toEqual([]);
   });
 });

--- a/tests/ai/ai-prepared-turn.test.ts
+++ b/tests/ai/ai-prepared-turn.test.ts
@@ -308,4 +308,66 @@ describe('prepared major-civilization planning', () => {
     expect(prepared.assignments.assignmentsByPlanId[prepared.portfolio.primaryPlan!.id])
       .not.toContain(warrior.id);
   });
+
+  it('drafts a repel plan against a pirate fleet sieging the civ when aiPressure is "pirates" (#528 MR2)', () => {
+    const state = createNewGame(undefined, 'prepared-pirate-dispatch', 'small');
+    state.settings = { ...state.settings, aiPressure: 'pirates' };
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+    const shipPosition = { q: anchor.q + 2, r: anchor.r };
+    state.units['pirate-ship'] = {
+      id: 'pirate-ship', type: 'pirate_frigate', owner: 'pirate-1', position: shipPosition,
+      movementPointsLeft: 4, health: 100, experience: 0,
+      hasMoved: false, hasActed: false, isResting: false,
+    };
+    state.pirates = {
+      ...state.pirates!,
+      factions: {
+        'pirate-1': {
+          id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
+          maritimeStage: 3, notoriety: 5, shipIds: ['pirate-ship'],
+          headquarters: { kind: 'coastal-enclave', position: shipPosition, integrity: 100, maxIntegrity: 100 },
+          tributeByCiv: {}, demandByCiv: {}, contract: null,
+          intent: { kind: 'blockade', targetCivId: 'ai-1', targetCityId: civ.cities[0], plannedRound: state.turn },
+          transitionGuards: { emittedEventKeys: [] },
+        },
+      },
+    };
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).toMatchObject({
+      objective: 'repel',
+      target: { kind: 'unit', id: 'pirate-ship' },
+    });
+  });
+
+  it('does not draft a repel plan against pirates when aiPressure is off (default, parity with today)', () => {
+    const state = createNewGame(undefined, 'prepared-pirate-dispatch-off', 'small');
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+    const shipPosition = { q: anchor.q + 2, r: anchor.r };
+    state.units['pirate-ship'] = {
+      id: 'pirate-ship', type: 'pirate_frigate', owner: 'pirate-1', position: shipPosition,
+      movementPointsLeft: 4, health: 100, experience: 0,
+      hasMoved: false, hasActed: false, isResting: false,
+    };
+    state.pirates = {
+      ...state.pirates!,
+      factions: {
+        'pirate-1': {
+          id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
+          maritimeStage: 3, notoriety: 5, shipIds: ['pirate-ship'],
+          headquarters: { kind: 'coastal-enclave', position: shipPosition, integrity: 100, maxIntegrity: 100 },
+          tributeByCiv: {}, demandByCiv: {}, contract: null,
+          intent: { kind: 'blockade', targetCivId: 'ai-1', targetCityId: civ.cities[0], plannedRound: state.turn },
+          transitionGuards: { emittedEventKeys: [] },
+        },
+      },
+    };
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).toBeNull();
+  });
 });

--- a/tests/ai/ai-prepared-turn.test.ts
+++ b/tests/ai/ai-prepared-turn.test.ts
@@ -342,8 +342,9 @@ describe('prepared major-civilization planning', () => {
     });
   });
 
-  it('does not draft a repel plan against pirates when aiPressure is off (default, parity with today)', () => {
+  it('does not draft a repel plan against pirates when aiPressure is explicitly off', () => {
     const state = createNewGame(undefined, 'prepared-pirate-dispatch-off', 'small');
+    state.settings = { ...state.settings, aiPressure: 'off' };
     const civ = state.civilizations['ai-1'];
     const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
     const shipPosition = { q: anchor.q + 2, r: anchor.r };

--- a/tests/ai/ai-prepared-turn.test.ts
+++ b/tests/ai/ai-prepared-turn.test.ts
@@ -342,6 +342,104 @@ describe('prepared major-civilization planning', () => {
     });
   });
 
+  it('pirate dispatch competes on score, not automatic priority: a strong nearby at-war capture beats it at explorer difficulty (#528 MR2)', () => {
+    const state = createNewGame(undefined, 'prepared-pirate-dispatch-compete-lose', 'small');
+    state.opponentChallenge = 'explorer'; // crisisDispatchWeight 0.5 -> pirate score 50
+    state.settings = { ...state.settings, aiPressure: 'pirates' };
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+
+    // Strong, nearby, at-war capture opportunity: strategicValue 75 + distantReasonBonus 35,
+    // minimal distance/loss/supply penalty at travelTurns 1 -- scores well over 50.
+    const cityTile = Object.values(state.map.tiles)
+      .filter(tile =>
+        hexDistance(anchor, tile.coord) === 1
+        && findPath(anchor, tile.coord, state.map, 'land') !== null)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    const city = foundCity('player', cityTile.coord, state.map, state.idCounters);
+    state.cities[city.id] = city;
+    state.civilizations.player.cities.push(city.id);
+    civ.knownCivilizations = ['player'];
+    civ.diplomacy.atWarWith = ['player'];
+    civ.visibility.tiles[hexKey(anchor)] = 'visible';
+    civ.visibility.tiles[hexKey(city.position)] = 'visible';
+
+    // Visible pirate fleet also targeting this civ.
+    const shipPosition = { q: anchor.q + 2, r: anchor.r };
+    state.units['pirate-ship'] = {
+      id: 'pirate-ship', type: 'pirate_frigate', owner: 'pirate-1', position: shipPosition,
+      movementPointsLeft: 4, health: 100, experience: 0,
+      hasMoved: false, hasActed: false, isResting: false,
+    };
+    civ.visibility.tiles[hexKey(shipPosition)] = 'visible';
+    state.pirates = {
+      ...state.pirates!,
+      factions: {
+        'pirate-1': {
+          id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
+          maritimeStage: 3, notoriety: 5, shipIds: ['pirate-ship'],
+          headquarters: { kind: 'coastal-enclave', position: shipPosition, integrity: 100, maxIntegrity: 100 },
+          tributeByCiv: {}, demandByCiv: {}, contract: null,
+          intent: { kind: 'blockade', targetCivId: 'ai-1', targetCityId: civ.cities[0], plannedRound: state.turn },
+          transitionGuards: { emittedEventKeys: [] },
+        },
+      },
+    };
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).toMatchObject({
+      objective: 'capture',
+      target: { kind: 'city', id: city.id },
+    });
+  });
+
+  it('pirate dispatch competes on score, not automatic priority: it beats a weak distant peaceful-neighbor resource opportunity at veteran difficulty (#528 MR2)', () => {
+    const state = createNewGame(undefined, 'prepared-pirate-dispatch-compete-win', 'small');
+    state.opponentChallenge = 'veteran'; // crisisDispatchWeight 1.5 -> pirate score 150
+    state.settings = { ...state.settings, aiPressure: 'pirates' };
+    const civ = state.civilizations['ai-1'];
+    const anchor = civ.units.map(id => state.units[id]).find(Boolean)!.position;
+
+    // Weak, distant resource opportunity: strategicValue capped at 55, no distant-reason
+    // bonus, and a real distance penalty -- scores well under 150.
+    const resourceTile = Object.values(state.map.tiles)
+      .filter(tile => hexDistance(anchor, tile.coord) === 5)
+      .sort((left, right) => hexKey(left.coord).localeCompare(hexKey(right.coord)))[0];
+    resourceTile.resource = 'iron';
+    resourceTile.owner = null;
+    civ.visibility.tiles[hexKey(resourceTile.coord)] = 'visible';
+    civ.visibility.tiles[hexKey(anchor)] = 'visible';
+
+    const shipPosition = { q: anchor.q + 2, r: anchor.r };
+    state.units['pirate-ship'] = {
+      id: 'pirate-ship', type: 'pirate_frigate', owner: 'pirate-1', position: shipPosition,
+      movementPointsLeft: 4, health: 100, experience: 0,
+      hasMoved: false, hasActed: false, isResting: false,
+    };
+    civ.visibility.tiles[hexKey(shipPosition)] = 'visible';
+    state.pirates = {
+      ...state.pirates!,
+      factions: {
+        'pirate-1': {
+          id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
+          maritimeStage: 3, notoriety: 5, shipIds: ['pirate-ship'],
+          headquarters: { kind: 'coastal-enclave', position: shipPosition, integrity: 100, maxIntegrity: 100 },
+          tributeByCiv: {}, demandByCiv: {}, contract: null,
+          intent: { kind: 'blockade', targetCivId: 'ai-1', targetCityId: civ.cities[0], plannedRound: state.turn },
+          transitionGuards: { emittedEventKeys: [] },
+        },
+      },
+    };
+
+    const prepared = prepareMajorCivStrategicPlan(state, 'ai-1');
+
+    expect(prepared.portfolio.primaryPlan).toMatchObject({
+      objective: 'repel',
+      target: { kind: 'unit', id: 'pirate-ship' },
+    });
+  });
+
   it('does not draft a repel plan against pirates when aiPressure is explicitly off', () => {
     const state = createNewGame(undefined, 'prepared-pirate-dispatch-off', 'small');
     state.settings = { ...state.settings, aiPressure: 'off' };

--- a/tests/core/opponent-challenge.test.ts
+++ b/tests/core/opponent-challenge.test.ts
@@ -156,6 +156,17 @@ describe('city siege destruction era knob (#522)', () => {
   });
 });
 
+describe('AI competence knobs (#528 MR2)', () => {
+  it('carries spec values', () => {
+    expect(OPPONENT_CHALLENGE_PROFILES.explorer).toMatchObject({
+      crisisResponseDelayTurns: 4, crisisRemedyGoldMultiplier: 3.0, crisisDispatchWeight: 0.5 });
+    expect(OPPONENT_CHALLENGE_PROFILES.standard).toMatchObject({
+      crisisResponseDelayTurns: 2, crisisRemedyGoldMultiplier: 2.0, crisisDispatchWeight: 1.0 });
+    expect(OPPONENT_CHALLENGE_PROFILES.veteran).toMatchObject({
+      crisisResponseDelayTurns: 0, crisisRemedyGoldMultiplier: 1.2, crisisDispatchWeight: 1.5 });
+  });
+});
+
 describe('per-civ pending challenge', () => {
   it('setPendingChallengeForCiv stages a change without touching other civs', () => {
     const state = stateWith('standard', undefined);

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -53,6 +53,14 @@ function addCity(state: GameState): City {
   return city;
 }
 
+function addCityForCiv(state: GameState, civId: string): City {
+  const city = addCity(state);
+  city.owner = civId;
+  state.civilizations.player.cities = [];
+  state.civilizations[civId].cities = [city.id];
+  return city;
+}
+
 function faction(headquarters: PirateFactionState['headquarters'], shipIds: string[]): PirateFactionState {
   return {
     id: 'pirate-1', name: 'The Red Wake', spawnedRound: 1, behavior: 'blockading',
@@ -609,5 +617,42 @@ describe('pirate naval siege (#522)', () => {
     processPiratesForCompletedRound(state, bus);
 
     expect(onCounterFire).toHaveBeenCalledWith(expect.objectContaining({ cityId: 'port', source: 'pirate' }));
+  });
+});
+
+describe('AI pirate pressure eligibility (#528 MR2 Task 2.2)', () => {
+  function aiTargetState(): GameState {
+    const state = fixture();
+    addCityForCiv(state, 'ai-1');
+    addUnit(state, 'leader', 'pirate_frigate', 'pirate-1', { q: 5, r: 1 });
+    state.pirates!.factions['pirate-1'] = faction({
+      kind: 'coastal-enclave',
+      position: { q: 1, r: 1 },
+      integrity: 100,
+      maxIntegrity: 100,
+    }, ['leader']);
+    state.opponentAI = createEmptyOpponentAIState();
+    return state;
+  }
+
+  it('reserves independent-threat pressure against an AI civ when aiPressure is "pirates"', () => {
+    const state = aiTargetState();
+    state.settings = { ...state.settings, aiPressure: 'pirates' };
+
+    const result = processPiratesForCompletedRound(state, new EventBus());
+
+    expect(result.state.pirates!.factions['pirate-1'].intent).toMatchObject({ targetCivId: 'ai-1' });
+    expect(result.state.opponentAI!.pressureByCiv['ai-1']?.activeIndependentThreatIds)
+      .toEqual(['pirate:pirate-1']);
+  });
+
+  it('does not reserve pressure against an AI civ when aiPressure is off (default, parity with today)', () => {
+    const state = aiTargetState();
+
+    const result = processPiratesForCompletedRound(state, new EventBus());
+
+    expect(result.state.pirates!.factions['pirate-1'].intent).toMatchObject({ targetCivId: 'ai-1' });
+    expect(result.state.opponentAI!.pressureByCiv['ai-1']?.activeIndependentThreatIds ?? [])
+      .toEqual([]);
   });
 });

--- a/tests/systems/pirate-system.test.ts
+++ b/tests/systems/pirate-system.test.ts
@@ -635,7 +635,7 @@ describe('AI pirate pressure eligibility (#528 MR2 Task 2.2)', () => {
     return state;
   }
 
-  it('reserves independent-threat pressure against an AI civ when aiPressure is "pirates"', () => {
+  it('reserves independent-threat pressure against an AI civ when aiPressure is "pirates" (default since #528 MR2)', () => {
     const state = aiTargetState();
     state.settings = { ...state.settings, aiPressure: 'pirates' };
 
@@ -646,8 +646,9 @@ describe('AI pirate pressure eligibility (#528 MR2 Task 2.2)', () => {
       .toEqual(['pirate:pirate-1']);
   });
 
-  it('does not reserve pressure against an AI civ when aiPressure is off (default, parity with today)', () => {
+  it('does not reserve pressure against an AI civ when aiPressure is explicitly off', () => {
     const state = aiTargetState();
+    state.settings = { ...state.settings, aiPressure: 'off' };
 
     const result = processPiratesForCompletedRound(state, new EventBus());
 

--- a/tests/systems/threat-pressure-system.test.ts
+++ b/tests/systems/threat-pressure-system.test.ts
@@ -202,9 +202,10 @@ describe('processLandResurgence', () => {
 });
 
 describe('processThreatPressure — hot-seat isolation', () => {
-  it('only evaluates human players — AI civ never gets resurgence', () => {
+  it('excludes AI civs from resurgence when aiPressure is off', () => {
     const state = makeTestState({ era: 3, turn: 30 });
     state.civilizations['p1'].isHuman = false;
+    state.settings = { ...state.settings, aiPressure: 'off' };
     state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 10 };
     const events: any[] = [];
     const bus = { emit: (e: string, p: any) => events.push({ e, ...p }) } as any;
@@ -803,10 +804,18 @@ describe('computeThreatScore', () => {
     expect(score).toBeGreaterThan(5);
   });
 
-  it('returns 0 for AI civ', () => {
+  it('returns 0 for AI civ when aiPressure is off', () => {
     const state = makeTestState();
     state.civilizations['p1'].isHuman = false;
+    state.settings = { ...state.settings, aiPressure: 'off' };
     expect(computeThreatScore(state, 'p1', 'continent-0')).toBe(0);
+  });
+
+  it('is nonzero for AI civ when aiPressure is "pirates" (default since #528 MR2)', () => {
+    const state = makeTestState({ era: 2, turn: 20 });
+    state.civilizations['p1'].isHuman = false;
+    state.civilizations['p1'].lastCombatTurnByLandmass = { 'continent-0': 10 };
+    expect(computeThreatScore(state, 'p1', 'continent-0')).toBeGreaterThan(0);
   });
 
   it('returns 0 when civ has no city on landmass', () => {

--- a/tests/systems/world-pressure-eligibility.test.ts
+++ b/tests/systems/world-pressure-eligibility.test.ts
@@ -13,13 +13,15 @@ describe('world-pressure eligibility', () => {
       'ai-1': { id: 'ai-1', isHuman: false, isEliminated: false, cities: ['c2'] },
     },
   } as any);
-  it('flags off: humans only (parity with today)', () => {
-    expect(getCrisisEligibleCivIds(base())).toEqual(['h1']);
-    expect(isPiratePressureEligible(base(), 'ai-1')).toBe(false);
+  it('flags explicitly off: humans only', () => {
+    expect(getCrisisEligibleCivIds(base('off'))).toEqual(['h1']);
+    expect(isPiratePressureEligible(base('off'), 'ai-1')).toBe(false);
   });
-  it('pirates flag: pirate pressure includes AI, crisis does not', () => {
+  it('pirates flag (default since #528 MR2): pirate pressure includes AI, crisis does not', () => {
     expect(isPiratePressureEligible(base('pirates'), 'ai-1')).toBe(true);
     expect(isCrisisPressureEligible(base('pirates'), 'ai-1')).toBe(false);
+    // Unset settings now resolve to 'pirates', not 'off' -- same result as explicit.
+    expect(isPiratePressureEligible(base(), 'ai-1')).toBe(true);
   });
   it('full flag: both include AI', () => {
     expect(getCrisisEligibleCivIds(base('full'))).toEqual(['ai-1', 'h1']);

--- a/tests/systems/world-pressure-flags.test.ts
+++ b/tests/systems/world-pressure-flags.test.ts
@@ -3,13 +3,16 @@ import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import type { GameSettings } from '@/core/types';
 
 describe('resolveWorldPressureFlags', () => {
-  it('defaults everything off for legacy saves (undefined settings fields)', () => {
+  it('defaults aiPressure to "pirates" (#528 MR2 rollout) and the rest off for legacy saves (undefined settings fields)', () => {
     expect(resolveWorldPressureFlags({} as GameSettings)).toEqual({
-      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+      aiPressure: 'pirates', aiPressureVisibility: false, aiCrisisInteractions: 'off',
     });
     expect(resolveWorldPressureFlags(undefined)).toEqual({
-      aiPressure: 'off', aiPressureVisibility: false, aiCrisisInteractions: 'off',
+      aiPressure: 'pirates', aiPressureVisibility: false, aiCrisisInteractions: 'off',
     });
+  });
+  it('defaults aiPressure to "off" only when explicitly set that way', () => {
+    expect(resolveWorldPressureFlags({ aiPressure: 'off' } as GameSettings).aiPressure).toBe('off');
   });
   it('passes explicit values through', () => {
     const settings = { aiPressure: 'pirates', aiPressureVisibility: true, aiCrisisInteractions: 'benign' } as GameSettings;


### PR DESCRIPTION
## Summary

Executes MR 2 (Tasks 2.1–2.3) of the world-pressure symmetry plan: pirate fleets now pressure AI coastal cities, and AI civs dispatch warships in response. First player-invisible fairness stage goes live — `aiPressure` default flips from `'off'` to `'pirates'` in the final commit.

- **Task 2.1** — three AI competence knobs on `OpponentChallengeProfile`: `crisisResponseDelayTurns` (4/2/0), `crisisRemedyGoldMultiplier` (3.0/2.0/1.2), `crisisDispatchWeight` (0.5/1.0/1.5) for explorer/standard/veteran. Only `crisisDispatchWeight` is consumed in this MR — the other two are crisis-response knobs for MR3, not pirates.
- **Task 2.2** — AI pirate spawn eligibility, swapping the human-only pressure-bookkeeping gate for `isPiratePressureEligible`.
- **Task 2.3** — new `ai-crisis-response.ts` (`getCrisisDispatchCandidates`) merged into the AI plan-portfolio candidate list as a `'repel'` objective competing for `primaryPlan` through the existing scoring, not a parallel decision path.

## Deviation from the plan (drift check, noted per spec-fidelity.md)

The plan's Task 2.2/2.3 cited `threat-pressure-system.ts`'s `processPirateSpawn`/`PirateFleet`/`state.pirateFleets` — **that path is dead code**, confirmed by grep (never called from `turn-manager.ts`) and by PR #549's own commit message stating that fleet/siege model was retired for the newer faction-based `pirate-system.ts`. Re-scoped both tasks to the live system:
- Task 2.2's real gate is `pirate-system.ts`'s `processPurposefulMovementAndCombat` (the only place a faction's targeting decision is reserved into the `pressureByCiv` ledger).
- Task 2.3's dispatch candidates source from `state.pirates.factions` (via `getPirateFleetLeader`), not `state.pirateFleets`.

## Bug found and fixed during implementation

The AI-playability simulation's own `targetWasPerceived` invariant caught a real defect: `getCrisisDispatchCandidates` produced an "exact target" plan against a pirate ship the AI hadn't actually perceived. Added a fog-of-war gate (`isVisible`) — a dispatch candidate now requires the civ to currently see the fleet leader's tile, matching how the existing pirate-intel system already scopes AI pirate awareness.

## Inline review (balance, fun, mechanics, ages, playstyles, difficulty, AI, UI/UX, architecture, extensibility, data, SFX, saves, testing, regressions, solo, hot seat)

- **UI/UX/SFX**: correctly untouched — visibility ships in MR5, interactions in MR6/7.
- **Balance/AI**: added two integration tests proving the `'repel'` dispatch candidate genuinely *competes* on score against real objective candidates rather than always/never winning — a strong nearby at-war capture beats it at explorer difficulty (score 50), and it beats a weak distant resource opportunity at veteran difficulty (score 150).
- **Saves**: the default flip is the documented rollout mechanism — existing saves have no `aiPressure` field, so they pick up `'pirates'` on load. Humans were always eligible regardless of flag, so no regression for existing human-targeted saves.
- **Solo/hot seat**: no `currentPlayer`/hardcoded-`'player'` branching; eligibility is per-civ, unaffected by seat count.
- **Testing/regressions**: full suite (6,298 tests) green; fixed fallout in pre-existing tests that implicitly relied on the old off-by-default AI behavior (`threat-pressure-system.test.ts`, `world-pressure-eligibility.test.ts`) by pinning `aiPressure: 'off'` where that was the actual thing under test.

## Test plan

- [x] `bash scripts/run-with-mise.sh yarn build` — clean
- [x] `bash scripts/run-with-mise.sh yarn test` — 6298 passed, 3 skipped, 0 failed
- [x] New: `ai-crisis-response.test.ts` (6 cases incl. fog-of-war), competence-knob assertions, pirate-system eligibility (positive + explicit-off), 4 `ai-prepared-turn.test.ts` integration cases (positive, explicit-off, 2 score-competition)

Depends on: MR1 (#527, merged). Part of the world-pressure symmetry arc, index #535.