### PR TITLE
feat(tech): era 5-13 content honesty sweep (#524 MR2)

### DIFF
--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -712,7 +712,7 @@ export const BUILDINGS: Record<string, Building> = {
     id: 'air_force_command', name: 'Air Force Command', category: 'military',
     // Two keys: production 3 ≤ 3, science 2 ≤ 3; total 5 ≤ 9 (era 9 ceiling) ✓
     yields: { food: 0, production: 3, gold: 0, science: 2 }, productionCost: 280,
-    description: 'Centralised aviation command. +3 production and +2 science empire-wide. Your air units gain +4 strength in combat.',
+    description: 'Centralised aviation command. +3 production and +2 science empire-wide. Your air units gain +4 strength when attacking.',
     techRequired: 'air-superiority',
     pacing: { band: 'marquee', role: 'national-project', impact: 1.5, scope: 'empire', snowball: 1.4, urgency: 1.2, situationality: 1.3, unlockBreadth: 1 },
     uniquePerEmpire: true, nationalProject: { homeEra: 9 },

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -68,11 +68,12 @@ export function getUnrestPressureBreakdown(
     if (distancePressure > 0) rows.push({ label: 'Distance from capital', amount: distancePressure });
   }
 
-  // Recent conquest
+  // Recent conquest — constitutional-law (#524 MR2) halves this row's amount.
   if (city.conquestTurn !== undefined) {
     const turnsSince = state.turn - city.conquestTurn;
     if (turnsSince < CONQUEST_UNREST_DURATION) {
-      rows.push({ label: 'Recent conquest', amount: 25 });
+      const hasConstitutionalLaw = civ.techState.completed.includes('constitutional-law');
+      rows.push({ label: 'Recent conquest', amount: hasConstitutionalLaw ? 13 : 25 });
     }
   }
 

--- a/tests/systems/description-honesty.test.ts
+++ b/tests/systems/description-honesty.test.ts
@@ -18,6 +18,10 @@ const DENYLIST_PATTERNS: RegExp[] = [
   /gunpowder units train faster/i,
   /units train with bonus strength/i,
   /early unit training costs reduced/i,
+  // #524 MR2: air_force_command's +4 strength modifier only applies when the air
+  // unit is attacking (unit-modifier-definitions.ts: when: 'attacking') — the old
+  // "in combat" wording implied it also applied on defense, which it never has.
+  /air units gain \+4 strength in combat/i,
 ];
 
 function collectStrings(): Array<{ source: string; text: string }> {

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -544,6 +544,30 @@ describe('faction-system', () => {
       const rows = getUnrestPressureBreakdown('city-1', stateWithOtherCivTech);
       expect(rows.find(r => r.label === 'Recent conquest')?.amount).toBe(25);
     });
+
+    it('changes the actual unrest-escalation outcome at the trigger boundary', () => {
+      // Recent conquest (25) + war weariness (2 wars * 8 = 16) = 41 > UNREST_TRIGGER_PRESSURE (40):
+      // crosses the trigger without the tech. With constitutional-law, Recent conquest
+      // halves to 13, so 13 + 16 = 29 stays under the trigger — proving the row-value
+      // change actually flips processFactionTurn's real escalation decision, not just
+      // the isolated breakdown number.
+      const stateWithoutTech = makeState({ conquestTurn: 0, atWarCount: 2 });
+      const resultWithoutTech = processFactionTurn(stateWithoutTech, bus);
+      expect(resultWithoutTech.cities['city-1'].unrestLevel).toBe(1);
+
+      const stateWithTech: GameState = {
+        ...stateWithoutTech,
+        civilizations: {
+          ...stateWithoutTech.civilizations,
+          player: {
+            ...stateWithoutTech.civilizations['player'],
+            techState: { ...stateWithoutTech.civilizations['player'].techState, completed: ['constitutional-law'] },
+          },
+        },
+      };
+      const resultWithTech = processFactionTurn(stateWithTech, bus);
+      expect(resultWithTech.cities['city-1'].unrestLevel).toBe(0);
+    });
   });
 
   it('reports helper values for appease cost and production penalties', () => {

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -507,6 +507,45 @@ describe('faction-system', () => {
     expect(result.cities['city-1'].conquestTurn).toBeUndefined();
   });
 
+  describe('#524 MR2 — constitutional-law reduces recent-conquest unrest', () => {
+    it('halves the Recent conquest pressure row when the owner has constitutional-law', () => {
+      const state = makeState({ conquestTurn: 0 });
+      const stateWithTech: GameState = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          player: {
+            ...state.civilizations['player'],
+            techState: { ...state.civilizations['player'].techState, completed: ['constitutional-law'] },
+          },
+        },
+      };
+
+      const withoutTech = getUnrestPressureBreakdown('city-1', state).find(r => r.label === 'Recent conquest');
+      const withTech = getUnrestPressureBreakdown('city-1', stateWithTech).find(r => r.label === 'Recent conquest');
+
+      expect(withoutTech?.amount).toBe(25);
+      expect(withTech?.amount).toBe(13);
+    });
+
+    it('does not reduce Recent conquest pressure for a different civ\'s tech', () => {
+      const state = makeState({ conquestTurn: 0 });
+      const stateWithOtherCivTech: GameState = {
+        ...state,
+        civilizations: {
+          ...state.civilizations,
+          'ai-1': {
+            ...state.civilizations['ai-1'],
+            techState: { ...state.civilizations['ai-1'].techState, completed: ['constitutional-law'] },
+          },
+        },
+      };
+
+      const rows = getUnrestPressureBreakdown('city-1', stateWithOtherCivTech);
+      expect(rows.find(r => r.label === 'Recent conquest')?.amount).toBe(25);
+    });
+  });
+
   it('reports helper values for appease cost and production penalties', () => {
     const stable = makeCity('stable', 'player', { q: 0, r: 0 });
     const unrest = { ...stable, unrestLevel: 1 as const };


### PR DESCRIPTION
Part of the #524 arc — index: #587. MR2 (#589): era 5–13 `Tech.unlocks`/`Building.description`/`UNIT_DESCRIPTIONS` honesty sweep, run after MR1 (#588, merged in #595).

## Method

Grep-based systematic verification: extracted all 248 tech ids across `tech-definitions-eras5-7/8/9/10/11/12/13.ts`, then grepped each id across `src/` excluding the definition files themselves. A tech with **zero** references anywhere else in the codebase cannot have any of its concrete claims be true — this is the same class of proof MR1/#588 used per-tech, applied exhaustively instead of to a pre-selected list.

Zero-hit result: **5 techs** — `constitutional-law`, `epidemic-control`, `missionary-zeal`, `motorized-transport`, `propaganda`.

For everything with ≥1 hit, I additionally spot-checked every building (96) and unit (34) gated by an era 5–13 tech for numeric-claim accuracy against their resolver (`unit-modifier-definitions.ts`, `combat-system.ts`, `combat-context.ts`, `cyber-warfare-system.ts`, `attack-targeting.ts`, `network-effect-resolver.ts`) — including the era-13 entry the issue body specifically flagged (`quantum-computing` → Data Center +2 science: confirmed true, `tech-yield-definitions.ts:238`). One wording-precision issue turned up this way (see below); everything else spot-checked was accurate, including several claims phrased ambiguously enough to be worth double-checking (`air_force_command`'s "+4 strength in combat" turned out to be attack-only; `destroyer` vs submarines, `jet_fighter` vs bombers, `stealth_bomber`'s evasion-vs-return-fire behavior, `cyber_defense_center`/`signals_hub`'s block percentages — all confirmed exact).

## Inventory — the 5 zero-hit findings

| id | era | claim | verdict | disposition | save decision |
|---|---|---|---|---|---|
| `constitutional-law` | 5 | "Reduces unrest in newly captured cities" | dead | **fixed here** — table-row: `getUnrestPressureBreakdown`'s "Recent conquest" row (`faction-system.ts`) now checks `constitutional-law` and halves the row from 25 to 13 | none (derives from `completedTechs`) |
| `propaganda` | 6 | "Spy missions to flip loyalties available in foreign cities" | dead | **escalated** — MR2a scope block appended to #587 (new `SpyMissionType`, city-ownership transfer, AI, UI — not a table row) | n/a, not implemented here |
| `epidemic-control` | 6 | "City population loss from famine halved" | dead | already scheduled — MR3/#590 (famine system doesn't exist yet) | n/a |
| `missionary-zeal` | 6 | "Missionaries spread religion to conquered cities faster" | dead | already scheduled — MR5/#592 (religion system doesn't exist yet) | n/a |
| `motorized-transport` | 9 | "Automobiles and trucks reshape logistics; supply chains reach further than ever" | not a claim | pure flavor text, no number/mechanic asserted — nothing to fix | n/a |

## Wording-precision fix (found via spot-check, not the zero-hit scan)

`air_force_command` building description said "Your air units gain +4 strength in combat" — the modifier (`unit-modifier-definitions.ts:161`) only applies `when: 'attacking'`, never on defense. Reworded to "when attacking"; added a `description-honesty.test.ts` denylist entry for the old phrase per the rewrite-exception protocol.

## Testing

- New tests: `tests/systems/faction-system.test.ts` — `constitutional-law` halves "Recent conquest" for the owning civ only (negative test: a different civ's tech doesn't affect this city).
- `bash scripts/run-with-mise.sh yarn build` — clean (tsc + vite).
- `bash scripts/run-with-mise.sh yarn test` — 398 files, 6500 passed, 3 pre-existing skips, 0 failures. No pacing-audit/reference-economy snapshot shifts (the constitutional-law change is an unrest-pressure reduction, not a yield, so it's outside `RESEARCH_OUTPUT_BY_ERA`'s inputs).

## Out of scope

The MR2a spy-loyalty-flip mechanic (see #587 comment) is deliberately not implemented here — it's a new player-facing flow (new spy mission, city capture via espionage, AI, UI), not a table-row fix, and needs its own step-level plan per #587's arc mechanics.

Refs #587, #589.
