### PR TITLE
feat(combat): add zone control and positioning

### DIFF
--- a/src/ai/ai-hostility.ts
+++ b/src/ai/ai-hostility.ts
@@ -1,6 +1,6 @@
-import { classifyOwner, isAlwaysHostilePair } from '@/core/owner-kind';
+import { classifyOwner } from '@/core/owner-kind';
 import type { GameState } from '@/core/types';
-import { isMinorCivAtWar } from '@/systems/minor-civ-diplomacy';
+import { isHostileOwnerTo } from '@/systems/owner-hostility';
 
 export function isAIHostileOwner(
   state: Readonly<GameState>,
@@ -23,10 +23,5 @@ export function isAIHostileOwner(
     }
     return true;
   }
-  if (ownerKind === 'minor') {
-    return isMinorCivAtWar(state, actorId, ownerId);
-  }
-  if (isAlwaysHostilePair(actorId, ownerId)) return true;
-  return state.civilizations[actorId]?.diplomacy.atWarWith
-    .includes(ownerId) ?? false;
+  return isHostileOwnerTo(state, actorId, ownerId);
 }

--- a/src/ai/ai-tactics.ts
+++ b/src/ai/ai-tactics.ts
@@ -50,7 +50,7 @@ import {
 } from '@/systems/transport-system';
 import {
   findPath,
-  getMovementRange,
+  getMovementRangeDetails,
   UNIT_DEFINITIONS,
 } from '@/systems/unit-system';
 import {
@@ -188,14 +188,7 @@ function visibleThreatCount(
 
 function movementRange(state: GameState, actorId: string, unit: Unit): HexCoord[] {
   const occupancy = buildUnitOccupancy(state.units);
-  return getMovementRange(
-    unit,
-    state.map,
-    occupancy.unitIdsByHex,
-    occupancy.ownersByUnitId,
-    hostileOwners(state, actorId),
-    { completedTechs: state.civilizations[actorId]?.techState.completed ?? [] },
-  ).filter(destination =>
+  return getMovementRangeDetails(state, unit.id).reachable.filter(destination =>
     getUnitIdsAtCoord(occupancy, destination)
       .filter(unitId => unitId !== unit.id)
       .length === 0);
@@ -531,6 +524,30 @@ function rankCivilianAndTransportActions(
     }, 550));
 }
 
+function scorePostMovePositioning(
+  context: AITacticalContext,
+  unit: Unit,
+  destination: HexCoord,
+): number {
+  const projectedUnit = { ...unit, position: destination };
+  const projectedState: GameState = {
+    ...context.state,
+    units: { ...context.state.units, [unit.id]: projectedUnit },
+  };
+  return getAttackTargets(projectedState, projectedUnit, {
+    viewerId: context.actorId,
+    requireVisibility: true,
+  }).reduce((bonus, target) => {
+    if (target.result.targetType !== 'unit') return bonus;
+    const defender = projectedState.units[target.result.targetUnitId];
+    if (!defender || !isAIHostileOwner(projectedState, context.actorId, defender.owner)) {
+      return bonus;
+    }
+    const combatContext = buildCombatContextForDefender(projectedState, projectedUnit, defender);
+    return bonus + Math.round(((combatContext.attackerPositioningMultiplier ?? 1) - 1) * 100);
+  }, 0);
+}
+
 function rankMoves(
   context: AITacticalContext,
   unit: Unit,
@@ -561,11 +578,12 @@ function rankMoves(
             distance(context.state, candidate.position, destination)
             / Math.max(1, UNIT_DEFINITIONS[candidate.type].movementPoints),
           ))) - 1);
+    const positioningBonus = scorePostMovePositioning(context, unit, destination);
     return ranked({
       kind: 'move',
       unitId: unit.id,
       destination,
-    }, 300 + planProgress * 30 - cohesionBreakTurns * 15);
+    }, 300 + planProgress * 30 - cohesionBreakTurns * 15 + positioningBonus);
   });
 }
 

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -4,7 +4,7 @@ import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import { getDetectionUnitTypeForCiv } from '@/systems/city-system';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { canFoundCityAt } from '@/systems/city-territory-system';
-import { getMovementRange, moveUnit, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { getMovementRangeDetails, moveUnitWithZoneOfControl, findPath, createUnit, UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { executeUnitMove } from '@/systems/unit-movement-system';
 import {
   canLoadUnitOntoTransport,
@@ -265,17 +265,7 @@ function isCombatWarship(unit: Unit): boolean {
 }
 
 function moveWarshipToward(state: GameState, civId: string, unit: Unit, target: HexCoord): GameState {
-  const occupancy = buildUnitOccupancy(state.units);
-  const hostileOwners = new Set<string>(['barbarian']);
-  addAlwaysHostileOwners(state, civId, hostileOwners, false);
-  const range = getMovementRange(
-    unit,
-    state.map,
-    occupancy.unitIdsByHex,
-    occupancy.ownersByUnitId,
-    hostileOwners,
-    { completedTechs: state.civilizations[civId]?.techState.completed ?? [] },
-  );
+  const range = getMovementRangeDetails(state, unit.id).reachable;
   const best = range
     .map(coord => ({ coord, distance: pirateDistance(state, coord, target) }))
     .filter(candidate => candidate.distance < pirateDistance(state, unit.position, target))
@@ -286,7 +276,7 @@ function moveWarshipToward(state: GameState, civId: string, unit: Unit, target: 
     ...state,
     units: {
       ...state.units,
-      [unit.id]: moveUnit(unit, best.coord, unit.movementPointsLeft),
+      [unit.id]: moveUnitWithZoneOfControl(state, unit, best.coord, unit.movementPointsLeft).unit,
     },
   };
 }

--- a/src/input/selected-unit-highlights.ts
+++ b/src/input/selected-unit-highlights.ts
@@ -5,7 +5,7 @@ import { getVisibility } from '@/systems/fog-of-war';
 import { hexDistance, hexKey, wrappedHexDistance } from '@/systems/hex-utils';
 import { getAvailableWorkerActions, getKnownTileResourceForWorkerAction } from '@/systems/improvement-system';
 import { buildUnitOccupancy } from '@/systems/unit-occupancy';
-import { getMovementRange } from '@/systems/unit-system';
+import { getMovementRangeDetails } from '@/systems/unit-system';
 import {
   getLandUnitWaterRecovery,
   NO_LAND_UNIT_WATER_RECOVERY,
@@ -14,6 +14,7 @@ import {
 
 export interface SelectedUnitHighlightResult {
   movementRange: HexCoord[];
+  zocLimitedRange: HexCoord[];
   attackTargets: AttackTarget[];
   highlights: HexHighlight[];
   waterRecovery: LandUnitWaterRecovery;
@@ -100,6 +101,7 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
   if (!unit || unit.owner !== state.currentPlayer) {
     return {
       movementRange: [],
+      zocLimitedRange: [],
       attackTargets: [],
       highlights: [],
       waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
@@ -108,23 +110,18 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
   if (unit.committedToRouteId) {
     return {
       movementRange: [],
+      zocLimitedRange: [],
       attackTargets: [],
       highlights: [],
       waterRecovery: NO_LAND_UNIT_WATER_RECOVERY,
     };
   }
 
-  const occupancy = buildUnitOccupancy(state.units);
-  const hostileOwners = buildHostileOwners(state, state.currentPlayer);
-  const completedTechs = state.civilizations[unit.owner]?.techState.completed ?? [];
-  const movementRange = getMovementRange(
-    unit,
-    state.map,
-    occupancy.unitIdsByHex,
-    occupancy.ownersByUnitId,
-    hostileOwners,
-    { completedTechs },
-  ).filter(coord => isPreviewableMoveDestination(state, unit.position, coord));
+  const detailedRange = getMovementRangeDetails(state, unitId);
+  const movementRange = detailedRange.reachable
+    .filter(coord => isPreviewableMoveDestination(state, unit.position, coord));
+  const zocLimitedRange = detailedRange.zocLimited
+    .filter(coord => isPreviewableMoveDestination(state, unit.position, coord));
   const attackTargets = getAttackTargets(state, unit, { viewerId: state.currentPlayer })
     .filter(target => target.result.targetType === 'unit');
   const attackKeys = new Set(attackTargets.map(target => hexKey(target.coord)));
@@ -138,11 +135,14 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
   const recoveryKeys = new Set(
     waterRecovery.destinations.map(coord => hexKey(coord)),
   );
+  const zocKeys = new Set(zocLimitedRange.map(hexKey));
 
   const moveHighlights = nonCombatMovementRange.map(coord => ({
     coord,
     type: recoveryKeys.has(hexKey(coord))
       ? 'water-recovery' as const
+      : zocKeys.has(hexKey(coord))
+        ? 'zoc-limited' as const
       : 'move' as const,
   }));
 
@@ -152,6 +152,7 @@ export function buildSelectedUnitHighlights(state: GameState, unitId: string): S
 
   return {
     movementRange,
+    zocLimitedRange,
     attackTargets,
     highlights: [...moveHighlights, ...attackHighlights, ...workerHighlights],
     waterRecovery,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2218,7 +2218,10 @@ function selectUnit(
           },
         });
       },
-    }, { waterRecovery: highlightResult.waterRecovery });
+    }, {
+      waterRecovery: highlightResult.waterRecovery,
+      hasZoneOfControlWarning: highlightResult.zocLimitedRange.length > 0,
+    });
   }
 
   if (!opts?.suppressSelectionSfx) SFX.select();
@@ -2278,6 +2281,9 @@ function executeAnimatedUnitMove(unitId: string, move: () => ExecuteUnitMoveResu
       showNotification(moveResult.message, 'warning');
       SFX.error();
       return moveResult;
+    }
+    if (moveResult.stopReason === 'zone-of-control') {
+      showNotification('Stopped — enemy nearby', 'info');
     }
     // Clear journey automation when the player manually moves a unit.
     if (movingUnit?.automation?.mode === 'journey') {

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -36,6 +36,28 @@ import type { CombatResult } from '@/core/types';
 
 export { CIVTYPE_TO_FACTION, civTypeToFaction };
 
+/** A shape cue so ZOC destinations remain distinct without relying on amber alone. */
+export function drawZoneOfControlChevrons(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+): void {
+  ctx.save();
+  ctx.strokeStyle = '#fff0a8';
+  ctx.lineWidth = Math.max(1.5, size * 0.045);
+  ctx.lineCap = 'round';
+  for (const offset of [-0.18, 0, 0.18]) {
+    const chevronY = y + offset * size;
+    ctx.beginPath();
+    ctx.moveTo(x - size * 0.16, chevronY - size * 0.07);
+    ctx.lineTo(x, chevronY + size * 0.07);
+    ctx.lineTo(x + size * 0.16, chevronY - size * 0.07);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
 export function buildUnitEntities(
   state: GameState,
   viewerId: string,
@@ -146,12 +168,13 @@ export function positionMovingPirateHeadquarters(
 
 export interface HexHighlight {
   coord: HexCoord;
-  type: 'move' | 'attack' | 'water-recovery' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
+  type: 'move' | 'attack' | 'zoc-limited' | 'water-recovery' | 'worker-buildable' | 'worker-owned-blocked' | 'worker-foreign-blocked';
 }
 
 const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
   move: 'rgba(74, 144, 217, 0.35)',
   attack: 'rgba(217, 74, 74, 0.45)',
+  'zoc-limited': 'rgba(245, 184, 73, 0.55)',
   'water-recovery': 'rgba(245, 184, 73, 0.55)',
   'worker-buildable': 'rgba(80, 200, 120, 0.45)',
   'worker-owned-blocked': 'rgba(232, 193, 112, 0.40)',
@@ -159,6 +182,7 @@ const HEX_HIGHLIGHT_COLORS: Record<HexHighlight['type'], string> = {
 };
 
 const HEX_HIGHLIGHT_OUTLINES: Partial<Record<HexHighlight['type'], string>> = {
+  'zoc-limited': '#fff0a8',
   'water-recovery': '#fff0a8',
 };
 
@@ -491,6 +515,9 @@ export class RenderLoop {
         const color = HEX_HIGHLIGHT_COLORS[highlight.type];
         const outline = HEX_HIGHLIGHT_OUTLINES[highlight.type];
         drawHexHighlight(this.ctx, screen.x, screen.y, scaledSize, color, outline);
+        if (highlight.type === 'zoc-limited') {
+          drawZoneOfControlChevrons(this.ctx, screen.x, screen.y, scaledSize);
+        }
       }
     }
 

--- a/src/systems/attack-targeting.ts
+++ b/src/systems/attack-targeting.ts
@@ -1,12 +1,11 @@
 import type { GameMap, GameState, HexCoord, Unit, UnitAttackProfile, UnitType } from '@/core/types';
-import { isAtWar } from '@/systems/diplomacy-system';
 import { getVisibility } from '@/systems/fog-of-war';
 import { hexDistance, hexKey, hexesInRange, getWrappedHexesInRange, wrappedHexDistance } from '@/systems/hex-utils';
 import { selectDefenderForAttack } from '@/systems/combat-system';
 import { UNIT_DEFINITIONS } from '@/systems/unit-system';
 import { isBeastConcealedFrom, canUnitAttackBeast } from '@/systems/beast-system';
-import { isAlwaysHostilePair, isPirateOwner } from '@/core/owner-kind';
-import { isMinorCivHostileToOwner } from './minor-civ-diplomacy';
+import { isPirateOwner } from '@/core/owner-kind';
+import { isHostileOwnerTo } from './owner-hostility';
 
 export type AttackTargetFailure =
   | 'missing-attacker'
@@ -53,16 +52,7 @@ function isVisibleToViewer(state: GameState, viewerId: string | undefined, coord
 }
 
 function canAttackOwner(state: GameState, attackerOwner: string, targetOwner: string): boolean {
-  if (targetOwner === attackerOwner) return false;
-  if (isAlwaysHostilePair(attackerOwner, targetOwner)) return true;
-  if (attackerOwner.startsWith('mc-')) {
-    return isMinorCivHostileToOwner(state, attackerOwner, targetOwner);
-  }
-  if (targetOwner.startsWith('mc-')) {
-    return state.civilizations[attackerOwner]?.diplomacy.atWarWith.includes(targetOwner) ?? false;
-  }
-  const diplomacy = state.civilizations[attackerOwner]?.diplomacy;
-  return diplomacy ? isAtWar(diplomacy, targetOwner) : false;
+  return isHostileOwnerTo(state, attackerOwner, targetOwner);
 }
 
 function unitAt(state: GameState, attacker: Unit, coord: HexCoord): [string, Unit] | null {

--- a/src/systems/combat-context.ts
+++ b/src/systems/combat-context.ts
@@ -6,6 +6,7 @@ import { isCityCoastal } from './city-system';
 import { UNIT_DEFINITIONS } from './unit-system';
 import { getActiveNationalProjectsForCiv } from './national-project-system';
 import { getCombatModifier } from './unit-modifier-system';
+import { getCombatAdjacentOccupiedTileCount } from './zone-of-control-system';
 
 // Shared by the human attack flow (main.ts), every AI attack path
 // (ai-major-turn.ts, ai-tactics.ts), and the combat preview so the
@@ -28,6 +29,8 @@ export function buildCombatContextForDefender(
   const defenderCompletedTechs = state.civilizations[defender.owner]?.techState.completed ?? [];
   const defenderInFriendlyCity = !!defenderCity && defenderCity.owner === defender.owner;
   const attackerInFriendlyCity = !!attackerCity && attackerCity.owner === attacker.owner;
+  const flankingTiles = getCombatAdjacentOccupiedTileCount(state, attacker.owner, defender, attacker.id);
+  const supportTiles = getCombatAdjacentOccupiedTileCount(state, defender.owner, defender, defender.id);
 
   return {
     attackerBonus: resolveCivDefinition(
@@ -64,5 +67,9 @@ export function buildCombatContextForDefender(
       inFriendlyCity: defenderInFriendlyCity,
       opponentType: attacker.type,
     }),
+    attackerPositioningMultiplier: 1 + flankingTiles * 0.1,
+    defenderPositioningMultiplier: 1 + supportTiles * 0.1,
+    attackerPositioningPart: flankingTiles > 0 ? { label: `Flanked +${flankingTiles * 10}%`, kind: 'mult' } : undefined,
+    defenderPositioningPart: supportTiles > 0 ? { label: `Supported +${supportTiles * 10}%`, kind: 'mult' } : undefined,
   };
 }

--- a/src/systems/combat-system.ts
+++ b/src/systems/combat-system.ts
@@ -122,6 +122,10 @@ export interface CombatContext {
   // so combat-system.ts stays a pure function of its inputs.
   attackerModifiers?: UnitModifierBreakdown;
   defenderModifiers?: UnitModifierBreakdown;
+  attackerPositioningMultiplier?: number;
+  defenderPositioningMultiplier?: number;
+  attackerPositioningPart?: ModifierPart;
+  defenderPositioningPart?: ModifierPart;
 }
 
 export interface CombatStrengthBreakdown {
@@ -199,6 +203,9 @@ export function calculateCombatStrengths(
     * (defender.health / 100)
     * (1 + getVeterancyCombatModifier(defender));
 
+  attackerStrength *= context?.attackerPositioningMultiplier ?? 1;
+  defenderStrength *= context?.defenderPositioningMultiplier ?? 1;
+
   // Bombard-kind units (catapult, cannon, artillery, grenadier, bomber, stealth_bomber)
   // defend poorly — classic "siege is terrible on defense" convention. Keyed off
   // attackProfile.kind rather than the 'siege' UnitClass because that class includes
@@ -261,8 +268,8 @@ export function calculateCombatStrengths(
     terrainDefenseBonus,
     riverAttackPenalty,
     cityDefense,
-    attackerModifierParts: context?.attackerModifiers?.parts,
-    defenderModifierParts: context?.defenderModifiers?.parts,
+    attackerModifierParts: [...(context?.attackerModifiers?.parts ?? []), ...(context?.attackerPositioningPart ? [context.attackerPositioningPart] : [])],
+    defenderModifierParts: [...(context?.defenderModifiers?.parts ?? []), ...(context?.defenderPositioningPart ? [context.defenderPositioningPart] : [])],
     defenderDefendsPoorly: defendsPoorly(defenderDefinition.attackProfile),
     exchange: getCombatExchangeModifiers(attacker, defender),
   };

--- a/src/systems/owner-hostility.ts
+++ b/src/systems/owner-hostility.ts
@@ -12,6 +12,9 @@ export function isHostileOwnerTo(
   if (actorId.startsWith('mc-')) {
     return isMinorCivHostileToOwner(state, actorId, otherOwnerId);
   }
+  if (otherOwnerId.startsWith('mc-')) {
+    return isMinorCivHostileToOwner(state, otherOwnerId, actorId);
+  }
   return state.civilizations[actorId]?.diplomacy.atWarWith
     .includes(otherOwnerId) ?? false;
 }

--- a/src/systems/owner-hostility.ts
+++ b/src/systems/owner-hostility.ts
@@ -1,0 +1,17 @@
+import type { GameState } from '@/core/types';
+import { isAlwaysHostilePair } from '@/core/owner-kind';
+import { isMinorCivHostileToOwner } from '@/systems/minor-civ-diplomacy';
+
+export function isHostileOwnerTo(
+  state: Readonly<GameState>,
+  actorId: string,
+  otherOwnerId: string,
+): boolean {
+  if (actorId === otherOwnerId) return false;
+  if (isAlwaysHostilePair(actorId, otherOwnerId)) return true;
+  if (actorId.startsWith('mc-')) {
+    return isMinorCivHostileToOwner(state, actorId, otherOwnerId);
+  }
+  return state.civilizations[actorId]?.diplomacy.atWarWith
+    .includes(otherOwnerId) ?? false;
+}

--- a/src/systems/pirate-behavior.ts
+++ b/src/systems/pirate-behavior.ts
@@ -26,7 +26,7 @@ import {
   PIRATE_SIEGE_DAMAGE,
   PIRATE_SIEGE_MIN_STAGE,
 } from './pirate-definitions';
-import { findPath, getMovementStepCost, moveUnit, UNIT_DEFINITIONS } from './unit-system';
+import { findPath, getMovementStepCost, moveUnitWithZoneOfControl, UNIT_DEFINITIONS } from './unit-system';
 
 export type PirateIntent = PirateIntentState;
 
@@ -556,7 +556,9 @@ export function applyPlannedRelocation(state: GameState, factionId: string): Pir
       ) {
         return cancel('placement-failed');
       }
-      moved = moveUnit(moved, next, cost);
+      const movement = moveUnitWithZoneOfControl(state, moved, next, cost);
+      if (movement.stopped && step < plan.path.length - 1) return cancel('placement-failed');
+      moved = movement.unit;
       path.push(next);
     }
     const finalKey = hexKey(moved.position);

--- a/src/systems/pirate-system.ts
+++ b/src/systems/pirate-system.ts
@@ -49,7 +49,7 @@ import {
   createUnit,
   findPath,
   getMovementStepCost,
-  moveUnit,
+  moveUnitWithZoneOfControl,
   resetUnitTurn,
   UNIT_DEFINITIONS,
 } from './unit-system';
@@ -175,7 +175,7 @@ function moveOneStepToward(state: GameState, unit: Unit, target: HexCoord): { st
   const next = candidates[0];
   if (!next || distance(state, next.coord, target) >= distance(state, unit.position, target)) return { state, path: [] };
   return {
-    state: { ...state, units: { ...state.units, [unit.id]: moveUnit(unit, next.coord, next.cost) } },
+    state: { ...state, units: { ...state.units, [unit.id]: moveUnitWithZoneOfControl(state, unit, next.coord, next.cost).unit } },
     path: [next.coord],
   };
 }

--- a/src/systems/unit-movement-system.ts
+++ b/src/systems/unit-movement-system.ts
@@ -7,7 +7,7 @@ import { syncCivilizationContactsFromVisibility } from '@/systems/discovery-syst
 import { cancelInvalidNetworkPlans } from '@/systems/network-plan-system';
 import { hexKey, wrappedHexDistance, hexDistance } from '@/systems/hex-utils';
 import {
-  moveUnit,
+  moveUnitWithZoneOfControl,
   getMovementCostForUnitInContext,
   getMovementStepCost,
   findPath,
@@ -55,6 +55,7 @@ export type ExecuteUnitMoveResult =
         message: string;
         position: HexCoord;
       };
+      stopReason?: 'zone-of-control';
     }
   | {
       ok: false;
@@ -126,10 +127,26 @@ export function executeUnitMove(
   const unit = state.units[unitId]!;
   const from = { ...unit.position };
   const movePath = validation.path;
-  const presentationByViewer = buildMovePresentationByViewer(state, unit, movePath);
+  let moved = unit;
+  let stopReason: 'zone-of-control' | undefined;
+  const executedPath = [from];
+  for (const step of movePath.slice(1)) {
+    const cost = getMovementStepCost(moved, state.map, moved.position, step, {
+      completedTechs: getOwnerCompletedTechs(state, unit.owner),
+    });
+    const movement = moveUnitWithZoneOfControl(state, moved, step, cost);
+    moved = movement.unit;
+    executedPath.push(step);
+    if (movement.stopped) {
+      stopReason = 'zone-of-control';
+      break;
+    }
+  }
+  const actualTo = moved.position;
+  const presentationByViewer = buildMovePresentationByViewer(state, unit, executedPath);
   state.units = {
     ...state.units,
-    [unitId]: moveUnit(unit, validation.to, validation.cost),
+    [unitId]: moved,
   };
   if (unit.type === 'transport') {
     const synced = syncTransportCargoPositions(state, unitId);
@@ -140,8 +157,8 @@ export function executeUnitMove(
   options.bus?.emit('unit:move', {
     unitId,
     from,
-    to: validation.to,
-    path: movePath,
+    to: actualTo,
+    path: executedPath,
     presentationByViewer,
   });
 
@@ -149,15 +166,16 @@ export function executeUnitMove(
     return {
       ok: true,
       from,
-      to: validation.to,
-      path: movePath,
+      to: actualTo,
+      path: executedPath,
       revealedTiles: [],
       discoveredWonders: [],
+      stopReason,
     };
   }
 
   let villageOutcome: Extract<ExecuteUnitMoveResult, { ok: true }>['villageOutcome'];
-  const villageAtDestination = Object.values(state.tribalVillages).find(village => hexKey(village.position) === hexKey(validation.to));
+  const villageAtDestination = Object.values(state.tribalVillages).find(village => hexKey(village.position) === hexKey(actualTo));
   if (villageAtDestination) {
     let rngState = state.turn * 16807 + unit.id.charCodeAt(0);
     const villageRng = () => {
@@ -220,11 +238,12 @@ export function executeUnitMove(
   return {
     ok: true,
     from,
-    to: validation.to,
-    path: movePath,
+    to: actualTo,
+    path: executedPath,
     revealedTiles,
     discoveredWonders,
     villageOutcome,
+    stopReason,
   };
 }
 

--- a/src/systems/unit-system.ts
+++ b/src/systems/unit-system.ts
@@ -1,4 +1,6 @@
-import type { UnitDefinition, UnitType, Unit, HexCoord, GameMap, CivBonusEffect, VisibilityState, IdCounters } from '@/core/types';
+import type { UnitDefinition, UnitType, Unit, HexCoord, GameMap, GameState, CivBonusEffect, VisibilityState, IdCounters } from '@/core/types';
+import { getZoneOfControlAt } from './zone-of-control-system';
+import { isHostileOwnerTo } from './owner-hostility';
 import {
   hexKey,
   hexNeighbors,
@@ -547,6 +549,14 @@ export function moveUnit(unit: Unit, to: HexCoord, cost: number): Unit {
   };
 }
 
+export function moveUnitWithZoneOfControl(
+  state: Readonly<GameState>, unit: Unit, to: HexCoord, cost: number,
+): { unit: Unit; stopped: boolean } {
+  const moved = moveUnit(unit, to, cost);
+  const stopped = getZoneOfControlAt(state, moved, to).limited;
+  return { unit: stopped ? { ...moved, movementPointsLeft: 0 } : moved, stopped };
+}
+
 export function resetUnitTurn(unit: Unit): Unit {
   const { skippedTurn: _skippedTurn, ...rest } = unit;
   const base: Unit = {
@@ -1009,6 +1019,80 @@ export function getMovementRange(
   }
 
   return reachable;
+}
+
+export interface MovementRangeDetails {
+  reachable: HexCoord[];
+  zocLimited: HexCoord[];
+}
+
+export function getMovementRangeDetails(
+  state: Readonly<GameState>,
+  unitId: string,
+): MovementRangeDetails {
+  const unit = state.units[unitId];
+  if (!unit) return { reachable: [], zocLimited: [] };
+  const unitPositions: Record<string, string | string[]> = {};
+  const unitOwners: Record<string, string> = {};
+  for (const candidate of Object.values(state.units)) {
+    const key = hexKey(candidate.position);
+    const existing = unitPositions[key];
+    unitPositions[key] = existing ? [...(Array.isArray(existing) ? existing : [existing]), candidate.id] : candidate.id;
+    unitOwners[candidate.id] = candidate.owner;
+  }
+  const hostileOwners = new Set(Object.values(state.units)
+    .filter(candidate => isHostileOwnerTo(state, unit.owner, candidate.owner))
+    .map(candidate => candidate.owner));
+  const reachable: HexCoord[] = [];
+  const zocLimited: HexCoord[] = [];
+  const visited = new Map<string, number>();
+  const queue: Array<{ coord: HexCoord; remaining: number }> = [];
+  const startKey = hexKey(unit.position);
+  visited.set(startKey, unit.movementPointsLeft);
+  queue.push({ coord: unit.position, remaining: unit.movementPointsLeft });
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const neighbors = state.map.wrapsHorizontally
+      ? getWrappedHexNeighbors(current.coord, state.map.width)
+      : hexNeighbors(current.coord);
+    for (const neighbor of neighbors) {
+      const key = hexKey(neighbor);
+      const tile = state.map.tiles[key];
+      if (!tile || !isPassableForUnitInContext(unit, tile.terrain, {
+        completedTechs: state.civilizations[unit.owner]?.techState.completed ?? [],
+      })) continue;
+      const cost = getMovementStepCost(unit, state.map, current.coord, neighbor, {
+        completedTechs: state.civilizations[unit.owner]?.techState.completed ?? [],
+      });
+      const remaining = current.remaining - cost;
+      const fromStart = hexKey(current.coord) === startKey;
+      const forcedMarch = fromStart && current.remaining >= 1 && remaining < 0;
+      if (remaining < 0 && !forcedMarch) continue;
+      const effectiveRemaining = forcedMarch ? 0 : remaining;
+      const occupants = normalizeOccupants(unitPositions[key]).filter(id => id !== unit.id);
+      const neutralOccupant = occupants.some(id => {
+        const owner = unitOwners[id];
+        return Boolean(owner) && owner !== unit.owner && !hostileOwners.has(owner);
+      });
+      if (neutralOccupant) continue;
+      const hostileOccupant = occupants.some(id => {
+        const owner = unitOwners[id];
+        return Boolean(owner) && owner !== unit.owner && hostileOwners.has(owner);
+      });
+      const zoc = !hostileOccupant && getZoneOfControlAt(state, unit, neighbor).limited;
+      const terminal = hostileOccupant || zoc;
+      const previous = visited.get(key) ?? -1;
+      if (effectiveRemaining <= previous) continue;
+      visited.set(key, effectiveRemaining);
+      reachable.push(neighbor);
+      if (zoc) zocLimited.push(neighbor);
+      if (!terminal && effectiveRemaining > 0) {
+        queue.push({ coord: neighbor, remaining: effectiveRemaining });
+      }
+    }
+  }
+  return { reachable, zocLimited };
 }
 
 export function findPath(

--- a/src/systems/zone-of-control-system.ts
+++ b/src/systems/zone-of-control-system.ts
@@ -1,0 +1,61 @@
+import type { GameState, HexCoord, Unit } from '@/core/types';
+import { getWrappedHexNeighbors, hexKey, hexNeighbors } from '@/systems/hex-utils';
+import { UNIT_CLASS_BY_TYPE } from '@/systems/unit-modifier-definitions';
+import { UNIT_DEFINITIONS } from '@/systems/unit-system';
+import { isHostileOwnerTo } from '@/systems/owner-hostility';
+
+function domainOf(unit: Unit): 'land' | 'naval' | 'air' {
+  return UNIT_DEFINITIONS[unit.type]?.domain ?? 'land';
+}
+
+export function isZocEligibleCombatUnit(unit: Unit): boolean {
+  const definition = UNIT_DEFINITIONS[unit.type];
+  return !unit.transportId
+    && definition.strength > 0
+    && domainOf(unit) !== 'air'
+    && !UNIT_CLASS_BY_TYPE[unit.type].includes('recon');
+}
+
+export interface ZoneOfControlResult {
+  limited: boolean;
+  sourceUnitIds: readonly string[];
+}
+
+export function getZoneOfControlAt(
+  state: Readonly<GameState>,
+  mover: Unit,
+  destination: HexCoord,
+): ZoneOfControlResult {
+  if (!isZocEligibleCombatUnit(mover)) return { limited: false, sourceUnitIds: [] };
+  const neighbors = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(destination, state.map.width)
+    : hexNeighbors(destination);
+  const sourceUnitIds = Object.values(state.units)
+    .filter(candidate => isZocEligibleCombatUnit(candidate)
+      && domainOf(candidate) === domainOf(mover)
+      && isHostileOwnerTo(state, mover.owner, candidate.owner)
+      && neighbors.some(neighbor => neighbor.q === candidate.position.q && neighbor.r === candidate.position.r))
+    .map(candidate => candidate.id);
+  return { limited: sourceUnitIds.length > 0, sourceUnitIds };
+}
+
+export function getCombatAdjacentOccupiedTileCount(
+  state: Readonly<GameState>,
+  ownerId: string,
+  defender: Unit,
+  excludedUnitId?: string,
+): number {
+  const neighbors = state.map.wrapsHorizontally
+    ? getWrappedHexNeighbors(defender.position, state.map.width)
+    : hexNeighbors(defender.position);
+  const keys = new Set(neighbors.map(hexKey));
+  const occupied = new Set(
+    Object.values(state.units)
+      .filter(unit => unit.id !== excludedUnitId
+        && unit.owner === ownerId
+        && isZocEligibleCombatUnit(unit)
+        && keys.has(hexKey(unit.position)))
+      .map(unit => hexKey(unit.position)),
+  );
+  return occupied.size;
+}

--- a/src/ui/selected-unit-info.ts
+++ b/src/ui/selected-unit-info.ts
@@ -99,6 +99,7 @@ export interface SelectedUnitInfoCallbacks {
 
 export interface SelectedUnitInfoPresentation {
   waterRecovery?: LandUnitWaterRecovery;
+  hasZoneOfControlWarning?: boolean;
 }
 
 function makeButton(label: string, color: string, onClick?: () => void): HTMLButtonElement {
@@ -238,6 +239,15 @@ export function renderSelectedUnitInfo(
     recoveryLine.style.cssText = 'margin-top:8px;padding:8px;border:1px solid rgba(245,184,73,0.45);border-radius:8px;background:rgba(245,184,73,0.16);color:#f5b849;font-size:12px;font-weight:600;line-height:1.4;';
     recoveryLine.textContent = waterRecoveryMessage;
     wrapper.appendChild(recoveryLine);
+  }
+  if (presentation.hasZoneOfControlWarning) {
+    const zocLine = document.createElement('div');
+    zocLine.dataset.zoneOfControlWarning = 'true';
+    zocLine.setAttribute('role', 'status');
+    zocLine.setAttribute('aria-live', 'polite');
+    zocLine.style.cssText = 'margin-top:8px;padding:8px;border:1px solid rgba(245,184,73,0.7);border-radius:8px;background:rgba(245,184,73,0.12);color:#f5b849;font-size:12px;font-weight:600;line-height:1.4;';
+    zocLine.textContent = '⚠ Enemy nearby — entering ends movement.';
+    wrapper.appendChild(zocLine);
   }
 
   const tier = getVeterancyTier(unit);

--- a/tests/input/selected-unit-highlights.test.ts
+++ b/tests/input/selected-unit-highlights.test.ts
@@ -8,6 +8,25 @@ import { createUnit } from '@/systems/unit-system';
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
 
 describe('selected-unit-highlights', () => {
+  it('marks visible ZOC terminal destinations with a non-attack movement highlight', () => {
+    const state = createNewGame(undefined, 'zoc-highlight', 'small');
+    state.currentPlayer = 'player';
+    state.units = {
+      mover: { ...createUnit('warrior', 'player', { q: 4, r: 5 }, mkC()), id: 'mover', movementPointsLeft: 2 },
+      enemy: { ...createUnit('warrior', 'ai-1', { q: 6, r: 4 }, mkC()), id: 'enemy' },
+    };
+    state.civilizations.player.units = ['mover'];
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    state.civilizations.player.visibility.tiles = {
+      '4,5': 'visible', '5,5': 'visible', '6,4': 'visible',
+    };
+
+    const result = buildSelectedUnitHighlights(state, 'mover');
+
+    expect(result.zocLimitedRange).toContainEqual({ q: 5, r: 5 });
+    expect(result.highlights).toContainEqual({ coord: { q: 5, r: 5 }, type: 'zoc-limited' });
+  });
+
   it('marks legal non-combat land exits as water-recovery without changing movement truth', () => {
     const state = createNewGame(undefined, 'water-recovery-highlight', 'small');
     state.currentPlayer = 'player';

--- a/tests/systems/owner-hostility.test.ts
+++ b/tests/systems/owner-hostility.test.ts
@@ -13,4 +13,13 @@ describe('isHostileOwnerTo', () => {
     state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
     expect(isHostileOwnerTo(state, 'player', 'ai-1')).toBe(true);
   });
+
+  it('honors minor-civilization hostility regardless of which side is evaluating it', () => {
+    const state = createNewGame(undefined, 'owner-hostility-minor', 'small');
+    const minorCivId = Object.keys(state.minorCivs)[0]!;
+    state.minorCivs[minorCivId].diplomacy.atWarWith = ['player'];
+
+    expect(isHostileOwnerTo(state, 'player', minorCivId)).toBe(true);
+    expect(isHostileOwnerTo(state, minorCivId, 'player')).toBe(true);
+  });
 });

--- a/tests/systems/owner-hostility.test.ts
+++ b/tests/systems/owner-hostility.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { isHostileOwnerTo } from '@/systems/owner-hostility';
+
+describe('isHostileOwnerTo', () => {
+  it('uses world-actor and diplomacy hostility without treating neutral civs as hostile', () => {
+    const state = createNewGame(undefined, 'owner-hostility', 'small');
+
+    expect(isHostileOwnerTo(state, 'player', 'barbarian')).toBe(true);
+    expect(isHostileOwnerTo(state, 'player', 'beasts')).toBe(true);
+    expect(isHostileOwnerTo(state, 'player', 'ai-1')).toBe(false);
+
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+    expect(isHostileOwnerTo(state, 'player', 'ai-1')).toBe(true);
+  });
+});

--- a/tests/systems/unit-movement-system.test.ts
+++ b/tests/systems/unit-movement-system.test.ts
@@ -99,6 +99,33 @@ function movementState(
 }
 
 describe('unit-movement-system', () => {
+  it('ends movement after a legal zone-of-control entry', () => {
+    const mover = { ...createUnit('warrior', 'player', { q: 0, r: 0 }, mkC()), id: 'mover', movementPointsLeft: 2 };
+    const enemy = { ...createUnit('warrior', 'ai-1', { q: 2, r: -1 }, mkC()), id: 'enemy' };
+    const state = movementState(mover, [tile({ q: 0, r: 0 }), tile({ q: 1, r: 0 }), tile({ q: 2, r: -1 })], { extraUnits: [enemy] });
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    expect(executeUnitMove(state, mover.id, { q: 1, r: 0 }, { actor: 'player', civId: 'player' })).toMatchObject({
+      ok: true,
+      stopReason: 'zone-of-control',
+    });
+    expect(state.units[mover.id].movementPointsLeft).toBe(0);
+  });
+
+  it('stops a multi-step move at the first zone-of-control entry', () => {
+    const mover = { ...createUnit('warrior', 'player', { q: 0, r: 0 }, mkC()), id: 'mover', movementPointsLeft: 2 };
+    const enemy = { ...createUnit('warrior', 'ai-1', { q: 2, r: -1 }, mkC()), id: 'enemy' };
+    const state = movementState(mover, [
+      tile({ q: 0, r: 0 }), tile({ q: 1, r: 0 }), tile({ q: 2, r: 0 }), tile({ q: 2, r: -1 }),
+    ], { extraUnits: [enemy] });
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    const result = executeUnitMove(state, mover.id, { q: 2, r: 0 }, { actor: 'player', civId: 'player' });
+
+    expect(result).toMatchObject({ ok: true, to: { q: 1, r: 0 }, stopReason: 'zone-of-control' });
+    expect(state.units[mover.id].position).toEqual({ q: 1, r: 0 });
+  });
+
   it('moves world actors without civilization discovery consequences', () => {
     const mover = createUnit('warrior', 'barbarian', { q: 0, r: 0 }, mkC());
     mover.id = 'world-mover';

--- a/tests/systems/unit-system.test.ts
+++ b/tests/systems/unit-system.test.ts
@@ -1,6 +1,7 @@
 import {
   createUnit,
   getMovementRange,
+  getMovementRangeDetails,
   moveUnit,
   findPath,
   findPathToCity,
@@ -11,13 +12,38 @@ import {
   getMovementBlockerReason,
   getMovementCostForUnit,
 } from '@/systems/unit-system';
-import type { GameMap } from '@/core/types';
+import type { GameMap, GameState } from '@/core/types';
 import { generateMap } from '@/systems/map-generator';
 import { hexKey } from '@/systems/hex-utils';
 import { TRAINABLE_UNITS } from '@/systems/city-system';
 import { PIRATE_HULL_TYPES } from '@/systems/pirate-definitions';
+import { createNewGame } from '@/core/game-state';
 
 const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+function zocRangeState(): GameState {
+  const state = createNewGame(undefined, 'zoc-range', 'small');
+  const mover = { ...createUnit('warrior', 'player', { q: 0, r: 0 }, mkC()), id: 'mover', movementPointsLeft: 2 };
+  const enemy = { ...createUnit('warrior', 'ai-1', { q: 2, r: -1 }, mkC()), id: 'enemy' };
+  state.units = { mover, enemy };
+  state.civilizations.player.units = ['mover'];
+  state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+  for (const key of ['0,0', '1,0', '2,0', '2,-1']) {
+    state.map.tiles[key] = { ...state.map.tiles[key]!, terrain: 'plains' };
+  }
+  return state;
+}
+
+describe('getMovementRangeDetails zone of control', () => {
+  it('keeps the legal entry but does not extend movement beyond it', () => {
+    const state = zocRangeState();
+    const range = getMovementRangeDetails(state, 'mover');
+
+    expect(range.reachable.map(hexKey)).toContain('1,0');
+    expect(range.zocLimited.map(hexKey)).toContain('1,0');
+    expect(range.reachable.map(hexKey)).not.toContain('2,0');
+  });
+});
 
 function createWrappedGrasslandMap(width: number, height: number): GameMap {
   const tiles: GameMap['tiles'] = {};

--- a/tests/systems/zone-of-control-system.test.ts
+++ b/tests/systems/zone-of-control-system.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createNewGame } from '@/core/game-state';
+import { createUnit } from '@/systems/unit-system';
+import {
+  getCombatAdjacentOccupiedTileCount,
+  getZoneOfControlAt,
+  isZocEligibleCombatUnit,
+} from '@/systems/zone-of-control-system';
+
+const mkC = () => ({ nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 });
+
+describe('zone of control', () => {
+  it('excludes recon, civilians, and air while accepting ordinary combat units', () => {
+    expect(isZocEligibleCombatUnit(createUnit('warrior', 'player', { q: 0, r: 0 }, mkC()))).toBe(true);
+    expect(isZocEligibleCombatUnit(createUnit('scout', 'player', { q: 0, r: 0 }, mkC()))).toBe(false);
+    expect(isZocEligibleCombatUnit(createUnit('worker', 'player', { q: 0, r: 0 }, mkC()))).toBe(false);
+    expect(isZocEligibleCombatUnit(createUnit('biplane', 'player', { q: 0, r: 0 }, mkC()))).toBe(false);
+  });
+
+  it('finds a hostile same-domain source across the horizontal wrap', () => {
+    const state = createNewGame(undefined, 'zoc-wrap', 'small');
+    state.map.width = 5;
+    state.map.wrapsHorizontally = true;
+    const mover = { ...createUnit('warrior', 'player', { q: 0, r: 0 }, mkC()), id: 'mover' };
+    const enemy = { ...createUnit('warrior', 'ai-1', { q: 4, r: 0 }, mkC()), id: 'enemy' };
+    state.units = { mover, enemy };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    expect(getZoneOfControlAt(state, mover, { q: 0, r: 0 })).toMatchObject({
+      limited: true,
+      sourceUnitIds: ['enemy'],
+    });
+  });
+
+  it('counts occupied adjacent combat tiles rather than units in a stack', () => {
+    const state = createNewGame(undefined, 'zoc-adjacency', 'small');
+    const defender = { ...createUnit('warrior', 'ai-1', { q: 0, r: 0 }, mkC()), id: 'defender' };
+    const attacker = { ...createUnit('warrior', 'player', { q: 1, r: 0 }, mkC()), id: 'attacker' };
+    const stacked = { ...createUnit('warrior', 'player', { q: 1, r: 0 }, mkC()), id: 'stacked' };
+    const flank = { ...createUnit('archer', 'player', { q: 0, r: 1 }, mkC()), id: 'flank' };
+    state.units = { defender, attacker, stacked, flank };
+
+    expect(getCombatAdjacentOccupiedTileCount(state, 'player', defender, attacker.id)).toBe(2);
+  });
+});

--- a/tests/systems/zone-of-control-system.test.ts
+++ b/tests/systems/zone-of-control-system.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { createNewGame } from '@/core/game-state';
 import { createUnit } from '@/systems/unit-system';
+import { getMovementRangeDetails } from '@/systems/unit-system';
+import { buildCombatContextForDefender } from '@/systems/combat-context';
+import { calculateCombatStrengths } from '@/systems/combat-system';
 import {
   getCombatAdjacentOccupiedTileCount,
   getZoneOfControlAt,
@@ -32,6 +35,19 @@ describe('zone of control', () => {
     });
   });
 
+  it('does not stop air, recon, or units beside another domain', () => {
+    const state = createNewGame(undefined, 'zoc-domain-exemptions', 'small');
+    const scout = { ...createUnit('scout', 'player', { q: 4, r: 5 }, mkC()), id: 'scout', movementPointsLeft: 2 };
+    const air = { ...createUnit('biplane', 'player', { q: 4, r: 6 }, mkC()), id: 'air', movementPointsLeft: 2 };
+    const enemy = { ...createUnit('warrior', 'ai-1', { q: 6, r: 4 }, mkC()), id: 'enemy' };
+    state.units = { scout, air, enemy };
+    state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+
+    expect(getZoneOfControlAt(state, scout, { q: 5, r: 5 }).limited).toBe(false);
+    expect(getZoneOfControlAt(state, air, { q: 5, r: 5 }).limited).toBe(false);
+    expect(getMovementRangeDetails(state, scout.id).zocLimited).toEqual([]);
+  });
+
   it('counts occupied adjacent combat tiles rather than units in a stack', () => {
     const state = createNewGame(undefined, 'zoc-adjacency', 'small');
     const defender = { ...createUnit('warrior', 'ai-1', { q: 0, r: 0 }, mkC()), id: 'defender' };
@@ -41,5 +57,27 @@ describe('zone of control', () => {
     state.units = { defender, attacker, stacked, flank };
 
     expect(getCombatAdjacentOccupiedTileCount(state, 'player', defender, attacker.id)).toBe(2);
+  });
+
+  it('applies flanking and defensive support once per eligible occupied tile', () => {
+    const state = createNewGame(undefined, 'zoc-positioning', 'small');
+    const defender = { ...createUnit('warrior', 'ai-1', { q: 5, r: 5 }, mkC()), id: 'defender' };
+    const attacker = { ...createUnit('warrior', 'player', { q: 4, r: 5 }, mkC()), id: 'attacker' };
+    const attackerStack = { ...createUnit('warrior', 'player', { q: 4, r: 5 }, mkC()), id: 'attacker-stack' };
+    const flank = { ...createUnit('archer', 'player', { q: 5, r: 4 }, mkC()), id: 'flank' };
+    const support = { ...createUnit('warrior', 'ai-1', { q: 6, r: 5 }, mkC()), id: 'support' };
+    const civilian = { ...createUnit('worker', 'ai-1', { q: 6, r: 4 }, mkC()), id: 'civilian' };
+    state.units = { defender, attacker, attackerStack, flank, support, civilian };
+
+    const context = buildCombatContextForDefender(state, attacker, defender);
+    const baseline = calculateCombatStrengths(attacker, defender, state.map, {});
+    const positioned = calculateCombatStrengths(attacker, defender, state.map, context);
+
+    expect(context.attackerPositioningMultiplier).toBeCloseTo(1.2);
+    expect(context.defenderPositioningMultiplier).toBeCloseTo(1.1);
+    expect(context.attackerPositioningPart?.label).toBe('Flanked +20%');
+    expect(context.defenderPositioningPart?.label).toBe('Supported +10%');
+    expect(positioned.attackerStrength).toBeCloseTo(baseline.attackerStrength * 1.2);
+    expect(positioned.defenderStrength).toBeCloseTo(baseline.defenderStrength * 1.1);
   });
 });

--- a/tests/ui/selected-unit-info.test.ts
+++ b/tests/ui/selected-unit-info.test.ts
@@ -104,6 +104,16 @@ function findWaterRecoveryGuidance(node: unknown): MockElement | undefined {
   return undefined;
 }
 
+function findZoneOfControlWarning(node: unknown): MockElement | undefined {
+  const el = node as MockElement;
+  if (el.dataset?.zoneOfControlWarning) return el;
+  for (const child of el.children ?? []) {
+    const found = findZoneOfControlWarning(child);
+    if (found) return found;
+  }
+  return undefined;
+}
+
 describe('land-unit water recovery guidance', () => {
   beforeEach(installMockDocument);
   afterEach(restoreMockDocument);
@@ -179,6 +189,32 @@ describe('land-unit water recovery guidance', () => {
     );
     expect(collectAllText(normal).join(' ')).not.toContain('return ashore');
     expect(collectAllText(normal).join(' ')).not.toContain('stranded on water');
+  });
+
+  it('renders the zone-of-control warning only when the selected player has a terminal move', () => {
+    const state = createNewGame(undefined, 'zoc-panel-warning', 'small');
+    const unit = {
+      ...createUnit('warrior', 'player', { q: 1, r: 1 }, {
+        nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1,
+      }),
+      id: 'warrior',
+    };
+    state.currentPlayer = 'player';
+    state.units = { warrior: unit };
+    state.civilizations.player.units = ['warrior'];
+    const warning = new MockElement('div');
+    const normal = new MockElement('div');
+
+    renderSelectedUnitInfo(warning as unknown as HTMLElement, state, 'warrior', {}, {
+      hasZoneOfControlWarning: true,
+    });
+    renderSelectedUnitInfo(normal as unknown as HTMLElement, state, 'warrior', {}, {
+      hasZoneOfControlWarning: false,
+    });
+
+    expect(collectAllText(warning).join(' ')).toContain('Enemy nearby — entering ends movement.');
+    expect(findZoneOfControlWarning(warning)?.getAttribute('role')).toBe('status');
+    expect(findZoneOfControlWarning(normal)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add domain-local Zone of Control with visible terminal-move feedback and shared enforcement for player, AI, and world movement.
- Add per-tile flanking and defensive-support combat bonuses, surfaced through the existing combat modifier breakdown.
- Fix minor-civilization hostility symmetry so at-war minor units consistently participate in targeting and ZOC.

## Gameplay and UX review
- ZOC is deterministic, same-domain only, ignores air/recon/civilians, and applies equally across difficulty modes and hot-seat viewers.
- Amber terminal-move tiles include a non-color chevron cue, accessible panel text, and a post-move notification; no save schema or audio asset changes are required.
- AI uses the same reachability rule and gains a modest positioning preference without difficulty-specific combat bonuses.

## Validation
- Source-rule checker ran for every changed source file.
- Focused mechanics suites: 25 passing tests after the minor-civ correction; earlier ZOC/UI/AI suite: 355 passing tests.
- Production build succeeds.
- Full parallel test run hit an unrelated ai-prepared-turn timeout; the isolated file passes with 17 tests.