### PR TITLE
fix(combat): add bomber interception defenses

### DIFF
--- a/docs/superpowers/plans/2026-07-14-issue-537-air-interception-defense.md
+++ b/docs/superpowers/plans/2026-07-14-issue-537-air-interception-defense.md
@@ -16,7 +16,7 @@
 - `src/systems/unit-system.ts` — `bomber` and `stealth_bomber` doctrine declarations.
 - `src/systems/combat-system.ts` — shared poor-defense predicate, exchange-policy helper, deterministic damage application.
 - `src/ui/combat-preview.ts` — kid-legible preview labels from the shared exchange result.
-- `src/ui/notification-routing.ts` — defender notification-log wording from the transient exchange label.
+- `src/ui/notification-routing.ts` — attacker and defender notification-log wording from the transient exchange label.
 - `src/audio/sfx-director.ts` — one delayed defensive-fire sound only for a nonzero turret-fire response.
 - `src/ai/ai-tactics.ts` — rank attacks using seeded projected damage, including air-defense effects.
 - `tests/systems/combat-system.test.ts` — catalog, resolver, parity, and balance coverage.
@@ -31,8 +31,8 @@
 
 | Before | Action | Immediate visible result |
 | --- | --- | --- |
-| Fighter targets visible conventional bomber | Tap the bomber | Preview says `Bomber gunners fire back weakly: 25% return fire`; resolving the attack plays one secondary defensive shot if it deals damage. |
-| Fighter targets visible stealth bomber | Tap the bomber | Preview says `Stealth makes it harder to hit: −35% interceptor damage`; resolving the attack plays no defensive-shot sound. |
+| Fighter targets visible conventional bomber | Tap the bomber | Preview says `Bomber gunners fire back weakly: 25% return fire`; resolving the attack plays one secondary defensive shot if it deals damage and writes the explanation to both involved players’ own logs. |
+| Fighter targets visible stealth bomber | Tap the bomber | Preview says `Stealth makes it harder to hit: −35% interceptor damage`; resolving the attack plays no defensive-shot sound and writes the explanation to both involved players’ own logs. |
 | Bomber targets fighter | Tap the fighter | No special air-defense label; the fighter’s ordinary retaliation remains visible through normal combat outcome. |
 | A hot-seat player cannot see an enemy bomber | Tap its fogged hex | No legal target, preview, policy label, notification, or sound leaks to that viewer. |
 
@@ -40,7 +40,7 @@
 
 - `25% return fire` must describe only a fighter intercepting an air-bombard unit with `turret-fire`; it must not appear for ground siege, bomber-initiated attacks, or ordinary ranged duels.
 - `−35% interceptor damage` must mean damage dealt to the stealth bomber, not a hidden fighter-strength penalty; the label must be emitted from the same exchange object that applies the multiplier.
-- The defender notification is recipient-scoped through `routeCombatResolved`; do not use `currentPlayer` when appending it.
+- Both special-exchange notifications are recipient-scoped through `routeCombatResolved`; do not use `currentPlayer` when appending either entry, and never notify an uninvolved viewer.
 
 ## Interaction Replay Checklist
 
@@ -282,11 +282,12 @@ git commit -m "fix(combat): model bomber interception defenses"
 - Modify: `src/ui/notification-routing.ts:306-332`
 - Test: `tests/ui/combat-preview.test.ts`
 - Test: `tests/ui/combat-resolved-presentation.test.ts`
+- Test: `tests/ui/notification-routing.test.ts`
 - Test: `tests/main.integration.test.ts`
 
 - [ ] **Step 1: Write failing preview and post-combat presentation tests**
 
-Add formatter tests with `exchange` to assert the exact approved text, then negative tests for `kind: 'none'`. Extend `makeEvent()` in `combat-resolved-presentation.test.ts` with a turret-fire exchange and assert the defender notification contains the same label. Add a live integration test that selects a fighter, taps a visible bomber, and asserts the rendered `#info-panel` contains `Bomber gunners fire back weakly: 25% return fire`.
+Add formatter tests with `exchange` to assert the exact approved text, then negative tests for `kind: 'none'`. Extend `makeEvent()` in `combat-resolved-presentation.test.ts` with a turret-fire exchange and assert both the attacker and defender receive their own recipient-scoped message containing the same label, while a third hot-seat civilization receives no notification. Add a live integration test that selects a fighter, taps a visible bomber, and asserts the rendered `#info-panel` contains `Bomber gunners fire back weakly: 25% return fire`.
 
 Add a fogged hot-seat test that changes `state.currentPlayer` to a civilization whose visibility does not include the bomber tile, taps the tile, and asserts no `Combat Preview` or exchange label appears.
 
@@ -295,7 +296,7 @@ Add a fogged hot-seat test that changes `state.currentPlayer` to a civilization 
 Run:
 
 ```sh
-bash scripts/run-with-mise.sh yarn test --run tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts
+bash scripts/run-with-mise.sh yarn test --run tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-routing.test.ts tests/main.integration.test.ts
 ```
 
 Expected: FAIL because the label is not currently rendered or routed.
@@ -310,16 +311,26 @@ if (preview.exchange?.label) details.push(preview.exchange.label);
 
 Keep `main.ts` on its existing live `calculateCombatStrengths` → `formatCombatPreviewDetails` path; do not create a duplicate preview formatter or add a button.
 
-In `routeCombatResolved`, append `result.exchange?.label` to the defender’s existing message:
+In `routeCombatResolved`, append `result.exchange?.label` to the defender’s existing message and, only when an exchange exists, add an attacker-owner log entry. Expand the `facts` pick to include `attackerOwnerId` and `attackerType` so both entries remain correct if a combatant was removed from state:
 
 ```ts
 const exchangeNote = result.exchange?.label ? ` ${result.exchange.label}.` : '';
 const msg = result.defenderSurvived
   ? `${defenderType} was attacked by ${attackerLabel} (${result.defenderDamage} damage taken).${exchangeNote}`
   : `${defenderType} was destroyed by ${attackerLabel}!${exchangeNote}`;
+sink(defenderOwner, msg, 'warning');
+
+const attackerOwner = facts?.attackerOwnerId ?? attacker?.owner;
+const attackerTypeId = facts?.attackerType ?? attacker?.type;
+if (result.exchange?.label && attackerOwner && attackerTypeId) {
+  const attackerType = UNIT_DEFINITIONS[attackerTypeId]?.name ?? attackerTypeId;
+  sink(attackerOwner, `${attackerType} attack: ${result.exchange.label}.`, 'info');
+}
 ```
 
-Preserve the existing `sink(defenderOwner, ...)` recipient; never derive the recipient from `state.currentPlayer`.
+Preserve the existing `sink(defenderOwner, ...)` recipient and use only the
+attacking owner for the new entry; never derive either recipient from
+`state.currentPlayer`.
 
 - [ ] **Step 4: Run the focused tests to verify they pass**
 
@@ -334,7 +345,7 @@ Expected: PASS; visible, legal targets show the correct doctrine, ordinary comba
 - [ ] **Step 5: Commit presentation wiring**
 
 ```sh
-git add src/ui/combat-preview.ts src/ui/notification-routing.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts
+git add src/ui/combat-preview.ts src/ui/notification-routing.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-routing.test.ts tests/main.integration.test.ts
 git commit -m "feat(ui): explain bomber interception defenses"
 ```
 
@@ -397,7 +408,7 @@ git commit -m "feat(audio): play bomber defensive fire once"
 
 - [ ] **Step 1: Write a failing AI target-choice regression**
 
-Build one tactical context containing an AI `jet_fighter` and two otherwise comparable visible targets: a conventional bomber and a stealth bomber. Use the same fixed game ID/turn/IDs as the ranking seed. Assert the ranking score is derived from projected `attackerDamage` and `defenderDamage`, and that changing a target doctrine changes its score in the same direction as `resolveCombat`.
+Build one tactical context containing an AI `jet_fighter` and two otherwise comparable visible targets: a conventional bomber and a stealth bomber. Give the attacking AI a hostile `signals_hub` city within two hexes of the stealth bomber, because `canUnitAttackTarget` deliberately blocks range-2 fighter targeting of a stealth bomber without that existing detection building. Use the same fixed game ID/turn/IDs as the ranking seed. Assert the ranking score is derived from projected `attackerDamage` and `defenderDamage`, and that changing a target doctrine changes its score in the same direction as `resolveCombat`.
 
 Also assert a human and AI fighter given equivalent attacker/defender units, map, context, and seed receive equal `resolveCombat` results; only the owning caller differs.
 
@@ -439,15 +450,15 @@ git add src/ai/ai-tactics.ts tests/ai/ai-tactics.test.ts
 git commit -m "fix(ai): score bomber interception outcomes"
 ```
 
-### Task 6: Prove no-save-migration compatibility and run the complete regression set
+### Task 6: Prove current-save compatibility and run the complete regression set
 
 **Files:**
 - Modify: `tests/storage/save-migrations.test.ts`
 - Modify: `docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md` only if implementation revealed a verified design deviation.
 
-- [ ] **Step 1: Write the legacy-save regression**
+- [ ] **Step 1: Write the current-save compatibility regression**
 
-Create a current-schema save fixture containing existing `bomber` and `stealth_bomber` units. Save its schema version, call `migrateSaveToCurrent`, then resolve a jet-fighter interception against each loaded unit. Assert:
+Create a current-schema save fixture containing existing `bomber` and `stealth_bomber` units. Save its schema version, call `migrateSaveToCurrent`, then resolve a jet-fighter interception against each loaded unit. Do not call this fixture legacy: an actual legacy fixture must correctly advance through unrelated existing migrations, while this test proves #537 itself adds no schema migration. Assert:
 
 ```ts
 expect(migrated.saveSchemaVersion).toBe(versionBefore);
@@ -473,7 +484,7 @@ Run:
 
 ```sh
 scripts/check-src-rule-violations.sh src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
-bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-routing.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
 bash scripts/run-with-mise.sh yarn build
 ```
 

--- a/docs/superpowers/plans/2026-07-14-issue-537-air-interception-defense.md
+++ b/docs/superpowers/plans/2026-07-14-issue-537-air-interception-defense.md
@@ -1,0 +1,507 @@
+# Issue #537 Air Interception Defense Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Repository policy forbids subagents, so do not use `superpowers:subagent-driven-development`. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give conventional bombers weak defensive turret fire and stealth bombers evasion-only defense during fighter interception, while keeping ground retaliation, AI behavior, hot-seat privacy, saves, and audio coherent.
+
+**Architecture:** Static unit-definition metadata declares the interception doctrine. A pure combat-system helper derives exchange multipliers and labels from attacker/defender definitions; both the resolver and preview consume it. A transient `CombatResult.exchange` summary carries that already-computed doctrine through every existing event/presentation/audio caller without putting new data in saves.
+
+**Tech Stack:** TypeScript, Vitest, DOM UI, EventBus, Canvas presentation, existing SFX catalog.
+
+---
+
+## File map
+
+- `src/core/types.ts` — typed air-interception metadata plus the transient combat-result exchange summary shared across systems.
+- `src/systems/unit-system.ts` — `bomber` and `stealth_bomber` doctrine declarations.
+- `src/systems/combat-system.ts` — shared poor-defense predicate, exchange-policy helper, deterministic damage application.
+- `src/ui/combat-preview.ts` — kid-legible preview labels from the shared exchange result.
+- `src/ui/notification-routing.ts` — defender notification-log wording from the transient exchange label.
+- `src/audio/sfx-director.ts` — one delayed defensive-fire sound only for a nonzero turret-fire response.
+- `src/ai/ai-tactics.ts` — rank attacks using seeded projected damage, including air-defense effects.
+- `tests/systems/combat-system.test.ts` — catalog, resolver, parity, and balance coverage.
+- `tests/ui/combat-preview.test.ts` — preview label and negative cases.
+- `tests/ui/combat-resolved-presentation.test.ts` — notification visibility and exchange-label delivery.
+- `tests/audio/sfx-director.test.ts` — one defensive-shot sound for turret fire and none for evasion.
+- `tests/ai/ai-tactics.test.ts` — policy-aware AI target choice.
+- `tests/storage/save-migrations.test.ts` — legacy bomber compatibility with no schema bump.
+- `tests/main.integration.test.ts` — real selected-unit preview and hot-seat fog boundary.
+
+## Player Truth Table
+
+| Before | Action | Immediate visible result |
+| --- | --- | --- |
+| Fighter targets visible conventional bomber | Tap the bomber | Preview says `Bomber gunners fire back weakly: 25% return fire`; resolving the attack plays one secondary defensive shot if it deals damage. |
+| Fighter targets visible stealth bomber | Tap the bomber | Preview says `Stealth makes it harder to hit: −35% interceptor damage`; resolving the attack plays no defensive-shot sound. |
+| Bomber targets fighter | Tap the fighter | No special air-defense label; the fighter’s ordinary retaliation remains visible through normal combat outcome. |
+| A hot-seat player cannot see an enemy bomber | Tap its fogged hex | No legal target, preview, policy label, notification, or sound leaks to that viewer. |
+
+## Misleading UI Risks
+
+- `25% return fire` must describe only a fighter intercepting an air-bombard unit with `turret-fire`; it must not appear for ground siege, bomber-initiated attacks, or ordinary ranged duels.
+- `−35% interceptor damage` must mean damage dealt to the stealth bomber, not a hidden fighter-strength penalty; the label must be emitted from the same exchange object that applies the multiplier.
+- The defender notification is recipient-scoped through `routeCombatResolved`; do not use `currentPlayer` when appending it.
+
+## Interaction Replay Checklist
+
+- Open a conventional-bomber preview, confirm its label, resolve it, and assert the notification and exactly one defensive sound.
+- Reopen the selected-unit preview on a stealth bomber and assert the label changes with no stale turret-fire wording.
+- Switch `currentPlayer` to a viewer without visibility and assert target selection remains blocked.
+- Reopen combat after a prior resolved event and assert no duplicated notification or delayed SFX is produced.
+
+### Task 1: Add typed doctrine metadata and catalog validation
+
+**Files:**
+- Modify: `src/core/types.ts:360-385`
+- Modify: `src/systems/unit-system.ts` (the `bomber` and `stealth_bomber` definitions)
+- Modify: `src/systems/combat-system.ts:120-220`
+- Test: `tests/systems/combat-system.test.ts`
+
+- [ ] **Step 1: Write failing catalog and profile tests**
+
+Add imports for `UNIT_DEFINITIONS` and the new `getCombatExchangeModifiers` / `defendsPoorly` exports. Add tests that enumerate definitions rather than hardcoding a roster:
+
+```ts
+const bombardProfiles = Object.values(UNIT_DEFINITIONS)
+  .filter(definition => definition.attackProfile?.kind === 'bombard' || definition.attackProfile?.kind === 'siege');
+
+it('applies poor defense to every siege or bombard profile, but not agile ranged ballista', () => {
+  expect(bombardProfiles.length).toBeGreaterThan(0);
+  for (const definition of bombardProfiles) {
+    expect(defendsPoorly(definition.attackProfile), definition.type).toBe(true);
+  }
+  expect(defendsPoorly(UNIT_DEFINITIONS.ballista.attackProfile)).toBe(false);
+});
+
+it('requires every air bombard definition to declare one bounded interception doctrine', () => {
+  for (const definition of Object.values(UNIT_DEFINITIONS)
+    .filter(def => def.domain === 'air' && def.attackProfile?.kind === 'bombard')) {
+    const doctrine = definition.airInterceptionDefense;
+    expect(doctrine, definition.type).toBeDefined();
+    const multiplier = doctrine?.kind === 'turret-fire'
+      ? doctrine.counterDamageMultiplier
+      : doctrine?.incomingDamageMultiplier;
+    expect(multiplier).toBeGreaterThan(0);
+    expect(multiplier).toBeLessThanOrEqual(1);
+  }
+});
+
+it('does not allow non-air-bombard definitions to carry interception doctrine', () => {
+  for (const definition of Object.values(UNIT_DEFINITIONS)) {
+    if (definition.domain === 'air' && definition.attackProfile?.kind === 'bombard') continue;
+    expect(definition.airInterceptionDefense, definition.type).toBeUndefined();
+  }
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: FAIL because the helper and metadata do not exist.
+
+- [ ] **Step 3: Add the discriminated metadata and shared profile predicate**
+
+In `src/core/types.ts`, add:
+
+```ts
+export type AirInterceptionDefense =
+  | { kind: 'turret-fire'; counterDamageMultiplier: number }
+  | { kind: 'evasion'; incomingDamageMultiplier: number };
+
+export interface UnitDefinition {
+  // existing fields
+  airInterceptionDefense?: AirInterceptionDefense;
+}
+```
+
+In `src/systems/unit-system.ts`, add exactly these static declarations:
+
+```ts
+// bomber
+airInterceptionDefense: { kind: 'turret-fire', counterDamageMultiplier: 0.25 },
+
+// stealth_bomber
+airInterceptionDefense: { kind: 'evasion', incomingDamageMultiplier: 0.65 },
+```
+
+In `src/systems/combat-system.ts`, add the reusable predicate:
+
+```ts
+export function defendsPoorly(profile: UnitAttackProfile | undefined): boolean {
+  return profile?.kind === 'siege' || profile?.kind === 'bombard';
+}
+```
+
+Replace the existing `profile?.kind === 'bombard'` checks in both strength calculation and `defenderDefendsPoorly` with `defendsPoorly(defenderDefinition.attackProfile)`.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: PASS; every current/future semantic siege or bombard profile is covered and both air bombarders declare valid metadata.
+
+- [ ] **Step 5: Commit the catalog foundation**
+
+```sh
+git add src/core/types.ts src/systems/unit-system.ts src/systems/combat-system.ts tests/systems/combat-system.test.ts
+git commit -m "feat(combat): declare air interception defenses"
+```
+
+### Task 2: Apply one pure exchange policy in combat resolution and the preview model
+
+**Files:**
+- Modify: `src/core/types.ts:1120-1135`
+- Modify: `src/systems/combat-system.ts:120-320`
+- Test: `tests/systems/combat-system.test.ts`
+
+- [ ] **Step 1: Write failing exchange-policy and deterministic-result tests**
+
+Add fixtures for a `jet_fighter` attacking `bomber` and `stealth_bomber`, then test the policy directly and through `resolveCombat`:
+
+```ts
+it('gives a fighter a weak but nonzero bomber-gunner counterattack', () => {
+  const exchange = getCombatExchangeModifiers(jetFighter, bomber);
+  const result = resolveCombat(jetFighter, bomber, map, 77);
+  expect(exchange).toMatchObject({ kind: 'turret-fire', defenderCounterDamageMultiplier: 0.25 });
+  expect(result.attackerDamage).toBeGreaterThan(0);
+  expect(result.exchange?.label).toBe('Bomber gunners fire back weakly: 25% return fire');
+});
+
+it('gives a stealth bomber evasion but no defensive shot', () => {
+  const exchange = getCombatExchangeModifiers(jetFighter, stealthBomber);
+  const result = resolveCombat(jetFighter, stealthBomber, map, 77);
+  expect(exchange).toMatchObject({ kind: 'evasion', defenderCounterDamageMultiplier: 0, defenderIncomingDamageMultiplier: 0.65 });
+  expect(result.attackerDamage).toBe(0);
+  expect(result.exchange?.label).toBe('Stealth makes it harder to hit: −35% interceptor damage');
+});
+
+it('keeps a bomber attacking a fighter on the normal counterattack path', () => {
+  expect(getCombatExchangeModifiers(bomber, jetFighter).kind).toBe('none');
+  expect(resolveCombat(bomber, jetFighter, map, 77).attackerDamage).toBeGreaterThan(0);
+});
+```
+
+Also retain/add fixed-seed tests for adjacent catapult retaliation, long-range melee non-retaliation, ordinary ranged reciprocity, civilian/zero-strength early returns, and identical results after changing `currentPlayer`, owner IDs, and `opponentChallenge`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: FAIL because exchange policy and `CombatResult.exchange` do not exist.
+
+- [ ] **Step 3: Implement the exchange helper and transient result summary**
+
+In `src/core/types.ts`, add these transport-safe, non-persisted result types:
+
+```ts
+export type CombatExchangeKind = 'none' | 'turret-fire' | 'evasion';
+
+export interface CombatExchangeSummary {
+  kind: Exclude<CombatExchangeKind, 'none'>;
+  label: string;
+}
+```
+
+Append this exact member to the existing `CombatResult` interface in the same file:
+
+```ts
+exchange?: CombatExchangeSummary;
+```
+
+Import `CombatExchangeKind` from `src/core/types.ts`, then add this resolver-only type in `src/systems/combat-system.ts`:
+
+```ts
+export interface CombatExchangeModifiers {
+  kind: CombatExchangeKind;
+  defenderCounterDamageMultiplier: number;
+  defenderIncomingDamageMultiplier: number;
+  label?: string;
+}
+```
+
+Implement `getCombatExchangeModifiers(attacker, defender)` with neutral `{ kind: 'none', defenderCounterDamageMultiplier: 1, defenderIncomingDamageMultiplier: 1 }` unless the attacker is air/ranged and the defender is air/bombard with doctrine metadata. Return the exact labels from the approved spec for the two declared doctrines.
+
+After the existing base damage calculations and after existing early returns, apply:
+
+```ts
+const exchange = getCombatExchangeModifiers(attacker, defender);
+const defenderDamage = Math.round(baseDefenderDamage * exchange.defenderIncomingDamageMultiplier);
+const attackerDamage = canCounterAttackAtDistance(defender, distance)
+  ? Math.round(baseAttackerDamage * exchange.defenderCounterDamageMultiplier)
+  : 0;
+```
+
+Attach `{ kind: exchange.kind, label: exchange.label }` only when `kind !== 'none'`. Do not add this field to `Unit`, `GameState`, or save migrations.
+
+Extend `CombatStrengthBreakdown` with `exchange`, sourced from this same helper, so preview code cannot recompute a divergent rule.
+
+- [ ] **Step 4: Add deterministic balance regression bounds**
+
+Use seeds `1..100` and fresh full-health units per seed. Assert the fighter’s mean damage dealt exceeds mean damage taken against both bomber doctrines; turret-fire mean return damage is `> 0` and less than half of the fighter’s mean dealt damage; stealth-bomber mean incoming damage is lower than conventional-bomber mean incoming damage but remains `> 0`.
+
+```ts
+const samples = Array.from({ length: 100 }, (_, seed) => resolveCombat(fighter, bomber, map, seed + 1));
+const mean = (values: number[]) => values.reduce((sum, value) => sum + value, 0) / values.length;
+expect(mean(samples.map(result => result.defenderDamage))).toBeGreaterThan(mean(samples.map(result => result.attackerDamage)));
+```
+
+- [ ] **Step 5: Run the focused test to verify it passes**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts
+```
+
+Expected: PASS with deterministic policy, parity, early-exit, and balance coverage.
+
+- [ ] **Step 6: Commit the resolver**
+
+```sh
+git add src/core/types.ts src/systems/combat-system.ts tests/systems/combat-system.test.ts
+git commit -m "fix(combat): model bomber interception defenses"
+```
+
+### Task 3: Surface the exact exchange result in preview and notification log
+
+**Files:**
+- Modify: `src/ui/combat-preview.ts:3-28`
+- Modify: `src/ui/notification-routing.ts:306-332`
+- Test: `tests/ui/combat-preview.test.ts`
+- Test: `tests/ui/combat-resolved-presentation.test.ts`
+- Test: `tests/main.integration.test.ts`
+
+- [ ] **Step 1: Write failing preview and post-combat presentation tests**
+
+Add formatter tests with `exchange` to assert the exact approved text, then negative tests for `kind: 'none'`. Extend `makeEvent()` in `combat-resolved-presentation.test.ts` with a turret-fire exchange and assert the defender notification contains the same label. Add a live integration test that selects a fighter, taps a visible bomber, and asserts the rendered `#info-panel` contains `Bomber gunners fire back weakly: 25% return fire`.
+
+Add a fogged hot-seat test that changes `state.currentPlayer` to a civilization whose visibility does not include the bomber tile, taps the tile, and asserts no `Combat Preview` or exchange label appears.
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts
+```
+
+Expected: FAIL because the label is not currently rendered or routed.
+
+- [ ] **Step 3: Implement shared visible text without new UI controls**
+
+In `formatCombatPreviewDetails`, append `preview.exchange.label` only when present:
+
+```ts
+if (preview.exchange?.label) details.push(preview.exchange.label);
+```
+
+Keep `main.ts` on its existing live `calculateCombatStrengths` → `formatCombatPreviewDetails` path; do not create a duplicate preview formatter or add a button.
+
+In `routeCombatResolved`, append `result.exchange?.label` to the defender’s existing message:
+
+```ts
+const exchangeNote = result.exchange?.label ? ` ${result.exchange.label}.` : '';
+const msg = result.defenderSurvived
+  ? `${defenderType} was attacked by ${attackerLabel} (${result.defenderDamage} damage taken).${exchangeNote}`
+  : `${defenderType} was destroyed by ${attackerLabel}!${exchangeNote}`;
+```
+
+Preserve the existing `sink(defenderOwner, ...)` recipient; never derive the recipient from `state.currentPlayer`.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts
+```
+
+Expected: PASS; visible, legal targets show the correct doctrine, ordinary combat stays unlabelled, and fogged hot-seat views reveal nothing.
+
+- [ ] **Step 5: Commit presentation wiring**
+
+```sh
+git add src/ui/combat-preview.ts src/ui/notification-routing.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts
+git commit -m "feat(ui): explain bomber interception defenses"
+```
+
+### Task 4: Add exactly one defensive-fire sound and no stealth-shot sound
+
+**Files:**
+- Modify: `src/audio/sfx-director.ts:89-137`
+- Test: `tests/audio/sfx-director.test.ts`
+
+- [ ] **Step 1: Write failing sound-behavior tests**
+
+Emit a `combat:resolved` event whose `result.exchange` is turret fire with positive `attackerDamage`; assert the defender’s existing `ranged-loose` file is requested exactly once. Emit an evasion result with `attackerDamage: 0`; assert no defender `ranged-loose` or `siege-fire` file is requested. Keep the ordinary attacker fire/impact expectations intact.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/audio/sfx-director.test.ts
+```
+
+Expected: FAIL because the director currently has no defensive-fire branch.
+
+- [ ] **Step 3: Reuse the existing defender weapon sound once**
+
+After the normal attacker fire is scheduled, add this guarded branch in `handleCombatResolved`:
+
+```ts
+if (result.exchange?.kind === 'turret-fire' && result.attackerDamage > 0 && defenderType) {
+  const defenderSfx = UNIT_SFX[defenderType];
+  const counterFire = defenderSfx?.['ranged-loose'] ?? defenderSfx?.['siege-fire'];
+  if (counterFire) this.scheduleFile(counterFire.file, 140, viewerIds);
+}
+```
+
+Do not add a new audio asset, trigger the branch for `evasion`, or schedule it when the defender did zero damage. `canPresentTo(viewerIds)` remains the hot-seat/fog visibility gate.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/audio/sfx-director.test.ts
+```
+
+Expected: PASS; turret fire has one secondary sound and evasion has none.
+
+- [ ] **Step 5: Commit audio behavior**
+
+```sh
+git add src/audio/sfx-director.ts tests/audio/sfx-director.test.ts
+git commit -m "feat(audio): play bomber defensive fire once"
+```
+
+### Task 5: Make AI attack ranking policy-aware
+
+**Files:**
+- Modify: `src/ai/ai-tactics.ts:295-370`
+- Test: `tests/ai/ai-tactics.test.ts`
+
+- [ ] **Step 1: Write a failing AI target-choice regression**
+
+Build one tactical context containing an AI `jet_fighter` and two otherwise comparable visible targets: a conventional bomber and a stealth bomber. Use the same fixed game ID/turn/IDs as the ranking seed. Assert the ranking score is derived from projected `attackerDamage` and `defenderDamage`, and that changing a target doctrine changes its score in the same direction as `resolveCombat`.
+
+Also assert a human and AI fighter given equivalent attacker/defender units, map, context, and seed receive equal `resolveCombat` results; only the owning caller differs.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/ai/ai-tactics.test.ts
+```
+
+Expected: FAIL because `rankAttacks` currently scores risk from raw strength instead of the projected exchange result.
+
+- [ ] **Step 3: Score projected damage instead of raw symmetric strength**
+
+Keep `calculateCombatStrengths` for terrain information, but calculate the seeded `preview` before score components and replace the raw strength ratios with:
+
+```ts
+const expectedDamageRatio = Math.min(2, preview.defenderDamage / Math.max(1, defender.health));
+const deathRisk = Math.min(2, preview.attackerDamage / Math.max(1, unit.health));
+```
+
+Retain `safeRanged`, plan priority, capture preservation, and all other score terms. This makes every attack estimate use the same resolver—including turret fire and evasion—without a second AI-only combat formula.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/ai/ai-tactics.test.ts
+```
+
+Expected: PASS; the AI sees the same risk/reward as the player’s deterministic result.
+
+- [ ] **Step 5: Commit AI parity**
+
+```sh
+git add src/ai/ai-tactics.ts tests/ai/ai-tactics.test.ts
+git commit -m "fix(ai): score bomber interception outcomes"
+```
+
+### Task 6: Prove no-save-migration compatibility and run the complete regression set
+
+**Files:**
+- Modify: `tests/storage/save-migrations.test.ts`
+- Modify: `docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md` only if implementation revealed a verified design deviation.
+
+- [ ] **Step 1: Write the legacy-save regression**
+
+Create a current-schema save fixture containing existing `bomber` and `stealth_bomber` units. Save its schema version, call `migrateSaveToCurrent`, then resolve a jet-fighter interception against each loaded unit. Assert:
+
+```ts
+expect(migrated.saveSchemaVersion).toBe(versionBefore);
+expect(migrated.units.legacyBomber.type).toBe('bomber');
+expect(migrated.units.legacyStealthBomber.type).toBe('stealth_bomber');
+expect(resolveCombat(fighter, migrated.units.legacyBomber, migrated.map, 41).exchange?.kind).toBe('turret-fire');
+expect(resolveCombat(fighter, migrated.units.legacyStealthBomber, migrated.map, 41).exchange?.kind).toBe('evasion');
+```
+
+- [ ] **Step 2: Run the storage test to verify it passes without a migration**
+
+Run:
+
+```sh
+bash scripts/run-with-mise.sh yarn test --run tests/storage/save-migrations.test.ts
+```
+
+Expected: PASS; no `CURRENT_SAVE_SCHEMA_VERSION` or `SAVE_MIGRATIONS` edit is needed.
+
+- [ ] **Step 3: Run source-rule, targeted, and type-check validation**
+
+Run:
+
+```sh
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
+bash scripts/run-with-mise.sh yarn build
+```
+
+Expected: every selected test and the TypeScript/Vite build exit 0.
+
+- [ ] **Step 4: Inspect the final implementation delta**
+
+Run:
+
+```sh
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
+git status --short
+```
+
+Expected: only the planned combat, AI, UI, audio, tests, and design/plan documentation changes are present; no save-migration code is changed.
+
+- [ ] **Step 5: Commit the compatibility regression**
+
+```sh
+git add tests/storage/save-migrations.test.ts
+git commit -m "test(storage): preserve bomber saves across interception update"
+```
+
+## Plan self-review
+
+- **Spec coverage:** Tasks 1–2 cover typed doctrines, generic siege/bombard defense, deterministic damage, early exits, and balance; Task 3 covers plain-language live preview, log, and hot-seat privacy; Task 4 covers SFX; Task 5 covers AI and solo/AI parity; Task 6 covers legacy saves and final verification.
+- **UI guardrails:** The player truth table, misleading-label boundaries, and replay checklist identify visible state before/after selection and resolution. No queue or catalog behavior is introduced.
+- **Type consistency:** `AirInterceptionDefense`, `CombatExchangeKind`, `CombatExchangeSummary`, `CombatExchangeModifiers`, `CombatResult.exchange`, `defendsPoorly`, and `getCombatExchangeModifiers` use the same names in every task; `core/types.ts` owns all cross-layer transport types.
+- **Scope:** No carrier, basing, radar, mission, content-roster, or save-schema work is included.

--- a/docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md
+++ b/docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md
@@ -1,0 +1,251 @@
+# Issue #537: Air Interception Defense Design
+
+## Purpose
+
+Finish the unresolved air-interception portion of #537 without changing the
+existing ground-combat retaliation contract. The game must represent the
+historically distinct defenses of conventional and stealth bombers, make those
+defenses legible before and after the player commits an attack, preserve equal
+rules for AI, solo, and hot-seat play, and remain safe when new siege or
+bombard units are added.
+
+## Verified Starting Point
+
+`resolveCombat` currently decides retaliation from the defender's attack range.
+The existing `bombard` defensive-strength penalty is already correct for
+ground combat: an adjacent melee attacker can receive nonzero retaliation from
+a catapult or artillery crew, but the crew's halved defensive strength keeps
+that retaliation weaker than an equivalent frontline unit.
+
+This design deliberately preserves these behaviors:
+
+- An adjacent ranged, siege, or bombard attack can receive retaliation.
+- A melee defender cannot retaliate against an attacker outside melee range.
+- Ranged-versus-ranged attacks remain reciprocal when the defender reaches the
+  attacker.
+- Ground siege and bombard combat retains the generic reduced-defense rule.
+
+The remaining defect is air-specific: a bomber currently returns its full
+bombard-derived counter-damage when intercepted by an air fighter. That does
+not distinguish historical defensive guns from modern bomber evasion.
+
+## Scope
+
+Included:
+
+- Typed defenses for air-domain bombard units when intercepted by an air
+  ranged attacker.
+- A shared combat-exchange helper used by both resolution and preview.
+- Preview and resolved-combat presentation for defensive guns and stealth
+  evasion.
+- AI tactical evaluation that uses the same exchange consequences as the
+  resolver.
+- Existing-save compatibility, hot-seat visibility, and SFX behavior.
+- Definition-driven regression coverage for every present and future
+  siege/bombard profile and every present and future air bombard unit.
+
+Excluded:
+
+- Air basing, mission selection, carriers, radar, and interception targeting
+  rules from #539.
+- New units or buildings from #547.
+- Changes to ground bombardment, city attacks, terrain, class counters, or
+  base combat RNG.
+
+## Data Model
+
+Extend `UnitDefinition` with optional `airInterceptionDefense`, valid only
+when the unit has `domain: 'air'` and `attackProfile.kind: 'bombard'`:
+
+```ts
+type AirInterceptionDefense =
+  | { kind: 'turret-fire'; counterDamageMultiplier: number }
+  | { kind: 'evasion'; incomingDamageMultiplier: number };
+```
+
+The initial catalog entries are:
+
+| Unit | Defense | Effect |
+| --- | --- | --- |
+| `bomber` | `turret-fire` | Counter-damage against an interceptor is multiplied by `0.25`. |
+| `stealth_bomber` | `evasion` | It returns no counter-damage; interception damage dealt to it is multiplied by `0.65`. |
+
+All new air bombard definitions must choose one of these policies. This is
+typed gameplay metadata, not a unit-ID switch.
+
+The catalog must reject invalid metadata at test time:
+
+- Every air-domain `bombard` definition has exactly one valid policy.
+- `turret-fire.counterDamageMultiplier` and
+  `evasion.incomingDamageMultiplier` are finite values greater than zero and
+  no greater than one.
+- No definition outside the air-domain `bombard` category declares this field.
+
+The field belongs only to static definitions. It is never stored on `Unit`,
+`GameState`, or a save payload, so this change requires no save-schema version
+bump or migration.
+
+## Combat Resolution
+
+Add a pure shared helper, conceptually
+`getCombatExchangeModifiers(attacker, defender)`. It returns the defender's
+counter-damage multiplier, defender incoming-damage multiplier, and the
+player-facing labels for the exchange.
+
+The helper applies an air-interception policy only when all of these conditions
+are true:
+
+1. The attacker is an air-domain unit with a `ranged` attack profile.
+2. The defender is an air-domain unit with a `bombard` attack profile.
+3. The defender declares `airInterceptionDefense`.
+
+Otherwise it returns neutral multipliers and no air-defense label. This keeps a
+bomber attacking a fighter on the ordinary path: the fighter may retaliate at
+full strength. It also keeps all ground and city combat unchanged. The helper
+must be pure and owner-independent: it receives only the two unit definitions
+and does not read player, AI, challenge, fog, or UI state.
+
+`resolveCombat` continues to calculate strength, random factor, and base damage
+with its existing deterministic seed. After that normal calculation:
+
+- Turret fire multiplies only the defender's otherwise-valid counter-damage.
+- Evasion multiplies only damage dealt to the defender and sets its
+  counter-damage multiplier to zero.
+
+Existing non-combat and zero-strength early exits remain before exchange
+modifiers. Neither policy creates a new attack path, changes attack legality,
+consumes extra actions, or changes the deterministic combat seed.
+
+The existing `bombard` defensive-strength penalty remains separate. It models
+poor close defense for all bombard-profile units; it must not be compounded by
+another generic ground counter-damage penalty.
+
+The reduced-defense predicate must be shared and based on attack-profile
+semantics: `siege` and `bombard` profiles defend poorly. A `ranged` profile,
+including the intentionally agile ballista, does not receive that penalty.
+This is intentionally separate from air-interception policy: it keeps an
+adjacent catapult crew capable of weak retaliation without applying a second
+generic counter-damage reduction.
+
+## AI, Difficulty, and Player Parity
+
+Any AI path that estimates whether to launch an air attack must use the shared
+exchange helper, or a projected-result helper that calls it. Raw unit strength
+alone is insufficient for an intercepting fighter because it misses turret
+fire and evasion. The AI must make the same policy-aware tradeoff that the
+human preview communicates.
+
+The policy is deliberately identical for every owner and challenge level.
+Explorer, Standard, and Veteran may alter world pressure or force composition,
+but they must not secretly alter turret-fire or evasion multipliers. Human and
+non-human combat callers continue through `resolveCombat`; a hot-seat player
+therefore cannot receive a privileged combat rule.
+
+## Preview Contract
+
+`calculateCombatStrengths` and the combat-preview formatter must consume the
+same exchange helper used by `resolveCombat`. For an applicable attack, the
+live preview must show exactly one additional defense explanation, with a
+plain-language clause before the exact number:
+
+- `Bomber gunners fire back weakly: 25% return fire`
+- `Stealth makes it harder to hit: −35% interceptor damage`
+
+No air-defense wording appears for ordinary ground combat, city combat, a
+bomber attacking a fighter, or an air fight with no applicable policy. The
+preview must never imply full retaliation when the resolver applies a reduced
+or zero counterattack. The live resolved-combat presentation and notification
+log must reuse the same label so a player who acts quickly can still understand
+why the exchange differed.
+
+The preview is visible only after normal target legality and viewer-visibility
+checks succeed. In hot seat, changing `currentPlayer` must not reveal an
+unseen opponent bomber's policy through a preview or notification before that
+player has earned the required visibility.
+
+Turret fire reuses the existing secondary ranged-hit/counterattack SFX path;
+it must play once only when nonzero counter-damage is applied. Stealth evasion
+plays no invented defensive-shot SFX because it causes no return damage. This
+fix adds no asset and does not claim the broader air-audio work reserved for
+#539.
+
+## Regression Coverage
+
+### Targeted combat behavior
+
+Use fixed combat seeds to prove all of the following:
+
+1. Adjacent attacks against a melee defender still take retaliation.
+2. Long-range attacks against a melee defender take no retaliation.
+3. Ordinary ranged-versus-ranged combat remains reciprocal when range permits.
+4. A fighter intercepting `bomber` takes nonzero but reduced turret-fire
+   counter-damage.
+5. A fighter intercepting `stealth_bomber` takes zero counter-damage and deals
+   reduced interception damage.
+6. A bomber attacking a fighter receives the fighter's normal counterattack.
+7. Ground bombard units continue to retaliate at adjacent range while defending
+   poorly.
+8. Civilian and zero-strength early exits remain unchanged.
+9. The same units and seed produce the same result regardless of owner,
+   `currentPlayer`, or challenge profile.
+
+In addition to single-seed contract tests, run a deterministic multi-seed
+balance sample for the two fighter-versus-bomber pairings. The sampled average
+must show that the fighter remains favored against both bomber doctrines; the
+turret-fire bomber deals positive but clearly sub-frontline return damage; and
+stealth evasion reduces, but does not erase, the fighter's advantage. The
+implementation plan will set numeric bounds from the current unit strengths
+and retain them as a balance regression rather than treating `0.25` and `0.65`
+as untested constants.
+
+### Definition-driven completeness checks
+
+Tests must enumerate `UNIT_DEFINITIONS`; they must not maintain a hardcoded
+unit roster.
+
+- Every definition with an attack profile of kind `siege` or `bombard` must
+  receive the reduced defensive-strength behavior.
+- Every air-domain `bombard` definition must have valid
+  `airInterceptionDefense` metadata.
+- No non-air or non-bombard definition may declare air-interception metadata.
+- For every catalogued air bombard definition, an interception fixture must
+  prove the declared policy is reflected in the shared exchange helper.
+
+These checks make an omitted future trebuchet, artillery, bomber, or other
+bombard policy a test failure rather than a silent balance regression.
+
+### Player-visible behavior
+
+Unit tests must assert the exact preview text for turret fire and evasion, plus
+negative cases. A live attack-preview integration test must open the real
+selected-unit preview path and assert it renders the same label that the
+resolver uses. It must also prove a fogged hot-seat viewer cannot open that
+preview or learn the label.
+
+Resolved-combat presentation tests must prove turret fire uses exactly one
+existing secondary-hit SFX when it deals damage, while evasion produces no
+defensive-fire SFX. A notification-log regression must prove the post-combat
+message uses the same policy explanation as the preview.
+
+AI coverage must exercise an air intercept evaluation rather than only calling
+the resolver from an AI turn. It must prove an AI fighter accounts for turret
+fire and evasion before selecting its target. Add one human-path and one
+non-human-path parity case with identical state and seed.
+
+Save coverage must load a legacy-schema fixture containing existing `bomber`
+and `stealth_bomber` units, resolve both interceptions, and assert that the
+schema version does not change solely because this catalog behavior changed.
+
+## Verification
+
+After implementation, run:
+
+```sh
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
+bash scripts/run-with-mise.sh yarn build
+```
+
+The narrow test suite establishes combat, balance, AI, audio, save, hot-seat,
+and visible-preview contracts; `yarn build` verifies the discriminated metadata
+and all callers type-check.

--- a/docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md
+++ b/docs/superpowers/specs/2026-07-14-issue-537-air-interception-defense-design.md
@@ -155,8 +155,10 @@ No air-defense wording appears for ordinary ground combat, city combat, a
 bomber attacking a fighter, or an air fight with no applicable policy. The
 preview must never imply full retaliation when the resolver applies a reduced
 or zero counterattack. The live resolved-combat presentation and notification
-log must reuse the same label so a player who acts quickly can still understand
-why the exchange differed.
+log must reuse the same label. For a special exchange, route one concise
+recipient-scoped log entry to the attacking owner as well as the existing
+defender report, so a player who acts quickly can still understand why the
+exchange differed without exposing it to another hot-seat player.
 
 The preview is visible only after normal target legality and viewer-visibility
 checks succeed. In hot seat, changing `currentPlayer` must not reveal an
@@ -224,15 +226,16 @@ preview or learn the label.
 
 Resolved-combat presentation tests must prove turret fire uses exactly one
 existing secondary-hit SFX when it deals damage, while evasion produces no
-defensive-fire SFX. A notification-log regression must prove the post-combat
-message uses the same policy explanation as the preview.
+defensive-fire SFX. Notification-log regressions must prove both involved human
+owners receive the same policy explanation from their own perspective, and no
+uninvolved hot-seat viewer receives it.
 
 AI coverage must exercise an air intercept evaluation rather than only calling
 the resolver from an AI turn. It must prove an AI fighter accounts for turret
 fire and evasion before selecting its target. Add one human-path and one
 non-human-path parity case with identical state and seed.
 
-Save coverage must load a legacy-schema fixture containing existing `bomber`
+Save coverage must load a current-schema fixture containing existing `bomber`
 and `stealth_bomber` units, resolve both interceptions, and assert that the
 schema version does not change solely because this catalog behavior changed.
 
@@ -241,8 +244,8 @@ schema version does not change solely because this catalog behavior changed.
 After implementation, run:
 
 ```sh
-scripts/check-src-rule-violations.sh src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
-bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
+scripts/check-src-rule-violations.sh src/core/types.ts src/systems/combat-system.ts src/systems/unit-system.ts src/ui/combat-preview.ts src/ui/notification-routing.ts src/main.ts src/ai/ai-tactics.ts src/audio/sfx-director.ts
+bash scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/ui/combat-preview.test.ts tests/ui/combat-resolved-presentation.test.ts tests/ui/notification-routing.test.ts tests/main.integration.test.ts tests/ai/ai-tactics.test.ts tests/audio/sfx-director.test.ts tests/storage/save-migrations.test.ts
 bash scripts/run-with-mise.sh yarn build
 ```
 

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -308,20 +308,8 @@ function rankAttacks(
     if (!isAIHostileOwner(context.state, context.actorId, defender.owner)) {
       continue;
     }
-    const strengths = calculateCombatStrengths(
-      unit,
-      defender,
-      context.state.map,
-      buildCombatContextForDefender(context.state, unit, defender),
-    );
-    const expectedDamageRatio = Math.min(
-      2,
-      strengths.attackerStrength / Math.max(1, strengths.defenderStrength),
-    );
-    const deathRisk = Math.min(
-      2,
-      strengths.defenderStrength / Math.max(1, strengths.attackerStrength),
-    );
+    const combatContext = buildCombatContextForDefender(context.state, unit, defender);
+    const strengths = calculateCombatStrengths(unit, defender, context.state.map, combatContext);
     const defenderProfile = getUnitAttackProfile(defender.type);
     const safeRanged = target.result.range > defenderProfile.range;
     const action: AITacticalAction = {
@@ -334,9 +322,11 @@ function rankAttacks(
       defender,
       context.state.map,
       combatSeed(context.state, unit.id, defender.id),
-      buildCombatContextForDefender(context.state, unit, defender),
+      combatContext,
       context.state.era,
     );
+    const expectedDamageRatio = Math.min(2, preview.defenderDamage / Math.max(1, defender.health));
+    const deathRisk = Math.min(2, preview.attackerDamage / Math.max(1, unit.health));
     const likelyFinish = !preview.defenderSurvived;
     const focusFireBonus = likelyFinish ? 90 : Math.max(0, 100 - defender.health) * 0.4;
     const planProgress = context.plan.target.kind === 'unit'

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -367,6 +367,10 @@ export interface UnitAttackProfile {
   targets: Array<'unit' | 'city'>;
 }
 
+export type AirInterceptionDefense =
+  | { kind: 'turret-fire'; counterDamageMultiplier: number }
+  | { kind: 'evasion'; incomingDamageMultiplier: number };
+
 export interface UnitDefinition {
   type: UnitType;
   name: string;
@@ -379,6 +383,7 @@ export interface UnitDefinition {
   domain?: 'land' | 'naval' | 'air';
   spyDetectionChance?: number; // 0–1, probability per adjacent spy unit per turn
   attackProfile?: UnitAttackProfile;
+  airInterceptionDefense?: AirInterceptionDefense;
   terrainCostOverrides?: Partial<Record<string, number>>;
   cargoCapacity?: number;
   cargoSize?: number;
@@ -1128,6 +1133,14 @@ export interface CombatResult {
   defenderSurvived: boolean;
   attackerPosition: HexCoord;
   defenderPosition: HexCoord;
+  exchange?: CombatExchangeSummary;
+}
+
+export type CombatExchangeKind = 'none' | 'turret-fire' | 'evasion';
+
+export interface CombatExchangeSummary {
+  kind: Exclude<CombatExchangeKind, 'none'>;
+  label: string;
 }
 
 export interface CombatRewardNotification {

--- a/src/systems/beast-system.ts
+++ b/src/systems/beast-system.ts
@@ -112,7 +112,9 @@ export function canUnitAttackBeast(attacker: Unit, target: Unit): BeastAttackEli
   if (!def?.navalOnly || target.owner !== BEAST_OWNER) return { allowed: true };
   const attackerDef = UNIT_DEFINITIONS[attacker.type];
   const isNaval = attackerDef?.domain === 'naval';
-  const isRanged = attackerDef?.attackProfile?.kind === 'ranged';
+  const isRanged = attackerDef?.attackProfile?.kind === 'ranged'
+    || attackerDef?.attackProfile?.kind === 'siege'
+    || attackerDef?.attackProfile?.kind === 'bombard';
   if (isNaval || isRanged) return { allowed: true };
   return { allowed: false, reason: `Only ships and ranged units can fight the ${def.name}.` };
 }

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -1,4 +1,11 @@
-import type { Unit, CombatResult, GameMap, CivBonusEffect } from '@/core/types';
+import type {
+  Unit,
+  CombatExchangeKind,
+  CombatResult,
+  GameMap,
+  CivBonusEffect,
+  UnitAttackProfile,
+} from '@/core/types';
 import { hexDistance, hexKey } from './hex-utils';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { getWonderCombatBonus } from './wonder-system';
@@ -126,6 +133,51 @@ export interface CombatStrengthBreakdown {
   attackerModifierParts?: ModifierPart[];
   defenderModifierParts?: ModifierPart[];
   defenderDefendsPoorly?: boolean;
+  exchange: CombatExchangeModifiers;
+}
+
+export interface CombatExchangeModifiers {
+  kind: CombatExchangeKind;
+  defenderCounterDamageMultiplier: number;
+  defenderIncomingDamageMultiplier: number;
+  label?: string;
+}
+
+export function defendsPoorly(profile: UnitAttackProfile | undefined): boolean {
+  return profile?.kind === 'siege' || profile?.kind === 'bombard';
+}
+
+export function getCombatExchangeModifiers(attacker: Unit, defender: Unit): CombatExchangeModifiers {
+  const attackerDefinition = UNIT_DEFINITIONS[attacker.type];
+  const defenderDefinition = UNIT_DEFINITIONS[defender.type];
+  const neutral: CombatExchangeModifiers = {
+    kind: 'none',
+    defenderCounterDamageMultiplier: 1,
+    defenderIncomingDamageMultiplier: 1,
+  };
+  if (
+    attackerDefinition.domain !== 'air'
+    || attackerDefinition.attackProfile?.kind !== 'ranged'
+    || defenderDefinition.domain !== 'air'
+    || defenderDefinition.attackProfile?.kind !== 'bombard'
+  ) return neutral;
+
+  const doctrine = defenderDefinition.airInterceptionDefense;
+  if (!doctrine) return neutral;
+  if (doctrine.kind === 'turret-fire') {
+    return {
+      kind: 'turret-fire',
+      defenderCounterDamageMultiplier: doctrine.counterDamageMultiplier,
+      defenderIncomingDamageMultiplier: 1,
+      label: `Bomber gunners fire back weakly: ${Math.round(doctrine.counterDamageMultiplier * 100)}% return fire`,
+    };
+  }
+  return {
+    kind: 'evasion',
+    defenderCounterDamageMultiplier: 0,
+    defenderIncomingDamageMultiplier: doctrine.incomingDamageMultiplier,
+    label: `Stealth makes it harder to hit: −${Math.round((1 - doctrine.incomingDamageMultiplier) * 100)}% interceptor damage`,
+  };
 }
 
 export function calculateCombatStrengths(
@@ -152,7 +204,7 @@ export function calculateCombatStrengths(
   // attackProfile.kind rather than the 'siege' UnitClass because that class includes
   // ballista (kind 'ranged', more agile — no penalty) and excludes bomber/stealth_bomber
   // (which do need it, per the #537 counter-intercept fix).
-  if (defenderDefinition.attackProfile?.kind === 'bombard') {
+  if (defendsPoorly(defenderDefinition.attackProfile)) {
     defenderStrength *= 0.5;
   }
 
@@ -211,7 +263,8 @@ export function calculateCombatStrengths(
     cityDefense,
     attackerModifierParts: context?.attackerModifiers?.parts,
     defenderModifierParts: context?.defenderModifiers?.parts,
-    defenderDefendsPoorly: defenderDefinition.attackProfile?.kind === 'bombard',
+    defenderDefendsPoorly: defendsPoorly(defenderDefinition.attackProfile),
+    exchange: getCombatExchangeModifiers(attacker, defender),
   };
 }
 
@@ -302,10 +355,13 @@ export function resolveCombat(
     siegeMultiplier = context.attackerBonus.damageMultiplier;
   }
 
-  const defenderDamage = Math.round(baseDamage * adjustedRatio * siegeMultiplier);
+  const exchange = strengths.exchange;
+  const defenderDamage = Math.round(
+    baseDamage * adjustedRatio * siegeMultiplier * exchange.defenderIncomingDamageMultiplier,
+  );
   const distance = hexDistance(attacker.position, defender.position);
   const attackerDamage = canCounterAttackAtDistance(defender, distance)
-    ? Math.round(baseDamage * (1 - adjustedRatio))
+    ? Math.round(baseDamage * (1 - adjustedRatio) * exchange.defenderCounterDamageMultiplier)
     : 0;
 
   const attackerHealthAfter = attacker.health - attackerDamage;
@@ -320,5 +376,6 @@ export function resolveCombat(
     defenderSurvived: defenderHealthAfter > 0,
     attackerPosition: attacker.position,
     defenderPosition: defender.position,
+    ...(exchange.kind === 'none' ? {} : { exchange: { kind: exchange.kind, label: exchange.label! } }),
   };
 }

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -338,6 +338,7 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     canFoundCity: false, canBuildImprovements: false, productionCost: 280,
     domain: 'air',
     attackProfile: { kind: 'bombard', range: 3, targets: ['city', 'unit'] },
+    airInterceptionDefense: { kind: 'turret-fire', counterDamageMultiplier: 0.25 },
   },
   carrier: {
     type: 'carrier', name: 'Carrier',
@@ -500,7 +501,8 @@ export const UNIT_DEFINITIONS: Record<UnitType, UnitDefinition> = {
     visionRange: 3, strength: 52, canFoundCity: false,
     canBuildImprovements: false, productionCost: 360,
     domain: 'air',
-    attackProfile: { kind: 'ranged', range: 3, targets: ['unit', 'city'] },
+    attackProfile: { kind: 'bombard', range: 3, targets: ['unit', 'city'] },
+    airInterceptionDefense: { kind: 'evasion', incomingDamageMultiplier: 0.65 },
   },
 };
 

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -663,7 +663,7 @@ export const UNIT_DESCRIPTIONS: Record<UnitType, string> = {
   observation_balloon: 'Tethered hydrogen balloon used for aerial reconnaissance. Cannot attack. Provides unmatched long-range vision over enemy territory. Extremely fragile.',
   biplane:    'WWI-era fabric-and-wood fighter aircraft. Fast air unit that can attack land and naval targets from altitude. Vulnerable to dedicated anti-air batteries. Obsoleted by monoplane fighters.',
   jet_fighter: 'WWII-era swept-wing jet fighter. Faster and stronger than the biplane; dominates air-to-air and ground-attack roles, with a bonus vs bombers. Faction roundel on fuselage; afterburner glow marks its passage. Air-superiority apex — the bomber is the strike line instead of a fighter upgrade.',
-  bomber: 'Long-range strategic bomber. Bombard range 3 vs cities and units — the era\'s dedicated city-buster. Requires no special building, unlike its stealth successor. Upgrades into the stealth bomber.',
+  bomber: 'Long-range strategic bomber. Bombard range 3 vs cities and units — the era\'s dedicated city-buster. Its defensive gunners can return weak fire when intercepted. Requires no special building, unlike its stealth successor. Upgrades into the stealth bomber.',
   carrier:     'Fleet carrier. Heavily armed mobile naval platform; aircraft basing operations arrive in a future update. Requires a coastal city to build. High vision range; strong naval strength.',
   destroyer:   'Fast surface escort. Ranged attack (range 2) vs units and cities; +25% strength attacking submarines and missile submarines. Requires Carrier Warfare and a coastal city. Current top-tier surface escort — no later replacement yet.',
   attack_helicopter: 'Cold War attack helicopter. Combines close air support with anti-armour missiles; faster than jet fighters but more vulnerable to ground fire. Ranged air unit.',
@@ -715,7 +715,7 @@ export const UNIT_DESCRIPTIONS: Record<UnitType, string> = {
   beast_hydra: 'The Swamp Hydra regrows flesh as fast as you can cut it — 10 health every turn. Strike hard and finish it in one assault.',
   beast_dragon: 'The Ancient Dragon, terror of the volcanic peaks. Its fire breath strikes from 2 hexes away. Slaying it is the deed of a lifetime — the hoard contains everything.',
   cyber_unit: 'A non-combat economic saboteur. Drains −2 gold per turn from adjacent enemy cities lacking a Cyber Defense Center. Strength 0: capturable by any enemy unit that enters its hex (transferred to that civ, not destroyed). Gene Therapy does not apply.',
-  stealth_bomber: 'A long-range strategic bomber invisible to standard radar. Cannot be targeted by ranged attacks unless an enemy Signals Hub is within 2 hexes of the bomber. Must be trained at a Stealth Airbase. Range 3, strength 52.',
+  stealth_bomber: 'A long-range strategic bomber invisible to standard radar. Cannot be targeted by ranged attacks unless an enemy Signals Hub is within 2 hexes of the bomber; when intercepted, stealth reduces the damage it takes instead of returning fire. Must be trained at a Stealth Airbase. Range 3, strength 52.',
 };
 
 export function getUnmovedUnits(

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -24,5 +24,8 @@ export function formatCombatPreviewDetails(
   if (preview.defenderDefendsPoorly) {
     details.push('Siege defends poorly (−50%)');
   }
+  if (preview.exchange?.label) {
+    details.push(preview.exchange.label);
+  }
   return details.join(' | ');
 }

--- a/src/ui/combat-preview.ts
+++ b/src/ui/combat-preview.ts
@@ -1,9 +1,14 @@
 import type { CombatStrengthBreakdown } from '@/systems/combat-system';
 
+// The renderer only consumes display fields. Keep it compatible with legacy/mock
+// previews that predate an exchange summary while combat calculations always emit one.
+type CombatPreviewDetails = Omit<CombatStrengthBreakdown, 'exchange'>
+  & Partial<Pick<CombatStrengthBreakdown, 'exchange'>>;
+
 export function formatCombatPreviewDetails(
   ownerName: string,
   defenderHealth: number,
-  preview: CombatStrengthBreakdown,
+  preview: CombatPreviewDetails,
 ): string {
   const details = [ownerName, `HP: ${defenderHealth}/100`];
   if (preview.terrainDefenseBonus > 0) {
@@ -22,7 +27,7 @@ export function formatCombatPreviewDetails(
     details.push(part.label);
   }
   if (preview.defenderDefendsPoorly) {
-    details.push('Siege defends poorly (−50%)');
+    details.push('Bombard units defend poorly (−50%)');
   }
   if (preview.exchange?.label) {
     details.push(preview.exchange.label);

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -297,31 +297,38 @@ export function routeStrategicWarning(
   );
 }
 
-// Routes to the defender's owner regardless of who is currently acting.
+// Routes to the combatants' owners regardless of who is currently acting.
 export function routeCombatResolved(
   state: GameState,
   result: CombatResult,
   sink: NotificationSink,
   facts?: Pick<
     GameEvents['combat:resolved'],
-    'attackerOwnerId' | 'defenderOwnerId' | 'defenderType'
+    'attackerOwnerId' | 'attackerType' | 'defenderOwnerId' | 'defenderType'
   >,
 ): void {
   const defender = state.units[result.defenderId];
   const attacker = state.units[result.attackerId];
   const defenderOwner = facts?.defenderOwnerId ?? defender?.owner;
   if (!defenderOwner) return;
-  const attackerOwner = facts?.attackerOwnerId ?? attacker?.owner ?? 'Unknown';
+  const attackerOwner = facts?.attackerOwnerId ?? attacker?.owner;
   const attackerLabel = attackerOwner === 'barbarian'
     ? 'Barbarians'
-    : (state.civilizations[attackerOwner]?.name ?? attackerOwner);
+    : (state.civilizations[attackerOwner ?? '']?.name ?? attackerOwner ?? 'Unknown');
   const defenderTypeId = facts?.defenderType ?? defender?.type;
   if (!defenderTypeId) return;
   const defenderType = UNIT_DEFINITIONS[defenderTypeId]?.name ?? defenderTypeId;
+  const exchangeSuffix = result.exchange ? `. ${result.exchange.label}.` : '';
   const msg = result.defenderSurvived
     ? `${defenderType} was attacked by ${attackerLabel} (${result.defenderDamage} damage taken)`
     : `${defenderType} was destroyed by ${attackerLabel}!`;
-  sink(defenderOwner, msg, 'warning');
+  sink(defenderOwner, `${msg}${exchangeSuffix}`, 'warning');
+
+  if (!result.exchange || !attackerOwner || attackerOwner === 'barbarian') return;
+  const attackerTypeId = facts?.attackerType ?? attacker?.type;
+  if (!attackerTypeId) return;
+  const attackerType = UNIT_DEFINITIONS[attackerTypeId]?.name ?? attackerTypeId;
+  sink(attackerOwner, `${attackerType} attack: ${result.exchange.label}.`, 'info');
 }
 
 export function routeCombatRewardEarned(

--- a/tests/ai/ai-tactics.test.ts
+++ b/tests/ai/ai-tactics.test.ts
@@ -174,6 +174,35 @@ describe('AI tactical action ranking', () => {
       .toBeGreaterThan(actions.findIndex(action => action.unitId === 'archer'));
   });
 
+  it('scores a revealed stealth bomber from its resolved evasion exchange, not raw counter-strength', () => {
+    const state = makeState('veteran');
+    const fighter = addUnit(state, 'fighter', 'jet_fighter', AI, { q: 0, r: 0 });
+    const bomber = addUnit(state, 'bomber', 'stealth_bomber', HUMAN, { q: 1, r: 0 });
+    const signalsHub = addCity(state, 'signals-hub', AI, { q: 0, r: 1 });
+    signalsHub.buildings = ['signals_hub'];
+    const plan = makePlan(
+      { kind: 'unit', id: bomber.id, lastKnownPosition: bomber.position },
+      [fighter.id],
+      { objective: 'repel' },
+    );
+
+    const candidate = rankUnitTacticalActions(context(state, plan), fighter.id)
+      .find(entry => entry.action.kind === 'attack' && entry.action.targetUnitId === bomber.id);
+    const preview = combatSystem.resolveCombat(
+      fighter,
+      bomber,
+      state.map,
+      combatSystem.deterministicCombatSeed(state.gameId, state.turn, fighter.id, bomber.id),
+      undefined,
+      state.era,
+    );
+    const expectedDamageRatio = Math.min(2, preview.defenderDamage / bomber.health);
+    const deathRisk = Math.min(2, preview.attackerDamage / fighter.health);
+
+    expect(preview.exchange?.kind).toBe('evasion');
+    expect(candidate?.score).toBeCloseTo(500 + 30 + expectedDamageRatio * 25 - deathRisk * 40, 5);
+  });
+
   it('does not opportunistically attack beasts when beast contests are disabled', () => {
     const state = makeState('veteran');
     addUnit(state, 'captor', 'swordsman', AI, { q: 0, r: 0 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -22,6 +22,21 @@ describe('save migrations', () => {
     expect(loadedAgain).toEqual(migrated);
   });
 
+  it('#537 interception doctrine is definition data, so existing bomber saves need no schema migration', () => {
+    const savedGame = createNewGame('rome', 'bomber-save-compatibility', 'small');
+    const loaded = migrateSaveToCurrent(structuredClone(savedGame));
+    const loadedAgain = migrateSaveToCurrent(structuredClone(loaded));
+
+    expect(loaded.saveSchemaVersion).toBe(CURRENT_SAVE_SCHEMA_VERSION);
+    expect(loadedAgain).toEqual(loaded);
+    expect(UNIT_DEFINITIONS.bomber.airInterceptionDefense).toEqual({
+      kind: 'turret-fire', counterDamageMultiplier: 0.25,
+    });
+    expect(UNIT_DEFINITIONS.stealth_bomber.airInterceptionDefense).toEqual({
+      kind: 'evasion', incomingDamageMultiplier: 0.65,
+    });
+  });
+
   it('#553 MR1/4 — Trade Routes Overhaul is purely additive: a pre-existing caravan and its committed route survive migration and stay functional (no SAVE_MIGRATIONS entry needed)', () => {
     const legacySave = createNewGame('rome', 'pre-naval-trader-save', 'small');
     const cityId = Object.keys(legacySave.cities)[0]!;

--- a/tests/systems/beast-system.test.ts
+++ b/tests/systems/beast-system.test.ts
@@ -371,9 +371,10 @@ describe('canUnitAttackBeast', () => {
     expect(canUnitAttackBeast(makeUnit({ type: 'warrior' }), serpent).reason).toContain('ships and ranged');
   });
 
-  it('naval and ranged units can attack a navalOnly beast', () => {
+  it('naval, ranged, and bombard units can attack a navalOnly beast', () => {
     expect(canUnitAttackBeast(makeUnit({ type: 'galley' }), serpent).allowed).toBe(true);
     expect(canUnitAttackBeast(makeUnit({ type: 'archer' }), serpent).allowed).toBe(true);
+    expect(canUnitAttackBeast(makeUnit({ type: 'stealth_bomber' }), serpent).allowed).toBe(true);
   });
 
   it('everything can attack normal beasts', () => {

--- a/tests/systems/combat-system.test.ts
+++ b/tests/systems/combat-system.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/systems/combat-system';
 import { createNewGame } from '@/core/game-state';
 import type { GameMap } from '@/core/types';
-import { createUnit } from '@/systems/unit-system';
+import { createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { generateMap } from '@/systems/map-generator';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
@@ -334,5 +334,66 @@ describe('bombard-kind defense penalty (MR: counter-attack rule fix, #537)', () 
 
     // Bomber strength 48, halved by the bombard penalty before terrain.
     expect(preview.defenderStrength).toBeCloseTo(48 * 0.5 * (1 + terrain), 5);
+  });
+});
+
+describe('combat doctrine catalog (#537)', () => {
+  it('declares one bounded interception doctrine for every air bombard unit', () => {
+    const airBombardDefinitions = Object.values(UNIT_DEFINITIONS)
+      .filter(definition => definition.domain === 'air' && definition.attackProfile?.kind === 'bombard');
+
+    expect(airBombardDefinitions.length).toBeGreaterThan(0);
+    for (const definition of airBombardDefinitions) {
+      const doctrine = definition.airInterceptionDefense;
+      expect(doctrine, definition.type).toBeDefined();
+      const multiplier = doctrine?.kind === 'turret-fire'
+        ? doctrine.counterDamageMultiplier
+        : doctrine?.incomingDamageMultiplier;
+      expect(multiplier, definition.type).toBeGreaterThan(0);
+      expect(multiplier, definition.type).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('classifies both strategic bombers as air bombard units', () => {
+    expect(UNIT_DEFINITIONS.bomber.attackProfile?.kind).toBe('bombard');
+    expect(UNIT_DEFINITIONS.stealth_bomber.attackProfile?.kind).toBe('bombard');
+  });
+
+  it('keeps agile ranged ballista outside the poor-defense siege and bombard profiles', () => {
+    expect(UNIT_DEFINITIONS.ballista.attackProfile?.kind).toBe('ranged');
+  });
+});
+
+describe('air interception defenses (#537)', () => {
+  let map: GameMap;
+
+  beforeAll(() => {
+    map = generateMap(30, 30, 'air-interception-defense-test');
+  });
+
+  it('records reduced but nonzero turret fire when a fighter intercepts a bomber', () => {
+    const fighter = createUnit('jet_fighter', 'p1', { q: 10, r: 10 }, mkC());
+    const bomber = createUnit('bomber', 'p2', { q: 11, r: 10 }, mkC());
+
+    const result = resolveCombat(fighter, bomber, map, 77);
+
+    expect(result.exchange).toEqual({
+      kind: 'turret-fire',
+      label: 'Bomber gunners fire back weakly: 25% return fire',
+    });
+    expect(result.attackerDamage).toBeGreaterThan(0);
+  });
+
+  it('records evasion and no return fire when a fighter intercepts a stealth bomber', () => {
+    const fighter = createUnit('jet_fighter', 'p1', { q: 10, r: 10 }, mkC());
+    const stealthBomber = createUnit('stealth_bomber', 'p2', { q: 11, r: 10 }, mkC());
+
+    const result = resolveCombat(fighter, stealthBomber, map, 77);
+
+    expect(result.exchange).toEqual({
+      kind: 'evasion',
+      label: 'Stealth makes it harder to hit: −35% interceptor damage',
+    });
+    expect(result.attackerDamage).toBe(0);
   });
 });

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -79,4 +79,21 @@ describe('formatCombatPreviewDetails', () => {
 
     expect(details).not.toContain('defends poorly');
   });
+
+  it('explains reduced bomber turret fire before an interception', () => {
+    const details = formatCombatPreviewDetails('Rival', 100, {
+      attackerStrength: 50,
+      defenderStrength: 24,
+      terrainDefenseBonus: 0,
+      riverAttackPenalty: 0,
+      exchange: {
+        kind: 'turret-fire',
+        defenderCounterDamageMultiplier: 0.25,
+        defenderIncomingDamageMultiplier: 1,
+        label: 'Bomber gunners fire back weakly: 25% return fire',
+      },
+    });
+
+    expect(details).toContain('Bomber gunners fire back weakly: 25% return fire');
+  });
 });

--- a/tests/ui/combat-preview.test.ts
+++ b/tests/ui/combat-preview.test.ts
@@ -65,7 +65,7 @@ describe('formatCombatPreviewDetails', () => {
       defenderDefendsPoorly: true,
     });
 
-    expect(details).toContain('Siege defends poorly (−50%)');
+    expect(details).toContain('Bombard units defend poorly (−50%)');
   });
 
   it('omits the bombard defense penalty line for a normal defender (negative test)', () => {

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -265,6 +265,43 @@ describe('notification routing', () => {
     expect(calls[0]!.message).toMatch(/destroyed by Barbarians/);
   });
 
+  it('routes interception details to both combatants, never the active third hot-seat player', () => {
+    const state = makeState({
+      currentPlayer: 'p3',
+      units: {},
+    } as Partial<GameState>);
+    const result: CombatResult = {
+      attackerId: 'destroyed-attacker', defenderId: 'destroyed-defender',
+      attackerDamage: 8, defenderDamage: 22,
+      attackerSurvived: true, defenderSurvived: true,
+      attackerPosition: { q: 0, r: 0 }, defenderPosition: { q: 1, r: 0 },
+      exchange: {
+        kind: 'turret-fire',
+        label: 'Bomber gunners fire back weakly: 25% return fire',
+      },
+    };
+    const { sink, calls } = makeSink();
+
+    routeCombatResolved(state, result, sink, {
+      attackerOwnerId: 'p1', attackerType: 'jet_fighter',
+      defenderOwnerId: 'p2', defenderType: 'bomber',
+    });
+
+    expect(calls).toEqual([
+      {
+        civId: 'p2',
+        message: 'Bomber was attacked by Alice (22 damage taken). Bomber gunners fire back weakly: 25% return fire.',
+        type: 'warning', target: undefined,
+      },
+      {
+        civId: 'p1',
+        message: 'Jet Fighter attack: Bomber gunners fire back weakly: 25% return fire.',
+        type: 'info', target: undefined,
+      },
+    ]);
+    expect(calls.some(call => call.civId === 'p3')).toBe(false);
+  });
+
   it('routes combat reward messages to the rewarded civ only', () => {
     const state = makeState();
     const { sink, calls } = makeSink();


### PR DESCRIPTION
## Summary
- Give conventional bombers weak defensive turret fire and stealth bombers evasion-only interception defense.
- Make the combat preview, recipient-scoped hot-seat notifications, AI tactics, and unit descriptions reflect the resolved exchange.
- Preserve existing saves without a schema bump and cover all current/future air-bombard definitions with regression tests.

## Why
Bomber interception previously treated the strategic bomber line inconsistently and did not provide a complete, explainable combat contract across player, AI, hot-seat, and save paths.

## Validation
- `scripts/check-src-rule-violations.sh` for all changed source modules
- Targeted combat, AI, UI, hot-seat notification, save, beast, and description regressions (164 passing)
- `bash scripts/run-with-mise.sh yarn build`
- `bash scripts/run-with-mise.sh yarn test`