### PR TITLE
feat(tech): implement the four #524 MR1 dead promises

### DIFF
--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -687,6 +687,21 @@ export function processTurn(
         applySharedVision(newState.civilizations[civId].visibility, mcPositions, newState.map);
       }
     }
+
+    // #524 MR1: electric-telegraph — allied major civs share vision around their cities.
+    // One-directional per tech holder: your telegraph, your intel; the ally needs their own
+    // tech to see yours.
+    if (newState.civilizations[civId].techState.completed.includes('electric-telegraph')) {
+      const allies = newState.civilizations[civId].diplomacy.treaties
+        .filter(t => t.type === 'alliance')
+        .map(t => (t.civA === civId ? t.civB : t.civA));
+      for (const allyId of allies) {
+        const allyCityPositions = (newState.civilizations[allyId]?.cities ?? [])
+          .map(cid => newState.cities[cid]?.position)
+          .filter(Boolean) as HexCoord[];
+        applySharedVision(newState.civilizations[civId].visibility, allyCityPositions, newState.map);
+      }
+    }
     refreshLastSeenPresentationsForCiv(newState, civId);
 
     // Clear expired advisor disable timers after all start-of-turn effects are processed.

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -234,7 +234,9 @@ export function processTurn(
 
       const activeRouteCount = (newState.marketplace?.tradeRoutes ?? [])
         .filter(route => route.fromCityId === cityId || route.toCityId === cityId).length;
-      const baseYields = calculateCityYields(city, newState.map, civDef?.bonusEffect, civ.techState.completed, { activeRouteCount }, newState.turn);
+      const hostsCompletedLegendaryWonder = Object.values(newState.completedLegendaryWonders ?? {})
+        .some(w => w.cityId === cityId);
+      const baseYields = calculateCityYields(city, newState.map, civDef?.bonusEffect, civ.techState.completed, { activeRouteCount, hostsCompletedLegendaryWonder }, newState.turn);
       const wonderCityBonuses = getLegendaryWonderCityYieldBonus(newState, civId, cityId);
       const unrestMultiplier = Math.min(getUnrestYieldMultiplier(city), getOccupiedCityYieldMultiplier(city))
         * getCrisisYieldMultiplier(newState, cityId);

--- a/src/systems/city-founding-system.ts
+++ b/src/systems/city-founding-system.ts
@@ -5,10 +5,13 @@ import { foundCity } from '@/systems/city-system';
 import {
   buildTerritoryTileFlippedEvents,
   canFoundCityAt,
+  canonicalizeCityCoord,
   recalculateTerritory,
 } from '@/systems/city-territory-system';
 import { resolveCivDefinition } from '@/systems/civ-registry';
+import { hexKey } from '@/systems/hex-utils';
 import { initializeLegendaryWonderProjectsForCity } from '@/systems/legendary-wonder-system';
+import { getFoundingBonusProduction } from '@/systems/tech-yield-definitions';
 
 export interface FoundCityInStateResult {
   state: GameState;
@@ -36,6 +39,13 @@ export function foundCityInState(
   let nextState = structuredClone(state);
   const nextCivilization = nextState.civilizations[settler.owner];
   const definition = resolveCivDefinition(nextState, nextCivilization.civType);
+  const existingOwnedCityIds = nextCivilization.cities.filter(cityId =>
+    nextState.cities[cityId]?.owner === settler.owner);
+  const targetRegion = nextState.map.tiles[hexKey(canonicalizeCityCoord(settler.position, nextState.map))]?.regionKey;
+  const isForeignLandmass = targetRegion != null && !existingOwnedCityIds.some(cityId => {
+    const c = nextState.cities[cityId];
+    return c != null && nextState.map.tiles[hexKey(canonicalizeCityCoord(c.position, nextState.map))]?.regionKey === targetRegion;
+  });
   const city = foundCity(
     settler.owner,
     settler.position,
@@ -47,10 +57,9 @@ export function foundCityInState(
       civName: definition?.name ?? nextCivilization.name,
       usedNames: collectUsedCityNames(nextState),
       completedTechs: nextCivilization.techState.completed,
+      foundingProductionBonus: getFoundingBonusProduction(nextCivilization.techState.completed, isForeignLandmass),
     },
   );
-  const existingOwnedCityIds = nextCivilization.cities.filter(cityId =>
-    nextState.cities[cityId]?.owner === settler.owner);
   const recoveredFromNearDefeat = nextCivilization.nearDefeat === true
     && existingOwnedCityIds.length >= 1;
   const { [settlerId]: _removed, ...remainingUnits } = nextState.units;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -4,7 +4,7 @@ import { hexKey, hexesInRange, hexNeighbors, wrapHexCoord } from './hex-utils';
 import { drawNextCityName, DEFAULT_CITY_NAMES } from './city-name-system';
 import { INITIAL_CITY_FOCUS, INITIAL_CITY_MATURITY } from './city-maturity-system';
 import { TECH_COST_DISCOUNTS, getFoundingBonusFood } from './tech-yield-definitions';
-import { UNIT_CLASS_BY_TYPE, type UnitClass } from './unit-modifier-definitions';
+import { UNIT_CLASS_BY_TYPE, isMilitaryUnitType, type UnitClass } from './unit-modifier-definitions';
 import { getResourceAdvantageMultiplier } from './resource-advantages';
 import {
   getLegendaryWonderDisplayName,
@@ -1278,7 +1278,9 @@ function getTechCostDiscountMultiplier(itemId: string, isUnit: boolean, complete
       ? !isUnit
       : discount.appliesTo === 'units'
         ? isUnit
-        : (discount.appliesTo as string[]).includes(itemId);
+        : discount.appliesTo === 'military-units'
+          ? isUnit && isMilitaryUnitType(itemId)
+          : (discount.appliesTo as string[]).includes(itemId);
     if (applies) multiplier *= discount.multiplier;
   }
   return multiplier;

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -20,6 +20,7 @@ export interface FoundCityOptions {
   usedNames?: Set<string>;
   civName?: string;
   completedTechs?: string[];
+  foundingProductionBonus?: number;
 }
 
 export const BUILDINGS: Record<string, Building> = {
@@ -1715,7 +1716,7 @@ export function foundCity(owner: string, position: HexCoord, map: GameMap, count
     foodNeeded: 15,
     buildings: [],
     productionQueue: [],
-    productionProgress: 0,
+    productionProgress: options.foundingProductionBonus ?? 0,
     ownedTiles,
     workedTiles: [],
     focus: INITIAL_CITY_FOCUS,

--- a/src/systems/city-work-system.ts
+++ b/src/systems/city-work-system.ts
@@ -209,7 +209,9 @@ export function calculateProjectedCityYields(
     : assignCityFocus(state, cityId, city.focus);
   const projectedCity = workResult.state.cities[cityId] ?? city;
   const completedTechs = workResult.state.civilizations?.[projectedCity.owner]?.techState.completed ?? [];
-  const baseYields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect, completedTechs, {}, state.turn);
+  const hostsCompletedLegendaryWonder = Object.values(workResult.state.completedLegendaryWonders ?? {})
+    .some(w => w.cityId === cityId);
+  const baseYields = calculateCityYields(projectedCity, workResult.state.map, bonusEffect, completedTechs, { hostsCompletedLegendaryWonder }, state.turn);
   // City-work helpers also support lightweight presentation fixtures that omit
   // civilization records; those have no resource access to aggregate.
   const resourceBonus = workResult.state.civilizations

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -55,7 +55,7 @@ const ERA_5_TECHS: Tech[] = [
     unlocksBuildings: ['explorers_guild'], era: 5 },
   { id: 'colonial-charter', name: 'Colonial Charter', track: 'exploration', cost: 125,
     prerequisites: ['exploration-tech', 'military-logistics'],
-    unlocks: ['Settlers founding cities on foreign landmasses receive +5 production bonus'], era: 5 },
+    unlocks: ['Cities founded on foreign landmasses start with +5 production'], era: 5 },
 
   // AGRICULTURE (2)
   { id: 'plantation-farming', name: 'Plantation Farming', track: 'agriculture', cost: 100,

--- a/src/systems/tech-definitions-eras5-7.ts
+++ b/src/systems/tech-definitions-eras5-7.ts
@@ -383,7 +383,7 @@ const ERA_7_TECHS: Tech[] = [
     unlocks: ['Print Shop unlocked — mass literacy and news distribution building'], unlocksBuildings: ['print_shop'], era: 7 },
   { id: 'electric-telegraph', name: 'Electric Telegraph', track: 'communication', cost: 210,
     prerequisites: ['courier-network', 'newspaper-press'],
-    unlocks: ['+1 gold per road connection in trade network; diplomatic vision range increased'], era: 7 },
+    unlocks: ['+1 gold per city connected to your capital by road (max +8); allied civilizations share vision around their cities'], era: 7 },
 
   // ESPIONAGE (2)
   { id: 'covert-operations', name: 'Covert Operations', track: 'espionage', cost: 145,

--- a/src/systems/tech-yield-definitions.ts
+++ b/src/systems/tech-yield-definitions.ts
@@ -22,6 +22,7 @@ export type YieldKind =
   | { kind: 'perLuxuryResource'; gold: number }
   | { kind: 'perOwnedNaturalWonder'; science: number }
   | { kind: 'foundingBonus'; food: number }
+  | { kind: 'foundingProductionBonus'; production: number; foreignLandmassOnly: boolean }
   /** Flat bonus applied once to the civ's totals — not per city (see MR6 "empire-wide" rule). */
   | { kind: 'empireFlat'; yields: Partial<ResourceYield> }
   /** Applied per worked tile whose terrain matches, resolved in tile-yield.ts. */
@@ -49,6 +50,7 @@ export interface TechYieldModifier {
 export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   // --- Era 5 ---
   { techId: 'guilds', label: '+1 gold per active trade route', effect: { kind: 'perTradeRoute', gold: 1 } },
+  { techId: 'colonial-charter', label: 'Cities founded on foreign landmasses start with +5 production', effect: { kind: 'foundingProductionBonus', production: 5, foreignLandmassOnly: true } },
   { techId: 'colonial-trade', label: 'Trade routes to foreign civs yield +2 gold', effect: { kind: 'perTradeRoute', gold: 2, foreignOnly: true } },
   { techId: 'scientific-method', label: '+1 science per library empire-wide', effect: { kind: 'perBuildingId', buildingIds: ['library'], yields: { science: 1 } } },
   { techId: 'printing-press', label: '+1 science per library empire-wide', effect: { kind: 'perBuildingId', buildingIds: ['library'], yields: { science: 1 } } },
@@ -261,6 +263,21 @@ export function getFoundingBonusFood(completedTechs: string[]): number {
     if (modifier.effect.kind !== 'foundingBonus') continue;
     if (!techSet.has(modifier.techId)) continue;
     bonus += modifier.effect.food;
+  }
+
+  return bonus;
+}
+
+/** Production bonus applied once at city-founding time (not a per-turn yield). */
+export function getFoundingBonusProduction(completedTechs: string[], isForeignLandmass: boolean): number {
+  const techSet = new Set(completedTechs);
+  let bonus = 0;
+
+  for (const modifier of TECH_YIELD_MODIFIERS) {
+    if (modifier.effect.kind !== 'foundingProductionBonus') continue;
+    if (!techSet.has(modifier.techId)) continue;
+    if (modifier.effect.foreignLandmassOnly && !isForeignLandmass) continue;
+    bonus += modifier.effect.production;
   }
 
   return bonus;

--- a/src/systems/tech-yield-definitions.ts
+++ b/src/systems/tech-yield-definitions.ts
@@ -12,6 +12,7 @@ export type YieldKind =
       requiresCoastal?: boolean;
       minBuildings?: number;
       requiresMissingBuilding?: string[];
+      requiresWonder?: true;
     }
   | { kind: 'perBuildingCategory'; category: BuildingCategory; yields: Partial<ResourceYield> }
   | { kind: 'perBuildingId'; buildingIds: string[]; yields: Partial<ResourceYield> }
@@ -51,6 +52,7 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
   // --- Era 5 ---
   { techId: 'guilds', label: '+1 gold per active trade route', effect: { kind: 'perTradeRoute', gold: 1 } },
   { techId: 'colonial-charter', label: 'Cities founded on foreign landmasses start with +5 production', effect: { kind: 'foundingProductionBonus', production: 5, foreignLandmassOnly: true } },
+  { techId: 'renaissance-architecture', label: '+2 production in cities containing a wonder', effect: { kind: 'cityFlatConditional', requiresWonder: true, yields: { production: 2 } } },
   { techId: 'colonial-trade', label: 'Trade routes to foreign civs yield +2 gold', effect: { kind: 'perTradeRoute', gold: 2, foreignOnly: true } },
   { techId: 'scientific-method', label: '+1 science per library empire-wide', effect: { kind: 'perBuildingId', buildingIds: ['library'], yields: { science: 1 } } },
   { techId: 'printing-press', label: '+1 science per library empire-wide', effect: { kind: 'perBuildingId', buildingIds: ['library'], yields: { science: 1 } } },

--- a/src/systems/tech-yield-definitions.ts
+++ b/src/systems/tech-yield-definitions.ts
@@ -237,7 +237,7 @@ export const TECH_YIELD_MODIFIERS: TechYieldModifier[] = [
 
 export interface TechCostDiscount {
   techId: string;
-  appliesTo: 'buildings' | 'units' | UnitType[];
+  appliesTo: 'buildings' | 'units' | 'military-units' | UnitType[];
   multiplier: number;
 }
 
@@ -246,6 +246,10 @@ export const TECH_COST_DISCOUNTS: TechCostDiscount[] = [
   { techId: 'cannon-casting', appliesTo: ['cannon'], multiplier: 0.85 },
   { techId: 'mass-production', appliesTo: 'units', multiplier: 0.95 },
   { techId: 'manifest-destiny', appliesTo: ['settler'], multiplier: 0.80 },
+  // Stacks multiplicatively with mass-production ('units', 0.95): military units pay
+  // ×0.8075 from era 8. Verified imperial_general_staff carries no unit discount in
+  // getBuildingDiscountMultiplier — update this comment if that changes.
+  { techId: 'general-mobilization', appliesTo: 'military-units', multiplier: 0.85 },
 ];
 
 /** Food bonus applied once at city-founding time (not a per-turn yield). */

--- a/src/systems/tech-yield-system.ts
+++ b/src/systems/tech-yield-system.ts
@@ -236,7 +236,10 @@ export function getConnectedCityTechGold(completedTechs: string[], connectedCity
   if (completedTechs.includes('courier-network')) perCity += 1;
   if (completedTechs.includes('colonial-railways')) perCity += 2;
   if (completedTechs.includes('transcontinental-rail') && completedTechs.includes('railway-expansion')) perCity += 2;
-  return perCity * connectedCityCount;
+  // electric-telegraph: +1 per connected city, capped at +8 (own term; other techs uncapped per MR7 spec).
+  const telegraphGold = completedTechs.includes('electric-telegraph')
+    ? Math.min(8, connectedCityCount) : 0;
+  return perCity * connectedCityCount + telegraphGold;
 }
 
 /** Flat gold per distinct owned luxury resource (e.g. distillation). */

--- a/src/systems/tech-yield-system.ts
+++ b/src/systems/tech-yield-system.ts
@@ -64,9 +64,10 @@ export interface TechYieldPart {
 
 /**
  * Per-city tech modifiers only. `empirePercent`, `perTradeRoute`,
- * `perLuxuryResource`, and `foundingBonus` are resolved by their own
- * dedicated helpers below — each is listed explicitly (as a no-op) here so
- * the switch stays exhaustive and a future unhandled kind fails the build.
+ * `perLuxuryResource`, `foundingBonus`, and `foundingProductionBonus` are
+ * resolved by their own dedicated helpers below — each is listed explicitly
+ * (as a no-op) here so the switch stays exhaustive and a future unhandled
+ * kind fails the build.
  */
 export interface CityTechYieldContext {
   /** Active trade routes (sent or received) touching this city — powers `perCityRoute`. */
@@ -138,6 +139,7 @@ export function getCityTechYields(
       case 'perTradeRoute':
       case 'perLuxuryResource':
       case 'foundingBonus':
+      case 'foundingProductionBonus':
       case 'empireFlat':
       case 'terrainYield':
       case 'perCompletedLegendaryWonder':

--- a/src/systems/tech-yield-system.ts
+++ b/src/systems/tech-yield-system.ts
@@ -34,6 +34,8 @@ function cityFlatConditionalMatches(
   city: City,
   map: GameMap,
   effect: Extract<YieldKind, { kind: 'cityFlatConditional' }>,
+  context: CityTechYieldContext,
+  hasNaturalWonder: boolean,
 ): boolean {
   if (effect.requiresAnyBuilding && !effect.requiresAnyBuilding.some(id => city.buildings.includes(id))) {
     return false;
@@ -53,6 +55,7 @@ function cityFlatConditionalMatches(
   }
   if (effect.requiresCoastal && !isCityCoastal(city, map)) return false;
   if (effect.minBuildings != null && city.buildings.length < effect.minBuildings) return false;
+  if (effect.requiresWonder && !hasNaturalWonder && !context.hostsCompletedLegendaryWonder) return false;
   return true;
 }
 
@@ -72,6 +75,8 @@ export interface TechYieldPart {
 export interface CityTechYieldContext {
   /** Active trade routes (sent or received) touching this city — powers `perCityRoute`. */
   activeRouteCount?: number;
+  /** This city hosts a completed legendary wonder — powers `cityFlatConditional.requiresWonder`. */
+  hostsCompletedLegendaryWonder?: boolean;
 }
 
 export function getCityTechYields(
@@ -99,7 +104,7 @@ export function getCityTechYields(
         addYield(contribution, effect.yields);
         break;
       case 'cityFlatConditional':
-        if (cityFlatConditionalMatches(city, map, effect)) {
+        if (cityFlatConditionalMatches(city, map, effect, context, naturalWonderCount > 0)) {
           addYield(contribution, effect.yields);
         }
         break;

--- a/src/systems/unit-modifier-definitions.ts
+++ b/src/systems/unit-modifier-definitions.ts
@@ -92,6 +92,13 @@ export const UNIT_CLASS_BY_TYPE: Record<UnitType, UnitClass[]> = {
   stealth_bomber: ['air'],
 };
 
+/** Military = trainable unit whose classes include neither 'civilian' nor 'spy'. */
+export function isMilitaryUnitType(unitType: string): boolean {
+  const classes = UNIT_CLASS_BY_TYPE[unitType as UnitType];
+  if (!classes || classes.length === 0) return false;
+  return !classes.includes('civilian') && !classes.includes('spy');
+}
+
 export type ModifierEffect = 'combatStrength' | 'healing' | 'vision';
 export type ModifierMode = 'flat' | 'multiplier';
 export type ModifierWhen = 'attacking' | 'defending' | 'always';

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -151,6 +151,10 @@ export function createCityPanel(
     city,
     state.map,
     state.civilizations[city.owner]?.techState.completed ?? [],
+    {
+      hostsCompletedLegendaryWonder: Object.values(state.completedLegendaryWonders ?? {})
+        .some(w => w.cityId === city.id),
+    },
   ).parts;
   const yields = {
     food: Math.floor(baseYields.food * yieldMultiplier),

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -979,6 +979,73 @@ describe('processTurn', () => {
     );
   });
 
+  describe('electric-telegraph allied shared vision (#524 MR1)', () => {
+    function setUpAlliedCivs() {
+      const state = createNewGame(undefined, 'electric-telegraph-vision', 'small');
+      state.map = { ...createWrappedGrasslandMap(20, 20), wrapsHorizontally: false };
+      state.units = {};
+      state.cities = {};
+      state.minorCivs = {};
+
+      for (const civ of Object.values(state.civilizations)) {
+        civ.units = [];
+        civ.cities = [];
+        civ.visibility = createVisibilityMap();
+      }
+
+      const counters = mkC();
+      const allyCity = foundCity('ai-1', { q: 0, r: 0 }, state.map, counters);
+      state.cities[allyCity.id] = allyCity;
+      state.civilizations['ai-1'].cities = [allyCity.id];
+
+      const playerCity = foundCity('player', { q: 15, r: 15 }, state.map, counters);
+      state.cities[playerCity.id] = playerCity;
+      state.civilizations.player.cities = [playerCity.id];
+
+      state.civilizations.player.diplomacy.treaties.push({
+        type: 'alliance', civA: 'player', civB: 'ai-1', turnsRemaining: -1,
+      });
+
+      return state;
+    }
+
+    it('reveals the ally city when the tech holder has both electric-telegraph and an alliance', () => {
+      const state = setUpAlliedCivs();
+      state.civilizations.player.techState.completed.push('electric-telegraph');
+
+      const result = processTurn(state, new EventBus());
+
+      expect(getVisibility(result.civilizations.player.visibility, { q: 0, r: 0 })).toBe('visible');
+    });
+
+    it('does not reveal the ally city without electric-telegraph researched', () => {
+      const state = setUpAlliedCivs();
+
+      const result = processTurn(state, new EventBus());
+
+      expect(getVisibility(result.civilizations.player.visibility, { q: 0, r: 0 })).not.toBe('visible');
+    });
+
+    it('does not reveal an allied civ with the tech but no alliance', () => {
+      const state = setUpAlliedCivs();
+      state.civilizations.player.techState.completed.push('electric-telegraph');
+      state.civilizations.player.diplomacy.treaties = [];
+
+      const result = processTurn(state, new EventBus());
+
+      expect(getVisibility(result.civilizations.player.visibility, { q: 0, r: 0 })).not.toBe('visible');
+    });
+
+    it('does not leak vision back to the ally, who has no electric-telegraph of their own', () => {
+      const state = setUpAlliedCivs();
+      state.civilizations.player.techState.completed.push('electric-telegraph');
+
+      const result = processTurn(state, new EventBus());
+
+      expect(getVisibility(result.civilizations['ai-1'].visibility, { q: 15, r: 15 })).not.toBe('visible');
+    });
+  });
+
   it('processTurn can still resolve a saved custom civ definition after JSON round-trip', () => {
     const state = createNewGame({
       civType: 'custom-sunfolk',

--- a/tests/systems/city-founding-system.test.ts
+++ b/tests/systems/city-founding-system.test.ts
@@ -4,7 +4,7 @@ import { createNewGame } from '@/core/game-state';
 import type { GameState, HexCoord } from '@/core/types';
 import { foundCityInState } from '@/systems/city-founding-system';
 import { foundCity } from '@/systems/city-system';
-import { cityDistance } from '@/systems/city-territory-system';
+import { canFoundCityAt, cityDistance } from '@/systems/city-territory-system';
 import { hexKey } from '@/systems/hex-utils';
 
 function getSettlerId(state: GameState, civId: string): string {
@@ -25,6 +25,16 @@ function findDistantLand(
     && candidate.terrain !== 'mountain'
     && cityDistance(candidate.coord, from, state.map) >= minimumDistance);
   if (!tile) throw new Error('missing distant land tile');
+  return tile.coord;
+}
+
+function findFoundableLand(state: GameState): HexCoord {
+  const tile = Object.values(state.map.tiles).find(candidate =>
+    candidate.terrain !== 'ocean'
+    && candidate.terrain !== 'coast'
+    && candidate.terrain !== 'mountain'
+    && canFoundCityAt(state, candidate.coord));
+  if (!tile) throw new Error('missing foundable land tile');
   return tile.coord;
 }
 
@@ -135,5 +145,72 @@ describe('foundCityInState', () => {
     expect(() => foundCityInState(state, settlerId, new EventBus()))
       .toThrow('Settler has already acted');
     expect(state).toEqual(before);
+  });
+});
+
+describe('foundCityInState — colonial-charter founding production bonus', () => {
+  function setUpTwoLandmassCiv(seed: string) {
+    const state = createNewGame(undefined, seed, 'small');
+    const civId = 'player';
+    const settlerId = getSettlerId(state, civId);
+    const settlerPosition = state.units[settlerId].position;
+    state.map.tiles[hexKey(settlerPosition)].regionKey = 'continent-new';
+
+    const existingPosition = findDistantLand(state, settlerPosition);
+    const existing = foundCity(civId, existingPosition, state.map, state.idCounters);
+    state.map.tiles[hexKey(existing.position)].regionKey = 'continent-home';
+    state.cities[existing.id] = existing;
+    state.civilizations[civId].cities = [existing.id];
+
+    return { state, civId, settlerId };
+  }
+
+  it('grants +5 production founding on a foreign landmass with colonial-charter', () => {
+    const { state, settlerId } = setUpTwoLandmassCiv('founding-colonial-foreign');
+    state.civilizations.player.techState.completed.push('colonial-charter');
+
+    const result = foundCityInState(state, settlerId, new EventBus());
+
+    expect(result.state.cities[result.cityId].productionProgress).toBe(5);
+  });
+
+  it('does not grant the bonus founding on the home landmass', () => {
+    const { state, settlerId } = setUpTwoLandmassCiv('founding-colonial-home');
+    state.civilizations.player.techState.completed.push('colonial-charter');
+    const settlerPosition = state.units[settlerId].position;
+    state.map.tiles[hexKey(settlerPosition)].regionKey = 'continent-home';
+
+    const result = foundCityInState(state, settlerId, new EventBus());
+
+    expect(result.state.cities[result.cityId].productionProgress).toBe(0);
+  });
+
+  it('does not grant the bonus without colonial-charter researched', () => {
+    const { state, settlerId } = setUpTwoLandmassCiv('founding-colonial-no-tech');
+
+    const result = foundCityInState(state, settlerId, new EventBus());
+
+    expect(result.state.cities[result.cityId].productionProgress).toBe(0);
+  });
+
+  it('does not grant the bonus for a second city on an already-owned foreign landmass', () => {
+    const { state, civId, settlerId } = setUpTwoLandmassCiv('founding-colonial-second');
+    state.civilizations.player.techState.completed.push('colonial-charter');
+    const settlerPosition = state.units[settlerId].position;
+
+    const firstResult = foundCityInState(state, settlerId, new EventBus());
+    expect(firstResult.state.cities[firstResult.cityId].productionProgress).toBe(5);
+
+    const secondPosition = findFoundableLand(firstResult.state);
+    firstResult.state.units['second-settler'] = {
+      id: 'second-settler', type: 'settler', owner: civId,
+      position: secondPosition, movementPointsLeft: 2,
+      health: 100, experience: 0, hasMoved: false, hasActed: false, isResting: false,
+    };
+    firstResult.state.civilizations[civId].units.push('second-settler');
+    firstResult.state.map.tiles[hexKey(secondPosition)].regionKey = 'continent-new';
+
+    const secondResult = foundCityInState(firstResult.state, 'second-settler', new EventBus());
+    expect(secondResult.state.cities[secondResult.cityId].productionProgress).toBe(0);
   });
 });

--- a/tests/systems/production-costs.test.ts
+++ b/tests/systems/production-costs.test.ts
@@ -103,4 +103,24 @@ describe('production cost catalog', () => {
     expect(getProductionCostForItem('settler', { era: 3, completedTechs: ['manifest-destiny'] })).toBe(Math.ceil(baseline * 0.8));
     expect(getProductionCostForItem('worker', { era: 3, completedTechs: ['manifest-destiny'] })).toBe(getProductionCostForItem('worker', { era: 3 }));
   });
+
+  it('applies general-mobilization -15% to a military unit (musketeer)', () => {
+    const baseline = getProductionCostForItem('musketeer', { era: 8 });
+    expect(getProductionCostForItem('musketeer', { era: 8, completedTechs: ['general-mobilization'] })).toBe(Math.ceil(baseline * 0.85));
+  });
+
+  it('does not apply general-mobilization to civilian or spy units', () => {
+    expect(getProductionCostForItem('settler', { era: 8, completedTechs: ['general-mobilization'] })).toBe(getProductionCostForItem('settler', { era: 8 }));
+    expect(getProductionCostForItem('worker', { era: 8, completedTechs: ['general-mobilization'] })).toBe(getProductionCostForItem('worker', { era: 8 }));
+    expect(getProductionCostForItem('spy_scout', { era: 8, completedTechs: ['general-mobilization'] })).toBe(getProductionCostForItem('spy_scout', { era: 8 }));
+  });
+
+  it('stacks general-mobilization multiplicatively with mass-production', () => {
+    const baseline = getProductionCostForItem('musketeer', { era: 8 });
+    const stacked = getProductionCostForItem('musketeer', {
+      era: 8,
+      completedTechs: ['general-mobilization', 'mass-production'],
+    });
+    expect(stacked).toBe(Math.ceil(baseline * 0.85 * 0.95));
+  });
 });

--- a/tests/systems/tech-yield-system.test.ts
+++ b/tests/systems/tech-yield-system.test.ts
@@ -511,4 +511,17 @@ describe('MR7: getConnectedCityTechGold (courier-network / colonial-railways / t
       1,
     )).toBe(5);
   });
+
+  it('electric-telegraph grants +1 gold per connected city, capped at +8', () => {
+    expect(getConnectedCityTechGold(['electric-telegraph'], 5)).toBe(5);
+    expect(getConnectedCityTechGold(['electric-telegraph'], 12)).toBe(8);
+  });
+
+  it('electric-telegraph stacks additively with courier-network, still capped only on its own term', () => {
+    expect(getConnectedCityTechGold(['electric-telegraph', 'courier-network'], 12)).toBe(1 * 12 + 8);
+  });
+
+  it('electric-telegraph contributes nothing without the tech', () => {
+    expect(getConnectedCityTechGold(['courier-network'], 12)).toBe(12);
+  });
 });

--- a/tests/systems/tech-yield-system.test.ts
+++ b/tests/systems/tech-yield-system.test.ts
@@ -213,6 +213,28 @@ describe('getCityTechYields — per-kind coverage', () => {
     forceTile(map, wonderTile, 'mountain', { wonder: null });
     expect(getCityTechYields(city, map, ['natural-history']).total.science).toBe(0);
   });
+
+  it('cityFlatConditional (requiresWonder): applies for a city hosting a completed legendary wonder', () => {
+    const city = makeCity();
+    expect(getCityTechYields(city, map, ['renaissance-architecture'], { hostsCompletedLegendaryWonder: true }).total.production).toBe(2);
+  });
+
+  it('cityFlatConditional (requiresWonder): applies for a city with a natural wonder tile', () => {
+    const centerCoord = Object.values(map.tiles).find(t => t.terrain === 'grassland' && !t.hasRiver)!.coord;
+    const city = { ...foundCity('player', centerCoord, map, mkC()), population: 1 };
+    const wonderTile = city.ownedTiles.find(c => hexKey(c) !== hexKey(city.position))!;
+    forceTile(map, wonderTile, 'mountain', { wonder: 'test-natural-wonder' });
+    expect(getCityTechYields(city, map, ['renaissance-architecture']).total.production).toBe(2);
+
+    forceTile(map, wonderTile, 'mountain', { wonder: null });
+    expect(getCityTechYields(city, map, ['renaissance-architecture']).total.production).toBe(0);
+  });
+
+  it('cityFlatConditional (requiresWonder): does not apply for a city with neither wonder kind', () => {
+    const city = makeCity();
+    expect(getCityTechYields(city, map, ['renaissance-architecture']).total.production).toBe(0);
+    expect(getCityTechYields(city, map, ['renaissance-architecture'], { hostsCompletedLegendaryWonder: false }).total.production).toBe(0);
+  });
 });
 
 describe('getEmpireTechPercents / applyEmpireTechPercents', () => {


### PR DESCRIPTION
Part of the #524 arc — index: #587. Implements all four era 5–8 tech `unlocks` promises from #588, making them mechanically true. One commit per effect, each TDD'd (failing test → implement → pass).

## Effect 1 — general-mobilization (era 8)
"All cities train military units 15% faster"
- New `isMilitaryUnitType()` helper (`unit-modifier-definitions.ts`): military = trainable unit whose classes include neither `'civilian'` nor `'spy'`.
- New `TechCostDiscount.appliesTo: 'military-units'` variant, resolved in `getTechCostDiscountMultiplier` (`city-system.ts`).
- Stacks multiplicatively with `mass-production` (0.95): military units pay ×0.8075 from era 8. Verified `imperial_general_staff` carries no separate unit discount.
- Save decision: none (derives from `completedTechs`).

## Effect 2 — colonial-charter (era 5)
"Cities founded on foreign landmasses start with +5 production"
- New `foundingProductionBonus` yield kind + `getFoundingBonusProduction()` helper (`tech-yield-definitions.ts`).
- `FoundCityOptions.foundingProductionBonus` threads into `foundCity`'s `productionProgress`.
- `foundCityInState` (`city-founding-system.ts`) hoists the owned-city lookup above the `foundCity` call and compares `regionKey` (landmass id) between the target tile and every existing owned city to determine "foreign."
- Tech text updated to match the row label exactly.
- **Save decision: from-now-on** — pre-existing cities are unaffected retroactively.

## Effect 3 — renaissance-architecture (era 5)
"+2 production in cities containing a wonder"
- New `cityFlatConditional.requiresWonder` flag, satisfied by either a natural-wonder tile in `ownedTiles` or a completed legendary wonder hosted in the city.
- `CityTechYieldContext.hostsCompletedLegendaryWonder` threaded through **every** real yield-computation call site that can see game state — not just the city-panel display breakdown:
  - `calculateProjectedCityYields` (`city-work-system.ts`) — the shared choke point used by AI production/research scoring, quest cost estimates, council advice, and every UI panel's projected yields.
  - The direct `calculateCityYields` call in `turn-manager.ts`'s real per-turn production-application path.
  - `city-panel.ts`'s `getCityTechYields` call (the itemized tech-yield breakdown list).
- Save decision: none (derived each turn from `state.completedLegendaryWonders` + tile data).

## Effect 4 — electric-telegraph (era 7)
"+1 gold per city connected to your capital by road (max +8); allied civilizations share vision around their cities"
- `getConnectedCityTechGold` gains an independent capped term (`min(8, connectedCityCount)`) that stacks additively with the existing uncapped `courier-network`/`colonial-railways`/`transcontinental-rail` terms.
- `turn-manager.ts`: for each civ with the tech, walks `diplomacy.treaties` for active alliances and calls `applySharedVision` around each ally's cities. One-directional per tech holder — your telegraph, your intel; the ally needs their own electric-telegraph to see back.
- Save decision: none (derived each turn).

## Testing
- `yarn test` (398 test files, 6497 tests) and `yarn build` (tsc + vite) both green. One pre-existing, unrelated test (`world-pressure-fairness.test.ts`, a pooled multi-seed crisis-pressure simulation) intermittently exceeds its own 120s budget under sandbox load — reproduced identically on the pre-change baseline commit, so it is not a regression from this change.
- New unit tests: `tests/systems/production-costs.test.ts` (general-mobilization discount + stacking), `tests/systems/city-founding-system.test.ts` (colonial-charter foreign/home/no-tech/second-city cases), `tests/systems/tech-yield-system.test.ts` (renaissance-architecture requiresWonder + electric-telegraph gold cap), `tests/core/turn-manager.test.ts` (electric-telegraph allied shared-vision: reveal, no-tech, no-alliance, no-reverse-leak).
- Manual smoke via dev server: solo campaign start + 2-player hot-seat campaign start (through the full setup wizard, player hand-off screens, and turn-start briefing), both confirmed via the "All techs" tab that all four updated `unlocks` strings render correctly, with no new console errors.

Refs #587, #588. Never "closes #524" — this is MR1 of a larger arc.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PVWhMLs2AhRuZMaoHq83QK)_