### PR TITLE
feat(religion): religion core — state, Sacred Council, boons, passive spread (#591 MR4)

### DIFF
--- a/.claude/rules/game-balance.md
+++ b/.claude/rules/game-balance.md
@@ -89,6 +89,18 @@ ceilings above, applied to happiness).
 - UI must show `(fading)` label when multiplier is 0.5.
 - Build UI must label national-project yield numbers as empire-wide so they cannot be mistaken for host-city yields.
 
+## Milestone National Projects (#591 MR4)
+
+`NationalProject.milestone?: true` marks a one-time permanent-trigger project (e.g. Sacred Council):
+- Buildable from `homeEra` onward — **no upper build-window bound** (`getAvailableBuildings` and the
+  belt-and-suspenders dequeue guard in `processCity` both skip the `homeEra + 1` upper check for
+  milestone NPs).
+- **Never expires** — `expireNationalProjects` skips milestone NPs unconditionally, regardless of
+  era delta. The building stays in `city.buildings` and `builtNationalProjects` forever.
+- **No `civYieldBonus`/`cityYieldBonus`** — its effect is a one-time state-mutating side effect
+  (e.g. founding a religion), not an ongoing yield. Enforced by `national-project-balance.test.ts`.
+- Still `uniquePerEmpire: true` — one per civ, same as every other national project.
+
 ## National Project Production Discounts
 
 MR12 added a second class of national-project effect distinct from `civYieldBonus`: empire-wide *production cost discounts* (e.g. Tribal Muster Ground: era-1/2 melee units train 10% cheaper). These are cost multipliers, not yields, so the yield ceilings above do not apply to them — but they have their own rules:

--- a/.claude/rules/game-balance.md
+++ b/.claude/rules/game-balance.md
@@ -71,6 +71,7 @@ proportionate to what's already here.
 | Concert Hall building | city | +1 | era 6+ (`baroque-music`) |
 | Luxury resources (each type owned) | empire | +1 each | varies by resource |
 | Beast-slayer's feast (Hunt crisis reward) | empire | +2 | temporary, 5 turns |
+| Religious serenity (Serenity boon) | city (own-faith followers only) | +1 | era 3+ (Sacred Council + serenity boon chosen) |
 
 **Rule:** any new happiness source (building, wonder, tech, resource) must add
 a row here and stay at +1 per single source unless a documented gameplay

--- a/docs/superpowers/plans/2026-07-18-issue-591-religion-core.md
+++ b/docs/superpowers/plans/2026-07-18-issue-591-religion-core.md
@@ -1,0 +1,1001 @@
+# Religion Core Implementation Plan (#524 MR4, issue #591)
+
+> **For agentic workers:** Execute inline in this session (project policy forbids subagents). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add religion as a real game system — founding via a new "milestone" national project (Sacred Council), invented per-civ names, three boons (Serenity/Tithes/Fervor), and passive faith spread/conversion between cities.
+
+**Architecture:** Two new state slices (`religions`, `cityFaith`), one new system pair (`religion-definitions.ts` data, `religion-system.ts` logic), a new `milestone` flag on the existing `NationalProject` type that bypasses the build-window/fade machinery at exactly the sites that currently assume every NP fades. Boon effects plug into the existing per-city happiness-row list and per-civ gross-gold accumulator — the same seams `.claude/rules/game-balance.md` already documents for other economy terms.
+
+**Tech Stack:** TypeScript, vitest. No new deps.
+
+## Global Constraints
+
+- Religion names are **invented, culture-flavored, never real-world faiths** (per user decision on file, matches project convention for wonder/quest content).
+- No war-gate on spread or Tithes (user decision this session — matches unrest-contagion precedent, which also ignores diplomacy).
+- `conversionProgress` is singular per city (`{ toReligionId, points }`, not a map) — when the locally-strongest religion for a city changes to a **different** religion than the one currently tracked, `points` resets to 0 for the new target. When it's the same tracked religion, points accumulate normally. ("Weaker records stall but are not erased" refers to *other cities'* progress toward other religions, not a multi-target ledger inside one city — the type only ever holds one target.)
+- Religions are never deleted once founded (permanent world fact, same precedent as `completedLegendaryWonders`) — only per-city `cityFaith` entries get cleaned up, and only when their city is actually removed (`raze`), never on ownership transfer (the city record persists across capture, so `cityFaith` persists for free — no explicit code needed there).
+- Fervor's MR4 description says ONLY "faster conversion" — never mention territory/loyalty (that's MR6, and promising it now would be a new dead promise).
+- This MR is economy-affecting (Serenity happiness, Tithes gold) — pacing gates (`pacing-audit.test.ts`, `pacing-reference-economy.test.ts`) must be re-run and any snapshot shift justified in the PR body.
+- PR body: grep the drafted body for `closes?\s+#\d+` (case-insensitive) before running `gh pr create` — this exact arc has hit the false-auto-close bug twice already (#595, #600) from negated "never closes #524" phrasing GitHub's parser doesn't understand negation on.
+
+---
+
+## Drift-checked facts (verified against `main` @ edf2a6a6, 2026-07-18)
+
+| Fact | Location |
+|---|---|
+| `NationalProject { homeEra: number }` | `src/core/types.ts:447` |
+| Build-window filter (production queue availability) | `src/systems/city-system.ts:1767-1771` inside `getAvailableBuildings` |
+| Build-window dequeue guard | `src/systems/city-system.ts:1946-1963` inside `processCity` |
+| Fade/expiry | `src/systems/national-project-system.ts`: `getNationalProjectMultiplier`, `getActiveNationalProjectsForCiv`, `getNationalProjectCivYieldBonus`, `expireNationalProjects` |
+| `expireNationalProjects` removes ANY built NP once `era - eraBuilt >= 3`, unconditionally | `src/systems/national-project-system.ts:110-144` — **milestone NPs must be excluded here or Sacred Council silently vanishes from the holy city after 3 eras even though the religion it founded persists forever** |
+| era-3 NP cost/pacing norms (120-125 production, `pacing.band: 'marquee', role: 'national-project'`) | `src/systems/city-system.ts:278-304` (`philosophers_circle`, `road_corps`, `iron_legion`) |
+| Temple building already gated on `philosophy`, era 3 | `.claude/rules/game-balance.md` happiness inventory |
+| `requiresBuildings: string[]` already supported generically | `Building` type + `getAvailableBuildings` line 1764-1766 |
+| Per-city unrest pressure rows (Serenity's insertion point) | `getUnrestPressureBreakdown` in `src/systems/faction-system.ts:46-105` — per-city rows like `Happiness buildings` already follow the `-amount*2` pressure-reduction convention |
+| Per-civ gross gold accumulator (Tithes' insertion point) | `projectCivGrossGold` in `src/systems/economy-system.ts:491-565`, insert after the `getClaimedTrophyGoldPerTurn` line |
+| City ownership transfer (capture, `occupy` disposition) keeps the city record — `cityFaith` persists automatically | `src/systems/city-capture-system.ts` `resolveMajorCityCapture` occupy branch |
+| City raze deletes the city record — `cityFaith` must be explicitly cleaned up here | `src/systems/city-capture-system.ts` raze branch, `delete nextCities[cityId]` |
+| `hasMetCivilization(state, viewerCivId, targetCivId)` for discovery-gated notifications | `src/systems/discovery-system.ts:77` |
+| `deliver: NotificationSink` from `createNotificationDelivery` — the only path for game-consequence notifications per `.claude/rules/ui-panels.md` | `src/ui/notification-delivery.ts` |
+| Full-screen pending-choice modal precedent (model the boon modal on this) | `src/ui/required-choice-panel.ts` — DOM-built, `textContent` only, `createGameButton` |
+| 29 civ ids need name candidates | `src/systems/civ-definitions.ts` (egypt, rome, greece, mongolia, babylon, zulu, china, persia, england, aztec, japan, india, france, germany, gondor, rohan, russia, ottoman, shire, isengard, spain, viking, prydain, annuvin, wakanda, avalon, lothlorien, narnia, atlantis) |
+| `migrateSaveToCurrent` already has an unconditional post-migration-loop hook (added in MR3) | `src/storage/save-migrations.ts` — `normalizeCrisisArchetypes` runs right before the final return; add sibling defaults for `religions`/`cityFaith` there or as an equivalent unconditional default |
+
+---
+
+## Task 1: Types + state slices + save migration defaults
+
+**Files:**
+- Modify: `src/core/types.ts` (`Religion`, `CityFaith`, `state.religions`, `state.cityFaith`, `NationalProject.milestone`, events)
+- Modify: `src/storage/save-migrations.ts`
+- Test: `tests/storage/save-migrations.test.ts`
+
+- [ ] **Step 1: Add types**
+
+```ts
+// src/core/types.ts — new interfaces, near ActiveCrisis
+export type ReligionBoon = 'serenity' | 'tithes' | 'fervor';
+
+export interface Religion {
+  id: string;            // 'religion-<ownerCivId>'
+  name: string;
+  ownerCivId: string;
+  boon?: ReligionBoon;    // absent = pending choice, no effects
+  foundedTurn: number;
+}
+
+export interface CityFaith {
+  religionId: string;
+  isHolyCity?: true;
+  conversionProgress?: { toReligionId: string; points: number };
+  // loyaltyProgress added by MR6 (#593)
+}
+```
+
+Add to `GameState`: `religions?: Record<string, Religion>; cityFaith?: Record<string, CityFaith>;` — **optional**, matching `activeCrises`/`pirates`/`espionage`'s established convention. (Course-corrected during implementation: non-optional broke 36 TS errors across 20 pre-existing minimal-literal-`GameState` test fixtures that don't spread every field. Optional + `?? {}` at read sites is the actual codebase-wide pattern for late-added slices — defaulted to `{}` in `createNewGame` and `migrateSaveToCurrent` regardless, so real gameplay code never sees `undefined`, only test fixtures that predate this field do.)
+
+Add to `NationalProject`: `milestone?: true;`
+
+Add events (find the `GameEvents` interface, insert near `'crisis:started'`):
+```ts
+'religion:founded': { religionId: string; civId: string; cityId: string; name: string };
+'religion:city-converted': { cityId: string; toReligionId: string; fromReligionId?: string };
+```
+
+- [ ] **Step 2: Wire defaults into `createNewGame`**
+
+Read `src/core/game-state.ts`'s `createNewGame` function fully first. Add `religions: {}, cityFaith: {}` to the returned `GameState` literal, in the same style as neighboring empty-record defaults (e.g. wherever `barbarianCamps: {}` or similar already sits).
+
+- [ ] **Step 3: Write failing migration test**
+
+```ts
+// tests/storage/save-migrations.test.ts
+describe('#591 MR4 — religion state defaults', () => {
+  it('defaults religions and cityFaith to {} for a save predating this feature', () => {
+    const save = createNewGame('rome', 'religion-defaults-drift', 'small');
+    delete (save as Record<string, unknown>).religions;
+    delete (save as Record<string, unknown>).cityFaith;
+    const migrated = migrateSaveToCurrent(save);
+    expect(migrated.religions).toEqual({});
+    expect(migrated.cityFaith).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 4: Run to verify failure, then add the defaulting**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/storage/save-migrations.test.ts`
+
+In `src/storage/save-migrations.ts`, find the `normalizeCrisisArchetypes` call site added in MR3 (right before `migrateSaveToCurrent`'s final return) and add a sibling default, e.g.:
+
+```ts
+function withReligionDefaults(state: GameState): GameState {
+  return {
+    ...state,
+    religions: state.religions ?? {},
+    cityFaith: state.cityFaith ?? {},
+  };
+}
+```
+
+Chain it into the same final-return expression `normalizeCrisisArchetypes` uses (read the exact current code first — do not guess the variable name).
+
+- [ ] **Step 5: Run to verify pass, commit**
+
+```bash
+git add src/core/types.ts src/core/game-state.ts src/storage/save-migrations.ts tests/storage/save-migrations.test.ts
+git commit -m "feat(religion): add religion/cityFaith state slices + save defaults (#591 MR4)"
+```
+
+---
+
+## Task 2: `religion-definitions.ts`
+
+**Files:**
+- Create: `src/systems/religion-definitions.ts`
+- Test: `tests/systems/religion-definitions.test.ts`
+
+**Interfaces:**
+- Produces: `NAME_CANDIDATES: Record<string, string[]>` (keyed by civType id, 2 invented names each) + `NEUTRAL_NAME_CANDIDATES: string[]` (for custom/unlisted civ types); `CONVERSION_THRESHOLD = 100`; `OWN_CITY_ACCRUAL = 15`; `FOREIGN_ADJACENT_ACCRUAL = 7`; `FOREIGN_ADJACENT_CAP = 2`; `TRADE_ROUTE_ACCRUAL = 5`; `OCCUPATION_ACCRUAL = 5` (unused until MR5 — export it anyway so MR5 doesn't redefine it); `FERVOR_MULTIPLIER = 1.25`; `TITHES_CAP = 10`; `BOON_DESCRIPTIONS: Record<ReligionBoon, string>`.
+
+- [ ] **Step 1: Write the data file**
+
+```ts
+import type { ReligionBoon } from '@/core/types';
+
+export const CONVERSION_THRESHOLD = 100;
+export const OWN_CITY_ACCRUAL = 15;
+export const FOREIGN_ADJACENT_ACCRUAL = 7;
+export const FOREIGN_ADJACENT_CAP = 2;
+export const TRADE_ROUTE_ACCRUAL = 5;
+// Wired starting MR5 (#592) — occupied cities accrue toward the occupier's faith.
+// Defined here now so MR5 doesn't need to touch this file's constant block.
+export const OCCUPATION_ACCRUAL = 5;
+export const FERVOR_MULTIPLIER = 1.25;
+export const TITHES_CAP = 10;
+
+// Invented, culture-flavored faith names — NEVER real-world religions (project
+// convention, matches wonder/quest content rules). 2 candidates per civ id; seeded
+// pick + player rename at founding.
+export const NAME_CANDIDATES: Record<string, string[]> = {
+  egypt: ['Cult of the River Dawn', 'Order of the Sundered Sky'],
+  rome: ['Cult of the Eternal Hearth', 'Order of the Twelve Standards'],
+  greece: ['Path of the Wine-Dark Sea', 'Circle of the First Light'],
+  mongolia: ['Way of the Endless Steppe', 'Cult of the Sky Father'],
+  babylon: ['Order of the Hanging Star', 'Cult of the River Reeds'],
+  zulu: ['Path of the Rising Spear', 'Circle of the Great Kraal'],
+  china: ['Way of the Jade Harmony', 'Order of the Silk Dawn'],
+  persia: ['Cult of the Burning Garden', 'Order of the Golden Road'],
+  england: ['Order of the White Cliff', 'Cult of the Grey Tide'],
+  aztec: ['Path of the Fifth Sun', 'Cult of the Feathered Rain'],
+  japan: ['Way of the Cherry Watch', 'Order of the Still Water'],
+  india: ['Path of the Monsoon Bell', 'Circle of the Sacred Peacock'],
+  france: ['Order of the Gilded Lily', 'Cult of the Northern Rose'],
+  germany: ['Order of the Iron Oak', 'Cult of the Black Forest'],
+  gondor: ['Order of the White Tree', 'Cult of the Sea-Kings'],
+  rohan: ['Path of the Horse Lords', 'Circle of the Golden Hall'],
+  russia: ['Cult of the Frozen Bell', 'Order of the Northern Bear'],
+  ottoman: ['Order of the Crescent Watch', 'Path of the Red Tulip'],
+  shire: ['Circle of the Green Hill', 'Order of the Second Breakfast'], // kid-readable, playful, matches Shire tone
+  isengard: ['Cult of the Broken Stone', 'Order of the Grinding Wheel'],
+  spain: ['Order of the Golden Coast', 'Cult of the Iron Sun'],
+  viking: ['Path of the Longship Star', 'Order of the Frost Raven'],
+  prydain: ['Circle of the Cauldron Born', 'Order of the Grey King'],
+  annuvin: ['Cult of the Hollow Crown', 'Order of the Undying Mist'],
+  wakanda: ['Order of the Panther Star', 'Cult of the Vibrant Heart'],
+  avalon: ['Order of the Lake Mist', 'Circle of the Once and Future'],
+  lothlorien: ['Circle of the Golden Mallorn', 'Order of the Starlit Bough'],
+  narnia: ['Circle of the Deep Magic', 'Order of the Eternal Snow'],
+  atlantis: ['Cult of the Sunken Star', 'Order of the Tidal Throne'],
+};
+
+export const NEUTRAL_NAME_CANDIDATES: string[] = [
+  'Order of the First Dawn',
+  'Circle of the Wandering Star',
+  'Path of the Quiet Flame',
+];
+
+export const BOON_DESCRIPTIONS: Record<ReligionBoon, string> = {
+  serenity: '+1 happiness in every city that follows your faith.',
+  tithes: `+1 gold per turn from every foreign city that follows your faith, up to +${TITHES_CAP} gold.`,
+  // MR4-honest: only conversion speed. Territory/loyalty effects ship in MR6 (#593) —
+  // do not add wording here until that MR actually implements them.
+  fervor: 'Your faith spreads 25% faster.',
+};
+```
+
+- [ ] **Step 2: Write tests**
+
+```ts
+// tests/systems/religion-definitions.test.ts
+import { describe, it, expect } from 'vitest';
+import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
+import { NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, BOON_DESCRIPTIONS } from '@/systems/religion-definitions';
+
+describe('#591 MR4 — religion definitions', () => {
+  it('has at least 2 name candidates for every playable civ id', () => {
+    for (const civId of Object.keys(CIV_DEFINITIONS)) {
+      expect(NAME_CANDIDATES[civId]?.length ?? 0).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('has a non-empty neutral pool for custom civs', () => {
+    expect(NEUTRAL_NAME_CANDIDATES.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('no candidate name matches a real-world major religion (spot check)', () => {
+    const bannedSubstrings = ['christ', 'islam', 'muslim', 'buddh', 'hindu', 'judai', 'jewish', 'catholic', 'protestant'];
+    const all = [...Object.values(NAME_CANDIDATES).flat(), ...NEUTRAL_NAME_CANDIDATES];
+    for (const name of all) {
+      const lower = name.toLowerCase();
+      for (const banned of bannedSubstrings) {
+        expect(lower).not.toContain(banned);
+      }
+    }
+  });
+
+  it('fervor description mentions only conversion speed, not territory/loyalty (MR4 honesty)', () => {
+    const lower = BOON_DESCRIPTIONS.fervor.toLowerCase();
+    expect(lower).not.toMatch(/territory|loyalty|flip/);
+  });
+});
+```
+
+- [ ] **Step 3: Run, verify pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/religion-definitions.test.ts` — if the civ-id coverage test fails, read `CIV_DEFINITIONS`'s actual keys (my grep above may have missed or added an id) and fix the `NAME_CANDIDATES` table, not the test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/systems/religion-definitions.ts tests/systems/religion-definitions.test.ts
+git commit -m "feat(religion): add religion-definitions.ts (names, constants, boon table) (#591 MR4)"
+```
+
+---
+
+## Task 3: `milestone` national project — bypass build-window/fade at all three sites
+
+**Files:**
+- Modify: `src/systems/city-system.ts` (two bypass sites)
+- Modify: `src/systems/national-project-system.ts` (`expireNationalProjects`)
+- Modify: `.claude/rules/game-balance.md` (contract clause)
+- Test: `tests/systems/national-project-balance.test.ts`, `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// tests/systems/national-project-balance.test.ts — add near existing NP contract tests
+describe('#591 MR4 — milestone national projects', () => {
+  it('every milestone NP has no civYieldBonus/cityYieldBonus and is uniquePerEmpire', () => {
+    for (const building of Object.values(BUILDINGS)) {
+      if (!building.nationalProject?.milestone) continue;
+      expect(building.civYieldBonus).toBeUndefined();
+      expect(building.cityYieldBonus).toBeUndefined();
+      expect(building.uniquePerEmpire).toBe(true);
+    }
+  });
+});
+```
+
+```ts
+// tests/systems/city-system.test.ts — add near existing getAvailableBuildings / processCity NP tests
+describe('#591 MR4 — milestone NP has no upper build-window bound', () => {
+  it('stays available in getAvailableBuildings far beyond homeEra + 1', () => {
+    // Use a real milestone building once Task 3 defines sacred_council (era 3); assert
+    // getAvailableBuildings still includes it at era 10 given the temple prereq is met
+    // and it hasn't been built yet, unlike a normal NP which would drop out after era 4.
+  });
+
+  it('is never dropped by the belt-and-suspenders dequeue guard regardless of era', () => {
+    // Queue sacred_council, advance era far past homeEra+1, run processCity, assert it
+    // is NOT in droppedProductionItems and remains in productionQueue.
+  });
+});
+```
+
+```ts
+// tests/systems/national-project-system.test.ts (create if it doesn't exist — check first)
+describe('#591 MR4 — expireNationalProjects never expires a milestone NP', () => {
+  it('leaves a milestone NP in builtNationalProjects and city.buildings at era - eraBuilt >= 3', () => {
+    // Build a minimal state with builtNationalProjects['civ:sacred_council'] eraBuilt=1,
+    // newEra=10 (delta 9, far past the normal >=3 expiry threshold), city.buildings
+    // includes 'sacred_council'. Assert expireNationalProjects leaves both untouched
+    // and returns expired: [].
+  });
+
+  it('still expires a normal (non-milestone) NP at delta >= 3, unaffected by this change', () => {
+    // Regression: use an existing non-milestone NP id (e.g. 'philosophers_circle') and
+    // assert the existing expiry behavior is unchanged.
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/national-project-balance.test.ts tests/systems/city-system.test.ts tests/systems/national-project-system.test.ts`
+
+- [ ] **Step 3: Add the `milestone` bypass in `getAvailableBuildings`**
+
+Replace:
+```ts
+    if (b.nationalProject) {
+      const currentEra = era ?? 1;
+      if (currentEra < b.nationalProject.homeEra || currentEra > b.nationalProject.homeEra + 1) return false;
+      if (b.uniquePerEmpire && civId && builtNationalProjectKeys?.has(`${civId}:${b.id}`)) return false;
+    }
+```
+with:
+```ts
+    if (b.nationalProject) {
+      const currentEra = era ?? 1;
+      const belowWindow = currentEra < b.nationalProject.homeEra;
+      const aboveWindow = !b.nationalProject.milestone && currentEra > b.nationalProject.homeEra + 1;
+      if (belowWindow || aboveWindow) return false;
+      if (b.uniquePerEmpire && civId && builtNationalProjectKeys?.has(`${civId}:${b.id}`)) return false;
+    }
+```
+
+- [ ] **Step 4: Add the bypass in the dequeue guard**
+
+Replace:
+```ts
+      const inWindow = era >= bldg.nationalProject.homeEra && era <= bldg.nationalProject.homeEra + 1;
+```
+with:
+```ts
+      const inWindow = era >= bldg.nationalProject.homeEra
+        && (bldg.nationalProject.milestone || era <= bldg.nationalProject.homeEra + 1);
+```
+
+- [ ] **Step 5: Add the bypass in `expireNationalProjects`**
+
+In `src/systems/national-project-system.ts`, replace:
+```ts
+  for (const [key, record] of Object.entries(state.builtNationalProjects ?? {})) {
+    if (newEra - record.eraBuilt >= 3) {
+      const buildingId = key.split(':').slice(1).join(':');
+      toExpire.push({ civId: record.civId, cityId: record.cityId, buildingId });
+    }
+  }
+```
+with:
+```ts
+  for (const [key, record] of Object.entries(state.builtNationalProjects ?? {})) {
+    const buildingId = key.split(':').slice(1).join(':');
+    if (BUILDINGS[buildingId]?.nationalProject?.milestone) continue; // permanent — see #591 MR4
+    if (newEra - record.eraBuilt >= 3) {
+      toExpire.push({ civId: record.civId, cityId: record.cityId, buildingId });
+    }
+  }
+```
+
+- [ ] **Step 6: Add the `game-balance.md` contract clause**
+
+Add to `.claude/rules/game-balance.md`, in the "National Project Lifecycle Contract" section:
+
+```markdown
+## Milestone National Projects (#591 MR4)
+
+`NationalProject.milestone?: true` marks a one-time permanent-trigger project (e.g. Sacred Council):
+- Buildable from `homeEra` onward — **no upper build-window bound** (`getAvailableBuildings` and the
+  belt-and-suspenders dequeue guard in `processCity` both skip the `homeEra + 1` upper check for
+  milestone NPs).
+- **Never expires** — `expireNationalProjects` skips milestone NPs unconditionally, regardless of
+  era delta. The building stays in `city.buildings` and `builtNationalProjects` forever.
+- **No `civYieldBonus`/`cityYieldBonus`** — its effect is a one-time state-mutating side effect
+  (e.g. founding a religion), not an ongoing yield. Enforced by `national-project-balance.test.ts`.
+- Still `uniquePerEmpire: true` — one per civ, same as every other national project.
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/national-project-balance.test.ts tests/systems/city-system.test.ts tests/systems/national-project-system.test.ts`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/systems/city-system.ts src/systems/national-project-system.ts .claude/rules/game-balance.md tests/systems/national-project-balance.test.ts tests/systems/city-system.test.ts tests/systems/national-project-system.test.ts
+git commit -m "feat(national-project): add milestone flag (no build-window cap, never expires) (#591 MR4)"
+```
+
+---
+
+## Task 4: Sacred Council building definition
+
+**Files:**
+- Modify: `src/systems/city-system.ts` (add `sacred_council` to `BUILDINGS`, add to `PRODUCTION_ICONS`)
+- Test: `tests/systems/city-system.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+describe('#591 MR4 — sacred_council national project shape', () => {
+  it('requires a temple, is gated on philosophy, era 3, milestone, no yield bonus', () => {
+    const b = BUILDINGS.sacred_council;
+    expect(b.requiresBuildings).toEqual(['temple']);
+    expect(b.techRequired).toBe('philosophy');
+    expect(b.nationalProject).toEqual({ homeEra: 3, milestone: true });
+    expect(b.uniquePerEmpire).toBe(true);
+    expect(b.civYieldBonus).toBeUndefined();
+  });
+
+  it('has a production icon', () => {
+    expect(PRODUCTION_ICONS.sacred_council).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/city-system.test.ts`
+
+- [ ] **Step 3: Add the definition**
+
+Add near the other era-3 national projects (after `iron_legion`, before the `// Era 4` comment):
+
+```ts
+  sacred_council: {
+    id: 'sacred_council', name: 'Sacred Council', category: 'culture',
+    yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 120,
+    description: 'Founds your empire\'s faith. One-time — permanent effect, never fades.',
+    techRequired: 'philosophy', requiresBuildings: ['temple'],
+    pacing: { band: 'marquee', role: 'national-project', impact: 1.5, scope: 'empire', snowball: 1.3, urgency: 1.1, situationality: 1, unlockBreadth: 1 },
+    uniquePerEmpire: true, nationalProject: { homeEra: 3, milestone: true },
+  },
+```
+
+Add `sacred_council: '⛩️'` to `PRODUCTION_ICONS` (pick an icon not already used elsewhere in that map — check first).
+
+- [ ] **Step 4: Run to verify pass, commit**
+
+```bash
+git add src/systems/city-system.ts tests/systems/city-system.test.ts
+git commit -m "feat(religion): add Sacred Council milestone national project (#591 MR4)"
+```
+
+---
+
+## Task 5: `religion-system.ts` core — founding, boon choice, strongest-pressure, turn processing
+
+**Files:**
+- Create: `src/systems/religion-system.ts`
+- Test: `tests/systems/religion-system.test.ts`
+
+**Interfaces:**
+- Consumes: `Religion`, `CityFaith` (Task 1); `NAME_CANDIDATES`, `NEUTRAL_NAME_CANDIDATES`, accrual constants, `CONVERSION_THRESHOLD`, `FERVOR_MULTIPLIER` (Task 2); `seededLcg` (`@/systems/seeded-lcg`); `hexNeighbors`/`mapDistance` (`@/systems/hex-utils`); `state.marketplace.tradeRoutes` shape (already used by crisis-system.ts, MR3).
+- Produces: `foundReligion(state, civId, cityId, bus): GameState`; `chooseBoon(state, religionId, boon): GameState`; `getStrongestPressure(state, cityId): { religionId: string; accrual: number } | null`; `processReligionTurn(state, bus): GameState`.
+
+- [ ] **Step 1: Write failing tests for `foundReligion`**
+
+```ts
+// tests/systems/religion-system.test.ts
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { foundReligion, chooseBoon, getStrongestPressure, processReligionTurn } from '@/systems/religion-system';
+import { makeReligionFixture } from './helpers/religion-fixture'; // new fixture, see Step 2
+
+describe('#591 MR4 — foundReligion', () => {
+  it('creates a religion, marks the building city as holy, and has capital + building city adopt it', () => {
+    const { state, civId, capitalId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const next = foundReligion(state, civId, templeCity, bus);
+    const religionId = `religion-${civId}`;
+    expect(next.religions[religionId]).toMatchObject({ ownerCivId: civId, boon: undefined });
+    expect(next.cityFaith[templeCity]).toMatchObject({ religionId, isHolyCity: true });
+    expect(next.cityFaith[capitalId]).toMatchObject({ religionId });
+  });
+
+  it('is a no-op if the civ already has a religion (uniquePerEmpire enforced at the state layer too, not just NP queueing)', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const founded = foundReligion(state, civId, templeCity, bus);
+    const second = foundReligion(founded, civId, templeCity, bus);
+    expect(second).toBe(founded);
+  });
+
+  it('picks a name from NAME_CANDIDATES deterministically by seed', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const a = foundReligion(state, civId, templeCity, new EventBus());
+    const b = foundReligion(state, civId, templeCity, new EventBus());
+    expect(a.religions[`religion-${civId}`].name).toBe(b.religions[`religion-${civId}`].name);
+  });
+
+  it('emits religion:founded exactly once', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('religion:founded', e => events.push(e));
+    foundReligion(state, civId, templeCity, bus);
+    expect(events).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Write the fixture helper**
+
+```ts
+// tests/systems/helpers/religion-fixture.ts
+// Mirror the shape/style of tests/systems/helpers/crisis-fixture.ts (read it first for
+// exact City/Civilization field completeness) -- minimal state with:
+// - civId 'p1', capitalId 'capital' (population 5, no buildings), templeCity 'temple-city'
+//   (population 4, buildings: ['temple'], distinct position from capital)
+// - state.religions: {}, state.cityFaith: {}
+// - a second civ 'p2' with its own city, for cross-civ spread/conversion tests
+// - state.marketplace: { tradeRoutes: [], prices: {}, priceHistory: {}, purchasedResources: [] }
+//   (or reuse createMarketplaceState() from '@/systems/trade-system' for a valid default)
+export function makeReligionFixture(overrides: ...): { state: GameState; civId: string; capitalId: string; templeCity: string; otherCivId: string; otherCity: string } { ... }
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/religion-system.test.ts`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 4: Implement `foundReligion`**
+
+```ts
+// src/systems/religion-system.ts
+import type { City, GameState, Religion, ReligionBoon } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { seededLcg } from './seeded-lcg';
+import { NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, CONVERSION_THRESHOLD, OWN_CITY_ACCRUAL, FOREIGN_ADJACENT_ACCRUAL, FOREIGN_ADJACENT_CAP, TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER } from './religion-definitions';
+import { getCapitalCityId } from './capital-system';
+import { mapDistance } from './hex-utils';
+
+function pickReligionName(civType: string, seed: number): string {
+  const pool = NAME_CANDIDATES[civType] ?? NEUTRAL_NAME_CANDIDATES;
+  const rng = seededLcg(seed);
+  return pool[Math.floor(rng() * pool.length)];
+}
+
+export function foundReligion(
+  state: GameState,
+  civId: string,
+  buildingCityId: string,
+  bus: EventBus,
+): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+  const alreadyHasReligion = Object.values(state.religions).some(r => r.ownerCivId === civId);
+  if (alreadyHasReligion) return state;
+
+  const religionId = `religion-${civId}`;
+  const seed = state.turn * 92821 + civId.split('').reduce((a, ch) => a + ch.charCodeAt(0), 0) * 17;
+  const name = pickReligionName(civ.civType, seed);
+
+  const religion: Religion = { id: religionId, name, ownerCivId: civId, foundedTurn: state.turn };
+  const capitalId = getCapitalCityId(state, civId);
+
+  const cityFaith = { ...state.cityFaith };
+  cityFaith[buildingCityId] = { religionId, isHolyCity: true };
+  if (capitalId && capitalId !== buildingCityId) {
+    cityFaith[capitalId] = { religionId };
+  }
+
+  const nextState: GameState = {
+    ...state,
+    religions: { ...state.religions, [religionId]: religion },
+    cityFaith,
+  };
+  bus.emit('religion:founded', { religionId, civId, cityId: buildingCityId, name });
+  return nextState;
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `bash scripts/run-with-mise.sh yarn test tests/systems/religion-system.test.ts`
+
+- [ ] **Step 6: Write + implement `chooseBoon`**
+
+Test:
+```ts
+describe('#591 MR4 — chooseBoon', () => {
+  it('sets the boon on the owner\'s religion', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const next = chooseBoon(founded, `religion-${civId}`, 'serenity');
+    expect(next.religions[`religion-${civId}`].boon).toBe('serenity');
+  });
+
+  it('is a no-op for a nonexistent religion id', () => {
+    const { state } = makeReligionFixture();
+    expect(chooseBoon(state, 'no-such-religion', 'tithes')).toBe(state);
+  });
+});
+```
+
+Implementation:
+```ts
+export function chooseBoon(state: GameState, religionId: string, boon: ReligionBoon): GameState {
+  const religion = state.religions[religionId];
+  if (!religion) return state;
+  return { ...state, religions: { ...state.religions, [religionId]: { ...religion, boon } } };
+}
+```
+
+- [ ] **Step 7: Run, commit**
+
+```bash
+git add src/systems/religion-system.ts tests/systems/religion-system.test.ts tests/systems/helpers/religion-fixture.ts
+git commit -m "feat(religion): foundReligion + chooseBoon (#591 MR4)"
+```
+
+---
+
+## Task 6: Passive spread — `getStrongestPressure` + `processReligionTurn`
+
+**Files:**
+- Modify: `src/systems/religion-system.ts`
+- Test: `tests/systems/religion-system.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+describe('#591 MR4 — getStrongestPressure', () => {
+  it('returns null for a city with no nearby religion sources', () => {
+    const { state } = makeReligionFixture();
+    expect(getStrongestPressure(state, 'capital')).toBeNull();
+  });
+
+  it('picks the religion with the highest accrual, tie-broken by religion id', () => {
+    // Build two religions with equal accrual pressure on the same target city; assert
+    // the lexicographically-smaller religion id wins (matches weightedPick-style
+    // tie-break convention used elsewhere in this codebase, e.g. crisis-system.ts).
+  });
+
+  it('caps foreign-adjacent accrual at 2 source cities (FOREIGN_ADJACENT_CAP)', () => {
+    // 3+ adjacent foreign follower cities of the same religion should not accrue more
+    // than 2 * FOREIGN_ADJACENT_ACCRUAL.
+  });
+
+  it('applies the Fervor multiplier when the source religion\'s owner chose fervor', () => {
+    // Same geometry, boon: 'fervor' vs boon: 'serenity' -- fervor's accrual should be
+    // exactly FERVOR_MULTIPLIER times higher (floored per the constant's own "floor" note).
+  });
+});
+
+describe('#591 MR4 — processReligionTurn', () => {
+  it('accrues points toward the strongest pressure each turn', () => { ... });
+
+  it('resets points when the strongest target religion changes to a different one', () => {
+    // Force a city's strongest religion to flip from religion A to religion B between
+    // two ticks (e.g. by changing which adjacent city follows which faith) and assert
+    // points reset to a fresh small accrual, not carried over from A.
+  });
+
+  it('converts a city at >= 100 points, fires religion:city-converted, clears progress', () => {
+    // Run enough turns (or seed points near threshold via state override) to cross 100.
+  });
+
+  it('never accrues progress in a holy city, even under maximum pressure', () => {
+    // Regression per the issue's explicit requirement -- surround the holy city with
+    // multiple strong rival-religion sources and assert cityFaith[holyCityId] is
+    // unchanged after many ticks.
+  });
+
+  it('does not touch a city already following the strongest-pressure religion (already converted, no self-progress)', () => { ... });
+
+  it('is deterministic: identical result on cloned state', () => {
+    const { state } = makeReligionFixture();
+    const bus = new EventBus();
+    const a = processReligionTurn(structuredClone(state), bus);
+    const b = processReligionTurn(structuredClone(state), new EventBus());
+    expect(a).toEqual(b);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement `getStrongestPressure`**
+
+```ts
+interface PressureSource {
+  religionId: string;
+  accrual: number;
+}
+
+export function getStrongestPressure(state: GameState, cityId: string): PressureSource | null {
+  const city = state.cities[cityId];
+  if (!city) return null;
+  const sources = new Map<string, number>(); // religionId -> accrual
+
+  for (const religion of Object.values(state.religions)) {
+    const followerCityIds = Object.entries(state.cityFaith)
+      .filter(([, faith]) => faith.religionId === religion.id)
+      .map(([id]) => id);
+    if (followerCityIds.length === 0) continue;
+
+    const fervorMultiplier = religion.boon === 'fervor' ? FERVOR_MULTIPLIER : 1;
+    let accrual = 0;
+
+    if (city.owner === religion.ownerCivId) {
+      // Own-civ city: +OWN_CITY_ACCRUAL if adjacent to OR trade-routed with a follower city.
+      const hasOwnSource = followerCityIds.some(fid => {
+        if (fid === cityId) return false;
+        const followerCity = state.cities[fid];
+        if (!followerCity) return false;
+        return mapDistance(state.map, city.position, followerCity.position) === 1;
+      });
+      if (hasOwnSource) accrual += OWN_CITY_ACCRUAL;
+    } else {
+      const adjacentCount = Math.min(FOREIGN_ADJACENT_CAP, followerCityIds.filter(fid => {
+        const followerCity = state.cities[fid];
+        return followerCity && mapDistance(state.map, city.position, followerCity.position) === 1;
+      }).length);
+      accrual += adjacentCount * FOREIGN_ADJACENT_ACCRUAL;
+    }
+
+    const hasTradeRouteSource = (state.marketplace?.tradeRoutes ?? []).some(route => {
+      const otherId = route.fromCityId === cityId ? route.toCityId : route.toCityId === cityId ? route.fromCityId : null;
+      return otherId && followerCityIds.includes(otherId);
+    });
+    if (hasTradeRouteSource) accrual += TRADE_ROUTE_ACCRUAL;
+
+    if (accrual > 0) sources.set(religion.id, Math.round(accrual * fervorMultiplier));
+  }
+
+  if (sources.size === 0) return null;
+  const sorted = [...sources.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return { religionId: sorted[0][0], accrual: sorted[0][1] };
+}
+```
+
+Re-verify the exact `TradeRoute` field names (`fromCityId`/`toCityId`) against `src/core/types.ts` before finalizing — MR3's crisis-system.ts used this same shape, but confirm it hasn't drifted.
+
+- [ ] **Step 4: Implement `processReligionTurn`**
+
+```ts
+export function processReligionTurn(state: GameState, bus: EventBus): GameState {
+  let cityFaith = { ...state.cityFaith };
+  let changed = false;
+
+  for (const cityId of Object.keys(state.cities).sort()) {
+    const city = state.cities[cityId];
+    const faith = cityFaith[cityId];
+    if (faith?.isHolyCity) continue; // holy cities never accrue
+
+    const pressure = getStrongestPressure(state, cityId);
+    if (!pressure) continue;
+    if (faith?.religionId === pressure.religionId) continue; // already follows the strongest religion
+
+    const existingProgress = faith?.conversionProgress;
+    const carriedPoints = existingProgress?.toReligionId === pressure.religionId ? existingProgress.points : 0;
+    const nextPoints = carriedPoints + pressure.accrual;
+
+    if (nextPoints >= CONVERSION_THRESHOLD) {
+      const fromReligionId = faith?.religionId;
+      cityFaith = { ...cityFaith, [cityId]: { religionId: pressure.religionId } };
+      changed = true;
+      bus.emit('religion:city-converted', { cityId, toReligionId: pressure.religionId, fromReligionId });
+    } else {
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: { ...(faith ?? {}), religionId: faith?.religionId ?? pressure.religionId, conversionProgress: { toReligionId: pressure.religionId, points: nextPoints } },
+      };
+      changed = true;
+    }
+  }
+
+  return changed ? { ...state, cityFaith } : state;
+}
+```
+
+Note the `religionId: faith?.religionId ?? pressure.religionId` line: a city with NO faith at all needs *some* `religionId` value to satisfy the `CityFaith` type while progress accrues toward conversion — using the pressure target as a placeholder "not yet converted, tracking toward X" religionId is consistent with how `conversionProgress.toReligionId` already names the real target; re-read this against the locked type once implemented and adjust if a cleaner shape (e.g. making `religionId` on `CityFaith` optional) reads better — flag this as an implementation judgment call in the PR body if changed from the issue's literal interface.
+
+- [ ] **Step 5: Wire into turn processing**
+
+Find where `processCrisisTurn`/`processCrisisScheduler`-equivalent turn-system calls are threaded in `src/core/turn-manager.ts` (same file MR3 touched) and add `processReligionTurn` in the same per-turn sequence, after city yield processing (religions read `state.cities`/`state.marketplace` which must already reflect this turn's state, so ordering matters less than "runs once per turn" — but read the surrounding turn-manager.ts sequence first to slot it in consistently with similar systems like crisis processing).
+
+- [ ] **Step 6: Run to verify pass, commit**
+
+```bash
+git add src/systems/religion-system.ts src/core/turn-manager.ts tests/systems/religion-system.test.ts
+git commit -m "feat(religion): passive spread + conversion (processReligionTurn) (#591 MR4)"
+```
+
+---
+
+## Task 7: Boon effects — Serenity happiness, Tithes gold
+
+**Files:**
+- Modify: `src/systems/faction-system.ts` (`getUnrestPressureBreakdown`)
+- Modify: `src/systems/economy-system.ts` (`projectCivGrossGold`)
+- Modify: `.claude/rules/game-balance.md` (happiness inventory row)
+- Test: `tests/systems/faction-system.test.ts`, `tests/systems/economy-system.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+// tests/systems/faction-system.test.ts
+describe('#591 MR4 — Serenity happiness row', () => {
+  it('adds a Religious serenity pressure-reduction row for a city following its owner\'s serenity-boon faith', () => { ... });
+  it('does not add the row when the boon is not serenity, or the city follows a different faith', () => { ... });
+});
+```
+
+```ts
+// tests/systems/economy-system.test.ts
+describe('#591 MR4 — Tithes gold', () => {
+  it('adds +1 gold per foreign city following the tithes-boon religion, capped at TITHES_CAP', () => { ... });
+  it('contributes 0 when the boon is not tithes', () => { ... });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+- [ ] **Step 3: Implement Serenity**
+
+In `src/systems/faction-system.ts`, add near `getCityHappinessFromBuildings` usage inside `getUnrestPressureBreakdown`:
+
+```ts
+  const cityFaith = state.cityFaith?.[cityId];
+  if (cityFaith) {
+    const religion = state.religions?.[cityFaith.religionId];
+    if (religion && religion.ownerCivId === owner && religion.boon === 'serenity') {
+      rows.push({ label: 'Religious serenity', amount: -2 }); // +1 happiness * -2 pressure convention
+    }
+  }
+```
+
+Add the corresponding row to `.claude/rules/game-balance.md`'s Happiness Inventory table: `| Religious serenity (boon) | city (faith-following) | +1 | era 3+ (Sacred Council + serenity boon) |`.
+
+- [ ] **Step 4: Implement Tithes**
+
+Add a helper (in `religion-system.ts`, imported by `economy-system.ts` — check for a circular-import risk first, same diligence as MR3's `crisis-system.ts` importing `city-work-system.ts`):
+
+```ts
+// religion-system.ts
+export function getReligionTithesGold(state: GameState, civId: string): number {
+  const religion = Object.values(state.religions).find(r => r.ownerCivId === civId && r.boon === 'tithes');
+  if (!religion) return 0;
+  const foreignFollowerCount = Object.entries(state.cityFaith)
+    .filter(([cityId, faith]) => faith.religionId === religion.id && state.cities[cityId]?.owner !== civId)
+    .length;
+  return Math.min(TITHES_CAP, foreignFollowerCount);
+}
+```
+
+In `src/systems/economy-system.ts`'s `projectCivGrossGold`, add after the `getClaimedTrophyGoldPerTurn` line:
+```ts
+  grossGold += getReligionTithesGold(state, civId);
+```
+
+- [ ] **Step 5: Run to verify pass, commit**
+
+```bash
+git add src/systems/faction-system.ts src/systems/economy-system.ts src/systems/religion-system.ts .claude/rules/game-balance.md tests/systems/faction-system.test.ts tests/systems/economy-system.test.ts
+git commit -m "feat(religion): wire Serenity happiness + Tithes gold boon effects (#591 MR4)"
+```
+
+---
+
+## Task 8: Sacred Council completion → found religion; boon-pending AI heuristic; city lifecycle
+
+**Files:**
+- Modify: `src/core/turn-manager.ts` (production-completion hook — find where `completedBuilding` from `CityProcessResult` is consumed and other building-completion side effects (e.g. legendary wonder progress, national project registration) already live)
+- Modify: `src/ai/basic-ai.ts` or `src/ai/ai-production.ts` (AI boon choice heuristic — find where AI-owned pending decisions are resolved each turn, e.g. AI tech choice, for the right file)
+- Modify: `src/systems/city-capture-system.ts` (raze path: delete `cityFaith[cityId]`)
+- Test: `tests/core/turn-manager.test.ts` or equivalent, `tests/ai/*.test.ts`, `tests/systems/city-capture-system.test.ts`
+
+- [ ] **Step 1: Find the existing building-completion side-effect dispatch**
+
+Read `src/core/turn-manager.ts` around wherever `result.completedBuilding` (from `CityProcessResult`, `src/systems/city-system.ts`) is handled per civ per turn — national projects likely already have a branch here for registering into `state.builtNationalProjects`. Add: `if (result.completedBuilding === 'sacred_council') nextState = foundReligion(nextState, civId, cityId, bus);` in the same conditional cluster.
+
+- [ ] **Step 2: Write a turn-manager-level test**
+
+```ts
+// Wherever building-completion effects are already tested for this file
+it('#591 MR4: completing Sacred Council founds a religion at the building city', () => {
+  // Full turn-manager fixture with a city that has Temple + philosophy + enough
+  // production queued for sacred_council to complete this turn. Assert
+  // state.religions has exactly one entry owned by the civ after processTurn.
+});
+```
+
+- [ ] **Step 3: AI boon heuristic**
+
+Find where AI civs make deterministic per-turn choices already (tech priority selection is the closest existing analog — check `src/ai/basic-ai.ts` or wherever `ai-production.ts`'s per-turn AI loop lives). Add a step: for every AI civ with a religion where `boon` is undefined, choose immediately:
+
+```ts
+// religion-system.ts
+export function chooseAiBoon(state: GameState, civId: string): ReligionBoon {
+  const civ = state.civilizations[civId];
+  const atWar = (civ?.diplomacy.atWarWith?.length ?? 0) > 0;
+  const cities = (civ?.cities ?? []).map(id => state.cities[id]).filter((c): c is City => !!c);
+  const avgUnrest = cities.length ? cities.reduce((sum, c) => sum + c.unrestLevel, 0) / cities.length : 0;
+  if (avgUnrest >= 1) return 'serenity';
+  if (atWar) return 'fervor';
+  return 'tithes';
+}
+```
+
+Wire it into the AI per-turn pass: for each AI civ, `if (religion && religion.boon === undefined) nextState = chooseBoon(nextState, religion.id, chooseAiBoon(nextState, civId));`.
+
+- [ ] **Step 4: Write AI boon test**
+
+```ts
+it('#591 MR4: AI picks serenity when unhappy, fervor when at war, else tithes', () => { ... 3 cases ... });
+it('#591 MR4: AI chooses immediately (never leaves its own religion pending)', () => {
+  // After one full AI turn pass with a founded-but-boonless AI religion, assert boon is set.
+});
+```
+
+- [ ] **Step 5: City lifecycle — raze cleanup**
+
+In `src/systems/city-capture-system.ts`'s raze branch, alongside `delete nextCities[cityId];`, add:
+```ts
+  const nextCityFaith = { ...state.cityFaith };
+  delete nextCityFaith[cityId];
+```
+and thread `cityFaith: nextCityFaith` into the raze path's `nextState` literal.
+
+- [ ] **Step 6: Write lifecycle tests**
+
+```ts
+// tests/systems/city-capture-system.test.ts
+it('#591 MR4: deletes cityFaith when a city is razed', () => { ... });
+it('#591 MR4: preserves cityFaith when a city is captured (occupy), just under the new owner', () => {
+  // Confirms the "kept on ownership transfer" rule holds with NO explicit code needed
+  // beyond not touching cityFaith in the occupy branch -- a regression test, not new logic.
+});
+```
+
+- [ ] **Step 7: Run full suite for this task's files, commit**
+
+```bash
+git add src/core/turn-manager.ts src/ai/*.ts src/systems/religion-system.ts src/systems/city-capture-system.ts tests/
+git commit -m "feat(religion): wire Sacred Council founding, AI boon choice, city lifecycle (#591 MR4)"
+```
+
+---
+
+## Task 9: UI — city panel Faith row, boon modal, diplomacy panel religion summary
+
+**Files:**
+- Modify: `src/ui/city-panel.ts` (Faith row)
+- Create: `src/ui/religion-boon-modal.ts` (model on `src/ui/required-choice-panel.ts`)
+- Modify: `src/ui/diplomacy-panel.ts` (religion summary block)
+- Modify: `src/main.ts` (wire the modal open/close + boon choice callback, same pattern as other modals)
+- Test: `tests/ui/city-panel-religion.test.ts` (new, mirrors `city-panel-crisis.test.ts`'s structure), `tests/ui/religion-boon-modal.test.ts`, `tests/ui/diplomacy-panel.test.ts`
+
+- [ ] **Step 1: City panel Faith row — write failing test**
+
+Mirror `tests/ui/city-panel-crisis.test.ts`'s `withFamineCrisis`/fixture pattern, but for `cityFaith`. Assert: faith name renders, holy-city label renders when `isHolyCity`, in-progress conversion shows source religion name + derived turns-remaining (`Math.ceil((CONVERSION_THRESHOLD - points) / accrual)`, display-only — do not store a materialized "turns left" field).
+
+- [ ] **Step 2: Implement the Faith row**
+
+Add a data block + `setText` calls following the exact pattern the crisis chips already use in this file (`getCrisisDisplayName`-style lookup, `data-text` attribute, populate via `setText` after `panel.innerHTML = html`).
+
+- [ ] **Step 3: Boon modal — write failing test, then implement**
+
+Model directly on `src/ui/required-choice-panel.ts`: full-screen overlay, `createGameButton` for each of the 3 boon choices, `textContent` for all copy (XSS-safe), descriptions pulled from `BOON_DESCRIPTIONS`. Wire `onChooseBoon(religionId, boon)` callback through `main.ts` the same way `onChooseResearch` is wired for the required-choice panel — find that wiring site and mirror it.
+
+- [ ] **Step 4: Diplomacy panel religion summary — write failing test, then implement**
+
+Add a small block near the top of `createDiplomacyPanel` (after the `playerCiv`/`playerDiplomacy` setup, before the `civRows` loop) showing the player's own religion name, boon (or "choose a boon" prompt if pending), and own/foreign follower counts — all sourced from `state.religions`/`state.cityFaith` filtered to `ownerCivId === state.currentPlayer`.
+
+- [ ] **Step 5: Run all UI tests, commit**
+
+```bash
+git add src/ui/city-panel.ts src/ui/religion-boon-modal.ts src/ui/diplomacy-panel.ts src/main.ts tests/ui/
+git commit -m "feat(religion): city panel Faith row, boon modal, diplomacy religion summary (#591 MR4)"
+```
+
+---
+
+## Task 10: Full gates + inline review + PR
+
+- [ ] **Step 1:** `bash scripts/run-with-mise.sh yarn test` — 0 failures.
+- [ ] **Step 2:** `bash scripts/run-with-mise.sh yarn build` — 0 type errors.
+- [ ] **Step 3:** Re-run `tests/systems/pacing-audit.test.ts` and `tests/systems/pacing-reference-economy.test.ts` (Serenity/Tithes are economy-affecting) — document any snapshot shift in the PR body per `.claude/rules/game-balance.md`.
+- [ ] **Step 4:** Inline multi-dimensional review (gameplay balance, fun, ages 7-43, play styles, difficulty modes, AI, UI/UX, architecture/extensibility, data, SFX, save compatibility, solo/hot-seat regressions) — same rigor as MR3's review. Specifically check:
+  - Does `state.currentPlayer` gate the diplomacy panel's religion summary and the boon modal correctly for hot-seat?
+  - Does a human civ's pending boon actually re-prompt at the start of THEIR turn specifically (not any turn)?
+  - SFX: is there an existing generic "national project completed" or "milestone" stinger this can reuse, or does Sacred Council's founding need a bespoke moment flagged for later (MR7 audio polish already covers stingers per the arc plan)?
+  - Grep the PR body draft for `closes?\s+#\d+` before opening.
+- [ ] **Step 5:** `git fetch origin main && git rebase origin/main`, re-run build+test.
+- [ ] **Step 6:** Open the PR (title: `feat(religion): religion core — state, Sacred Council, boons, passive spread (#591 MR4)`), reference #591/#587, do NOT use the literal substring "closes #524" anywhere.

--- a/src/ai/ai-production.ts
+++ b/src/ai/ai-production.ts
@@ -179,8 +179,19 @@ function projectedBuildingMaintenanceImpact(
   );
 }
 
+// A milestone national project (#591 MR4) has no civYieldBonus by contract -- its
+// effect is a one-time state mutation (e.g. founding a religion), not an ongoing
+// yield. Scoring it via yields alone would value it at 0, deeply undercutting its
+// production cost in the candidate score formula below and making the AI functionally
+// never build it. Flat value roughly matching a mid-tier same-era normal NP (e.g.
+// era 3's iron_legion at 2.5, philosophers_circle at 3.75) -- generic to the
+// `milestone` flag, not sacred_council-specific, so any future milestone NP scores
+// reasonably without a new branch here.
+const MILESTONE_NP_ECONOMY_VALUE = 4;
+
 export function economyValue(buildingId: string): number {
   const building = BUILDINGS[buildingId];
+  if (building?.nationalProject?.milestone) return MILESTONE_NP_ECONOMY_VALUE;
   const yields = building?.nationalProject
     ? building.civYieldBonus ?? building.yields
     : building?.yields;

--- a/src/ai/basic-ai.ts
+++ b/src/ai/basic-ai.ts
@@ -103,6 +103,7 @@ import { applyWorkerAction, getWorkerChargesRemaining } from '@/systems/worker-a
 import { getAvailableWorkerActions, getKnownTileResourceForWorkerAction } from '@/systems/improvement-system';
 import { chooseRoadBuilderUnit } from '@/systems/road-network';
 import { canBuildRoad } from '@/systems/road-system';
+import { chooseAiBoon, chooseBoon } from '@/systems/religion-system';
 
 function addAlwaysHostileOwners(
   state: GameState,
@@ -589,6 +590,13 @@ function processAITurnInternal(
       newState = foundCityInState(newState, settler.id, bus).state;
       civ = newState.civilizations[civId];
     }
+  }
+
+  // Boon choice (#591 MR4) is administrative, not plan-driven -- an AI civ with a
+  // founded-but-boonless religion decides immediately, every turn it hasn't yet.
+  const ownReligion = Object.values(newState.religions ?? {}).find(r => r.ownerCivId === civId);
+  if (ownReligion && ownReligion.boon === undefined) {
+    newState = chooseBoon(newState, ownReligion.id, chooseAiBoon(newState, civId));
   }
 
   // Catastrophe restoration (#526 MR4) is likewise administrative rather than

--- a/src/core/game-state.ts
+++ b/src/core/game-state.ts
@@ -367,6 +367,8 @@ export function createNewGame(
     settings,
     mapScript,
     startPlacementMode,
+    religions: {},
+    cityFaith: {},
   };
 
   // Place minor civilizations
@@ -535,6 +537,8 @@ export function createHotSeatGame(
     settings,
     mapScript,
     startPlacementMode,
+    religions: {},
+    cityFaith: {},
   };
 
   // Place minor civilizations

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -91,6 +91,7 @@ import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } 
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
 import { processCrisisTurn, processCrisisScheduler, getCrisisYieldMultiplier } from '@/systems/crisis-system';
+import { processReligionTurn } from '@/systems/religion-system';
 import { applyCrisisResponses } from '@/ai/ai-crisis-response';
 import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import {
@@ -144,6 +145,7 @@ export function processTurn(
   newState = processFactionTurn(newState, bus);
   newState = processBreakawayTurn(newState, bus);
   newState = processCrisisTurn(newState, bus);
+  newState = processReligionTurn(newState, bus);
   // AI civ turns run later via the AI round scheduler, so responses recorded
   // here (quarantine/fund-remedy) shape the same round's plans (#529 MR3 Task 3.2).
   if (resolveWorldPressureFlags(newState.settings).aiPressure === 'full') {

--- a/src/core/turn-manager.ts
+++ b/src/core/turn-manager.ts
@@ -91,7 +91,7 @@ import { processFactionTurn, getUnrestYieldMultiplier, isCityProductionLocked } 
 import { getOccupiedCityYieldMultiplier, tickOccupiedCities } from '@/systems/city-occupation-system';
 import { processBreakawayTurn } from '@/systems/breakaway-system';
 import { processCrisisTurn, processCrisisScheduler, getCrisisYieldMultiplier } from '@/systems/crisis-system';
-import { processReligionTurn } from '@/systems/religion-system';
+import { processReligionTurn, foundReligion } from '@/systems/religion-system';
 import { applyCrisisResponses } from '@/ai/ai-crisis-response';
 import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import {
@@ -335,6 +335,9 @@ export function processTurn(
             buildingId: result.completedBuilding,
             eraBuilt: newState.era,
           });
+          if (result.completedBuilding === 'sacred_council') {
+            newState = foundReligion(newState, civId, cityId, bus);
+          }
         }
       }
       for (const item of result.droppedProductionItems) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -446,6 +446,10 @@ export type CityMaturity = 'outpost' | 'village' | 'town' | 'city' | 'metropolis
 
 export interface NationalProject {
   homeEra: number;
+  // #591 MR4: one-time permanent-trigger project (e.g. Sacred Council). Buildable from
+  // homeEra onward with NO upper build-window bound, and NEVER expires. See
+  // .claude/rules/game-balance.md "Milestone National Projects".
+  milestone?: true;
 }
 
 export interface Building {
@@ -1576,6 +1580,31 @@ export interface GameState {
   startPlacementMode?: StartPlacementMode;
   activeCrises?: Record<string, ActiveCrisis>;
   reconReveals?: ReconReveal[];
+  // #591 MR4: religion core. Optional -- absent on legacy saves and the many minimal
+  // literal-GameState test fixtures across this codebase (same convention as
+  // activeCrises/pirates/espionage). Defaulted to {} in createNewGame for new games and
+  // in migrateSaveToCurrent for old saves; every other reader must use `?? {}`.
+  religions?: Record<string, Religion>;
+  cityFaith?: Record<string, CityFaith>;
+}
+
+// --- Religion (#591 MR4) ---
+
+export type ReligionBoon = 'serenity' | 'tithes' | 'fervor';
+
+export interface Religion {
+  id: string;            // 'religion-<ownerCivId>'
+  name: string;          // invented, renameable
+  ownerCivId: string;
+  boon?: ReligionBoon;    // absent = choice pending; re-prompt owner each turn; NO boon effects until chosen
+  foundedTurn: number;
+}
+
+export interface CityFaith {
+  religionId: string;
+  isHolyCity?: true;      // founding city — permanently immune to conversion, under ANY owner
+  conversionProgress?: { toReligionId: string; points: number };  // converts at CONVERSION_THRESHOLD
+  // loyaltyProgress added by MR6 (#593)
 }
 
 export interface ReconReveal {
@@ -1840,6 +1869,8 @@ export interface GameEvents {
   'civ:eliminated':                 { civId: string; eliminatedBy: string };
   // Crisis events & revolutionary movements (#381, #354)
   'crisis:started':   { crisisId: string; flavorId: string; civId: string; cityIds: string[] };
+  'religion:founded': { religionId: string; civId: string; cityId: string; name: string };
+  'religion:city-converted': { cityId: string; toReligionId: string; fromReligionId?: string };
   'crisis:spread':    { crisisId: string; fromCityId: string; toCityId: string };
   // civId/foeName are populated for Hunt transitions (spawn -> menacing, menacing ->
   // assaulting) — carried directly rather than re-read from state because both are set

--- a/src/main.ts
+++ b/src/main.ts
@@ -99,6 +99,8 @@ import { renderUnitStackPanel } from '@/ui/unit-stack-panel';
 import { createUnitTurnFlow } from '@/ui/unit-turn-flow';
 import { createUiInteractionState } from '@/ui/ui-interaction-state';
 import { closePlanningPanels, createRequiredChoicePanel } from '@/ui/required-choice-panel';
+import { createReligionBoonModal } from '@/ui/religion-boon-modal';
+import { chooseBoon } from '@/systems/religion-system';
 import { showCampaignSetup } from '@/ui/campaign-setup';
 import { showGameModeSelect } from '@/ui/game-mode-select';
 import { createPacingDebugPanel } from '@/ui/pacing-debug-panel';
@@ -1394,6 +1396,37 @@ function openCityPanelForCity(city: import('@/core/types').City): void {
 function closeRequiredChoicePanel(): void {
   document.getElementById('required-choice-panel')?.remove();
   setBlockingOverlay(null);
+}
+
+// #591 MR4: a founded-but-boonless religion has NO effects until the owner chooses —
+// re-prompted every time the owner attempts to end their turn, same blocking pattern as
+// showRequiredChoicesIfNeeded (the only other "must decide before proceeding" surface
+// in this file), so a human owner can never leave their own religion pending forever.
+function showReligionBoonIfNeeded(): boolean {
+  const civId = gameState.currentPlayer;
+  const civ = gameState.civilizations[civId];
+  if (!civ?.isHuman) return false;
+  const ownReligion = Object.values(gameState.religions ?? {}).find(r => r.ownerCivId === civId);
+  if (!ownReligion || ownReligion.boon !== undefined) {
+    document.getElementById('religion-boon-modal')?.remove();
+    return false;
+  }
+  if (document.getElementById('religion-boon-modal')) return true;
+
+  closePlanningPanels(document);
+  setBlockingOverlay('religion-boon');
+  createReligionBoonModal(uiLayer, {
+    religionName: ownReligion.name,
+    onChooseBoon: (boon) => {
+      gameState = chooseBoon(gameState, ownReligion.id, boon);
+      document.getElementById('religion-boon-modal')?.remove();
+      setBlockingOverlay(null);
+      showNotification(`${ownReligion.name} now grants ${boon}.`, 'success');
+      renderLoop.setGameState(gameState);
+      updateHUD();
+    },
+  });
+  return true;
 }
 
 function refreshRequiredChoicesAfterAction(): void {
@@ -3836,6 +3869,11 @@ async function beginHotSeatHandoff(
 async function endTurn(options: { allowUnmovedUnits?: boolean } = {}): Promise<void> {
   if (gameState.gameOver) return;
   try {
+    if (showReligionBoonIfNeeded()) {
+      showNotification('Choose a boon for your religion before ending the turn.', 'info');
+      return;
+    }
+
     if (showRequiredChoicesIfNeeded()) {
       showNotification('Choose production and research before ending the turn.', 'info');
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -243,6 +243,7 @@ import {
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
   routeReligionFounded,
+  routeReligionCityConverted,
   routeOpportunisticWar,
   routeSabotageReliefDiscovered,
   type NotificationSink,
@@ -4536,6 +4537,10 @@ bus.on('crisis:started', event => {
 
 bus.on('religion:founded', event => {
   routeReligionFounded(gameState, event, appendToCivLog);
+});
+
+bus.on('religion:city-converted', event => {
+  routeReligionCityConverted(gameState, event, appendToCivLog);
 });
 
 bus.on('crisis:spread', event => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -242,6 +242,7 @@ import {
   routeWorldPressureCrisisResolved,
   routeCrisisFoeHuntedByAlly,
   routeCrisisAidSent,
+  routeReligionFounded,
   routeOpportunisticWar,
   routeSabotageReliefDiscovered,
   type NotificationSink,
@@ -4531,6 +4532,10 @@ bus.on('faction:critical-status', event => {
 bus.on('crisis:started', event => {
   routeCrisisStarted(gameState, event, appendToCivLog);
   routeWorldPressureCrisisStarted(gameState, event, appendToCivLog);
+});
+
+bus.on('religion:founded', event => {
+  routeReligionFounded(gameState, event, appendToCivLog);
 });
 
 bus.on('crisis:spread', event => {

--- a/src/renderer/sprites/sprite-catalog.ts
+++ b/src/renderer/sprites/sprite-catalog.ts
@@ -351,6 +351,7 @@ export const BUILDING_SPRITE_CATALOG: Record<string, BuildingSpriteComponent> = 
   philosophers_circle:    ForumSprite,
   road_corps:             WorkshopSprite,
   iron_legion:            ArmorySprite,
+  sacred_council:         TempleSprite,
   imperial_archive:       ArchiveSprite,
   praetorian_legion:      BarracksSprite,
   royal_mint:             BankSprite,

--- a/src/storage/save-migrations.ts
+++ b/src/storage/save-migrations.ts
@@ -263,6 +263,18 @@ function normalizeCrisisArchetypes(state: GameState): GameState {
   return { ...state, activeCrises };
 }
 
+// #591 MR4: religions/cityFaith are non-optional on GameState but predate this MR, so
+// any save from before it is missing both fields entirely. Defaulted unconditionally
+// (not a versioned migration -- additive, no schema bump) alongside the crisis
+// normalization above.
+function withReligionDefaults(state: GameState): GameState {
+  return {
+    ...state,
+    religions: state.religions ?? {},
+    cityFaith: state.cityFaith ?? {},
+  };
+}
+
 export const SAVE_MIGRATIONS: Readonly<Record<number, SaveMigration>> = {
   1: migrateToEra13Foundation,
   2: migrateLateResources,
@@ -298,5 +310,5 @@ export function migrateSaveToCurrent(raw: unknown): GameState {
     state = { ...migration(state), saveSchemaVersion: version };
   }
   const migrated = state.gameId ? state : migrateToEra13Foundation(state);
-  return normalizeCrisisArchetypes(migrated);
+  return withReligionDefaults(normalizeCrisisArchetypes(migrated));
 }

--- a/src/systems/city-capture-system.ts
+++ b/src/systems/city-capture-system.ts
@@ -560,10 +560,18 @@ export function resolveMajorCityCapture(
   const nextCities = { ...state.cities };
   delete nextCities[cityId];
 
+  // #591 MR4: cityFaith is keyed by cityId -- razing a city must clean it up here, the
+  // same way it does for legendaryWonderProjects above. Capture (occupy) does NOT need
+  // this: the city record persists across ownership transfer, so faith persists with it
+  // for free (see resolveMajorCityCapture's occupy branch -- no cityFaith touch there).
+  const nextCityFaith = { ...(state.cityFaith ?? {}) };
+  delete nextCityFaith[cityId];
+
   const nextState: GameState = {
     ...state,
     cities: nextCities,
     civilizations: nextCivilizations,
+    cityFaith: nextCityFaith,
     legendaryWonderProjects: removeLegendaryWonderProjectsForCity(state.legendaryWonderProjects, cityId),
   };
   const elimination = eliminateCivilization(nextState, previousOwnerId, newOwnerId);

--- a/src/systems/city-system.ts
+++ b/src/systems/city-system.ts
@@ -302,6 +302,14 @@ export const BUILDINGS: Record<string, Building> = {
     uniquePerEmpire: true, nationalProject: { homeEra: 3 },
     civYieldBonus: { production: 2 },
   },
+  sacred_council: {
+    id: 'sacred_council', name: 'Sacred Council', category: 'culture',
+    yields: { food: 0, production: 0, gold: 0, science: 0 }, productionCost: 120,
+    description: 'Founds your empire\'s faith. One-time — permanent effect, never fades.',
+    techRequired: 'philosophy', requiresBuildings: ['temple'],
+    pacing: { band: 'marquee', role: 'national-project', impact: 1.5, scope: 'empire', snowball: 1.3, urgency: 1.1, situationality: 1, unlockBreadth: 1 },
+    uniquePerEmpire: true, nationalProject: { homeEra: 3, milestone: true },
+  },
 
   // Era 4
   imperial_archive: {
@@ -1474,6 +1482,7 @@ export const PRODUCTION_ICONS: Record<string, string> = {
   philosophers_circle:  '🏛️',
   road_corps:           '🛤️',
   iron_legion:          '🛡️',
+  sacred_council:       '📿',
   imperial_archive:     '📚',
   praetorian_legion:    '⚔️',
   royal_mint:           '💰',
@@ -1766,7 +1775,11 @@ export function getAvailableBuildings(
     }
     if (b.nationalProject) {
       const currentEra = era ?? 1;
-      if (currentEra < b.nationalProject.homeEra || currentEra > b.nationalProject.homeEra + 1) return false;
+      const belowWindow = currentEra < b.nationalProject.homeEra;
+      // Milestone NPs (#591 MR4) have no upper build-window bound -- they're buildable
+      // from homeEra onward forever, unlike a normal NP's homeEra..homeEra+1 window.
+      const aboveWindow = !b.nationalProject.milestone && currentEra > b.nationalProject.homeEra + 1;
+      if (belowWindow || aboveWindow) return false;
       if (b.uniquePerEmpire && civId && builtNationalProjectKeys?.has(`${civId}:${b.id}`)) return false;
     }
     return true;
@@ -1949,7 +1962,8 @@ export function processCity(
     const filteredNP = newQueue.filter((item: string) => {
       const bldg = BUILDINGS[item];
       if (!bldg?.nationalProject) return true;
-      const inWindow = era >= bldg.nationalProject.homeEra && era <= bldg.nationalProject.homeEra + 1;
+      const inWindow = era >= bldg.nationalProject.homeEra
+        && (bldg.nationalProject.milestone || era <= bldg.nationalProject.homeEra + 1);
       if (!inWindow) {
         droppedProductionItems.push({ itemId: item, itemKind: 'building', reason: 'build-window-expired' });
       }

--- a/src/systems/economy-system.ts
+++ b/src/systems/economy-system.ts
@@ -15,6 +15,7 @@ import { getLegendaryWonderCityYieldBonus, getLegendaryWonderCivYieldBonus } fro
 import { getActiveNationalProjectsForCiv, getNationalProjectCivYieldBonus } from './national-project-system';
 import { processTradeRouteIncome } from './trade-system';
 import { getClaimedTrophyGoldPerTurn } from './beast-system';
+import { getReligionTithesGold } from './religion-system';
 import { createUnit, UNIT_DEFINITIONS } from './unit-system';
 import { resolveCivDefinition } from './civ-registry';
 import { getCivAvailableResources, getCivHappinessFromResources } from './resource-acquisition-system';
@@ -560,6 +561,7 @@ export function projectCivGrossGold(
   }
 
   grossGold += getClaimedTrophyGoldPerTurn(state, civId);
+  grossGold += getReligionTithesGold(state, civId);
 
   return grossGold;
 }

--- a/src/systems/faction-system.ts
+++ b/src/systems/faction-system.ts
@@ -98,6 +98,15 @@ export function getUnrestPressureBreakdown(
   const buildingHappiness = getCityHappinessFromBuildings(city);
   if (buildingHappiness > 0) rows.push({ label: 'Happiness buildings', amount: -buildingHappiness * 2 });
 
+  // #591 MR4: Serenity boon — +1 happiness in cities following the owner's OWN faith.
+  const cityFaith = state.cityFaith?.[cityId];
+  if (cityFaith) {
+    const religion = state.religions?.[cityFaith.religionId];
+    if (religion && religion.ownerCivId === owner && religion.boon === 'serenity') {
+      rows.push({ label: 'Religious serenity', amount: -2 });
+    }
+  }
+
   const contagion = getContagionSpread(cityId, state).pressure;
   if (contagion > 0) rows.push({ label: 'Uprising contagion', amount: contagion });
 

--- a/src/systems/national-project-system.ts
+++ b/src/systems/national-project-system.ts
@@ -113,8 +113,9 @@ export function expireNationalProjects(
 ): { state: GameState; expired: ExpiredNationalProject[] } {
   const toExpire: ExpiredNationalProject[] = [];
   for (const [key, record] of Object.entries(state.builtNationalProjects ?? {})) {
+    const buildingId = key.split(':').slice(1).join(':');
+    if (BUILDINGS[buildingId]?.nationalProject?.milestone) continue; // permanent — see #591 MR4
     if (newEra - record.eraBuilt >= 3) {
-      const buildingId = key.split(':').slice(1).join(':');
       toExpire.push({ civId: record.civId, cityId: record.cityId, buildingId });
     }
   }

--- a/src/systems/religion-definitions.ts
+++ b/src/systems/religion-definitions.ts
@@ -1,0 +1,61 @@
+import type { ReligionBoon } from '@/core/types';
+
+export const CONVERSION_THRESHOLD = 100;
+export const OWN_CITY_ACCRUAL = 15;
+export const FOREIGN_ADJACENT_ACCRUAL = 7;
+export const FOREIGN_ADJACENT_CAP = 2;
+export const TRADE_ROUTE_ACCRUAL = 5;
+// Wired starting MR5 (#592) — occupied cities accrue toward the occupier's faith.
+// Defined here now so MR5 doesn't need to touch this file's constant block.
+export const OCCUPATION_ACCRUAL = 5;
+export const FERVOR_MULTIPLIER = 1.25;
+export const TITHES_CAP = 10;
+
+// Invented, culture-flavored faith names — NEVER real-world religions (project
+// convention, matches wonder/quest content rules). 2 candidates per civ id; seeded
+// pick + player rename at founding.
+export const NAME_CANDIDATES: Record<string, string[]> = {
+  egypt: ['Cult of the River Dawn', 'Order of the Sundered Sky'],
+  rome: ['Cult of the Eternal Hearth', 'Order of the Twelve Standards'],
+  greece: ['Path of the Wine-Dark Sea', 'Circle of the First Light'],
+  mongolia: ['Way of the Endless Steppe', 'Cult of the Sky Father'],
+  babylon: ['Order of the Hanging Star', 'Cult of the River Reeds'],
+  zulu: ['Path of the Rising Spear', 'Circle of the Great Kraal'],
+  china: ['Way of the Jade Harmony', 'Order of the Silk Dawn'],
+  persia: ['Cult of the Burning Garden', 'Order of the Golden Road'],
+  england: ['Order of the White Cliff', 'Cult of the Grey Tide'],
+  aztec: ['Path of the Fifth Sun', 'Cult of the Feathered Rain'],
+  japan: ['Way of the Cherry Watch', 'Order of the Still Water'],
+  india: ['Path of the Monsoon Bell', 'Circle of the Sacred Peacock'],
+  france: ['Order of the Gilded Lily', 'Cult of the Northern Rose'],
+  germany: ['Order of the Iron Oak', 'Cult of the Black Forest'],
+  gondor: ['Order of the White Tree', 'Cult of the Sea-Kings'],
+  rohan: ['Path of the Horse Lords', 'Circle of the Golden Hall'],
+  russia: ['Cult of the Frozen Bell', 'Order of the Northern Bear'],
+  ottoman: ['Order of the Crescent Watch', 'Path of the Red Tulip'],
+  shire: ['Circle of the Green Hill', 'Order of the Second Breakfast'],
+  isengard: ['Cult of the Broken Stone', 'Order of the Grinding Wheel'],
+  spain: ['Order of the Golden Coast', 'Cult of the Iron Sun'],
+  viking: ['Path of the Longship Star', 'Order of the Frost Raven'],
+  prydain: ['Circle of the Cauldron Born', 'Order of the Grey King'],
+  annuvin: ['Cult of the Hollow Crown', 'Order of the Undying Mist'],
+  wakanda: ['Order of the Panther Star', 'Cult of the Vibrant Heart'],
+  avalon: ['Order of the Lake Mist', 'Circle of the Once and Future'],
+  lothlorien: ['Circle of the Golden Mallorn', 'Order of the Starlit Bough'],
+  narnia: ['Circle of the Deep Magic', 'Order of the Eternal Snow'],
+  atlantis: ['Cult of the Sunken Star', 'Order of the Tidal Throne'],
+};
+
+export const NEUTRAL_NAME_CANDIDATES: string[] = [
+  'Order of the First Dawn',
+  'Circle of the Wandering Star',
+  'Path of the Quiet Flame',
+];
+
+export const BOON_DESCRIPTIONS: Record<ReligionBoon, string> = {
+  serenity: '+1 happiness in every city that follows your faith.',
+  tithes: `+1 gold per turn from every foreign city that follows your faith, up to +${TITHES_CAP} gold.`,
+  // MR4-honest: only conversion speed. Territory/loyalty effects ship in MR6 (#593) —
+  // do not add wording here until that MR actually implements them.
+  fervor: 'Your faith spreads 25% faster.',
+};

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -1,8 +1,13 @@
 import type { GameState, Religion, ReligionBoon } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { seededLcg } from './seeded-lcg';
-import { NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES } from './religion-definitions';
+import {
+  NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, CONVERSION_THRESHOLD,
+  OWN_CITY_ACCRUAL, FOREIGN_ADJACENT_ACCRUAL, FOREIGN_ADJACENT_CAP,
+  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER,
+} from './religion-definitions';
 import { getCapitalCityId } from './capital-system';
+import { mapDistance } from './hex-utils';
 
 function pickReligionName(civType: string, seed: number): string {
   const pool = NAME_CANDIDATES[civType] ?? NEUTRAL_NAME_CANDIDATES;
@@ -47,4 +52,102 @@ export function chooseBoon(state: GameState, religionId: string, boon: ReligionB
   const religion = state.religions?.[religionId];
   if (!religion) return state;
   return { ...state, religions: { ...state.religions, [religionId]: { ...religion, boon } } };
+}
+
+export interface ReligionPressureSource {
+  religionId: string;
+  accrual: number;
+}
+
+// Highest-accrual religion currently pressuring a city, or null if none. No war-gate —
+// spread and Tithes both key off geography/faith only (user decision, #591 MR4).
+export function getStrongestPressure(state: GameState, cityId: string): ReligionPressureSource | null {
+  const city = state.cities[cityId];
+  if (!city) return null;
+  const cityFaithMap = state.cityFaith ?? {};
+  const sources = new Map<string, number>(); // religionId -> accrual
+
+  for (const religion of Object.values(state.religions ?? {})) {
+    const followerCityIds = Object.entries(cityFaithMap)
+      .filter(([, faith]) => faith.religionId === religion.id)
+      .map(([id]) => id);
+    if (followerCityIds.length === 0) continue;
+
+    const fervorMultiplier = religion.boon === 'fervor' ? FERVOR_MULTIPLIER : 1;
+    let accrual = 0;
+
+    if (city.owner === religion.ownerCivId) {
+      // Own-civ city: +OWN_CITY_ACCRUAL if adjacent to a follower city (any number of
+      // adjacent sources counts once — this is "does my faith already touch this city",
+      // not a per-source stack, unlike the foreign case below).
+      const hasOwnSource = followerCityIds.some(fid => {
+        if (fid === cityId) return false;
+        const followerCity = state.cities[fid];
+        return !!followerCity && mapDistance(state.map, city.position, followerCity.position) === 1;
+      });
+      if (hasOwnSource) accrual += OWN_CITY_ACCRUAL;
+    } else {
+      const adjacentCount = Math.min(FOREIGN_ADJACENT_CAP, followerCityIds.filter(fid => {
+        const followerCity = state.cities[fid];
+        return !!followerCity && mapDistance(state.map, city.position, followerCity.position) === 1;
+      }).length);
+      accrual += adjacentCount * FOREIGN_ADJACENT_ACCRUAL;
+    }
+
+    const hasTradeRouteSource = (state.marketplace?.tradeRoutes ?? []).some(route => {
+      const otherId = route.fromCityId === cityId ? route.toCityId : route.toCityId === cityId ? route.fromCityId : null;
+      return !!otherId && followerCityIds.includes(otherId);
+    });
+    if (hasTradeRouteSource) accrual += TRADE_ROUTE_ACCRUAL;
+
+    if (accrual > 0) sources.set(religion.id, Math.round(accrual * fervorMultiplier));
+  }
+
+  if (sources.size === 0) return null;
+  const sorted = [...sources.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return { religionId: sorted[0][0], accrual: sorted[0][1] };
+}
+
+// Passive faith spread + conversion (#591 MR4). Holy cities never accrue. A city tracks
+// progress toward exactly one target religion at a time (the current strongest); if the
+// strongest religion changes to a DIFFERENT one, progress resets for the new target —
+// "weaker records stall but are not erased" describes OTHER cities' independent
+// progress, not a multi-target ledger inside a single city (the CityFaith type only
+// ever holds one conversionProgress record).
+export function processReligionTurn(state: GameState, bus: EventBus): GameState {
+  const cityFaithMap = state.cityFaith ?? {};
+  let cityFaith = { ...cityFaithMap };
+  let changed = false;
+
+  for (const cityId of Object.keys(state.cities).sort()) {
+    const faith = cityFaith[cityId];
+    if (faith?.isHolyCity) continue;
+
+    const pressure = getStrongestPressure(state, cityId);
+    if (!pressure) continue;
+    if (faith?.religionId === pressure.religionId) continue; // already follows the strongest religion
+
+    const existingProgress = faith?.conversionProgress;
+    const carriedPoints = existingProgress?.toReligionId === pressure.religionId ? existingProgress.points : 0;
+    const nextPoints = carriedPoints + pressure.accrual;
+
+    if (nextPoints >= CONVERSION_THRESHOLD) {
+      const fromReligionId = faith?.religionId;
+      cityFaith = { ...cityFaith, [cityId]: { religionId: pressure.religionId } };
+      changed = true;
+      bus.emit('religion:city-converted', { cityId, toReligionId: pressure.religionId, fromReligionId });
+    } else {
+      cityFaith = {
+        ...cityFaith,
+        [cityId]: {
+          ...(faith ?? {}),
+          religionId: faith?.religionId ?? pressure.religionId,
+          conversionProgress: { toReligionId: pressure.religionId, points: nextPoints },
+        },
+      };
+      changed = true;
+    }
+  }
+
+  return changed ? { ...state, cityFaith } : state;
 }

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -151,7 +151,11 @@ export function processReligionTurn(state: GameState, bus: EventBus): GameState 
 
     const pressure = getStrongestPressure(state, cityId);
     if (!pressure) continue;
-    if (faith?.religionId === pressure.religionId) continue; // already follows the strongest religion
+    // Skip only a SETTLED follower of the strongest religion (no conversionProgress —
+    // it already fully converted). A city mid-conversion toward this same religion has
+    // religionId set to the pending target from its first accrual turn (see below) but
+    // must NOT be skipped here, or it would freeze at turn-1's point total forever.
+    if (faith?.religionId === pressure.religionId && !faith?.conversionProgress) continue;
 
     const existingProgress = faith?.conversionProgress;
     const carriedPoints = existingProgress?.toReligionId === pressure.religionId ? existingProgress.points : 0;

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -4,7 +4,7 @@ import { seededLcg } from './seeded-lcg';
 import {
   NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, CONVERSION_THRESHOLD,
   OWN_CITY_ACCRUAL, FOREIGN_ADJACENT_ACCRUAL, FOREIGN_ADJACENT_CAP,
-  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER,
+  TRADE_ROUTE_ACCRUAL, FERVOR_MULTIPLIER, TITHES_CAP,
 } from './religion-definitions';
 import { getCapitalCityId } from './capital-system';
 import { mapDistance } from './hex-utils';
@@ -52,6 +52,18 @@ export function chooseBoon(state: GameState, religionId: string, boon: ReligionB
   const religion = state.religions?.[religionId];
   if (!religion) return state;
   return { ...state, religions: { ...state.religions, [religionId]: { ...religion, boon } } };
+}
+
+// #591 MR4: Tithes boon — +1 gold per FOREIGN city following the owner's own faith,
+// capped at TITHES_CAP. Own-civ follower cities never count (foreign-only, per boon
+// wording).
+export function getReligionTithesGold(state: GameState, civId: string): number {
+  const religion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === civId && r.boon === 'tithes');
+  if (!religion) return 0;
+  const foreignFollowerCount = Object.entries(state.cityFaith ?? {})
+    .filter(([cityId, faith]) => faith.religionId === religion.id && state.cities[cityId]?.owner !== civId)
+    .length;
+  return Math.min(TITHES_CAP, foreignFollowerCount);
 }
 
 export interface ReligionPressureSource {

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -1,4 +1,4 @@
-import type { GameState, Religion, ReligionBoon } from '@/core/types';
+import type { City, GameState, Religion, ReligionBoon } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
 import { seededLcg } from './seeded-lcg';
 import {
@@ -64,6 +64,20 @@ export function getReligionTithesGold(state: GameState, civId: string): number {
     .filter(([cityId, faith]) => faith.religionId === religion.id && state.cities[cityId]?.owner !== civId)
     .length;
   return Math.min(TITHES_CAP, foreignFollowerCount);
+}
+
+// #591 MR4: deterministic AI boon choice — unhappy empire wants Serenity, an at-war
+// empire wants Fervor (faster conversion pressure on captured/contested cities), else
+// Tithes for the passive gold. Chosen immediately (no AI ever leaves its own religion
+// pending).
+export function chooseAiBoon(state: GameState, civId: string): ReligionBoon {
+  const civ = state.civilizations[civId];
+  const atWar = (civ?.diplomacy.atWarWith?.length ?? 0) > 0;
+  const cities = (civ?.cities ?? []).map(id => state.cities[id]).filter((c): c is City => !!c);
+  const avgUnrest = cities.length ? cities.reduce((sum, c) => sum + c.unrestLevel, 0) / cities.length : 0;
+  if (avgUnrest >= 1) return 'serenity';
+  if (atWar) return 'fervor';
+  return 'tithes';
 }
 
 export interface ReligionPressureSource {

--- a/src/systems/religion-system.ts
+++ b/src/systems/religion-system.ts
@@ -1,0 +1,50 @@
+import type { GameState, Religion, ReligionBoon } from '@/core/types';
+import type { EventBus } from '@/core/event-bus';
+import { seededLcg } from './seeded-lcg';
+import { NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES } from './religion-definitions';
+import { getCapitalCityId } from './capital-system';
+
+function pickReligionName(civType: string, seed: number): string {
+  const pool = NAME_CANDIDATES[civType] ?? NEUTRAL_NAME_CANDIDATES;
+  const rng = seededLcg(seed);
+  return pool[Math.floor(rng() * pool.length)];
+}
+
+export function foundReligion(
+  state: GameState,
+  civId: string,
+  buildingCityId: string,
+  bus: EventBus,
+): GameState {
+  const civ = state.civilizations[civId];
+  if (!civ) return state;
+  const alreadyHasReligion = Object.values(state.religions ?? {}).some(r => r.ownerCivId === civId);
+  if (alreadyHasReligion) return state;
+
+  const religionId = `religion-${civId}`;
+  const seed = state.turn * 92821 + civId.split('').reduce((a, ch) => a + ch.charCodeAt(0), 0) * 17;
+  const name = pickReligionName(civ.civType, seed);
+
+  const religion: Religion = { id: religionId, name, ownerCivId: civId, foundedTurn: state.turn };
+  const capitalId = getCapitalCityId(state, civId);
+
+  const cityFaith = { ...(state.cityFaith ?? {}) };
+  cityFaith[buildingCityId] = { religionId, isHolyCity: true };
+  if (capitalId && capitalId !== buildingCityId) {
+    cityFaith[capitalId] = { religionId };
+  }
+
+  const nextState: GameState = {
+    ...state,
+    religions: { ...(state.religions ?? {}), [religionId]: religion },
+    cityFaith,
+  };
+  bus.emit('religion:founded', { religionId, civId, cityId: buildingCityId, name });
+  return nextState;
+}
+
+export function chooseBoon(state: GameState, religionId: string, boon: ReligionBoon): GameState {
+  const religion = state.religions?.[religionId];
+  if (!religion) return state;
+  return { ...state, religions: { ...state.religions, [religionId]: { ...religion, boon } } };
+}

--- a/src/systems/tech-definitions-eras1-4.ts
+++ b/src/systems/tech-definitions-eras1-4.ts
@@ -27,7 +27,7 @@ export const TECH_TREE_ERAS_1_4: Tech[] = [
   { id: 'wheel', name: 'The Wheel', track: 'science', cost: 10, prerequisites: ['fire'], unlocks: ['Foundational mechanics knowledge'], unlocksBuildings: ['caravanserai'], era: 2 },
   { id: 'mathematics', name: 'Mathematics', track: 'science', cost: 25, prerequisites: ['writing'], unlocks: [], unlocksBuildings: ['archive', 'scribes_hall'], era: 2 },
   { id: 'engineering', name: 'Engineering', track: 'science', cost: 55, prerequisites: ['mathematics', 'wheel'], unlocks: [], unlocksBuildings: ['aqueduct', 'forge'], era: 3 },
-  { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: [], unlocksBuildings: ['temple', 'philosophers_circle'], era: 3 },
+  { id: 'philosophy', name: 'Philosophy', track: 'science', cost: 70, prerequisites: ['writing'], unlocks: [], unlocksBuildings: ['temple', 'philosophers_circle', 'sacred_council'], era: 3 },
   { id: 'astronomy', name: 'Astronomy', track: 'science', cost: 75, prerequisites: ['mathematics'], unlocks: [], unlocksBuildings: ['observatory'], era: 4 },
   { id: 'medicine', name: 'Medicine', track: 'science', cost: 75, prerequisites: ['philosophy', 'pottery'], unlocks: ['City population grows faster', 'Send medical aid to a plague-struck civilization you have met'], era: 4 },
 

--- a/src/ui/city-panel.ts
+++ b/src/ui/city-panel.ts
@@ -40,6 +40,8 @@ import {
 } from '@/systems/faction-system';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { getCrisisYieldMultiplier, getOutbreakSeverityMultiplier, getCatastropheRecoveryMultiplier, FAMINE_CONTAINMENT_SURPLUS_TURNS } from '@/systems/crisis-system';
+import { getStrongestPressure } from '@/systems/religion-system';
+import { CONVERSION_THRESHOLD } from '@/systems/religion-definitions';
 import { resolvePressureSeverityForCiv } from '@/core/opponent-challenge';
 import { getCityIntrinsicStrength, isCityHpRegenerating } from '@/systems/city-siege-system';
 import { getOccupiedCityMood, getOccupiedCityYieldMultiplier } from '@/systems/city-occupation-system';
@@ -430,6 +432,30 @@ export function createCityPanel(
         <button type="button" data-remedy-crisis="${chip.crisis.id}:${city.id}" ${chip.remedyDisabled ? 'disabled' : ''} title="${chip.remedyLabel}" style="min-height:44px;padding:7px 12px;border-radius:6px;font-size:12px;font-weight:bold;cursor:${chip.remedyDisabled ? 'default' : 'pointer'};background:${chip.remedyDisabled ? 'rgba(255,255,255,0.08)' : '#d4aa2c'};color:${chip.remedyDisabled ? 'rgba(255,255,255,0.4)' : '#1a1a1a'};border:none;">${chip.remedyLabel}</button>
       </div>
     </div>`).join('');
+  // Faith row (#591 MR4): a city has at most one faith relationship at a time, so this
+  // is a single optional row, not a chip list like crises. `getStrongestPressure` is
+  // recomputed at display time only to derive turns-remaining (display-only per the
+  // issue's "points ÷ current rate" spec) — it never mutates state.
+  const cityFaithEntry = state.cityFaith?.[city.id];
+  const faithReligion = cityFaithEntry ? state.religions?.[cityFaithEntry.religionId] : undefined;
+  const faithData = cityFaithEntry && faithReligion ? (() => {
+    const progress = cityFaithEntry.conversionProgress;
+    const pressure = progress ? getStrongestPressure(state, city.id) : null;
+    const turnsRemaining = progress && pressure && pressure.accrual > 0
+      ? Math.ceil((CONVERSION_THRESHOLD - progress.points) / pressure.accrual)
+      : null;
+    return {
+      religionName: faithReligion.name,
+      isHolyCity: !!cityFaithEntry.isHolyCity,
+      inProgress: !!progress,
+      turnsRemaining,
+    };
+  })() : null;
+  const faithSectionHtml = faithData ? `
+    <div style="background:rgba(150,120,217,0.12);border:1px solid rgba(150,120,217,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
+      <div style="font-weight:bold;color:#b39ddb;margin-bottom:4px;">🙏 Faith</div>
+      <div data-text="faith-status"></div>
+    </div>` : '';
   const getFutureBuildingUpkeep = (buildingId: string): number => {
     const projected = calculateCityBuildingMaintenance(state, {
       ...city,
@@ -820,6 +846,7 @@ export function createCityPanel(
     ${crisisSectionHtml}
     ${famineSectionHtml}
     ${catastropheSectionHtml}
+    ${faithSectionHtml}
     ${resilienceSectionHtml}
 
     <div style="display:flex;gap:8px;margin-bottom:12px;flex-wrap:wrap;">
@@ -916,6 +943,15 @@ export function createCityPanel(
       : 'Build farms or a granary to run a food surplus and end the famine naturally';
     setText(`famine-progress-${idx}`, progressText);
   });
+
+  if (faithData) {
+    const statusText = faithData.isHolyCity
+      ? `Holy City of ${faithData.religionName}`
+      : faithData.inProgress
+        ? `Converting to ${faithData.religionName}${faithData.turnsRemaining !== null ? ` — ~${faithData.turnsRemaining} turn${faithData.turnsRemaining === 1 ? '' : 's'} remaining` : ''}`
+        : `Follows ${faithData.religionName}`;
+    setText('faith-status', statusText);
+  }
 
   catastropheChips.forEach((chip, idx) => {
     const displayName = getCrisisDisplayName(chip.flavor, state.era);

--- a/src/ui/diplomacy-panel.ts
+++ b/src/ui/diplomacy-panel.ts
@@ -128,6 +128,30 @@ export function createDiplomacyPanel(
   // single read path, never state.activeCrises directly.
   const worldPressurePresentation = getWorldPressurePresentationForViewer(state, state.currentPlayer);
 
+  // Religion summary (#591 MR4): the viewer's OWN religion only -- name, boon (or a
+  // pending-choice note), and own/foreign follower counts. Text injected via textContent
+  // below (XSS-safe) -- the template only carries the static shell + data-text hooks.
+  const ownReligion = Object.values(state.religions ?? {}).find(r => r.ownerCivId === state.currentPlayer);
+  const religionSummary = ownReligion ? (() => {
+    const followerCityIds = Object.entries(state.cityFaith ?? {})
+      .filter(([, faith]) => faith.religionId === ownReligion.id)
+      .map(([cityId]) => cityId);
+    const ownFollowers = followerCityIds.filter(id => state.cities[id]?.owner === state.currentPlayer).length;
+    const foreignFollowers = followerCityIds.length - ownFollowers;
+    const boonLabel = ownReligion.boon
+      ? `${ownReligion.boon.charAt(0).toUpperCase()}${ownReligion.boon.slice(1)}`
+      : 'Choosing a boon…';
+    return {
+      nameLine: `🙏 ${ownReligion.name}`,
+      statusLine: `Boon: ${boonLabel} · ${ownFollowers} own cit${ownFollowers === 1 ? 'y' : 'ies'}, ${foreignFollowers} foreign cit${foreignFollowers === 1 ? 'y' : 'ies'} following`,
+    };
+  })() : null;
+  const religionSummaryHtml = religionSummary ? `
+    <div style="background:rgba(150,120,217,0.12);border:1px solid rgba(150,120,217,0.35);border-radius:8px;padding:10px 12px;margin-bottom:16px;font-size:12px;">
+      <div style="font-weight:bold;color:#b39ddb;margin-bottom:4px;" data-text="religion-name"></div>
+      <div style="opacity:0.85;" data-text="religion-status"></div>
+    </div>` : '';
+
   // Pre-compute all data to avoid iterating twice
   const civRows: CivRowData[] = [];
   let civIdx = 0;
@@ -474,6 +498,7 @@ export function createDiplomacyPanel(
       <h2 style="font-size:18px;color:#e8c170;margin:0;">Diplomacy</h2>
       <span id="diplo-close" style="cursor:pointer;font-size:24px;opacity:0.6;">✕</span>
     </div>
+    ${religionSummaryHtml}
     ${civRowsHtml}
     ${minorCivsHtml}
   `;
@@ -485,6 +510,11 @@ export function createDiplomacyPanel(
     const el = panel.querySelector(`[data-text="${sel}"]`);
     if (el) el.textContent = text;
   };
+
+  if (religionSummary) {
+    setText('religion-name', religionSummary.nameLine);
+    setText('religion-status', religionSummary.statusLine);
+  }
 
   for (const row of civRows) {
     setText(`civ-name-${row.civIdx}`, row.name);

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -474,6 +474,33 @@ export function routeReligionFounded(
   }
 }
 
+// #591 MR4: the issue's spec explicitly calls for a notification on conversion too
+// ("fire religion:city-converted (+ notification where discovery allows)"), not just
+// founding. Two distinct recipients, since city ownership and religion ownership are
+// independent: the CITY's owner always sees it (it's their own city's internal
+// affairs, regardless of who founded the faith it now follows); the NEW religion's
+// owner is told they gained a follower, but only if they're a different civ AND have
+// met the city's owner (discovery-gated, same convention as routeReligionFounded).
+// Deliberately no "you lost a follower" notification to the old religion's owner --
+// not called for by the spec, and would double the notification volume for a mechanic
+// that already ticks somewhat frequently via passive spread.
+export function routeReligionCityConverted(
+  state: GameState,
+  event: GameEvents['religion:city-converted'],
+  sink: NotificationSink,
+): void {
+  const city = state.cities[event.cityId];
+  if (!city) return;
+  const toReligion = state.religions?.[event.toReligionId];
+  if (!toReligion) return;
+
+  sink(city.owner, `${city.name} now follows ${toReligion.name}.`, 'info');
+
+  if (toReligion.ownerCivId !== city.owner && hasMetCivilization(state, toReligion.ownerCivId, city.owner)) {
+    sink(toReligion.ownerCivId, `${city.name} has converted to ${toReligion.name}!`, 'success');
+  }
+}
+
 export function routeCrisisEscalated(
   state: GameState,
   event: GameEvents['crisis:escalated'],

--- a/src/ui/notification-routing.ts
+++ b/src/ui/notification-routing.ts
@@ -10,6 +10,7 @@ import { presentStrategicWarning } from '@/ui/strategic-warning-presentation';
 import { getCrisisFlavor, getCrisisDisplayName } from '@/systems/crisis-flavor-definitions';
 import { resolveWorldPressureFlags } from '@/systems/world-pressure-flags';
 import { getWitnessCivIds } from '@/systems/crisis-interaction-system';
+import { hasMetCivilization } from '@/systems/discovery-system';
 
 export type NotificationSink = (
   civId: string,
@@ -451,6 +452,26 @@ export function routeCrisisStarted(
     coord: { ...city.position },
     label: name,
   } : undefined);
+}
+
+// #591 MR4: unlike the wonder-completion pattern (notifies everyone, anonymizes the
+// name), religion founding is notified ONLY to civs who have already met the founder —
+// the issue's spec calls this out explicitly as "discovery-gated", stricter than the
+// wonder precedent. The founder themself always sees it (hasMetCivilization treats
+// self-vs-self as met).
+export function routeReligionFounded(
+  state: GameState,
+  event: GameEvents['religion:founded'],
+  sink: NotificationSink,
+): void {
+  const city = state.cities[event.cityId];
+  for (const civId of Object.keys(state.civilizations)) {
+    if (!hasMetCivilization(state, civId, event.civId)) continue;
+    const message = civId === event.civId
+      ? `${event.name} has been founded in ${city?.name ?? 'your empire'}!`
+      : `${state.civilizations[event.civId]?.name ?? 'A rival civilization'} has founded ${event.name}.`;
+    sink(civId, message, 'success');
+  }
 }
 
 export function routeCrisisEscalated(

--- a/src/ui/religion-boon-modal.ts
+++ b/src/ui/religion-boon-modal.ts
@@ -1,0 +1,66 @@
+import type { ReligionBoon } from '@/core/types';
+import { BOON_DESCRIPTIONS } from '@/systems/religion-definitions';
+import { createGameButton } from '@/ui/ui-kit';
+
+export interface ReligionBoonModalConfig {
+  religionName: string;
+  onChooseBoon: (boon: ReligionBoon) => void;
+}
+
+const BOON_LABELS: Record<ReligionBoon, string> = {
+  serenity: 'Serenity',
+  tithes: 'Tithes',
+  fervor: 'Fervor',
+};
+
+// Models directly on required-choice-panel.ts: full-screen overlay, textContent only
+// (XSS-safe), createGameButton for every action. A civ's religion founds immediately
+// (no blocking the game), but stays without effects until a boon is chosen — this modal
+// re-opens at the start of the owner's turn every turn the boon remains unset.
+export function createReligionBoonModal(
+  container: HTMLElement,
+  config: ReligionBoonModalConfig,
+): HTMLElement {
+  container.querySelector('#religion-boon-modal')?.remove();
+
+  const modal = document.createElement('div');
+  modal.id = 'religion-boon-modal';
+  modal.style.cssText = 'position:absolute;inset:0;background:rgba(12,12,24,0.96);z-index:45;padding:16px;overflow:auto;';
+
+  const title = document.createElement('h2');
+  title.textContent = `Choose a Boon for ${config.religionName}`;
+  title.style.cssText = 'font-size:20px;color:#e8c170;margin:0 0 8px;';
+  modal.appendChild(title);
+
+  const intro = document.createElement('p');
+  intro.textContent = 'Your faith has no effect until you choose how it blesses your empire. Pick one — this cannot be changed later.';
+  intro.style.cssText = 'font-size:13px;opacity:0.8;margin:0 0 16px;';
+  modal.appendChild(intro);
+
+  const boons: ReligionBoon[] = ['serenity', 'tithes', 'fervor'];
+  for (const boon of boons) {
+    const card = document.createElement('div');
+    card.style.cssText = 'margin-bottom:12px;background:rgba(255,255,255,0.06);border-radius:10px;padding:12px;';
+
+    const heading = document.createElement('h3');
+    heading.textContent = BOON_LABELS[boon];
+    heading.style.cssText = 'font-size:16px;color:#e8c170;margin:0 0 6px;';
+    card.appendChild(heading);
+
+    const desc = document.createElement('p');
+    desc.textContent = BOON_DESCRIPTIONS[boon];
+    desc.style.cssText = 'font-size:13px;opacity:0.85;margin:0 0 10px;';
+    card.appendChild(desc);
+
+    const button = createGameButton(`Choose ${BOON_LABELS[boon]}`, 'primary');
+    button.style.width = '100%';
+    button.dataset.chooseBoon = boon;
+    button.addEventListener('click', () => config.onChooseBoon(boon));
+    card.appendChild(button);
+
+    modal.appendChild(card);
+  }
+
+  container.appendChild(modal);
+  return modal;
+}

--- a/tests/ai/ai-production.test.ts
+++ b/tests/ai/ai-production.test.ts
@@ -454,3 +454,34 @@ describe('happiness building AI scoring (#552)', () => {
     expect(temple!.economyScore).toBe(economyValue('temple'));
   });
 });
+
+describe('#591 MR4 — milestone national project AI scoring', () => {
+  it('economyValue treats a milestone NP as comparable to a normal same-era NP, not worthless', () => {
+    // sacred_council has civYieldBonus: undefined (its effect is a one-time state
+    // mutation, not a yield) -- without a milestone-specific floor, economyValue would
+    // score it 0, deeply undercutting its 120-production-turn cost in the candidate
+    // score formula (score = economyScore*2 - productionTurns*1.5 - ...) and making the
+    // AI functionally never build it. Compare against philosophers_circle (era 3 NP,
+    // civYieldBonus: { science: 3 } -> economyValue 3.75) as a same-era reference point.
+    expect(economyValue('sacred_council')).toBeGreaterThan(0);
+    expect(economyValue('sacred_council')).toBeGreaterThanOrEqual(economyValue('iron_legion'));
+  });
+
+  it('sacred_council scores comparably to a same-cost, same-era normal NP (not singled out as worthless)', () => {
+    // Absolute score floors are meaningless here -- productionTurns dominates the
+    // formula and swings hugely with this fixture's (low, unrealistic-for-era-3)
+    // production rate. The real fairness check is RELATIVE: does sacred_council score
+    // in the same ballpark as iron_legion, an equal-cost (120) era-3 NP, under the
+    // identical city/production conditions -- proving the milestone floor actually
+    // closed the gap, not just made the number less negative in isolation.
+    const state = setupState(['philosophy', 'iron-forging']);
+    state.era = 3; // sacred_council homeEra: 3 -- below-window check still applies to milestone NPs
+    state.cities['city-a']!.buildings = ['temple'];
+    const candidates = generateAIProductionCandidates(state, 'ai-1', 'city-a', [], aggressive);
+    const sacredCouncil = candidates.find(c => c.itemId === 'sacred_council');
+    const ironLegion = candidates.find(c => c.itemId === 'iron_legion');
+    expect(sacredCouncil).toBeDefined();
+    expect(ironLegion).toBeDefined();
+    expect(Math.abs(sacredCouncil!.score - ironLegion!.score)).toBeLessThan(5);
+  });
+});

--- a/tests/ai/basic-ai.test.ts
+++ b/tests/ai/basic-ai.test.ts
@@ -2626,3 +2626,42 @@ describe('#436 — AI appease uses the shared helper', () => {
     expect(afterAiTurn.civilizations['ai-1'].gold).toBe(0);
   });
 });
+
+describe('#591 MR4 — AI boon choice', () => {
+  function withPendingReligion(seed: string): { state: GameState; aiCityId: string; religionId: string } {
+    let state = createNewGame(undefined, seed, 'small');
+    state = processAITurn(state, 'ai-1', new EventBus());
+    const aiCityId = state.civilizations['ai-1'].cities[0];
+    if (!aiCityId) throw new Error('ai-1 has no city after its first turn');
+    const religionId = 'religion-ai-1';
+    state.religions = { [religionId]: { id: religionId, name: 'Order of Test', ownerCivId: 'ai-1', foundedTurn: 1 } };
+    state.cityFaith = { [aiCityId]: { religionId, isHolyCity: true } };
+    return { state, aiCityId, religionId };
+  }
+
+  it('AI never leaves its own religion pending -- chooses a boon within one turn', () => {
+    const { state, religionId } = withPendingReligion('591-ai-boon-choose');
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    expect(next.religions![religionId].boon).toBeDefined();
+  });
+
+  it('picks serenity when the AI has unhappy cities', () => {
+    const { state, aiCityId, religionId } = withPendingReligion('591-ai-boon-unhappy');
+    state.cities[aiCityId] = { ...state.cities[aiCityId], unrestLevel: 2 };
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    expect(next.religions![religionId].boon).toBe('serenity');
+  });
+
+  it('picks fervor when at war and not unhappy', () => {
+    const { state, religionId } = withPendingReligion('591-ai-boon-war');
+    state.civilizations['ai-1'].diplomacy.atWarWith = ['player'];
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    expect(next.religions![religionId].boon).toBe('fervor');
+  });
+
+  it('picks tithes when neither unhappy nor at war', () => {
+    const { state, religionId } = withPendingReligion('591-ai-boon-peace');
+    const next = processAITurn(state, 'ai-1', new EventBus());
+    expect(next.religions![religionId].boon).toBe('tithes');
+  });
+});

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1556,4 +1556,29 @@ describe('journey automation', () => {
     const next = processTurn(state, new EventBus());
     expect(next.cityFaith?.[neighbor.id]?.conversionProgress?.toReligionId).toBe(religionId);
   });
+
+  it('#591 MR4: completing Sacred Council founds a religion at the building city', () => {
+    const state = createNewGame(undefined, 'sacred-council-completion', 'small');
+    const civId = 'player';
+    const pos = { q: 0, r: 0 };
+    state.map.tiles[hexKey(pos)] = {
+      coord: pos, terrain: 'grassland', elevation: 'lowland', resource: null,
+      improvement: 'none', owner: civId, improvementTurnsLeft: 0, hasRiver: false, wonder: null,
+    };
+    const city = foundCity(civId, pos, state.map, state.idCounters);
+    city.workedTiles = [];
+    city.buildings = ['temple'];
+    city.productionQueue = ['sacred_council'];
+    city.productionProgress = 119; // 1 short of the 120 cost -- completes with even minimal production this turn
+    state.cities = { [city.id]: city };
+    state.civilizations[civId].cities = [city.id];
+    state.civilizations[civId].techState.completed = ['philosophy'];
+    state.units = {};
+    state.barbarianCamps = {};
+
+    const next = processTurn(state, new EventBus());
+    const religionId = `religion-${civId}`;
+    expect(next.religions?.[religionId]).toMatchObject({ ownerCivId: civId });
+    expect(next.cityFaith?.[city.id]).toMatchObject({ religionId, isHolyCity: true });
+  });
 });

--- a/tests/core/turn-manager.test.ts
+++ b/tests/core/turn-manager.test.ts
@@ -1523,4 +1523,37 @@ describe('journey automation', () => {
     expect(blockedEvents[0].unitId).toBe(unitId);
     expect(result.units[unitId]!.automation).toBeUndefined();
   });
+
+  it('#591 MR4: processTurn advances religion spread (processReligionTurn is wired in)', () => {
+    const state = createNewGame(undefined, 'religion-turn-wiring', 'small');
+    const civId = 'player';
+    const capitalPos = { q: 0, r: 0 };
+    const neighborPos = { q: 1, r: 0 };
+    state.map = {
+      width: 20, height: 20, wrapsHorizontally: false, rivers: [],
+      tiles: Object.fromEntries([capitalPos, neighborPos].map(pos => [
+        hexKey(pos),
+        {
+          coord: pos, terrain: 'grassland', elevation: 'lowland', resource: null,
+          improvement: 'none', owner: civId, improvementTurnsLeft: 0, hasRiver: false,
+          wonder: null, regionKey: 'continent-0',
+        },
+      ])),
+    };
+    const capital = foundCity(civId, capitalPos, state.map, state.idCounters);
+    const neighbor = foundCity(civId, neighborPos, state.map, state.idCounters);
+    capital.workedTiles = []; capital.productionQueue = [];
+    neighbor.workedTiles = []; neighbor.productionQueue = [];
+    state.cities = { [capital.id]: capital, [neighbor.id]: neighbor };
+    state.civilizations[civId].cities = [capital.id, neighbor.id];
+    state.units = {};
+    state.barbarianCamps = {};
+
+    const religionId = `religion-${civId}`;
+    state.religions = { [religionId]: { id: religionId, name: 'Order of Test', ownerCivId: civId, foundedTurn: 1 } };
+    state.cityFaith = { [capital.id]: { religionId, isHolyCity: true } };
+
+    const next = processTurn(state, new EventBus());
+    expect(next.cityFaith?.[neighbor.id]?.conversionProgress?.toReligionId).toBe(religionId);
+  });
 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -391,4 +391,13 @@ describe('#591 MR4 — religion state defaults', () => {
     expect(migrated.religions).toEqual(save.religions);
     expect(migrated.cityFaith).toEqual(save.cityFaith);
   });
+
+  it('is idempotent across repeated loads', () => {
+    const save = createNewGame('rome', 'religion-defaults-idempotent', 'small');
+    save.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', foundedTurn: 5 } };
+    save.cityFaith = { capital: { religionId: 'religion-player', isHolyCity: true } };
+    const migrated = migrateSaveToCurrent(save);
+    const loadedAgain = migrateSaveToCurrent(migrated);
+    expect(loadedAgain).toEqual(migrated);
+  });
 });

--- a/tests/storage/save-migrations.test.ts
+++ b/tests/storage/save-migrations.test.ts
@@ -372,3 +372,23 @@ describe('#590 MR3 — defensive crisis archetype normalization', () => {
     expect(loadedAgain).toEqual(migrated);
   });
 });
+
+describe('#591 MR4 — religion state defaults', () => {
+  it('defaults religions and cityFaith to {} for a save predating this feature', () => {
+    const save = createNewGame('rome', 'religion-defaults-drift', 'small');
+    delete save.religions;
+    delete save.cityFaith;
+    const migrated = migrateSaveToCurrent(save);
+    expect(migrated.religions).toEqual({});
+    expect(migrated.cityFaith).toEqual({});
+  });
+
+  it('preserves existing religions/cityFaith data unchanged', () => {
+    const save = createNewGame('rome', 'religion-defaults-preserve', 'small');
+    save.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', foundedTurn: 5 } };
+    save.cityFaith = { capital: { religionId: 'religion-player', isHolyCity: true } };
+    const migrated = migrateSaveToCurrent(save);
+    expect(migrated.religions).toEqual(save.religions);
+    expect(migrated.cityFaith).toEqual(save.cityFaith);
+  });
+});

--- a/tests/systems/city-capture-system.test.ts
+++ b/tests/systems/city-capture-system.test.ts
@@ -407,6 +407,25 @@ describe('city-capture-system', () => {
     );
   });
 
+  it('#591 MR4: deletes cityFaith when a city is razed', () => {
+    const state = makeExposedCityCaptureState({ population: 6, buildings: ['granary'] });
+    state.cityFaith = { athens: { religionId: 'religion-ai-1', isHolyCity: true } };
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'raze', state.turn);
+
+    expect(result.state.cityFaith?.athens).toBeUndefined();
+  });
+
+  it('#591 MR4: preserves cityFaith (under the new owner) when a city is captured (occupy)', () => {
+    const state = makeExposedCityCaptureState({ population: 6, buildings: ['granary'] });
+    state.cityFaith = { athens: { religionId: 'religion-ai-1', isHolyCity: true } };
+
+    const result = resolveMajorCityCapture(state, 'athens', 'player', 'occupy', state.turn);
+
+    expect(result.state.cityFaith?.athens).toEqual({ religionId: 'religion-ai-1', isHolyCity: true });
+    expect(result.state.cities.athens.owner).toBe('player');
+  });
+
   it('razes a population-1 major city when the conqueror chooses raze', () => {
     const state = makeExposedCityCaptureState({ population: 1, buildings: ['granary'] });
 

--- a/tests/systems/city-system.test.ts
+++ b/tests/systems/city-system.test.ts
@@ -368,6 +368,23 @@ describe('getAvailableBuildings', () => {
     const available = getAvailableBuildings(city, ['siege-warfare', 'black-powder'], map);
     expect(available.find(b => b.id === 'siege-workshop')).toBeUndefined();
   });
+
+  it('#591 MR4: sacred_council (milestone) stays available far beyond homeEra + 1, unlike a normal NP', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = { ...foundCity('p1', landTile.coord, map, mkC()), buildings: ['temple'] };
+    // era 10 is far past sacred_council's homeEra(3) + 1 = 4 -- a normal NP would drop out.
+    const available = getAvailableBuildings(city, ['philosophy'], map, undefined, 10);
+    expect(available.find(b => b.id === 'sacred_council')).toBeDefined();
+  });
+
+  it('#591 MR4: sacred_council requires a temple even though it also requires philosophy tech', () => {
+    const map = generateMap(30, 30, 'city-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland')!;
+    const city = foundCity('p1', landTile.coord, map, mkC()); // no temple built
+    const available = getAvailableBuildings(city, ['philosophy'], map, undefined, 3);
+    expect(available.find(b => b.id === 'sacred_council')).toBeUndefined();
+  });
 });
 
 describe('#443 — building obsolescence data', () => {
@@ -991,6 +1008,24 @@ describe('processCity — droppedProductionItems (issue #457)', () => {
 
     expect(result.droppedProductionItems).toEqual([]);
     expect(result.city.productionQueue).toContain('sacred_grove');
+  });
+
+  it('#591 MR4: never drops a milestone national project (sacred_council) regardless of how far past homeEra+1 the era is', () => {
+    const map = generateMap(30, 30, 'np-milestone-keep-test');
+    const landTile = Object.values(map.tiles).find(t => t.terrain === 'grassland' || t.terrain === 'plains')!;
+    const city = {
+      ...foundCity('p1', landTile.coord, map, mkC()),
+      buildings: ['temple'],
+      productionQueue: ['sacred_council'],
+      productionProgress: 0,
+    };
+
+    // sacred_council has nationalProject.homeEra: 3, milestone: true -- a normal NP
+    // would be dropped at era 10 (far past homeEra + 1 = 4), a milestone NP must not be.
+    const result = processCity(city, map, 2, 1, undefined, ['philosophy'], undefined, 10);
+
+    expect(result.droppedProductionItems).toEqual([]);
+    expect(result.city.productionQueue).toContain('sacred_council');
   });
 
   it('disambiguates unit obsoleted vs resource-lost, and prefers obsoleted on a tie', () => {

--- a/tests/systems/economy-system.test.ts
+++ b/tests/systems/economy-system.test.ts
@@ -352,6 +352,70 @@ describe('rush buy', () => {
   });
 });
 
+describe('#591 MR4 — Tithes gold', () => {
+  it('adds +1 gold per foreign city following the tithes-boon religion, capped at TITHES_CAP', () => {
+    const state = makeState();
+    const withTithes: GameState = {
+      ...state,
+      religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'tithes', foundedTurn: 1 } },
+      cities: {
+        ...state.cities,
+        'foreign-1': { ...state.cities.capital, id: 'foreign-1', owner: 'rival' },
+        'foreign-2': { ...state.cities.capital, id: 'foreign-2', owner: 'rival' },
+      },
+      cityFaith: {
+        'foreign-1': { religionId: 'religion-player' },
+        'foreign-2': { religionId: 'religion-player' },
+      },
+    };
+    const withoutTithes = { ...withTithes, religions: {} };
+    const gold = projectCivGrossGold(withTithes, 'player');
+    const baseline = projectCivGrossGold(withoutTithes, 'player');
+    expect(gold - baseline).toBe(2);
+  });
+
+  it('does not count own-civ follower cities toward Tithes', () => {
+    const state = makeState();
+    const withTithes: GameState = {
+      ...state,
+      religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'tithes', foundedTurn: 1 } },
+      cityFaith: { capital: { religionId: 'religion-player', isHolyCity: true } },
+    };
+    const withoutTithes = { ...withTithes, religions: {} };
+    expect(projectCivGrossGold(withTithes, 'player') - projectCivGrossGold(withoutTithes, 'player')).toBe(0);
+  });
+
+  it('contributes 0 when the boon is not tithes', () => {
+    const state = makeState();
+    const withSerenity: GameState = {
+      ...state,
+      religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'serenity', foundedTurn: 1 } },
+      cities: { ...state.cities, 'foreign-1': { ...state.cities.capital, id: 'foreign-1', owner: 'rival' } },
+      cityFaith: { 'foreign-1': { religionId: 'religion-player' } },
+    };
+    const withoutReligion = { ...withSerenity, religions: {} };
+    expect(projectCivGrossGold(withSerenity, 'player') - projectCivGrossGold(withoutReligion, 'player')).toBe(0);
+  });
+
+  it('caps at TITHES_CAP even with many foreign follower cities', () => {
+    const state = makeState();
+    const foreignCities: GameState['cities'] = {};
+    const cityFaith: GameState['cityFaith'] = {};
+    for (let i = 0; i < 15; i++) {
+      foreignCities[`foreign-${i}`] = { ...state.cities.capital, id: `foreign-${i}`, owner: 'rival' };
+      cityFaith[`foreign-${i}`] = { religionId: 'religion-player' };
+    }
+    const withTithes: GameState = {
+      ...state,
+      religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'tithes', foundedTurn: 1 } },
+      cities: { ...state.cities, ...foreignCities },
+      cityFaith,
+    };
+    const withoutTithes = { ...withTithes, religions: {} };
+    expect(projectCivGrossGold(withTithes, 'player') - projectCivGrossGold(withoutTithes, 'player')).toBe(10);
+  });
+});
+
 describe('pirate economy modifiers', () => {
   it('zeros routes involving a blockaded city and reduces that city gold once without changing food or production', () => {
     const state = makeState();

--- a/tests/systems/faction-system.test.ts
+++ b/tests/systems/faction-system.test.ts
@@ -1018,4 +1018,47 @@ describe('unrest pressure breakdown (#552)', () => {
     expect(row).toBeDefined();
     expect(row!.amount).toBe(-2);
   });
+
+  describe('#591 MR4 — Religious serenity boon row', () => {
+    it('adds a -2 Religious serenity row when the city follows its own civ\'s serenity-boon faith', () => {
+      const state = makeState({ cityCount: 1 });
+      const withFaith: GameState = {
+        ...state,
+        religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'serenity', foundedTurn: 1 } },
+        cityFaith: { 'city-1': { religionId: 'religion-player' } },
+      };
+      const rows = getUnrestPressureBreakdown('city-1', withFaith, 0);
+      const row = rows.find(r => r.label === 'Religious serenity');
+      expect(row).toBeDefined();
+      expect(row!.amount).toBe(-2);
+    });
+
+    it('does not add the row when the boon is not serenity', () => {
+      const state = makeState({ cityCount: 1 });
+      const withFaith: GameState = {
+        ...state,
+        religions: { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'tithes', foundedTurn: 1 } },
+        cityFaith: { 'city-1': { religionId: 'religion-player' } },
+      };
+      const rows = getUnrestPressureBreakdown('city-1', withFaith, 0);
+      expect(rows.find(r => r.label === 'Religious serenity')).toBeUndefined();
+    });
+
+    it('does not add the row when the city follows a foreign civ\'s serenity faith', () => {
+      const state = makeState({ cityCount: 1 });
+      const withFaith: GameState = {
+        ...state,
+        religions: { 'religion-rival': { id: 'religion-rival', name: 'Order of Rival', ownerCivId: 'rival', boon: 'serenity', foundedTurn: 1 } },
+        cityFaith: { 'city-1': { religionId: 'religion-rival' } },
+      };
+      const rows = getUnrestPressureBreakdown('city-1', withFaith, 0);
+      expect(rows.find(r => r.label === 'Religious serenity')).toBeUndefined();
+    });
+
+    it('does not add the row when the city has no faith at all', () => {
+      const state = makeState({ cityCount: 1 });
+      const rows = getUnrestPressureBreakdown('city-1', state, 0);
+      expect(rows.find(r => r.label === 'Religious serenity')).toBeUndefined();
+    });
+  });
 });

--- a/tests/systems/helpers/religion-fixture.ts
+++ b/tests/systems/helpers/religion-fixture.ts
@@ -1,0 +1,104 @@
+import type { City, GameState, HexCoord, HexTile } from '@/core/types';
+import { createDiplomacyState } from '@/systems/diplomacy-system';
+import { createMarketplaceState } from '@/systems/trade-system';
+import { hexKey } from '@/systems/hex-utils';
+
+const LANDMASS = 'landmass-1';
+
+function makeTile(coord: HexCoord, owner: string | null, terrain: HexTile['terrain'] = 'grassland'): HexTile {
+  return {
+    coord, terrain, elevation: 'lowland', resource: null, improvement: 'none', owner,
+    improvementTurnsLeft: 0, hasRiver: false, wonder: null, regionKey: LANDMASS,
+  };
+}
+
+function makeCity(id: string, owner: string, position: HexCoord, overrides: Partial<City> = {}): City {
+  return {
+    id, name: id, owner, position, population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [position], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+}
+
+export function makeReligionFixture({
+  turn = 40,
+  era = 4,
+}: { turn?: number; era?: number } = {}): {
+  state: GameState;
+  civId: string;
+  capitalId: string;
+  templeCity: string;
+  otherCivId: string;
+  otherCity: string;
+} {
+  const civId = 'p1';
+  const otherCivId = 'p2';
+  const capitalId = 'capital';
+  const templeCity = 'temple-city';
+  const otherCity = 'other-city';
+
+  const capitalPos: HexCoord = { q: 0, r: 0 };
+  const templePos: HexCoord = { q: 5, r: 0 };
+  const otherPos: HexCoord = { q: 10, r: 10 };
+
+  const cities: Record<string, City> = {
+    [capitalId]: makeCity(capitalId, civId, capitalPos),
+    [templeCity]: makeCity(templeCity, civId, templePos, { buildings: ['temple'] }),
+    [otherCity]: makeCity(otherCity, otherCivId, otherPos),
+  };
+
+  const tiles: Record<string, HexTile> = {
+    [hexKey(capitalPos)]: makeTile(capitalPos, civId),
+    [hexKey(templePos)]: makeTile(templePos, civId),
+    [hexKey(otherPos)]: makeTile(otherPos, otherCivId),
+  };
+
+  const ids = [civId, otherCivId];
+
+  const state: GameState = {
+    turn,
+    era,
+    currentPlayer: civId,
+    gameOver: false,
+    winner: null,
+    map: { width: 20, height: 20, tiles, wrapsHorizontally: false, rivers: [] },
+    units: {},
+    cities,
+    civilizations: {
+      [civId]: {
+        id: civId, name: 'Player', color: '#4a90d9', isHuman: true, civType: 'egypt',
+        cities: [capitalId, templeCity], units: [],
+        techState: { completed: ['philosophy'], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 500, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState(ids, civId),
+      },
+      [otherCivId]: {
+        id: otherCivId, name: 'Other', color: '#c2410c', isHuman: false, civType: 'rome',
+        cities: [otherCity], units: [],
+        techState: { completed: [], currentResearch: null, researchProgress: 0, researchQueue: [], trackPriorities: {} as any },
+        gold: 500, visibility: { tiles: {} }, score: 0,
+        diplomacy: createDiplomacyState(ids, otherCivId),
+      },
+    },
+    barbarianCamps: {},
+    minorCivs: {},
+    tutorial: { active: false, currentStep: 'complete', completedSteps: [] },
+    settings: {
+      mapSize: 'small', soundEnabled: false, musicEnabled: false, musicVolume: 0, sfxVolume: 0,
+      tutorialEnabled: false, advisorsEnabled: {} as any, councilTalkLevel: 'normal',
+    },
+    tribalVillages: {},
+    discoveredWonders: {},
+    wonderDiscoverers: {},
+    embargoes: [],
+    defensiveLeagues: [],
+    idCounters: { nextUnitId: 1, nextCityId: 1, nextCampId: 1, nextQuestId: 1 },
+    marketplace: { ...createMarketplaceState(), tradeRoutes: [] },
+    religions: {},
+    cityFaith: {},
+  } as GameState;
+
+  return { state, civId, capitalId, templeCity, otherCivId, otherCity };
+}

--- a/tests/systems/national-project-balance.test.ts
+++ b/tests/systems/national-project-balance.test.ts
@@ -161,3 +161,15 @@ describe('era 12 national project coverage (MR11)', () => {
     expect(np?.civYieldBonus).toEqual({ production: 6 });
   });
 });
+
+describe('#591 MR4 — milestone national projects', () => {
+  it('every milestone NP has no civYieldBonus/cityYieldBonus and is uniquePerEmpire', () => {
+    const milestoneNPs = nationalProjects.filter(np => np.nationalProject?.milestone);
+    expect(milestoneNPs.length).toBeGreaterThan(0); // guard: sacred_council should exist by the time this runs
+    for (const np of milestoneNPs) {
+      expect(np.civYieldBonus, `${np.id} must not have civYieldBonus`).toBeUndefined();
+      expect((np as any).cityYieldBonus, `${np.id} must not have cityYieldBonus`).toBeUndefined();
+      expect(np.uniquePerEmpire, `${np.id} missing uniquePerEmpire`).toBe(true);
+    }
+  });
+});

--- a/tests/systems/national-project-system.test.ts
+++ b/tests/systems/national-project-system.test.ts
@@ -245,4 +245,26 @@ describe('expireNationalProjects', () => {
     expect(next.cities['city1'].buildings).not.toContain('royal_academy');
     expect(next.cities['city1'].buildings).toContain('library');
   });
+
+  it('#591 MR4: never expires a milestone NP (sacred_council), even far past the normal delta>=3 threshold', () => {
+    const state = makeState({
+      era: 20,
+      cities: {
+        city1: {
+          id: 'city1', name: 'Rome', owner: 'p1', position: { q: 0, r: 0 },
+          population: 3, food: 0, foodNeeded: 10,
+          buildings: ['temple', 'sacred_council'],
+          productionQueue: [], productionProgress: 0,
+          ownedTiles: [], workedTiles: [], focus: 'balanced', maturity: 'town',
+        } as any,
+      },
+      builtNationalProjects: {
+        'p1:sacred_council': { civId: 'p1', cityId: 'city1', eraBuilt: 3 },
+      },
+    });
+    const { state: next, expired } = expireNationalProjects(state, 20);
+    expect(expired).toHaveLength(0);
+    expect(next.builtNationalProjects?.['p1:sacred_council']).toBeDefined();
+    expect(next.cities['city1'].buildings).toContain('sacred_council');
+  });
 });

--- a/tests/systems/pacing-reference-economy.test.ts
+++ b/tests/systems/pacing-reference-economy.test.ts
@@ -9,8 +9,16 @@ describe('pacing reference economy (Part C exact-value pin)', () => {
   // test fails, that is Part C working as designed (see .claude/rules/game-balance.md's Pacing
   // Regression Prevention section): update BOTH this expectation and the matching
   // RESEARCH_OUTPUT_BY_ERA entry in pacing-model.ts together, with a one-line justification.
+  // #591 MR4: eras 7-13 shifted upward. Sacred Council (a milestone national project) is
+  // the first building to list `temple` in requiresBuildings, which forces `temple` past
+  // the bounded profile's "recently-gated" window (isForcedPrereq in
+  // eligibleBuildingIds) at every later era -- temple's own +1 science now counts as
+  // active production indefinitely, same as any other prereq chain. This is intentional:
+  // a milestone project is buildable forever, so its prerequisite building staying
+  // "relevant infrastructure" indefinitely in the reference economy is the correct model,
+  // not a leak.
   const expectedBoundedByEra: Record<number, number> = {
-    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 29, 8: 46, 9: 59, 10: 66, 11: 93, 12: 103, 13: 102,
+    1: 2, 2: 6, 3: 8, 4: 9, 5: 9, 6: 24, 7: 35, 8: 50, 9: 68, 10: 75, 11: 103, 12: 113, 13: 113,
   };
   const expectedMaximalByEra: Record<number, number> = {
     1: 2, 2: 6, 3: 8, 4: 9, 5: 13, 6: 34, 7: 48, 8: 79, 9: 118, 10: 135, 11: 170, 12: 198, 13: 236,

--- a/tests/systems/religion-definitions.test.ts
+++ b/tests/systems/religion-definitions.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { CIV_DEFINITIONS } from '@/systems/civ-definitions';
+import { NAME_CANDIDATES, NEUTRAL_NAME_CANDIDATES, BOON_DESCRIPTIONS } from '@/systems/religion-definitions';
+
+describe('#591 MR4 — religion definitions', () => {
+  it('has at least 2 name candidates for every playable civ id', () => {
+    for (const civ of CIV_DEFINITIONS) {
+      expect(NAME_CANDIDATES[civ.id]?.length ?? 0).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it('has a non-empty neutral pool for custom civs', () => {
+    expect(NEUTRAL_NAME_CANDIDATES.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('no candidate name matches a real-world major religion (spot check)', () => {
+    const bannedSubstrings = ['christ', 'islam', 'muslim', 'buddh', 'hindu', 'judai', 'jewish', 'catholic', 'protestant'];
+    const all = [...Object.values(NAME_CANDIDATES).flat(), ...NEUTRAL_NAME_CANDIDATES];
+    for (const name of all) {
+      const lower = name.toLowerCase();
+      for (const banned of bannedSubstrings) {
+        expect(lower).not.toContain(banned);
+      }
+    }
+  });
+
+  it('every name is unique across the whole table (no accidental duplicate faith names)', () => {
+    const all = [...Object.values(NAME_CANDIDATES).flat(), ...NEUTRAL_NAME_CANDIDATES];
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  it('fervor description mentions only conversion speed, not territory/loyalty (MR4 honesty)', () => {
+    const lower = BOON_DESCRIPTIONS.fervor.toLowerCase();
+    expect(lower).not.toMatch(/territory|loyalty|flip/);
+  });
+});

--- a/tests/systems/religion-spread.test.ts
+++ b/tests/systems/religion-spread.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import type { City, GameState, HexCoord, HexTile } from '@/core/types';
+import { foundReligion, getStrongestPressure, processReligionTurn } from '@/systems/religion-system';
+import { CONVERSION_THRESHOLD } from '@/systems/religion-definitions';
+import { makeReligionFixture } from './helpers/religion-fixture';
+import { hexKey } from '@/systems/hex-utils';
+
+function addCity(state: GameState, id: string, owner: string, coord: HexCoord, overrides: Partial<City> = {}): GameState {
+  const tile: HexTile = {
+    coord, terrain: 'grassland', elevation: 'lowland', resource: null, improvement: 'none',
+    owner, improvementTurnsLeft: 0, hasRiver: false, wonder: null, regionKey: 'landmass-1',
+  };
+  const city: City = {
+    id, name: id, owner, position: coord, population: 4, food: 0, foodNeeded: 20,
+    buildings: [], productionQueue: [], productionProgress: 0,
+    ownedTiles: [coord], workedTiles: [], focus: 'balanced', maturity: 'outpost',
+    unrestLevel: 0, unrestTurns: 0, spyUnrestBonus: 0,
+    ...overrides,
+  };
+  return {
+    ...state,
+    map: { ...state.map, tiles: { ...state.map.tiles, [hexKey(coord)]: tile } },
+    cities: { ...state.cities, [id]: city },
+  };
+}
+
+describe('#591 MR4 — getStrongestPressure', () => {
+  it('returns null for a city with no nearby religion sources', () => {
+    const { state, capitalId } = makeReligionFixture();
+    expect(getStrongestPressure(state, capitalId)).toBeNull();
+  });
+
+  it('own-civ city adjacent to a follower city accrues OWN_CITY_ACCRUAL', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    // A new own-civ city adjacent to templeCity (5,0) -> (6,0), distance 1.
+    const withNeighbor = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
+    const pressure = getStrongestPressure(withNeighbor, 'own-neighbor');
+    expect(pressure).toEqual({ religionId: `religion-${civId}`, accrual: 15 });
+  });
+
+  it('foreign city adjacent to follower cities accrues FOREIGN_ADJACENT_ACCRUAL, capped at 2 sources', () => {
+    const { state, civId, templeCity, otherCivId } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    // 3 follower cities all adjacent to a single foreign city at (6,0).
+    let working = addCity(founded, 'f1', civId, { q: 5, r: 1 }, { buildings: [] });
+    working = { ...working, cityFaith: { ...working.cityFaith, f1: { religionId: `religion-${civId}` } } };
+    working = addCity(working, 'f2', civId, { q: 7, r: -1 });
+    working = { ...working, cityFaith: { ...working.cityFaith, f2: { religionId: `religion-${civId}` } } };
+    working = addCity(working, 'f3', civId, { q: 6, r: -1 });
+    working = { ...working, cityFaith: { ...working.cityFaith, f3: { religionId: `religion-${civId}` } } };
+    working = addCity(working, 'foreign-target', otherCivId, { q: 6, r: 0 });
+    const pressure = getStrongestPressure(working, 'foreign-target');
+    // 3 adjacent followers exist but cap is 2 sources * 7 = 14, never 21.
+    expect(pressure).toEqual({ religionId: `religion-${civId}`, accrual: 14 });
+  });
+
+  it('trade-route-only adjacency (no geographic adjacency) accrues TRADE_ROUTE_ACCRUAL', () => {
+    const { state, civId, templeCity, otherCivId } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    let working = addCity(founded, 'far-foreign', otherCivId, { q: 15, r: 15 });
+    working = {
+      ...working,
+      marketplace: { ...working.marketplace!, tradeRoutes: [{ id: 'route-1', fromCityId: templeCity, toCityId: 'far-foreign', goldPerTrip: 10, turnsPerTrip: 3 }] },
+    };
+    const pressure = getStrongestPressure(working, 'far-foreign');
+    expect(pressure).toEqual({ religionId: `religion-${civId}`, accrual: 5 });
+  });
+
+  it('picks the religion with the highest accrual, tie-broken by religion id', () => {
+    const { state, civId, templeCity, otherCivId, otherCity } = makeReligionFixture();
+    let working = foundReligion(state, civId, templeCity, new EventBus());
+    working = foundReligion(working, otherCivId, otherCity, new EventBus());
+    // Put a neutral third-civ city adjacent to BOTH follower cities with equal accrual
+    // (both foreign, one adjacent source each -> 7 each) to force the tie-break.
+    working = addCity(working, 'third-city', 'p3', { q: 6, r: 0 }); // adjacent to templeCity (5,0)
+    working = addCity(working, 'p3-other', 'p3', { q: 11, r: 10 }); // adjacent to otherCity (10,10)
+    // third-city is adjacent to templeCity only; p3-other is adjacent to otherCity only.
+    // Merge both onto one city adjacent to both religions' holy cities is geometrically
+    // awkward on a hex grid -- instead assert each resolves to its own (only) source,
+    // which already proves accrual computation reads the right religion per city.
+    expect(getStrongestPressure(working, 'third-city')).toEqual({ religionId: `religion-${civId}`, accrual: 7 });
+    expect(getStrongestPressure(working, 'p3-other')).toEqual({ religionId: `religion-${otherCivId}`, accrual: 7 });
+  });
+
+  it('applies the Fervor multiplier to accrual', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const withFervor = { ...founded, religions: { ...founded.religions, [`religion-${civId}`]: { ...founded.religions![`religion-${civId}`], boon: 'fervor' as const } } };
+    const withNeighbor = addCity(withFervor, 'own-neighbor', civId, { q: 6, r: 0 });
+    const pressure = getStrongestPressure(withNeighbor, 'own-neighbor');
+    expect(pressure!.accrual).toBe(Math.round(15 * 1.25));
+  });
+});
+
+describe('#591 MR4 — processReligionTurn', () => {
+  it('accrues points toward the strongest pressure each turn', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const withNeighbor = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
+    const next = processReligionTurn(withNeighbor, new EventBus());
+    expect(next.cityFaith!['own-neighbor'].conversionProgress).toEqual({ toReligionId: `religion-${civId}`, points: 15 });
+  });
+
+  it('converts a city at >= threshold points, fires religion:city-converted, clears progress', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    let working = addCity(founded, 'own-neighbor', civId, {
+      q: 6, r: 0,
+    }, {});
+    working = {
+      ...working,
+      cityFaith: { ...working.cityFaith, 'own-neighbor': { conversionProgress: { toReligionId: `religion-${civId}`, points: CONVERSION_THRESHOLD - 10 } } as any },
+    };
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('religion:city-converted', e => events.push(e));
+    const next = processReligionTurn(working, bus);
+    expect(next.cityFaith!['own-neighbor']).toEqual({ religionId: `religion-${civId}` });
+    expect(events).toHaveLength(1);
+  });
+
+  it('resets points when the strongest target religion changes to a different one', () => {
+    const { state, civId, templeCity, otherCivId, otherCity } = makeReligionFixture();
+    let working = foundReligion(state, civId, templeCity, new EventBus());
+    working = foundReligion(working, otherCivId, otherCity, new EventBus());
+    working = addCity(working, 'contested', 'p3', { q: 6, r: 0 }); // adjacent to templeCity only initially
+    working = {
+      ...working,
+      cityFaith: { ...working.cityFaith, contested: { religionId: `religion-${civId}`, conversionProgress: { toReligionId: `religion-${civId}`, points: 50 } } as any },
+    };
+    // Now make it ALSO adjacent to two of otherCiv's follower cities so the other
+    // religion's accrual (7*2=14) exceeds civId's own single-source accrual isn't
+    // possible here since 'contested' isn't civId's own city -- rebuild as a foreign
+    // city relative to both religions, with otherCivId's religion now stronger.
+    working = addCity(working, 'other-f1', otherCivId, { q: 5, r: 1 });
+    working = { ...working, cityFaith: { ...working.cityFaith, 'other-f1': { religionId: `religion-${otherCivId}` } } };
+    working = addCity(working, 'other-f2', otherCivId, { q: 7, r: -1 });
+    working = { ...working, cityFaith: { ...working.cityFaith, 'other-f2': { religionId: `religion-${otherCivId}` } } };
+    // contested is owned by 'p3' (foreign to both) -- adjacent to templeCity (civId, 1
+    // source, 7) and to other-f1/other-f2 (otherCivId, 2 sources, 14). otherCivId wins.
+    const next = processReligionTurn(working, new EventBus());
+    expect(next.cityFaith!.contested.conversionProgress).toEqual({ toReligionId: `religion-${otherCivId}`, points: 14 });
+  });
+
+  it('never accrues progress in a holy city, even under maximum pressure', () => {
+    const { state, civId, templeCity, otherCivId } = makeReligionFixture();
+    let working = foundReligion(state, civId, templeCity, new EventBus());
+    working = foundReligion(working, otherCivId, 'other-city', new EventBus());
+    // Surround the holy city with strong rival sources.
+    working = addCity(working, 'rival-1', otherCivId, { q: 4, r: 0 });
+    working = { ...working, cityFaith: { ...working.cityFaith, 'rival-1': { religionId: `religion-${otherCivId}` } } };
+    const before = working.cityFaith![templeCity];
+    const next = processReligionTurn(working, new EventBus());
+    expect(next.cityFaith![templeCity]).toEqual(before);
+  });
+
+  it('is deterministic: identical result on cloned state', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const withNeighbor = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
+    const a = processReligionTurn(structuredClone(withNeighbor), new EventBus());
+    const b = processReligionTurn(structuredClone(withNeighbor), new EventBus());
+    expect(a).toEqual(b);
+  });
+});

--- a/tests/systems/religion-spread.test.ts
+++ b/tests/systems/religion-spread.test.ts
@@ -156,6 +156,28 @@ describe('#591 MR4 — processReligionTurn', () => {
     expect(next.cityFaith![templeCity]).toEqual(before);
   });
 
+  it('accrual does not freeze after the first turn (regression: religionId gets set on turn 1 even before conversion completes)', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const withNeighbor = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
+    let working = withNeighbor;
+    for (let i = 0; i < 3; i++) {
+      working = processReligionTurn(working, new EventBus());
+    }
+    // 3 turns * 15/turn = 45, not frozen at 15 after turn 1.
+    expect(working.cityFaith!['own-neighbor'].conversionProgress).toEqual({ toReligionId: `religion-${civId}`, points: 45 });
+  });
+
+  it('does not re-touch a city that already fully converted (settled follower, no conversionProgress)', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    let working = addCity(founded, 'own-neighbor', civId, { q: 6, r: 0 });
+    working = { ...working, cityFaith: { ...working.cityFaith, 'own-neighbor': { religionId: `religion-${civId}` } } };
+    const before = working.cityFaith!['own-neighbor'];
+    const next = processReligionTurn(working, new EventBus());
+    expect(next.cityFaith!['own-neighbor']).toEqual(before);
+  });
+
   it('is deterministic: identical result on cloned state', () => {
     const { state, civId, templeCity } = makeReligionFixture();
     const founded = foundReligion(state, civId, templeCity, new EventBus());

--- a/tests/systems/religion-system.test.ts
+++ b/tests/systems/religion-system.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { EventBus } from '@/core/event-bus';
+import { foundReligion, chooseBoon } from '@/systems/religion-system';
+import { makeReligionFixture } from './helpers/religion-fixture';
+
+describe('#591 MR4 — foundReligion', () => {
+  it('creates a religion, marks the building city as holy, and has the capital adopt it', () => {
+    const { state, civId, capitalId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const next = foundReligion(state, civId, templeCity, bus);
+    const religionId = `religion-${civId}`;
+    expect(next.religions![religionId]).toMatchObject({ ownerCivId: civId });
+    expect(next.religions![religionId].boon).toBeUndefined();
+    expect(next.cityFaith![templeCity]).toMatchObject({ religionId, isHolyCity: true });
+    expect(next.cityFaith![capitalId]).toMatchObject({ religionId });
+  });
+
+  it('does not double-count the building city as both holy and capital when they are the same city', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion({ ...state, civilizations: { ...state.civilizations, [civId]: { ...state.civilizations[civId], cities: [templeCity] } } }, civId, templeCity, new EventBus());
+    expect(founded.cityFaith![templeCity]).toMatchObject({ religionId: `religion-${civId}`, isHolyCity: true });
+  });
+
+  it('is a no-op if the civ already has a religion', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const founded = foundReligion(state, civId, templeCity, bus);
+    const second = foundReligion(founded, civId, templeCity, bus);
+    expect(second).toBe(founded);
+  });
+
+  it('picks a name from NAME_CANDIDATES deterministically by seed', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const a = foundReligion(state, civId, templeCity, new EventBus());
+    const b = foundReligion(state, civId, templeCity, new EventBus());
+    expect(a.religions![`religion-${civId}`].name).toBe(b.religions![`religion-${civId}`].name);
+    expect(a.religions![`religion-${civId}`].name.length).toBeGreaterThan(0);
+  });
+
+  it('emits religion:founded exactly once', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const bus = new EventBus();
+    const events: unknown[] = [];
+    bus.on('religion:founded', e => events.push(e));
+    foundReligion(state, civId, templeCity, bus);
+    expect(events).toHaveLength(1);
+  });
+
+  it('is a no-op for a nonexistent civ', () => {
+    const { state, templeCity } = makeReligionFixture();
+    const next = foundReligion(state, 'no-such-civ', templeCity, new EventBus());
+    expect(next).toBe(state);
+  });
+});
+
+describe('#591 MR4 — chooseBoon', () => {
+  it('sets the boon on the owner\'s religion', () => {
+    const { state, civId, templeCity } = makeReligionFixture();
+    const founded = foundReligion(state, civId, templeCity, new EventBus());
+    const next = chooseBoon(founded, `religion-${civId}`, 'serenity');
+    expect(next.religions![`religion-${civId}`].boon).toBe('serenity');
+  });
+
+  it('is a no-op for a nonexistent religion id', () => {
+    const { state } = makeReligionFixture();
+    expect(chooseBoon(state, 'no-such-religion', 'tithes')).toBe(state);
+  });
+});

--- a/tests/ui/city-panel-religion.test.ts
+++ b/tests/ui/city-panel-religion.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { createCityPanel } from '@/ui/city-panel';
+import { makeWonderPanelFixture } from './helpers/wonder-panel-fixture';
+import type { GameState } from '@/core/types';
+
+function withFaith(overrides: Partial<GameState> = {}) {
+  const { container, city, state } = makeWonderPanelFixture();
+  const withReligionState: GameState = {
+    ...state,
+    religions: { 'religion-owner': { id: 'religion-owner', name: 'Order of Test', ownerCivId: city.owner, foundedTurn: 1 } },
+    ...overrides,
+  };
+  return { container, city, state: withReligionState };
+}
+
+describe('#591 MR4 — city panel Faith row', () => {
+  it('shows "Holy City of {name}" for the founding city', () => {
+    const { container, city, state } = withFaith();
+    const withCityFaith = { ...state, cityFaith: { [city.id]: { religionId: 'religion-owner', isHolyCity: true as const } } };
+    const panel = createCityPanel(container, city, withCityFaith, { onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {} });
+    expect(panel.textContent).toContain('Holy City of Order of Test');
+  });
+
+  it('shows "Follows {name}" for a settled follower (no conversionProgress)', () => {
+    const { container, city, state } = withFaith();
+    const withCityFaith = { ...state, cityFaith: { [city.id]: { religionId: 'religion-owner' } } };
+    const panel = createCityPanel(container, city, withCityFaith, { onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {} });
+    expect(panel.textContent).toContain('Follows Order of Test');
+  });
+
+  it('shows in-progress conversion with a derived turns-remaining figure', () => {
+    const { container, city, state } = withFaith();
+    const withCityFaith: GameState = {
+      ...state,
+      cityFaith: { [city.id]: { religionId: 'religion-owner', conversionProgress: { toReligionId: 'religion-owner', points: 85 } } },
+    };
+    const panel = createCityPanel(container, city, withCityFaith, { onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {} });
+    expect(panel.textContent).toContain('Converting to Order of Test');
+    expect(panel.textContent).toContain('turn');
+  });
+
+  it('renders no Faith row when the city has no faith', () => {
+    const { container, city, state } = withFaith();
+    const panel = createCityPanel(container, city, state, { onBuild: () => {}, onOpenWonderPanel: () => {}, onClose: () => {} });
+    expect(panel.textContent).not.toContain('Faith');
+  });
+});

--- a/tests/ui/diplomacy-panel.test.ts
+++ b/tests/ui/diplomacy-panel.test.ts
@@ -901,3 +901,41 @@ describe('diplomacy-panel Send Aid button (#526 MR6 Task 6.3)', () => {
     expect(button!.title).toBe('Requires Medicine.');
   });
 });
+
+describe('#591 MR4 — diplomacy panel religion summary', () => {
+  it('shows the viewer\'s own religion name, boon, and follower counts', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+    state.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', boon: 'tithes', foundedTurn: 1 } };
+    state.cityFaith = {
+      'city-border': { religionId: 'religion-player', isHolyCity: true },
+      'outsider-city-placeholder': { religionId: 'religion-player' },
+    };
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.textContent).toContain('Order of Test');
+    expect(panel.textContent).toContain('Tithes');
+  });
+
+  it('shows a pending-choice note when the boon is not yet chosen', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+    state.religions = { 'religion-player': { id: 'religion-player', name: 'Order of Test', ownerCivId: 'player', foundedTurn: 1 } };
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.textContent).toContain('Choosing a boon');
+  });
+
+  it('renders no religion summary when the viewer has not founded a religion', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player' });
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.querySelector('[data-text="religion-name"]')).toBeNull();
+  });
+
+  it('never shows a rival civ\'s religion as the viewer\'s own', () => {
+    const { container, state } = makeDiplomacyFixture({ currentPlayer: 'player', includeThirdCiv: true });
+    state.religions = { 'religion-outsider': { id: 'religion-outsider', name: 'Rival Faith', ownerCivId: 'outsider', boon: 'fervor', foundedTurn: 1 } };
+    const panel = createDiplomacyPanel(container, state, { onAction: () => {}, onClose: () => {}, onSendAid: () => {} });
+
+    expect(panel.textContent).not.toContain('Rival Faith');
+  });
+});

--- a/tests/ui/religion-boon-modal.test.ts
+++ b/tests/ui/religion-boon-modal.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createReligionBoonModal } from '@/ui/religion-boon-modal';
+
+describe('#591 MR4 — religion boon modal', () => {
+  it('shows the religion name and a description for each of the three boons', () => {
+    const container = document.createElement('div');
+    createReligionBoonModal(container, { religionName: 'Order of Test', onChooseBoon: () => {} });
+    expect(container.textContent).toContain('Order of Test');
+    expect(container.textContent).toContain('happiness');
+    expect(container.textContent).toContain('gold');
+    expect(container.textContent).toContain('25% faster');
+  });
+
+  it('clicking a boon button invokes onChooseBoon with the right boon', () => {
+    const container = document.createElement('div');
+    const onChooseBoon = vi.fn();
+    createReligionBoonModal(container, { religionName: 'Order of Test', onChooseBoon });
+    const button = container.querySelector<HTMLButtonElement>('[data-choose-boon="fervor"]');
+    expect(button).toBeTruthy();
+    button!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(onChooseBoon).toHaveBeenCalledWith('fervor');
+  });
+
+  it('removes a previously-open modal before rendering a new one (no duplicates)', () => {
+    const container = document.createElement('div');
+    createReligionBoonModal(container, { religionName: 'First', onChooseBoon: () => {} });
+    createReligionBoonModal(container, { religionName: 'Second', onChooseBoon: () => {} });
+    expect(container.querySelectorAll('#religion-boon-modal')).toHaveLength(1);
+    expect(container.textContent).toContain('Second');
+    expect(container.textContent).not.toContain('First');
+  });
+});

--- a/tests/ui/religion-notification-routing.test.ts
+++ b/tests/ui/religion-notification-routing.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '@/core/types';
+import { routeReligionFounded } from '@/ui/notification-routing';
+
+// Deliberately a separate file from notification-routing.test.ts: that file mocks
+// @/systems/discovery-system at module scope with a narrow hardcoded stub built for an
+// older test, which would silently constrain (and, when we tried, broke) any test here
+// needing real hasMetCivilization behavior across more than one specific civ pair.
+function makeState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    turn: 5,
+    currentPlayer: 'p1',
+    civilizations: {
+      p1: { id: 'p1', name: 'Alice', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, knownCivilizations: ['p2'], cities: ['c1'], units: [] },
+      p2: { id: 'p2', name: 'Bob', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+      p3: { id: 'p3', name: 'Carol', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] }, // never met p1
+    },
+    units: {},
+    cities: { c1: { id: 'c1', name: 'Thebes', owner: 'p1', position: { q: 0, r: 0 }, ownedTiles: [] } },
+    map: { width: 1, height: 1, wrapsHorizontally: false, rivers: [], tiles: {} },
+    ...overrides,
+  } as GameState;
+}
+
+function makeSink() {
+  const calls: Array<{ civId: string; message: string; type: string }> = [];
+  const sink = (civId: string, message: string, type: string) => calls.push({ civId, message, type });
+  return { sink, calls };
+}
+
+describe('#591 MR4 — religion:founded routing', () => {
+  it('notifies the founder and any civ that has met them, never a stranger civ', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+    routeReligionFounded(state, { religionId: 'religion-p1', civId: 'p1', cityId: 'c1', name: 'Order of Test' }, sink as never);
+
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toContain('p1');
+    expect(civIds).toContain('p2');
+    expect(civIds).not.toContain('p3');
+  });
+
+  it('the founder sees a first-person message naming their own city; others see a third-person message', () => {
+    const state = makeState();
+    const { sink, calls } = makeSink();
+    routeReligionFounded(state, { religionId: 'religion-p1', civId: 'p1', cityId: 'c1', name: 'Order of Test' }, sink as never);
+
+    const founderCall = calls.find(c => c.civId === 'p1')!;
+    const observerCall = calls.find(c => c.civId === 'p2')!;
+    expect(founderCall.message).toContain('Thebes');
+    expect(observerCall.message).toContain('Alice');
+    expect(observerCall.message).toContain('Order of Test');
+  });
+
+  it('notifies nobody beyond the founder when no one else has met them', () => {
+    const state = makeState({
+      civilizations: {
+        p1: { id: 'p1', name: 'Alice', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: ['c1'], units: [] },
+        p2: { id: 'p2', name: 'Bob', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+      } as unknown as GameState['civilizations'],
+    });
+    const { sink, calls } = makeSink();
+    routeReligionFounded(state, { religionId: 'religion-p1', civId: 'p1', cityId: 'c1', name: 'Order of Test' }, sink as never);
+
+    expect(calls.map(c => c.civId)).toEqual(['p1']);
+  });
+});

--- a/tests/ui/religion-notification-routing.test.ts
+++ b/tests/ui/religion-notification-routing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { GameState } from '@/core/types';
-import { routeReligionFounded } from '@/ui/notification-routing';
+import { routeReligionFounded, routeReligionCityConverted } from '@/ui/notification-routing';
 
 // Deliberately a separate file from notification-routing.test.ts: that file mocks
 // @/systems/discovery-system at module scope with a narrow hardcoded stub built for an
@@ -61,6 +61,44 @@ describe('#591 MR4 — religion:founded routing', () => {
     });
     const { sink, calls } = makeSink();
     routeReligionFounded(state, { religionId: 'religion-p1', civId: 'p1', cityId: 'c1', name: 'Order of Test' }, sink as never);
+
+    expect(calls.map(c => c.civId)).toEqual(['p1']);
+  });
+});
+
+describe('#591 MR4 — religion:city-converted routing', () => {
+  it('notifies the city\'s own owner, and the new religion\'s owner if a different civ who has met them', () => {
+    const state = makeState({
+      religions: { 'religion-p2': { id: 'religion-p2', name: 'Order of Rivals', ownerCivId: 'p2', foundedTurn: 1 } },
+    });
+    const { sink, calls } = makeSink();
+    routeReligionCityConverted(state, { cityId: 'c1', toReligionId: 'religion-p2' }, sink as never);
+
+    const civIds = calls.map(c => c.civId);
+    expect(civIds).toContain('p1'); // c1's own owner
+    expect(civIds).toContain('p2'); // religion-p2's owner, gained a follower
+  });
+
+  it('does not double-notify when the city owner and the new religion\'s owner are the same civ', () => {
+    const state = makeState({
+      religions: { 'religion-p1': { id: 'religion-p1', name: 'Order of Test', ownerCivId: 'p1', foundedTurn: 1 } },
+    });
+    const { sink, calls } = makeSink();
+    routeReligionCityConverted(state, { cityId: 'c1', toReligionId: 'religion-p1' }, sink as never);
+
+    expect(calls.map(c => c.civId)).toEqual(['p1']);
+  });
+
+  it('does not notify the new religion\'s owner if they have never met the city\'s owner', () => {
+    const state = makeState({
+      civilizations: {
+        p1: { id: 'p1', name: 'Alice', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: ['c1'], units: [] },
+        p3: { id: 'p3', name: 'Carol', diplomacy: { relationships: {}, atWarWith: [], treaties: [] }, visibility: { tiles: {} }, cities: [], units: [] },
+      } as unknown as GameState['civilizations'],
+      religions: { 'religion-p3': { id: 'religion-p3', name: 'Order of Strangers', ownerCivId: 'p3', foundedTurn: 1 } },
+    });
+    const { sink, calls } = makeSink();
+    routeReligionCityConverted(state, { cityId: 'c1', toReligionId: 'religion-p3' }, sink as never);
 
     expect(calls.map(c => c.civId)).toEqual(['p1']);
   });


### PR DESCRIPTION
## Summary

Part of the #524 arc (index: #587). MR4 — religion core: state, Sacred Council (a new "milestone" national project category), invented per-civ names, three boons, and passive faith spread/conversion. Fixes half of `missionary-zeal`'s dead promise by making religion exist for real; the missionary half is MR5 (#592).

- Two new state slices: `state.religions`, `state.cityFaith` (optional on `GameState`, matching the established convention for late-added slices like `activeCrises`/`pirates`/`espionage` rather than fighting ~20 pre-existing minimal-literal test fixtures).
- New `NationalProject.milestone` flag: a one-time, permanent-trigger project — buildable from `homeEra` onward with no upper build-window bound, never expires, no yield bonus (its effect is a one-time state mutation). Bypassed at the three sites that assume every NP fades (`getAvailableBuildings`, the belt-and-suspenders dequeue guard, `expireNationalProjects`).
- **Sacred Council**: era 3, requires Temple + `philosophy`, milestone. Completing it founds a religion, marks the building city holy (permanently immune to conversion), and has the capital adopt the faith too.
- Three boons (owner picks exactly one, no effects until chosen): **Serenity** (+1 happiness per own-faith-following city), **Tithes** (+1 gold per foreign follower city, capped at 10), **Fervor** (+25% conversion speed — MR4-honest description mentions only speed; territory/loyalty effects are MR6's to add).
- Passive spread: each turn, an eligible city accrues toward whichever religion is locally strongest (own-city adjacency +15, foreign adjacency +7 per source capped at 2, trade-route +5, Fervor ×1.25), converts at 100 points. No war-gate (user decision — matches the existing unrest-contagion precedent).
- 29 invented, culture-flavored faith names (2 per civ id) + a neutral pool for custom civs — never real-world religions.
- AI: founds Sacred Council via the standard definition-driven NP path; chooses a boon deterministically and immediately (unhappy → Serenity, at war → Fervor, else Tithes).
- UI: city panel Faith row (name, holy-city label, in-progress conversion with derived turns-remaining), a boon-choice modal (blocks end-turn until chosen, same pattern as the existing required-choice panel), and a religion summary block in the diplomacy panel (viewer's own religion only).

## Branch audit / locked-interface coverage

| Requirement | Where |
|---|---|
| `milestone` NP: no upper build window | `getAvailableBuildings` + `processCity`'s dequeue guard, `city-system.ts` |
| `milestone` NP: never expires | `expireNationalProjects`, `national-project-system.ts` |
| `milestone` NP: no yield bonus | Enforced generically for all milestone NPs in `national-project-balance.test.ts` |
| Holy city never accrues conversion | `processReligionTurn` skip check + regression test at max pressure |
| `conversionProgress` reset semantics | Documented decision: switching target religion resets points; same-target accrual accumulates (the `CityFaith` type only ever holds one target, not a per-religion ledger) |
| Boon pending → no effects, re-prompts | `showReligionBoonIfNeeded` blocks end-turn (mirrors the only existing "must decide" UI pattern in this codebase) until chosen; boon effects (`Serenity`/`Tithes`) check `boon === '...'` explicitly |
| `cityFaith` kept on capture, deleted on raze | Capture path untouched (city record persists → faith persists for free); raze path explicitly deletes the entry, with regression tests for both |
| Discovery-gated founding notification | **Found missing during review** — added `routeReligionFounded`, stricter than the wonder-completion precedent (notifies only civs who've met the founder, not everyone with an anonymized name) |
| AI actually builds Sacred Council | **Found broken during review** — `economyValue()` scored it 0 (no yield), deeply undercutting its production cost in the AI's candidate formula; added a generic milestone-NP floor so any future milestone project scores reasonably too |

## Real bug fixed pre-review (caught by a multi-turn test, not a playtest)

`processReligionTurn`'s early-exit check compared `cityFaith.religionId` against the pressure target to decide "already follows the strongest religion, skip" — but a city mid-conversion gets `religionId` set to the pending target on its very first accrual turn (before actually converting), so every city's conversion progress froze at its turn-1 point total forever. Fixed to only skip a *settled* follower (no `conversionProgress` present); a city still mid-conversion toward the same target keeps accruing. Covered by a new multi-turn regression test.

## Save decision

Additive only: two new optional slices, both default to `{}` via `createNewGame` (new games) and `migrateSaveToCurrent` (old saves) — no schema version bump. No retroactive religion founding on old saves. Migration fixtures cover defaulting, preservation of existing data, and idempotency across repeated loads.

## Pacing gates

Sacred Council's `requiresBuildings: ['temple']` is the first chain that forces `temple` past the bounded-profile reference economy's recency window at later eras (temple's own `+1 science` now counts as active production indefinitely once *any* building lists it as a prerequisite) — the bounded-profile pin shifted upward for eras 7–13. Documented inline in `pacing-reference-economy.test.ts` with the mechanism explained; the maximal profile (what `RESEARCH_OUTPUT_BY_ERA` actually targets) is unaffected, and the era-over-era outlier gate still passes.

## Tests

New: `religion-definitions.test.ts`, `religion-system.test.ts`, `religion-spread.test.ts` (spread/conversion/holy-city/freeze-regression), `city-panel-religion.test.ts`, `religion-boon-modal.test.ts`, `religion-notification-routing.test.ts` (deliberately a separate file from `notification-routing.test.ts`, which mocks discovery-system at module scope for an older, unrelated test). Extended: `national-project-balance.test.ts`, `national-project-system.test.ts`, `city-system.test.ts` (milestone NP behavior), `faction-system.test.ts` (Serenity row), `economy-system.test.ts` (Tithes gold), `city-capture-system.test.ts` (cityFaith lifecycle), `basic-ai.test.ts` (AI boon choice), `ai-production.test.ts` (milestone NP scoring), `turn-manager.test.ts` (religion turn wiring + Sacred Council completion), `save-migrations.test.ts`.

`yarn build` and `yarn test` both green (6638 tests passing, 0 type errors).

Reference #591, #587. NOT #524 — per arc convention, that issue's owner handles it manually at the end of the arc.
