### PR TITLE
feat(pressure): MR7 — exploit weakness + sabotage relief

### DIFF
--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -51,6 +51,7 @@ import {
   isSpyUnitType,
   getSpyCaptureRelationshipPenalty,
 } from '@/systems/espionage-system';
+import { applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { createRng } from '@/systems/map-generator';
 import { appeaseFaction } from '@/systems/faction-system';
 import {
@@ -1003,6 +1004,11 @@ function processAITurnInternal(
             );
           }
           bus.emit('diplomacy:war-declared', { attackerId: civId, defenderId: decision.targetCiv, opponentKind: resolveOpponentKind(decision.targetCiv) });
+          // #526 MR7 Task 7.1: AI-declarer parity -- an AI that happens to declare war
+          // on a crisis-struck civ eats the same opportunistic-war reputation penalty a
+          // human would (accepted design note; teaching AI war-scoring to avoid this
+          // timing is out of scope for this arc).
+          newState = applyOpportunisticWarPenaltyIfCrisisStruck(newState, civId, decision.targetCiv, bus);
           break;
         case 'request_peace':
           newState = enqueuePeaceRequest(newState, civId, decision.targetCiv, bus);
@@ -1497,7 +1503,11 @@ export function chooseAiMission(
 ): SpyMissionType | null {
   const civ = state.civilizations[aiCivId];
   if (!civ) return null;
-  const available = getAvailableMissions(civ.techState.completed);
+  // sabotage_relief is human-initiated only in this arc (spec §Interactions: "Aid,
+  // exploit, and sabotage are human-initiated only... AI-initiated versions are a
+  // future extension") -- excluded here rather than relying on it never sorting first.
+  const available: SpyMissionType[] = getAvailableMissions(civ.techState.completed)
+    .filter(mission => mission !== 'sabotage_relief');
   if (available.length === 0) return null;
 
   const personality = getPersonality(state, civ.civType ?? 'generic');

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -1227,7 +1227,11 @@ function processAITurnInternal(
     const civEspForMission = newState.espionage?.[civId];
     if (civEspForMission) {
       const completedTechs = newState.civilizations[civId].techState.completed ?? [];
-      const infiltrationMissions = getAvailableMissions(completedTechs).filter(m => m !== 'scout_area');
+      // #526 MR7 review fix: this random-pick infiltration-mission path bypasses
+      // chooseAiMission entirely, so its own sabotage_relief exclusion (human-initiated
+      // only, per spec §Interactions) never applied here -- excluded separately.
+      const infiltrationMissions = getAvailableMissions(completedTechs)
+        .filter(m => m !== 'scout_area' && m !== 'sabotage_relief');
       if (infiltrationMissions.length > 0) {
         for (const spy of Object.values(civEspForMission.spies)) {
           if (spy.status !== 'stationed' || !spy.infiltrationCityId || spy.currentMission) continue;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -770,7 +770,9 @@ export type SpyMissionType =
   | 'cyber_attack'
   | 'misinformation_campaign'
   | 'election_interference'
-  | 'satellite_surveillance';
+  | 'satellite_surveillance'
+  // covert-operations tech (#526 MR7): human-initiated only, see chooseAiMission
+  | 'sabotage_relief';     // pause a rival's outbreak remedy for 4 turns; witnessed on discovery
 
 export interface SpyMission {
   type: SpyMissionType;
@@ -1713,6 +1715,10 @@ export interface GameEvents {
   'game:loaded': { turn: number };
   'game:over': { winnerId: string };
   'diplomacy:war-declared': { attackerId: string; defenderId: string; opponentKind: 'major' | 'minor' | 'barbarian' };
+  // #526 MR7 Task 7.1: fired alongside diplomacy:war-declared whenever the declared-upon
+  // civ has an active crisis -- applyOpportunisticWarPenaltyIfCrisisStruck already applied
+  // the reputation deltas by the time this fires.
+  'diplomacy:opportunistic-war': { actorId: string; targetCivId: string; crisisId: string };
   'diplomacy:peace-requested': { fromCivId: string; toCivId: string };
   'diplomacy:peace-made': { civA: string; civB: string };
   'era:advanced': { era: number };
@@ -1825,6 +1831,10 @@ export interface GameEvents {
   'crisis:foe-hunted-by-ally': { crisisId: string; killerCivId: string; targetCivId: string; foeName?: string };
   // #526 MR6 send_aid interaction.
   'crisis:aid-sent': { crisisId: string; actorCivId: string; targetCivId: string; goldCost: number };
+  // #526 MR7 sabotage_relief: fired only when the covert sabotage is discovered (the
+  // detection roll at mission-success time) -- an undiscovered sabotage fires nothing,
+  // per spec §Interactions "Undiscovered: no penalty."
+  'espionage:sabotage-relief-discovered': { crisisId: string; actorCivId: string; targetCivId: string };
 }
 
 // --- Crisis Events & Revolutionary Movements ---
@@ -1849,4 +1859,6 @@ export interface ActiveCrisis {
   foeName?: string;
   lastHuntKillerCivId?: string;
   aidedByCivIds?: string[]; // #526 MR6 send_aid: enforces once-per-crisis-per-actor
+  // #526 MR7 sabotage_relief: one active sabotage per crisis, across all actors.
+  sabotage?: { byCivId: string; untilTurn: number; discovered: boolean };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,6 +237,8 @@ import {
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
+  routeOpportunisticWar,
+  routeSabotageReliefDiscovered,
   type NotificationSink,
 } from '@/ui/notification-routing';
 import { createNotificationDelivery } from '@/ui/notification-delivery';
@@ -263,7 +265,7 @@ import { removeRouteForUnit, createMarketplaceState, getEffectiveGoldPerTurn, ge
 import { establishQuestAwareRoute } from '@/systems/quest-aware-trade-system';
 import { emitMinorCivQuestTransitions } from '@/systems/quest-chain-system';
 import { performMinorCivFestival, performMinorCivGift, performMinorCivReparations, setMinorCivWarState } from '@/systems/minor-civ-actions';
-import { canSendAid, applySendAid } from '@/systems/crisis-interaction-system';
+import { canSendAid, applySendAid, applyOpportunisticWarPenaltyIfCrisisStruck } from '@/systems/crisis-interaction-system';
 import { MINOR_CIV_DEFINITIONS } from '@/systems/minor-civ-definitions';
 import { openEstablishRoutePanel } from '@/ui/establish-route-panel';
 import { RoundPresentationGate } from '@/presentation/round-presentation-gate';
@@ -943,6 +945,9 @@ function toggleNotificationLog(): void {
 function handleDiplomaticAction(targetCivId: string, action: DiplomaticAction): void {
   const cp = gameState.currentPlayer;
   gameState = applyDiplomaticAction(gameState, cp, targetCivId, action, bus);
+  if (action === 'declare_war') {
+    gameState = applyOpportunisticWarPenaltyIfCrisisStruck(gameState, cp, targetCivId, bus);
+  }
   renderLoop.setGameState(gameState);
   updateHUD();
   openDiplomacyPanel();
@@ -2525,6 +2530,7 @@ function ensurePlayerWarState(targetCivId: string): void {
   currentCiv().diplomacy = declareWar(currentCiv().diplomacy, targetCivId, gameState.turn);
   targetCiv.diplomacy = declareWar(targetCiv.diplomacy, cp, gameState.turn);
   bus.emit('diplomacy:war-declared', { attackerId: cp, defenderId: targetCivId, opponentKind: resolveOpponentKind(targetCivId) });
+  gameState = applyOpportunisticWarPenaltyIfCrisisStruck(gameState, cp, targetCivId, bus);
 }
 
 function finalizePendingCityCaptureChoice(
@@ -4392,6 +4398,14 @@ bus.on('crisis:foe-hunted-by-ally', event => {
 
 bus.on('crisis:aid-sent', event => {
   routeCrisisAidSent(gameState, event, appendToCivLog);
+});
+
+bus.on('diplomacy:opportunistic-war', event => {
+  routeOpportunisticWar(gameState, event, appendToCivLog);
+});
+
+bus.on('espionage:sabotage-relief-discovered', event => {
+  routeSabotageReliefDiscovered(gameState, event, appendToCivLog);
 });
 
 bus.on('economy:treasury-strain', event => {

--- a/src/systems/crisis-interaction-definitions.ts
+++ b/src/systems/crisis-interaction-definitions.ts
@@ -1,0 +1,142 @@
+// Leaf module (#526 MR7 review fix): the definition table, witness/reputation
+// resolvers, and the opportunistic-war penalty live here rather than in
+// crisis-interaction-system.ts specifically so espionage-system.ts can import them
+// without a circular import. crisis-interaction-system.ts (send_aid's canSendAid/
+// applySendAid) needs faction-system.ts, which imports city-system.ts, which imports
+// espionage-system.ts (isSpyUnitType) -- so crisis-interaction-system.ts is NOT safe
+// for espionage-system.ts to import. This module only depends on diplomacy-system.ts,
+// discovery-system.ts, and world-pressure-flags.ts, none of which reach back to
+// city-system.ts, so it is safe for both crisis-interaction-system.ts (which re-exports
+// everything below for existing callers) and espionage-system.ts to import directly.
+import type { ActiveCrisis, CrisisArchetype, GameState } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { modifyRelationship } from './diplomacy-system';
+import { hasMetCivilization } from './discovery-system';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+
+export interface CrisisInteractionDefinition {
+  id: 'hunt_their_foe' | 'send_aid' | 'exploit_weakness' | 'sabotage_relief';
+  // send_aid's tech gate differs by crisis archetype (medicine for outbreak,
+  // trade-routes for catastrophe) -- a per-archetype map, resolved via
+  // resolveInteractionTechRequired, keeps this one row instead of two.
+  techRequired: string | null | Partial<Record<CrisisArchetype, string>>;
+  kind: 'overt' | 'covert';
+  targetReputationDelta: number;
+  witnessReputationDelta: number;
+  oncePerCrisisPerActor: boolean;
+}
+
+// One row per hook (spec §Interactions) -- the resolver consumes rows generically, so a
+// future hook is a row, not a branch (same pattern as NP_PRODUCTION_DISCOUNTS in
+// city-system.ts, per .claude/rules/game-balance.md). MR6 shipped the first two rows;
+// MR7 appends exploit_weakness and sabotage_relief.
+export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[] = [
+  { id: 'hunt_their_foe', techRequired: null, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+  { id: 'send_aid', techRequired: { outbreak: 'medicine', catastrophe: 'trade-routes' }, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+  // exploit_weakness's reputation penalty applies to ANY war declared on a crisis-struck
+  // civ regardless of the declarer's tech (see applyOpportunisticWarPenaltyIfCrisisStruck
+  // below) -- techRequired here gates only the bonus intel detail in
+  // world-pressure-presentation.ts, not the reputation consequence itself.
+  { id: 'exploit_weakness', techRequired: 'diplomatic-networks', kind: 'overt', targetReputationDelta: -15, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
+  // sabotage_relief has no per-actor once-only limit -- uniqueness is "one active
+  // sabotage per crisis, across all actors" and is enforced by checking
+  // ActiveCrisis.sabotage directly (espionage-system.ts), not this generic flag. This
+  // row is the single source of truth for the -25/-8 deltas espionage-system.ts applies
+  // on discovery -- if you change them here, they change there too (same import).
+  { id: 'sabotage_relief', techRequired: 'covert-operations', kind: 'covert', targetReputationDelta: -25, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
+];
+
+export function getCrisisInteractionDefinition(
+  id: CrisisInteractionDefinition['id'],
+): CrisisInteractionDefinition | undefined {
+  return CRISIS_INTERACTION_DEFINITIONS.find(def => def.id === id);
+}
+
+// string | null: the row's literal gate (or none). undefined: the row's gate is a
+// per-archetype map with no entry for this archetype -- i.e. never satisfiable, since
+// no tech unlocks the hook for that archetype at all (e.g. send_aid vs. a hunt crisis).
+export function resolveInteractionTechRequired(
+  def: CrisisInteractionDefinition,
+  archetype?: CrisisArchetype,
+): string | null | undefined {
+  if (def.techRequired === null || typeof def.techRequired === 'string') return def.techRequired;
+  if (!archetype) return undefined;
+  return def.techRequired[archetype];
+}
+
+export function getActiveCrisisForCiv(
+  state: GameState,
+  civId: string,
+  archetype?: CrisisArchetype,
+): ActiveCrisis | undefined {
+  return Object.values(state.activeCrises ?? {})
+    .find(crisis => crisis.targetCivId === civId && (!archetype || crisis.archetype === archetype));
+}
+
+// Witnesses: civs that have met BOTH actor and target, excluding actor/target themselves
+// (spec §Interactions -- "civs that have met both actor and target, including human civs").
+export function getWitnessCivIds(state: GameState, actorId: string, targetId: string): string[] {
+  return Object.keys(state.civilizations)
+    .filter(civId => civId !== actorId && civId !== targetId)
+    .filter(civId => hasMetCivilization(state, civId, actorId) && hasMetCivilization(state, civId, targetId))
+    .sort();
+}
+
+function applyBilateralRelationshipDelta(
+  state: GameState,
+  civAId: string,
+  civBId: string,
+  delta: number,
+): GameState {
+  const civA = state.civilizations[civAId];
+  const civB = state.civilizations[civBId];
+  if (!civA || !civB) return state;
+  return {
+    ...state,
+    civilizations: {
+      ...state.civilizations,
+      [civAId]: { ...civA, diplomacy: modifyRelationship(civA.diplomacy, civBId, delta) },
+      [civBId]: { ...civB, diplomacy: modifyRelationship(civB.diplomacy, civAId, delta) },
+    },
+  };
+}
+
+// Bilateral actor<->target delta, then bilateral actor<->witness delta for every witness.
+// No special-casing by either party's humanity -- hot-seat co-op and AI-on-AI interactions
+// go through the exact same path.
+export function applyInteractionReputation(
+  state: GameState,
+  actorId: string,
+  targetId: string,
+  def: CrisisInteractionDefinition,
+): GameState {
+  const witnessIds = getWitnessCivIds(state, actorId, targetId);
+  let next = applyBilateralRelationshipDelta(state, actorId, targetId, def.targetReputationDelta);
+  for (const witnessId of witnessIds) {
+    next = applyBilateralRelationshipDelta(next, actorId, witnessId, def.witnessReputationDelta);
+  }
+  return next;
+}
+
+// Exploit weakness (#526 MR7 Task 7.1): declaring war on a civ with ANY active crisis is
+// marked opportunistic, regardless of the declarer's own tech level -- diplomatic-networks
+// only gates the bonus intel detail (world-pressure-presentation.ts), not this consequence.
+// Actor-complete: called from every real war-declaration path (main.ts's diplomacy-panel
+// handler and ensurePlayerWarState, basic-ai.ts's AI decision loop) rather than being
+// threaded through declareWar itself, which would create a diplomacy-system.ts <->
+// crisis-interaction-system.ts import cycle (diplomacy-system.ts is already imported BY
+// this module for modifyRelationship).
+export function applyOpportunisticWarPenaltyIfCrisisStruck(
+  state: GameState,
+  actorId: string,
+  targetCivId: string,
+  bus: EventBus,
+): GameState {
+  if (resolveWorldPressureFlags(state.settings).aiCrisisInteractions !== 'full') return state;
+  const crisis = getActiveCrisisForCiv(state, targetCivId);
+  if (!crisis) return state;
+
+  const next = applyInteractionReputation(state, actorId, targetCivId, getCrisisInteractionDefinition('exploit_weakness')!);
+  bus.emit('diplomacy:opportunistic-war', { actorId, targetCivId, crisisId: crisis.id });
+  return next;
+}

--- a/src/systems/crisis-interaction-system.ts
+++ b/src/systems/crisis-interaction-system.ts
@@ -19,11 +19,20 @@ export interface CrisisInteractionDefinition {
 
 // One row per hook (spec §Interactions) -- the resolver consumes rows generically, so a
 // future hook is a row, not a branch (same pattern as NP_PRODUCTION_DISCOUNTS in
-// city-system.ts, per .claude/rules/game-balance.md). MR6 ships the first two rows;
+// city-system.ts, per .claude/rules/game-balance.md). MR6 shipped the first two rows;
 // MR7 appends exploit_weakness and sabotage_relief.
 export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[] = [
   { id: 'hunt_their_foe', techRequired: null, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
   { id: 'send_aid', techRequired: { outbreak: 'medicine', catastrophe: 'trade-routes' }, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
+  // exploit_weakness's reputation penalty applies to ANY war declared on a crisis-struck
+  // civ regardless of the declarer's tech (see applyOpportunisticWarPenaltyIfCrisisStruck
+  // below) -- techRequired here gates only the bonus intel detail in
+  // world-pressure-presentation.ts, not the reputation consequence itself.
+  { id: 'exploit_weakness', techRequired: 'diplomatic-networks', kind: 'overt', targetReputationDelta: -15, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
+  // sabotage_relief has no per-actor once-only limit -- uniqueness is "one active
+  // sabotage per crisis, across all actors" and is enforced by checking
+  // ActiveCrisis.sabotage directly (espionage-system.ts), not this generic flag.
+  { id: 'sabotage_relief', techRequired: 'covert-operations', kind: 'covert', targetReputationDelta: -25, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
 ];
 
 export function getCrisisInteractionDefinition(
@@ -42,6 +51,18 @@ export function resolveInteractionTechRequired(
   if (def.techRequired === null || typeof def.techRequired === 'string') return def.techRequired;
   if (!archetype) return undefined;
   return def.techRequired[archetype];
+}
+
+// Local (not imported from crisis-system.ts) to avoid a two-file import cycle --
+// crisis-system.ts already imports applyInteractionReputation/getCrisisInteractionDefinition
+// FROM this module, so this module must not import anything back from crisis-system.ts.
+export function getActiveCrisisForCiv(
+  state: GameState,
+  civId: string,
+  archetype?: CrisisArchetype,
+): ActiveCrisis | undefined {
+  return Object.values(state.activeCrises ?? {})
+    .find(crisis => crisis.targetCivId === civId && (!archetype || crisis.archetype === archetype));
 }
 
 // Witnesses: civs that have met BOTH actor and target, excluding actor/target themselves
@@ -86,6 +107,29 @@ export function applyInteractionReputation(
   for (const witnessId of witnessIds) {
     next = applyBilateralRelationshipDelta(next, actorId, witnessId, def.witnessReputationDelta);
   }
+  return next;
+}
+
+// Exploit weakness (#526 MR7 Task 7.1): declaring war on a civ with ANY active crisis is
+// marked opportunistic, regardless of the declarer's own tech level -- diplomatic-networks
+// only gates the bonus intel detail (world-pressure-presentation.ts), not this consequence.
+// Actor-complete: called from every real war-declaration path (main.ts's diplomacy-panel
+// handler and ensurePlayerWarState, basic-ai.ts's AI decision loop) rather than being
+// threaded through declareWar itself, which would create a diplomacy-system.ts <->
+// crisis-interaction-system.ts import cycle (diplomacy-system.ts is already imported BY
+// this module for modifyRelationship).
+export function applyOpportunisticWarPenaltyIfCrisisStruck(
+  state: GameState,
+  actorId: string,
+  targetCivId: string,
+  bus: EventBus,
+): GameState {
+  if (resolveWorldPressureFlags(state.settings).aiCrisisInteractions !== 'full') return state;
+  const crisis = getActiveCrisisForCiv(state, targetCivId);
+  if (!crisis) return state;
+
+  const next = applyInteractionReputation(state, actorId, targetCivId, getCrisisInteractionDefinition('exploit_weakness')!);
+  bus.emit('diplomacy:opportunistic-war', { actorId, targetCivId, crisisId: crisis.id });
   return next;
 }
 

--- a/src/systems/crisis-interaction-system.ts
+++ b/src/systems/crisis-interaction-system.ts
@@ -1,137 +1,29 @@
-import type { ActiveCrisis, City, CrisisArchetype, GameState } from '@/core/types';
+import type { ActiveCrisis, City, GameState } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
-import { modifyRelationship } from './diplomacy-system';
-import { hasMetCivilization } from './discovery-system';
-import { resolveWorldPressureFlags } from './world-pressure-flags';
 import { getCityAppeaseCost } from './faction-system';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+import {
+  getCrisisInteractionDefinition,
+  resolveInteractionTechRequired,
+  applyInteractionReputation,
+} from './crisis-interaction-definitions';
 
-export interface CrisisInteractionDefinition {
-  id: 'hunt_their_foe' | 'send_aid' | 'exploit_weakness' | 'sabotage_relief';
-  // send_aid's tech gate differs by crisis archetype (medicine for outbreak,
-  // trade-routes for catastrophe) -- a per-archetype map, resolved via
-  // resolveInteractionTechRequired, keeps this one row instead of two.
-  techRequired: string | null | Partial<Record<CrisisArchetype, string>>;
-  kind: 'overt' | 'covert';
-  targetReputationDelta: number;
-  witnessReputationDelta: number;
-  oncePerCrisisPerActor: boolean;
-}
-
-// One row per hook (spec §Interactions) -- the resolver consumes rows generically, so a
-// future hook is a row, not a branch (same pattern as NP_PRODUCTION_DISCOUNTS in
-// city-system.ts, per .claude/rules/game-balance.md). MR6 shipped the first two rows;
-// MR7 appends exploit_weakness and sabotage_relief.
-export const CRISIS_INTERACTION_DEFINITIONS: CrisisInteractionDefinition[] = [
-  { id: 'hunt_their_foe', techRequired: null, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
-  { id: 'send_aid', techRequired: { outbreak: 'medicine', catastrophe: 'trade-routes' }, kind: 'overt', targetReputationDelta: 15, witnessReputationDelta: 4, oncePerCrisisPerActor: true },
-  // exploit_weakness's reputation penalty applies to ANY war declared on a crisis-struck
-  // civ regardless of the declarer's tech (see applyOpportunisticWarPenaltyIfCrisisStruck
-  // below) -- techRequired here gates only the bonus intel detail in
-  // world-pressure-presentation.ts, not the reputation consequence itself.
-  { id: 'exploit_weakness', techRequired: 'diplomatic-networks', kind: 'overt', targetReputationDelta: -15, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
-  // sabotage_relief has no per-actor once-only limit -- uniqueness is "one active
-  // sabotage per crisis, across all actors" and is enforced by checking
-  // ActiveCrisis.sabotage directly (espionage-system.ts), not this generic flag.
-  { id: 'sabotage_relief', techRequired: 'covert-operations', kind: 'covert', targetReputationDelta: -25, witnessReputationDelta: -8, oncePerCrisisPerActor: false },
-];
-
-export function getCrisisInteractionDefinition(
-  id: CrisisInteractionDefinition['id'],
-): CrisisInteractionDefinition | undefined {
-  return CRISIS_INTERACTION_DEFINITIONS.find(def => def.id === id);
-}
-
-// string | null: the row's literal gate (or none). undefined: the row's gate is a
-// per-archetype map with no entry for this archetype -- i.e. never satisfiable, since
-// no tech unlocks the hook for that archetype at all (e.g. send_aid vs. a hunt crisis).
-export function resolveInteractionTechRequired(
-  def: CrisisInteractionDefinition,
-  archetype?: CrisisArchetype,
-): string | null | undefined {
-  if (def.techRequired === null || typeof def.techRequired === 'string') return def.techRequired;
-  if (!archetype) return undefined;
-  return def.techRequired[archetype];
-}
-
-// Local (not imported from crisis-system.ts) to avoid a two-file import cycle --
-// crisis-system.ts already imports applyInteractionReputation/getCrisisInteractionDefinition
-// FROM this module, so this module must not import anything back from crisis-system.ts.
-export function getActiveCrisisForCiv(
-  state: GameState,
-  civId: string,
-  archetype?: CrisisArchetype,
-): ActiveCrisis | undefined {
-  return Object.values(state.activeCrises ?? {})
-    .find(crisis => crisis.targetCivId === civId && (!archetype || crisis.archetype === archetype));
-}
-
-// Witnesses: civs that have met BOTH actor and target, excluding actor/target themselves
-// (spec §Interactions -- "civs that have met both actor and target, including human civs").
-export function getWitnessCivIds(state: GameState, actorId: string, targetId: string): string[] {
-  return Object.keys(state.civilizations)
-    .filter(civId => civId !== actorId && civId !== targetId)
-    .filter(civId => hasMetCivilization(state, civId, actorId) && hasMetCivilization(state, civId, targetId))
-    .sort();
-}
-
-function applyBilateralRelationshipDelta(
-  state: GameState,
-  civAId: string,
-  civBId: string,
-  delta: number,
-): GameState {
-  const civA = state.civilizations[civAId];
-  const civB = state.civilizations[civBId];
-  if (!civA || !civB) return state;
-  return {
-    ...state,
-    civilizations: {
-      ...state.civilizations,
-      [civAId]: { ...civA, diplomacy: modifyRelationship(civA.diplomacy, civBId, delta) },
-      [civBId]: { ...civB, diplomacy: modifyRelationship(civB.diplomacy, civAId, delta) },
-    },
-  };
-}
-
-// Bilateral actor<->target delta, then bilateral actor<->witness delta for every witness.
-// No special-casing by either party's humanity -- hot-seat co-op and AI-on-AI interactions
-// go through the exact same path.
-export function applyInteractionReputation(
-  state: GameState,
-  actorId: string,
-  targetId: string,
-  def: CrisisInteractionDefinition,
-): GameState {
-  const witnessIds = getWitnessCivIds(state, actorId, targetId);
-  let next = applyBilateralRelationshipDelta(state, actorId, targetId, def.targetReputationDelta);
-  for (const witnessId of witnessIds) {
-    next = applyBilateralRelationshipDelta(next, actorId, witnessId, def.witnessReputationDelta);
-  }
-  return next;
-}
-
-// Exploit weakness (#526 MR7 Task 7.1): declaring war on a civ with ANY active crisis is
-// marked opportunistic, regardless of the declarer's own tech level -- diplomatic-networks
-// only gates the bonus intel detail (world-pressure-presentation.ts), not this consequence.
-// Actor-complete: called from every real war-declaration path (main.ts's diplomacy-panel
-// handler and ensurePlayerWarState, basic-ai.ts's AI decision loop) rather than being
-// threaded through declareWar itself, which would create a diplomacy-system.ts <->
-// crisis-interaction-system.ts import cycle (diplomacy-system.ts is already imported BY
-// this module for modifyRelationship).
-export function applyOpportunisticWarPenaltyIfCrisisStruck(
-  state: GameState,
-  actorId: string,
-  targetCivId: string,
-  bus: EventBus,
-): GameState {
-  if (resolveWorldPressureFlags(state.settings).aiCrisisInteractions !== 'full') return state;
-  const crisis = getActiveCrisisForCiv(state, targetCivId);
-  if (!crisis) return state;
-
-  const next = applyInteractionReputation(state, actorId, targetCivId, getCrisisInteractionDefinition('exploit_weakness')!);
-  bus.emit('diplomacy:opportunistic-war', { actorId, targetCivId, crisisId: crisis.id });
-  return next;
-}
+// Re-exported for existing callers (main.ts, crisis-system.ts, tests) -- the actual
+// definitions live in crisis-interaction-definitions.ts, a leaf module with no
+// faction-system.ts/city-system.ts dependency, so espionage-system.ts can import them
+// directly without the circular import this file's own faction-system.ts dependency
+// (below, for send_aid's gold cost) would otherwise create. See that file's header
+// comment for the full cycle.
+export type { CrisisInteractionDefinition } from './crisis-interaction-definitions';
+export {
+  CRISIS_INTERACTION_DEFINITIONS,
+  getCrisisInteractionDefinition,
+  resolveInteractionTechRequired,
+  getActiveCrisisForCiv,
+  getWitnessCivIds,
+  applyInteractionReputation,
+  applyOpportunisticWarPenaltyIfCrisisStruck,
+} from './crisis-interaction-definitions';
 
 // The city a send-aid payment is priced/applied against: the most populous city among
 // the crisis's own cityIds (works for both outbreak, where cityIds are the infected

--- a/src/systems/crisis-system.ts
+++ b/src/systems/crisis-system.ts
@@ -174,8 +174,15 @@ function tickOutbreakCrisis(
   let nextState = state;
   const severity = flavor.severityByChallenge[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
 
+  // #526 MR7 sabotage_relief: an unexpired sabotage pauses remedy completions entirely
+  // (spread below is unaffected); clear it once its window passes so remedy resumes.
+  if (working.sabotage && working.sabotage.untilTurn <= state.turn) {
+    working = { ...working, sabotage: undefined };
+  }
+  const remedyPaused = working.sabotage !== undefined && working.sabotage.untilTurn > state.turn;
+
   // Remedy completion
-  if (working.remedyCompletionByCity) {
+  if (working.remedyCompletionByCity && !remedyPaused) {
     const remaining: Record<string, number> = {};
     let cityIds = working.cityIds;
     let quarantinedCityIds = working.quarantinedCityIds;

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -21,7 +21,11 @@ import {
   ESPIONAGE_SUCCESS_CHANCE_MIN,
 } from './espionage-modifier-definitions';
 import { resolveWorldPressureFlags } from './world-pressure-flags';
-import { hasMetCivilization } from './discovery-system';
+import {
+  getActiveCrisisForCiv,
+  getCrisisInteractionDefinition,
+  applyInteractionReputation,
+} from './crisis-interaction-definitions'; // leaf module -- see its header comment for why not crisis-interaction-system.ts
 
 const SPY_NAMES = [
   'Shadow', 'Whisper', 'Ghost', 'Cipher', 'Raven',
@@ -741,15 +745,9 @@ export function resolveMissionResult(
     // no sabotage already in place ("one active sabotage per crisis, across all
     // actors") -- catastrophe crises have no remedy timer to pause. Flag-gated the same
     // way canSendAid gates send_aid: 'off'/'benign' keep this hook dark.
-    // Crisis lookup is inlined (not imported from crisis-interaction-system.ts) -- that
-    // module imports faction-system.ts, which imports city-system.ts, which imports
-    // isSpyUnitType FROM this file; importing crisis-interaction-system.ts here would
-    // close that loop into a genuine ESM circular-import (verified: it breaks
-    // city-territory-system.ts's top-level `Object.values(BUILDINGS)`).
     case 'sabotage_relief': {
       if (resolveWorldPressureFlags(gameState.settings).aiCrisisInteractions !== 'full') return {};
-      const crisis = Object.values(gameState.activeCrises ?? {})
-        .find(c => c.targetCivId === targetCivId && c.archetype === 'outbreak');
+      const crisis = getActiveCrisisForCiv(gameState, targetCivId, 'outbreak');
       if (!crisis || crisis.sabotage) return {};
       return { sabotageCrisisId: crisis.id };
     }
@@ -1341,20 +1339,9 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
                 },
               };
               if (discovered) {
-                // Bilateral actor<->target (-25) and actor<->witness (-8) deltas --
-                // mirrors crisis-interaction-system.ts's sabotage_relief row (-25/-8)
-                // and applyInteractionReputation's witness rule (met BOTH parties),
-                // inlined rather than imported to avoid the circular-import noted above.
-                if (state.civilizations[civId] && state.civilizations[targetCivId]) {
-                  state.civilizations[civId].diplomacy = modifyRelationship(state.civilizations[civId].diplomacy, targetCivId, -25);
-                  state.civilizations[targetCivId].diplomacy = modifyRelationship(state.civilizations[targetCivId].diplomacy, civId, -25);
-                }
-                for (const witnessId of Object.keys(state.civilizations)) {
-                  if (witnessId === civId || witnessId === targetCivId) continue;
-                  if (!hasMetCivilization(state, witnessId, civId) || !hasMetCivilization(state, witnessId, targetCivId)) continue;
-                  state.civilizations[civId].diplomacy = modifyRelationship(state.civilizations[civId].diplomacy, witnessId, -8);
-                  state.civilizations[witnessId].diplomacy = modifyRelationship(state.civilizations[witnessId].diplomacy, civId, -8);
-                }
+                state = applyInteractionReputation(
+                  state, civId, targetCivId, getCrisisInteractionDefinition('sabotage_relief')!,
+                );
                 bus.emit('espionage:sabotage-relief-discovered', { crisisId, actorCivId: civId, targetCivId });
               }
             }

--- a/src/systems/espionage-system.ts
+++ b/src/systems/espionage-system.ts
@@ -20,6 +20,8 @@ import {
   ESPIONAGE_SUCCESS_CHANCE_MAX,
   ESPIONAGE_SUCCESS_CHANCE_MIN,
 } from './espionage-modifier-definitions';
+import { resolveWorldPressureFlags } from './world-pressure-flags';
+import { hasMetCivilization } from './discovery-system';
 
 const SPY_NAMES = [
   'Shadow', 'Whisper', 'Ghost', 'Cipher', 'Raven',
@@ -48,6 +50,7 @@ const MISSION_BASE_SUCCESS = {
   misinformation_campaign: 0.55,
   election_interference: 0.40,
   satellite_surveillance: 0.70,
+  sabotage_relief: 0.60, // #526 MR7: reuses sabotage_production's detection parameters
 } as Record<SpyMissionType, number>;
 
 const MISSION_DURATIONS = {
@@ -67,6 +70,7 @@ const MISSION_DURATIONS = {
   misinformation_campaign: 3,
   election_interference: 5,
   satellite_surveillance: 1,
+  sabotage_relief: 4, // #526 MR7: reuses sabotage_production's duration
 } as Record<SpyMissionType, number>;
 
 // --- State creation ---
@@ -346,6 +350,10 @@ const STAGE_4_TECHS = ['cryptography', 'counter-intelligence']; // either unlock
 const STAGE_5_TECHS = ['cold-war-networks'];       // era 10 — Cold War propaganda/subversion
 const STAGE_6_TECHS = ['satellite-surveillance'];   // era 11 — spy satellites
 const STAGE_7_TECHS = ['cyber-intelligence'];        // era 12 — cyber operative attacks
+// #526 MR7: covert-operations (era 7) gates sabotage_relief -- its own bucket rather
+// than folded into STAGE_4_TECHS, since covert-operations isn't one of that stage's
+// gating techs (cryptography/counter-intelligence) and gates only this one mission.
+const SABOTAGE_RELIEF_TECHS = ['covert-operations'];
 
 const STAGE_1_MISSIONS: SpyMissionType[] = ['scout_area', 'monitor_troops'];
 const STAGE_2_MISSIONS: SpyMissionType[] = ['gather_intel', 'identify_resources', 'monitor_diplomacy'];
@@ -354,6 +362,7 @@ const STAGE_4_MISSIONS: SpyMissionType[] = ['assassinate_advisor', 'forge_docume
 const STAGE_5_MISSIONS: SpyMissionType[] = ['misinformation_campaign', 'election_interference'];
 const STAGE_6_MISSIONS: SpyMissionType[] = ['satellite_surveillance'];
 const STAGE_7_MISSIONS: SpyMissionType[] = ['cyber_attack'];
+const SABOTAGE_RELIEF_MISSIONS: SpyMissionType[] = ['sabotage_relief'];
 
 export function getAvailableMissions(completedTechs: string[]): SpyMissionType[] {
   const missions: SpyMissionType[] = [];
@@ -364,6 +373,7 @@ export function getAvailableMissions(completedTechs: string[]): SpyMissionType[]
   if (STAGE_5_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_5_MISSIONS);
   if (STAGE_6_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_6_MISSIONS);
   if (STAGE_7_TECHS.some(t => completedTechs.includes(t))) missions.push(...STAGE_7_MISSIONS);
+  if (SABOTAGE_RELIEF_TECHS.some(t => completedTechs.includes(t))) missions.push(...SABOTAGE_RELIEF_MISSIONS);
   return missions;
 }
 
@@ -435,7 +445,7 @@ const PROMOTION_XP_THRESHOLD = 60;
 
 // Mission categories for auto-promotion
 const INFILTRATOR_MISSIONS = new Set<SpyMissionType>([
-  'steal_tech', 'sabotage_production', 'assassinate_advisor', 'arms_smuggling',
+  'steal_tech', 'sabotage_production', 'assassinate_advisor', 'arms_smuggling', 'sabotage_relief',
 ]);
 const HANDLER_MISSIONS = new Set<SpyMissionType>([
   'incite_unrest', 'forge_documents', 'fund_rebels', 'monitor_diplomacy',
@@ -459,6 +469,7 @@ const XP_PER_MISSION = {
   misinformation_campaign: 14,
   election_interference: 16,
   satellite_surveillance: 8,
+  sabotage_relief: 12, // #526 MR7: matches sabotage_production's xp
 } as Record<SpyMissionType, number>;
 
 const EXPULSION_COOLDOWN = 5;
@@ -618,6 +629,9 @@ export interface MissionResult {
   researchPenaltyTurns?: number;
   researchPenaltyMultiplier?: number;
   grantTerritoryVision?: boolean;
+  // sabotage_relief (#526 MR7): the outbreak crisis to pause, if the target civ has one
+  // eligible (active, no existing sabotage already in place).
+  sabotageCrisisId?: string;
 }
 
 const SCOUT_VISION_RADIUS = 3;
@@ -721,6 +735,23 @@ export function resolveMissionResult(
       const lostTurns = 3 + Math.floor(rng() * 3); // 3-5 turns
       const lostProgress = lostTurns * 5; // ~5 production/turn
       return { productionLost: lostProgress };
+    }
+
+    // sabotage_relief (#526 MR7): only eligible against an active OUTBREAK crisis with
+    // no sabotage already in place ("one active sabotage per crisis, across all
+    // actors") -- catastrophe crises have no remedy timer to pause. Flag-gated the same
+    // way canSendAid gates send_aid: 'off'/'benign' keep this hook dark.
+    // Crisis lookup is inlined (not imported from crisis-interaction-system.ts) -- that
+    // module imports faction-system.ts, which imports city-system.ts, which imports
+    // isSpyUnitType FROM this file; importing crisis-interaction-system.ts here would
+    // close that loop into a genuine ESM circular-import (verified: it breaks
+    // city-territory-system.ts's top-level `Object.values(BUILDINGS)`).
+    case 'sabotage_relief': {
+      if (resolveWorldPressureFlags(gameState.settings).aiCrisisInteractions !== 'full') return {};
+      const crisis = Object.values(gameState.activeCrises ?? {})
+        .find(c => c.targetCivId === targetCivId && c.archetype === 'outbreak');
+      if (!crisis || crisis.sabotage) return {};
+      return { sabotageCrisisId: crisis.id };
     }
 
     case 'incite_unrest': {
@@ -1283,6 +1314,48 @@ export function processEspionageTurn(state: GameState, bus: EventBus): GameState
                   cities: { ...state.cities, [spyTarget.targetCityId]: { ...tc, productionProgress } },
                   ...(updatedProjects ? { legendaryWonderProjects: updatedProjects } : {}),
                 };
+              }
+            }
+          }
+
+          // sabotage_relief (#526 MR7): places the sabotage on the target civ's outbreak
+          // crisis, then rolls ONE detection check reusing the same 0.3 baseline capture
+          // threshold every mission's fail-path detection uses (no new stealth
+          // subsystem, per spec §Interactions). Discovery applies reputation
+          // immediately and emits the discovery event; undiscovered stays silent
+          // ("Undiscovered: no penalty").
+          if (evt.missionType === 'sabotage_relief' && result.sabotageCrisisId) {
+            const originalSpy = civEspBefore.spies[evt.spyId];
+            const crisisId = result.sabotageCrisisId as string;
+            const crisis = state.activeCrises?.[crisisId];
+            const targetCivId = originalSpy?.targetCivId;
+            if (crisis && !crisis.sabotage && targetCivId) {
+              const untilTurn = state.turn + 4;
+              const detectRng = createRng(`sab-relief-detect-${evt.spyId}-${crisisId}-${state.turn}`);
+              const discovered = detectRng() < 0.3;
+              state = {
+                ...state,
+                activeCrises: {
+                  ...state.activeCrises,
+                  [crisisId]: { ...crisis, sabotage: { byCivId: civId, untilTurn, discovered } },
+                },
+              };
+              if (discovered) {
+                // Bilateral actor<->target (-25) and actor<->witness (-8) deltas --
+                // mirrors crisis-interaction-system.ts's sabotage_relief row (-25/-8)
+                // and applyInteractionReputation's witness rule (met BOTH parties),
+                // inlined rather than imported to avoid the circular-import noted above.
+                if (state.civilizations[civId] && state.civilizations[targetCivId]) {
+                  state.civilizations[civId].diplomacy = modifyRelationship(state.civilizations[civId].diplomacy, targetCivId, -25);
+                  state.civilizations[targetCivId].diplomacy = modifyRelationship(state.civilizations[targetCivId].diplomacy, civId, -25);
+                }
+                for (const witnessId of Object.keys(state.civilizations)) {
+                  if (witnessId === civId || witnessId === targetCivId) continue;
+                  if (!hasMetCivilization(state, witnessId, civId) || !hasMetCivilization(state, witnessId, targetCivId)) continue;
+                  state.civilizations[civId].diplomacy = modifyRelationship(state.civilizations[civId].diplomacy, witnessId, -8);
+                  state.civilizations[witnessId].diplomacy = modifyRelationship(state.civilizations[witnessId].diplomacy, civId, -8);
+                }
+                bus.emit('espionage:sabotage-relief-discovered', { crisisId, actorCivId: civId, targetCivId });
               }
             }
           }

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -129,7 +129,7 @@ const ERA_5_TECHS: Tech[] = [
     unlocks: ['+1 spy slot empire-wide'], era: 5 },
   { id: 'diplomatic-networks', name: 'Diplomatic Networks', track: 'espionage', cost: 100,
     prerequisites: ['counter-intelligence'],
-    unlocks: ['Spy missions in foreign capitals have +20% success rate'], era: 5 },
+    unlocks: ['Spy missions in foreign capitals have +20% success rate', 'Reveal detailed crisis intelligence on civilizations you have met'], era: 5 },
 
   // SPIRITUALITY (2)
   { id: 'reformation', name: 'Reformation', track: 'spirituality', cost: 100,
@@ -388,7 +388,7 @@ const ERA_7_TECHS: Tech[] = [
   // ESPIONAGE (2)
   { id: 'covert-operations', name: 'Covert Operations', track: 'espionage', cost: 145,
     prerequisites: ['counter-espionage', 'propaganda'],
-    unlocks: ['+2 spy slots empire-wide; covert missions have +15% success rate'], era: 7 },
+    unlocks: ['+2 spy slots empire-wide; covert missions have +15% success rate', "Spy mission: sabotage a rival's crisis relief"], era: 7 },
   { id: 'secret-police', name: 'Secret Police', track: 'espionage', cost: 210,
     prerequisites: ['counter-espionage', 'separation-of-powers'],
     unlocks: ['Enemy spy missions in your cities have -30% success rate; spy detection bonus'], era: 7 },

--- a/src/systems/world-pressure-flags.ts
+++ b/src/systems/world-pressure-flags.ts
@@ -11,13 +11,13 @@ export interface WorldPressureFlags {
 
 // Stage defaults: flipped by the final MR of each stage. aiPressure flipped to
 // 'pirates' in #528 (MR2), then 'full' in #529 (MR3); aiPressureVisibility flipped to
-// true in #531 (MR5); aiCrisisInteractions flipped to 'benign' in #532 (MR6) -- this is
-// the rollout mechanism: existing saves have no aiCrisisInteractions field, so they pick
-// up hunt-their-foe/send-aid on load. MR 7 flips interactions to 'full'.
+// true in #531 (MR5); aiCrisisInteractions flipped to 'benign' in #532 (MR6), then
+// 'full' in #533 (MR7) -- this is the rollout mechanism: existing saves have no
+// aiCrisisInteractions field, so they pick up exploit-weakness/sabotage-relief on load.
 export function resolveWorldPressureFlags(settings: GameSettings | undefined): WorldPressureFlags {
   return {
     aiPressure: settings?.aiPressure ?? 'full',
     aiPressureVisibility: settings?.aiPressureVisibility ?? true,
-    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'benign',
+    aiCrisisInteractions: settings?.aiCrisisInteractions ?? 'full',
   };
 }

--- a/src/systems/world-pressure-presentation.ts
+++ b/src/systems/world-pressure-presentation.ts
@@ -1,7 +1,8 @@
-import type { GameState, HexCoord, CrisisArchetype } from '@/core/types';
+import type { ActiveCrisis, GameState, HexCoord, CrisisArchetype } from '@/core/types';
 import { getVisibility } from './fog-of-war';
 import { getCrisisFlavor, getCrisisDisplayName } from './crisis-flavor-definitions';
 import { resolveWorldPressureFlags } from './world-pressure-flags';
+import { resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 
 export interface WorldPressureCityBadge {
   cityId: string;
@@ -14,6 +15,11 @@ export interface WorldPressureStatusLine {
   crisisId: string;
   archetype: CrisisArchetype;
   text: string; // e.g. "Suffering: Red Tide outbreak — 3 cities, 4 turns"
+  // #526 MR7 exploit_weakness: severity + infected-city-name intel, present only when
+  // the viewer has completed diplomatic-networks (spec §Interactions "Full crisis
+  // intel on known civs"). Base text above is always visible once aiPressureVisibility
+  // is on -- this is the additional gated detail.
+  detail?: string;
 }
 
 export interface WorldPressurePresentation {
@@ -22,6 +28,22 @@ export interface WorldPressurePresentation {
 }
 
 const EMPTY_PRESENTATION: WorldPressurePresentation = { cityBadges: [], statusLinesByCivId: {} };
+
+const SEVERITY_LABEL: Record<'explorer' | 'standard' | 'veteran', string> = {
+  explorer: 'Mild', standard: 'Standard', veteran: 'Severe',
+};
+
+// #526 MR7 exploit_weakness: severity tier (as experienced by the target civ) + the
+// actual infected/devastated city names -- both are new information beyond the always-
+// visible base status line, which only shows a bare city COUNT.
+function buildExploitWeaknessDetail(state: GameState, crisis: ActiveCrisis): string {
+  const severity = SEVERITY_LABEL[resolvePressureSeverityForCiv(state, crisis.targetCivId)];
+  const cityNames = crisis.cityIds
+    .map(id => state.cities[id]?.name)
+    .filter((name): name is string => Boolean(name));
+  const cityList = cityNames.length > 0 ? cityNames.join(', ') : 'unknown cities';
+  return `${severity}-level crisis. Affected cities: ${cityList}.`;
+}
 
 // Single viewer-safe read path for all AI-pressure UI (spec §Visibility). Every
 // panel/renderer surface must go through this — never read state.activeCrises directly.
@@ -56,6 +78,9 @@ export function getWorldPressurePresentationForViewer(
       crisisId: crisis.id,
       archetype: crisis.archetype,
       text: `Suffering: ${displayName} — ${cityCount} ${cityCount === 1 ? 'city' : 'cities'}, ${turns} ${turns === 1 ? 'turn' : 'turns'}`,
+      ...(viewer.techState?.completed.includes('diplomatic-networks')
+        ? { detail: buildExploitWeaknessDetail(state, crisis) }
+        : {}),
     };
 
     if (!viewer.visibility) continue;

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -320,6 +320,17 @@ export function createCityPanel(
     const isQuarantined = crisis.quarantinedCityIds?.includes(city.id) ?? false;
     const remedyCompletionTurn = crisis.remedyCompletionByCity?.[city.id];
     const remedyPending = remedyCompletionTurn !== undefined;
+    // #526 MR7 sabotage_relief: while an unexpired sabotage holds this crisis, the
+    // scheduler (crisis-system.ts) freezes remedyCompletionByCity rather than clearing
+    // it -- the affected player still deserves an honest status line instead of a
+    // "cured in 0 turns" countdown that never resolves. Undiscovered sabotage names no
+    // one (matching "undiscovered: no penalty/notification" -- the saboteur stays
+    // anonymous); once discovered, the target already knows via the reputation hit and
+    // witnessed notification, so naming them here is consistent, not a new leak.
+    const sabotaged = crisis.sabotage !== undefined && crisis.sabotage.untilTurn > state.turn;
+    const sabotageDiscoveredBy = sabotaged && crisis.sabotage!.discovered
+      ? state.civilizations[crisis.sabotage!.byCivId]?.name ?? null
+      : null;
     const remedyCost = getCityAppeaseCost(city);
     const canAffordRemedy = (civ?.gold ?? 0) >= remedyCost;
     const yieldPenaltyPct = Math.round(severity.yieldPenalty * 100);
@@ -335,7 +346,7 @@ export function createCityPanel(
         : `Remedy (${remedyCost} gold)`;
 
     return {
-      crisis, flavor, isQuarantined, remedyPending, remedyCompletionTurn,
+      crisis, flavor, isQuarantined, remedyPending, remedyCompletionTurn, sabotaged, sabotageDiscoveredBy,
       yieldPenaltyPct, quarantinedPenaltyPct,
       quarantineDisabled, quarantineLabel, remedyDisabled, remedyLabel,
     };
@@ -817,7 +828,11 @@ export function createCityPanel(
 
   crisisChips.forEach((chip, idx) => {
     const displayName = getCrisisDisplayName(chip.flavor, state.era);
-    const stageText = chip.remedyPending
+    const stageText = chip.sabotaged
+      ? chip.sabotageDiscoveredBy
+        ? `Remedy underway — ${chip.sabotageDiscoveredBy}'s spies were caught disrupting relief!`
+        : 'Remedy underway — relief efforts have been mysteriously disrupted'
+      : chip.remedyPending
       ? `Remedy underway — cured in ${Math.max(0, chip.remedyCompletionTurn! - state.turn)} turn${Math.max(0, chip.remedyCompletionTurn! - state.turn) === 1 ? '' : 's'}`
       : chip.isQuarantined
         ? `Quarantined — spread stopped, −${chip.quarantinedPenaltyPct}% yields`

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -84,6 +84,9 @@ interface CivRowData {
   atWar: boolean;
   warSinceText: string | null;
   worldPressureStatusText: string | null;
+  // #526 MR7 Task 7.1: exploit_weakness intel (severity + infected cities), gated on
+  // the viewer's own diplomatic-networks -- see world-pressure-presentation.ts.
+  worldPressureDetailText: string | null;
   sendAidCrisisId: string | null;
   sendAidLabel: string | null;
   sendAidHelpText: string | null;
@@ -259,6 +262,7 @@ export function createDiplomacyPanel(
       atWar,
       warSinceText,
       worldPressureStatusText: worldPressureLine?.text ?? null,
+      worldPressureDetailText: worldPressureLine?.detail ?? null,
       sendAidCrisisId,
       sendAidLabel,
       sendAidHelpText,
@@ -379,6 +383,12 @@ export function createDiplomacyPanel(
       ? `<div style="font-size:11px;color:#e88;margin-bottom:8px;" data-text="world-pressure-${row.civIdx}"></div>`
       : '';
 
+    // #526 MR7 Task 7.1: exploit_weakness intel detail line, immediately below the base
+    // status line -- only present at all when the viewer has diplomatic-networks.
+    const worldPressureDetailHtml = row.worldPressureDetailText
+      ? `<div style="font-size:10px;opacity:0.75;margin-bottom:8px;" data-text="world-pressure-detail-${row.civIdx}"></div>`
+      : '';
+
     const sendAidHtml = row.sendAidCrisisId
       ? `<div style="margin-bottom:8px;">
           <div style="font-size:10px;opacity:0.75;margin-bottom:4px;" data-text="send-aid-help-${row.civIdx}"></div>
@@ -409,6 +419,7 @@ export function createDiplomacyPanel(
             <div style="font-size:11px;opacity:0.6;"><span data-text="civ-bonus-${row.civIdx}"></span> · <span data-text="civ-status-${row.civIdx}"></span></div>
             ${warSinceHtml}
             ${worldPressureHtml}
+            ${worldPressureDetailHtml}
             ${treatyProposalsHtml}
           </div>
         </div>
@@ -490,6 +501,9 @@ export function createDiplomacyPanel(
     }
     if (row.worldPressureStatusText) {
       setText(`world-pressure-${row.civIdx}`, row.worldPressureStatusText);
+    }
+    if (row.worldPressureDetailText) {
+      setText(`world-pressure-detail-${row.civIdx}`, row.worldPressureDetailText);
     }
     if (row.sendAidCrisisId) {
       setText(`send-aid-help-${row.civIdx}`, row.sendAidHelpText ?? '');

--- a/src/ui/espionage-panel.ts
+++ b/src/ui/espionage-panel.ts
@@ -86,6 +86,7 @@ const MISSION_LABELS: Record<SpyMissionType, string> = {
   misinformation_campaign: 'Misinformation Campaign',
   election_interference: 'Election Interference',
   satellite_surveillance: 'Satellite Surveillance',
+  sabotage_relief: 'Sabotage Relief',
 };
 
 const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
@@ -106,6 +107,7 @@ const MISSION_STAGE: Record<SpyMissionType, 1 | 2 | 3 | 4 | 5> = {
   misinformation_campaign: 5,
   election_interference: 5,
   satellite_surveillance: 5,
+  sabotage_relief: 5, // covert-operations is era 7, same UI bucket as the other era 5-7 missions
 };
 
 function toMissionCatalog(missions: SpyMissionType[]): MissionCatalogEntry[] {

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -581,6 +581,43 @@ export function routeCrisisAidSent(
   }
 }
 
+// Exploit weakness (#526 MR7 Task 7.1): the target already learns of the war itself via
+// routeWarDeclared (bound to diplomacy:war-declared, which fires alongside this event) --
+// this router adds the "opportunistic" framing specifically for witnesses (met BOTH actor
+// and target), matching the reputation set applyOpportunisticWarPenaltyIfCrisisStruck used.
+export function routeOpportunisticWar(
+  state: GameState,
+  event: GameEvents['diplomacy:opportunistic-war'],
+  sink: NotificationSink,
+): void {
+  const actorName = state.civilizations[event.actorId]?.name ?? 'A civilization';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a civilization';
+  const message = `${actorName} declared war on ${targetName} while they were struggling with a crisis!`;
+
+  for (const witnessId of getWitnessCivIds(state, event.actorId, event.targetCivId)) {
+    sink(witnessId, message, 'warning');
+  }
+}
+
+// Sabotage relief (#526 MR7 Task 7.2): fires only when the covert sabotage is discovered
+// -- notifies the target directly plus every witness, per spec §Interactions ("Human
+// witnesses receive a notification when a covert act... is discovered"). Family-tone
+// string matches the spec's own example verbatim.
+export function routeSabotageReliefDiscovered(
+  state: GameState,
+  event: GameEvents['espionage:sabotage-relief-discovered'],
+  sink: NotificationSink,
+): void {
+  const actorName = state.civilizations[event.actorCivId]?.name ?? 'A civilization';
+  const targetName = state.civilizations[event.targetCivId]?.name ?? 'a civilization';
+  const message = `${actorName}'s spies were caught sabotaging ${targetName}'s relief!`;
+
+  sink(event.targetCivId, message, 'warning');
+  for (const witnessId of getWitnessCivIds(state, event.actorCivId, event.targetCivId)) {
+    sink(witnessId, message, 'warning');
+  }
+}
+
 // Fans out to viewers who know the AI target civ (met-civ gate, spec §Visibility).
 // AI-targeted crises only -- a human's own crisis already notifies its owner via
 // routeCrisisStarted above. Fires on crisis:started only, never per spread/siege tick:

--- a/tests/ai/ai-espionage.test.ts
+++ b/tests/ai/ai-espionage.test.ts
@@ -190,6 +190,46 @@ describe('AI espionage decisions', () => {
       expect(mission).not.toBe('sabotage_relief');
     });
   });
+
+  // #526 MR7 review fix: infiltrated (embedded) spies pick their next mission via a
+  // separate random-pick path in processAITurn (the "3) Stationed-inside spies issue
+  // missions" block) that bypasses chooseAiMission entirely -- it needs its own
+  // sabotage_relief exclusion, which this regression caught missing on first pass.
+  describe('infiltrated-spy mission selection', () => {
+    it('never issues sabotage_relief to an embedded spy, across many turn seeds', () => {
+      const startedMissionTypes: string[] = [];
+      for (let turn = 1; turn <= 60; turn++) {
+        const state = makeAiTestState();
+        state.turn = turn;
+        state.civilizations['ai-egypt'].techState.completed = [
+          'espionage-scouting', 'espionage-informants', 'spy-networks', 'covert-operations',
+        ];
+        let aiEsp = { ...createEspionageCivState(), maxSpies: 1 };
+        ({ state: aiEsp } = createSpyFromUnit(aiEsp, 'spy-embed', 'ai-egypt', 'spy_agent', `seed-${turn}`));
+        aiEsp = {
+          ...aiEsp,
+          spies: {
+            'spy-embed': {
+              ...aiEsp.spies['spy-embed'],
+              status: 'stationed',
+              infiltrationCityId: 'city-player-1',
+              targetCivId: 'player',
+              targetCityId: 'city-player-1',
+              currentMission: null,
+            },
+          },
+        };
+        state.espionage = { ...state.espionage, 'ai-egypt': aiEsp };
+
+        const bus = new EventBus();
+        bus.on('espionage:mission-started', event => startedMissionTypes.push(event.missionType));
+        processAITurn(state, 'ai-egypt', bus);
+      }
+
+      expect(startedMissionTypes.length).toBeGreaterThan(0); // sanity: the path actually fired
+      expect(startedMissionTypes).not.toContain('sabotage_relief');
+    });
+  });
 });
 
 describe('AI capture verdict', () => {

--- a/tests/ai/ai-espionage.test.ts
+++ b/tests/ai/ai-espionage.test.ts
@@ -174,6 +174,21 @@ describe('AI espionage decisions', () => {
       const mission = chooseAiMission(state, 'ai-egypt');
       expect(mission).toBeNull();
     });
+
+    // #526 MR7: sabotage_relief is human-initiated only in this arc.
+    it('never chooses sabotage_relief, even when it is the only mission covert-operations unlocks', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].techState.completed = ['covert-operations'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).toBeNull();
+    });
+
+    it('never chooses sabotage_relief even when it would otherwise sort first among available missions', () => {
+      const state = makeAiTestState();
+      state.civilizations['ai-egypt'].techState.completed = ['covert-operations', 'espionage-scouting'];
+      const mission = chooseAiMission(state, 'ai-egypt');
+      expect(mission).not.toBe('sabotage_relief');
+    });
   });
 });
 

--- a/tests/systems/crisis-interaction-system.test.ts
+++ b/tests/systems/crisis-interaction-system.test.ts
@@ -9,6 +9,8 @@ import {
   resolveInteractionTechRequired,
   getWitnessCivIds,
   applyInteractionReputation,
+  applyOpportunisticWarPenaltyIfCrisisStruck,
+  getActiveCrisisForCiv,
   canSendAid,
   applySendAid,
 } from '@/systems/crisis-interaction-system';
@@ -32,9 +34,24 @@ function threeCivState(overrides: Partial<GameState> = {}): GameState {
 }
 
 describe('CRISIS_INTERACTION_DEFINITIONS', () => {
-  it('ships hunt_their_foe and send_aid as the MR6 rows', () => {
+  it('ships hunt_their_foe, send_aid, exploit_weakness, and sabotage_relief rows', () => {
     const ids = CRISIS_INTERACTION_DEFINITIONS.map(def => def.id);
-    expect(ids).toEqual(['hunt_their_foe', 'send_aid']);
+    expect(ids).toEqual(['hunt_their_foe', 'send_aid', 'exploit_weakness', 'sabotage_relief']);
+  });
+
+  it('exploit_weakness deltas are -15 target / -8 witness (MR7)', () => {
+    const def = getCrisisInteractionDefinition('exploit_weakness')!;
+    expect(def.targetReputationDelta).toBe(-15);
+    expect(def.witnessReputationDelta).toBe(-8);
+    expect(def.techRequired).toBe('diplomatic-networks');
+  });
+
+  it('sabotage_relief deltas are -25 target / -8 witness (MR7)', () => {
+    const def = getCrisisInteractionDefinition('sabotage_relief')!;
+    expect(def.targetReputationDelta).toBe(-25);
+    expect(def.witnessReputationDelta).toBe(-8);
+    expect(def.techRequired).toBe('covert-operations');
+    expect(def.kind).toBe('covert');
   });
 
   it('hunt_their_foe requires no tech', () => {
@@ -260,5 +277,86 @@ describe('applySendAid', () => {
     const next = applySendAid(state, 'civA', crisisId, new EventBus());
     expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(15);
     expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(15);
+  });
+});
+
+// actor=civA (the war declarer), target=civB (crisis-struck), witness=civC.
+function opportunisticWarState({
+  hasCrisis = true,
+  interactions = 'full' as 'off' | 'benign' | 'full',
+}: { hasCrisis?: boolean; interactions?: 'off' | 'benign' | 'full' } = {}): { state: GameState; crisisId: string } {
+  const base = threeCivState({
+    settings: { aiCrisisInteractions: interactions } as GameState['settings'],
+  });
+  const crisisId = 'crisis-exploit';
+  const crisis: ActiveCrisis = {
+    id: crisisId, flavorId: 'plague', archetype: 'outbreak', targetCivId: 'civB',
+    cityIds: ['some-city'], tileKeys: [], startedTurn: 5, stage: 'active', turnsInStage: 2,
+  };
+  return {
+    state: { ...base, activeCrises: hasCrisis ? { [crisisId]: crisis } : {} },
+    crisisId,
+  };
+}
+
+describe('getActiveCrisisForCiv', () => {
+  it('finds the active crisis targeting the given civ', () => {
+    const { state, crisisId } = opportunisticWarState();
+    expect(getActiveCrisisForCiv(state, 'civB')?.id).toBe(crisisId);
+  });
+
+  it('returns undefined for a civ with no active crisis (negative)', () => {
+    const { state } = opportunisticWarState({ hasCrisis: false });
+    expect(getActiveCrisisForCiv(state, 'civB')).toBeUndefined();
+  });
+
+  it('filters by archetype when provided', () => {
+    const { state } = opportunisticWarState();
+    expect(getActiveCrisisForCiv(state, 'civB', 'outbreak')).toBeDefined();
+    expect(getActiveCrisisForCiv(state, 'civB', 'catastrophe')).toBeUndefined();
+  });
+});
+
+describe('applyOpportunisticWarPenaltyIfCrisisStruck', () => {
+  it('applies exploit_weakness deltas and emits diplomacy:opportunistic-war when the target has an active crisis', () => {
+    const { state, crisisId } = opportunisticWarState();
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('diplomacy:opportunistic-war', event => events.push(event));
+
+    const next = applyOpportunisticWarPenaltyIfCrisisStruck(state, 'civA', 'civB', bus);
+
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(-15);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(-15);
+    expect(next.civilizations.civA.diplomacy.relationships.civC).toBe(-8);
+    expect(next.civilizations.civC.diplomacy.relationships.civA).toBe(-8);
+    expect(events).toEqual([{ actorId: 'civA', targetCivId: 'civB', crisisId }]);
+  });
+
+  it('is a no-op when the target has no active crisis (war on a healthy civ)', () => {
+    const { state } = opportunisticWarState({ hasCrisis: false });
+    const next = applyOpportunisticWarPenaltyIfCrisisStruck(state, 'civA', 'civB', new EventBus());
+    expect(next).toBe(state);
+  });
+
+  it('is a no-op when aiCrisisInteractions is not "full" (benign stage keeps this hook dark)', () => {
+    const { state } = opportunisticWarState({ interactions: 'benign' });
+    const next = applyOpportunisticWarPenaltyIfCrisisStruck(state, 'civA', 'civB', new EventBus());
+    expect(next).toBe(state);
+  });
+
+  it('applies regardless of the declarer\'s own tech (reputation is not gated by diplomatic-networks)', () => {
+    const { state } = opportunisticWarState();
+    // civA has no techState/completed list at all in this fixture -- still applies.
+    const next = applyOpportunisticWarPenaltyIfCrisisStruck(state, 'civA', 'civB', new EventBus());
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(-15);
+  });
+
+  it('AI-declarer parity: an AI actor (isHuman: false) eats the same penalty a human would -- no humanity special-casing', () => {
+    const { state } = opportunisticWarState();
+    state.civilizations.civA.isHuman = false;
+    const next = applyOpportunisticWarPenaltyIfCrisisStruck(state, 'civA', 'civB', new EventBus());
+    expect(next.civilizations.civA.diplomacy.relationships.civB).toBe(-15);
+    expect(next.civilizations.civB.diplomacy.relationships.civA).toBe(-15);
   });
 });

--- a/tests/systems/crisis-outbreak.test.ts
+++ b/tests/systems/crisis-outbreak.test.ts
@@ -84,6 +84,38 @@ describe('outbreak resolver', () => {
     expect(next.activeCrises?.['crisis-1']).toBeUndefined();
   });
 
+  // #526 MR7 Task 7.2: sabotage_relief pauses remedy completions.
+  it('an unexpired sabotage pauses remedy completion even though the completion turn has passed', () => {
+    const { state } = withCrisis({
+      remedyCompletionByCity: { c1: 41 },
+      sabotage: { byCivId: 'saboteur', untilTurn: 45, discovered: false },
+    });
+    const next = processCrisisTurn({ ...state, turn: 41 }, new EventBus());
+    expect(next.activeCrises?.['crisis-1']).toBeDefined();
+    expect(next.activeCrises!['crisis-1'].remedyCompletionByCity).toEqual({ c1: 41 });
+    expect(next.activeCrises!['crisis-1'].sabotage?.untilTurn).toBe(45);
+  });
+
+  it('sabotage clears once its window passes, and remedy resumes normally on the next tick', () => {
+    const { state } = withCrisis({
+      remedyCompletionByCity: { c1: 41 },
+      sabotage: { byCivId: 'saboteur', untilTurn: 41, discovered: false },
+    });
+    const next = processCrisisTurn({ ...state, turn: 41 }, new EventBus());
+    expect(next.activeCrises?.['crisis-1']).toBeUndefined(); // remedy completed -> crisis resolved
+  });
+
+  it('spread still proceeds while remedy is paused by sabotage', () => {
+    let { state } = withCrisis({
+      sabotage: { byCivId: 'saboteur', untilTurn: 100, discovered: false },
+    });
+    let s: GameState = state;
+    for (let i = 0; i < 30; i++) {
+      s = processCrisisTurn({ ...s, turn: s.turn + 1 }, new EventBus());
+    }
+    expect(s.activeCrises!['crisis-1'].cityIds.length).toBeGreaterThan(1);
+  });
+
   it('explorer auto-expiry resolves the crisis as expired', () => {
     const { state } = makeCrisisFixture({ era: 3, turn: 40, challenge: 'explorer' });
     const crisis: ActiveCrisis = {

--- a/tests/systems/crisis-sabotage-relief.test.ts
+++ b/tests/systems/crisis-sabotage-relief.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import type { ActiveCrisis, GameState } from '@/core/types';
+import { getAvailableMissions, resolveMissionResult, processEspionageTurn } from '@/systems/espionage-system';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+
+// #526 MR7 Task 7.2 -- sabotage_relief mission gating and eligibility.
+
+function makeCrisisGameState(overrides: Partial<GameState> = {}): GameState {
+  const ids = ['player', 'rival'];
+  const crisis: ActiveCrisis = {
+    id: 'crisis-1', flavorId: 'plague', archetype: 'outbreak', targetCivId: 'rival',
+    cityIds: ['city-rival-1'], tileKeys: [], startedTurn: 1, stage: 'active', turnsInStage: 1,
+  };
+  return {
+    turn: 12,
+    era: 5,
+    currentPlayer: 'player',
+    map: { width: 4, height: 4, tiles: {}, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities: {
+      'city-player-1': {
+        id: 'city-player-1', name: 'Capital', owner: 'player', position: { q: 0, r: 0 }, population: 4,
+        food: 0, foodNeeded: 20, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [{ q: 0, r: 0 }], workedTiles: [], focus: 'balanced', maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      },
+      'city-rival-1': {
+        id: 'city-rival-1', name: 'Carthage', owner: 'rival', position: { q: 1, r: 1 }, population: 4,
+        food: 0, foodNeeded: 20, buildings: [], productionQueue: [], productionProgress: 0,
+        ownedTiles: [{ q: 1, r: 1 }], workedTiles: [], focus: 'balanced', maturity: 'outpost', unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+      },
+    },
+    civilizations: {
+      player: {
+        id: 'player', name: 'Rome', isHuman: true, civType: 'rome', cities: ['city-player-1'], units: [],
+        techState: { completed: ['covert-operations'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, knownCivilizations: ['rival'], score: 0,
+        diplomacy: createDiplomacyState(ids, 'player'),
+      },
+      rival: {
+        id: 'rival', name: 'Carthage', isHuman: false, civType: 'egypt', cities: ['city-rival-1'], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 0, visibility: { tiles: {} }, knownCivilizations: ['player'], score: 0,
+        diplomacy: createDiplomacyState(ids, 'rival'),
+      },
+    },
+    activeCrises: { [crisis.id]: crisis },
+    settings: {} as GameState['settings'],
+    ...overrides,
+  } as unknown as GameState;
+}
+
+describe('sabotage_relief mission availability', () => {
+  it('is unlocked by covert-operations', () => {
+    expect(getAvailableMissions(['covert-operations'])).toContain('sabotage_relief');
+  });
+
+  it('is not available without covert-operations (negative)', () => {
+    expect(getAvailableMissions(['espionage-scouting', 'espionage-informants', 'spy-networks'])).not.toContain('sabotage_relief');
+  });
+});
+
+describe('resolveMissionResult sabotage_relief eligibility', () => {
+  it('targets the active outbreak crisis when eligible', () => {
+    const state = makeCrisisGameState();
+    const result = resolveMissionResult('sabotage_relief', 'rival', 'city-rival-1', state, 'player', 'spy-1');
+    expect(result.sabotageCrisisId).toBe('crisis-1');
+  });
+
+  it('is a no-op when the target civ has no active crisis (negative)', () => {
+    const state = makeCrisisGameState({ activeCrises: {} });
+    const result = resolveMissionResult('sabotage_relief', 'rival', 'city-rival-1', state, 'player', 'spy-1');
+    expect(result.sabotageCrisisId).toBeUndefined();
+  });
+
+  it('is a no-op when the crisis is a catastrophe (no remedy timer to pause) (negative)', () => {
+    const state = makeCrisisGameState();
+    state.activeCrises!['crisis-1'] = { ...state.activeCrises!['crisis-1'], archetype: 'catastrophe' };
+    const result = resolveMissionResult('sabotage_relief', 'rival', 'city-rival-1', state, 'player', 'spy-1');
+    expect(result.sabotageCrisisId).toBeUndefined();
+  });
+
+  it('is a no-op when the crisis already has an active sabotage -- one active sabotage per crisis, across all actors (negative)', () => {
+    const state = makeCrisisGameState();
+    state.activeCrises!['crisis-1'] = {
+      ...state.activeCrises!['crisis-1'],
+      sabotage: { byCivId: 'some-other-civ', untilTurn: 20, discovered: false },
+    };
+    const result = resolveMissionResult('sabotage_relief', 'rival', 'city-rival-1', state, 'player', 'spy-1');
+    expect(result.sabotageCrisisId).toBeUndefined();
+  });
+
+  it('is a no-op when aiCrisisInteractions is not "full" (negative)', () => {
+    const state = makeCrisisGameState({ settings: { aiCrisisInteractions: 'benign' } as GameState['settings'] });
+    const result = resolveMissionResult('sabotage_relief', 'rival', 'city-rival-1', state, 'player', 'spy-1');
+    expect(result.sabotageCrisisId).toBeUndefined();
+  });
+});
+
+// Full integration through processEspionageTurn -- turn numbers below are precomputed
+// against the exact seeded-RNG sequences (mission-success roll seeded
+// `esp-turn-${turn}-player`, detection roll seeded `sab-relief-detect-spy-1-crisis-1-${turn}`)
+// so the outcome is deterministic, not statistical: turn 1 rolls a mission success AND a
+// detection roll under the 0.3 threshold (discovered); turn 3 rolls a mission success AND
+// a detection roll at/above 0.3 (undiscovered).
+function makeSpyFixture(turn: number): GameState {
+  const state = makeCrisisGameState({ turn });
+  return {
+    ...state,
+    espionage: {
+      player: {
+        spies: {
+          'spy-1': {
+            id: 'spy-1', owner: 'player', name: 'Agent Echo', unitType: 'spy_agent',
+            targetCivId: 'rival', targetCityId: 'city-rival-1', position: { q: 1, r: 1 },
+            status: 'on_mission', experience: 100, promotion: 'infiltrator',
+            currentMission: { type: 'sabotage_relief', turnsRemaining: 1, turnsTotal: 4, targetCivId: 'rival', targetCityId: 'city-rival-1' },
+            cooldownTurns: 0, promotionAvailable: false, feedsFalseIntel: false,
+          },
+        },
+        maxSpies: 1,
+        counterIntelligence: {},
+      },
+      rival: { spies: {}, maxSpies: 1, counterIntelligence: {} },
+    },
+  } as unknown as GameState;
+}
+
+describe('processEspionageTurn sabotage_relief integration', () => {
+  it('discovered: places the sabotage, applies bilateral reputation, and emits the discovery event', () => {
+    const state = makeSpyFixture(1);
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('espionage:sabotage-relief-discovered', e => events.push(e));
+
+    const next = processEspionageTurn(state, bus);
+
+    expect(next.activeCrises!['crisis-1'].sabotage).toEqual({ byCivId: 'player', untilTurn: 1 + 4, discovered: true });
+    expect(next.civilizations.player.diplomacy.relationships.rival).toBe(-25);
+    expect(next.civilizations.rival.diplomacy.relationships.player).toBe(-25);
+    expect(events).toEqual([{ crisisId: 'crisis-1', actorCivId: 'player', targetCivId: 'rival' }]);
+  });
+
+  it('undiscovered: places the sabotage but applies zero reputation change and emits nothing', () => {
+    const state = makeSpyFixture(3);
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('espionage:sabotage-relief-discovered', e => events.push(e));
+
+    const next = processEspionageTurn(state, bus);
+
+    const sabotage = next.activeCrises!['crisis-1'].sabotage;
+    expect(sabotage?.byCivId).toBe('player');
+    expect(sabotage?.discovered).toBe(false);
+    expect(next.civilizations.player.diplomacy.relationships.rival ?? 0).toBe(0);
+    expect(next.civilizations.rival.diplomacy.relationships.player ?? 0).toBe(0);
+    expect(events).toHaveLength(0);
+  });
+});

--- a/tests/systems/world-pressure-flags.test.ts
+++ b/tests/systems/world-pressure-flags.test.ts
@@ -3,12 +3,12 @@ import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import type { GameSettings } from '@/core/types';
 
 describe('resolveWorldPressureFlags', () => {
-  it('defaults aiPressure to "full" (#529 MR3), aiPressureVisibility to true (#531 MR5), and aiCrisisInteractions to "benign" (#532 MR6), for legacy saves (undefined settings fields)', () => {
+  it('defaults aiPressure to "full" (#529 MR3), aiPressureVisibility to true (#531 MR5), and aiCrisisInteractions to "full" (#533 MR7), for legacy saves (undefined settings fields)', () => {
     expect(resolveWorldPressureFlags({} as GameSettings)).toEqual({
-      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
+      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'full',
     });
     expect(resolveWorldPressureFlags(undefined)).toEqual({
-      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'benign',
+      aiPressure: 'full', aiPressureVisibility: true, aiCrisisInteractions: 'full',
     });
   });
   it('defaults aiPressureVisibility to false only when explicitly set that way', () => {

--- a/tests/systems/world-pressure-presentation.test.ts
+++ b/tests/systems/world-pressure-presentation.test.ts
@@ -91,4 +91,26 @@ describe('getWorldPressurePresentationForViewer', () => {
     expect(result.statusLinesByCivId['viewer']).toBeUndefined();
     expect(result.cityBadges).toEqual([]);
   });
+
+  // #526 MR7 Task 7.1: exploit_weakness intel detail.
+  it('omits detail when the viewer lacks diplomatic-networks (no techState at all)', () => {
+    const state = baseCrisisState();
+    const result = getWorldPressurePresentationForViewer(state, 'viewer');
+    expect(result.statusLinesByCivId['ai-1'].detail).toBeUndefined();
+  });
+
+  it('omits detail when the viewer has techState but not diplomatic-networks (negative)', () => {
+    const state = baseCrisisState();
+    state.civilizations.viewer.techState = { completed: ['bronze-working'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} } as unknown as GameState['civilizations'][string]['techState'];
+    const result = getWorldPressurePresentationForViewer(state, 'viewer');
+    expect(result.statusLinesByCivId['ai-1'].detail).toBeUndefined();
+  });
+
+  it('includes severity + infected city names when the viewer has diplomatic-networks', () => {
+    const state = baseCrisisState();
+    state.civilizations.viewer.techState = { completed: ['diplomatic-networks'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} } as unknown as GameState['civilizations'][string]['techState'];
+    state.cities['ai-city'].name = 'Alexandria';
+    const result = getWorldPressurePresentationForViewer(state, 'viewer');
+    expect(result.statusLinesByCivId['ai-1'].detail).toContain('Alexandria');
+  });
 });

--- a/tests/ui/city-panel-crisis.test.ts
+++ b/tests/ui/city-panel-crisis.test.ts
@@ -141,6 +141,67 @@ describe('city-panel crisis chip', () => {
     expect(panel.querySelector('[data-quarantine-crisis]')).toBeNull();
     expect(panel.querySelector('[data-remedy-crisis]')).toBeNull();
   });
+
+  // #526 MR7 Task 7.2 review fix: a scheduled remedy frozen by an active sabotage must
+  // not show a stale/wrong "cured in 0 turns" countdown -- the target still deserves an
+  // honest status line even though the saboteur stays anonymous while undiscovered.
+  // Fixture state.turn is 40 (tests/systems/helpers/legendary-wonder-fixture.ts).
+  it('shows an anonymous "disrupted" status instead of a stale countdown while an undiscovered sabotage is active', () => {
+    const { container, city, state } = withPlagueCrisis({
+      remedyCompletionByCity: { 'city-river': 40 }, // already at/past its natural completion turn
+      sabotage: { byCivId: 'saboteur', untilTurn: 44, discovered: false }, // still active (turn 40 < 44)
+    });
+    state.civilizations[city.owner].gold = 1000;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onQuarantineCrisis: vi.fn(() => state),
+      onRemedyCrisis: vi.fn(() => state),
+    });
+
+    expect(panel.textContent).toContain('mysteriously disrupted');
+    expect(panel.textContent).not.toContain('cured in 0 turns');
+  });
+
+  it('names the saboteur once the sabotage has been discovered', () => {
+    const { container, city, state } = withPlagueCrisis({
+      remedyCompletionByCity: { 'city-river': 40 },
+      sabotage: { byCivId: 'saboteur', untilTurn: 100, discovered: true },
+    });
+    state.civilizations[city.owner].gold = 1000;
+    state.civilizations.saboteur = { ...state.civilizations[city.owner], id: 'saboteur', name: 'Carthage' };
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onQuarantineCrisis: vi.fn(() => state),
+      onRemedyCrisis: vi.fn(() => state),
+    });
+
+    expect(panel.textContent).toContain("Carthage's spies were caught disrupting relief!");
+  });
+
+  it('shows the normal countdown once the sabotage window has passed (resumed)', () => {
+    const { container, city, state } = withPlagueCrisis({
+      remedyCompletionByCity: { 'city-river': 42 }, // 2 turns from now
+      sabotage: { byCivId: 'saboteur', untilTurn: 39, discovered: false }, // already expired (turn 40 >= 39)
+    });
+    state.civilizations[city.owner].gold = 1000;
+
+    const panel = createCityPanel(container, city, state, {
+      onBuild: () => {},
+      onOpenWonderPanel: () => {},
+      onClose: () => {},
+      onQuarantineCrisis: vi.fn(() => state),
+      onRemedyCrisis: vi.fn(() => state),
+    });
+
+    expect(panel.textContent).toContain('cured in 2 turns');
+    expect(panel.textContent).not.toContain('mysteriously disrupted');
+  });
 });
 
 describe('city-panel catastrophe chip (MR2)', () => {

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -726,6 +726,33 @@ describe('diplomacy-panel world-pressure crisis status line (#526 MR5 Task 5.3)'
     const second = render();
     expect(second.textContent).not.toContain('Suffering:');
   });
+
+  // #526 MR7 Task 7.1: exploit_weakness intel detail line.
+  it('shows the intel detail line when the viewer has diplomatic-networks', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.settings.aiPressureVisibility = true;
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.techState.completed = ['diplomatic-networks'];
+    addOutsiderCrisis(state);
+    state.cities['outsider-city'].name = 'Alexandria';
+
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {} });
+
+    expect(panel.textContent).toContain('Alexandria');
+  });
+
+  it('omits the intel detail line when the viewer lacks diplomatic-networks (negative)', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.settings.aiPressureVisibility = true;
+    state.civilizations.player.knownCivilizations = ['outsider'];
+    state.civilizations.player.techState.completed = [];
+    addOutsiderCrisis(state);
+    state.cities['outsider-city'].name = 'Alexandria';
+
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {} });
+
+    expect(panel.textContent).not.toContain('Alexandria');
+  });
 });
 
 describe('diplomacy-panel Send Aid button (#526 MR6 Task 6.3)', () => {

--- a/tests/ui/notification-routing.test.ts
+++ b/tests/ui/notification-routing.test.ts
@@ -24,6 +24,8 @@ import {
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
+  routeOpportunisticWar,
+  routeSabotageReliefDiscovered,
   type NotificationSink,
 } from '@/ui/notification-routing';
 
@@ -901,5 +903,55 @@ describe('crisis:aid-sent routing (#526 MR6 Task 6.3)', () => {
     const { sink, calls } = makeSink();
     routeCrisisAidSent(aidState(), { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage', goldCost: 45 }, sink);
     expect(calls.some(c => c.civId === 'rome')).toBe(false);
+  });
+});
+
+describe('diplomacy:opportunistic-war routing (#526 MR7 Task 7.1)', () => {
+  function warState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['carthage', 'egypt'] },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'egypt'] },
+        egypt: { id: 'egypt', name: 'Egypt', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'carthage'] }, // met both
+        nubia: { id: 'nubia', name: 'Nubia', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: [] }, // met neither
+      } as any,
+    });
+  }
+
+  it('notifies only witnesses who have met both the declarer and the target', () => {
+    const { sink, calls } = makeSink();
+    routeOpportunisticWar(warState(), { actorId: 'rome', targetCivId: 'carthage', crisisId: 'crisis-1' }, sink);
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toEqual(['egypt']);
+    expect(calls[0]!.message).toBe('Rome declared war on Carthage while they were struggling with a crisis!');
+  });
+
+  it('does not notify the target directly (routeWarDeclared already covers the war itself)', () => {
+    const { sink, calls } = makeSink();
+    routeOpportunisticWar(warState(), { actorId: 'rome', targetCivId: 'carthage', crisisId: 'crisis-1' }, sink);
+    expect(calls.some(c => c.civId === 'carthage')).toBe(false);
+  });
+});
+
+describe('espionage:sabotage-relief-discovered routing (#526 MR7 Task 7.2)', () => {
+  function sabotageState(): GameState {
+    return makeState({
+      civilizations: {
+        rome: { id: 'rome', name: 'Rome', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['carthage', 'egypt'] },
+        carthage: { id: 'carthage', name: 'Carthage', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'egypt'] },
+        egypt: { id: 'egypt', name: 'Egypt', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: ['rome', 'carthage'] }, // met both
+        nubia: { id: 'nubia', name: 'Nubia', cities: [], units: [], diplomacy: { relationships: {} }, visibility: { tiles: {} }, knownCivilizations: [] }, // met neither
+      } as any,
+    });
+  }
+
+  it('notifies the sabotaged target directly and every witness, with the spec\'s exact family-tone string', () => {
+    const { sink, calls } = makeSink();
+    routeSabotageReliefDiscovered(sabotageState(), { crisisId: 'crisis-1', actorCivId: 'rome', targetCivId: 'carthage' }, sink);
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toContain('carthage');
+    expect(civIds).toContain('egypt');
+    expect(civIds).not.toContain('nubia');
+    expect(calls.every(c => c.message === "Rome's spies were caught sabotaging Carthage's relief!")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

MR7 of the world-pressure symmetry arc (#526) — the final gameplay-surface stage before the balance pass. Implements all three plan tasks (`docs/superpowers/plans/2026-07-11-world-pressure-symmetry.md`, MR7) against spec §Interactions:

- **Task 7.1** — `exploit_weakness`: declaring war on a civ with ANY active crisis (human or AI, no humanity special-casing) applies -15 target / -8 witness reputation via `applyOpportunisticWarPenaltyIfCrisisStruck`, wired into every real war-declaration path (diplomacy panel's `declare_war` action, `ensurePlayerWarState`'s combat-triggered war, and the AI decision loop in `basic-ai.ts`). `diplomatic-networks` gates an additional intel-detail line (severity + infected city names) on the AI-pressure status line — but not the reputation consequence itself, which applies regardless of the declarer's tech (see the code comment on the definition row).
- **Task 7.2** — `sabotage_relief`: new `covert-operations`-gated spy mission. Pauses a rival's active **outbreak** crisis's remedy completion for 4 turns (one active sabotage per crisis, across all actors — catastrophe crises have no remedy timer, so they're ineligible). Reuses `sabotage_production`'s success/duration/xp parameters. A single detection roll at mission-success time (the same 0.3 baseline every mission's fail-path capture check already uses — no new stealth subsystem) decides discovery: undiscovered stays silent, discovered applies -25/-8 reputation plus a witnessed notification ("X's spies were caught sabotaging Y's relief!"). Human-initiated only per spec — excluded from `chooseAiMission`.
- **Task 7.3** — `diplomatic-networks` and `covert-operations` gain honest `unlocks` text for their new effects in the same commit.
- Flips `aiCrisisInteractions` default to `'full'`.

### Deviations from the plan (noted per `.claude/rules/spec-fidelity.md`)

- The plan suggested threading the `exploit_weakness` penalty through `declareWar`/`diplomacy-system.ts` directly. Importing `crisis-interaction-system.ts` into `diplomacy-system.ts` would create a two-file import cycle (`crisis-interaction-system.ts` already imports `diplomacy-system.ts` for `modifyRelationship`). Instead, the penalty is applied by every real war-declaration call site via the same shared, actor-agnostic helper — still one mutation point (satisfying the actor-complete rule), just invoked from three call sites instead of threaded through `declareWar` itself.
- `sabotage_relief`'s reputation/witness logic is **inlined** in `espionage-system.ts` rather than imported from `crisis-interaction-system.ts`. That import edge would close a real five-hop ESM cycle: `city-system.ts` → `espionage-system.ts` (existing `isSpyUnitType` import) → `crisis-interaction-system.ts` (the edge I almost added) → `faction-system.ts` → `city-system.ts`. I verified this concretely broke `city-territory-system.ts`'s top-level `Object.values(BUILDINGS)` read (248 test files failed) before reverting to the inlined approach — the deltas (-25/-8) are kept in sync via a code comment cross-referencing the source-of-truth definition row.

## Test plan

- [x] `bash scripts/run-with-mise.sh yarn build` — green (tsc + vite)
- [x] `bash scripts/run-with-mise.sh yarn test` — green, full suite (396 files / 6440 tests) + hook smoke tests
- [x] Task 7.1: war on crisis-struck civ applies deltas + event; war on healthy civ is a no-op; flag-gated to `'full'`; applies regardless of declarer's own tech; AI-declarer parity — `tests/systems/crisis-interaction-system.test.ts`
- [x] Task 7.1: intel detail gated on `diplomatic-networks`, includes severity + infected city names, omitted otherwise — `tests/systems/world-pressure-presentation.test.ts`
- [x] Task 7.1: notification routing — witnesses only, not the target directly (routeWarDeclared already covers that) — `tests/ui/notification-routing.test.ts`
- [x] Task 7.2: mission availability gated by `covert-operations`; eligibility (no crisis / catastrophe / already-sabotaged / flag-off all negative) — `tests/systems/crisis-sabotage-relief.test.ts`
- [x] Task 7.2: full `processEspionageTurn` integration — discovered (deterministic seed) places sabotage + bilateral reputation + event; undiscovered places sabotage with zero reputation change and no event — `tests/systems/crisis-sabotage-relief.test.ts`
- [x] Task 7.2: remedy pause/resume at the crisis-tick level, spread unaffected — `tests/systems/crisis-outbreak.test.ts`
- [x] Task 7.2: never AI-initiated, even when it's the only or highest-sorting available mission — `tests/ai/ai-espionage.test.ts`
- [x] Task 7.2: discovery notification routed to target + witnesses with the spec's exact family-tone string — `tests/ui/notification-routing.test.ts`
- [x] Task 7.3: `resolveMissionResult`/`applyOpportunisticWarPenaltyIfCrisisStruck` tests above double as the honesty proof for the new `unlocks` text

Related: #526 (design), #535 (implementation index — do not write "closes #535" here per the arc's ground rules). Depends on MR6 (#532), which is already on `main`.