### PR TITLE
fix(render): anchor effect animations to hexes; wrap-fix journey/route/road lines

### DIFF
--- a/docs/superpowers/plans/2026-07-14-zone-of-control-flanking-support.md
+++ b/docs/superpowers/plans/2026-07-14-zone-of-control-flanking-support.md
@@ -1,0 +1,427 @@
+# Zone of Control and Flanking/Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add domain-local zone of control (ZOC), adjacent-tile flanking/support bonuses, clear pre-move and post-move player feedback, and equivalent behavior for AI and hostile world actors.
+
+**Architecture:** Keep movement truth, ZOC eligibility, and combat-adjacency counting in small stateless system helpers. A detailed movement-range API supplies both legal destinations and its ZOC-terminal subset; the existing array-returning API remains a compatibility wrapper. Combat positioning enters resolution through `buildCombatContextForDefender`, so live combat, previews, and AI use the same modifier parts.
+
+**Tech Stack:** TypeScript, Vitest, Canvas 2D renderer, DOM UI, existing event bus and canonical movement/combat systems.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/systems/owner-hostility.ts` | One owner-pair hostility predicate shared by movement, combat targeting, and ZOC. |
+| `src/systems/zone-of-control-system.ts` | Domain/eligibility rules, wrapped-neighbor ZOC lookup, terminal move result, and combat-adjacent occupied-tile counts. |
+| `src/systems/unit-system.ts` | Detailed movement range API that stops expansion after a ZOC-terminal entry while retaining `getMovementRange` compatibility. |
+| `src/systems/unit-movement-system.ts` | Canonical finalization of a move, including zeroing remaining movement after a ZOC entry and returning an optional player-facing stop reason. |
+| `src/input/selected-unit-highlights.ts` | Converts detailed range data into normal and ZOC-limited player highlights. |
+| `src/renderer/render-loop.ts` | Adds a high-contrast `zoc-limited` Canvas highlight style. |
+| `src/ui/selected-unit-info.ts` | Renders the non-color pre-move legend when the selected unit has ZOC-limited destinations. |
+| `src/systems/combat-context.ts`, `src/systems/combat-system.ts` | Adds positional modifier inputs/parts and applies the exact +10%-per-tile strength multipliers. |
+| `src/ui/combat-preview.ts` | Displays the supplied positional modifier parts. |
+| `src/ai/ai-tactics.ts` | Adds deterministic post-move flanking/support value to otherwise comparable move candidates. |
+| `src/ai/basic-ai.ts`, `src/systems/pirate-system.ts`, `src/systems/pirate-behavior.ts` | Routes retained direct movement through the same ZOC finalizer or canonical executor. |
+| Mirrored tests listed per task | Prove rules, player-visible state, AI/world parity, and balance. |
+
+## Player Truth Table
+
+| Before | Player action | Internal result | Immediate visible result |
+|---|---|---|---|
+| Selected land/naval combat unit has normal movement and a hostile same-domain combat unit nearby | Select the unit | Detailed range marks legal terminal ZOC destinations | Normal destinations stay blue; terminal ones are amber with the ZOC icon/pattern and `Enemy nearby — entering ends movement` in the selected-unit panel. |
+| Player taps an amber destination | Move resolves | Unit enters the tile and `movementPointsLeft` becomes `0` | Unit animates to the destination, selected-unit flow advances, and the notification says `Stopped — enemy nearby`. |
+| Player selects recon, civilian, or air unit | Select the unit | ZOC is not considered | No amber ZOC destinations or legend appear. |
+| Player opens combat preview with adjacent allies | Tap attack target | Canonical combat context adds tile-count modifiers | Preview shows the exact `Flanked +N%` and/or `Supported +N%` text before Attack. |
+
+## Misleading UI Risks
+
+- A `zoc-limited` tile must be in the legal movement range; a blocked, hostile-occupied, unexplored-too-far, or insufficient-movement tile must never receive the amber type.
+- Amber alone is insufficient. The renderer must also apply a distinct outline/pattern/icon, and the selected-unit surface must expose the pre-move explanation text.
+- Attack-target tiles retain the existing attack type; ZOC only decorates legal non-attack movement destinations.
+- The legend is shown only when the selected unit has at least one ZOC-limited destination, and disappears on deselect/reselect when none remain.
+
+## Interaction Replay Checklist
+
+1. Select a unit with a ZOC-limited destination; confirm amber tile, non-color cue, and legend.
+2. Tap the amber tile; confirm movement, exhausted movement, and stop notification.
+3. Reselect the exhausted unit; confirm stale movement and legend do not remain.
+4. Deselect and select recon/air/civilian and a unit with no nearby hostile; confirm no false ZOC surface.
+5. In hot seat, switch current player and select that player’s unit; confirm the same viewer-scoped highlights and no hardcoded `player` owner.
+
+## Task 1: Centralize hostility and pure ZOC/combat-positioning rules
+
+**Files:**
+- Create: `src/systems/owner-hostility.ts`
+- Create: `src/systems/zone-of-control-system.ts`
+- Create: `tests/systems/owner-hostility.test.ts`
+- Create: `tests/systems/zone-of-control-system.test.ts`
+- Modify: `src/systems/attack-targeting.ts`
+- Modify: `src/ai/ai-hostility.ts`
+
+- [ ] **Step 1: Write failing hostility tests.**
+
+```ts
+expect(isHostileOwnerTo(state, 'player', 'barbarian')).toBe(true);
+expect(isHostileOwnerTo(state, 'player', 'beasts')).toBe(true);
+expect(isHostileOwnerTo(state, 'player', 'ai-1')).toBe(false);
+state.civilizations.player.diplomacy.atWarWith = ['ai-1'];
+expect(isHostileOwnerTo(state, 'player', 'ai-1')).toBe(true);
+```
+
+- [ ] **Step 2: Run the new test and confirm the missing-module failure.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/owner-hostility.test.ts`
+
+Expected: FAIL because `@/systems/owner-hostility` does not exist.
+
+- [ ] **Step 3: Add the shared owner predicate.**
+
+```ts
+// src/systems/owner-hostility.ts
+export function isHostileOwnerTo(
+  state: Readonly<GameState>, actorId: string, otherOwnerId: string,
+): boolean {
+  if (actorId === otherOwnerId) return false;
+  if (isAlwaysHostilePair(actorId, otherOwnerId)) return true;
+  if (actorId.startsWith('mc-')) return isMinorCivHostileToOwner(state, actorId, otherOwnerId);
+  if (otherOwnerId.startsWith('mc-')) {
+    return state.civilizations[actorId]?.diplomacy.atWarWith.includes(otherOwnerId) ?? false;
+  }
+  return state.civilizations[actorId]?.diplomacy.atWarWith.includes(otherOwnerId) ?? false;
+}
+```
+
+Refactor `attack-targeting.ts` and `ai-hostility.ts` to call this helper. Preserve the existing AI-only decision to decline beast contests in `isAIHostileOwner`; do not weaken the universal game-rule hostility predicate used by ZOC.
+
+- [ ] **Step 4: Write failing ZOC and adjacency tests.**
+
+```ts
+expect(isZocEligibleCombatUnit(warrior)).toBe(true);
+expect(isZocEligibleCombatUnit(scout)).toBe(false);
+expect(isZocEligibleCombatUnit(worker)).toBe(false);
+expect(isZocEligibleCombatUnit(biplane)).toBe(false);
+expect(getCombatAdjacentOccupiedTileCount(state, attacker, defender)).toBe(2);
+```
+
+Include land/naval same-domain positives, cross-domain negatives, a wrapped map-edge positive, a stack counted once, and barbarian/beast/pirate/rebel sources.
+
+- [ ] **Step 5: Implement the pure helpers.**
+
+```ts
+export interface ZoneOfControlResult {
+  limited: boolean;
+  sourceUnitIds: readonly string[];
+}
+
+export function getZoneOfControlAt(
+  state: Readonly<GameState>, mover: Unit, destination: HexCoord,
+): ZoneOfControlResult;
+
+export function getCombatAdjacentOccupiedTileCount(
+  state: Readonly<GameState>, ownerId: string, defender: Unit, excludedUnitId?: string,
+): number;
+```
+
+Define “eligible” once: non-transported, strength greater than zero, not recon class, and non-air. `getZoneOfControlAt` traverses with `getWrappedHexNeighbors` when `map.wrapsHorizontally` and `hexNeighbors` otherwise, filters hostile eligible same-domain units, and returns `limited: sourceUnitIds.length > 0`. `getCombatAdjacentOccupiedTileCount` traverses the same neighbors, filters eligible units owned by `ownerId` after excluding `excludedUnitId`, stores each `hexKey(neighbor)` once, and returns the set size. Do not count the defender’s own tile in support.
+
+- [ ] **Step 6: Run focused rule tests.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/owner-hostility.test.ts tests/systems/zone-of-control-system.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the rule foundation.**
+
+```bash
+git add src/systems/owner-hostility.ts src/systems/zone-of-control-system.ts src/systems/attack-targeting.ts src/ai/ai-hostility.ts tests/systems/owner-hostility.test.ts tests/systems/zone-of-control-system.test.ts
+git commit -m "feat(combat): add shared zone of control rules"
+```
+
+## Task 2: Make every gameplay movement path ZOC-aware
+
+**Files:**
+- Modify: `src/systems/unit-system.ts`
+- Modify: `src/systems/unit-movement-system.ts`
+- Modify: `src/ai/basic-ai.ts`
+- Modify: `src/systems/pirate-system.ts`
+- Modify: `src/systems/pirate-behavior.ts`
+- Test: `tests/systems/unit-system.test.ts`
+- Test: `tests/systems/unit-movement-system.test.ts`
+- Test: `tests/ai/basic-ai-pirates.test.ts`
+- Test: `tests/systems/pirate-system.test.ts`
+- Test: `tests/systems/pirate-behavior.test.ts`
+
+- [ ] **Step 1: Write failing detailed-range tests.**
+
+```ts
+const range = getMovementRangeDetails(state, mover, { completedTechs: [] });
+expect(range.reachable.map(hexKey)).toContain('1,0');
+expect(range.zocLimited.map(hexKey)).toContain('1,0');
+expect(range.reachable.map(hexKey)).not.toContain('2,0'); // cannot continue past entry
+expect(getMovementRange(mover, state.map, occupancy.unitIdsByHex, occupancy.ownersByUnitId, hostileOwners).map(hexKey)).toContain('1,0');
+```
+
+Cover forced march, wrapping, a unit beginning in ZOC, land/naval parity, and recon/air/civilian negative cases.
+
+- [ ] **Step 2: Add a detailed range API without breaking current callers.**
+
+```ts
+export interface MovementRangeDetails {
+  reachable: HexCoord[];
+  zocLimited: HexCoord[];
+}
+
+export function getMovementRangeDetails(
+  state: Readonly<GameState>, unitId: string,
+): MovementRangeDetails;
+
+export function getMovementRange(
+  unit: Unit, map: GameMap, unitPositions: Record<string, string | string[]>,
+  unitOwners?: Record<string, string>, hostileOwners?: Set<string>, options: UnitMovementContext = {},
+): HexCoord[];
+```
+
+`getMovementRangeDetails` builds occupancy from `state.units`, derives hostile owners with `isHostileOwnerTo(state, unit.owner, candidate.owner)`, and follows the current BFS exactly. When it enters a legal ZOC tile, add that coordinate to both arrays but never enqueue it. `getMovementRange` retains its current signature and existing non-state utility behavior; update every gameplay caller that needs ZOC to call the detailed state API. Preserve current hostile-occupant, road, river, terrain, technology, and forced-march logic.
+
+- [ ] **Step 3: Write failing canonical-execution tests.**
+
+```ts
+const result = executeUnitMove(state, 'mover', { q: 1, r: 0 }, { actor: 'player', civId: 'player' });
+expect(result).toMatchObject({ ok: true, stopReason: 'zone-of-control' });
+expect(state.units.mover.movementPointsLeft).toBe(0);
+expect(state.units.mover.position).toEqual({ q: 1, r: 0 });
+```
+
+Add a world-actor equivalent and assertions that no destination is blocked solely by ZOC.
+
+- [ ] **Step 4: Implement one move-finalization helper and use it in `executeUnitMove`.**
+
+```ts
+export interface FinalizedUnitMove { unit: Unit; stopReason?: 'zone-of-control'; }
+
+export function finalizeUnitMove(state: Readonly<GameState>, unit: Unit, to: HexCoord, cost: number): FinalizedUnitMove {
+  const moved = moveUnit(unit, to, cost);
+  return getZoneOfControlAt(state, moved, to).limited
+    ? { unit: { ...moved, movementPointsLeft: 0 }, stopReason: 'zone-of-control' }
+    : { unit: moved };
+}
+```
+
+Extend the successful `ExecuteUnitMoveResult` with `stopReason?: 'zone-of-control'`; retain all existing event, transport, visibility, and route-cleanup behavior.
+
+- [ ] **Step 5: Remove direct-move bypasses.**
+
+For every direct `moveUnit` call found by `rg -n "moveUnit\\(" src/ai src/systems`, either migrate it to `executeUnitMove` or replace it with `finalizeUnitMove` using the state before the move. In particular, update `moveWarshipToward`, pirate pursuit, pirate one-step movement, and pirate formation relocation. In formation relocation, stop a vessel after its first ZOC-limited step and reject/cancel the atomic formation plan if that would make formation placement inconsistent; never move through ZOC in a later loop iteration.
+
+- [ ] **Step 6: Prove direct-path parity.**
+
+Add one test each for the basic-AI naval pursuit path, pirate-system move, and pirate-behavior movement path. Each places a hostile same-domain unit beside the entered tile and asserts `movementPointsLeft === 0` and no subsequent step. Keep existing pirate formation atomicity assertions.
+
+- [ ] **Step 7: Run movement and world-path tests.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit canonical movement parity.**
+
+```bash
+git add src/systems/unit-system.ts src/systems/unit-movement-system.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/pirate-behavior.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts
+git commit -m "feat(movement): apply zone of control to all movers"
+```
+
+## Task 3: Apply flanking/support in canonical combat strength and previews
+
+**Files:**
+- Modify: `src/systems/combat-context.ts`
+- Modify: `src/systems/combat-system.ts`
+- Modify: `src/ui/combat-preview.ts`
+- Test: `tests/systems/combat-system.test.ts`
+- Test: `tests/systems/unit-modifier-system.test.ts`
+- Test: `tests/ui/combat-preview.test.ts`
+
+- [ ] **Step 1: Write failing combat-context and preview tests.**
+
+```ts
+expect(context.attackerPositioning?.multiplier).toBeCloseTo(1.2);
+expect(context.attackerPositioning?.part.label).toBe('Flanked +20%');
+expect(formatCombatPreviewDetails('Rival', 100, strengths)).toContain('Flanked +20%');
+expect(formatCombatPreviewDetails('Rival', 100, strengths)).toContain('Supported +10%');
+```
+
+Add negative tests for a stacked second unit, civilian/recon/air presence, attacker-own tile, defender-own tile, foreign tile, and ranged six-tile flank. Assert a melee attacker tops out at +50%, ranged flanking at +60%, and defender support at +60%.
+
+- [ ] **Step 2: Extend `CombatContext` with positional multiplier/part inputs.**
+
+```ts
+export interface PositioningCombatModifier {
+  multiplier: number;
+  part?: ModifierPart;
+}
+// Add attackerPositioning?: PositioningCombatModifier and defenderPositioning?: PositioningCombatModifier.
+```
+
+`buildCombatContextForDefender` derives counts through `getCombatAdjacentOccupiedTileCount`, then creates `Flanked +${count * 10}%` and `Supported +${count * 10}%` parts only when the count is nonzero.
+
+- [ ] **Step 3: Apply and expose the canonical modifiers.**
+
+In `calculateCombatStrengths`, multiply base attacker/defender strengths by the new positioning multiplier before existing unit-modifier/city-defense processing, and append the parts to the existing modifier-part arrays. Preserve the pure `calculateCombatStrengths` signature: no state lookup inside combat resolution.
+
+- [ ] **Step 4: Add balance sampling before changing any constants.**
+
+Copy the seeded loop pattern from `tests/systems/unit-modifier-system.test.ts`. Run three Stone Age warrior scenarios: no adjacency bonus, two-tile flank/support, and each maximum case (five-tile melee flank, six-tile ranged flank, six-tile support). Assert the same-tier average remains 2–4 exchanges. If a maximum scenario fails, stop the implementation and record the result for an explicit balance decision—do not add a cap.
+
+- [ ] **Step 5: Run combat tests.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/combat-system.test.ts tests/systems/unit-modifier-system.test.ts tests/ui/combat-preview.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit combat positioning.**
+
+```bash
+git add src/systems/combat-context.ts src/systems/combat-system.ts src/ui/combat-preview.ts tests/systems/combat-system.test.ts tests/systems/unit-modifier-system.test.ts tests/ui/combat-preview.test.ts
+git commit -m "feat(combat): add flanking and support bonuses"
+```
+
+## Task 4: Render clear ZOC movement truth and feedback
+
+**Files:**
+- Modify: `src/input/selected-unit-highlights.ts`
+- Modify: `src/renderer/render-loop.ts`
+- Modify: `src/ui/selected-unit-info.ts`
+- Modify: `src/main.ts`
+- Test: `tests/input/selected-unit-highlights.test.ts`
+- Test: `tests/renderer/render-loop-wrap.test.ts`
+- Test: `tests/ui/selected-unit-info.test.ts`
+- Test: `tests/input/selected-unit-movement-feedback.test.ts`
+
+- [ ] **Step 1: Write failing selected-highlight tests.**
+
+```ts
+expect(result.zocLimitedRange.map(hexKey)).toContain('1,0');
+expect(result.highlights).toContainEqual({ coord: { q: 1, r: 0 }, type: 'zoc-limited' });
+expect(result.highlights).not.toContainEqual({ coord: { q: 2, r: 0 }, type: 'zoc-limited' });
+```
+
+Add a hot-seat fixture with `currentPlayer = 'ai-1'`, a no-ZOC legend negative test, and a wrapped highlight mirror test.
+
+- [ ] **Step 2: Extend highlight presentation.**
+
+Add `zocLimitedRange: HexCoord[]` and `hasZoneOfControlWarning: boolean` to `SelectedUnitHighlightResult`. Create `type: 'zoc-limited'` in `HexHighlight`, render it amber with a high-contrast outline distinct from `water-recovery`, and preserve attack precedence.
+
+- [ ] **Step 3: Render the pre-move explanation.**
+
+Add `hasZoneOfControlWarning?: boolean` to `SelectedUnitInfoPresentation`; when true, render exactly `Enemy nearby — entering ends movement` in the selected-unit panel. In `main.ts`, pass the flag returned by `buildSelectedUnitHighlights`. The line must be removed by the existing `replaceChildren()` rerender when the next selection has no ZOC-limited destination.
+
+- [ ] **Step 4: Wire the post-move stop notification without an error SFX.**
+
+After a successful `executeAnimatedUnitMove`, if `moveResult.stopReason === 'zone-of-control'`, call `showNotification('Stopped — enemy nearby', 'info')`. Do not call `SFX.error()` and do not add new audio assets. Ensure this happens before the next-unit selection callback so it is visible to the player.
+
+- [ ] **Step 5: Run UI/renderer tests.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-movement-feedback.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit player-visible ZOC feedback.**
+
+```bash
+git add src/input/selected-unit-highlights.ts src/renderer/render-loop.ts src/ui/selected-unit-info.ts src/main.ts tests/input/selected-unit-highlights.test.ts tests/renderer/render-loop-wrap.test.ts tests/ui/selected-unit-info.test.ts tests/input/selected-unit-movement-feedback.test.ts
+git commit -m "feat(ui): show zone of control movement warnings"
+```
+
+## Task 5: Make major AI value positional combat advantage
+
+**Files:**
+- Modify: `src/ai/ai-tactics.ts`
+- Test: `tests/ai/ai-tactics.test.ts`
+
+- [ ] **Step 1: Write a failing deterministic candidate-ranking test.**
+
+```ts
+const moves = rankUnitTacticalActions(context(state, plan), mover.id)
+  .filter((candidate): candidate is RankedAITacticalAction & { action: { kind: 'move' } } => candidate.action.kind === 'move');
+expect(moves[0]?.action).toEqual({ kind: 'move', unitId: mover.id, destination: flankDestination });
+expect(moves[0]!.score).toBeGreaterThan(moves[1]!.score);
+```
+
+Build two equally target-progressing moves where only one places the mover on a tile that provides an adjacent friendly combat position around the planned enemy. Keep visibility, health, movement, and cohesion equal.
+
+- [ ] **Step 2: Add a pure positioning-score helper in `ai-tactics.ts`.**
+
+```ts
+function scorePostMovePositioning(context: AITacticalContext, unit: Unit, destination: HexCoord): number {
+  const projected = { ...context.state, units: { ...context.state.units, [unit.id]: { ...unit, position: destination } } };
+  const projectedUnit = projected.units[unit.id]!;
+  return getAttackTargets(projected, projectedUnit, { viewerId: context.actorId, requireVisibility: true })
+    .filter(target => target.result.targetType === 'unit')
+    .reduce((score, target) => {
+      const defender = projected.units[target.result.targetUnitId]!;
+      const combat = buildCombatContextForDefender(projected, projectedUnit, defender);
+      return score + ((combat.attackerPositioning?.multiplier ?? 1) - 1) * 100;
+    }, 0);
+}
+```
+
+Use the canonical context output, not duplicate adjacency math. Add this score after target progress and before deterministic tie-breaks; keep existing difficulty profiles responsible only for seeded near-best selection.
+
+- [ ] **Step 3: Add a regression for the negative boundary.**
+
+Assert that a candidate adjacent only to a civilian/recon/air unit receives no positional score and that a ZOC-limited move does not gain value from imaginary follow-on movement.
+
+- [ ] **Step 4: Run tactical tests.**
+
+Run: `./scripts/run-with-mise.sh yarn test --run tests/ai/ai-tactics.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit AI parity.**
+
+```bash
+git add src/ai/ai-tactics.ts tests/ai/ai-tactics.test.ts
+git commit -m "feat(ai): value combat flanking positions"
+```
+
+## Task 6: Full verification and implementation review
+
+**Files:**
+- Review: all files changed by Tasks 1–5
+
+- [ ] **Step 1: Run the source rule checker.**
+
+Run: `scripts/check-src-rule-violations.sh src/systems/owner-hostility.ts src/systems/zone-of-control-system.ts src/systems/unit-system.ts src/systems/unit-movement-system.ts src/systems/combat-context.ts src/systems/combat-system.ts src/ui/combat-preview.ts src/input/selected-unit-highlights.ts src/renderer/render-loop.ts src/ui/selected-unit-info.ts src/main.ts src/ai/ai-tactics.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/pirate-behavior.ts`
+
+Expected: no violations.
+
+- [ ] **Step 2: Run the complete required test suite.**
+
+Run: `./scripts/run-with-mise.sh yarn test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Build TypeScript and production assets.**
+
+Run: `./scripts/run-with-mise.sh yarn build`
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect both branch and local deltas.**
+
+```bash
+git diff --stat origin/main...HEAD
+git diff --stat
+git diff origin/main...HEAD
+git diff
+```
+
+Confirm there is no saved-state schema change or migration, no new SFX/audio call, no hardcoded hot-seat owner, every direct gameplay mover uses ZOC finalization, and the UI truth table is satisfied.
+
+## Plan Self-Review
+
+- **Spec coverage:** Task 1 covers hostility, owner-agnostic world actors, domains, recon/civilian/air exclusions, wrapping, and stack semantics. Task 2 covers all movement execution paths and no schema change. Task 3 covers flanking/support, preview, stacking, and maximum-envelopment balance. Task 4 covers the amber non-color UI, notification, solo/hot-seat behavior, and no SFX. Task 5 covers major-AI positional parity. Task 6 enforces regression, build, and delta review.
+- **Placeholder scan:** No implementation step relies on unspecified “appropriate” behavior; each carries a concrete predicate, test, command, or acceptance condition.
+- **Type consistency:** `MovementRangeDetails`, `FinalizedUnitMove`, `PositioningCombatModifier`, `zocLimitedRange`, and `stopReason: 'zone-of-control'` are introduced before later tasks consume them.

--- a/docs/superpowers/plans/2026-07-14-zone-of-control-flanking-support.md
+++ b/docs/superpowers/plans/2026-07-14-zone-of-control-flanking-support.md
@@ -51,6 +51,18 @@
 4. Deselect and select recon/air/civilian and a unit with no nearby hostile; confirm no false ZOC surface.
 5. In hot seat, switch current player and select that player’s unit; confirm the same viewer-scoped highlights and no hardcoded `player` owner.
 
+## Direct Movement Caller Inventory
+
+| Caller | ZOC treatment | Verification |
+|---|---|---|
+| `executeUnitMove` | Calls `finalizeUnitMove`; applies to player, major-AI, minor-civ, and world moves. | Player and world cases in `unit-movement-system.test.ts`. |
+| `ai-tactics.ts` | Uses `getMovementRangeDetails(...).reachable`; execution remains through the major-AI executor. | Terminal candidate coverage in `ai-tactics.test.ts`. |
+| `basic-ai.ts` naval pursuit | Calls `finalizeUnitMove`. | `basic-ai-pirates.test.ts`. |
+| `pirate-system.ts` and `pirate-behavior.ts` combat vessels | Call `finalizeUnitMove`; formation relocation halts/cancels atomically on terminal entry. | Pirate system and behavior tests. |
+| `advanceRouteRunners` and loaded/civilian route movement | Explicitly exempt: civilians do not receive or exert ZOC. | Existing route-runner test remains unchanged; add a negative exemption assertion if its movement helper is touched. |
+
+The implementation must rerun `rg -n "moveUnit\\(" src/ai src/systems` after Task 2 and add any newly discovered ZOC-eligible caller to this table and to a parity regression before completion.
+
 ## Task 1: Centralize hostility and pure ZOC/combat-positioning rules
 
 **Files:**
@@ -146,18 +158,20 @@ git commit -m "feat(combat): add shared zone of control rules"
 - Modify: `src/systems/unit-system.ts`
 - Modify: `src/systems/unit-movement-system.ts`
 - Modify: `src/ai/basic-ai.ts`
+- Modify: `src/ai/ai-tactics.ts`
 - Modify: `src/systems/pirate-system.ts`
 - Modify: `src/systems/pirate-behavior.ts`
 - Test: `tests/systems/unit-system.test.ts`
 - Test: `tests/systems/unit-movement-system.test.ts`
 - Test: `tests/ai/basic-ai-pirates.test.ts`
+- Test: `tests/ai/ai-tactics.test.ts`
 - Test: `tests/systems/pirate-system.test.ts`
 - Test: `tests/systems/pirate-behavior.test.ts`
 
 - [ ] **Step 1: Write failing detailed-range tests.**
 
 ```ts
-const range = getMovementRangeDetails(state, mover, { completedTechs: [] });
+const range = getMovementRangeDetails(state, mover.id);
 expect(range.reachable.map(hexKey)).toContain('1,0');
 expect(range.zocLimited.map(hexKey)).toContain('1,0');
 expect(range.reachable.map(hexKey)).not.toContain('2,0'); // cannot continue past entry
@@ -184,7 +198,7 @@ export function getMovementRange(
 ): HexCoord[];
 ```
 
-`getMovementRangeDetails` builds occupancy from `state.units`, derives hostile owners with `isHostileOwnerTo(state, unit.owner, candidate.owner)`, and follows the current BFS exactly. When it enters a legal ZOC tile, add that coordinate to both arrays but never enqueue it. `getMovementRange` retains its current signature and existing non-state utility behavior; update every gameplay caller that needs ZOC to call the detailed state API. Preserve current hostile-occupant, road, river, terrain, technology, and forced-march logic.
+`getMovementRangeDetails` always has the exact signature `(state: Readonly<GameState>, unitId: string)`. It builds occupancy from `state.units`, derives hostile owners with `isHostileOwnerTo(state, unit.owner, candidate.owner)`, and follows the current BFS exactly. When it enters a legal ZOC tile, add that coordinate to both arrays but never enqueue it. `getMovementRange` retains its current signature and existing non-state utility behavior; update every gameplay caller that needs ZOC to call the detailed state API. Preserve current hostile-occupant, road, river, terrain, technology, and forced-march logic.
 
 - [ ] **Step 3: Write failing canonical-execution tests.**
 
@@ -216,20 +230,22 @@ Extend the successful `ExecuteUnitMoveResult` with `stopReason?: 'zone-of-contro
 
 For every direct `moveUnit` call found by `rg -n "moveUnit\\(" src/ai src/systems`, either migrate it to `executeUnitMove` or replace it with `finalizeUnitMove` using the state before the move. In particular, update `moveWarshipToward`, pirate pursuit, pirate one-step movement, and pirate formation relocation. In formation relocation, stop a vessel after its first ZOC-limited step and reject/cancel the atomic formation plan if that would make formation placement inconsistent; never move through ZOC in a later loop iteration.
 
+Replace `ai-tactics.ts`’s local `movementRange()` implementation with `getMovementRangeDetails(state, unit.id).reachable`, then retain its current occupancy filter. This ensures a major-AI candidate cannot route past a terminal ZOC tile before Task 5 scores it.
+
 - [ ] **Step 6: Prove direct-path parity.**
 
 Add one test each for the basic-AI naval pursuit path, pirate-system move, and pirate-behavior movement path. Each places a hostile same-domain unit beside the entered tile and asserts `movementPointsLeft === 0` and no subsequent step. Keep existing pirate formation atomicity assertions.
 
 - [ ] **Step 7: Run movement and world-path tests.**
 
-Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts`
+Run: `./scripts/run-with-mise.sh yarn test --run tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/ai/ai-tactics.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts`
 
 Expected: PASS.
 
 - [ ] **Step 8: Commit canonical movement parity.**
 
 ```bash
-git add src/systems/unit-system.ts src/systems/unit-movement-system.ts src/ai/basic-ai.ts src/systems/pirate-system.ts src/systems/pirate-behavior.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts
+git add src/systems/unit-system.ts src/systems/unit-movement-system.ts src/ai/basic-ai.ts src/ai/ai-tactics.ts src/systems/pirate-system.ts src/systems/pirate-behavior.ts tests/systems/unit-system.test.ts tests/systems/unit-movement-system.test.ts tests/ai/basic-ai-pirates.test.ts tests/ai/ai-tactics.test.ts tests/systems/pirate-system.test.ts tests/systems/pirate-behavior.test.ts
 git commit -m "feat(movement): apply zone of control to all movers"
 ```
 
@@ -311,7 +327,7 @@ Add a hot-seat fixture with `currentPlayer = 'ai-1'`, a no-ZOC legend negative t
 
 - [ ] **Step 2: Extend highlight presentation.**
 
-Add `zocLimitedRange: HexCoord[]` and `hasZoneOfControlWarning: boolean` to `SelectedUnitHighlightResult`. Create `type: 'zoc-limited'` in `HexHighlight`, render it amber with a high-contrast outline distinct from `water-recovery`, and preserve attack precedence.
+Add `zocLimitedRange: HexCoord[]` and `hasZoneOfControlWarning: boolean` to `SelectedUnitHighlightResult`. Create `type: 'zoc-limited'` in `HexHighlight`, render it amber with a high-contrast outline distinct from `water-recovery`, and preserve attack precedence. Extend `HexHighlight` with `pattern?: 'zoc'`; for `pattern === 'zoc'`, `RenderLoop.render()` draws three short inward chevrons after `drawHexHighlight`. The renderer test asserts those three `moveTo`/`lineTo` strokes in addition to amber fill and outline, so the non-color cue is not merely a color variant.
 
 - [ ] **Step 3: Render the pre-move explanation.**
 
@@ -338,6 +354,7 @@ git commit -m "feat(ui): show zone of control movement warnings"
 
 **Files:**
 - Modify: `src/ai/ai-tactics.ts`
+- Modify: `src/ai/ai-hostility.ts`
 - Test: `tests/ai/ai-tactics.test.ts`
 
 - [ ] **Step 1: Write a failing deterministic candidate-ranking test.**
@@ -373,13 +390,25 @@ Use the canonical context output, not duplicate adjacency math. Add this score a
 
 Assert that a candidate adjacent only to a civilian/recon/air unit receives no positional score and that a ZOC-limited move does not gain value from imaginary follow-on movement.
 
-- [ ] **Step 4: Run tactical tests.**
+- [ ] **Step 4: Prove all challenge profiles retain the same rules.**
+
+```ts
+for (const challenge of Object.keys(OPPONENT_CHALLENGE_PROFILES) as OpponentChallenge[]) {
+  const state = makeState(challenge);
+  expect(getMovementRangeDetails(state, mover.id).zocLimited).toContainEqual(zocEntry);
+  expect(scorePostMovePositioning(context(state, plan), mover, flankDestination)).toBe(expectedScore);
+}
+```
+
+The assertion intentionally does not call `chooseUnitTacticalAction`: challenge profiles may vary the seeded near-best choice, but they must not change ZOC legality, exhaustion, or canonical positional value.
+
+- [ ] **Step 5: Run tactical tests.**
 
 Run: `./scripts/run-with-mise.sh yarn test --run tests/ai/ai-tactics.test.ts`
 
 Expected: PASS.
 
-- [ ] **Step 5: Commit AI parity.**
+- [ ] **Step 6: Commit AI parity.**
 
 ```bash
 git add src/ai/ai-tactics.ts tests/ai/ai-tactics.test.ts

--- a/docs/superpowers/specs/2026-07-14-zone-of-control-flanking-support-design.md
+++ b/docs/superpowers/specs/2026-07-14-zone-of-control-flanking-support-design.md
@@ -1,0 +1,107 @@
+# Zone of Control and Flanking/Support Design
+
+**Issue:** #538 — `design(combat): zone of control + flanking/support bonuses`  
+**Status:** Approved for planning  
+**Date:** 2026-07-14
+
+## Goal
+
+Make battlefield positioning matter without obscuring why a move or combat result changed. Combat units can hold a line through zone of control (ZOC), while adjacent friendly combat positions provide visible flanking and support bonuses.
+
+The player must see a ZOC-limited destination before moving and must receive a plain-language explanation after the unit stops. The same gameplay rules apply to the player, major AI, and hostile world actors.
+
+## Scope and Rules
+
+### Zone of control
+
+A unit that enters a tile adjacent to a hostile qualifying combat unit may complete that move, but its remaining movement immediately becomes zero. ZOC never makes that destination illegal; it is a reachable terminal destination for the current turn.
+
+ZOC is evaluated for the entered tile, after normal terrain, road, river, technology, occupancy, and hostile-city movement validation. A unit starting adjacent to an enemy is not trapped: it can move normally until it enters a qualifying hostile ZOC tile.
+
+ZOC is domain-local:
+
+- A land combat unit affects land combat units.
+- A naval combat unit affects naval combat units.
+- Air units neither exert nor receive ZOC. Their current movement model crosses terrain at a fixed cost and their interactions remain combat-at-range rather than map-tile pinning.
+- A unit cannot affect another domain across a coastline.
+
+A qualifying ZOC source is a hostile, non-air combat unit in the same domain. Recon and civilian/non-combat units neither exert nor receive ZOC. A stack exerts ZOC if it contains a qualifying combat unit; where a strength choice is needed, use its strongest qualifying combat unit rather than treating each stacked unit as another source.
+
+Hostility must use the existing owner/diplomacy semantics. The rule applies symmetrically to major civilizations and the hostile world actors already represented by units: barbarians, beasts, pirates, and rebels. It does not vary by difficulty, player count, hot-seat mode, or save state.
+
+Horizontal map wrapping must be honored when detecting adjacency.
+
+### Movement presentation and feedback
+
+Movement-range calculation must distinguish ordinary reachable tiles from ZOC-limited reachable tiles. The renderer presents the latter in **amber** with a warning treatment (icon or equivalent), while ordinary reachable tiles retain the existing movement presentation. Amber means: “Reachable, but movement ends here.” It must not look like an impassable or attack-only tile.
+
+When a unit enters a ZOC-limited tile, the live player movement path uses `MovementBlockerReason`-style feedback with the new `zone-of-control` code and the text:
+
+> Stopped — enemy nearby
+
+The message is player-facing; non-player callers still receive the same canonical movement outcome without requiring UI notification logic.
+
+### Flanking and support
+
+Combat receives two independent +10% bonuses per eligible adjacent tile:
+
+- **Flanking:** the attacker gains +10% for each adjacent tile to the defender containing a friendly combat unit other than the attacker’s own tile.
+- **Support:** the defender gains +10% for each adjacent tile to the defender containing a friendly combat unit other than the defender’s own tile.
+
+Each bonus counts **occupied adjacent tiles**, not units. A stack of two or more friendly combat units on one adjacent hex contributes only one +10% bonus. A tile qualifies only when it contains at least one friendly combat unit; tiles occupied only by recon or civilian units do not qualify. Air units do not participate in either adjacency bonus.
+
+The canonical combat-strength calculation returns labeled modifier parts so the existing combat preview shows the exact result, for example `Flanked +20%` and `Supported +10%`. Combat resolution and every prediction path use those same values.
+
+## Architecture
+
+Introduce focused, stateless helper(s) in the unit/combat systems rather than duplicating caller-specific checks.
+
+1. A ZOC helper determines whether a unit qualifies as a source/recipient and whether a destination is in a hostile same-domain ZOC, using map-aware neighbor traversal and the game’s existing owner hostility semantics.
+2. The movement-range and path/step validation path exposes the terminal-ZOC outcome. `executeUnitMove` applies it by setting the moved unit’s remaining movement to zero. Player movement, AI movement, and world movement all route through canonical movement helpers.
+3. The movement-rendering path receives the ZOC-limited subset of legal destinations and renders it amber. The existing player feedback path maps the result to `zone-of-control` and its message.
+4. A combat-adjacency helper counts eligible friendly occupied neighboring tiles for attacker and defender. `calculateCombatStrengths` applies the percentages and exposes modifier parts. `formatCombatPreviewDetails` renders those parts without reimplementing the rule.
+5. `ai-tactics.ts` continues to evaluate combat via the canonical combat context/strength preview, with tactical ranking explicitly favoring available flanks and avoiding choices that abandon beneficial adjacent support when relevant. World actor movement stays on the canonical ZOC-aware path.
+
+The implementation must not add saved fields, turn-persistent control maps, schema migrations, or sound effects. A precomputed control map is intentionally out of scope: it creates invalidation work without a current consumer beyond ZOC.
+
+## Code Areas to Verify During Planning
+
+The plan must verify current signatures before editing. The audited starting points are:
+
+- `src/systems/unit-system.ts`: `getMovementStepCost`, `getMovementRange`, `findPath`, and `MovementBlockerReason`.
+- `src/systems/unit-movement-system.ts`: `executeUnitMove` and `validateUnitMove` as the live shared mutation path.
+- `src/main.ts` and the renderer/highlight path: selected-unit movement range, amber ZOC subset, and user-visible notification wiring.
+- `src/systems/combat-system.ts`, `src/systems/combat-context.ts`, and `src/ui/combat-preview.ts`: canonical strength computation, modifier parts, and preview text.
+- `src/ai/ai-tactics.ts`, `src/systems/barbarian-system.ts`, `src/systems/pirate-system.ts`, and beast movement behavior: major-AI and world-actor parity.
+
+## Error Handling and Edge Cases
+
+- Preserve current passability, occupancy, and forced-march semantics. ZOC is a legal-move terminal effect, not a replacement for those rules.
+- Do not count an enemy that is not hostile under existing diplomacy/owner rules.
+- Do not count an air, recon, civilian, transported, or mismatched-domain unit as a ZOC source or adjacency-bonus contributor.
+- Do not double-count a stack for ZOC sources or combat bonuses.
+- Keep wrapped-neighbor behavior identical in movement, combat adjacency, and rendering so the map edge cannot disagree with resolution.
+- Ensure the display only marks tiles that are truly reachable; a tile beyond normal movement range is never surfaced merely because it lies in ZOC.
+
+## Verification Contract
+
+Add focused regression coverage before production changes, including:
+
+1. Land and naval ZOC both stop a same-domain combat mover after legal entry; cross-domain and air interactions do not.
+2. Recon and civilian units do not exert or receive ZOC; a starting unit can leave ZOC normally.
+3. Hostile barbarian, beast, pirate, and rebel movement both respects and exerts the same rule, with at least one non-player execution-path parity test.
+4. Wrapped-map adjacency matches ordinary adjacency behavior.
+5. The movement range exposes legal ZOC-limited tiles separately from ordinary reachable tiles; the live renderer uses amber for them and does not mark unreachable tiles.
+6. The live player move consumes the remaining movement and visibly reports `Stopped — enemy nearby`.
+7. Flanking and support apply one +10% increment per adjacent eligible friendly-occupied tile; the attacker/defender’s own tile, civilians, recon, air units, and additional units in a stack do not add an increment.
+8. Combat preview labels show the calculated flanking and support bonuses, and combat resolution uses the same values.
+9. AI tactical scoring recognizes a flanking improvement through the canonical strength preview rather than an independent combat formula.
+10. Seeded early-era same-tier combat sampling remains within the existing two-to-four-exchange pacing target after the new bonuses are included.
+
+Run the mirrored unit, movement, combat, AI tactics, and UI/renderer tests; the source-rule checker for changed `src/` files; and a TypeScript build. The implementation plan must enumerate exact test files after verifying current locations.
+
+## Out of Scope
+
+- New anti-air units, anti-air interception radius, or aircraft basing changes. Existing city anti-air remains a combat-defense modifier against air attackers.
+- Any difficulty scaling, save migration, new audio, or changes to solo/hot-seat rules.
+- Supply lines, territory-control systems, or persistent/precomputed ZOC state.

--- a/docs/superpowers/specs/2026-07-14-zone-of-control-flanking-support-design.md
+++ b/docs/superpowers/specs/2026-07-14-zone-of-control-flanking-support-design.md
@@ -33,7 +33,9 @@ Horizontal map wrapping must be honored when detecting adjacency.
 
 ### Movement presentation and feedback
 
-Movement-range calculation must distinguish ordinary reachable tiles from ZOC-limited reachable tiles. The renderer presents the latter in **amber** with a warning treatment (icon or equivalent), while ordinary reachable tiles retain the existing movement presentation. Amber means: “Reachable, but movement ends here.” It must not look like an impassable or attack-only tile.
+Movement-range calculation must distinguish ordinary reachable tiles from ZOC-limited reachable tiles. The renderer presents the latter in **amber** with a distinct warning icon or pattern, while ordinary reachable tiles retain the existing movement presentation. Amber means: “Reachable, but movement ends here.” It must not look like an impassable or attack-only tile.
+
+Before the move, the selected-unit movement surface supplies the same non-color explanation in its legend, tooltip, or tap-accessible equivalent: `Enemy nearby — entering ends movement`. The player can therefore understand the warning without relying on color or discovering the rule after committing. The renderer test must assert this explanatory text as well as the distinct tile treatment.
 
 When a unit enters a ZOC-limited tile, the live player movement path uses `MovementBlockerReason`-style feedback with the new `zone-of-control` code and the text:
 
@@ -52,15 +54,17 @@ Each bonus counts **occupied adjacent tiles**, not units. A stack of two or more
 
 The canonical combat-strength calculation returns labeled modifier parts so the existing combat preview shows the exact result, for example `Flanked +20%` and `Supported +10%`. Combat resolution and every prediction path use those same values.
 
+The bonus remains uncapped: a defender can receive up to six eligible adjacent-tile increments (+60%). A melee attacker occupies one neighboring tile and can therefore receive up to five additional flanking increments (+50%); a ranged attacker outside the adjacent ring can receive up to six (+60%). This is intentional so a completed envelopment is meaningful, but it is a balance acceptance gate rather than an assumption. Seeded early-era sampling must include open, two-tile, and maximum-envelopment scenarios and keep same-tier fights within the two-to-four-exchange target; if a maximum-envelopment scenario fails that target, the implementation must stop for a balance decision rather than silently introduce a cap.
+
 ## Architecture
 
 Introduce focused, stateless helper(s) in the unit/combat systems rather than duplicating caller-specific checks.
 
 1. A ZOC helper determines whether a unit qualifies as a source/recipient and whether a destination is in a hostile same-domain ZOC, using map-aware neighbor traversal and the game’s existing owner hostility semantics.
-2. The movement-range and path/step validation path exposes the terminal-ZOC outcome. `executeUnitMove` applies it by setting the moved unit’s remaining movement to zero. Player movement, AI movement, and world movement all route through canonical movement helpers.
+2. The movement-range and path/step validation path exposes the terminal-ZOC outcome. A shared lower-level move-finalization helper applies it by setting the moved unit’s remaining movement to zero. `executeUnitMove` uses that helper, and every retained direct `moveUnit` caller (including basic AI and pirate/world behavior) must use it too; alternatively, migrate the caller to `executeUnitMove`. No gameplay caller may bypass ZOC.
 3. The movement-rendering path receives the ZOC-limited subset of legal destinations and renders it amber. The existing player feedback path maps the result to `zone-of-control` and its message.
 4. A combat-adjacency helper counts eligible friendly occupied neighboring tiles for attacker and defender. `calculateCombatStrengths` applies the percentages and exposes modifier parts. `formatCombatPreviewDetails` renders those parts without reimplementing the rule.
-5. `ai-tactics.ts` continues to evaluate combat via the canonical combat context/strength preview, with tactical ranking explicitly favoring available flanks and avoiding choices that abandon beneficial adjacent support when relevant. World actor movement stays on the canonical ZOC-aware path.
+5. `ai-tactics.ts` continues to evaluate combat via the canonical combat context/strength preview. Its candidate ranking explicitly evaluates the post-move positional effect: when two otherwise comparable legal moves differ in the attacker’s next-turn flanking/support value, prefer the position with the greater canonical value; do not reproduce the combat formula in AI code. Apply the same shared movement finalization to world-actor behavior.
 
 The implementation must not add saved fields, turn-persistent control maps, schema migrations, or sound effects. A precomputed control map is intentionally out of scope: it creates invalidation work without a current consumer beyond ZOC.
 
@@ -72,7 +76,7 @@ The plan must verify current signatures before editing. The audited starting poi
 - `src/systems/unit-movement-system.ts`: `executeUnitMove` and `validateUnitMove` as the live shared mutation path.
 - `src/main.ts` and the renderer/highlight path: selected-unit movement range, amber ZOC subset, and user-visible notification wiring.
 - `src/systems/combat-system.ts`, `src/systems/combat-context.ts`, and `src/ui/combat-preview.ts`: canonical strength computation, modifier parts, and preview text.
-- `src/ai/ai-tactics.ts`, `src/systems/barbarian-system.ts`, `src/systems/pirate-system.ts`, and beast movement behavior: major-AI and world-actor parity.
+- `src/ai/ai-tactics.ts`, `src/ai/basic-ai.ts`, `src/systems/barbarian-system.ts`, `src/systems/pirate-system.ts`, and `src/systems/pirate-behavior.ts`: major-AI and world-actor parity, including all retained direct movement callers.
 
 ## Error Handling and Edge Cases
 
@@ -91,12 +95,13 @@ Add focused regression coverage before production changes, including:
 2. Recon and civilian units do not exert or receive ZOC; a starting unit can leave ZOC normally.
 3. Hostile barbarian, beast, pirate, and rebel movement both respects and exerts the same rule, with at least one non-player execution-path parity test.
 4. Wrapped-map adjacency matches ordinary adjacency behavior.
-5. The movement range exposes legal ZOC-limited tiles separately from ordinary reachable tiles; the live renderer uses amber for them and does not mark unreachable tiles.
+5. The movement range exposes legal ZOC-limited tiles separately from ordinary reachable tiles; the live renderer uses amber plus a non-color warning icon/pattern for them, exposes `Enemy nearby — entering ends movement` before selection, and does not mark unreachable tiles.
 6. The live player move consumes the remaining movement and visibly reports `Stopped — enemy nearby`.
 7. Flanking and support apply one +10% increment per adjacent eligible friendly-occupied tile; the attacker/defender’s own tile, civilians, recon, air units, and additional units in a stack do not add an increment.
 8. Combat preview labels show the calculated flanking and support bonuses, and combat resolution uses the same values.
-9. AI tactical scoring recognizes a flanking improvement through the canonical strength preview rather than an independent combat formula.
-10. Seeded early-era same-tier combat sampling remains within the existing two-to-four-exchange pacing target after the new bonuses are included.
+9. Major-AI tactical scoring deterministically prefers a legal position with better next-turn flanking/support value over an otherwise comparable alternative, using the canonical calculation rather than an independent formula.
+10. Each retained direct movement path and at least one world-actor behavior apply the same ZOC finalization as player movement.
+11. Seeded early-era same-tier combat sampling remains within the existing two-to-four-exchange pacing target for open, two-tile, and maximum-envelopment scenarios after the new bonuses are included: five-tile melee flanking, six-tile ranged flanking, and six-tile defender support. A failed maximum-envelopment check requires an explicit balance decision; it must not silently add a cap.
 
 Run the mirrored unit, movement, combat, AI tactics, and UI/renderer tests; the source-rule checker for changed `src/` files; and a TypeScript build. The implementation plan must enumerate exact test files after verifying current locations.
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2798,13 +2798,10 @@ function executeAttack(attackerId: string, targetKey: string): void {
   }
 
   // `attacker` was captured before applyCombatOutcomeToState — safe even if attacker was destroyed
-  const worldPixel = hexToPixel(attacker.position, renderLoop.camera.hexSize);
-  const screen = renderLoop.camera.worldToScreen(worldPixel.x, worldPixel.y);
-  const size = renderLoop.camera.hexSize * renderLoop.camera.zoom;
   SFX.combat();
   renderLoop.setGameState(gameState);
   updateHUD();
-  renderLoop.animations.add('combat-flash', 400, { x: screen.x, y: screen.y, size }, () => selectNextUnit());
+  renderLoop.animations.add('combat-flash', 400, { coord: attacker.position }, () => selectNextUnit());
 }
 
 function restAction(): void {

--- a/src/renderer/animation-system.ts
+++ b/src/renderer/animation-system.ts
@@ -1,17 +1,45 @@
+import type { HexCoord } from '@/core/types';
+import { hexToPixel } from '@/systems/hex-utils';
+import type { Camera } from './camera';
+import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+
+export type EffectAnimationType =
+  | 'combat-flash'
+  | 'wonder-discovery-pulse'
+  | 'wonder-discovery-static-highlight'
+  | 'disembark-flash';
+
+export interface EffectAnimationData {
+  /** Hex the effect marks. Screen position is derived from the camera every frame. */
+  coord: HexCoord;
+  accent?: string;
+  glow?: string;
+}
+
 export interface Animation {
   id: string;
-  type: string;
+  type: EffectAnimationType;
   startTime: number;
   duration: number;
-  data: any;
+  data: EffectAnimationData;
   onComplete?: () => void;
+}
+
+export interface AnimationMapContext {
+  width: number;
+  wrapsHorizontally: boolean;
 }
 
 export class AnimationSystem {
   private animations: Animation[] = [];
   private nextId = 1;
 
-  add(type: string, duration: number, data: any, onComplete?: () => void): string {
+  add(
+    type: EffectAnimationType,
+    duration: number,
+    data: EffectAnimationData,
+    onComplete?: () => void,
+  ): string {
     const id = `anim-${this.nextId++}`;
     this.animations.push({
       id,
@@ -24,14 +52,23 @@ export class AnimationSystem {
     return id;
   }
 
-  update(ctx: CanvasRenderingContext2D, now: number): void {
+  update(ctx: CanvasRenderingContext2D, camera: Camera, map: AnimationMapContext, now: number): void {
     const completed: Animation[] = [];
 
     for (const anim of this.animations) {
       const elapsed = now - anim.startTime;
       const progress = Math.min(1, elapsed / anim.duration);
 
-      this.renderAnimation(ctx, anim, progress);
+      const renderCoords = map.wrapsHorizontally
+        ? getHorizontalWrapRenderCoords(anim.data.coord, map.width, camera)
+        : [anim.data.coord];
+      for (const renderCoord of renderCoords) {
+        if (!camera.isHexVisible(renderCoord)) continue;
+        const pixel = hexToPixel(renderCoord, camera.hexSize);
+        const screen = camera.worldToScreen(pixel.x, pixel.y);
+        const size = camera.hexSize * camera.zoom;
+        this.renderAnimation(ctx, anim, progress, screen.x, screen.y, size);
+      }
 
       if (progress >= 1) {
         completed.push(anim);
@@ -45,23 +82,16 @@ export class AnimationSystem {
     }
   }
 
-  hasAnimations(): boolean {
-    return this.animations.length > 0;
-  }
-
-  private renderAnimation(ctx: CanvasRenderingContext2D, anim: Animation, progress: number): void {
+  private renderAnimation(
+    ctx: CanvasRenderingContext2D,
+    anim: Animation,
+    progress: number,
+    x: number,
+    y: number,
+    size: number,
+  ): void {
     switch (anim.type) {
-      case 'hex-reveal': {
-        const { x, y, size } = anim.data;
-        const alpha = 1 - progress;
-        ctx.fillStyle = `rgba(15, 15, 25, ${alpha * 0.95})`;
-        ctx.beginPath();
-        ctx.arc(x, y, size * (1 + progress * 0.3), 0, Math.PI * 2);
-        ctx.fill();
-        break;
-      }
       case 'combat-flash': {
-        const { x, y, size } = anim.data;
         const alpha = 1 - progress;
         ctx.fillStyle = `rgba(255, 100, 50, ${alpha * 0.6})`;
         ctx.beginPath();
@@ -70,17 +100,17 @@ export class AnimationSystem {
         break;
       }
       case 'wonder-discovery-pulse': {
-        const { x, y, size, accent, glow } = anim.data;
+        const { accent, glow } = anim.data;
         const alpha = 1 - progress;
         ctx.save();
-        ctx.strokeStyle = glow;
+        ctx.strokeStyle = glow ?? '#fff';
         ctx.globalAlpha = Math.max(0.15, alpha);
         ctx.lineWidth = Math.max(2, size * 0.06);
         ctx.beginPath();
         ctx.arc(x, y, size * (0.48 + progress * 0.72), 0, Math.PI * 2);
         ctx.stroke();
         ctx.globalAlpha = Math.max(0.10, alpha * 0.35);
-        ctx.fillStyle = accent;
+        ctx.fillStyle = accent ?? '#fff';
         ctx.beginPath();
         ctx.arc(x, y, size * (0.32 + progress * 0.18), 0, Math.PI * 2);
         ctx.fill();
@@ -88,9 +118,9 @@ export class AnimationSystem {
         break;
       }
       case 'wonder-discovery-static-highlight': {
-        const { x, y, size, accent } = anim.data;
+        const { accent } = anim.data;
         ctx.save();
-        ctx.strokeStyle = accent;
+        ctx.strokeStyle = accent ?? '#fff';
         ctx.globalAlpha = 0.85;
         ctx.lineWidth = Math.max(2, size * 0.05);
         ctx.beginPath();
@@ -101,7 +131,6 @@ export class AnimationSystem {
       }
       case 'disembark-flash': {
         // Expanding teal ring — signals a unit has disembarked at this hex.
-        const { x, y, size } = anim.data;
         const alpha = 1 - progress;
         ctx.save();
         ctx.strokeStyle = `rgba(74, 200, 217, ${alpha * 0.7})`;

--- a/src/renderer/hex-renderer.ts
+++ b/src/renderer/hex-renderer.ts
@@ -1,7 +1,7 @@
 import type { GameMap, HexCoord, HexTile, TerrainType, VisibilityMap } from '@/core/types';
 import { hexToPixel, hexesInRange, HEX_CORNERS_POINTY, hexNeighbors, getWrappedHexNeighbors, hexKey } from '@/systems/hex-utils';
 import { Camera } from './camera';
-import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { getHorizontalWrapRenderCoords, nearestWrappedCoord } from './wrap-rendering';
 import { shouldRenderOwnedTileBorder, shouldRenderOwnedTileBorderForPresentation } from './render-visibility';
 import { resolveTilePresentationForViewer, type TilePresentationKind } from './tile-presentation';
 import { drawNaturalWonderLandmark } from './wonders/natural-wonder-renderer';
@@ -328,8 +328,13 @@ function drawRoadOrRailSegment(
 ): void {
   const isRail = endpointHasRail(map, visibility, completedTechsByCiv, from)
     && endpointHasRail(map, visibility, completedTechsByCiv, to);
-  if (isRail && drawRailSegment(ctx, camera, from, to)) return;
-  drawRoadSegment(ctx, camera, from, to);
+  // Seam-crossing pairs arrive with canonical coords (getWrappedHexNeighbors
+  // canonicalizes); draw to the nearest wrap copy of `to` so the segment is a
+  // short step, not a line spanning the whole map. Eligibility lookups above
+  // stay canonical-safe either way (tile presentation re-wraps internally).
+  const renderTo = map.wrapsHorizontally ? nearestWrappedCoord(from, to, map.width) : to;
+  if (isRail && drawRailSegment(ctx, camera, from, renderTo)) return;
+  drawRoadSegment(ctx, camera, from, renderTo);
 }
 
 export function drawRoads(

--- a/src/renderer/render-loop.ts
+++ b/src/renderer/render-loop.ts
@@ -7,7 +7,7 @@ import { drawUnitPresentations } from './unit-renderer';
 import { drawCities } from './city-renderer';
 import { AnimationSystem } from './animation-system';
 import { hexToPixel, hexKey } from '@/systems/hex-utils';
-import { getHorizontalWrapRenderCoords } from './wrap-rendering';
+import { getHorizontalWrapRenderCoords, nearestWrappedCoord } from './wrap-rendering';
 import { getVisibility } from '@/systems/fog-of-war';
 import { createMovementAnimation, getMovementAnimationPosition, getMovingUnitIds, type UnitMovementAnimation } from './unit-movement-animation';
 import { resolveUnitVisual } from './unit-visual-resolver';
@@ -297,16 +297,11 @@ export class RenderLoop {
     options: { reducedMotion: boolean },
   ): void {
     this.camera.centerOn(coord);
-    const pixel = hexToPixel(coord, this.camera.hexSize);
-    const screen = this.camera.worldToScreen(pixel.x, pixel.y);
-    const size = this.camera.hexSize * this.camera.zoom;
     this.animations.add(
       options.reducedMotion ? 'wonder-discovery-static-highlight' : 'wonder-discovery-pulse',
       900,
       {
-        x: screen.x,
-        y: screen.y,
-        size,
+        coord,
         accent: visual.palette.accent,
         glow: visual.palette.glow,
       },
@@ -350,10 +345,7 @@ export class RenderLoop {
    */
   animateUnitAppear(position: HexCoord): void {
     if (prefersReducedMotion()) return;
-    const pixel = hexToPixel(position, this.camera.hexSize);
-    const screen = this.camera.worldToScreen(pixel.x, pixel.y);
-    const size = this.camera.hexSize * this.camera.zoom;
-    this.animations.add('disembark-flash', 500, { x: screen.x, y: screen.y, size });
+    this.animations.add('disembark-flash', 500, { coord: position });
   }
 
   hasMovingUnit(unitId: string): boolean {
@@ -532,21 +524,32 @@ export class RenderLoop {
       }
     }
 
-    // Draw journey path overlay
+    // Draw journey path overlay. Seam-crossing steps are unwrapped into a
+    // pixel-continuous polyline, then drawn once per visible wrap copy.
     if (this.journeyPath && this.journeyPath.length >= 2) {
+      const renderPath: HexCoord[] = [this.journeyPath[0]!];
+      for (let i = 1; i < this.journeyPath.length; i++) {
+        renderPath.push(
+          this.state.map.wrapsHorizontally
+            ? nearestWrappedCoord(renderPath[i - 1]!, this.journeyPath[i]!, this.state.map.width)
+            : this.journeyPath[i]!,
+        );
+      }
       this.ctx.save();
       this.ctx.strokeStyle = 'rgba(255, 200, 50, 0.8)';
       this.ctx.lineWidth = 3;
       this.ctx.setLineDash([6, 4]);
-      this.ctx.beginPath();
-      let started = false;
-      for (const coord of this.journeyPath) {
-        const pixel = hexToPixel(coord, this.camera.hexSize);
-        const screen = this.camera.worldToScreen(pixel.x, pixel.y);
-        if (!started) { this.ctx.moveTo(screen.x, screen.y); started = true; }
-        else { this.ctx.lineTo(screen.x, screen.y); }
+      for (const offset of this.visibleWrapOffsets(renderPath)) {
+        this.ctx.beginPath();
+        let started = false;
+        for (const coord of renderPath) {
+          const pixel = hexToPixel({ q: coord.q + offset, r: coord.r }, this.camera.hexSize);
+          const screen = this.camera.worldToScreen(pixel.x, pixel.y);
+          if (!started) { this.ctx.moveTo(screen.x, screen.y); started = true; }
+          else { this.ctx.lineTo(screen.x, screen.y); }
+        }
+        this.ctx.stroke();
       }
-      this.ctx.stroke();
       this.ctx.restore();
     }
 
@@ -720,8 +723,8 @@ export class RenderLoop {
       this.state.map,
     );
 
-    // Draw animations
-    this.animations.update(this.ctx, performance.now());
+    // Draw animations (world-anchored: screen position derives from the camera each frame)
+    this.animations.update(this.ctx, this.camera, this.state.map, performance.now());
 
   }
 
@@ -805,18 +808,44 @@ export class RenderLoop {
       const toVis   = playerCiv.visibility ? getVisibility(playerCiv.visibility, toCity.position) : 'unexplored';
       if (fromVis === 'unexplored' || toVis === 'unexplored') continue;
 
-      const fromPx = hexToPixel(fromCity.position, this.camera.hexSize);
-      const toPx   = hexToPixel(toCity.position, this.camera.hexSize);
-      const fromScreen = this.camera.worldToScreen(fromPx.x, fromPx.y);
-      const toScreen   = this.camera.worldToScreen(toPx.x, toPx.y);
+      // Route lines crossing the wrap seam draw to the nearest ghost copy of
+      // the destination, once per visible wrap copy of the pair.
+      const toPosition = this.state.map.wrapsHorizontally
+        ? nearestWrappedCoord(fromCity.position, toCity.position, this.state.map.width)
+        : toCity.position;
+      for (const offset of this.visibleWrapOffsets([fromCity.position, toPosition])) {
+        const fromPx = hexToPixel({ q: fromCity.position.q + offset, r: fromCity.position.r }, this.camera.hexSize);
+        const toPx   = hexToPixel({ q: toPosition.q + offset, r: toPosition.r }, this.camera.hexSize);
+        const fromScreen = this.camera.worldToScreen(fromPx.x, fromPx.y);
+        const toScreen   = this.camera.worldToScreen(toPx.x, toPx.y);
 
-      this.ctx.beginPath();
-      this.ctx.moveTo(fromScreen.x, fromScreen.y);
-      this.ctx.lineTo(toScreen.x, toScreen.y);
-      this.ctx.stroke();
+        this.ctx.beginPath();
+        this.ctx.moveTo(fromScreen.x, fromScreen.y);
+        this.ctx.lineTo(toScreen.x, toScreen.y);
+        this.ctx.stroke();
+      }
     }
 
     this.ctx.restore();
+  }
+
+  /**
+   * Wrap offsets (multiples of map width, applied to q) under which at least
+   * one of `coords` lands on screen. Always [0] for non-wrapping maps, so
+   * callers can share one code path.
+   */
+  private visibleWrapOffsets(coords: readonly HexCoord[]): number[] {
+    if (!this.state?.map.wrapsHorizontally || coords.length === 0) return [0];
+    const width = this.state.map.width;
+    const offsets = new Set<number>();
+    for (const endpoint of [coords[0]!, coords[coords.length - 1]!]) {
+      for (const copy of getHorizontalWrapRenderCoords(endpoint, width, this.camera)) {
+        offsets.add(copy.q - endpoint.q);
+      }
+    }
+    return Array.from(offsets).filter(offset =>
+      coords.some(coord => this.camera.isHexVisible({ q: coord.q + offset, r: coord.r })),
+    );
   }
 
 }

--- a/src/renderer/unit-movement-animation.ts
+++ b/src/renderer/unit-movement-animation.ts
@@ -1,5 +1,6 @@
 import type { GameMap, HexCoord, Unit } from '@/core/types';
 import type { UnitMotionState } from '@/renderer/unit-visual-resolver';
+import { nearestWrappedCoord } from '@/renderer/wrap-rendering';
 
 export const MOVEMENT_MS_PER_HEX = 220;
 export const MOVEMENT_MAX_MS = 800;
@@ -28,11 +29,7 @@ export function getMovementDurationMs(stepCount: number): number {
 
 function wrappedRenderStep(from: HexCoord, to: HexCoord, map: GameMap): HexCoord {
   if (!map.wrapsHorizontally) return to;
-  const directDelta = to.q - from.q;
-  const westDelta = to.q - map.width - from.q;
-  const eastDelta = to.q + map.width - from.q;
-  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0]!;
-  return { q: from.q + bestDelta, r: to.r };
+  return nearestWrappedCoord(from, to, map.width);
 }
 
 export function createMovementAnimation(unit: Unit, path: HexCoord[], map: GameMap): UnitMovementAnimation {

--- a/src/renderer/wrap-rendering.ts
+++ b/src/renderer/wrap-rendering.ts
@@ -2,6 +2,21 @@ import type { HexCoord } from '@/core/types';
 import { hexToPixel } from '@/systems/hex-utils';
 import { Camera } from './camera';
 
+/**
+ * Pick the render copy of `to` (canonical, or a ±mapWidth ghost) nearest to
+ * `from`, so a segment crossing the horizontal wrap seam draws as a short
+ * step instead of a line spanning the whole map. Pass mapWidth <= 0 for
+ * non-wrapping maps to get `to` unchanged.
+ */
+export function nearestWrappedCoord(from: HexCoord, to: HexCoord, mapWidth: number): HexCoord {
+  if (mapWidth <= 0) return { ...to };
+  const directDelta = to.q - from.q;
+  const westDelta = to.q - mapWidth - from.q;
+  const eastDelta = to.q + mapWidth - from.q;
+  const bestDelta = [directDelta, westDelta, eastDelta].sort((a, b) => Math.abs(a) - Math.abs(b))[0]!;
+  return { q: from.q + bestDelta, r: to.r };
+}
+
 export function getHorizontalWrapRenderCoords(
   coord: HexCoord,
   mapWidth: number,

--- a/tests/renderer/animation-system.test.ts
+++ b/tests/renderer/animation-system.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AnimationSystem } from '@/renderer/animation-system';
+import { Camera } from '@/renderer/camera';
+import { hexToPixel } from '@/systems/hex-utils';
+
+function mockCtx() {
+  return {
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    stroke: vi.fn(),
+    save: vi.fn(),
+    restore: vi.fn(),
+    fillStyle: '',
+    strokeStyle: '',
+    globalAlpha: 1,
+    lineWidth: 0,
+  } as unknown as CanvasRenderingContext2D & {
+    arc: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeCamera(): Camera {
+  const camera = new Camera();
+  camera.setViewport(320, 240);
+  return camera;
+}
+
+const FLAT_MAP = { width: 10, wrapsHorizontally: false };
+const WRAP_MAP = { width: 10, wrapsHorizontally: true };
+
+function expectedScreen(camera: Camera, coord: { q: number; r: number }): { x: number; y: number } {
+  const pixel = hexToPixel(coord, camera.hexSize);
+  return camera.worldToScreen(pixel.x, pixel.y);
+}
+
+describe('AnimationSystem camera tracking', () => {
+  it('draws the combat flash at the hex position under the current camera each frame', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    const coord = { q: 2, r: 1 };
+    camera.centerOn(coord);
+    const ctx = mockCtx();
+    const start = performance.now();
+    animations.add('combat-flash', 400, { coord });
+
+    animations.update(ctx, camera, FLAT_MAP, start + 100);
+    const first = expectedScreen(camera, coord);
+    expect(ctx.arc).toHaveBeenLastCalledWith(first.x, first.y, expect.any(Number), 0, Math.PI * 2);
+
+    camera.pan(-40, -30);
+    animations.update(ctx, camera, FLAT_MAP, start + 200);
+    const second = expectedScreen(camera, coord);
+    expect(second).not.toEqual(first);
+    expect(ctx.arc).toHaveBeenLastCalledWith(second.x, second.y, expect.any(Number), 0, Math.PI * 2);
+  });
+
+  it('recomputes the effect size when the camera zoom changes mid-animation', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    const coord = { q: 2, r: 1 };
+    camera.centerOn(coord);
+    const ctx = mockCtx();
+    const start = performance.now();
+    animations.add('combat-flash', 400, { coord });
+
+    animations.update(ctx, camera, FLAT_MAP, start);
+    const radiusAtZoom1 = ctx.arc.mock.lastCall![2] as number;
+
+    camera.setZoom(2, 160, 120);
+    camera.centerOn(coord);
+    animations.update(ctx, camera, FLAT_MAP, start);
+    const radiusAtZoom2 = ctx.arc.mock.lastCall![2] as number;
+
+    expect(radiusAtZoom2).toBeCloseTo(radiusAtZoom1 * 2);
+  });
+
+  it('draws the effect at the visible ghost copy when the camera views the wrap seam', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    // Camera centered on the ghost copy (q = -1 side of the seam); the
+    // canonical coordinate q = 9 is far off-screen to the east.
+    camera.centerOn({ q: -1, r: 1 });
+    const coord = { q: 9, r: 1 };
+    const ctx = mockCtx();
+    animations.add('disembark-flash', 500, { coord });
+
+    animations.update(ctx, camera, WRAP_MAP, performance.now());
+
+    const ghost = expectedScreen(camera, { q: -1, r: 1 });
+    expect(ctx.arc).toHaveBeenCalledWith(ghost.x, ghost.y, expect.any(Number), 0, Math.PI * 2);
+  });
+
+  it('skips drawing entirely when no wrap copy of the hex is on screen', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    camera.centerOn({ q: 2, r: 1 });
+    const ctx = mockCtx();
+    animations.add('combat-flash', 400, { coord: { q: 2, r: 200 } });
+
+    animations.update(ctx, camera, FLAT_MAP, performance.now());
+
+    expect(ctx.arc).not.toHaveBeenCalled();
+  });
+
+  it('renders the wonder pulse with its accent and glow palette', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    const coord = { q: 1, r: 1 };
+    camera.centerOn(coord);
+    const ctx = mockCtx();
+    const strokeStyles: string[] = [];
+    Object.defineProperty(ctx, 'strokeStyle', {
+      set: value => strokeStyles.push(String(value)),
+      get: () => strokeStyles[strokeStyles.length - 1] ?? '',
+    });
+    animations.add('wonder-discovery-pulse', 900, { coord, accent: '#accent', glow: '#glow' });
+
+    animations.update(ctx, camera, FLAT_MAP, performance.now());
+
+    expect(strokeStyles).toContain('#glow');
+  });
+
+  it('removes completed animations and fires onComplete exactly once', () => {
+    const animations = new AnimationSystem();
+    const camera = makeCamera();
+    const coord = { q: 1, r: 1 };
+    camera.centerOn(coord);
+    const ctx = mockCtx();
+    const onComplete = vi.fn();
+    const start = performance.now();
+    animations.add('combat-flash', 400, { coord }, onComplete);
+
+    animations.update(ctx, camera, FLAT_MAP, start + 500);
+    animations.update(ctx, camera, FLAT_MAP, start + 600);
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(ctx.arc).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/renderer/hex-renderer.test.ts
+++ b/tests/renderer/hex-renderer.test.ts
@@ -491,6 +491,38 @@ describe('drawRoads', () => {
     expect((ctx as unknown as MockCanvasContext).strokeCalls.length).toBeGreaterThan(0);
   });
 
+  it('draws a seam-crossing road pair as short stubs on both sides, never a full-map line', async () => {
+    const { drawRoads } = await import('@/renderer/hex-renderer');
+    const map: GameMap = {
+      width: 6,
+      height: 1,
+      wrapsHorizontally: true,
+      rivers: [],
+      tiles: {
+        '0,0': { coord: { q: 0, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+        '5,0': { coord: { q: 5, r: 0 }, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none', owner: 'player', improvementTurnsLeft: 0, hasRiver: false, wonder: null, hasRoad: true },
+      },
+    } as unknown as GameMap;
+    const segments: Array<{ fromX: number; toX: number }> = [];
+    let penX = 0;
+    const ctx = new MockCanvasContext() as unknown as CanvasRenderingContext2D;
+    (ctx as unknown as { moveTo: (x: number) => void }).moveTo = (x: number) => { penX = x; };
+    (ctx as unknown as { lineTo: (x: number) => void }).lineTo = (x: number) => {
+      segments.push({ fromX: penX, toX: x });
+      penX = x;
+    };
+
+    const camera = makeCamera();
+    drawRoads(ctx, map, camera, new Set());
+
+    // Both sides of the seam get a stub (base pass + ghost pass).
+    expect(segments.length).toBeGreaterThanOrEqual(2);
+    const hexStep = Math.sqrt(3) * camera.hexSize;
+    for (const segment of segments) {
+      expect(Math.abs(segment.toX - segment.fromX)).toBeLessThanOrEqual(hexStep * 1.5);
+    }
+  });
+
   it('draws a road segment into a city tile even without hasRoad on the city hex', async () => {
     const { drawRoads } = await import('@/renderer/hex-renderer');
     const map: GameMap = {

--- a/tests/renderer/render-loop-wrap.test.ts
+++ b/tests/renderer/render-loop-wrap.test.ts
@@ -48,18 +48,68 @@ import {
 import type { PirateHeadquartersMapEntity } from '@/renderer/pirate-headquarters-presentation';
 import type { GameState, Unit } from '@/core/types';
 
-function createCanvas(): HTMLCanvasElement {
+interface LineRecordingCtx {
+  moveTo: ReturnType<typeof vi.fn>;
+  lineTo: ReturnType<typeof vi.fn>;
+}
+
+function createCanvasWithCtx(): { canvas: HTMLCanvasElement; ctx: LineRecordingCtx } {
   const ctx = {
     clearRect: vi.fn(),
     fillRect: vi.fn(),
     fillStyle: '',
+    strokeStyle: '',
+    lineWidth: 0,
+    globalAlpha: 1,
     scale: vi.fn(),
-  } as unknown as CanvasRenderingContext2D;
+    save: vi.fn(),
+    restore: vi.fn(),
+    setLineDash: vi.fn(),
+    beginPath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+  };
 
-  return {
-    getContext: () => ctx,
+  const canvas = {
+    getContext: () => ctx as unknown as CanvasRenderingContext2D,
     getBoundingClientRect: () => ({ width: 320, height: 240 }),
   } as unknown as HTMLCanvasElement;
+
+  return { canvas, ctx };
+}
+
+function createCanvas(): HTMLCanvasElement {
+  return createCanvasWithCtx().canvas;
+}
+
+/**
+ * Reconstruct drawn line segments from moveTo/lineTo mock calls using their
+ * global invocation order: each lineTo continues from the previous point.
+ */
+function orderedLineSegments(ctx: LineRecordingCtx): Array<{ fromX: number; toX: number }> {
+  const events = [
+    ...ctx.moveTo.mock.calls.map((call, index) => ({
+      kind: 'moveTo' as const,
+      x: call[0] as number,
+      order: ctx.moveTo.mock.invocationCallOrder[index]!,
+    })),
+    ...ctx.lineTo.mock.calls.map((call, index) => ({
+      kind: 'lineTo' as const,
+      x: call[0] as number,
+      order: ctx.lineTo.mock.invocationCallOrder[index]!,
+    })),
+  ].sort((a, b) => a.order - b.order);
+
+  const segments: Array<{ fromX: number; toX: number }> = [];
+  for (let i = 1; i < events.length; i++) {
+    if (events[i]!.kind === 'lineTo') {
+      segments.push({ fromX: events[i - 1]!.x, toX: events[i]!.x });
+    }
+  }
+  return segments;
 }
 
 describe('render-loop wrap parity', () => {
@@ -234,6 +284,90 @@ describe('render-loop wrap parity', () => {
       expect.anything(),
       state.map,
     );
+  });
+
+  it('draws a seam-crossing journey path as a short wrapped step, not a full-map line', () => {
+    const { canvas, ctx } = createCanvasWithCtx();
+    const loop = new RenderLoop(canvas);
+    const state = {
+      turn: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 3, wrapsHorizontally: true, tiles: {}, rivers: [] },
+      tribalVillages: {}, minorCivs: {}, cities: {}, units: {},
+      civilizations: { player: { color: '#4a90d9', visibility: { tiles: {} } } },
+    } as unknown as GameState;
+
+    loop.setGameState(state);
+    loop.setJourneyPath([{ q: 4, r: 1 }, { q: 0, r: 1 }]);
+    loop.camera.centerOn({ q: 4.5, r: 1 });
+
+    (loop as unknown as { render: () => void }).render();
+
+    const segments = orderedLineSegments(ctx);
+    expect(segments.length).toBeGreaterThan(0);
+    const hexStep = Math.sqrt(3) * loop.camera.hexSize;
+    for (const segment of segments) {
+      expect(Math.abs(segment.toX - segment.fromX)).toBeLessThan(hexStep * 2);
+    }
+  });
+
+  it('draws the journey path at the visible ghost copy when the camera views the seam', () => {
+    const { canvas, ctx } = createCanvasWithCtx();
+    const loop = new RenderLoop(canvas);
+    const state = {
+      turn: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 3, wrapsHorizontally: true, tiles: {}, rivers: [] },
+      tribalVillages: {}, minorCivs: {}, cities: {}, units: {},
+      civilizations: { player: { color: '#4a90d9', visibility: { tiles: {} } } },
+    } as unknown as GameState;
+
+    loop.setGameState(state);
+    loop.setJourneyPath([{ q: 0, r: 1 }, { q: 1, r: 1 }]);
+    loop.camera.centerOn({ q: 5, r: 1 });
+
+    (loop as unknown as { render: () => void }).render();
+
+    const points = [
+      ...ctx.moveTo.mock.calls.map(call => call[0] as number),
+      ...ctx.lineTo.mock.calls.map(call => call[0] as number),
+    ];
+    expect(points.some(x => x >= 0 && x <= 320)).toBe(true);
+  });
+
+  it('draws a seam-crossing trade route as a short wrapped line, not a full-map line', () => {
+    const { canvas, ctx } = createCanvasWithCtx();
+    const loop = new RenderLoop(canvas);
+    const state = {
+      turn: 1,
+      currentPlayer: 'player',
+      map: { width: 5, height: 3, wrapsHorizontally: true, tiles: {}, rivers: [] },
+      tribalVillages: {}, minorCivs: {},
+      cities: {
+        c1: { id: 'c1', owner: 'player', position: { q: 4, r: 1 } },
+        c2: { id: 'c2', owner: 'player', position: { q: 0, r: 1 } },
+      },
+      units: {},
+      marketplace: { tradeRoutes: [{ fromCityId: 'c1', toCityId: 'c2' }] },
+      civilizations: {
+        player: {
+          color: '#4a90d9',
+          visibility: { tiles: { '4,1': 'visible', '0,1': 'visible' } },
+        },
+      },
+    } as unknown as GameState;
+
+    loop.setGameState(state);
+    loop.camera.centerOn({ q: 4.5, r: 1 });
+
+    (loop as unknown as { render: () => void }).render();
+
+    const segments = orderedLineSegments(ctx);
+    expect(segments.length).toBeGreaterThan(0);
+    const hexStep = Math.sqrt(3) * loop.camera.hexSize;
+    for (const segment of segments) {
+      expect(Math.abs(segment.toX - segment.fromX)).toBeLessThan(hexStep * 2);
+    }
   });
 
   it('runs movement completion callbacks after the unit leaves the moving set', () => {

--- a/tests/renderer/wonder-discovery-highlight.test.ts
+++ b/tests/renderer/wonder-discovery-highlight.test.ts
@@ -59,7 +59,11 @@ describe('wonder discovery highlight', () => {
     expect(add).toHaveBeenCalledWith(
       'wonder-discovery-pulse',
       900,
-      expect.objectContaining({ accent: expect.any(String), glow: expect.any(String) }),
+      expect.objectContaining({
+        coord: { q: 2, r: 0 },
+        accent: expect.any(String),
+        glow: expect.any(String),
+      }),
     );
   });
 
@@ -74,7 +78,7 @@ describe('wonder discovery highlight', () => {
     expect(add).toHaveBeenCalledWith(
       'wonder-discovery-static-highlight',
       900,
-      expect.objectContaining({ accent: expect.any(String) }),
+      expect.objectContaining({ coord: { q: 2, r: 0 }, accent: expect.any(String) }),
     );
     expect((loop as unknown as { highlights: unknown[] }).highlights).toEqual([{ coord: { q: 1, r: 0 }, type: 'move' }]);
   });

--- a/tests/renderer/wrap-rendering.test.ts
+++ b/tests/renderer/wrap-rendering.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Camera } from '@/renderer/camera';
-import { getHorizontalWrapRenderCoords } from '@/renderer/wrap-rendering';
+import { getHorizontalWrapRenderCoords, nearestWrappedCoord } from '@/renderer/wrap-rendering';
 
 describe('getHorizontalWrapRenderCoords', () => {
   it('returns the canonical coordinate when wrapping is unavailable', () => {
@@ -24,5 +24,23 @@ describe('getHorizontalWrapRenderCoords', () => {
     expect(renderedColumns).toContain(0);
     expect(renderedColumns).toContain(5);
     expect(renderedColumns).toContain(10);
+  });
+});
+
+describe('nearestWrappedCoord', () => {
+  it('returns the canonical coordinate when it is already the nearest copy', () => {
+    expect(nearestWrappedCoord({ q: 1, r: 0 }, { q: 2, r: 0 }, 10)).toEqual({ q: 2, r: 0 });
+  });
+
+  it('picks the westward ghost copy across the seam', () => {
+    expect(nearestWrappedCoord({ q: 0, r: 2 }, { q: 9, r: 2 }, 10)).toEqual({ q: -1, r: 2 });
+  });
+
+  it('picks the eastward ghost copy across the seam', () => {
+    expect(nearestWrappedCoord({ q: 9, r: 1 }, { q: 0, r: 1 }, 10)).toEqual({ q: 10, r: 1 });
+  });
+
+  it('returns the target unchanged when the map does not wrap', () => {
+    expect(nearestWrappedCoord({ q: 0, r: 0 }, { q: 9, r: 0 }, 0)).toEqual({ q: 9, r: 0 });
   });
 });


### PR DESCRIPTION
## Root cause (#525 — verified)

`AnimationSystem` stored screen-space pixels captured once at effect creation and replayed them every frame; `update()` never saw the camera. It was the only renderer violating the codebase invariant "recompute screen position from world coordinates each frame." Effects (combat flash, wonder-discovery pulse, disembark ring) drifted during pans, rendered at the wrong radius after mid-effect zoom (frozen `size` — a third failure mode beyond the issue's two), and vanished entirely near the wrap seam.

## Fix

- `AnimationSystem` now stores the **hex coordinate** in typed `EffectAnimationData`; `update(ctx, camera, map, now)` derives screen position and size from the camera each frame and draws every visible wrap copy via `getHorizontalWrapRenderCoords`, exactly like the tile/unit/fog passes.
- All three producers (combat flash in `main.ts`, wonder-discovery pulse/static highlight and disembark ring in `render-loop.ts`) pass hex coords. Reduced-motion behavior unchanged.
- Dead code removed with the contract change: the `hex-reveal` type (no producer anywhere) and unused `hasAnimations()`.

## Sibling bugs fixed (same family, found by audit)

1. **Journey path overlay** — drew canonical coords with no wrap handling: seam-crossing paths rendered as a full-map-width line, and the whole path was invisible when the camera viewed a ghost copy. Now unwrapped into a pixel-continuous polyline drawn once per visible wrap copy.
2. **Trade-route lines** — identical defect, same fix per route (owner-only privacy check untouched).
3. **Seam-crossing road/rail segments** — `getWrappedHexNeighbors` canonicalizes, so a road pair at `q=0`/`q=w-1` drew one stretched line across the whole map. Segments now draw to the nearest wrap copy of the far endpoint, producing short stubs on both sides of the seam; eligibility lookups stay canonical. (Rivers audited and safe — the generator never produces seam-crossing segments.)

`wrappedRenderStep` was generalized into `nearestWrappedCoord` in `wrap-rendering.ts`, now shared by unit movement animation, journey path, trade routes, and road segments.

## Review notes (balance / AI / saves / hot seat)

- Pure presentation: no game state, combat math, difficulty scaling, or RNG touched. No save migration — animations, paths, and route lines are transient per-frame render state, so existing saves render correctly immediately.
- AI behavior unchanged (these effects are feedback for the acting human's input). Hot-seat viewer scoping untouched; effects are sub-second and tied to the acting player's action.
- SFX timing (`SFX.combat()`) unchanged.
- Biggest UX win is on mobile: effects stay glued to their hex during routine pans, and combat feedback no longer silently disappears near the seam (which read as "my attack did nothing").

## Testing

- New `tests/renderer/animation-system.test.ts`: pan tracking, zoom-size recomputation, seam ghost-copy rendering, off-screen culling, palette pass-through, completion/`onComplete` semantics — each watched fail before the fix.
- New wrap regressions: journey path (short seam step + ghost-copy visibility), trade routes (short seam line), roads (short stubs on both seam sides, never a full-map line).
- `yarn build` and `yarn test` green: 399 files, 6512 passed / 3 skipped. Verified live in the dev server: game boots, map renders and pans cleanly, no console errors.

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)