### PR TITLE
feat(pressure): MR6 — hunt-their-foe and send-aid interactions

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1823,6 +1823,8 @@ export interface GameEvents {
   // Fires only when a hunt's killer differs from the crisis's own target civ (#526 MR6
   // hunt-their-foe interaction) -- a self-kill never emits this.
   'crisis:foe-hunted-by-ally': { crisisId: string; killerCivId: string; targetCivId: string; foeName?: string };
+  // #526 MR6 send_aid interaction.
+  'crisis:aid-sent': { crisisId: string; actorCivId: string; targetCivId: string; goldCost: number };
 }
 
 // --- Crisis Events & Revolutionary Movements ---
@@ -1846,4 +1848,5 @@ export interface ActiveCrisis {
   huntEntityId?: string;
   foeName?: string;
   lastHuntKillerCivId?: string;
+  aidedByCivIds?: string[]; // #526 MR6 send_aid: enforces once-per-crisis-per-actor
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1820,6 +1820,9 @@ export interface GameEvents {
   // foeName/killerCivId populated for Hunt's 'hunted' outcome, for the same
   // same-tick-freshness reason as crisis:escalated above.
   'crisis:resolved':  { crisisId: string; flavorId: string; civId: string; outcome: CrisisOutcome; foeName?: string; killerCivId?: string };
+  // Fires only when a hunt's killer differs from the crisis's own target civ (#526 MR6
+  // hunt-their-foe interaction) -- a self-kill never emits this.
+  'crisis:foe-hunted-by-ally': { crisisId: string; killerCivId: string; targetCivId: string; foeName?: string };
 }
 
 // --- Crisis Events & Revolutionary Movements ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,6 +236,7 @@ import {
   routeWorldPressureCrisisStarted,
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
+  routeCrisisAidSent,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationDelivery } from '@/ui/notification-delivery';
@@ -262,6 +263,7 @@ import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, ge
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { performMinorCivFestival, performMinorCivGift, performMinorCivReparations, setMinorCivWarState } from '@/systems/minor-civ-actions';
+import { canSendAid, applySendAid } from '@/systems/crisis-interaction-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
@@ -1064,6 +1066,19 @@ function handleMinorCivReparations(mcId: string): void {
   openDiplomacyPanel();
 }
 
+function handleSendAid(crisisId: string): void {
+  const check = canSendAid(gameState, gameState.currentPlayer, crisisId);
+  if (!check.ok) {
+    showNotification('Send Aid unavailable.', 'warning');
+    return;
+  }
+  gameState = applySendAid(gameState, gameState.currentPlayer, crisisId, bus);
+  showNotification('Aid sent.', 'success');
+  renderLoop.setGameState(gameState);
+  updateHUD();
+  openDiplomacyPanel();
+}
+
 function handleMinorCivWarPeace(mcId: string, currentlyAtWar: boolean): void {
   const result = setMinorCivWarState(gameState, gameState.currentPlayer, mcId, !currentlyAtWar);
   if (!result.ok) return;
@@ -1089,6 +1104,7 @@ function openDiplomacyPanel(): void {
     onSponsorFestival: handleSponsorFestival,
     onMinorCivReparations: handleMinorCivReparations,
     onMinorCivWarPeace: handleMinorCivWarPeace,
+    onSendAid: handleSendAid,
     onClose: () => {},
   });
 }
@@ -4372,6 +4388,10 @@ bus.on('crisis:resolved', event => {
 
 bus.on('crisis:foe-hunted-by-ally', event => {
   routeCrisisFoeHuntedByAlly(gameState, event, appendToCivLog);
+});
+
+bus.on('crisis:aid-sent', event => {
+  routeCrisisAidSent(gameState, event, appendToCivLog);
 });
 
 bus.on('economy:treasury-strain', event => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -235,6 +235,7 @@ import {
   routeCrisisResolved,
   routeWorldPressureCrisisStarted,
   routeWorldPressureCrisisResolved,
+  routeCrisisFoeHuntedByAlly,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationDelivery } from '@/ui/notification-delivery';
@@ -4367,6 +4368,10 @@ bus.on('crisis:escalated', event => {
 bus.on('crisis:resolved', event => {
   routeCrisisResolved(gameState, event, appendToCivLog);
   routeWorldPressureCrisisResolved(gameState, event, appendToCivLog);
+});
+
+bus.on('crisis:foe-hunted-by-ally', event => {
+  routeCrisisFoeHuntedByAlly(gameState, event, appendToCivLog);
 });
 
 bus.on('economy:treasury-strain', event => {

--- a/src/systems/crisis-interaction-system.ts
+++ b/src/systems/crisis-interaction-system.ts
@@ -1,0 +1,72 @@
+import type { GameState } from '@/core/types';
+import { modifyRelationship } from './diplomacy-system';
+import { hasMetCivilization } from './discovery-system';
+
+export interface CrisisInteractionDefinition {
+  id: 'hunt_their_foe' | 'send_aid' | 'exploit_weakness' | 'sabotage_relief';
+  techRequired: string | null;
+  kind: 'overt' | 'covert';
+  targetReputationDelta: number;
+  witnessReputationDelta: number;
+  oncePerCrisisPerActor: boolean;
+}
+
+// One row per hook (spec §Interactions) -- the resolver consumes rows generically, so a
+// future hook is a row, not a branch (same pattern as NP_PRODUCTION_DISCOUNTS in
+// city-system.ts, per .claude/rules/game-balance.md). MR6 ships the first two rows;
+// MR7 appends exploit_weakness and sabotage_relief.
+export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[] = [
+  { id: 'hunt_their_foe', techRequired: null, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+  { id: 'send_aid', techRequired: 'medicine', kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+];
+
+export function getCrisisInteractionDefinition(
+  id: CrisisInteractionDefinition['id'],
+): CrisisInteractionDefinition | undefined {
+  return CRISIS_INTERACTION_DEFINITIONS.find(def => def.id === id);
+}
+
+// Witnesses: civs that have met BOTH actor and target, excluding actor/target themselves
+// (spec §Interactions -- "civs that have met both actor and target, including human civs").
+export function getWitnessCivIds(state: GameState, actorId: string, targetId: string): string[] {
+  return Object.keys(state.civilizations)
+    .filter(civId => civId !== actorId && civId !== targetId)
+    .filter(civId => hasMetCivilization(state, civId, actorId) && hasMetCivilization(state, civId, targetId))
+    .sort();
+}
+
+function applyBilateralRelationshipDelta(
+  state: GameState,
+  civAId: string,
+  civBId: string,
+  delta: number,
+): GameState {
+  const civA = state.civilizations[civAId];
+  const civB = state.civilizations[civBId];
+  if (!civA || !civB) return state;
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civAId]: { ...civA, diplomacy: modifyRelationship(civA.diplomacy, civBId, delta) },
+      [civBId]: { ...civB, diplomacy: modifyRelationship(civB.diplomacy, civAId, delta) },
+    },
+  };
+}
+
+// Bilateral actor<->target delta, then bilateral actor<->witness delta for every witness.
+// No special-casing by either party's humanity -- hot-seat co-op and AI-on-AI interactions
+// go through the exact same path.
+export function applyInteractionReputation(
+  state: GameState,
+  actorId: string,
+  targetId: string,
+  def: CrisisInteractionDefinition,
+): GameState {
+  const witnessIds = getWitnessCivIds(state, actorId, targetId);
+  let next = applyBilateralRelationshipDelta(state, actorId, targetId, def.targetReputationDelta);
+  for (const witnessId of witnessIds) {
+    next = applyBilateralRelationshipDelta(next, actorId, witnessId, def.witnessReputationDelta);
+  }
+  return next;
+}

--- a/src/systems/crisis-interaction-system.ts
+++ b/src/systems/crisis-interaction-system.ts
@@ -102,11 +102,17 @@ function getSendAidCity(state: GameState, crisis: ActiveCrisis): City | undefine
 export type SendAidFailureReason =
   | 'no-tech' | 'already-aided' | 'not-enough-gold' | 'unknown-civ' | 'flag-off' | 'no-crisis';
 
+// goldCost and the missing techId ride along on every failure branch where they're
+// computable (i.e. once a real crisis+city exists), not just the branches that
+// specifically test them -- the diplomacy panel shows both in the disabled-button
+// tooltip regardless of which gate actually failed, so "Send Aid (75 Gold)" never
+// degrades to a bare "?" once the player has already located the right crisis.
 export function canSendAid(
   state: GameState,
   actorCivId: string,
   crisisId: string,
-): { ok: true; goldCost: number } | { ok: false; reason: SendAidFailureReason; goldCost?: number } {
+): { ok: true; goldCost: number }
+  | { ok: false; reason: SendAidFailureReason; goldCost?: number; techId?: string } {
   if (resolveWorldPressureFlags(state.settings).aiCrisisInteractions === 'off') {
     return { ok: false, reason: 'flag-off' };
   }
@@ -115,17 +121,21 @@ export function canSendAid(
 
   const crisis = state.activeCrises?.[crisisId];
   if (!crisis) return { ok: false, reason: 'no-crisis' };
-  if (crisis.aidedByCivIds?.includes(actorCivId)) return { ok: false, reason: 'already-aided' };
+
+  const city = getSendAidCity(state, crisis);
+  const goldCost = city ? getCityAppeaseCost(city) : undefined;
+
+  if (crisis.aidedByCivIds?.includes(actorCivId)) {
+    return { ok: false, reason: 'already-aided', goldCost };
+  }
 
   const def = getCrisisInteractionDefinition('send_aid')!;
   const techRequired = resolveInteractionTechRequired(def, crisis.archetype);
   if (techRequired === undefined || (techRequired !== null && !actor.techState.completed.includes(techRequired))) {
-    return { ok: false, reason: 'no-tech' };
+    return { ok: false, reason: 'no-tech', goldCost, techId: techRequired ?? undefined };
   }
 
-  const city = getSendAidCity(state, crisis);
-  if (!city) return { ok: false, reason: 'no-crisis' };
-  const goldCost = getCityAppeaseCost(city);
+  if (!city || goldCost === undefined) return { ok: false, reason: 'no-crisis' };
   if (actor.gold < goldCost) return { ok: false, reason: 'not-enough-gold', goldCost };
 
   return { ok: true, goldCost };

--- a/src/systems/crisis-interaction-system.ts
+++ b/src/systems/crisis-interaction-system.ts
@@ -1,10 +1,16 @@
-import type { GameState } from '@/core/types';
+import type { ActiveCrisis, City, CrisisArchetype, GameState } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
 import { modifyRelationship } from './diplomacy-system';
 import { hasMetCivilization } from './discovery-system';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+import { getCityAppeaseCost } from './faction-system';
 
 export interface CrisisInteractionDefinition {
   id: 'hunt_their_foe' | 'send_aid' | 'exploit_weakness' | 'sabotage_relief';
-  techRequired: string | null;
+  // send_aid's tech gate differs by crisis archetype (medicine for outbreak,
+  // trade-routes for catastrophe) -- a per-archetype map, resolved via
+  // resolveInteractionTechRequired, keeps this one row instead of two.
+  techRequired: string | null | Partial<Record<CrisisArchetype, string>>;
   kind: 'overt' | 'covert';
   targetReputationDelta: number;
   witnessReputationDelta: number;
@@ -17,13 +23,25 @@ export interface CrisisInteractionDefinition {
 // MR7 appends exploit_weakness and sabotage_relief.
 export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[] = [
   { id: 'hunt_their_foe', techRequired: null, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
-  { id: 'send_aid', techRequired: 'medicine', kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+  { id: 'send_aid', techRequired: { outbreak: 'medicine', catastrophe: 'trade-routes' }, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
 ];
 
 export function getCrisisInteractionDefinition(
   id: CrisisInteractionDefinition['id'],
 ): CrisisInteractionDefinition | undefined {
   return CRISIS_INTERACTION_DEFINITIONS.find(def => def.id === id);
+}
+
+// string | null: the row's literal gate (or none). undefined: the row's gate is a
+// per-archetype map with no entry for this archetype -- i.e. never satisfiable, since
+// no tech unlocks the hook for that archetype at all (e.g. send_aid vs. a hunt crisis).
+export function resolveInteractionTechRequired(
+  def: CrisisInteractionDefinition,
+  archetype?: CrisisArchetype,
+): string | null | undefined {
+  if (def.techRequired === null || typeof def.techRequired === 'string') return def.techRequired;
+  if (!archetype) return undefined;
+  return def.techRequired[archetype];
 }
 
 // Witnesses: civs that have met BOTH actor and target, excluding actor/target themselves
@@ -69,4 +87,110 @@ export function applyInteractionReputation(
     next = applyBilateralRelationshipDelta(next, actorId, witnessId, def.witnessReputationDelta);
   }
   return next;
+}
+
+// The city a send-aid payment is priced/applied against: the most populous city among
+// the crisis's own cityIds (works for both outbreak, where cityIds are the infected
+// cities, and catastrophe, where cityIds is the single devastated-tile owner's city).
+function getSendAidCity(state: GameState, crisis: ActiveCrisis): City | undefined {
+  return crisis.cityIds
+    .map(id => state.cities[id])
+    .filter((city): city is City => Boolean(city))
+    .sort((a, b) => b.population - a.population || a.id.localeCompare(b.id))[0];
+}
+
+export type SendAidFailureReason =
+  | 'no-tech' | 'already-aided' | 'not-enough-gold' | 'unknown-civ' | 'flag-off' | 'no-crisis';
+
+export function canSendAid(
+  state: GameState,
+  actorCivId: string,
+  crisisId: string,
+): { ok: true; goldCost: number } | { ok: false; reason: SendAidFailureReason; goldCost?: number } {
+  if (resolveWorldPressureFlags(state.settings).aiCrisisInteractions === 'off') {
+    return { ok: false, reason: 'flag-off' };
+  }
+  const actor = state.civilizations[actorCivId];
+  if (!actor) return { ok: false, reason: 'unknown-civ' };
+
+  const crisis = state.activeCrises?.[crisisId];
+  if (!crisis) return { ok: false, reason: 'no-crisis' };
+  if (crisis.aidedByCivIds?.includes(actorCivId)) return { ok: false, reason: 'already-aided' };
+
+  const def = getCrisisInteractionDefinition('send_aid')!;
+  const techRequired = resolveInteractionTechRequired(def, crisis.archetype);
+  if (techRequired === undefined || (techRequired !== null && !actor.techState.completed.includes(techRequired))) {
+    return { ok: false, reason: 'no-tech' };
+  }
+
+  const city = getSendAidCity(state, crisis);
+  if (!city) return { ok: false, reason: 'no-crisis' };
+  const goldCost = getCityAppeaseCost(city);
+  if (actor.gold < goldCost) return { ok: false, reason: 'not-enough-gold', goldCost };
+
+  return { ok: true, goldCost };
+}
+
+// Outbreak: pays the target's remedy cost from the ACTOR's treasury and writes the same
+// remedyCompletionByCity record applyRemedy would (crisis-system.ts's tick reads that
+// record unchanged either way) -- never call applyRemedy itself, it deducts the
+// TARGET's gold. Catastrophe: the actor's payment is credited to the target civ as
+// relief gold instead. Both archetypes: aidedByCivIds enforces once-per-crisis-per-actor,
+// reputation moves bilaterally (actor<->target, actor<->every witness), and
+// crisis:aid-sent fires once.
+export function applySendAid(
+  state: GameState,
+  actorCivId: string,
+  crisisId: string,
+  bus: EventBus,
+): GameState {
+  const check = canSendAid(state, actorCivId, crisisId);
+  if (!check.ok) return state;
+
+  const crisis = state.activeCrises![crisisId];
+  const actor = state.civilizations[actorCivId]!;
+  const city = getSendAidCity(state, crisis)!;
+
+  let nextState: GameState = {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [actorCivId]: { ...actor, gold: actor.gold - check.goldCost },
+    },
+  };
+
+  if (crisis.archetype === 'catastrophe') {
+    const targetCiv = nextState.civilizations[crisis.targetCivId];
+    if (targetCiv) {
+      nextState = {
+        ...nextState,
+        civilizations: {
+          ...nextState.civilizations,
+          [crisis.targetCivId]: { ...targetCiv, gold: targetCiv.gold + check.goldCost },
+        },
+      };
+    }
+  }
+
+  const updatedCrisis: ActiveCrisis = {
+    ...crisis,
+    aidedByCivIds: [...(crisis.aidedByCivIds ?? []), actorCivId],
+    ...(crisis.archetype === 'outbreak' ? {
+      remedyCompletionByCity: { ...(crisis.remedyCompletionByCity ?? {}), [city.id]: nextState.turn + 2 },
+    } : {}),
+  };
+  nextState = {
+    ...nextState,
+    activeCrises: { ...nextState.activeCrises, [crisisId]: updatedCrisis },
+  };
+
+  nextState = applyInteractionReputation(
+    nextState, actorCivId, crisis.targetCivId, getCrisisInteractionDefinition('send_aid')!,
+  );
+
+  bus.emit('crisis:aid-sent', {
+    crisisId, actorCivId, targetCivId: crisis.targetCivId, goldCost: check.goldCost,
+  });
+
+  return nextState;
 }

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -12,6 +12,8 @@ import { BEAST_DEFINITIONS } from './beast-definitions';
 import { BEAST_OWNER, isTerrainPassableForBeast } from './beast-system';
 import { createUnit } from './unit-system';
 import { buildUnitOccupancy, getUnitIdsAtCoord } from './unit-occupancy';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+import { applyInteractionReputation, getCrisisInteractionDefinition } from './crisis-interaction-system';
 
 export const CRISIS_PRESSURE_FLOOR = 2.0;
 export const EXTERNAL_THREAT_RECENCY_TURNS = 5;
@@ -548,6 +550,21 @@ function tickHuntCrisis(
         [killerCivId]: { ...killerCiv, feastUntilTurn: nextState.turn + 5 },
       },
     };
+  }
+  // Hunt-their-foe (#526 MR6): killerCivId is only ever recorded as a real major-civ id
+  // (hunt-crisis-linkage.ts's isMajorCivOwner check), so "differs from the target" alone
+  // identifies a genuine third-civ kill -- no separate humanity/major-civ check needed.
+  // Dark until aiCrisisInteractions leaves 'off' (MR6's own rollout flag).
+  if (
+    killerCivId !== working.targetCivId
+    && resolveWorldPressureFlags(nextState.settings).aiCrisisInteractions !== 'off'
+  ) {
+    nextState = applyInteractionReputation(
+      nextState, killerCivId, working.targetCivId, getCrisisInteractionDefinition('hunt_their_foe')!,
+    );
+    bus.emit('crisis:foe-hunted-by-ally', {
+      crisisId: working.id, killerCivId, targetCivId: working.targetCivId, foeName: working.foeName,
+    });
   }
   if (flavor.hunt.spawnKind === 'beast' && nextState.beasts) {
     // The ephemeral hunt lair (registered only so recordBeastSlain's hoard-gold path

--- a/src/systems/tech-definitions-eras1-4.ts
+++ b/src/systems/tech-definitions-eras1-4.ts
@@ -18,7 +18,7 @@ export const TECH_TREE_ERAS_1_4: Tech[] = [
   { id: 'irrigation', name: 'Irrigation', track: 'economy', cost: 25, prerequisites: ['pottery'], unlocks: ['River farms yield +1 production', 'Reveal Silk resource'], era: 2 },
   { id: 'currency', name: 'Currency', track: 'economy', cost: 60, prerequisites: ['pottery'], unlocks: ['Reveal Incense resource', 'Reveal Gold resource'], unlocksBuildings: ['marketplace'], era: 3 },
   { id: 'mining-tech', name: 'Advanced Mining', track: 'economy', cost: 65, prerequisites: ['animal-husbandry'], unlocks: ['Mines yield +1 production', 'Reveal Gems resource', 'Reveal Silver resource'], era: 3 },
-  { id: 'trade-routes', name: 'Trade Routes', track: 'economy', cost: 75, prerequisites: ['currency'], unlocks: ['Enable trade routes between cities'], unlocksUnits: ['caravan'], era: 4 },
+  { id: 'trade-routes', name: 'Trade Routes', track: 'economy', cost: 75, prerequisites: ['currency'], unlocks: ['Enable trade routes between cities', 'Send relief gold to a disaster-struck civilization you have met'], unlocksUnits: ['caravan'], era: 4 },
   { id: 'banking', name: 'Banking', track: 'economy', cost: 95, prerequisites: ['trade-routes', 'mathematics'], unlocks: ['+20% gold in all cities'], unlocksBuildings: ['bank', 'royal_mint'], era: 4 },
 
   // === SCIENCE TRACK (9 techs, with Slice 3 late-era scaffolding) ===
@@ -29,7 +29,7 @@ export const TECH_TREE_ERAS_1_4: Tech[] = [
   { id: 'engineering', name: 'Engineering', track: 'science', cost: 55, prerequisites: ['mathematics', 'wheel'], unlocks: [], unlocksBuildings: ['aqueduct', 'forge'], era: 3 },
   { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: [], unlocksBuildings: ['temple', 'philosophers_circle'], era: 3 },
   { id: 'astronomy', name: 'Astronomy', track: 'science', cost: 75, prerequisites: ['mathematics'], unlocks: [], unlocksBuildings: ['observatory'], era: 4 },
-  { id: 'medicine', name: 'Medicine', track: 'science', cost: 75, prerequisites: ['philosophy', 'pottery'], unlocks: ['City population grows faster'], era: 4 },
+  { id: 'medicine', name: 'Medicine', track: 'science', cost: 75, prerequisites: ['philosophy', 'pottery'], unlocks: ['City population grows faster', 'Send medical aid to a plague-struck civilization you have met'], era: 4 },
 
   // === CIVICS TRACK (8 techs, existing) ===
   { id: 'tribal-council', name: 'Tribal Council', track: 'civics', cost: 4, prerequisites: [], unlocks: ['Basic governance'], era: 1, pacing: { band: 'starter', role: 'foundational-civics', impact: 1, scope: 'empire', snowball: 1, urgency: 1, situationality: 1, unlockBreadth: 1.05 } },

--- a/src/systems/world-pressure-flags.ts
+++ b/src/systems/world-pressure-flags.ts
@@ -11,13 +11,13 @@ export interface WorldPressureFlags {
 
 // Stage defaults: flipped by the final MR of each stage. aiPressure flipped to
 // 'pirates' in #528 (MR2), then 'full' in #529 (MR3); aiPressureVisibility flipped to
-// true in #531 (MR5) -- this is the rollout mechanism: existing saves have no
-// aiPressureVisibility field, so they pick up the new default on load. MR 6/7 flip
-// interactions. Until then, that one stays dark.
+// true in #531 (MR5); aiCrisisInteractions flipped to 'benign' in #532 (MR6) -- this is
+// the rollout mechanism: existing saves have no aiCrisisInteractions field, so they pick
+// up hunt-their-foe/send-aid on load. MR 7 flips interactions to 'full'.
 export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags {
   return {
     aiPressure: settings?.aiPressure ?? 'full',
     aiPressureVisibility: settings?.aiPressureVisibility ?? true,
-    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'off',
+    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'benign',
   };
 }

--- a/src/systems/world-pressure-presentation.ts
+++ b/src/systems/world-pressure-presentation.ts
@@ -11,6 +11,8 @@ export interface WorldPressureCityBadge {
 
 export interface WorldPressureStatusLine {
   civId: string;
+  crisisId: string;
+  archetype: CrisisArchetype;
   text: string; // e.g. "Suffering: Red Tide outbreak — 3 cities, 4 turns"
 }
 
@@ -51,6 +53,8 @@ export function getWorldPressurePresentationForViewer(
     const turns = crisis.turnsInStage;
     statusLinesByCivId[targetCivId] = {
       civId: targetCivId,
+      crisisId: crisis.id,
+      archetype: crisis.archetype,
       text: `Suffering: ${displayName} — ${cityCount} ${cityCount === 1 ? 'city' : 'cities'}, ${turns} ${turns === 1 ? 'turn' : 'turns'}`,
     };
 

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -28,6 +28,7 @@ import { minorCivReparationsCost } from '@/systems/minor-civ-actions';
 import { createGameButton } from '@/ui/ui-kit';
 import { getWorldPressurePresentationForViewer } from '@/systems/world-pressure-presentation';
 import { canSendAid, type SendAidFailureReason } from '@/systems/crisis-interaction-system';
+import { TECH_TREE } from '@/systems/tech-definitions';
 
 export interface DiplomacyPanelCallbacks {
   onAction: (targetCivId: string, action: DiplomaticAction) => void;
@@ -46,9 +47,16 @@ export interface DiplomacyPanelCallbacks {
 
 // Reasons canSendAid can disable the button for -- all player-facing, per spec's "cost,
 // effect, and risk inline at the point of choice" UI requirement.
-function describeSendAidDisabledReason(reason: SendAidFailureReason, goldCost: number | null): string {
+function describeSendAidDisabledReason(
+  reason: SendAidFailureReason,
+  goldCost: number | null,
+  techId: string | null,
+): string {
   switch (reason) {
-    case 'no-tech': return 'Requires the technology that unlocks this aid.';
+    case 'no-tech': {
+      const techName = techId ? TECH_TREE.find(t => t.id === techId)?.name ?? techId : 'the required technology';
+      return `Requires ${techName}.`;
+    }
     case 'not-enough-gold': return goldCost !== null ? `Requires ${goldCost} gold.` : 'Not enough gold.';
     case 'already-aided': return 'You already sent aid for this crisis.';
     case 'flag-off': return 'Crisis interactions are not available yet.';
@@ -217,13 +225,17 @@ export function createDiplomacyPanel(
     if (worldPressureLine && worldPressureLine.archetype !== 'hunt') {
       sendAidCrisisId = worldPressureLine.crisisId;
       const check = canSendAid(state, state.currentPlayer, worldPressureLine.crisisId);
-      const goldCost = check.ok ? check.goldCost : check.goldCost ?? null;
+      const goldCost = check.goldCost ?? null;
       sendAidLabel = goldCost !== null ? `Send Aid (${goldCost} Gold)` : 'Send Aid';
-      sendAidHelpText = worldPressureLine.archetype === 'outbreak'
-        ? `Pay ${goldCost ?? '?'} gold — ${civ.name}'s outbreak is cured in 2 turns. ${civ.name} and onlookers will remember this.`
-        : `Pay ${goldCost ?? '?'} gold — ${civ.name} receives it as relief. ${civ.name} and onlookers will remember this.`;
       sendAidDisabled = !check.ok;
-      sendAidDisabledReason = check.ok ? null : describeSendAidDisabledReason(check.reason, goldCost);
+      if (!check.ok && check.reason === 'already-aided') {
+        sendAidHelpText = `You already sent aid to help ${civ.name} with this crisis.`;
+      } else {
+        sendAidHelpText = worldPressureLine.archetype === 'outbreak'
+          ? `Pay ${goldCost ?? '?'} gold — ${civ.name}'s outbreak is cured in 2 turns. ${civ.name} and onlookers will remember this.`
+          : `Pay ${goldCost ?? '?'} gold — ${civ.name} receives it as relief. ${civ.name} and onlookers will remember this.`;
+      }
+      sendAidDisabledReason = check.ok ? null : describeSendAidDisabledReason(check.reason, goldCost, check.techId ?? null);
     }
 
     civRows.push({

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -27,6 +27,7 @@ import { hasAccessibleLuxury } from '@/systems/quest-objective-system';
 import { minorCivReparationsCost } from '@/systems/minor-civ-actions';
 import { createGameButton } from '@/ui/ui-kit';
 import { getWorldPressurePresentationForViewer } from '@/systems/world-pressure-presentation';
+import { canSendAid, type SendAidFailureReason } from '@/systems/crisis-interaction-system';
 
 export interface DiplomacyPanelCallbacks {
   onAction: (targetCivId: string, action: DiplomaticAction) => void;
@@ -39,7 +40,22 @@ export interface DiplomacyPanelCallbacks {
   onSponsorFestival?: (mcId: string) => void;
   onMinorCivReparations?: (mcId: string) => void;
   onMinorCivWarPeace?: (mcId: string, currentlyAtWar: boolean) => void;
+  onSendAid?: (crisisId: string) => void;
   onClose: () => void;
+}
+
+// Reasons canSendAid can disable the button for -- all player-facing, per spec's "cost,
+// effect, and risk inline at the point of choice" UI requirement.
+function describeSendAidDisabledReason(reason: SendAidFailureReason, goldCost: number | null): string {
+  switch (reason) {
+    case 'no-tech': return 'Requires the technology that unlocks this aid.';
+    case 'not-enough-gold': return goldCost !== null ? `Requires ${goldCost} gold.` : 'Not enough gold.';
+    case 'already-aided': return 'You already sent aid for this crisis.';
+    case 'flag-off': return 'Crisis interactions are not available yet.';
+    case 'unknown-civ':
+    case 'no-crisis':
+      return 'Unavailable.';
+  }
 }
 
 interface CivRowData {
@@ -60,6 +76,11 @@ interface CivRowData {
   atWar: boolean;
   warSinceText: string | null;
   worldPressureStatusText: string | null;
+  sendAidCrisisId: string | null;
+  sendAidLabel: string | null;
+  sendAidHelpText: string | null;
+  sendAidDisabled: boolean;
+  sendAidDisabledReason: string | null;
 }
 
 interface MinorCivRowData {
@@ -183,6 +204,28 @@ export function createDiplomacyPanel(
         .map(request => request.treatyType),
     );
 
+    // Send Aid (#526 MR6 Task 6.3) -- the crisis status line's anchor button. Only
+    // outbreak/catastrophe archetypes are send-aid hooks (hunt uses hunt-their-foe
+    // instead), so a hunt-archetype crisis never gets a button at all rather than a
+    // permanently-disabled one with a misleading "requires tech" message.
+    const worldPressureLine = worldPressurePresentation.statusLinesByCivId[civId];
+    let sendAidCrisisId: string | null = null;
+    let sendAidLabel: string | null = null;
+    let sendAidHelpText: string | null = null;
+    let sendAidDisabled = false;
+    let sendAidDisabledReason: string | null = null;
+    if (worldPressureLine && worldPressureLine.archetype !== 'hunt') {
+      sendAidCrisisId = worldPressureLine.crisisId;
+      const check = canSendAid(state, state.currentPlayer, worldPressureLine.crisisId);
+      const goldCost = check.ok ? check.goldCost : check.goldCost ?? null;
+      sendAidLabel = goldCost !== null ? `Send Aid (${goldCost} Gold)` : 'Send Aid';
+      sendAidHelpText = worldPressureLine.archetype === 'outbreak'
+        ? `Pay ${goldCost ?? '?'} gold — ${civ.name}'s outbreak is cured in 2 turns. ${civ.name} and onlookers will remember this.`
+        : `Pay ${goldCost ?? '?'} gold — ${civ.name} receives it as relief. ${civ.name} and onlookers will remember this.`;
+      sendAidDisabled = !check.ok;
+      sendAidDisabledReason = check.ok ? null : describeSendAidDisabledReason(check.reason, goldCost);
+    }
+
     civRows.push({
       civId,
       civIdx,
@@ -203,7 +246,12 @@ export function createDiplomacyPanel(
       incomingTreatyProposals,
       atWar,
       warSinceText,
-      worldPressureStatusText: worldPressurePresentation.statusLinesByCivId[civId]?.text ?? null,
+      worldPressureStatusText: worldPressureLine?.text ?? null,
+      sendAidCrisisId,
+      sendAidLabel,
+      sendAidHelpText,
+      sendAidDisabled,
+      sendAidDisabledReason,
     });
     civIdx++;
   }
@@ -319,6 +367,13 @@ export function createDiplomacyPanel(
       ? `<div style="font-size:11px;color:#e88;margin-bottom:8px;" data-text="world-pressure-${row.civIdx}"></div>`
       : '';
 
+    const sendAidHtml = row.sendAidCrisisId
+      ? `<div style="margin-bottom:8px;">
+          <div style="font-size:10px;opacity:0.75;margin-bottom:4px;" data-text="send-aid-help-${row.civIdx}"></div>
+          <div data-role="send-aid-${row.civIdx}"></div>
+        </div>`
+      : '';
+
     let actionsHtml = '<div style="display:flex;flex-wrap:wrap;gap:6px;">';
     if (row.peaceRequestState === 'incoming' && row.peaceRequestId) {
       actionsHtml += `<button class="diplo-accept-peace" data-request-id="${row.peaceRequestId}" data-action="accept-peace-request" style="padding:6px 12px;background:rgba(74,155,74,0.3);border:1px solid #4a9b4a;border-radius:6px;color:white;cursor:pointer;font-size:11px;">Accept Peace</button>`;
@@ -351,6 +406,7 @@ export function createDiplomacyPanel(
             <div style="background:${row.barColor};border-radius:4px;height:8px;width:${row.barWidth}%;"></div>
           </div>
         </div>
+        ${sendAidHtml}
         ${treatiesHtml}
         ${actionsHtml}
       </div>
@@ -422,6 +478,17 @@ export function createDiplomacyPanel(
     }
     if (row.worldPressureStatusText) {
       setText(`world-pressure-${row.civIdx}`, row.worldPressureStatusText);
+    }
+    if (row.sendAidCrisisId) {
+      setText(`send-aid-help-${row.civIdx}`, row.sendAidHelpText ?? '');
+      const slot = panel.querySelector<HTMLElement>(`[data-role="send-aid-${row.civIdx}"]`);
+      if (slot) {
+        const button = createGameButton(row.sendAidLabel ?? 'Send Aid', 'secondary', { disabled: row.sendAidDisabled });
+        button.className = 'diplo-send-aid';
+        button.dataset.crisisId = row.sendAidCrisisId;
+        if (row.sendAidDisabledReason) button.title = row.sendAidDisabledReason;
+        slot.appendChild(button);
+      }
     }
     row.incomingTreatyProposals.forEach((proposal, pIdx) => {
       setText(`treaty-proposal-label-${row.civIdx}-${pIdx}`, proposal.label);
@@ -539,6 +606,14 @@ export function createDiplomacyPanel(
       const treatyType = button.dataset.treatyType! as TreatyType;
       panel.remove();
       callbacks.onBreakTreaty?.(civId, treatyType);
+    });
+  });
+
+  panel.querySelectorAll('.diplo-send-aid').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const crisisId = (btn as HTMLElement).dataset.crisisId!;
+      callbacks.onSendAid?.(crisisId);
+      panel.remove();
     });
   });
 

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -536,9 +536,13 @@ export function routeCrisisResolved(
   sink(event.civId, `${name} ${outcomeMessage[event.outcome]}`, type);
 }
 
-// Hunt-their-foe (#526 MR6 Task 6.2): "Rome slew the beast menacing Carthage!" to every
-// viewer who knows either civ (killer or target) -- deliberately broader than the
-// witness-reputation set in crisis-interaction-system.ts, which requires knowing BOTH.
+// Hunt-their-foe (#526 MR6 Task 6.2): "Rome slew the beast menacing Carthage!" to
+// third-party viewers who know either civ (killer or target) -- deliberately broader
+// than the witness-reputation set in crisis-interaction-system.ts, which requires
+// knowing BOTH. Never sinks to the killer or target themselves: routeCrisisResolved's
+// existing 'hunted' branch already tells them directly ("The beast-slayer's feast
+// begins!" / "{foe} has been slain by {killer}") from the same crisis:resolved event
+// that fires in the same tick -- sinking here too would double-notify both parties.
 export function routeCrisisFoeHuntedByAlly(
   state: GameState,
   event: GameEvents['crisis:foe-hunted-by-ally'],
@@ -550,10 +554,7 @@ export function routeCrisisFoeHuntedByAlly(
   const message = `${killerName} slew ${foeName} menacing ${targetName}!`;
 
   for (const [civId, civ] of Object.entries(state.civilizations)) {
-    if (civId === event.killerCivId || civId === event.targetCivId) {
-      sink(civId, message, 'success');
-      continue;
-    }
+    if (civId === event.killerCivId || civId === event.targetCivId) continue;
     const known = civ.knownCivilizations ?? [];
     if (known.includes(event.killerCivId) || known.includes(event.targetCivId)) {
       sink(civId, message, 'success');

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -535,6 +535,31 @@ export function routeCrisisResolved(
   sink(event.civId, `${name} ${outcomeMessage[event.outcome]}`, type);
 }
 
+// Hunt-their-foe (#526 MR6 Task 6.2): "Rome slew the beast menacing Carthage!" to every
+// viewer who knows either civ (killer or target) -- deliberately broader than the
+// witness-reputation set in crisis-interaction-system.ts, which requires knowing BOTH.
+export function routeCrisisFoeHuntedByAlly(
+  state: GameState,
+  event: GameEvents['crisis:foe-hunted-by-ally'],
+  sink: NotificationSink,
+): void {
+  const killerName = state.civilizations[event.killerCivId]?.name ?? 'A civilization';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a civilization';
+  const foeName = event.foeName ?? 'their foe';
+  const message = `${killerName} slew ${foeName} menacing ${targetName}!`;
+
+  for (const [civId, civ] of Object.entries(state.civilizations)) {
+    if (civId === event.killerCivId || civId === event.targetCivId) {
+      sink(civId, message, 'success');
+      continue;
+    }
+    const known = civ.knownCivilizations ?? [];
+    if (known.includes(event.killerCivId) || known.includes(event.targetCivId)) {
+      sink(civId, message, 'success');
+    }
+  }
+}
+
 // Fans out to viewers who know the AI target civ (met-civ gate, spec §Visibility).
 // AI-targeted crises only -- a human's own crisis already notifies its owner via
 // routeCrisisStarted above. Fires on crisis:started only, never per spread/siege tick:

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -9,6 +9,7 @@ import type { NotificationCityAction, NotificationEntry } from '@/core/notificat
 import { presentStrategicWarning } from '@/ui/strategic-warning-presentation';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
+import { getWitnessCivIds } from '@/systems/crisis-interaction-system';
 
 export type NotificationSink = (
   civId: string,
@@ -557,6 +558,25 @@ export function routeCrisisFoeHuntedByAlly(
     if (known.includes(event.killerCivId) || known.includes(event.targetCivId)) {
       sink(civId, message, 'success');
     }
+  }
+}
+
+// Send aid (#526 MR6 Task 6.3): notifies the aided target civ directly, plus every
+// witness (met BOTH actor and target -- same set applyInteractionReputation rewarded),
+// per spec §Interactions: "Human witnesses receive a notification... when overt acts
+// occur (aid sent...)". The actor gets immediate feedback from the panel itself.
+export function routeCrisisAidSent(
+  state: GameState,
+  event: GameEvents['crisis:aid-sent'],
+  sink: NotificationSink,
+): void {
+  const actorName = state.civilizations[event.actorCivId]?.name ?? 'A civilization';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a civilization';
+  const message = `${actorName} sent aid to ${targetName}!`;
+
+  sink(event.targetCivId, message, 'success');
+  for (const witnessId of getWitnessCivIds(state, event.actorCivId, event.targetCivId)) {
+    sink(witnessId, message, 'success');
   }
 }
 

--- a/tests/systems/crisis-hunt.test.ts
+++ b/tests/systems/crisis-hunt.test.ts
@@ -269,6 +269,97 @@ describe('hunt crisis — resolution, feast, escalation (MR3)', () => {
     expect(resolved.beasts!.lairs[lairId]).toBeUndefined();
   });
 
+});
+
+describe('hunt crisis — ally reward (#526 MR6 Task 6.2)', () => {
+  it('third-civ kill: moves both relationship sides by +15 and emits crisis:foe-hunted-by-ally once', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    state.settings.aiCrisisInteractions = 'benign';
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:foe-hunted-by-ally', event => events.push(event));
+
+    const next = processCrisisTurn(state, bus);
+
+    expect(next.civilizations.p1.diplomacy.relationships.killer).toBe(15);
+    expect(next.civilizations.killer.diplomacy.relationships.p1).toBe(15);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ crisisId, killerCivId: 'killer', targetCivId: 'p1', foeName: 'Test Beast' });
+  });
+
+  it('grants +4 to a witness civ that has met both the killer and the target', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    state.settings.aiCrisisInteractions = 'benign';
+    state.civilizations.witness = {
+      id: 'witness', name: 'Witness', color: '#888888', isHuman: false, civType: 'generic',
+      cities: [], units: [],
+      techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+      gold: 0, visibility: { tiles: {} }, score: 0,
+      diplomacy: createDiplomacyState(['p1', 'killer', 'witness'], 'witness'),
+      knownCivilizations: ['p1', 'killer'],
+    } as GameState['civilizations'][string];
+    void crisisId;
+
+    const next = processCrisisTurn(state, new EventBus());
+
+    expect(next.civilizations.killer.diplomacy.relationships.witness).toBe(4);
+    expect(next.civilizations.witness.diplomacy.relationships.killer).toBe(4);
+  });
+
+  it('self-kill (target civ kills its own foe): no reputation change, no event', () => {
+    const { state, crisisId } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'p1',
+    });
+    state.settings.aiCrisisInteractions = 'benign';
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:foe-hunted-by-ally', event => events.push(event));
+    void crisisId;
+
+    const next = processCrisisTurn(state, bus);
+
+    expect(next.civilizations.p1.diplomacy.relationships.killer ?? 0).toBe(0);
+    expect(events).toHaveLength(0);
+  });
+
+  it('AI killer of an AI target: same deltas apply (no humanity special-casing)', () => {
+    const { state } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    state.civilizations.p1.isHuman = false;
+    state.settings.aiCrisisInteractions = 'benign';
+
+    const next = processCrisisTurn(state, new EventBus());
+
+    expect(next.civilizations.p1.diplomacy.relationships.killer).toBe(15);
+    expect(next.civilizations.killer.diplomacy.relationships.p1).toBe(15);
+  });
+
+  it('produces no reputation change or event while aiCrisisInteractions is off (default -- dark until Task 6.4 flips it)', () => {
+    const { state } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:foe-hunted-by-ally', event => events.push(event));
+
+    const next = processCrisisTurn(state, bus);
+
+    expect(next.civilizations.p1.diplomacy.relationships.killer ?? 0).toBe(0);
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('hunt crisis — resolution, feast, escalation (MR3, continued)', () => {
   it('falls back to the target civ for the feast when no killer was ever attributed', () => {
     const { state, crisisId } = makeHuntFixture({
       flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,

--- a/tests/systems/crisis-hunt.test.ts
+++ b/tests/systems/crisis-hunt.test.ts
@@ -343,11 +343,12 @@ describe('hunt crisis — ally reward (#526 MR6 Task 6.2)', () => {
     expect(next.civilizations.killer.diplomacy.relationships.p1).toBe(15);
   });
 
-  it('produces no reputation change or event while aiCrisisInteractions is off (default -- dark until Task 6.4 flips it)', () => {
+  it('produces no reputation change or event when aiCrisisInteractions is explicitly off', () => {
     const { state } = makeHuntFixture({
       flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
       huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
     });
+    state.settings.aiCrisisInteractions = 'off';
     const bus = new EventBus();
     const events: unknown[] = [];
     bus.on('crisis:foe-hunted-by-ally', event => events.push(event));
@@ -356,6 +357,15 @@ describe('hunt crisis — ally reward (#526 MR6 Task 6.2)', () => {
 
     expect(next.civilizations.p1.diplomacy.relationships.killer ?? 0).toBe(0);
     expect(events).toHaveLength(0);
+  });
+
+  it('applies the reputation reward by default now that aiCrisisInteractions defaults to "benign" (#526 MR6 Task 6.4 rollout)', () => {
+    const { state } = makeHuntFixture({
+      flavorId: 'beast-awakening', stage: 'menacing', turnsInStage: 1,
+      huntEntityId: 'unit-99', foeName: 'Test Beast', lastHuntKillerCivId: 'killer',
+    });
+    const next = processCrisisTurn(state, new EventBus());
+    expect(next.civilizations.p1.diplomacy.relationships.killer).toBe(15);
   });
 });
 

--- a/tests/systems/crisis-interaction-system.test.ts
+++ b/tests/systems/crisis-interaction-system.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import {
+  CRISIS_INTERACTION_DEFINITIONS,
+  getCrisisInteractionDefinition,
+  getWitnessCivIds,
+  applyInteractionReputation,
+} from '@/systems/crisis-interaction-system';
+
+// actor=civA, target=civB, witness=civC (met both), non-witness=civD (met only actor).
+function threeCivState(overrides: Partial<GameState> = {}): GameState {
+  const ids = ['civA', 'civB', 'civC', 'civD'];
+  return {
+    turn: 10,
+    cities: {},
+    units: {},
+    map: { width: 1, height: 1, wrapsHorizontally: false, rivers: [], tiles: {} },
+    civilizations: {
+      civA: { id: 'civA', name: 'A', isHuman: true, cities: [], units: [], visibility: { tiles: {} }, diplomacy: createDiplomacyState(ids, 'civA'), knownCivilizations: ['civB', 'civC', 'civD'] },
+      civB: { id: 'civB', name: 'B', isHuman: false, cities: [], units: [], visibility: { tiles: {} }, diplomacy: createDiplomacyState(ids, 'civB'), knownCivilizations: ['civA', 'civC'] },
+      civC: { id: 'civC', name: 'C', isHuman: false, cities: [], units: [], visibility: { tiles: {} }, diplomacy: createDiplomacyState(ids, 'civC'), knownCivilizations: ['civA', 'civB'] },
+      civD: { id: 'civD', name: 'D', isHuman: false, cities: [], units: [], visibility: { tiles: {} }, diplomacy: createDiplomacyState(ids, 'civD'), knownCivilizations: ['civA'] },
+    },
+    ...overrides,
+  } as unknown as GameState;
+}
+
+describe('CRISIS_INTERACTION_DEFINITIONS', () => {
+  it('ships hunt_their_foe and send_aid as the MR6 rows', () => {
+    const ids = CRISIS_INTERACTION_DEFINITIONS.map(def => def.id);
+    expect(ids).toEqual(['hunt_their_foe', 'send_aid']);
+  });
+
+  it('hunt_their_foe requires no tech; send_aid requires medicine', () => {
+    expect(getCrisisInteractionDefinition('hunt_their_foe')?.techRequired).toBeNull();
+    expect(getCrisisInteractionDefinition('send_aid')?.techRequired).toBe('medicine');
+  });
+});
+
+describe('getWitnessCivIds', () => {
+  it('includes only civs that have met BOTH actor and target, excluding actor/target themselves', () => {
+    const state = threeCivState();
+    const witnesses = getWitnessCivIds(state, 'civA', 'civB');
+    expect(witnesses).toEqual(['civC']);
+    expect(witnesses).not.toContain('civA');
+    expect(witnesses).not.toContain('civB');
+    expect(witnesses).not.toContain('civD'); // met actor only, not target
+  });
+
+  it('returns an empty list when no third civ has met both parties (negative)', () => {
+    const state = threeCivState();
+    // hasMetCivilization is bidirectional -- clear the link from BOTH sides so civC
+    // and civB genuinely have no mutual-contact evidence.
+    state.civilizations.civC.knownCivilizations = ['civA'];
+    state.civilizations.civB.knownCivilizations = ['civA'];
+    expect(getWitnessCivIds(state, 'civA', 'civB')).toEqual([]);
+  });
+});
+
+describe('applyInteractionReputation', () => {
+  it('moves both sides of the actor<->target relationship', () => {
+    const state = threeCivState();
+    const def = getCrisisInteractionDefinition('hunt_their_foe')!;
+    const next = applyInteractionReputation(state, 'civA', 'civB', def);
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(15);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(15);
+  });
+
+  it('moves both sides of the actor<->witness relationship for every witness', () => {
+    const state = threeCivState();
+    const def = getCrisisInteractionDefinition('hunt_their_foe')!;
+    const next = applyInteractionReputation(state, 'civA', 'civB', def);
+    expect(next.civilizations.civA.diplomacy.relationships.civC).toBe(4);
+    expect(next.civilizations.civC.diplomacy.relationships.civA).toBe(4);
+  });
+
+  it('never touches a non-witness civ (civD, which only met the actor)', () => {
+    const state = threeCivState();
+    const def = getCrisisInteractionDefinition('hunt_their_foe')!;
+    const next = applyInteractionReputation(state, 'civA', 'civB', def);
+    expect(next.civilizations.civD.diplomacy.relationships.civA).toBe(0);
+    expect(next.civilizations.civA.diplomacy.relationships.civD).toBe(0);
+  });
+
+  it('clamps deltas at the +100 ceiling via modifyRelationship', () => {
+    const state = threeCivState();
+    state.civilizations.civA.diplomacy.relationships.civB = 90;
+    state.civilizations.civB.diplomacy.relationships.civA = 90;
+    const def = getCrisisInteractionDefinition('hunt_their_foe')!;
+    const next = applyInteractionReputation(state, 'civA', 'civB', def);
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(100);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(100);
+  });
+});

--- a/tests/systems/crisis-interaction-system.test.ts
+++ b/tests/systems/crisis-interaction-system.test.ts
@@ -1,11 +1,16 @@
 import { describe, it, expect } from 'vitest';
-import type { GameState } from '@/core/types';
+import type { ActiveCrisis, City, GameState } from '@/core/types';
+import { EventBus } from '@/core/event-bus';
 import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { getCityAppeaseCost } from '@/systems/faction-system';
 import {
   CRISIS_INTERACTION_DEFINITIONS,
   getCrisisInteractionDefinition,
+  resolveInteractionTechRequired,
   getWitnessCivIds,
   applyInteractionReputation,
+  canSendAid,
+  applySendAid,
 } from '@/systems/crisis-interaction-system';
 
 // actor=civA, target=civB, witness=civC (met both), non-witness=civD (met only actor).
@@ -32,9 +37,19 @@ describe('CRISIS_INTERACTION_DEFINITIONS', () => {
     expect(ids).toEqual(['hunt_their_foe', 'send_aid']);
   });
 
-  it('hunt_their_foe requires no tech; send_aid requires medicine', () => {
+  it('hunt_their_foe requires no tech', () => {
     expect(getCrisisInteractionDefinition('hunt_their_foe')?.techRequired).toBeNull();
-    expect(getCrisisInteractionDefinition('send_aid')?.techRequired).toBe('medicine');
+  });
+
+  it('send_aid requires medicine for outbreak and trade-routes for catastrophe (per-archetype map)', () => {
+    const def = getCrisisInteractionDefinition('send_aid')!;
+    expect(resolveInteractionTechRequired(def, 'outbreak')).toBe('medicine');
+    expect(resolveInteractionTechRequired(def, 'catastrophe')).toBe('trade-routes');
+  });
+
+  it('send_aid resolves to undefined (never satisfiable) for a hunt archetype -- not a send-aid hook', () => {
+    const def = getCrisisInteractionDefinition('send_aid')!;
+    expect(resolveInteractionTechRequired(def, 'hunt')).toBeUndefined();
   });
 });
 
@@ -91,5 +106,159 @@ describe('applyInteractionReputation', () => {
     const next = applyInteractionReputation(state, 'civA', 'civB', def);
     expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(100);
     expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(100);
+  });
+});
+
+// actor=civA (the aid-giver), target=civB (the crisis-struck civ), witness=civC.
+function sendAidState({
+  archetype = 'outbreak' as ActiveCrisis['archetype'],
+  actorGold = 200,
+  actorTechs = ['medicine', 'trade-routes'],
+  actorAlreadyAided = false,
+  interactions = 'benign' as 'off' | 'benign' | 'full',
+}: {
+  archetype?: ActiveCrisis['archetype'];
+  actorGold?: number;
+  actorTechs?: string[];
+  actorAlreadyAided?: boolean;
+  interactions?: 'off' | 'benign' | 'full';
+} = {}): { state: GameState; crisisId: string; cityId: string; goldCost: number } {
+  const ids = ['civA', 'civB', 'civC'];
+  const cityId = 'target-city';
+  const city: City = {
+    id: cityId, name: 'Carthage', owner: 'civB', position: { q: 0, r: 0 },
+    population: 9, food: 0, foodNeeded: 20, buildings: [], productionQueue: [],
+    productionProgress: 0, ownedTiles: [{ q: 0, r: 0 }], workedTiles: [],
+    focus: 'balanced', maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+  };
+  const crisisId = 'crisis-1';
+  const crisis: ActiveCrisis = {
+    id: crisisId, flavorId: archetype === 'outbreak' ? 'plague' : 'earthquake', archetype,
+    targetCivId: 'civB', cityIds: [cityId], tileKeys: [], startedTurn: 5, stage: archetype === 'outbreak' ? 'active' : 'recovery',
+    turnsInStage: 2,
+    ...(actorAlreadyAided ? { aidedByCivIds: ['civA'] } : {}),
+  };
+
+  const state: GameState = {
+    turn: 10,
+    cities: { [cityId]: city },
+    units: {},
+    map: { width: 1, height: 1, wrapsHorizontally: false, rivers: [], tiles: {} },
+    settings: { aiCrisisInteractions: interactions } as GameState['settings'],
+    civilizations: {
+      civA: {
+        id: 'civA', name: 'Rome', isHuman: true, cities: [], units: [], visibility: { tiles: {} },
+        gold: actorGold,
+        techState: { completed: actorTechs, currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        diplomacy: createDiplomacyState(ids, 'civA'), knownCivilizations: ['civB', 'civC'],
+      },
+      civB: {
+        id: 'civB', name: 'Carthage', isHuman: false, cities: [cityId], units: [], visibility: { tiles: {} },
+        gold: 50,
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        diplomacy: createDiplomacyState(ids, 'civB'), knownCivilizations: ['civA', 'civC'],
+      },
+      civC: {
+        id: 'civC', name: 'Egypt', isHuman: false, cities: [], units: [], visibility: { tiles: {} },
+        gold: 0,
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        diplomacy: createDiplomacyState(ids, 'civC'), knownCivilizations: ['civA', 'civB'],
+      },
+    },
+    activeCrises: { [crisisId]: crisis },
+  } as unknown as GameState;
+
+  return { state, crisisId, cityId, goldCost: getCityAppeaseCost(city) };
+}
+
+describe('canSendAid', () => {
+  it('returns ok:true with the correct gold cost for a valid outbreak aid attempt', () => {
+    const { state, crisisId, goldCost } = sendAidState({ archetype: 'outbreak' });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: true, goldCost });
+  });
+
+  it('rejects with flag-off when aiCrisisInteractions is off', () => {
+    const { state, crisisId } = sendAidState({ interactions: 'off' });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'flag-off' });
+  });
+
+  it('rejects with unknown-civ for a nonexistent actor', () => {
+    const { state, crisisId } = sendAidState();
+    expect(canSendAid(state, 'no-such-civ', crisisId)).toEqual({ ok: false, reason: 'unknown-civ' });
+  });
+
+  it('rejects with no-crisis for a nonexistent crisis id', () => {
+    const { state } = sendAidState();
+    expect(canSendAid(state, 'civA', 'no-such-crisis')).toEqual({ ok: false, reason: 'no-crisis' });
+  });
+
+  it('rejects with already-aided once the actor has already aided this crisis', () => {
+    const { state, crisisId } = sendAidState({ actorAlreadyAided: true });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'already-aided' });
+  });
+
+  it('rejects with no-tech when the actor lacks medicine for an outbreak', () => {
+    const { state, crisisId } = sendAidState({ archetype: 'outbreak', actorTechs: [] });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech' });
+  });
+
+  it('rejects with no-tech when the actor lacks trade-routes for a catastrophe', () => {
+    const { state, crisisId } = sendAidState({ archetype: 'catastrophe', actorTechs: [] });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech' });
+  });
+
+  it('rejects with not-enough-gold when the actor cannot afford the cost, still reporting the cost', () => {
+    const { state, crisisId, goldCost } = sendAidState({ actorGold: 0 });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'not-enough-gold', goldCost });
+  });
+});
+
+describe('applySendAid', () => {
+  it('outbreak: deducts gold from the actor only, schedules the remedy, marks aidedByCivIds, and applies bilateral reputation once', () => {
+    const { state, crisisId, cityId, goldCost } = sendAidState({ archetype: 'outbreak' });
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('crisis:aid-sent', event => events.push(event));
+
+    const next = applySendAid(state, 'civA', crisisId, bus);
+
+    expect(next.civilizations.civA.gold).toBe(200 - goldCost);
+    expect(next.civilizations.civB.gold).toBe(50); // target's own gold is untouched
+    expect(next.activeCrises![crisisId].remedyCompletionByCity).toEqual({ [cityId]: state.turn + 2 });
+    expect(next.activeCrises![crisisId].aidedByCivIds).toEqual(['civA']);
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(15);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(15);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ crisisId, actorCivId: 'civA', targetCivId: 'civB', goldCost });
+  });
+
+  it('catastrophe: deducts gold from the actor and credits it to the target civ as relief', () => {
+    const { state, crisisId, goldCost } = sendAidState({ archetype: 'catastrophe' });
+    const next = applySendAid(state, 'civA', crisisId, new EventBus());
+
+    expect(next.civilizations.civA.gold).toBe(200 - goldCost);
+    expect(next.civilizations.civB.gold).toBe(50 + goldCost);
+    expect(next.activeCrises![crisisId].aidedByCivIds).toEqual(['civA']);
+  });
+
+  it('grants +4 reputation to a witness who has met both the actor and the target', () => {
+    const { state, crisisId } = sendAidState();
+    const next = applySendAid(state, 'civA', crisisId, new EventBus());
+    expect(next.civilizations.civA.diplomacy.relationships.civC).toBe(4);
+    expect(next.civilizations.civC.diplomacy.relationships.civA).toBe(4);
+  });
+
+  it('is a no-op when canSendAid would reject (e.g. already aided) -- never double-deducts gold', () => {
+    const { state, crisisId } = sendAidState({ actorAlreadyAided: true });
+    const next = applySendAid(state, 'civA', crisisId, new EventBus());
+    expect(next).toBe(state);
+  });
+
+  it('human-target: human A aids human B\'s crisis -- both relationships move (hot-seat requirement)', () => {
+    const { state, crisisId } = sendAidState();
+    state.civilizations.civB.isHuman = true;
+    const next = applySendAid(state, 'civA', crisisId, new EventBus());
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(15);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(15);
   });
 });

--- a/tests/systems/crisis-interaction-system.test.ts
+++ b/tests/systems/crisis-interaction-system.test.ts
@@ -192,19 +192,19 @@ describe('canSendAid', () => {
     expect(canSendAid(state, 'civA', 'no-such-crisis')).toEqual({ ok: false, reason: 'no-crisis' });
   });
 
-  it('rejects with already-aided once the actor has already aided this crisis', () => {
-    const { state, crisisId } = sendAidState({ actorAlreadyAided: true });
-    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'already-aided' });
+  it('rejects with already-aided once the actor has already aided this crisis, still reporting the cost', () => {
+    const { state, crisisId, goldCost } = sendAidState({ actorAlreadyAided: true });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'already-aided', goldCost });
   });
 
-  it('rejects with no-tech when the actor lacks medicine for an outbreak', () => {
-    const { state, crisisId } = sendAidState({ archetype: 'outbreak', actorTechs: [] });
-    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech' });
+  it('rejects with no-tech when the actor lacks medicine for an outbreak, naming the missing tech and cost', () => {
+    const { state, crisisId, goldCost } = sendAidState({ archetype: 'outbreak', actorTechs: [] });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech', goldCost, techId: 'medicine' });
   });
 
-  it('rejects with no-tech when the actor lacks trade-routes for a catastrophe', () => {
-    const { state, crisisId } = sendAidState({ archetype: 'catastrophe', actorTechs: [] });
-    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech' });
+  it('rejects with no-tech when the actor lacks trade-routes for a catastrophe, naming the missing tech and cost', () => {
+    const { state, crisisId, goldCost } = sendAidState({ archetype: 'catastrophe', actorTechs: [] });
+    expect(canSendAid(state, 'civA', crisisId)).toEqual({ ok: false, reason: 'no-tech', goldCost, techId: 'trade-routes' });
   });
 
   it('rejects with not-enough-gold when the actor cannot afford the cost, still reporting the cost', () => {

--- a/tests/systems/world-pressure-flags.test.ts
+++ b/tests/systems/world-pressure-flags.test.ts
@@ -3,16 +3,19 @@ import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import type { GameSettings } from '@/core/types';
 
 describe('resolveWorldPressureFlags', () => {
-  it('defaults aiPressure to "full" (#529 MR3) and aiPressureVisibility to true (#531 MR5), interactions off, for legacy saves (undefined settings fields)', () => {
+  it('defaults aiPressure to "full" (#529 MR3), aiPressureVisibility to true (#531 MR5), and aiCrisisInteractions to "benign" (#532 MR6), for legacy saves (undefined settings fields)', () => {
     expect(resolveWorldPressureFlags({} as GameSettings)).toEqual({
-      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'off',
+      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
     });
     expect(resolveWorldPressureFlags(undefined)).toEqual({
-      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'off',
+      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
     });
   });
   it('defaults aiPressureVisibility to false only when explicitly set that way', () => {
     expect(resolveWorldPressureFlags({ aiPressureVisibility: false } as GameSettings).aiPressureVisibility).toBe(false);
+  });
+  it('defaults aiCrisisInteractions to "off" only when explicitly set that way', () => {
+    expect(resolveWorldPressureFlags({ aiCrisisInteractions: 'off' } as GameSettings).aiCrisisInteractions).toBe('off');
   });
   it('defaults aiPressure to "off" only when explicitly set that way', () => {
     expect(resolveWorldPressureFlags({ aiPressure: 'off' } as GameSettings).aiPressure).toBe('off');

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -791,14 +791,32 @@ describe('diplomacy-panel Send Aid button (#526 MR6 Task 6.3)', () => {
     expect(rerendered.textContent).not.toContain('Send Aid');
   });
 
-  it('disables the button and shows the reason as help text when the actor lacks the required tech', () => {
+  it('disables the button and names the specific missing tech in the help text (not a vague "requires tech")', () => {
     const { container, state } = readyState();
     state.civilizations.player.techState.completed = [];
     const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
 
     const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
     expect(button!.disabled).toBe(true);
-    expect(button!.title.length).toBeGreaterThan(0);
+    expect(button!.title).toBe('Requires Medicine.');
+  });
+
+  it('still shows the gold cost in the button label when disabled for a reason other than affordability', () => {
+    const { container, state } = readyState();
+    state.civilizations.player.techState.completed = [];
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button!.textContent).toContain('75');
+  });
+
+  it('shows a distinct "already sent aid" help line instead of the pay-gold line once already aided', () => {
+    const { container, state } = readyState();
+    state.activeCrises!['crisis-1']!.aidedByCivIds = ['player'];
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.textContent).toContain('already sent aid');
+    expect(panel.textContent).not.toContain('Pay 75 gold');
   });
 
   it('disables the button when the actor cannot afford the cost', () => {

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -727,3 +727,113 @@ describe('diplomacy-panel world-pressure crisis status line (#526 MR5 Task 5.3)'
     expect(second.textContent).not.toContain('Suffering:');
   });
 });
+
+describe('diplomacy-panel Send Aid button (#526 MR6 Task 6.3)', () => {
+  function addOutsiderCrisis(
+    state: ReturnType<typeof makeDiplomacyFixture>['state'],
+    archetype: 'outbreak' | 'catastrophe' = 'outbreak',
+  ): void {
+    state.cities['outsider-city'] = {
+      ...state.cities['city-border'],
+      id: 'outsider-city',
+      owner: 'outsider',
+      position: { q: 7, r: 7 },
+      ownedTiles: [{ q: 7, r: 7 }],
+      population: 5,
+    };
+    state.civilizations.outsider.cities = ['outsider-city'];
+    state.activeCrises = {
+      'crisis-1': {
+        id: 'crisis-1', flavorId: archetype === 'outbreak' ? 'plague' : 'earthquake', archetype,
+        targetCivId: 'outsider',
+        cityIds: ['outsider-city'], tileKeys: [], startedTurn: state.turn - 3,
+        stage: archetype === 'outbreak' ? 'active' : 'recovery', turnsInStage: 3,
+      },
+    };
+  }
+
+  function readyState(archetype: 'outbreak' | 'catastrophe' = 'outbreak') {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.settings.aiPressureVisibility = true;
+    state.settings.aiCrisisInteractions = 'benign';
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.techState.completed = ['medicine', 'trade-routes'];
+    addOutsiderCrisis(state, archetype);
+    return { container, state };
+  }
+
+  it('renders an enabled Send Aid button showing the gold cost, plus an effect/memory help line', () => {
+    const { container, state } = readyState();
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button).toBeTruthy();
+    expect(button!.disabled).toBe(false);
+    expect(button!.textContent).toContain('75');
+    expect(panel.textContent).toContain('will remember this');
+  });
+
+  it('clicking Send Aid invokes the callback with the crisis id, and the panel re-renders', () => {
+    const { container, state } = readyState();
+    let currentState = state;
+    const onSendAid = vi.fn((crisisId: string) => {
+      currentState = { ...currentState, activeCrises: {} }; // simulate main.ts applying aid + re-deriving state
+      render();
+    });
+    const render = (): HTMLElement => createDiplomacyPanel(container, currentState, { onAction: () => {}, onClose: () => {}, onSendAid });
+
+    const panel = render();
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]')!;
+    button.click();
+
+    expect(onSendAid).toHaveBeenCalledWith('crisis-1');
+    const rerendered = container.querySelector('#diplomacy-panel') as HTMLElement;
+    expect(rerendered.textContent).not.toContain('Send Aid');
+  });
+
+  it('disables the button and shows the reason as help text when the actor lacks the required tech', () => {
+    const { container, state } = readyState();
+    state.civilizations.player.techState.completed = [];
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button!.disabled).toBe(true);
+    expect(button!.title.length).toBeGreaterThan(0);
+  });
+
+  it('disables the button when the actor cannot afford the cost', () => {
+    const { container, state } = readyState();
+    state.civilizations.player.gold = 0;
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button!.disabled).toBe(true);
+    expect(button!.title).toContain('75');
+  });
+
+  it('keeps the Send Aid button visible but disabled once the actor has already aided this crisis', () => {
+    const { container, state } = readyState();
+    state.activeCrises!['crisis-1']!.aidedByCivIds = ['player'];
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button!.disabled).toBe(true);
+  });
+
+  it('does not render a Send Aid button for a hunt-archetype crisis (not a send-aid hook)', () => {
+    const { container, state } = readyState();
+    state.activeCrises!['crisis-1'] = { ...state.activeCrises!['crisis-1']!, archetype: 'hunt', flavorId: 'beast-awakening' };
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.querySelector('[data-crisis-id="crisis-1"]')).toBeNull();
+  });
+
+  it('works for a catastrophe crisis, requiring trade-routes instead of medicine', () => {
+    const { container, state } = readyState('catastrophe');
+    state.civilizations.player.techState.completed = ['medicine']; // missing trade-routes
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    const button = panel.querySelector<HTMLButtonElement>('[data-crisis-id="crisis-1"]');
+    expect(button!.disabled).toBe(true);
+  });
+});

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -22,6 +22,7 @@ import {
   routeCrisisResolved,
   routeWorldPressureCrisisStarted,
   routeWorldPressureCrisisResolved,
+  routeCrisisFoeHuntedByAlly,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -824,5 +825,43 @@ describe('world-pressure crisis notifications (#526 MR5 Task 5.2)', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]!.civId).toBe('p1');
     expect(calls.some(c => c.civId === 'p2')).toBe(false);
+  });
+});
+
+describe('crisis:foe-hunted-by-ally routing (#526 MR6 Task 6.2)', () => {
+  function huntState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', knownCivilizations: [] },
+        carthage: { id: 'carthage', name: 'Carthage', knownCivilizations: [] },
+        egypt: { id: 'egypt', name: 'Egypt', knownCivilizations: ['rome'] }, // knows only the killer
+        nubia: { id: 'nubia', name: 'Nubia', knownCivilizations: [] }, // knows neither
+      } as any,
+    });
+  }
+
+  it('notifies the killer and target directly, and a viewer who knows either civ', () => {
+    const { sink, calls } = makeSink();
+    routeCrisisFoeHuntedByAlly(
+      huntState(),
+      { crisisId: 'crisis-1', killerCivId: 'rome', targetCivId: 'carthage', foeName: 'Giant Boar' },
+      sink,
+    );
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toContain('rome');
+    expect(civIds).toContain('carthage');
+    expect(civIds).toContain('egypt');
+    expect(civIds).not.toContain('nubia');
+    expect(calls[0]!.message).toBe('Rome slew Giant Boar menacing Carthage!');
+  });
+
+  it('falls back to a generic foe phrase when foeName is absent instead of throwing', () => {
+    const { sink, calls } = makeSink();
+    routeCrisisFoeHuntedByAlly(
+      huntState(),
+      { crisisId: 'crisis-1', killerCivId: 'rome', targetCivId: 'carthage' },
+      sink,
+    );
+    expect(calls[0]!.message).toContain('their foe');
   });
 });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -849,7 +849,7 @@ describe('crisis:foe-hunted-by-ally routing (#526 MR6 Task 6.2)', () => {
     });
   }
 
-  it('notifies the killer and target directly, and a viewer who knows either civ', () => {
+  it('notifies a third-party viewer who knows either civ, but never the killer or target directly (routeCrisisResolved already covers them, same tick -- double-notify regression guard)', () => {
     const { sink, calls } = makeSink();
     routeCrisisFoeHuntedByAlly(
       huntState(),
@@ -857,9 +857,9 @@ describe('crisis:foe-hunted-by-ally routing (#526 MR6 Task 6.2)', () => {
       sink,
     );
     const civIds = calls.map(c => c.civId);
-    expect(civIds).toContain('rome');
-    expect(civIds).toContain('carthage');
-    expect(civIds).toContain('egypt');
+    expect(civIds).toEqual(['egypt']);
+    expect(civIds).not.toContain('rome');
+    expect(civIds).not.toContain('carthage');
     expect(civIds).not.toContain('nubia');
     expect(calls[0]!.message).toBe('Rome slew Giant Boar menacing Carthage!');
   });

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -23,11 +23,20 @@ import {
   routeWorldPressureCrisisStarted,
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
+  routeCrisisAidSent,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
 vi.mock('@/systems/discovery-system', () => ({
   hasMetCivilization: (_s: unknown, viewer: string, target: string) => viewer === 'p2' && target === 'p1',
+}));
+
+// getWitnessCivIds's real mutual-contact semantics are covered by
+// crisis-interaction-system.test.ts; here we only need control over which ids come back,
+// independent of the narrow discovery-system mock above (built for a different, older test).
+vi.mock('@/systems/crisis-interaction-system', () => ({
+  getWitnessCivIds: (_state: unknown, actorId: string, targetId: string) =>
+    actorId === 'rome' && targetId === 'carthage' ? ['egypt'] : [],
 }));
 
 vi.mock('@/systems/legendary-wonder-definitions', () => ({
@@ -863,5 +872,34 @@ describe('crisis:foe-hunted-by-ally routing (#526 MR6 Task 6.2)', () => {
       sink,
     );
     expect(calls[0]!.message).toContain('their foe');
+  });
+});
+
+describe('crisis:aid-sent routing (#526 MR6 Task 6.3)', () => {
+  function aidState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['carthage', 'egypt'] },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'egypt'] },
+        egypt: { id: 'egypt', name: 'Egypt', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'carthage'] }, // met both
+        nubia: { id: 'nubia', name: 'Nubia', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: [] }, // met neither
+      } as any,
+    });
+  }
+
+  it('notifies the aided target civ and every witness who has met both civs', () => {
+    const { sink, calls } = makeSink();
+    routeCrisisAidSent(aidState(), { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage', goldCost: 45 }, sink);
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toContain('carthage');
+    expect(civIds).toContain('egypt');
+    expect(civIds).not.toContain('nubia');
+    expect(calls[0]!.message).toBe('Rome sent aid to Carthage!');
+  });
+
+  it('does not notify the actor directly (the panel already gives immediate feedback)', () => {
+    const { sink, calls } = makeSink();
+    routeCrisisAidSent(aidState(), { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage', goldCost: 45 }, sink);
+    expect(calls.some(c => c.civId === 'rome')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

MR6 of the world-pressure symmetry arc (#526) — the first gameplay-surface stage. Implements all four plan tasks (docs/superpowers/plans/2026-07-11-world-pressure-symmetry.md, MR6) against spec §Interactions:

- **Task 6.1** — `CRISIS_INTERACTION_DEFINITIONS` (data table, one row per hook — a future hook is a row, not a branch), `getWitnessCivIds` (mutual contact via `hasMetCivilization`, excludes actor/target), `applyInteractionReputation` (bilateral target + bilateral witness deltas).
- **Task 6.2** — Hunt-their-foe: `tickHuntCrisis`'s existing `killerCivId` resolution now applies reputation and emits `crisis:foe-hunted-by-ally` whenever the killer differs from the crisis's own target civ (self-kills stay silent). New notification router fans "X slew Y menacing Z!" out to any viewer who knows either civ.
- **Task 6.3** — Send aid: `canSendAid`/`applySendAid`. Outbreak schedules the same `remedyCompletionByCity` record `applyRemedy` writes, but deducts the **actor's** gold (never calls `applyRemedy` itself — it deducts the target's). Catastrophe credits the payment to the target civ as relief. `aidedByCivIds` enforces once-per-crisis-per-actor. New diplomacy-panel button on each known civ's crisis status line (the MR5 anchor surface), built with `createGameButton`, showing cost in the label and a cost/effect/memory sentence as help text; disabled reasons surface as the button title. No button for hunt-archetype crises (not a send-aid hook).
- **Task 6.4** — `medicine`/`trade-routes` gain honest `unlocks` text for the effect they now gate. Flips `aiCrisisInteractions` default to `'benign'`.

### Deviations from the plan (noted per `.claude/rules/spec-fidelity.md`)

- `send_aid`'s tech gate differs by crisis archetype (`medicine` for outbreak, `trade-routes` for catastrophe) — encoded as a per-archetype map on the definition row (`resolveInteractionTechRequired`) rather than the plan's suggested "second row," since one row per hook is the table's actual invariant.
- `canSendAid`'s `not-enough-gold` failure also carries `goldCost` (an additive, non-breaking extension of the plan's literal type) so the diplomacy panel can show the real cost in the disabled-button tooltip instead of a generic "not enough gold" message.

## Test plan

- [x] `bash scripts/run-with-mise.sh yarn build` — green (tsc + vite)
- [x] `bash scripts/run-with-mise.sh yarn test` — green, full suite (395 files / 6408 tests) + hook smoke tests
- [x] Task 6.1: witness set (mutual-contact positive/negative), bilateral reputation (target + witness + non-witness), clamping — `tests/systems/crisis-interaction-system.test.ts`
- [x] Task 6.2: third-civ kill (+15/+15, +4 witness, event once), self-kill (no reputation, no event), AI-on-AI parity (no humanity special-casing), flag-off negative — `tests/systems/crisis-hunt.test.ts`; notification fan-out — `tests/ui/notification-routing.test.ts`
- [x] Task 6.3: happy path (outbreak + catastrophe), every `canSendAid` failure reason including `already-aided`, human-target hot-seat test (both relationships move), no-op on rejected `applySendAid` (never double-deducts) — `tests/systems/crisis-interaction-system.test.ts`; button render/disabled-state/click-through/re-render — `tests/ui/diplomacy-panel.test.ts`
- [x] Task 6.4: default-flip assertions in `tests/systems/world-pressure-flags.test.ts`; re-verified Task 6.2's flag-off test still passes with the flag now explicit rather than relying on the (now-flipped) default

Depends on: MR5 (#531, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)